### PR TITLE
[turbopack] Shrink InnerTaskStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
 [[package]]
 name = "bincode"
 version = "2.0.1"
-source = "git+https://github.com/bgw/bincode.git?branch=bgw%2Fpatches#19f09c5f6895d769883c10b3d374f761ab7fe83d"
+source = "git+https://github.com/lukesandberg/bincode.git?branch=customize_enum_variant#673ff4a740aacd7f5bf57d5f95f3967edf82d304"
 dependencies = [
  "bincode_derive",
  "serde",
@@ -573,7 +573,7 @@ dependencies = [
 [[package]]
 name = "bincode_derive"
 version = "2.0.1"
-source = "git+https://github.com/bgw/bincode.git?branch=bgw%2Fpatches#19f09c5f6895d769883c10b3d374f761ab7fe83d"
+source = "git+https://github.com/lukesandberg/bincode.git?branch=customize_enum_variant#673ff4a740aacd7f5bf57d5f95f3967edf82d304"
 dependencies = [
  "virtue",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -482,6 +482,6 @@ vergen-gitcl = { version = "1.0.8", features = ["cargo"] }
 webbrowser = "1.0.6"
 
 [patch.crates-io]
-bincode = { git = "https://github.com/bgw/bincode.git", branch = "bgw/patches" }
+bincode = { git = "https://github.com/lukesandberg/bincode.git", branch = "customize_enum_variant" }
 virtue = { git = "https://github.com/bgw/virtue.git", branch = "bgw/fix-generic-default-parsing" }
 mdxjs = { git = "https://github.com/mischnic/mdxjs-rs.git", branch = "swc-core-32" }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -61,7 +61,7 @@ use crate::{
     backing_storage::BackingStorage,
     data::{
         ActivenessState, AggregationNumber, CachedDataItem, CachedDataItemKey, CachedDataItemType,
-        CachedDataItemValueRef, CellRef, CollectibleRef, CollectiblesRef, Dirtyness,
+        CachedDataItemValueRef, CellRef, CollectibleRef, CollectiblesRef, Dirtiness,
         InProgressCellState, InProgressState, InProgressStateInner, OutputValue, RootType,
     },
     utils::{
@@ -2017,7 +2017,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         // find all outdated data items (removed cells, outdated edges)
         // Note: For persistent tasks we only want to call extract_if when there are actual cells to
         // remove to avoid tracking that as modification.
-        if task_id.is_transient() || iter_many!(task, CellData { cell }
+        if task_id.is_transient() || iter_many!(task, CellData { cell, }
             if cell_counters.get(&cell.type_id).is_none_or(|start_index| cell.index >= *start_index) => cell
         ).count() > 0 {
             removed_data.extend(task.extract_if(CachedDataItemType::CellData, |key, _| {
@@ -2370,28 +2370,28 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         ));
 
         // Grab the old dirty state
-        let old_dirtyness = get!(task, Dirty).cloned();
-        let (old_self_dirty, old_current_session_self_clean) = match old_dirtyness {
+        let old_dirtiness = get!(task, Dirty).cloned();
+        let (old_self_dirty, old_current_session_self_clean) = match old_dirtiness {
             None => (false, false),
-            Some(Dirtyness::Dirty) => (true, false),
-            Some(Dirtyness::SessionDependent) => {
+            Some(Dirtiness::Dirty) => (true, false),
+            Some(Dirtiness::SessionDependent) => {
                 let clean_in_current_session = get!(task, CurrentSessionClean).is_some();
                 (true, clean_in_current_session)
             }
         };
 
         // Compute the new dirty state
-        let (new_dirtyness, new_self_dirty, new_current_session_self_clean) = if session_dependent {
-            (Some(Dirtyness::SessionDependent), true, true)
+        let (new_dirtiness, new_self_dirty, new_current_session_self_clean) = if session_dependent {
+            (Some(Dirtiness::SessionDependent), true, true)
         } else {
             (None, false, false)
         };
 
         // Update the dirty state
-        if old_dirtyness != new_dirtyness {
-            if let Some(value) = new_dirtyness {
+        if old_dirtiness != new_dirtiness {
+            if let Some(value) = new_dirtiness {
                 task.insert(CachedDataItem::Dirty { value });
-            } else if old_dirtyness.is_some() {
+            } else if old_dirtiness.is_some() {
                 task.remove(&CachedDataItemKey::Dirty {});
             }
         }
@@ -2403,7 +2403,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             }
         }
 
-        // Propagate dirtyness changes
+        // Propagate dirtiness changes
         let data_update = if old_self_dirty != new_self_dirty
             || old_current_session_self_clean != new_current_session_self_clean
         {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -14,7 +14,7 @@ use crate::{
         storage::{get, get_mut, remove},
     },
     data::{
-        CachedDataItem, CachedDataItemKey, CachedDataItemValue, Dirtyness, InProgressState,
+        CachedDataItem, CachedDataItemKey, CachedDataItemValue, Dirtiness, InProgressState,
         InProgressStateInner,
     },
 };
@@ -232,11 +232,11 @@ pub fn make_task_dirty_internal(
         *stale = true;
     }
     let old = task.insert(CachedDataItem::Dirty {
-        value: Dirtyness::Dirty,
+        value: Dirtiness::Dirty,
     });
     let (old_self_dirty, old_current_session_self_clean) = match old {
         Some(CachedDataItemValue::Dirty {
-            value: Dirtyness::Dirty,
+            value: Dirtiness::Dirty,
         }) => {
             #[cfg(feature = "trace_task_dirty")]
             let _span = tracing::trace_span!(
@@ -250,7 +250,7 @@ pub fn make_task_dirty_internal(
             return;
         }
         Some(CachedDataItemValue::Dirty {
-            value: Dirtyness::SessionDependent,
+            value: Dirtiness::SessionDependent,
         }) => {
             // It was a session-dependent dirty before, so we need to remove that clean count
             let was_current_session_clean = remove!(task, CurrentSessionClean).is_some();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     backing_storage::BackingStorage,
     data::{
         CachedDataItem, CachedDataItemKey, CachedDataItemType, CachedDataItemValue,
-        CachedDataItemValueRef, CachedDataItemValueRefMut, Dirtyness,
+        CachedDataItemValueRef, CachedDataItemValueRefMut, Dirtiness,
     },
 };
 
@@ -409,16 +409,16 @@ pub trait TaskGuard: Debug {
     fn prefetch(&mut self) -> Option<FxIndexMap<TaskId, bool>>;
     fn is_immutable(&self) -> bool;
     fn is_dirty(&self) -> bool {
-        get!(self, Dirty).is_some_and(|dirtyness| match dirtyness {
-            Dirtyness::Dirty => true,
-            Dirtyness::SessionDependent => get!(self, CurrentSessionClean).is_none(),
+        get!(self, Dirty).is_some_and(|dirtiness| match dirtiness {
+            Dirtiness::Dirty => true,
+            Dirtiness::SessionDependent => get!(self, CurrentSessionClean).is_none(),
         })
     }
-    fn dirtyness_and_session(&self) -> Option<(Dirtyness, bool)> {
+    fn dirtiness_and_session(&self) -> Option<(Dirtiness, bool)> {
         match get!(self, Dirty)? {
-            Dirtyness::Dirty => Some((Dirtyness::Dirty, false)),
-            Dirtyness::SessionDependent => Some((
-                Dirtyness::SessionDependent,
+            Dirtiness::Dirty => Some((Dirtiness::Dirty, false)),
+            Dirtiness::SessionDependent => Some((
+                Dirtiness::SessionDependent,
                 get!(self, CurrentSessionClean).is_some(),
             )),
         }
@@ -427,8 +427,8 @@ pub trait TaskGuard: Debug {
     fn dirty(&self) -> (bool, bool) {
         match get!(self, Dirty) {
             None => (false, false),
-            Some(Dirtyness::Dirty) => (true, false),
-            Some(Dirtyness::SessionDependent) => (true, get!(self, CurrentSessionClean).is_some()),
+            Some(Dirtiness::Dirty) => (true, false),
+            Some(Dirtiness::SessionDependent) => (true, get!(self, CurrentSessionClean).is_some()),
         }
     }
     fn dirty_containers(&self) -> impl Iterator<Item = TaskId> {
@@ -470,22 +470,24 @@ pub trait TaskGuard: Debug {
         is_serializable_cell_content: bool,
         cell: CellId,
     ) -> Option<TypedSharedReference> {
-        if is_serializable_cell_content {
+        let reference = if is_serializable_cell_content {
             remove!(self, CellData { cell })
         } else {
-            remove!(self, TransientCellData { cell }).map(|sr| sr.into_typed(cell.type_id))
-        }
+            remove!(self, TransientCellData { cell })
+        };
+        reference.map(|sr| sr.into_typed(cell.type_id))
     }
     fn get_cell_data(
         &self,
         is_serializable_cell_content: bool,
         cell: CellId,
     ) -> Option<TypedSharedReference> {
-        if is_serializable_cell_content {
-            get!(self, CellData { cell }).cloned()
+        let reference = if is_serializable_cell_content {
+            get!(self, CellData { cell })
         } else {
-            get!(self, TransientCellData { cell }).map(|sr| sr.clone().into_typed(cell.type_id))
-        }
+            get!(self, TransientCellData { cell })
+        };
+        reference.map(|sr| sr.clone().into_typed(cell.type_id))
     }
     fn has_cell_data(&self, is_serializable_cell_content: bool, cell: CellId) -> bool {
         if is_serializable_cell_content {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -12,7 +12,8 @@ use crate::{
     backend::dynamic_storage::DynamicStorage,
     data::{
         AggregationNumber, CachedDataItem, CachedDataItemKey, CachedDataItemType,
-        CachedDataItemValue, CachedDataItemValueRef, CachedDataItemValueRefMut, OutputValue,
+        CachedDataItemValue, CachedDataItemValueRef, CachedDataItemValueRefMut, Dirtiness,
+        OutputValue,
     },
     data_storage::{AutoMapStorage, OptionStorage},
     utils::{
@@ -102,6 +103,12 @@ bitfield! {
     pub data_snapshot, set_data_snapshot: 5;
     /// Prefetched dependencies
     pub prefetched, set_prefetched: 6;
+    pub immutable, set_immutable: 7;
+    pub has_invalidator, set_has_invalidator: 8;
+    pub stateful, set_stateful: 9;
+    pub current_session_clean, set_current_session_clean: 10;
+    /// Dirty state: 2 bits to encode None (0), Dirty (1), SessionDependent (2)
+    pub u8, dirty_state, set_dirty_state: 12, 11;
 }
 
 impl InnerStorageState {
@@ -135,6 +142,26 @@ impl InnerStorageState {
     pub fn any_modified(&self) -> bool {
         self.meta_modified() || self.data_modified()
     }
+
+    /// Get the dirty state as an Option<Dirtiness>
+    /// Encoding: 0 = None, 1 = Dirty, 2 = SessionDependent
+    pub fn get_dirty(&self) -> Option<crate::data::Dirtiness> {
+        match self.dirty_state() {
+            0 => None,
+            1 => Some(crate::data::Dirtiness::Dirty),
+            2 => Some(crate::data::Dirtiness::SessionDependent),
+            _ => None, // Invalid state, treat as None
+        }
+    }
+
+    /// Set the dirty state from an Option<Dirtiness>
+    pub fn set_dirty(&mut self, dirtiness: Option<crate::data::Dirtiness>) {
+        match dirtiness {
+            None => self.set_dirty_state(0),
+            Some(crate::data::Dirtiness::Dirty) => self.set_dirty_state(1),
+            Some(crate::data::Dirtiness::SessionDependent) => self.set_dirty_state(2),
+        }
+    }
 }
 
 pub struct InnerStorageSnapshot {
@@ -145,6 +172,12 @@ pub struct InnerStorageSnapshot {
     dynamic: DynamicStorage,
     pub meta_modified: bool,
     pub data_modified: bool,
+    // Bitfield-backed items
+    stateful: bool,
+    immutable: bool,
+    has_invalidator: bool,
+    current_session_clean: bool,
+    dirty: Option<crate::data::Dirtiness>,
 }
 
 impl From<&InnerStorage> for InnerStorageSnapshot {
@@ -157,6 +190,11 @@ impl From<&InnerStorage> for InnerStorageSnapshot {
             dynamic: inner.dynamic.snapshot_for_persisting(),
             meta_modified: inner.state.meta_modified(),
             data_modified: inner.state.data_modified(),
+            stateful: inner.state.stateful(),
+            immutable: inner.state.immutable(),
+            has_invalidator: inner.state.has_invalidator(),
+            current_session_clean: inner.state.current_session_clean(),
+            dirty: inner.state.get_dirty(),
         }
     }
 }
@@ -192,6 +230,36 @@ impl InnerStorageSnapshot {
                     CachedDataItemValueRef::OutputDependent { value },
                 )
             }))
+            .chain(self.stateful.then_some({
+                (
+                    CachedDataItemKey::Stateful {},
+                    CachedDataItemValueRef::Stateful { value: &() },
+                )
+            }))
+            .chain(self.immutable.then_some({
+                (
+                    CachedDataItemKey::Immutable {},
+                    CachedDataItemValueRef::Immutable { value: &() },
+                )
+            }))
+            .chain(self.has_invalidator.then_some({
+                (
+                    CachedDataItemKey::HasInvalidator {},
+                    CachedDataItemValueRef::HasInvalidator { value: &() },
+                )
+            }))
+            .chain(self.current_session_clean.then_some({
+                (
+                    CachedDataItemKey::CurrentSessionClean {},
+                    CachedDataItemValueRef::CurrentSessionClean { value: &() },
+                )
+            }))
+            .chain(self.dirty.as_ref().map(|v| {
+                (
+                    CachedDataItemKey::Dirty {},
+                    CachedDataItemValueRef::Dirty { value: v },
+                )
+            }))
     }
 
     pub fn len(&self) -> usize {
@@ -201,6 +269,11 @@ impl InnerStorageSnapshot {
             + self.output.len()
             + self.upper.len()
             + self.output_dependent.len()
+            + (self.stateful as usize)
+            + (self.immutable as usize)
+            + (self.has_invalidator as usize)
+            + (self.current_session_clean as usize)
+            + (self.dirty.is_some() as usize)
     }
 }
 
@@ -232,6 +305,216 @@ impl InnerStorage {
 
     pub fn state_mut(&mut self) -> &mut InnerStorageState {
         &mut self.state
+    }
+
+    // Bitfield-backed storage operations
+    // These handle CachedDataItem variants that are stored as bits in InnerStorageState
+
+    /// Try to add a bitfield-backed item. Returns Some(true) if added, Some(false) if already
+    /// present, None if not a bitfield item.
+    fn try_add_bitfield(&mut self, item: &CachedDataItem) -> Option<bool> {
+        match item {
+            CachedDataItem::Stateful { .. } => {
+                if !self.state.stateful() {
+                    self.state.set_stateful(true);
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            }
+            CachedDataItem::Immutable { .. } => {
+                if !self.state.immutable() {
+                    self.state.set_immutable(true);
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            }
+            CachedDataItem::HasInvalidator { .. } => {
+                if !self.state.has_invalidator() {
+                    self.state.set_has_invalidator(true);
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            }
+            CachedDataItem::CurrentSessionClean { .. } => {
+                if !self.state.current_session_clean() {
+                    self.state.set_current_session_clean(true);
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            }
+            CachedDataItem::Dirty { value } => {
+                if self.state.get_dirty().is_none() {
+                    self.state.set_dirty(Some(*value));
+                    Some(true)
+                } else {
+                    Some(false)
+                }
+            }
+            _ => None,
+        }
+    }
+
+    /// Try to insert a bitfield-backed item. Returns Some(old_value) if it's a bitfield item, None
+    /// otherwise.
+    fn try_insert_bitfield(
+        &mut self,
+        item: &CachedDataItem,
+    ) -> Option<Option<CachedDataItemValue>> {
+        match item {
+            CachedDataItem::Stateful { .. } => {
+                let had_value = self.state.stateful();
+                self.state.set_stateful(true);
+                Some(had_value.then(|| CachedDataItemValue::Stateful { value: () }))
+            }
+            CachedDataItem::Immutable { .. } => {
+                let had_value = self.state.immutable();
+                self.state.set_immutable(true);
+                Some(had_value.then(|| CachedDataItemValue::Immutable { value: () }))
+            }
+            CachedDataItem::HasInvalidator { .. } => {
+                let had_value = self.state.has_invalidator();
+                self.state.set_has_invalidator(true);
+                Some(had_value.then(|| CachedDataItemValue::HasInvalidator { value: () }))
+            }
+            CachedDataItem::CurrentSessionClean { .. } => {
+                let had_value = self.state.current_session_clean();
+                self.state.set_current_session_clean(true);
+                Some(had_value.then(|| CachedDataItemValue::CurrentSessionClean { value: () }))
+            }
+            CachedDataItem::Dirty { value } => {
+                let old_value = self.state.get_dirty();
+                self.state.set_dirty(Some(*value));
+                Some(old_value.map(|v| CachedDataItemValue::Dirty { value: v }))
+            }
+            _ => None,
+        }
+    }
+
+    /// Try to remove a bitfield-backed item. Returns Some(old_value) if it's a bitfield item, None
+    /// otherwise.
+    fn try_remove_bitfield(
+        &mut self,
+        key: &CachedDataItemKey,
+    ) -> Option<Option<CachedDataItemValue>> {
+        match key {
+            CachedDataItemKey::Stateful { .. } => {
+                let had_value = self.state.stateful();
+                self.state.set_stateful(false);
+                Some(had_value.then(|| CachedDataItemValue::Stateful { value: () }))
+            }
+            CachedDataItemKey::Immutable { .. } => {
+                let had_value = self.state.immutable();
+                self.state.set_immutable(false);
+                Some(had_value.then(|| CachedDataItemValue::Immutable { value: () }))
+            }
+            CachedDataItemKey::HasInvalidator { .. } => {
+                let had_value = self.state.has_invalidator();
+                self.state.set_has_invalidator(false);
+                Some(had_value.then(|| CachedDataItemValue::HasInvalidator { value: () }))
+            }
+            CachedDataItemKey::CurrentSessionClean { .. } => {
+                let had_value = self.state.current_session_clean();
+                self.state.set_current_session_clean(false);
+                Some(had_value.then(|| CachedDataItemValue::CurrentSessionClean { value: () }))
+            }
+            CachedDataItemKey::Dirty { .. } => {
+                let old_value = self.state.get_dirty();
+                self.state.set_dirty(None);
+                Some(old_value.map(|v| CachedDataItemValue::Dirty { value: v }))
+            }
+            _ => None,
+        }
+    }
+
+    /// Try to get a bitfield-backed item. Returns Some(Some(value)) if present, Some(None) if
+    /// absent, None if not a bitfield item. Note: Dirty is not supported via get() because it
+    /// has a non-unit value and we can't return a reference to a bitfield. Use contains_key()
+    /// and then access via dynamic storage or use a different method.
+    fn try_get_bitfield(
+        &self,
+        key: &CachedDataItemKey,
+    ) -> Option<Option<CachedDataItemValueRef<'_>>> {
+        match key {
+            CachedDataItemKey::Stateful { .. } => Some(
+                self.state
+                    .stateful()
+                    .then_some(CachedDataItemValueRef::Stateful { value: &() }),
+            ),
+            CachedDataItemKey::Immutable { .. } => Some(
+                self.state
+                    .immutable()
+                    .then_some(CachedDataItemValueRef::Immutable { value: &() }),
+            ),
+            CachedDataItemKey::HasInvalidator { .. } => Some(
+                self.state
+                    .has_invalidator()
+                    .then_some(CachedDataItemValueRef::HasInvalidator { value: &() }),
+            ),
+            CachedDataItemKey::CurrentSessionClean { .. } => Some(
+                self.state
+                    .current_session_clean()
+                    .then_some(CachedDataItemValueRef::CurrentSessionClean { value: &() }),
+            ),
+            CachedDataItemKey::Dirty {} => {
+                Some(
+                    self.state
+                        .get_dirty()
+                        .map(|d| CachedDataItemValueRef::Dirty {
+                            value: match d {
+                                Dirtiness::Dirty => &Dirtiness::Dirty,
+                                Dirtiness::SessionDependent => &Dirtiness::SessionDependent,
+                            },
+                        }),
+                )
+            }
+            _ => None,
+        }
+    }
+
+    /// Try to check if a bitfield-backed item exists. Returns Some(exists) if it's a bitfield item,
+    /// None otherwise.
+    fn try_contains_bitfield(&self, key: &CachedDataItemKey) -> Option<bool> {
+        match key {
+            CachedDataItemKey::Stateful { .. } => Some(self.state.stateful()),
+            CachedDataItemKey::Immutable { .. } => Some(self.state.immutable()),
+            CachedDataItemKey::HasInvalidator { .. } => Some(self.state.has_invalidator()),
+            CachedDataItemKey::CurrentSessionClean { .. } => {
+                Some(self.state.current_session_clean())
+            }
+            CachedDataItemKey::Dirty { .. } => Some(self.state.get_dirty().is_some()),
+            _ => None,
+        }
+    }
+
+    /// Check if a key is a bitfield item (for methods that don't support bitfield access)
+    fn is_bitfield_key(&self, key: &CachedDataItemKey) -> bool {
+        matches!(
+            key,
+            CachedDataItemKey::Stateful { .. }
+                | CachedDataItemKey::Immutable { .. }
+                | CachedDataItemKey::HasInvalidator { .. }
+                | CachedDataItemKey::CurrentSessionClean { .. }
+                | CachedDataItemKey::Dirty { .. }
+        )
+    }
+
+    /// Count bitfield items for a given type. Returns Some(count) if it's a bitfield type, None
+    /// otherwise.
+    fn try_count_bitfield(&self, ty: CachedDataItemType) -> Option<usize> {
+        match ty {
+            CachedDataItemType::Stateful => Some(self.state.stateful() as usize),
+            CachedDataItemType::Immutable => Some(self.state.immutable() as usize),
+            CachedDataItemType::HasInvalidator => Some(self.state.has_invalidator() as usize),
+            CachedDataItemType::CurrentSessionClean => {
+                Some(self.state.current_session_clean() as usize)
+            }
+            CachedDataItemType::Dirty => Some(self.state.get_dirty().is_some() as usize),
+            _ => None,
+        }
     }
 }
 
@@ -451,54 +734,89 @@ macro_rules! generate_inner_storage {
     ($($config:tt)*) => {
         impl InnerStorage {
             pub fn add(&mut self, item: CachedDataItem) -> bool {
+                // Check bitfield storage first
+                if let Some(result) = self.try_add_bitfield(&item) {
+                    return result;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItem: self, item, value, none, add(value): $($config)*);
                 self.dynamic.add(item)
             }
 
             pub fn extend(&mut self, ty: CachedDataItemType, items: impl Iterator<Item = CachedDataItem>) -> bool {
+                // Note: extend is not optimized for bitfield items because it takes an iterator
+                // and we'd need to buffer it. It's rarely used for these items anyway.
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(extend: self, ty, items: $($config)*);
                 self.dynamic.extend(ty, items)
             }
 
             pub fn insert(&mut self, item: CachedDataItem) -> Option<CachedDataItemValue> {
+                // Check bitfield storage first
+                if let Some(result) = self.try_insert_bitfield(&item) {
+                    return result;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItem: self, item, value, option_value, insert(value): $($config)*);
                 self.dynamic.insert(item)
             }
 
             pub fn remove(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValue> {
+                // Check bitfield storage first
+                if let Some(result) = self.try_remove_bitfield(key) {
+                    return result;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemKey: self, key, option_value, remove(): $($config)*);
                 self.dynamic.remove(key)
             }
 
             pub fn count(&self, ty: CachedDataItemType) -> usize {
+                // Check bitfield storage first
+                if let Some(result) = self.try_count_bitfield(ty) {
+                    return result;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemType: self, ty, none, len(): $($config)*);
                 self.dynamic.count(ty)
             }
 
             pub fn get(&self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRef<'_>> {
+                // Check bitfield storage first
+                if let Some(result) = self.try_get_bitfield(key) {
+                    return result;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemKey: self, key, option_ref, get(): $($config)*);
                 self.dynamic.get(key)
             }
 
             pub fn contains_key(&self, key: &CachedDataItemKey) -> bool {
+                // Check bitfield storage first
+                if let Some(result) = self.try_contains_bitfield(key) {
+                    return result;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemKey: self, key, none, contains_key(): $($config)*);
                 self.dynamic.contains_key(key)
             }
 
             pub fn get_mut(&mut self, key: &CachedDataItemKey) -> Option<CachedDataItemValueRefMut<'_>> {
+                // Bitfield items don't support mutable access (they're just flags)
+                // Return None for bitfield keys so they fall through to dynamic storage
+                if self.is_bitfield_key(key) {
+                    return None;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemKey: self, key, option_ref_mut, get_mut(): $($config)*);
                 self.dynamic.get_mut(key)
             }
 
             pub fn shrink_to_fit(&mut self, ty: CachedDataItemType) {
+                // Bitfield types don't need shrinking
+                if self.try_count_bitfield(ty).is_some() {
+                    return;
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(CachedDataItemType: self, ty, none, shrink_to_fit(): $($config)*);
                 self.dynamic.shrink_to_fit(ty)
@@ -509,6 +827,49 @@ macro_rules! generate_inner_storage {
                 key: CachedDataItemKey,
                 update: impl FnOnce(Option<CachedDataItemValue>) -> Option<CachedDataItemValue>,
             ) {
+                // Check bitfield storage first - but we need to do this without moving `update`
+                if self.is_bitfield_key(&key) {
+                    // Handle bitfield update inline to avoid moving the closure
+                    match &key {
+                        CachedDataItemKey::Stateful { .. } => {
+                            let old = self.state.stateful().then(|| CachedDataItemValue::Stateful { value: () });
+                            let new = update(old);
+                            self.state.set_stateful(new.is_some());
+                            return;
+                        }
+                        CachedDataItemKey::Immutable { .. } => {
+                            let old = self.state.immutable().then(|| CachedDataItemValue::Immutable { value: () });
+                            let new = update(old);
+                            self.state.set_immutable(new.is_some());
+                            return;
+                        }
+                        CachedDataItemKey::HasInvalidator { .. } => {
+                            let old = self.state.has_invalidator().then(|| CachedDataItemValue::HasInvalidator { value: () });
+                            let new = update(old);
+                            self.state.set_has_invalidator(new.is_some());
+                            return;
+                        }
+                        CachedDataItemKey::CurrentSessionClean { .. } => {
+                            let old = self.state.current_session_clean().then(|| CachedDataItemValue::CurrentSessionClean { value: () });
+                            let new = update(old);
+                            self.state.set_current_session_clean(new.is_some());
+                            return;
+                        }
+                        CachedDataItemKey::Dirty { .. } => {
+                            let old = self.state.get_dirty().map(|v| CachedDataItemValue::Dirty { value: v });
+                            let new = update(old);
+                            self.state.set_dirty(new.and_then(|v| {
+                                if let CachedDataItemValue::Dirty { value } = v {
+                                    Some(value)
+                                } else {
+                                    None
+                                }
+                            }));
+                            return;
+                        }
+                        _ => unreachable!("is_bitfield_key returned true for non-bitfield key"),
+                    }
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(update: self, key, update: $($config)*);
                 self.dynamic.update(key, update)
@@ -522,6 +883,65 @@ macro_rules! generate_inner_storage {
             where
                 F: for<'a> FnMut(CachedDataItemKey, CachedDataItemValueRef<'a>) -> bool + 'l,
             {
+                // Handle bitfield types - they can be extracted if the predicate matches
+                match ty {
+                    CachedDataItemType::Stateful => {
+                        if self.state.stateful() {
+                            let key = CachedDataItemKey::Stateful {};
+                            let value_ref = CachedDataItemValueRef::Stateful { value: &() };
+                            if f(key, value_ref) {
+                                self.state.set_stateful(false);
+                                return InnerStorageIter::Bitfield(Some(CachedDataItem::Stateful { value: () }));
+                            }
+                        }
+                        return InnerStorageIter::Bitfield(None);
+                    }
+                    CachedDataItemType::Immutable => {
+                        if self.state.immutable() {
+                            let key = CachedDataItemKey::Immutable {};
+                            let value_ref = CachedDataItemValueRef::Immutable { value: &() };
+                            if f(key, value_ref) {
+                                self.state.set_immutable(false);
+                                return InnerStorageIter::Bitfield(Some(CachedDataItem::Immutable { value: () }));
+                            }
+                        }
+                        return InnerStorageIter::Bitfield(None);
+                    }
+                    CachedDataItemType::HasInvalidator => {
+                        if self.state.has_invalidator() {
+                            let key = CachedDataItemKey::HasInvalidator {};
+                            let value_ref = CachedDataItemValueRef::HasInvalidator { value: &() };
+                            if f(key, value_ref) {
+                                self.state.set_has_invalidator(false);
+                                return InnerStorageIter::Bitfield(Some(CachedDataItem::HasInvalidator { value: () }));
+                            }
+                        }
+                        return InnerStorageIter::Bitfield(None);
+                    }
+                    CachedDataItemType::CurrentSessionClean => {
+                        if self.state.current_session_clean() {
+                            let key = CachedDataItemKey::CurrentSessionClean {};
+                            let value_ref = CachedDataItemValueRef::CurrentSessionClean { value: &() };
+                            if f(key, value_ref) {
+                                self.state.set_current_session_clean(false);
+                                return InnerStorageIter::Bitfield(Some(CachedDataItem::CurrentSessionClean { value: () }));
+                            }
+                        }
+                        return InnerStorageIter::Bitfield(None);
+                    }
+                    CachedDataItemType::Dirty => {
+                        if let Some(dirty_value) = self.state.get_dirty() {
+                            let key = CachedDataItemKey::Dirty {};
+                            let value_ref = CachedDataItemValueRef::Dirty { value: &dirty_value };
+                            if f(key, value_ref) {
+                                self.state.set_dirty(None);
+                                return InnerStorageIter::Bitfield(Some(CachedDataItem::Dirty { value: dirty_value }));
+                            }
+                        }
+                        return InnerStorageIter::Bitfield(None);
+                    }
+                    _ => {}
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(extract_if: self, ty, f: $($config)*);
                 InnerStorageIter::Dynamic(self.dynamic.extract_if(ty, f))
@@ -533,6 +953,12 @@ macro_rules! generate_inner_storage {
                 f: impl FnOnce() -> CachedDataItemValue,
             ) -> CachedDataItemValueRefMut<'_>
             {
+                // Bitfield items don't support mutable access
+                // For these items, we just insert them and panic since they shouldn't be used this way
+                // In practice, bitfield items are only accessed via add/contains_key, not get_mut_or_insert_with
+                if self.is_bitfield_key(&key) {
+                    panic!("get_mut_or_insert_with not supported for bitfield items: {:?}", key);
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(get_mut_or_insert_with: self, key, f: $($config)*);
                 self.dynamic.get_mut_or_insert_with(key, f)
@@ -543,6 +969,47 @@ macro_rules! generate_inner_storage {
                 ty: CachedDataItemType,
             ) -> impl Iterator<Item = (CachedDataItemKey, CachedDataItemValueRef<'_>)>
             {
+                // Handle bitfield types - return an iterator with at most one element
+                // Note: Dirty is NOT supported via iter() because we can't return a reference to a bitfield value
+                match ty {
+                    CachedDataItemType::Stateful => {
+                        if self.state.stateful() {
+                            let item = (CachedDataItemKey::Stateful {}, CachedDataItemValueRef::Stateful { value: &() });
+                            return InnerStorageIter::Bitfield(Some(item));
+                        } else {
+                            return InnerStorageIter::Bitfield(None);
+                        }
+                    }
+                    CachedDataItemType::Immutable => {
+                        if self.state.immutable() {
+                            let item = (CachedDataItemKey::Immutable {}, CachedDataItemValueRef::Immutable { value: &() });
+                            return InnerStorageIter::Bitfield(Some(item));
+                        } else {
+                            return InnerStorageIter::Bitfield(None);
+                        }
+                    }
+                    CachedDataItemType::HasInvalidator => {
+                        if self.state.has_invalidator() {
+                            let item = (CachedDataItemKey::HasInvalidator {}, CachedDataItemValueRef::HasInvalidator { value: &() });
+                            return InnerStorageIter::Bitfield(Some(item));
+                        } else {
+                            return InnerStorageIter::Bitfield(None);
+                        }
+                    }
+                    CachedDataItemType::CurrentSessionClean => {
+                        if self.state.current_session_clean() {
+                            let item = (CachedDataItemKey::CurrentSessionClean {}, CachedDataItemValueRef::CurrentSessionClean { value: &() });
+                            return InnerStorageIter::Bitfield(Some(item));
+                        } else {
+                            return InnerStorageIter::Bitfield(None);
+                        }
+                    }
+                    // Dirty is not supported via iter() - can't return a reference to a bitfield value
+                    CachedDataItemType::Dirty => {
+                        return InnerStorageIter::Bitfield(None);
+                    }
+                    _ => {}
+                }
                 use crate::data_storage::Storage;
                 $crate::generate_inner_storage_internal!(iter: self, ty: $($config)*);
                 InnerStorageIter::Dynamic(self.dynamic.iter(ty))
@@ -559,15 +1026,16 @@ generate_inner_storage!(
     Upper task => upper,
 );
 
-enum InnerStorageIter<A, B, C, D, E> {
+enum InnerStorageIter<A, B, C, D, E, T> {
     AggregationNumber(A),
     OutputDependent(B),
     Output(C),
     Upper(D),
     Dynamic(E),
+    Bitfield(Option<T>),
 }
 
-impl<T, A, B, C, D, E> Iterator for InnerStorageIter<A, B, C, D, E>
+impl<T, A, B, C, D, E> Iterator for InnerStorageIter<A, B, C, D, E, T>
 where
     A: Iterator<Item = T>,
     B: Iterator<Item = T>,
@@ -584,6 +1052,7 @@ where
             InnerStorageIter::Output(iter) => iter.next(),
             InnerStorageIter::Upper(iter) => iter.next(),
             InnerStorageIter::Dynamic(iter) => iter.next(),
+            InnerStorageIter::Bitfield(item) => item.take(),
         }
     }
 }
@@ -619,6 +1088,41 @@ impl InnerStorage {
                     CachedDataItemValueRef::OutputDependent { value },
                 )
             }))
+            .chain(self.state.stateful().then_some({
+                (
+                    CachedDataItemKey::Stateful {},
+                    CachedDataItemValueRef::Stateful { value: &() },
+                )
+            }))
+            .chain(self.state.immutable().then_some({
+                (
+                    CachedDataItemKey::Immutable {},
+                    CachedDataItemValueRef::Immutable { value: &() },
+                )
+            }))
+            .chain(self.state.has_invalidator().then_some({
+                (
+                    CachedDataItemKey::HasInvalidator {},
+                    CachedDataItemValueRef::HasInvalidator { value: &() },
+                )
+            }))
+            .chain(self.state.current_session_clean().then_some({
+                (
+                    CachedDataItemKey::CurrentSessionClean {},
+                    CachedDataItemValueRef::CurrentSessionClean { value: &() },
+                )
+            }))
+            .chain(self.state.get_dirty().map(|d| {
+                (
+                    CachedDataItemKey::Dirty {},
+                    CachedDataItemValueRef::Dirty {
+                        value: match d {
+                            Dirtiness::Dirty => &Dirtiness::Dirty,
+                            Dirtiness::SessionDependent => &Dirtiness::SessionDependent,
+                        },
+                    },
+                )
+            }))
     }
 
     pub fn len(&self) -> usize {
@@ -628,6 +1132,11 @@ impl InnerStorage {
             + self.output.len()
             + self.upper.len()
             + self.output_dependent.len()
+            + (self.state.stateful() as usize)
+            + (self.state.immutable() as usize)
+            + (self.state.has_invalidator() as usize)
+            + (self.state.current_session_clean() as usize)
+            + (self.state.get_dirty().is_some() as usize)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -141,7 +141,7 @@ transient_traits!(ActivenessState);
 impl Eq for ActivenessState {}
 
 #[derive(Debug, Clone, Copy, Encode, Decode, PartialEq, Eq)]
-pub enum Dirtyness {
+pub enum Dirtiness {
     Dirty,
     SessionDependent,
 }
@@ -225,7 +225,7 @@ pub enum CachedDataItem {
 
     // State
     Dirty {
-        value: Dirtyness,
+        value: Dirtiness,
     },
     CurrentSessionClean {
         // TODO: bgw: Add a way to skip the entire enum variant in bincode (generating an error
@@ -241,9 +241,10 @@ pub enum CachedDataItem {
     },
 
     // Cells
+    #[bincode(with = "cell_data_bincode")]
     CellData {
         cell: CellId,
-        value: TypedSharedReference,
+        value: SharedReference,
     },
     TransientCellData {
         #[bincode(skip, default = "unreachable_decode")]
@@ -376,6 +377,45 @@ pub enum CachedDataItem {
     },
 }
 
+// Customized encoding/decoding for CellData
+// This allows us to serialize a SharedReference leveraging the type_id from the cell_id
+mod cell_data_bincode {
+    use bincode::{Decode, Encode};
+    use turbo_tasks::{CellId, SharedReference, TypedSharedReference};
+
+    use super::CachedDataItem;
+
+    pub fn encode<E: bincode::enc::Encoder>(
+        cell_id: &CellId,
+        value: &SharedReference,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        Encode::encode(&cell_id.index, encoder)?;
+        // This clone seems unnecessary.  We would need to inline TypedSharedReference encode to
+        // remove it.
+        value.clone().into_typed(cell_id.type_id).encode(encoder)
+    }
+    pub fn decode<Context, D: bincode::de::Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<CachedDataItem, bincode::error::DecodeError> {
+        let index = <u32 as Decode<Context>>::decode(decoder)?;
+        let reference = TypedSharedReference::decode(decoder)?;
+
+        Ok(CachedDataItem::CellData {
+            cell: CellId {
+                type_id: reference.type_id,
+                index,
+            },
+            value: reference.into_untyped(),
+        })
+    }
+    pub fn borrow_decode<'de, Context, D: bincode::de::BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<CachedDataItem, bincode::error::DecodeError> {
+        decode(decoder)
+    }
+}
+
 fn unreachable_decode<T>() -> T {
     unreachable!("CachedDataItem variant should not have been encoded, cannot decode")
 }
@@ -387,7 +427,10 @@ impl CachedDataItem {
         value: TypedSharedReference,
     ) -> Self {
         if is_serializable_cell_content {
-            CachedDataItem::CellData { cell, value }
+            CachedDataItem::CellData {
+                cell,
+                value: value.into_untyped(),
+            }
         } else {
             CachedDataItem::TransientCellData {
                 cell,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -719,9 +719,9 @@ mod tests {
 
     #[test]
     fn test_sizes() {
-        assert_eq!(std::mem::size_of::<super::CachedDataItem>(), 40);
+        assert_eq!(std::mem::size_of::<super::CachedDataItem>(), 32);
         assert_eq!(std::mem::size_of::<super::CachedDataItemKey>(), 20);
-        assert_eq!(std::mem::size_of::<super::CachedDataItemValue>(), 32);
+        assert_eq!(std::mem::size_of::<super::CachedDataItemValue>(), 24);
         assert_eq!(std::mem::size_of::<super::CachedDataItemStorage>(), 48);
     }
 }


### PR DESCRIPTION
# Optimize `InnerStorage` memory 

## What?
* Shrink the `CachedDataItem` enum from 40->32 bytes
   * this requires a new bincode feature that i am adding here: https://github.com/bgw/bincode/pull/8.  will wait to merge until that is resolved.
* Move a number of `CachedDataItem` values to be stored in the spare bitfields.

Both of these should reduce the size of the `DynamicStorage` vec by > 20%.

Also s/dirtyness/dirtiness/

## Performance

With this pr
```
~/projects/front/apps/vercel-site (main *)$ hyperfine -p 'rm -rf .next' -w 2 -r 10  'pnpm next build --turbopack --experimental-build-mode=compile'
Benchmark 1: pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     52.656 s ±  0.606 s    [User: 378.253 s, System: 53.273 s]
  Range (min … max):   51.994 s … 54.089 s    10 runs

/usr/bin/time output
         15855583232  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
             1922629  page reclaims
                  17  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                1656  messages sent
                3185  messages received
                  21  signals received
               28656  voluntary context switches
             3426002  involuntary context switches
          2029838290  instructions retired
           748306777  cycles elapsed
            89529856  peak memory footprint
```

From canary
```
~/projects/front/apps/vercel-site (main *)$ hyperfine -p 'rm -rf .next' -w 2 -r 10  'pnpm next build --turbopack --experimental-build-mode=compile'
Benchmark 1: pnpm next build --turbopack --experimental-build-mode=compile
  Time (mean ± σ):     52.910 s ±  0.405 s    [User: 382.280 s, System: 53.949 s]
  Range (min … max):   52.243 s … 53.593 s    10 runs

/usr/bin/time output
         15852617728  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
             2079707  page reclaims
                  17  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                1634  messages sent
                3177  messages received
                  22  signals received
               29010  voluntary context switches
             3270820  involuntary context switches
          2033246805  instructions retired
           767930658  cycles elapsed
            86777320  peak memory footprint
```