### PR TITLE
Validate module shape of pages API routes with actual `PageConfig` type

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -569,18 +569,13 @@ export function generateValidatorFile(
 `
   }
 
+  // Conditionally import types from next/types, merged into a single statement
+  const nextTypes: string[] = []
   if (pagesApiRouteValidations) {
+    nextTypes.push('PageConfig')
     typeDefinitions += `type ApiRouteConfig = {
   default: (req: any, res: any) => ReturnType<NextApiHandler>
-  config?: {
-    api?: {
-      bodyParser?: boolean | { sizeLimit?: string }
-      responseLimit?: string | number | boolean
-      externalResolver?: boolean
-    }
-    runtime?: 'edge' | 'experimental-edge' | 'nodejs' | string // necessary unless config is exported as const
-    maxDuration?: number
-  }
+  config?: PageConfig
 }
 
 `
@@ -617,8 +612,6 @@ export function generateValidatorFile(
     ? "import type { NextRequest } from 'next/server.js'\n"
     : ''
 
-  // Conditionally import types from next/types, merged into a single statement
-  const nextTypes: string[] = []
   if (pagesApiRouteValidations) {
     nextTypes.push('NextApiHandler')
   }


### PR DESCRIPTION
The automatic TypeScript validation of `export const config` in Pages Router's API routes was using an inlined type instead of using the type we document to use: `PageConfig`.

Now we validate with the same type existing apps might already be using. This became apparent in the downstack PR:

```
Type error: Type 'typeof import("~/pages/api/hello")' does not satisfy the constraint 'ApiRouteConfig'.
  The types of 'config.api.bodyParser' are incompatible between these types.
    Type 'false | { sizeLimit?: SizeLimit; }' is not assignable to type 'boolean | { sizeLimit?: string; }'.
      Type '{ sizeLimit?: SizeLimit; }' is not assignable to type 'boolean | { sizeLimit?: string; }'.
        Type '{ sizeLimit?: SizeLimit; }' is not assignable to type '{ sizeLimit?: string; }'.
          Types of property 'sizeLimit' are incompatible.
            Type 'SizeLimit' is not assignable to type 'string'.
              Type 'number' is not assignable to type 'string'.
```
-- https://github.com/vercel/next.js/actions/runs/20351794062/job/58478074488?pr=87319#step:32:636