### PR TITLE
[strict-route-types] Typecheck App Router page props

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -739,14 +739,14 @@ export function generateValidatorFileStrict(
 
   if (appPageValidations) {
     typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
-  default: React.ComponentType<{ params: Promise<ParamMap[Route]> } & any> | ((props: { params: Promise<ParamMap[Route]> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+  default: React.ComponentType<PageProps<Route>> | ((props: PageProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: PageProps<Route>,
     parent: ResolvingMetadata
   ) => Promise<any> | any
   generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
+    props: PageProps<Route>,
     parent: ResolvingViewport
   ) => Promise<any> | any
   metadata?: any
@@ -994,6 +994,7 @@ export function generateRouteTypesFileStrict(
   // Build export statement based on what's actually generated
   const routeExports = [
     'AppRoutes',
+    'PageProps',
     'PageRoutes',
     'LayoutRoutes',
     'RedirectRoutes',

--- a/test/e2e/app-dir/cache-components/app/cases/full_cached/page.tsx
+++ b/test/e2e/app-dir/cache-components/app/cases/full_cached/page.tsx
@@ -5,7 +5,7 @@ import { getSentinelValue } from '../../getSentinelValue'
 export default async function Page({
   searchParams: _unused,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   return (
     <>

--- a/test/e2e/app-dir/not-found-with-pages-i18n/app/app-dir/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/not-found-with-pages-i18n/app/app-dir/[[...slug]]/page.tsx
@@ -22,10 +22,10 @@ async function validateSlug(slug: string[]) {
 export default async function CatchAll({
   params,
 }: {
-  params: Promise<{ slug: string[] }>
+  params: Promise<{ slug?: string[] }>
 }) {
   const { slug } = await params
-  const slugArray = Array.isArray(slug) ? slug : [slug]
+  const slugArray = Array.isArray(slug) ? slug : []
 
   // Validate the slug
   const isValid = await validateSlug(slugArray)

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/(.)[...dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/@interception2/(.)[...dynamic]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 export default function Page({
   params,
 }: {
-  params: Promise<{ dynamic: string }>
+  params: Promise<{ dynamic: string[] }>
 }) {
   const router = useRouter()
   return (

--- a/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/[...dynamic]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-revalidation/app/catchall/[...dynamic]/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 export default function Page({
   params,
 }: {
-  params: Promise<{ dynamic: string }>
+  params: Promise<{ dynamic: string[] }>
 }) {
   const router = useRouter()
   return (

--- a/test/e2e/app-dir/revalidatetag-rsc/app/revalidate_via_page/page.tsx
+++ b/test/e2e/app-dir/revalidatetag-rsc/app/revalidate_via_page/page.tsx
@@ -6,10 +6,10 @@ import { revalidateTag } from 'next/cache'
 const RevalidateViaPage = async ({
   searchParams,
 }: {
-  searchParams: Promise<{ tag: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) => {
   const { tag } = await searchParams
-  revalidateTag(tag, 'max')
+  revalidateTag(tag as any, 'max')
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">

--- a/test/e2e/app-dir/segment-cache/client-params/app/[category]/[product]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/client-params/app/[category]/[product]/page.tsx
@@ -7,7 +7,7 @@ function Content({
   searchParams,
 }: {
   params: Promise<{ product: string }>
-  searchParams: Promise<{ foo: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   const { product } = use(params)
   const searchParamsDict = use(searchParams)
@@ -30,7 +30,7 @@ export default function ProductPage({
   searchParams,
 }: {
   params: Promise<{ product: string }>
-  searchParams: Promise<{ foo: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   return (
     <Suspense fallback="Loading...">

--- a/test/e2e/app-dir/segment-cache/client-params/app/client-page-with-search-param/page.tsx
+++ b/test/e2e/app-dir/segment-cache/client-params/app/client-page-with-search-param/page.tsx
@@ -2,7 +2,11 @@
 
 import { Suspense, use } from 'react'
 
-function Content({ searchParams }: { searchParams: Promise<{ foo: string }> }) {
+function Content({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}) {
   const searchParamsDict = use(searchParams)
 
   let query = null
@@ -20,7 +24,7 @@ function Content({ searchParams }: { searchParams: Promise<{ foo: string }> }) {
 export default function ClientPageWithSearchParam({
   searchParams,
 }: {
-  searchParams: Promise<{ foo: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   return (
     <Suspense fallback="Loading...">

--- a/test/e2e/app-dir/use-cache-private/app/search-params/page.tsx
+++ b/test/e2e/app-dir/use-cache-private/app/search-params/page.tsx
@@ -1,7 +1,7 @@
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ [key: string]: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   'use cache: private'
 

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/complex-args/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/complex-args/page.tsx
@@ -10,9 +10,9 @@ async function getCached({ p }) {
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
-  const n = parseInt((await searchParams).n, 16)
+  const n = parseInt((await searchParams).n as any, 16)
   const p = Promise.resolve(new Uint8Array([n]))
   return <p id="x">{await getCached({ p })}</p>
 }

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/custom-handler/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/custom-handler/page.tsx
@@ -10,9 +10,9 @@ async function getCachedRandom(x: number, children: React.ReactNode) {
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
-  const n = +(await searchParams).n
+  const n = +(await searchParams).n!
   const values = await getCachedRandom(
     n,
     <p id="r">rnd{Math.random()}</p> // This should not invalidate the cache

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/hoc/[slug]/with-slug.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/hoc/[slug]/with-slug.tsx
@@ -1,7 +1,10 @@
-export function withSlug<P extends { params: Promise<{ slug: string }> }>(
+export function withSlug(
   Component: React.ComponentType<{ slug: string }>
-): React.ComponentType<{ params: Promise<{ slug: string }> }> {
-  return async function ComponentWithSlug(props: P) {
+): // TODO(NXT-127): Use ComponentType
+React.JSXElementConstructor<{ params: Promise<{ slug: string }> }> {
+  return async function ComponentWithSlug(props: {
+    params: Promise<{ slug: string }>
+  }) {
     const params = await props.params
     const slug = params.slug
 

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/page.tsx
@@ -13,9 +13,9 @@ async function getCachedRandom(x: number, children: React.ReactNode) {
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ n: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
-  const n = +(await searchParams).n
+  const n = +(await searchParams).n!
   const values = await getCachedRandom(
     n,
     <p id="r">rnd{Math.random()}</p> // This should not invalidate the cache

--- a/test/production/app-dir/build-output-ssg-bailout/app/ssg-bailout/[id]/page.tsx
+++ b/test/production/app-dir/build-output-ssg-bailout/app/ssg-bailout/[id]/page.tsx
@@ -1,7 +1,7 @@
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ id: string }>
+  searchParams: Promise<Record<string, string | string[] | undefined>>
 }) {
   const { id } = await searchParams
   return <p>hello world {id}</p>

--- a/test/production/app-dir/types-gen-nounuselocal/types-gen-nounuselocal.test.ts
+++ b/test/production/app-dir/types-gen-nounuselocal/types-gen-nounuselocal.test.ts
@@ -55,7 +55,7 @@ describe('types-gen-nounuselocal', () => {
        }
 
 
-       export type { AppRoutes, PageRoutes, LayoutRoutes, RedirectRoutes, RewriteRoutes, ParamMap }
+       export type { AppRoutes, PageProps, PageRoutes, LayoutRoutes, RedirectRoutes, RewriteRoutes, ParamMap }
 
        declare global {
          /**


### PR DESCRIPTION
Flagged behind `experimental.strictRouteTypes`.

Enforces that `params` and `searchParams` actually match the current route. Previously props were just `any`. `props: PageProps<'/'>` should be used to type page props.

Pages in Pages Router don't have typed props since we currently don't collect valid props. Tightening types for Pages Router is out-of-scope for this project.

Closes https://linear.app/vercel/issue/NXT-122/