### PR TITLE
Turbopack: include LightningCSS MediaIntervalSyntax feature

### DIFF
--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -73,13 +73,15 @@ async fn get_lightningcss_browser_targets(
             Ok(if handle_nesting {
                 Vc::cell(Targets {
                     browsers: browserslist_browsers,
-                    include: Features::Nesting | Features::MediaRangeSyntax,
+                    include: Features::Nesting
+                        | Features::MediaRangeSyntax
+                        | Features::MediaIntervalSyntax,
                     ..Default::default()
                 })
             } else {
                 Vc::cell(Targets {
                     browsers: browserslist_browsers,
-                    include: Features::MediaRangeSyntax,
+                    include: Features::MediaRangeSyntax | Features::MediaIntervalSyntax,
                     ..Default::default()
                 })
             })


### PR DESCRIPTION
`MediaRangeSyntax` was added in a95f8612bcf08dbc52cc4b06e88b43d48f4429e7. From my testing, the reason for adding `MediaRangeSyntax` still holds, and also applies to `MediaIntervalSyntax`, which I think is enough merit alone to add this.

I stumbled across it separately though, via https://github.com/parcel-bundler/lightningcss/pull/1114

This bug in LightningCSS causes range syntax to be improperly compiled when `MediaIntervalSyntax` isn't enabled. Since Next 16 updated the default browserlist to browsers new enough to not need `MediaIntervalSyntax`, this was disabled by default, surfacing that bug.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
