### PR TITLE
test: de-flake client-cache deployment tests

### DIFF
--- a/test/e2e/app-dir/app-client-cache/client-cache.defaults.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.defaults.test.ts
@@ -268,6 +268,9 @@ describe('app dir client cache semantics (default semantics)', () => {
       })
 
       it('should refetch the full page after 5 mins', async () => {
+        // Wait for initial prefetch to complete before clicking
+        await browser.waitForIdleNetwork()
+
         const randomLoadingNumber = await browser
           .elementByCss('[href="/1?timeout=1000"]')
           .click()
@@ -284,6 +287,10 @@ describe('app dir client cache semantics (default semantics)', () => {
           .elementByCss('[href="/"]')
           .click()
           .waitForElementByCss('[href="/1?timeout=1000"]')
+
+        // Wait for prefetch requests to complete before clicking, otherwise
+        // clicking during an in-flight prefetch aborts it and skips loading state
+        await browser.waitForIdleNetwork()
 
         const newLoadingNumber = await browser
           .elementByCss('[href="/1?timeout=1000"]')

--- a/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
+++ b/test/e2e/app-dir/app-client-cache/client-cache.original.test.ts
@@ -360,6 +360,9 @@ describe('app dir client cache semantics (30s/5min)', () => {
         expect(newNumber).not.toBe(randomNumber)
       })
       it('should refetch the full page after 5 mins', async () => {
+        // Wait for initial prefetch to complete before clicking
+        await browser.waitForIdleNetwork()
+
         const randomLoadingNumber = await browser
           .elementByCss('[href="/1?timeout=1000"]')
           .click()
@@ -376,6 +379,10 @@ describe('app dir client cache semantics (30s/5min)', () => {
           .elementByCss('[href="/"]')
           .click()
           .waitForElementByCss('[href="/1?timeout=1000"]')
+
+        // Wait for prefetch requests to complete before clicking, otherwise
+        // clicking during an in-flight prefetch aborts it and skips loading state
+        await browser.waitForIdleNetwork()
 
         const newLoadingNumber = await browser
           .elementByCss('[href="/1?timeout=1000"]')


### PR DESCRIPTION
These tests aren't resilient to changes in router behavior after extensive refactors. What looks to be happening is a race between the prefetch being issued and the click firing:
1. Cache expires -> refetch prefetch is triggered
2. Click happens while prefetch is in-flight -> route entry is Pending
3. Since no fulfilled cache entry exists, `navigate()` falls through to `navigateDynamicallyWithNoPrefetch()`
4. This issues a full dynamic request
5. The full dynamic response is favored and skips the loading state

This ensures that we are waiting for network activity to finish before navigating. 