### PR TITLE
fix: #83183 Replace deprecated url.parse() with WHATWG URL API

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -396,6 +396,21 @@ export default defineConfig([
       '@next/internal/typechecked-require': 'error',
       'jsdoc/no-types': 'error',
       'jsdoc/no-undefined-types': 'error',
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector:
+            "CallExpression[callee.object.name='url'][callee.property.name='parse']",
+          message:
+            'url.parse() is deprecated (DEP0169). Use parseReqUrl from src/lib/url.ts instead.',
+        },
+        {
+          selector:
+            "CallExpression[callee.object.name='url'][callee.property.name='format']",
+          message:
+            'url.format() is deprecated (DEP0169). Use formatUrl from src/shared/lib/router/utils/format-url.ts instead.',
+        },
+      ],
     },
   },
   {

--- a/packages/create-next-app/helpers/is-online.ts
+++ b/packages/create-next-app/helpers/is-online.ts
@@ -1,6 +1,5 @@
 import { execSync } from 'node:child_process'
 import { lookup } from 'node:dns/promises'
-import url from 'node:url'
 
 function getProxy(): string | undefined {
   if (process.env.https_proxy) {
@@ -27,9 +26,14 @@ export async function getOnline(): Promise<boolean> {
       return false
     }
 
-    const { hostname } = url.parse(proxy)
-    if (!hostname) {
+    let hostname: string
+    try {
+      hostname = new URL(proxy).hostname
+    } catch {
       // Invalid proxy URL
+      return false
+    }
+    if (!hostname) {
       return false
     }
 

--- a/packages/next/src/lib/try-to-parse-path.ts
+++ b/packages/next/src/lib/try-to-parse-path.ts
@@ -1,6 +1,6 @@
 import type { Token } from 'next/dist/compiled/path-to-regexp'
 import { parse, tokensToRegexp } from 'next/dist/compiled/path-to-regexp'
-import { parse as parseURL } from 'url'
+import { parseReqUrl } from './url'
 import isError from './is-error'
 import { normalizeTokensForRegexp } from './route-pattern-normalizer'
 
@@ -67,8 +67,10 @@ export function tryToParsePath(
   const result: ParseResult = { route, parsedPath: route }
   try {
     if (options?.handleUrl) {
-      const parsed = parseURL(route, true)
-      result.parsedPath = `${parsed.pathname!}${parsed.hash || ''}`
+      const parsed = parseReqUrl(route)
+      if (parsed) {
+        result.parsedPath = `${parsed.pathname!}${parsed.hash || ''}`
+      }
     }
 
     result.tokens = parse(result.parsedPath)

--- a/packages/next/src/lib/url.ts
+++ b/packages/next/src/lib/url.ts
@@ -15,35 +15,62 @@ export function parseUrl(url: string): URL | undefined {
   return parsed
 }
 
-export function parseReqUrl(url: string): UrlWithParsedQuery | undefined {
-  const parsedUrl: URL | undefined = parseUrl(url)
+export function parseReqUrl(url: string): UrlWithParsedQuery {
+  const parsedUrl = parseUrl(url)
 
+  // Return fallback for invalid URLs (matches url.parse behavior which never returns undefined)
   if (!parsedUrl) {
-    return
+    return {
+      query: {},
+      hash: '',
+      search: '',
+      path: url,
+      pathname: url,
+      href: url,
+      host: '',
+      hostname: '',
+      protocol: '',
+      port: '',
+      auth: '',
+      slashes: null,
+    }
   }
 
   const query: Record<string, string | string[]> = {}
-
   for (const key of parsedUrl.searchParams.keys()) {
     const values = parsedUrl.searchParams.getAll(key)
     query[key] = values.length > 1 ? values : values[0]
   }
 
-  const legacyUrl: UrlWithParsedQuery = {
+  const shared = {
     query,
     hash: parsedUrl.hash,
     search: parsedUrl.search,
-    path: parsedUrl.pathname,
+    path: `${parsedUrl.pathname}${parsedUrl.search}`,
     pathname: parsedUrl.pathname,
-    href: `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`,
-    host: '',
-    hostname: '',
+    port: parsedUrl.port || '',
     auth: '',
-    protocol: '',
-    slashes: null,
-    port: '',
   }
-  return legacyUrl
+
+  if (!isFullStringUrl(url)) {
+    return {
+      ...shared,
+      href: `${parsedUrl.pathname}${parsedUrl.search}${parsedUrl.hash}`,
+      host: '',
+      hostname: '',
+      protocol: '',
+      slashes: null,
+    }
+  }
+
+  return {
+    ...shared,
+    href: parsedUrl.href,
+    host: parsedUrl.host,
+    hostname: parsedUrl.hostname,
+    protocol: parsedUrl.protocol,
+    slashes: true,
+  }
 }
 
 export function stripNextRscUnionQuery(relativeUrl: string): string {

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -46,7 +46,8 @@ import type { PathnameNormalizer } from './normalizers/request/pathname-normaliz
 import type { InstrumentationModule } from './instrumentation/types'
 
 import * as path from 'path'
-import { format as formatUrl, parse as parseUrl } from 'url'
+import { parseReqUrl } from '../lib/url'
+import { formatUrl } from '../shared/lib/router/utils/format-url'
 import { formatHostname } from './lib/format-hostname'
 import {
   APP_PATHS_MANIFEST,
@@ -648,7 +649,7 @@ export default abstract class Server<
     }
 
     if (req.url) {
-      const parsed = parseUrl(req.url)
+      const parsed = parseReqUrl(req.url)
       parsed.pathname = parsedUrl.pathname
       req.url = formatUrl(parsed)
     }
@@ -953,7 +954,7 @@ export default abstract class Server<
           throw new Error('Invariant: url can not be undefined')
         }
 
-        parsedUrl = parseUrl(req.url!, true)
+        parsedUrl = parseReqUrl(req.url!) as NextUrlWithParsedQuery
       }
 
       if (!parsedUrl.pathname) {
@@ -2052,7 +2053,7 @@ export default abstract class Server<
     // Compute the iSSG cache key. We use the rewroteUrl since
     // pages with fallback: false are allowed to be rewritten to
     // and we need to look up the path by the rewritten path
-    let urlPathname = parseUrl(req.url || '').pathname || '/'
+    let urlPathname = parseReqUrl(req.url || '').pathname || '/'
 
     let resolvedUrlPathname = getRequestMeta(req, 'rewroteURL') || urlPathname
 
@@ -2324,7 +2325,9 @@ export default abstract class Server<
     const request = isNodeNextRequest(req) ? req.originalRequest : req
     const response = isNodeNextResponse(res) ? res.originalResponse : res
 
-    const parsedInitUrl = parseUrl(getRequestMeta(req, 'initURL') || req.url)
+    const parsedInitUrl = parseReqUrl(
+      getRequestMeta(req, 'initURL') || req.url || ''
+    )
     let initPathname = parsedInitUrl.pathname || '/'
 
     for (const normalizer of [
@@ -2963,7 +2966,7 @@ export default abstract class Server<
     parsedUrl?: Pick<NextUrlWithParsedQuery, 'pathname' | 'query'>,
     setHeaders = true
   ): Promise<void> {
-    const { pathname, query } = parsedUrl ? parsedUrl : parseUrl(req.url!, true)
+    const { pathname, query } = parsedUrl ?? parseReqUrl(req.url!)
 
     // Ensure the locales are provided on the request meta.
     if (this.nextConfig.i18n) {

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -7,8 +7,9 @@ import type { NextUrlWithParsedQuery, RequestMeta } from '../request-meta'
 import '../node-environment'
 import '../require-hook'
 
-import url from 'url'
 import path from 'path'
+import { parseReqUrl } from '../../lib/url'
+import { formatUrl } from '../../shared/lib/router/utils/format-url'
 import loadConfig from '../config'
 import { serveStatic } from '../serve-static'
 import setupDebug from 'next/dist/compiled/debug'
@@ -368,7 +369,7 @@ export async function initialize(opts: {
           req.url = removePathPrefix(origUrl, config.assetPrefix)
         }
 
-        const parsedUrl = url.parse(req.url || '/')
+        const parsedUrl = parseReqUrl(req.url || '/')
 
         const hotReloaderResult = await development.bundler.hotReloader.run(
           req,
@@ -449,7 +450,7 @@ export async function initialize(opts: {
 
       // handle redirect
       if (!bodyStream && statusCode && statusCode > 300 && statusCode < 400) {
-        const destination = url.format(parsedUrl)
+        const destination = formatUrl(parsedUrl)
         res.statusCode = statusCode
         res.setHeader('location', destination)
 
@@ -508,14 +509,9 @@ export async function initialize(opts: {
         if (!(req.method === 'GET' || req.method === 'HEAD')) {
           res.setHeader('Allow', ['GET', 'HEAD'])
           res.statusCode = 405
-          return await invokeRender(
-            url.parse('/405', true),
-            '/405',
-            handleIndex,
-            {
-              invokeStatus: 405,
-            }
-          )
+          return await invokeRender(parseReqUrl('/405'), '/405', handleIndex, {
+            invokeStatus: 405,
+          })
         }
 
         try {
@@ -574,7 +570,7 @@ export async function initialize(opts: {
             const invokeStatus = err.statusCode
             res.statusCode = err.statusCode
             return await invokeRender(
-              url.parse(invokePath, true),
+              parseReqUrl(invokePath),
               invokePath,
               handleIndex,
               {
@@ -684,7 +680,7 @@ export async function initialize(opts: {
           console.error(err)
         }
         res.statusCode = Number(invokeStatus)
-        return await invokeRender(url.parse(invokePath, true), invokePath, 0, {
+        return await invokeRender(parseReqUrl(invokePath), invokePath, 0, {
           invokeStatus: res.statusCode,
         })
       } catch (err2) {

--- a/packages/next/src/server/lib/router-utils/proxy-request.ts
+++ b/packages/next/src/server/lib/router-utils/proxy-request.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { NextUrlWithParsedQuery } from '../../request-meta'
 
-import url from 'url'
+import { formatUrl } from '../../../shared/lib/router/utils/format-url'
 import { stringifyQuery } from '../../server-route-utils'
 import { Duplex } from 'stream'
 import { DetachedPromise } from '../../../lib/detached-promise'
@@ -18,7 +18,7 @@ export async function proxyRequest(
   delete (parsedUrl as any).query
   parsedUrl.search = stringifyQuery(req as any, query)
 
-  const target = url.format(parsedUrl)
+  const target = formatUrl(parsedUrl)
   const HttpProxy =
     require('next/dist/compiled/http-proxy') as typeof import('next/dist/compiled/http-proxy')
 

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -8,8 +8,8 @@ import type { Header } from '../../../lib/load-custom-routes'
 import type { UnwrapPromise } from '../../../lib/coalesced-function'
 import type { NextUrlWithParsedQuery } from '../../request-meta'
 
-import url from 'url'
 import path from 'node:path'
+import { parseReqUrl } from '../../../lib/url'
 import setupDebug from 'next/dist/compiled/debug'
 import { getCloneableBody } from '../../body-streams'
 import { filterReqHeaders, ipcForbiddenHeaders } from '../server-ipc/utils'
@@ -124,7 +124,7 @@ export function getResolveRoutes(
     let finished = false
     let resHeaders: Record<string, string | string[]> = {}
     let matchedOutput: FsOutput | null = null
-    let parsedUrl = url.parse(req.url || '', true) as NextUrlWithParsedQuery
+    let parsedUrl = parseReqUrl(req.url || '') as NextUrlWithParsedQuery
     let didRewrite = false
 
     const urlParts = (req.url || '').split('?', 1)
@@ -142,7 +142,9 @@ export function getResolveRoutes(
     // handle trailing slash as that is handled the same as a next.config.js
     // redirect
     if (urlNoQuery?.match(/(\\|\/\/)/)) {
-      parsedUrl = url.parse(normalizeRepeatedSlashes(req.url!), true)
+      parsedUrl = parseReqUrl(
+        normalizeRepeatedSlashes(req.url!)
+      ) as NextUrlWithParsedQuery
       return {
         parsedUrl,
         resHeaders,
@@ -662,7 +664,7 @@ export function getResolveRoutes(
               const destination = getRelativeURL(value, initUrl)
               resHeaders['x-middleware-rewrite'] = destination
 
-              parsedUrl = url.parse(destination, true)
+              parsedUrl = parseReqUrl(destination) as NextUrlWithParsedQuery
 
               if (parsedUrl.protocol) {
                 return {
@@ -697,7 +699,7 @@ export function getResolveRoutes(
                 // Process as redirect: update parsedUrl and convert to relative URL
                 const rel = getRelativeURL(value, initUrl)
                 resHeaders['location'] = rel
-                parsedUrl = url.parse(rel, true)
+                parsedUrl = parseReqUrl(rel) as NextUrlWithParsedQuery
 
                 return {
                   parsedUrl,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -10,7 +10,7 @@ import type { NextJsHotReloaderInterface } from '../../dev/hot-reloader-types'
 import { createDefineEnv } from '../../../build/swc'
 import { installBindings } from '../../../build/swc/install-bindings'
 import fs from 'fs'
-import url from 'url'
+import { parseReqUrl } from '../../../lib/url'
 import path from 'path'
 import qs from 'querystring'
 import Watchpack from 'next/dist/compiled/watchpack'
@@ -1213,7 +1213,7 @@ async function startWatcher(
   opts.fsChecker.devVirtualFsItems.add(devTurbopackMiddlewareManifestPath)
 
   async function requestHandler(req: IncomingMessage, res: ServerResponse) {
-    const parsedUrl = url.parse(req.url || '/')
+    const parsedUrl = parseReqUrl(req.url || '/')
 
     if (parsedUrl.pathname?.includes(clientPagesManifestPath)) {
       res.statusCode = 200

--- a/test/development/basic/misc.test.ts
+++ b/test/development/basic/misc.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
@@ -69,8 +68,9 @@ describe.each([[''], ['/docs']])(
           }
         )
 
-        const { pathname, hostname } = url.parse(
-          res.headers.get('location') || ''
+        const { pathname, hostname } = new URL(
+          res.headers.get('location') || '',
+          'http://n'
         )
         expect(res.status).toBe(308)
         expect(pathname).toBe(basePath + '/%2fexample.com')

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -6,7 +6,6 @@ import { fetchViaHTTP, getDistDir, renderViaHTTP } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { BUILD_MANIFEST, REACT_LOADABLE_MANIFEST } from 'next/constants'
 import path from 'path'
-import url from 'url'
 
 const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
 
@@ -47,7 +46,7 @@ describe('Client Navigation rendering', () => {
     it('should should not contain scripts that are not js', async () => {
       const $ = await get$('/')
       $('script[src]').each((_index, element) => {
-        const parsedUrl = url.parse($(element).attr('src'))
+        const parsedUrl = new URL($(element).attr('src'), 'http://n')
         if (!parsedUrl.pathname.endsWith('.js')) {
           throw new Error(
             `Page includes script that is not a javascript file ${parsedUrl.pathname}`

--- a/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
+++ b/test/e2e/app-dir/app-fetch-deduping/app-fetch-deduping.test.ts
@@ -1,6 +1,5 @@
 import { findPort, retry } from 'next-test-utils'
 import http from 'http'
-import url from 'url'
 import { outdent } from 'outdent'
 import { isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 
@@ -15,8 +14,8 @@ describe('app-fetch-deduping', () => {
       beforeAll(async () => {
         externalServerPort = await findPort()
         externalServer = http.createServer((req, res) => {
-          const parsedUrl = url.parse(req.url, true)
-          const overrideStatus = parsedUrl.query.status
+          const parsedUrl = new URL(req.url, 'http://n')
+          const overrideStatus = parsedUrl.searchParams.get('status')
 
           // if the requested url has a "status" search param, override the response status
           if (overrideStatus) {

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import assert from 'assert'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
@@ -456,14 +455,14 @@ describe('basePath', () => {
   it('should have correct href for a link', async () => {
     const browser = await webdriver(next.url, `${basePath}/hello`)
     const href = await browser.elementByCss('a').getAttribute('href')
-    const { pathname } = url.parse(href)
+    const { pathname } = new URL(href, 'http://n')
     expect(pathname).toBe(`${basePath}/other-page`)
   })
 
   it('should have correct href for a link to /', async () => {
     const browser = await webdriver(next.url, `${basePath}/link-to-root`)
     const href = await browser.elementByCss('#link-back').getAttribute('href')
-    const { pathname } = url.parse(href)
+    const { pathname } = new URL(href, 'http://n')
     expect(pathname).toBe(`${basePath}`)
   })
 

--- a/test/e2e/basepath/redirect-and-rewrite.test.ts
+++ b/test/e2e/basepath/redirect-and-rewrite.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, renderViaHTTP } from 'next-test-utils'
 
@@ -110,7 +109,7 @@ describe('basePath', () => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '', 'http://n')
     expect(pathname).toBe(`${basePath}/somewhere-else`)
     expect(res.status).toBe(307)
     const text = await res.text()
@@ -144,7 +143,7 @@ describe('basePath', () => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const { pathname } = new URL(res.headers.get('location') || '', 'http://n')
     expect(pathname).toBe('/another-destination')
     expect(res.status).toBe(307)
     const text = await res.text()

--- a/test/integration/basepath-root-catch-all/test/index.test.ts
+++ b/test/integration/basepath-root-catch-all/test/index.test.ts
@@ -8,7 +8,6 @@ import {
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 import fs from 'fs-extra'
-import url from 'url'
 
 let app
 let appPort
@@ -22,7 +21,7 @@ const runTests = () => {
     await browser.waitForElementByCss('#url')
 
     const dataUrl = await browser.elementByCss('#url').text()
-    const { pathname } = url.parse(dataUrl)
+    const { pathname } = new URL(dataUrl, 'http://n')
     expect(pathname).toBe(`/_next/data/${buildId}/root/catch-all.json`)
   })
 }

--- a/test/integration/custom-routes-i18n-index-redirect/test/index.test.ts
+++ b/test/integration/custom-routes-i18n-index-redirect/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import http from 'http'
 import { join } from 'path'
 import {
@@ -35,9 +34,9 @@ const runTests = () => {
         const text = await res.text()
         expect(text).toEqual(dest)
         if (dest.startsWith('/')) {
-          const parsed = url.parse(res.headers.get('location'))
+          const parsed = new URL(res.headers.get('location'), 'http://n')
           expect(parsed.pathname).toBe(dest)
-          expect(parsed.query).toBe(null)
+          expect(parsed.search).toBe('')
         } else {
           expect(res.headers.get('location')).toBe(dest)
         }

--- a/test/integration/custom-routes-i18n/test/index.test.ts
+++ b/test/integration/custom-routes-i18n/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import http from 'http'
 import { join } from 'path'
 import cheerio from 'cheerio'
@@ -42,9 +41,9 @@ const runTests = () => {
         const text = await res.text()
         expect(text).toEqual(dest)
         if (dest.startsWith('/')) {
-          const parsed = url.parse(res.headers.get('location'))
+          const parsed = new URL(res.headers.get('location'), 'http://n')
           expect(parsed.pathname).toBe(dest)
-          expect(parsed.query).toBe(null)
+          expect(parsed.search).toBe('')
         } else {
           expect(res.headers.get('location')).toBe(dest)
         }

--- a/test/integration/custom-routes/test/index.test.ts
+++ b/test/integration/custom-routes/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import http from 'http'
-import url from 'url'
 import stripAnsi from 'strip-ansi'
 import fs from 'fs-extra'
 import { join } from 'path'
@@ -392,21 +391,24 @@ const runTests = (isDev = false) => {
     const res1 = await fetchViaHTTP(appPort, '/redir-chain1', undefined, {
       redirect: 'manual',
     })
-    const res1location = url.parse(res1.headers.get('location')).pathname
+    const res1Url = new URL(res1.headers.get('location'), 'http://n')
+    const res1location = res1Url.pathname
     expect(res1.status).toBe(301)
     expect(res1location).toBe('/redir-chain2')
 
     const res2 = await fetchViaHTTP(appPort, res1location, undefined, {
       redirect: 'manual',
     })
-    const res2location = url.parse(res2.headers.get('location')).pathname
+    const res2Url = new URL(res2.headers.get('location'), 'http://n')
+    const res2location = res2Url.pathname
     expect(res2.status).toBe(302)
     expect(res2location).toBe('/redir-chain3')
 
     const res3 = await fetchViaHTTP(appPort, res2location, undefined, {
       redirect: 'manual',
     })
-    const res3location = url.parse(res3.headers.get('location')).pathname
+    const res3Url = new URL(res3.headers.get('location'), 'http://n')
+    const res3location = res3Url.pathname
     expect(res3.status).toBe(303)
     expect(res3location).toBe('/')
   })
@@ -443,18 +445,18 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/redirect1', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location'))
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/')
+    expect(parsedUrl.pathname).toBe('/')
   })
 
   it('should redirect with params successfully', async () => {
     const res = await fetchViaHTTP(appPort, '/hello/123/another', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location'))
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/blog/123')
+    expect(parsedUrl.pathname).toBe('/blog/123')
   })
 
   it('should redirect with hash successfully', async () => {
@@ -466,24 +468,21 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, hash, query } = url.parse(
-      res.headers.get('location'),
-      true
-    )
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(res.status).toBe(301)
-    expect(pathname).toBe('/docs/v2/network/status-codes')
-    expect(hash).toBe('#500')
-    expect(query).toEqual({})
+    expect(parsedUrl.pathname).toBe('/docs/v2/network/status-codes')
+    expect(parsedUrl.hash).toBe('#500')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
   })
 
   it('should redirect successfully with provided statusCode', async () => {
     const res = await fetchViaHTTP(appPort, '/redirect2', undefined, {
       redirect: 'manual',
     })
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(res.status).toBe(301)
-    expect(pathname).toBe('/')
-    expect(query).toEqual({})
+    expect(parsedUrl.pathname).toBe('/')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
   })
 
   it('should redirect successfully with catchall', async () => {
@@ -495,10 +494,10 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/somewhere')
-    expect(query).toEqual({})
+    expect(parsedUrl.pathname).toBe('/somewhere')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
   })
 
   it('should server static files through a rewrite', async () => {
@@ -583,10 +582,10 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/with-params')
-    expect(query).toEqual({
+    expect(parsedUrl.pathname).toBe('/with-params')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
       first: 'hello',
       second: 'world',
       a: 'b',
@@ -602,11 +601,11 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname, query } = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/with-params')
-    expect(query).toEqual({
-      // this should be decoded since url.parse decodes query values
+    expect(parsedUrl.pathname).toBe('/with-params')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
+      // this should be decoded since URLSearchParams decodes query values
       first: 'hello world?w=24&focalpoint=center',
       second: 'world',
       a: 'b',
@@ -652,9 +651,9 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/redirect-override', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const parsedUrl = new URL(res.headers.get('location') || '', 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/thank-you-next')
+    expect(parsedUrl.pathname).toBe('/thank-you-next')
   })
 
   it('should work successfully on the client', async () => {
@@ -809,10 +808,10 @@ const runTests = (isDev = false) => {
     expect(res.status).toBe(200)
     expect(
       [...externalServerHits].map((u) => {
-        const { pathname, query } = url.parse(u, true)
+        const parsedUrl = new URL(u, 'http://n')
         return {
-          pathname,
-          query,
+          pathname: parsedUrl.pathname,
+          query: Object.fromEntries(parsedUrl.searchParams),
         }
       })
     ).toEqual([
@@ -833,9 +832,9 @@ const runTests = (isDev = false) => {
     const res = await fetchViaHTTP(appPort, '/unnamed/first/final', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const parsedUrl = new URL(res.headers.get('location') || '', 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/got-unnamed')
+    expect(parsedUrl.pathname).toBe('/got-unnamed')
   })
 
   it('should support named like unnamed parameters correctly', async () => {
@@ -847,9 +846,9 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const parsedUrl = new URL(res.headers.get('location') || '', 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/first')
+    expect(parsedUrl.pathname).toBe('/first')
   })
 
   it('should add refresh header for 308 redirect', async () => {
@@ -909,14 +908,11 @@ const runTests = (isDev = false) => {
       }
     )
 
-    const { pathname, hostname, query } = url.parse(
-      res.headers.get('location') || '',
-      true
-    )
+    const parsedUrl = new URL(res.headers.get('location') || '', 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe(encodeURI('/\\google.com/about'))
-    expect(hostname).not.toBe('google.com')
-    expect(query).toEqual({})
+    expect(parsedUrl.pathname).toBe(encodeURI('/\\google.com/about'))
+    expect(parsedUrl.hostname).not.toBe('google.com')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
   })
 
   it('should handle unnamed parameters with multi-match successfully', async () => {
@@ -937,9 +933,9 @@ const runTests = (isDev = false) => {
         redirect: 'manual',
       }
     )
-    const { pathname } = url.parse(res.headers.get('location') || '')
+    const parsedUrl = new URL(res.headers.get('location') || '', 'http://n')
     expect(res.status).toBe(307)
-    expect(pathname).toBe('/integrations/-some/thing')
+    expect(parsedUrl.pathname).toBe('/integrations/-some/thing')
   })
 
   it('should redirect with URL in query correctly', async () => {
@@ -1278,10 +1274,10 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
 
-    expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(parsedUrl.pathname).toBe('/another')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
       myHeader: 'hello world!!',
     })
 
@@ -1304,10 +1300,10 @@ const runTests = (isDev = false) => {
     )
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
 
-    expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(parsedUrl.pathname).toBe('/another')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
       value: 'hellooo',
       'my-query': 'hellooo',
     })
@@ -1327,10 +1323,10 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
 
-    expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(parsedUrl.pathname).toBe('/another')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
       authorized: '1',
     })
 
@@ -1354,10 +1350,10 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
 
-    expect(parsed.pathname).toBe('/another')
-    expect(parsed.query).toEqual({
+    expect(parsedUrl.pathname).toBe('/another')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
       host: '1',
     })
   })
@@ -1376,12 +1372,12 @@ const runTests = (isDev = false) => {
     })
 
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'))
 
-    expect(parsed.protocol).toBe('https:')
-    expect(parsed.hostname).toBe('hello.example.com')
-    expect(parsed.pathname).toBe('/some-path/end')
-    expect(parsed.query).toEqual({
+    expect(parsedUrl.protocol).toBe('https:')
+    expect(parsedUrl.hostname).toBe('hello.example.com')
+    expect(parsedUrl.pathname).toBe('/some-path/end')
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
       a: 'b',
     })
   })
@@ -1396,10 +1392,20 @@ const runTests = (isDev = false) => {
       }
     )
     expect(res.status).toBe(307)
-    const parsed = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
 
-    expect(parsed.pathname).toBe('/somewhere')
-    expect(parsed.query).toEqual({
+    expect(parsedUrl.pathname).toBe('/somewhere')
+    const query = {}
+    for (const [key, value] of parsedUrl.searchParams) {
+      if (query[key]) {
+        query[key] = Array.isArray(query[key])
+          ? [...query[key], value]
+          : [query[key], value]
+      } else {
+        query[key] = value
+      }
+    }
+    expect(query).toEqual({
       hello: ['world', 'another'],
       value: 'another',
     })
@@ -2745,9 +2751,9 @@ describe('Custom routes', () => {
         expect(res.headers.get('x-custom-header')).toBeFalsy()
         expect(res.headers.get('x-another-header')).toBeFalsy()
 
-        const { pathname } = url.parse(res2.headers.get('location'))
+        const parsedUrl = new URL(res2.headers.get('location'), 'http://n')
         expect(res2.status).toBe(301)
-        expect(pathname).toBe('/docs/v2/advanced/now-for-github')
+        expect(parsedUrl.pathname).toBe('/docs/v2/advanced/now-for-github')
 
         expect(res3.status).toBe(404)
       })

--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -3,7 +3,6 @@
 import webdriver from 'next-webdriver'
 import { join, dirname } from 'path'
 import fs from 'fs-extra'
-import url from 'url'
 import {
   waitForRedbox,
   renderViaHTTP,
@@ -234,13 +233,11 @@ function runTests({ dev }) {
     ]) {
       const { id, pathname, query, hash, navQuery } = expectedValues
 
-      const parsedHref = url.parse(
-        await browser.elementByCss(`#${id}`).getAttribute('href'),
-        true
-      )
+      const href = await browser.elementByCss(`#${id}`).getAttribute('href')
+      const parsedHref = new URL(href, 'http://n')
       expect(parsedHref.pathname).toBe(pathname)
-      expect(parsedHref.query || {}).toEqual(query)
-      expect(parsedHref.hash || '').toBe(hash)
+      expect(Object.fromEntries(parsedHref.searchParams)).toEqual(query)
+      expect(parsedHref.hash).toBe(hash)
 
       await browser.eval('window.beforeNav = 1')
       await browser.elementByCss(`#${id}`).click()
@@ -262,25 +259,21 @@ function runTests({ dev }) {
 
   it('should handle only hash on dynamic route', async () => {
     const browser = await webdriver(appPort, '/post-1')
-    const parsedHref = url.parse(
-      await browser
-        .elementByCss('#dynamic-route-only-hash')
-        .getAttribute('href'),
-      true
-    )
+    const href = await browser
+      .elementByCss('#dynamic-route-only-hash')
+      .getAttribute('href')
+    const parsedHref = new URL(href, 'http://n')
     expect(parsedHref.pathname).toBe('/post-1')
     expect(parsedHref.hash).toBe('#only-hash')
-    expect(parsedHref.query || {}).toEqual({})
+    expect(Object.fromEntries(parsedHref.searchParams)).toEqual({})
 
-    const parsedHref2 = url.parse(
-      await browser
-        .elementByCss('#dynamic-route-only-hash-obj')
-        .getAttribute('href'),
-      true
-    )
+    const href2 = await browser
+      .elementByCss('#dynamic-route-only-hash-obj')
+      .getAttribute('href')
+    const parsedHref2 = new URL(href2, 'http://n')
     expect(parsedHref2.pathname).toBe('/post-1')
     expect(parsedHref2.hash).toBe('#only-hash-obj')
-    expect(parsedHref2.query || {}).toEqual({})
+    expect(Object.fromEntries(parsedHref2.searchParams)).toEqual({})
 
     expect(await browser.eval('window.location.hash')).toBe('')
 
@@ -543,9 +536,9 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-interpolated')
         .getAttribute('href')
 
-      const parsedHref = url.parse(href, true)
+      const parsedHref = new URL(href, 'http://n')
       expect(parsedHref.pathname).toBe('/post-1')
-      expect(parsedHref.query).toEqual({})
+      expect(Object.fromEntries(parsedHref.searchParams)).toEqual({})
 
       await browser.elementByCss('#view-post-1-interpolated').click()
       await browser.waitForElementByCss('#asdf')
@@ -569,9 +562,11 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-interpolated-more-query')
         .getAttribute('href')
 
-      const parsedHref = url.parse(href, true)
+      const parsedHref = new URL(href, 'http://n')
       expect(parsedHref.pathname).toBe('/post-1')
-      expect(parsedHref.query).toEqual({ another: 'value' })
+      expect(Object.fromEntries(parsedHref.searchParams)).toEqual({
+        another: 'value',
+      })
 
       await browser.elementByCss('#view-post-1-interpolated-more-query').click()
       await browser.waitForElementByCss('#asdf')
@@ -672,7 +667,8 @@ function runTests({ dev }) {
         .elementByCss('#view-post-1-comment-1-interpolated')
         .getAttribute('href')
 
-      expect(url.parse(href).pathname).toBe('/post-1/comment-1')
+      const parsedUrl = new URL(href, 'http://n')
+      expect(parsedUrl.pathname).toBe('/post-1/comment-1')
 
       await browser.elementByCss('#view-post-1-comment-1-interpolated').click()
       await browser.waitForElementByCss('#asdf')
@@ -904,7 +900,8 @@ function runTests({ dev }) {
         .elementByCss('#ssg-catch-all-single-interpolated')
         .getAttribute('href')
 
-      expect(url.parse(href).pathname).toBe('/p1/p2/all-ssg/hello')
+      const parsedUrl = new URL(href, 'http://n')
+      expect(parsedUrl.pathname).toBe('/p1/p2/all-ssg/hello')
 
       await browser.elementByCss('#ssg-catch-all-single-interpolated').click()
       await browser.waitForElementByCss('#all-ssg-content')
@@ -962,7 +959,8 @@ function runTests({ dev }) {
         .elementByCss('#ssg-catch-all-multi-interpolated')
         .getAttribute('href')
 
-      expect(url.parse(href).pathname).toBe('/p1/p2/all-ssg/hello1/hello2')
+      const parsedUrl = new URL(href, 'http://n')
+      expect(parsedUrl.pathname).toBe('/p1/p2/all-ssg/hello1/hello2')
 
       await browser.elementByCss('#ssg-catch-all-multi-interpolated').click()
       await browser.waitForElementByCss('#all-ssg-content')

--- a/test/integration/env-config/test/index.test.ts
+++ b/test/integration/env-config/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import fs from 'fs-extra'
 import { join } from 'path'
 import cheerio from 'cheerio'
@@ -79,7 +78,7 @@ const runTests = (mode = 'dev', didReload = false) => {
     const res = await fetchViaHTTP(appPort, '/hello', undefined, {
       redirect: 'manual',
     })
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(res.status).toBe(307)
     expect(pathname).toBe('/another')

--- a/test/integration/file-serving/test/index.test.ts
+++ b/test/integration/file-serving/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 /* eslint-disable jest/no-identical-title */
-import url from 'url'
 import fs from 'fs-extra'
 import { join } from 'path'
 import {
@@ -23,7 +22,7 @@ const expectStatus = async (path) => {
   const checkRes = async (res) => {
     if (res.status === 308) {
       const redirectDest = res.headers.get('location')
-      const parsedUrl = url.parse(redirectDest, true)
+      const parsedUrl = new URL(redirectDest, 'http://n')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
     } else {
       try {

--- a/test/integration/gssp-redirect-base-path/test/index.test.ts
+++ b/test/integration/gssp-redirect-base-path/test/index.test.ts
@@ -1,5 +1,4 @@
 /* eslint-env jest */
-import url from 'url'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -32,7 +31,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe(`${basePath}/404`)
   })
@@ -51,7 +50,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`/404`)
 
-    const parsedUrl = url.parse(res.headers.get('location'))
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(parsedUrl.pathname).toBe(`/404`)
 
     const browser = await webdriver(appPort, `${basePath}`)
@@ -61,7 +60,10 @@ const runTests = (isDev: boolean) => {
       /oops not found/
     )
 
-    const parsedUrl2 = url.parse(await browser.eval('window.location.href'))
+    const parsedUrl2 = new URL(
+      await browser.eval('window.location.href'),
+      'http://n'
+    )
     expect(parsedUrl2.pathname).toBe('/404')
   })
 
@@ -79,7 +81,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`${basePath}/404`)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe(`${basePath}/404`)
     expect(res.headers.get('refresh')).toContain(`url=${basePath}/404`)
@@ -99,7 +101,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`${basePath}/404`)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe(`${basePath}/404`)
     expect(res.headers.get('refresh')).toBe(null)
@@ -119,7 +121,7 @@ const runTests = (isDev: boolean) => {
     const text = await res.text()
     expect(text).toEqual(`${basePath}/404`)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe(`${basePath}/404`)
     expect(res.headers.get('refresh')).toBe(null)
@@ -143,7 +145,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe(`${basePath}/gsp-blog/redirect-dest-_gsp-blog_first`)
   })
 
@@ -166,7 +168,7 @@ const runTests = (isDev: boolean) => {
         },
       })
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref, 'http://n')
       // since it was cached the initial value is now the redirect
       // result
       expect(pathname).toBe(`${basePath}/gsp-blog/first`)
@@ -185,7 +187,7 @@ const runTests = (isDev: boolean) => {
     await browser.waitForElementByCss('#index')
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe(`${basePath}/gsp-blog/redirect-dest-_`)
   })
 
@@ -202,7 +204,7 @@ const runTests = (isDev: boolean) => {
       await browser.waitForElementByCss('#index')
 
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref, 'http://n')
       expect(pathname).toBe(`${basePath}`)
     })
   }
@@ -225,7 +227,7 @@ const runTests = (isDev: boolean) => {
     expect(initialHref).toBeFalsy()
 
     const curUrl = await browser.url()
-    const { pathname } = url.parse(curUrl)
+    const { pathname } = new URL(curUrl, 'http://n')
     expect(pathname).toBe('/docs/missing')
   })
 
@@ -274,7 +276,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const parsed = url.parse(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), 'http://n')
     expect(parsed.hostname).toBe('example.vercel.sh')
     expect(parsed.pathname).toBe('/')
   })
@@ -390,8 +392,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual(`${basePath}`)
   })
 
   it('should not replace history of the origin page when GSSP page is navigated to client-side (external)', async () => {
@@ -418,8 +420,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual(`${basePath}`)
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (internal)', async () => {
@@ -446,8 +448,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual(`${basePath}`)
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (external)', async () => {
@@ -474,8 +476,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual(`${basePath}`)
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual(`${basePath}`)
   })
 }
 

--- a/test/integration/gssp-redirect/test/index.test.ts
+++ b/test/integration/gssp-redirect/test/index.test.ts
@@ -1,5 +1,4 @@
 /* eslint-env jest */
-import url from 'url'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -30,7 +29,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe('/404')
   })
@@ -46,7 +45,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(308)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe('/404')
     expect(res.headers.get('refresh')).toMatch(/url=\/404/)
@@ -63,7 +62,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(301)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe('/404')
     expect(res.headers.get('refresh')).toBe(null)
@@ -80,7 +79,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(303)
 
-    const { pathname } = url.parse(res.headers.get('location'))
+    const { pathname } = new URL(res.headers.get('location'), 'http://n')
 
     expect(pathname).toBe('/404')
     expect(res.headers.get('refresh')).toBe(null)
@@ -104,7 +103,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe('/gsp-blog/redirect-dest-_gsp-blog_first')
   })
 
@@ -126,7 +125,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -148,7 +147,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -170,7 +169,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -192,7 +191,7 @@ const runTests = (isDev: boolean) => {
       },
     })
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe('/gsp-blog/first')
   })
 
@@ -215,7 +214,7 @@ const runTests = (isDev: boolean) => {
         },
       })
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref, 'http://n')
       // since it was cached the initial value is now the redirect
       // result
       expect(pathname).toBe('/gsp-blog/first')
@@ -230,7 +229,7 @@ const runTests = (isDev: boolean) => {
     await browser.waitForElementByCss('#index')
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
-    const { pathname } = url.parse(initialHref)
+    const { pathname } = new URL(initialHref, 'http://n')
     expect(pathname).toBe('/gsp-blog/redirect-dest-_')
   })
 
@@ -243,7 +242,7 @@ const runTests = (isDev: boolean) => {
       await browser.waitForElementByCss('#index')
 
       const initialHref = await browser.eval(() => (window as any).initialHref)
-      const { pathname } = url.parse(initialHref)
+      const { pathname } = new URL(initialHref, 'http://n')
       expect(pathname).toBe('/')
     })
   }
@@ -266,7 +265,7 @@ const runTests = (isDev: boolean) => {
     expect(initialHref).toBeFalsy()
 
     const curUrl = await browser.url()
-    const { pathname } = url.parse(curUrl)
+    const { pathname } = new URL(curUrl, 'http://n')
     expect(pathname).toBe('/missing')
   })
 
@@ -315,7 +314,7 @@ const runTests = (isDev: boolean) => {
     )
     expect(res.status).toBe(307)
 
-    const parsed = url.parse(res.headers.get('location'))
+    const parsed = new URL(res.headers.get('location'), 'http://n')
     expect(parsed.hostname).toBe('example.vercel.sh')
     expect(parsed.pathname).toBe('/')
   })
@@ -427,8 +426,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual('/')
   })
 
   it('should not replace history of the origin page when GSSP page is navigated to client-side (external)', async () => {
@@ -451,8 +450,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual('/')
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (internal)', async () => {
@@ -475,8 +474,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual('/')
   })
 
   it('should not replace history of the origin page when GSP page is navigated to client-side (external)', async () => {
@@ -499,8 +498,8 @@ const runTests = (isDev: boolean) => {
     })()`)
 
     const curUrl = await browser.url()
-    const { path } = url.parse(curUrl)
-    expect(path).toEqual('/')
+    const { pathname } = new URL(curUrl, 'http://n')
+    expect(pathname).toEqual('/')
   })
 }
 

--- a/test/integration/i18n-support-fallback-rewrite-legacy/test/index.test.ts
+++ b/test/integration/i18n-support-fallback-rewrite-legacy/test/index.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
@@ -18,6 +17,17 @@ const nextConfig = new File(join(appDir, 'next.config.js'))
 let appPort
 let app
 
+function formatUrl({
+  pathname,
+  query,
+}: {
+  pathname: string
+  query: Record<string, string>
+}) {
+  const search = new URLSearchParams(query).toString()
+  return pathname + (search ? `?${search}` : '')
+}
+
 function runTests() {
   it('should not rewrite for index page', async () => {
     for (const [pathname, query] of [
@@ -28,13 +38,13 @@ function runTests() {
       ['/en', { hello: 'world' }],
       ['/fr', { hello: 'world' }],
     ] as const) {
-      const asPath = url.format({ pathname, query })
+      const asPath = formatUrl({ pathname, query })
       const browser = await webdriver(appPort, asPath)
 
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         index: true,
         pathname: '/',
-        asPath: url.format({ pathname: '/', query }),
+        asPath: formatUrl({ pathname: '/', query }),
         query,
       })
       await waitFor(1000)
@@ -42,7 +52,7 @@ function runTests() {
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         index: true,
         pathname: '/',
-        asPath: url.format({ pathname: '/', query }),
+        asPath: formatUrl({ pathname: '/', query }),
         query,
       })
     }
@@ -57,13 +67,13 @@ function runTests() {
       ['/en/dynamic/first', { hello: 'world' }],
       ['/fr/dynamic/first', { hello: 'world' }],
     ] as const) {
-      const asPath = url.format({ pathname, query })
+      const asPath = formatUrl({ pathname, query })
       const browser = await webdriver(appPort, asPath)
 
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         dynamic: true,
         pathname: '/dynamic/[slug]',
-        asPath: url.format({ pathname: '/dynamic/first', query }),
+        asPath: formatUrl({ pathname: '/dynamic/first', query }),
         query: {
           ...query,
           slug: 'first',
@@ -74,7 +84,7 @@ function runTests() {
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         dynamic: true,
         pathname: '/dynamic/[slug]',
-        asPath: url.format({ pathname: '/dynamic/first', query }),
+        asPath: formatUrl({ pathname: '/dynamic/first', query }),
         query: {
           ...query,
           slug: 'first',

--- a/test/integration/i18n-support-fallback-rewrite/test/index.test.ts
+++ b/test/integration/i18n-support-fallback-rewrite/test/index.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
@@ -18,6 +17,17 @@ const nextConfig = new File(join(appDir, 'next.config.js'))
 let appPort
 let app
 
+function formatUrl({
+  pathname,
+  query,
+}: {
+  pathname: string
+  query: Record<string, string>
+}) {
+  const search = new URLSearchParams(query).toString()
+  return pathname + (search ? `?${search}` : '')
+}
+
 function runTests() {
   it('should not rewrite for index page', async () => {
     for (const [pathname, query] of [
@@ -28,13 +38,13 @@ function runTests() {
       ['/en', { hello: 'world' }],
       ['/fr', { hello: 'world' }],
     ] as const) {
-      const asPath = url.format({ pathname, query })
+      const asPath = formatUrl({ pathname, query })
       const browser = await webdriver(appPort, asPath)
 
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         index: true,
         pathname: '/',
-        asPath: url.format({ pathname: '/', query }),
+        asPath: formatUrl({ pathname: '/', query }),
         query,
       })
       await waitFor(1000)
@@ -42,7 +52,7 @@ function runTests() {
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         index: true,
         pathname: '/',
-        asPath: url.format({ pathname: '/', query }),
+        asPath: formatUrl({ pathname: '/', query }),
         query,
       })
     }
@@ -57,13 +67,13 @@ function runTests() {
       ['/en/dynamic/first', { hello: 'world' }],
       ['/fr/dynamic/first', { hello: 'world' }],
     ] as const) {
-      const asPath = url.format({ pathname, query })
+      const asPath = formatUrl({ pathname, query })
       const browser = await webdriver(appPort, asPath)
 
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         dynamic: true,
         pathname: '/dynamic/[slug]',
-        asPath: url.format({ pathname: '/dynamic/first', query }),
+        asPath: formatUrl({ pathname: '/dynamic/first', query }),
         query: {
           ...query,
           slug: 'first',
@@ -74,7 +84,7 @@ function runTests() {
       expect(JSON.parse(await browser.elementByCss('#router').text())).toEqual({
         dynamic: true,
         pathname: '/dynamic/[slug]',
-        asPath: url.format({ pathname: '/dynamic/first', query }),
+        asPath: formatUrl({ pathname: '/dynamic/first', query }),
         query: {
           ...query,
           slug: 'first',

--- a/test/integration/i18n-support/test/index.test.ts
+++ b/test/integration/i18n-support/test/index.test.ts
@@ -1,4 +1,3 @@
-import url from 'url'
 import http from 'http'
 import fs from 'fs-extra'
 import { join } from 'path'
@@ -287,9 +286,9 @@ describe('i18n Support', () => {
           } else {
             expect(res.status).toBe(307)
 
-            const parsed = url.parse(res.headers.get('location'), true)
+            const parsed = new URL(res.headers.get('location'), 'http://n')
             expect(parsed.pathname).toBe(`/${locale}/`)
-            expect(parsed.query).toEqual({})
+            expect(Object.fromEntries(parsed.searchParams)).toEqual({})
           }
         }
       })
@@ -485,9 +484,9 @@ describe('i18n Support', () => {
           } else {
             expect(res.status).toBe(307)
 
-            const parsed = url.parse(res.headers.get('location'), true)
+            const parsed = new URL(res.headers.get('location'), 'http://n')
             expect(parsed.pathname).toBe(`/${locale}`)
-            expect(parsed.query).toEqual({})
+            expect(Object.fromEntries(parsed.searchParams)).toEqual({})
           }
         }
       })

--- a/test/integration/i18n-support/test/shared.js
+++ b/test/integration/i18n-support/test/shared.js
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 
-import url from 'url'
 import glob from 'glob'
 import fs from 'fs-extra'
 import cheerio from 'cheerio'
@@ -492,7 +491,7 @@ export function runTests(ctx) {
       ['#to-gssp-slug', '/gssp/first'],
     ]) {
       const href = await browser.elementByCss(element).getAttribute('href')
-      const { hostname, pathname: hrefPathname } = url.parse(href)
+      const { hostname, pathname: hrefPathname } = new URL(href, 'http://n')
       expect(hostname).not.toBe('example.com')
       expect(hrefPathname).toBe(`${ctx.basePath || ''}/go${pathname}`)
     }
@@ -511,7 +510,7 @@ export function runTests(ctx) {
       ['#to-gssp-slug', '/gssp/first'],
     ]) {
       const href = await browser.elementByCss(element).getAttribute('href')
-      const { hostname, pathname: hrefPathname } = url.parse(href)
+      const { hostname, pathname: hrefPathname } = new URL(href, 'http://n')
       expect(hostname).not.toBe('example.com')
       expect(hrefPathname).toBe(`${ctx.basePath || ''}/go-BE${pathname}`)
     }
@@ -1897,7 +1896,7 @@ export function runTests(ctx) {
       })
       expect(res.status).toBe(308)
 
-      const parsed = url.parse(res.headers.get('location'), true)
+      const parsed = new URL(res.headers.get('location'), 'http://n')
       expect(parsed.pathname).toBe(path)
 
       if (hostname === 'localhost') {
@@ -1905,7 +1904,7 @@ export function runTests(ctx) {
       } else {
         expect(parsed.hostname).toBe(hostname)
       }
-      expect(parsed.query).toEqual(query)
+      expect(Object.fromEntries(parsed.searchParams)).toEqual(query)
     }
   })
 
@@ -1933,7 +1932,7 @@ export function runTests(ctx) {
       expect(res.status).toBe(shouldRedirect ? 307 : 200)
 
       if (shouldRedirect) {
-        const parsed = url.parse(res.headers.get('location'), true)
+        const parsed = new URL(res.headers.get('location'), 'http://n')
         expect(parsed.pathname).toBe(
           `${ctx.basePath}${locale || ''}${pathname || '/somewhere-else'}`
         )
@@ -2201,9 +2200,12 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(
+      await browser.eval('window.location.href'),
+      'http://n'
+    )
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2223,9 +2225,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/links`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'fr' })
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
+      nextLocale: 'fr',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#another')
@@ -2245,9 +2249,9 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2293,9 +2297,12 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(
+      await browser.eval('window.location.href'),
+      'http://n'
+    )
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2315,9 +2322,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/links`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'nl' })
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
+      nextLocale: 'nl',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#gsp')
@@ -2337,9 +2346,9 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2415,9 +2424,12 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(
+      await browser.eval('window.location.href'),
+      'http://n'
+    )
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2439,9 +2451,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/locale-false`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'fr' })
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
+      nextLocale: 'fr',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#another')
@@ -2461,9 +2475,9 @@ export function runTests(ctx) {
     ).toEqual({})
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('fr')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/fr/another`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2511,9 +2525,12 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    let parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    let parsedUrl = new URL(
+      await browser.eval('window.location.href'),
+      'http://n'
+    )
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     await browser.eval('window.history.back()')
     await browser.waitForElementByCss('#links')
@@ -2535,9 +2552,11 @@ export function runTests(ctx) {
       'en-US'
     )
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/locale-false`)
-    expect(parsedUrl.query).toEqual({ nextLocale: 'nl' })
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({
+      nextLocale: 'nl',
+    })
 
     await browser.eval('window.history.forward()')
     await browser.waitForElementByCss('#gsp')
@@ -2557,9 +2576,9 @@ export function runTests(ctx) {
     ).toEqual({ slug: 'first' })
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('nl')
 
-    parsedUrl = url.parse(await browser.eval('window.location.href'), true)
+    parsedUrl = new URL(await browser.eval('window.location.href'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl/gsp/fallback/first`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
     expect(await browser.eval('window.beforeNav')).toBe(1)
     expect(await browser.eval('window.caughtWarns')).toEqual([])
   })
@@ -2814,13 +2833,13 @@ export function runTests(ctx) {
           }
 
           if (shouldRedirect) {
-            const parsedUrl = url.parse(res.headers.get('location'), true)
+            const parsedUrl = new URL(res.headers.get('location'), 'http://n')
 
             const expectedPathname = `/${
               expectedDomainItem.defaultLocale === locale ? '' : locale
             }`
             expect(parsedUrl.pathname).toBe(expectedPathname)
-            expect(parsedUrl.query).toEqual({})
+            expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
             expect(parsedUrl.hostname).toBe(expectedDomainItem.domain)
           } else {
             const html = await res.text()
@@ -2972,12 +2991,12 @@ export function runTests(ctx) {
         expect(props.is404).toBe(true)
         expect(props.locale).toBe(locale)
 
-        const parsedUrl = url.parse(
+        const parsedUrl = new URL(
           await browser.eval('window.location.href'),
-          true
+          'http://n'
         )
         expect(parsedUrl.pathname).toBe(`${ctx.basePath}/${locale}/not-found`)
-        expect(parsedUrl.query).toEqual({})
+        expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
       }
     }
   })
@@ -3004,7 +3023,8 @@ export function runTests(ctx) {
     expect(await browser.elementByCss('#router-pathname').text()).toBe('/frank')
     expect(await browser.elementByCss('#router-as-path').text()).toBe('/frank')
     expect(
-      url.parse(await browser.eval(() => window.location.href)).pathname
+      new URL(await browser.eval(() => window.location.href), 'http://n')
+        .pathname
     ).toBe(`${ctx.basePath}/fr/frank`)
     expect(await browser.eval('window.beforeNav')).toBe(1)
   })
@@ -3048,14 +3068,14 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
+    const parsedUrl = new URL(
       await browser.eval('window.location.href'),
-      true
+      'http://n'
     )
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
@@ -3084,14 +3104,14 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
+    const parsedUrl = new URL(
       await browser.eval('window.location.href'),
-      true
+      'http://n'
     )
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
@@ -3119,14 +3139,14 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
+    const parsedUrl = new URL(
       await browser.eval('window.location.href'),
-      true
+      'http://n'
     )
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/blocking-fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
@@ -3155,14 +3175,14 @@ export function runTests(ctx) {
     expect(props.locale).toBe('en')
     expect(await browser.elementByCss('html').getAttribute('lang')).toBe('en')
 
-    const parsedUrl = url.parse(
+    const parsedUrl = new URL(
       await browser.eval('window.location.href'),
-      true
+      'http://n'
     )
     expect(parsedUrl.pathname).toBe(
       `${ctx.basePath}/en/not-found/blocking-fallback/first`
     )
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     if (ctx.isDev) {
       // make sure page doesn't reload un-necessarily in development
@@ -3290,9 +3310,9 @@ export function runTests(ctx) {
     )
     expect(res.status).toBe(307)
 
-    const parsedUrl = url.parse(res.headers.get('location'), true)
+    const parsedUrl = new URL(res.headers.get('location'), 'http://n')
     expect(parsedUrl.pathname).toBe(`${ctx.basePath}/nl-NL`)
-    expect(parsedUrl.query).toEqual({})
+    expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
 
     const res2 = await fetchViaHTTP(
       ctx.appPort,
@@ -3307,9 +3327,11 @@ export function runTests(ctx) {
     )
     expect(res2.status).toBe(307)
 
-    const parsedUrl2 = url.parse(res2.headers.get('location'), true)
+    const parsedUrl2 = new URL(res2.headers.get('location'), 'http://n')
     expect(parsedUrl2.pathname).toBe(`${ctx.basePath}/en`)
-    expect(parsedUrl2.query).toEqual({ hello: 'world' })
+    expect(Object.fromEntries(parsedUrl2.searchParams)).toEqual({
+      hello: 'world',
+    })
   })
 
   it('should use default locale for / without accept-language', async () => {
@@ -3450,7 +3472,8 @@ export function runTests(ctx) {
       expect(await browser.elementByCss('#router-pathname').text()).toBe('/')
       expect(await browser.elementByCss('#router-as-path').text()).toBe('/')
       expect(
-        url.parse(await browser.eval(() => window.location.href)).pathname
+        new URL(await browser.eval(() => window.location.href), 'http://n')
+          .pathname
       ).toBe(`${ctx.basePath || '/'}`)
     }
 
@@ -3478,7 +3501,8 @@ export function runTests(ctx) {
       '/another'
     )
     expect(
-      url.parse(await browser.eval(() => window.location.href)).pathname
+      new URL(await browser.eval(() => window.location.href), 'http://n')
+        .pathname
     ).toBe(`${ctx.basePath}/another`)
 
     await browser.elementByCss('#to-index').click()
@@ -3504,7 +3528,8 @@ export function runTests(ctx) {
     expect(await browser.elementByCss('#router-pathname').text()).toBe('/gsp')
     expect(await browser.elementByCss('#router-as-path').text()).toBe('/gsp')
     expect(
-      url.parse(await browser.eval(() => window.location.href)).pathname
+      new URL(await browser.eval(() => window.location.href), 'http://n')
+        .pathname
     ).toBe(`${ctx.basePath}/gsp`)
 
     await browser.elementByCss('#to-index').click()

--- a/test/integration/repeated-slashes/test/index.test.ts
+++ b/test/integration/repeated-slashes/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 import { join } from 'path'
 import fs from 'fs-extra'
-import url from 'url'
 import webdriver from 'next-webdriver'
 import escapeRegex from 'escape-string-regexp'
 import {
@@ -66,11 +65,11 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       )
 
       expect(res.status).toBe(307)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'), 'http://n')
 
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
       expect(parsedUrl.pathname).toBe('/test/google.com')
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
       expect(await res.text()).toBe('/test/google.com')
 
       const res2 = await fetchViaHTTP(
@@ -83,11 +82,11 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       )
 
       expect(res2.status).toBe(307)
-      const parsedUrl2 = url.parse(res2.headers.get('location'), true)
+      const parsedUrl2 = new URL(res2.headers.get('location'), 'http://n')
 
       expect(parsedUrl2.hostname).toBeOneOf(['localhost', '127.0.0.1'])
       expect(parsedUrl2.pathname).toBe('/test/google.com')
-      expect(parsedUrl2.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl2.searchParams)).toEqual({})
       expect(await res2.text()).toBe('/test/google.com')
     })
   }
@@ -99,10 +98,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
       })
       expect(res.status).toBe(308)
 
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'), 'http://n')
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
     }
 
     const browser = await webdriver(appPort, '//google.com')
@@ -128,10 +127,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         }
       )
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'), 'http://n')
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({ h: '1' })
+      expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({ h: '1' })
     }
 
     const browser = await webdriver(appPort, '//google.com?h=1')
@@ -152,10 +151,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'), 'http://n')
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
     }
 
     const browser = await webdriver(appPort, '//google.com#hello')
@@ -240,10 +239,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'), 'http://n')
       expect(parsedUrl.pathname).toBe('/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
       expect(await res.text()).toBe('/google.com')
     }
 
@@ -265,10 +264,10 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         redirect: 'manual',
       })
       expect(res.status).toBe(308)
-      const parsedUrl = url.parse(res.headers.get('location'), true)
+      const parsedUrl = new URL(res.headers.get('location'), 'http://n')
       expect(parsedUrl.pathname).toBe(isExport ? '//google.com' : '/google.com')
       expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(parsedUrl.query).toEqual({})
+      expect(Object.fromEntries(parsedUrl.searchParams)).toEqual({})
       expect(await res.text()).toBe('/google.com')
     }
 

--- a/test/production/pages-dir/production/test/security.ts
+++ b/test/production/pages-dir/production/test/security.ts
@@ -2,7 +2,6 @@
 import webdriver from 'next-webdriver'
 import { readFileSync } from 'fs'
 import http from 'http'
-import url from 'url'
 import { join } from 'path'
 import { getBrowserBodyText, waitFor, fetchViaHTTP } from 'next-test-utils'
 import { recursiveReadDir } from 'next/dist/lib/recursive-readdir'
@@ -215,12 +214,11 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const location = res.headers.get('location') || ''
+      const parsedUrl = new URL(location, 'http://n')
       expect(res.status).toBe(307)
-      expect(pathname).toBe(encodeURI('/\\google.com/about'))
-      expect(hostname).toBeOneOf(['localhost', '127.0.0.1'])
+      expect(parsedUrl.pathname).toBe(encodeURI('/\\google.com/about'))
+      expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
     })
 
     it('should handle encoded value in the pathname correctly %', async () => {
@@ -233,12 +231,11 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const location = res.headers.get('location') || ''
+      const parsedUrl = new URL(location, 'http://n')
       expect(res.status).toBe(307)
-      expect(pathname).toBe('/%25google.com/about')
-      expect(hostname).toBeOneOf(['localhost', '127.0.0.1'])
+      expect(parsedUrl.pathname).toBe('/%25google.com/about')
+      expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
     })
 
     it('should handle encoded value in the query correctly', async () => {
@@ -251,13 +248,12 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname, query } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const location = res.headers.get('location') || ''
+      const parsedUrl = new URL(location, 'http://n')
       expect(res.status).toBe(308)
-      expect(pathname).toBe('/trailing-redirect')
-      expect(hostname).toBeOneOf(['localhost', '127.0.0.1'])
-      expect(query).toBe(
+      expect(parsedUrl.pathname).toBe('/trailing-redirect')
+      expect(parsedUrl.hostname).toBeOneOf(['localhost', '127.0.0.1'])
+      expect(parsedUrl.search.slice(1)).toBe(
         'url=https%3A%2F%2Fgoogle.com%2Fimage%3Fcrop%3Dfocalpoint%26w%3D24&w=1200&q=100'
       )
     })
@@ -272,12 +268,11 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const location = res.headers.get('location') || ''
+      const parsedUrl = new URL(location, 'http://n')
       expect(res.status).toBe(307)
-      expect(pathname).toBe('/%2fgoogle.com/about')
-      expect(hostname).not.toBe('google.com')
+      expect(parsedUrl.pathname).toBe('/%2fgoogle.com/about')
+      expect(parsedUrl.hostname).not.toBe('google.com')
     })
 
     it('should handle encoded value in the pathname to query correctly (/)', async () => {
@@ -290,14 +285,13 @@ export default (next: NextInstance) => {
         }
       )
 
-      const { pathname, hostname, query } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const location = res.headers.get('location') || ''
+      const parsedUrl = new URL(location, 'http://n')
       expect(res.status).toBe(307)
-      expect(pathname).toBe('/about')
-      expect(query).toBe('foo=%2Fgoogle.com')
-      expect(hostname).not.toBe('google.com')
-      expect(hostname).not.toMatch(/google/)
+      expect(parsedUrl.pathname).toBe('/about')
+      expect(parsedUrl.search.slice(1)).toBe('foo=%2Fgoogle.com')
+      expect(parsedUrl.hostname).not.toBe('google.com')
+      expect(parsedUrl.hostname).not.toMatch(/google/)
     })
 
     it('should handle encoded / value for trailing slash correctly', async () => {
@@ -308,12 +302,11 @@ export default (next: NextInstance) => {
         { redirect: 'manual' }
       )
 
-      const { pathname, hostname } = url.parse(
-        res.headers.get('location') || ''
-      )
+      const location = res.headers.get('location') || ''
+      const parsedUrl = new URL(location, 'http://n')
       expect(res.status).toBe(308)
-      expect(pathname).toBe('/%2fexample.com')
-      expect(hostname).not.toBe('example.com')
+      expect(parsedUrl.pathname).toBe('/%2fexample.com')
+      expect(parsedUrl.hostname).not.toBe('example.com')
     })
 
     if (global.browserName !== 'internet explorer') {


### PR DESCRIPTION
## Summary

Fixes #83183

Replace Node.js deprecated `url.parse()` and `url.format()` with WHATWG URL API to resolve DEP0169 warnings in Node.js 24+.

### Changes
- Enhanced `parseReqUrl()` in `src/lib/url.ts` to match `url.parse()` behavior
- Replaced `url.parse()` with `parseReqUrl()` in core server files
- Replaced `url.format()` with `formatUrl()` from shared utils
- Updated test files to use direct WHATWG URL pattern
- Added ESLint rule to prevent future usage of deprecated APIs

### Why WHATWG URL?
- `url.parse()` is deprecated since Node.js 11 (DEP0169)
- WHATWG URL follows browser standard - consistent, predictable parsing
- Stricter validation - throws on malformed URLs instead of guessing
- No backwards compatibility needed (Next.js requires Node.js >=20.9.0)

## Test Plan
- [x] `pnpm build` passes
- [x] `pnpm typescript` passes
- [x] `pnpm test-dev test/integration/i18n-support-fallback-rewrite/` passes
- [x] `pnpm test-dev test/integration/i18n-support-fallback-rewrite-legacy/` passes