### PR TITLE
[strict-route-types] Enforce common React Component return types in App Router

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -739,7 +739,7 @@ export function generateValidatorFileStrict(
 
   if (appPageValidations) {
     typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
-  default: React.ComponentType<PageProps<Route>> | ((props: PageProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+  default: React.JSXElementConstructor<PageProps<Route>>
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
     props: PageProps<Route>,

--- a/test/e2e/app-dir/error-boundary-navigation/app/trigger-404/page.tsx
+++ b/test/e2e/app-dir/error-boundary-navigation/app/trigger-404/page.tsx
@@ -2,6 +2,6 @@ import { notFound } from 'next/navigation'
 
 export const dynamic = 'force-dynamic'
 
-export default function Page() {
+export default function Page(): never {
   notFound()
 }

--- a/test/e2e/app-dir/error-boundary-navigation/app/trigger-error/page.tsx
+++ b/test/e2e/app-dir/error-boundary-navigation/app/trigger-error/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic'
 
-export default function Page() {
+export default function Page(): never {
   throw new Error('This is an error')
 }

--- a/test/e2e/app-dir/global-not-found/basic/app/call-not-found/page.tsx
+++ b/test/e2e/app-dir/global-not-found/basic/app/call-not-found/page.tsx
@@ -2,6 +2,6 @@
 
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+export default function Page(): never {
   notFound()
 }

--- a/test/e2e/app-dir/global-not-found/both-present/app/call-not-found/page.tsx
+++ b/test/e2e/app-dir/global-not-found/both-present/app/call-not-found/page.tsx
@@ -2,6 +2,6 @@
 
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+export default function Page(): never {
   notFound()
 }

--- a/test/e2e/app-dir/global-not-found/css/app/call-not-found/page.tsx
+++ b/test/e2e/app-dir/global-not-found/css/app/call-not-found/page.tsx
@@ -2,6 +2,6 @@
 
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+export default function Page(): never {
   notFound()
 }

--- a/test/e2e/app-dir/global-not-found/metadata/app/call-not-found/page.tsx
+++ b/test/e2e/app-dir/global-not-found/metadata/app/call-not-found/page.tsx
@@ -2,6 +2,6 @@
 
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+export default function Page(): never {
   notFound()
 }

--- a/test/e2e/app-dir/global-not-found/not-present/app/call-not-found/page.tsx
+++ b/test/e2e/app-dir/global-not-found/not-present/app/call-not-found/page.tsx
@@ -2,6 +2,6 @@
 
 import { notFound } from 'next/navigation'
 
-export default function Page() {
+export default function Page(): never {
   notFound()
 }

--- a/test/e2e/app-dir/navigation/app/redirect/redirect-with-loading/page.tsx
+++ b/test/e2e/app-dir/navigation/app/redirect/redirect-with-loading/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation'
 
-export default async function Page() {
+export default async function Page(): Promise<never> {
   // fake delay 1s to trigger loading state
   await new Promise((res) => setTimeout(res, 1000))
 

--- a/test/e2e/app-dir/parallel-route-not-found/app/has-both-slots/not-found-error/page.tsx
+++ b/test/e2e/app-dir/parallel-route-not-found/app/has-both-slots/not-found-error/page.tsx
@@ -1,5 +1,5 @@
 import { notFound } from 'next/navigation'
 
-export default function NotFoundError() {
+export default function NotFoundError(): never {
   notFound()
 }

--- a/test/e2e/app-dir/rsc-redirect/app/origin/page.tsx
+++ b/test/e2e/app-dir/rsc-redirect/app/origin/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
-export default function Page() {
+export default function Page(): never {
   redirect('/dest')
 }

--- a/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/page.tsx
+++ b/test/e2e/app-dir/segment-cache/revalidation/app/refetch-on-new-base-tree/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation'
 
-export default function Page() {
+export default function Page(): never {
   redirect('/refetch-on-new-base-tree/a')
 }

--- a/test/e2e/app-dir/unstable-rethrow/app/redirect/page.tsx
+++ b/test/e2e/app-dir/unstable-rethrow/app/redirect/page.tsx
@@ -8,4 +8,5 @@ export default function Page() {
     unstable_rethrow(err)
     console.error('[test assertion]: error leaked', err)
   }
+  return null
 }

--- a/test/e2e/app-dir/use-cache/app/(dynamic)/hoc/[slug]/with-slug.tsx
+++ b/test/e2e/app-dir/use-cache/app/(dynamic)/hoc/[slug]/with-slug.tsx
@@ -1,7 +1,6 @@
 export function withSlug(
   Component: React.ComponentType<{ slug: string }>
-): // TODO(NXT-127): Use ComponentType
-React.JSXElementConstructor<{ params: Promise<{ slug: string }> }> {
+): React.ComponentType<{ params: Promise<{ slug: string }> }> {
   return async function ComponentWithSlug(props: {
     params: Promise<{ slug: string }>
   }) {

--- a/test/e2e/opentelemetry/instrumentation/app/app/[param]/loading/error/page.tsx
+++ b/test/e2e/opentelemetry/instrumentation/app/app/[param]/loading/error/page.tsx
@@ -1,6 +1,6 @@
 import { connection } from 'next/server'
 
-export default async function Page() {
+export default async function Page(): Promise<never> {
   await connection()
   // Simulate async work before throwing
   await new Promise((resolve) => setTimeout(resolve, 100))


### PR DESCRIPTION
Flagged behind `experimental.strictRouteTypes`.

Most notably this disallows `void`. We generally treat `void` as "forgot to add return" in React e.g. 
```tsx
async function Page() {
  <div />;
}
```
which is a common beginner mistake. The downside is that this breaks unconditional `notFound()` or `redirect()` in Next.js. Those function throw but even with `never` as a return type, [TypeScript will not infer that this causes the caller to return `never` as well](https://github.com/microsoft/TypeScript/issues/26537).

```tsx
// implicit `void` return type instead of `never` due to calling `notFound(): never`
function Page() {
  notFound()
}
```

The fix is to explicitly annotate unconditional `notFound` usage:
```tsx
function Page(): never {
  notFound()
}
```

Conditional usage would already have another `return` statement. If that's missing still, we'd consider this a mistake. You can always do `return` without a value to fix the type-issue.

Pages in Pages Router are not affected. Tightening types for Pages Router is out-of-scope for this project.

Closes https://linear.app/vercel/issue/NXT-127/