### PR TITLE
fix(turbopack): respect basePath when generating metadata icons

### DIFF
--- a/packages/next/src/lib/metadata/metadata-context.tsx
+++ b/packages/next/src/lib/metadata/metadata-context.tsx
@@ -1,11 +1,14 @@
 import type { AppRenderContext } from '../../server/app-render/app-render'
-import type { MetadataContext } from './types/resolvers'
+import type { MetadataContextWithBasePath } from './types/resolvers'
+
 
 export function createMetadataContext(
   renderOpts: AppRenderContext['renderOpts']
-): MetadataContext {
+): MetadataContextWithBasePath {
   return {
     trailingSlash: renderOpts.trailingSlash,
     isStaticMetadataRouteFile: false,
+    basePath: renderOpts.basePath,
   }
 }
+

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -13,6 +13,7 @@ import type { Twitter } from './types/twitter-types'
 import type { OpenGraph } from './types/opengraph-types'
 import type { AppDirModules } from '../../build/webpack/loaders/next-app-loader'
 import type { MetadataContext } from './types/resolvers'
+import type { MetadataContextWithBasePath } from './types/resolvers'
 import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type {
   AbsoluteTemplateString,
@@ -156,6 +157,35 @@ function normalizeMetadataBase(metadataBase: string | URL | null): URL | null {
   return metadataBase
 }
 
+function applyBasePathToIcons(
+  icons: ResolvedIcons | null,
+  basePath?: string
+): ResolvedIcons | null {
+  if (!icons || !basePath) return icons
+
+  const apply = (icon: IconDescriptor) => {
+    if (
+      icon.url instanceof URL ||
+      !icon.url.startsWith('/') ||
+      icon.url.startsWith(basePath)
+    ) {
+      return icon
+    }
+
+    return {
+      ...icon,
+      url: `${basePath}${icon.url}`,
+    }
+  }
+
+  return {
+    ...icons,
+    icon: icons.icon?.map(apply),
+    apple: icons.apple?.map(apply),
+    other: icons.other?.map(apply),
+  }
+}
+
 async function mergeStaticMetadata(
   metadataBase: MetadataBaseURL,
   source: Metadata | null,
@@ -206,6 +236,7 @@ async function mergeStaticMetadata(
 
   return target
 }
+
 
 /**
  * Merges the given metadata with the resolved metadata. Returns a new object.
@@ -293,12 +324,19 @@ async function mergeMetadata(
         )
         break
 
-      case 'icons': {
-        newResolvedMetadata.icons = convertUrlsToStrings(
-          resolveIcons(metadata.icons)
-        )
-        break
-      }
+        case 'icons': {
+          const resolvedIcons = resolveIcons(metadata.icons)
+
+          const ctx = metadataContext as MetadataContextWithBasePath
+
+          newResolvedMetadata.icons = convertUrlsToStrings(
+            applyBasePathToIcons(resolvedIcons, ctx.basePath)
+          )
+
+          break
+        }
+
+
       case 'appleWebApp':
         newResolvedMetadata.appleWebApp = resolveAppleWebApp(
           metadata.appleWebApp

--- a/packages/next/src/lib/metadata/types/resolvers.ts
+++ b/packages/next/src/lib/metadata/types/resolvers.ts
@@ -24,3 +24,7 @@ export type MetadataContext = {
   trailingSlash: boolean
   isStaticMetadataRouteFile: boolean
 }
+
+export type MetadataContextWithBasePath = MetadataContext & {
+  basePath?: string
+}


### PR DESCRIPTION

### What?
Fix metadata icon URLs generated with Turbopack to correctly respect `basePath`.

### Why?
When using Turbopack with a configured `basePath`, metadata icons (favicon, apple icons, etc.)
are generated without the basePath prefix, resulting in broken icon URLs.
This works correctly with Webpack but fails with Turbopack.

### How?
- Apply `basePath` to root-relative metadata icon URLs during metadata resolution
- Skip absolute URLs and prevent double-prefixing
- Match Webpack behavior without changing public APIs

Fixes #87422
