### PR TITLE
image-optimizer: add configurable upstream fetch timeout

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -414,6 +414,8 @@ module.exports = {
 }
 ```
 
+> **Good to know**: If the Image Optimization API times out fetching a remote image, you can increase `experimental.imgFetchTimeoutInSeconds` in `next.config.js`, use the `unoptimized` prop, or configure a custom `loader`/`loaderFile`. Setting `experimental.imgFetchTimeoutInSeconds` to `0` disables the upstream fetch timeout (no `AbortSignal.timeout`), which can lead to unbounded upstream waits.
+
 #### `overrideSrc`
 
 When providing the `src` prop to the `<Image>` component, both the `srcset` and `src` attributes are generated automatically for the resulting `<img>`.

--- a/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
@@ -329,6 +329,8 @@ module.exports = {
 }
 ```
 
+> **Good to know**: If the Image Optimization API times out fetching a remote image, you can increase `experimental.imgFetchTimeoutInSeconds` in `next.config.js`, use the `unoptimized` prop, or configure a custom `loader`/`loaderFile`. Setting `experimental.imgFetchTimeoutInSeconds` to `0` disables the upstream fetch timeout (no `AbortSignal.timeout`), which can lead to unbounded upstream waits.
+
 ## Other Props
 
 Other properties on the `<Image />` component will be passed to the underlying

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -217,6 +217,7 @@ export const experimentalSchema = {
   gzipSize: z.boolean().optional(),
   imgOptConcurrency: z.number().int().optional().nullable(),
   imgOptTimeoutInSeconds: z.number().int().optional(),
+  imgFetchTimeoutInSeconds: z.number().int().nonnegative().finite().optional(),
   imgOptMaxInputPixels: z.number().int().optional(),
   imgOptSequentialRead: z.boolean().optional().nullable(),
   imgOptSkipMetadata: z.boolean().optional().nullable(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -318,6 +318,7 @@ export interface ExperimentalConfig {
   fetchCacheKeyPrefix?: string
   imgOptConcurrency?: number | null
   imgOptTimeoutInSeconds?: number
+  imgFetchTimeoutInSeconds?: number
   imgOptMaxInputPixels?: number
   imgOptSequentialRead?: boolean | null
   imgOptSkipMetadata?: boolean | null
@@ -1518,6 +1519,7 @@ export const defaultConfig = Object.freeze({
     memoryBasedWorkersCount: false,
     imgOptConcurrency: null,
     imgOptTimeoutInSeconds: 7,
+    imgFetchTimeoutInSeconds: 7,
     imgOptMaxInputPixels: 268_402_689, // https://sharp.pixelplumbing.com/api-constructor#:~:text=%5Boptions.limitInputPixels%5D
     imgOptSequentialRead: null,
     imgOptSkipMetadata: null,
@@ -1667,6 +1669,7 @@ export interface NextConfigRuntime {
     | 'imgOptSequentialRead'
     | 'imgOptSkipMetadata'
     | 'imgOptTimeoutInSeconds'
+    | 'imgFetchTimeoutInSeconds'
     | 'proxyClientMaxBodySize'
     | 'proxyTimeout'
     | 'testProxy'
@@ -1722,6 +1725,7 @@ export function getNextConfigRuntime(
         imgOptSequentialRead: ex.imgOptSequentialRead,
         imgOptSkipMetadata: ex.imgOptSkipMetadata,
         imgOptTimeoutInSeconds: ex.imgOptTimeoutInSeconds,
+        imgFetchTimeoutInSeconds: ex.imgFetchTimeoutInSeconds,
         proxyClientMaxBodySize: ex.proxyClientMaxBodySize,
         proxyTimeout: ex.proxyTimeout,
         testProxy: ex.testProxy,

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -585,9 +585,11 @@ export class ImageOptimizerCache {
 }
 export class ImageError extends Error {
   statusCode: number
+  code?: string
 
-  constructor(statusCode: number, message: string) {
+  constructor(statusCode: number, message: string, code?: string) {
     super(message)
+    this.code = code
 
     // ensure an error status is used > 400
     if (statusCode >= 400) {
@@ -708,10 +710,33 @@ function isRedirect(statusCode: number) {
   return [301, 302, 303, 307, 308].includes(statusCode)
 }
 
+function isFetchTimeoutError(err: Error, timeoutSignalUsed: boolean): boolean {
+  if (err.name === 'TimeoutError') {
+    return true
+  }
+
+  if (timeoutSignalUsed && err.name === 'AbortError') {
+    return true
+  }
+
+  if (isError(err.cause)) {
+    if (err.cause.name === 'TimeoutError') {
+      return true
+    }
+
+    if (timeoutSignalUsed && err.cause.name === 'AbortError') {
+      return true
+    }
+  }
+
+  return false
+}
+
 export async function fetchExternalImage(
   href: string,
   dangerouslyAllowLocalIP: boolean,
-  count = 3
+  count = 3,
+  timeoutInSeconds?: number
 ): Promise<ImageUpstream> {
   if (!dangerouslyAllowLocalIP) {
     const { hostname } = new URL(href)
@@ -735,18 +760,26 @@ export async function fetchExternalImage(
       throw new ImageError(400, '"url" parameter is not allowed')
     }
   }
-  const res = await fetch(href, {
-    signal: AbortSignal.timeout(7_000),
-    redirect: 'manual',
-  }).catch((err) => err as Error)
+  const resolvedTimeoutInSeconds =
+    typeof timeoutInSeconds === 'number' ? timeoutInSeconds : 7
+  const requestInit: RequestInit = { redirect: 'manual' }
+
+  const timeoutSignalUsed = resolvedTimeoutInSeconds > 0
+
+  if (timeoutSignalUsed) {
+    requestInit.signal = AbortSignal.timeout(resolvedTimeoutInSeconds * 1000)
+  }
+
+  const res = await fetch(href, requestInit).catch((err) => err as Error)
 
   if (res instanceof Error) {
     const err = res as Error
-    if (err.name === 'TimeoutError') {
+    if (isFetchTimeoutError(err, timeoutSignalUsed)) {
       Log.error('upstream image response timed out for', href)
       throw new ImageError(
         504,
-        '"url" parameter is valid but upstream response timed out'
+        '"url" parameter is valid but upstream response timed out. Consider increasing experimental.imgFetchTimeoutInSeconds, using the unoptimized prop, or configuring a custom loader.',
+        'IMAGE_FETCH_TIMEOUT'
       )
     }
     throw err
@@ -766,7 +799,12 @@ export async function fetchExternalImage(
       )
     }
     const redirect = new URL(locationHeader, href).href
-    return fetchExternalImage(redirect, dangerouslyAllowLocalIP, count - 1)
+    return fetchExternalImage(
+      redirect,
+      dangerouslyAllowLocalIP,
+      count - 1,
+      timeoutInSeconds
+    )
   }
 
   if (!res.ok) {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -784,7 +784,8 @@ export default class NextNodeServer extends BaseServer<
         ? await fetchExternalImage(
             href,
             this.nextConfig.images.dangerouslyAllowLocalIP,
-            this.nextConfig.images.maximumRedirects
+            this.nextConfig.images.maximumRedirects,
+            this.nextConfig.experimental.imgFetchTimeoutInSeconds
           )
         : await fetchInternalImage(
             href,

--- a/test/integration/image-optimizer/test/index.test.ts
+++ b/test/integration/image-optimizer/test/index.test.ts
@@ -12,6 +12,9 @@ import {
   waitFor,
   getDistDir,
 } from 'next-test-utils'
+import { createServer } from 'http'
+import { readFile } from 'fs/promises'
+import { type AddressInfo } from 'net'
 import { join } from 'path'
 import { cleanImagesDir, expectWidth, fsToJson } from './util'
 
@@ -862,6 +865,130 @@ describe('Image Optimizer', () => {
       const res = await fetchViaHTTP(appPort, '/_next/image', query, opts)
       expect(res.status).toBe(200)
       expect(res.headers.get('Content-Type')).toBe('image/jpeg')
+    })
+  })
+
+  describe('experimental.imgFetchTimeoutInSeconds in next.config.js', () => {
+    let upstreamServer: ReturnType<typeof createServer>
+    let upstreamPort: number
+    let responseDelayMs = 0
+    let imageBuffer: Buffer
+
+    beforeAll(async () => {
+      imageBuffer = await readFile(join(appDir, 'public', 'test.jpg'))
+      upstreamServer = createServer((_req, res) => {
+        const delay = responseDelayMs
+        setTimeout(() => {
+          res.statusCode = 200
+          res.setHeader('Content-Type', 'image/jpeg')
+          res.end(imageBuffer)
+        }, delay)
+      })
+      await new Promise<void>((resolve) =>
+        upstreamServer.listen(0, '127.0.0.1', () => resolve())
+      )
+      upstreamPort = (upstreamServer.address() as AddressInfo).port
+    })
+
+    afterAll(async () => {
+      await new Promise<void>((resolve) =>
+        upstreamServer.close(() => resolve())
+      )
+    })
+
+    describe('when timeout is configured', () => {
+      let app
+      let appPort
+
+      beforeAll(async () => {
+        responseDelayMs = 1500
+        await nextConfig.replace(
+          '{ /* replaceme */ }',
+          JSON.stringify({
+            experimental: {
+              imgFetchTimeoutInSeconds: 1,
+            },
+            images: {
+              dangerouslyAllowLocalIP: true,
+              remotePatterns: [
+                {
+                  protocol: 'http',
+                  hostname: '127.0.0.1',
+                  port: String(upstreamPort),
+                },
+              ],
+            },
+          })
+        )
+        await cleanImagesDir(imagesDir)
+        appPort = await findPort()
+        app = await launchApp(appDir, appPort)
+      })
+
+      afterAll(async () => {
+        await killApp(app)
+        nextConfig.restore()
+      })
+
+      it('should return 504 for upstream timeouts with diagnostics', async () => {
+        const query = {
+          w: 256,
+          q: 75,
+          url: `http://127.0.0.1:${upstreamPort}/slow.jpg`,
+        }
+        const res = await fetchViaHTTP(appPort, '/_next/image', query, {})
+        expect(res.status).toBe(504)
+        const text = await res.text()
+        expect(text).toContain('imgFetchTimeoutInSeconds')
+        expect(text).toContain('unoptimized')
+        expect(text).toContain('custom loader')
+      })
+    })
+
+    describe('when timeout is disabled', () => {
+      let app
+      let appPort
+
+      beforeAll(async () => {
+        responseDelayMs = 1500
+        await nextConfig.replace(
+          '{ /* replaceme */ }',
+          JSON.stringify({
+            experimental: {
+              imgFetchTimeoutInSeconds: 0,
+            },
+            images: {
+              dangerouslyAllowLocalIP: true,
+              remotePatterns: [
+                {
+                  protocol: 'http',
+                  hostname: '127.0.0.1',
+                  port: String(upstreamPort),
+                },
+              ],
+            },
+          })
+        )
+        await cleanImagesDir(imagesDir)
+        appPort = await findPort()
+        app = await launchApp(appDir, appPort)
+      })
+
+      afterAll(async () => {
+        await killApp(app)
+        nextConfig.restore()
+      })
+
+      it('should allow slow upstream responses without a timeout', async () => {
+        const query = {
+          w: 256,
+          q: 75,
+          url: `http://127.0.0.1:${upstreamPort}/slow.jpg?disabled=1`,
+        }
+        const res = await fetchViaHTTP(appPort, '/_next/image', query, {})
+        expect(res.status).toBe(200)
+        expect(res.headers.get('Content-Type')).toBe('image/jpeg')
+      })
     })
   })
 

--- a/test/unit/image-optimizer/fetch-external-image.test.ts
+++ b/test/unit/image-optimizer/fetch-external-image.test.ts
@@ -1,0 +1,92 @@
+/* eslint-env jest */
+import { fetchExternalImage } from 'next/dist/server/image-optimizer'
+
+describe('fetchExternalImage', () => {
+  const href = 'https://example.com/test.jpg'
+  const originalFetch = global.fetch
+  const timeoutErrorCases = [
+    {
+      name: 'TimeoutError',
+      build: () => {
+        const err = new Error('Request timed out')
+        err.name = 'TimeoutError'
+        return err
+      },
+    },
+    {
+      name: 'AbortError',
+      build: () => {
+        const err = new Error('The operation was aborted')
+        err.name = 'AbortError'
+        return err
+      },
+    },
+    {
+      name: 'TimeoutError cause',
+      build: () => {
+        const cause = new Error('Upstream timed out')
+        cause.name = 'TimeoutError'
+        const err = new Error('Request failed')
+        err.cause = cause
+        return err
+      },
+    },
+    {
+      name: 'AbortError cause',
+      build: () => {
+        const cause = new Error('Upstream aborted')
+        cause.name = 'AbortError'
+        const err = new Error('Request failed')
+        err.cause = cause
+        return err
+      },
+    },
+  ]
+
+  afterEach(() => {
+    global.fetch = originalFetch
+  })
+
+  it.each(timeoutErrorCases)(
+    'maps $name to a 504 ImageError with a stable code',
+    async ({ build }) => {
+      global.fetch = jest.fn().mockRejectedValue(build())
+
+      await expect(fetchExternalImage(href, true, 0, 1)).rejects.toMatchObject({
+        statusCode: 504,
+        code: 'IMAGE_FETCH_TIMEOUT',
+      })
+    }
+  )
+
+  it('does not map non-timeout errors to IMAGE_FETCH_TIMEOUT', async () => {
+    const err = new TypeError('fetch failed')
+    global.fetch = jest.fn().mockRejectedValue(err)
+
+    await expect(fetchExternalImage(href, true, 0, 1)).rejects.toBe(err)
+  })
+
+  it('does not apply a timeout when set to 0', async () => {
+    const headers = new Map([
+      ['Content-Type', 'image/jpeg'],
+      ['Cache-Control', 'public, max-age=60'],
+      ['ETag', 'etag'],
+    ])
+    const res = {
+      ok: true,
+      status: 200,
+      headers,
+      arrayBuffer: jest
+        .fn()
+        .mockResolvedValue(new Uint8Array([0xff, 0xd8, 0xff])),
+    }
+    const fetchMock = jest.fn().mockResolvedValue(res)
+    global.fetch = fetchMock
+
+    const result = await fetchExternalImage(href, true, 0, 0)
+
+    const [, requestInit] = fetchMock.mock.calls[0]
+    expect(requestInit).toEqual({ redirect: 'manual' })
+    expect(Buffer.isBuffer(result.buffer)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

This PR introduces a new experimental configuration option, `experimental.imgFetchTimeoutInSeconds`, to make the upstream fetch timeout used by Next.js Image Optimization configurable for remote images.

The default behavior is unchanged (7s). Setting the value to `0` disables the upstream fetch timeout (no `AbortSignal.timeout` is attached).

## Motivation

Remote image optimization can fail on slower origins due to the hard-coded upstream fetch timeout. Making this timeout configurable allows applications to tune the bound while preserving Next.js’s default “bounded work” behavior.

## Changes

- Add `experimental.imgFetchTimeoutInSeconds` to the Next.js config schema/shared config:
  - Must be a finite, non-negative integer.
  - `undefined` => default remains 7 seconds (no behavior change).
  - `0` => disable upstream fetch timeout (no `AbortSignal.timeout`; upstream waits can be unbounded).

- Apply the configured fetch timeout in the remote image fetch path used by `/_next/image`.

- Harden timeout detection and ensure stable error semantics:
  - `TimeoutError` is always treated as an upstream fetch timeout.
  - `AbortError` (including `err.cause`) is treated as an upstream fetch timeout only when a timeout signal was attached for that request.
  - Upstream fetch timeouts map to `ImageError` 504 with a stable `code` (e.g. `IMAGE_FETCH_TIMEOUT`).

- Documentation updates:
  - Document `experimental.imgFetchTimeoutInSeconds` for both App Router (`next/image`) and Pages Router legacy Image docs, including the `0` escape hatch and warning about unbounded waits.

## Behavior / Compatibility

- Default behavior remains unchanged: upstream remote image fetch timeout is 7s unless configured.
- No redirect fallback is introduced; timeouts continue to surface as 504.
- This PR does not implement request header/cookie forwarding for remote images (out of scope; requires careful cache-key isolation and security considerations).

## Config example

```js
// next.config.js
module.exports = {
  experimental: {
    imgFetchTimeoutInSeconds: 30, // 0 disables the upstream fetch timeout
  },
}
```

Note: experimental.imgOptTimeoutInSeconds continues to control the Sharp processing timeout; this new option only affects the upstream fetch timeout.

## Tests

- pnpm --filter next build
- pnpm jest --runTestsByPath test/unit/image-optimizer/fetch-external-image.test.ts
- pnpm jest --runTestsByPath test/integration/image-optimizer/test/index.test.ts

## Related

- #72951 (configurable upstream timeout for remote image fetching)
- #72072 (discussion around hard-coded upstream fetch timeout)
- #76931 (header forwarding for remote images; intentionally out of scope here)