### PR TITLE
[strict-route-types] Typecheck pages router routes in absence of App Router

### DIFF
--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -20,6 +20,7 @@ import { hrtimeDurationToString } from './duration-to-string'
 function verifyTypeScriptSetup(
   dir: string,
   distDir: string,
+  strictRouteTypes: boolean,
   typeCheckPreflight: boolean,
   tsconfigPath: string | undefined,
   disableStaticImages: boolean,
@@ -50,6 +51,7 @@ function verifyTypeScriptSetup(
     .verifyTypeScriptSetup({
       dir,
       distDir,
+      strictRouteTypes,
       typeCheckPreflight,
       tsconfigPath,
       disableStaticImages,
@@ -117,6 +119,7 @@ export async function startTypeChecking({
         verifyTypeScriptSetup(
           dir,
           config.distDir,
+          Boolean(config.experimental.strictRouteTypes),
           !ignoreTypeScriptErrors,
           config.typescript.tsconfigPath,
           config.images.disableStaticImages,

--- a/packages/next/src/cli/next-test.ts
+++ b/packages/next/src/cli/next-test.ts
@@ -140,6 +140,7 @@ async function runPlaywright(
     const { version: typeScriptVersion } = await verifyTypeScriptSetup({
       dir: baseDir,
       distDir: nextConfig.distDir,
+      strictRouteTypes: Boolean(nextConfig.experimental.strictRouteTypes),
       typeCheckPreflight: false,
       tsconfigPath: nextConfig.typescript.tsconfigPath,
       disableStaticImages: nextConfig.images.disableStaticImages,

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -54,9 +54,12 @@ const nextTypegen = async (
   const distDir = join(baseDir, nextConfig.distDir)
   const { pagesDir, appDir } = findPagesDir(baseDir)
 
+  const strictRouteTypes = Boolean(nextConfig.experimental.strictRouteTypes)
+
   await verifyTypeScriptSetup({
     dir: baseDir,
     distDir: nextConfig.distDir,
+    strictRouteTypes,
     typeCheckPreflight: false,
     tsconfigPath: nextConfig.typescript.tsconfigPath,
     disableStaticImages: nextConfig.images.disableStaticImages,
@@ -172,7 +175,7 @@ const nextTypegen = async (
   await writeValidatorFile(
     routeTypesManifest,
     validatorFilePath,
-    Boolean(nextConfig.experimental.strictRouteTypes)
+    strictRouteTypes
   )
 
   // Generate cache-life types if cacheLife config exists

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.test.ts
@@ -16,6 +16,7 @@ describe('writeConfigurationDefaults()', () => {
   let isFirstTimeSetup: boolean
   let hasPagesDir: boolean
   let isolatedDevBuild = true
+  let experimentalStrictRouteTypes = true
 
   beforeEach(async () => {
     consoleLogSpy = jest.spyOn(console, 'log').mockImplementation()
@@ -47,7 +48,8 @@ describe('writeConfigurationDefaults()', () => {
         hasAppDir,
         distDir,
         hasPagesDir,
-        isolatedDevBuild
+        isolatedDevBuild,
+        experimentalStrictRouteTypes
       )
 
       const tsConfig = JSON.parse(
@@ -137,7 +139,8 @@ describe('writeConfigurationDefaults()', () => {
         hasAppDir,
         distDir,
         hasPagesDir,
-        isolatedDevBuild
+        isolatedDevBuild,
+        experimentalStrictRouteTypes
       )
 
       expect(stripAnsi(consoleLogSpy.mock.calls.flat().join('\n'))).not.toMatch(
@@ -170,7 +173,8 @@ describe('writeConfigurationDefaults()', () => {
             hasAppDir,
             distDir,
             hasPagesDir,
-            isolatedDevBuild
+            isolatedDevBuild,
+            experimentalStrictRouteTypes
           )
         ).resolves.not.toThrow()
 

--- a/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
+++ b/packages/next/src/lib/typescript/writeConfigurationDefaults.ts
@@ -190,7 +190,8 @@ export async function writeConfigurationDefaults(
   hasAppDir: boolean,
   distDir: string,
   hasPagesDir: boolean,
-  isolatedDevBuild: boolean | undefined
+  isolatedDevBuild: boolean | undefined,
+  strictRouteTypes: boolean
 ): Promise<void> {
   if (isFirstTimeSetup) {
     writeFileSync(tsConfigPath, '{}' + os.EOL)
@@ -276,27 +277,27 @@ export async function writeConfigurationDefaults(
 
   // Get type definition glob patterns using shared utility to ensure consistency
   // with other TypeScript infrastructure (e.g., runTypeCheck.ts)
-  const nextAppTypes = getTypeDefinitionGlobPatterns(
+  const nextTypes = getTypeDefinitionGlobPatterns(
     distDir,
     resolvedIsolatedDevBuild
   )
 
   if (!('include' in userTsConfig)) {
-    userTsConfig.include = hasAppDir
-      ? ['next-env.d.ts', ...nextAppTypes, '**/*.mts', '**/*.ts', '**/*.tsx']
-      : ['next-env.d.ts', '**/*.mts', '**/*.ts', '**/*.tsx']
+    const defaultInclude =
+      hasAppDir || strictRouteTypes
+        ? ['next-env.d.ts', ...nextTypes, '**/*.mts', '**/*.ts', '**/*.tsx']
+        : ['next-env.d.ts', '**/*.mts', '**/*.ts', '**/*.tsx']
+
+    userTsConfig.include = defaultInclude
     suggestedActions.push(
       cyan('include') +
-        ' was set to ' +
-        bold(
-          hasAppDir
-            ? `['next-env.d.ts', ${nextAppTypes.map((type) => `'${type}'`).join(', ')}, '**/*.mts', '**/*.ts', '**/*.tsx']`
-            : `['next-env.d.ts', '**/*.mts', '**/*.ts', '**/*.tsx']`
-        )
+        ' was set to [' +
+        bold(defaultInclude.map((type) => `'${type}'`).join(', ')) +
+        ']'
     )
-  } else if (hasAppDir) {
+  } else if (hasAppDir || strictRouteTypes) {
     const missingFromResolved = []
-    for (const type of nextAppTypes) {
+    for (const type of nextTypes) {
       if (!userTsConfig.include.includes(type)) {
         missingFromResolved.push(type)
       }

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -37,6 +37,7 @@ export async function verifyTypeScriptSetup({
   dir,
   distDir,
   cacheDir,
+  strictRouteTypes,
   tsconfigPath,
   typeCheckPreflight,
   disableStaticImages,
@@ -50,6 +51,7 @@ export async function verifyTypeScriptSetup({
   dir: string
   distDir: string
   cacheDir?: string
+  strictRouteTypes: boolean
   tsconfigPath: string | undefined
   typeCheckPreflight: boolean
   disableStaticImages: boolean
@@ -136,7 +138,8 @@ export async function verifyTypeScriptSetup({
       hasAppDir,
       distDir,
       hasPagesDir,
-      isolatedDevBuild
+      isolatedDevBuild,
+      strictRouteTypes
     )
     // Write out the necessary `next-env.d.ts` file to correctly register
     // Next.js' types:

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -143,6 +143,7 @@ async function verifyTypeScript(opts: SetupOpts) {
   const verifyResult = await verifyTypeScriptSetup({
     dir: opts.dir,
     distDir: opts.nextConfig.distDir,
+    strictRouteTypes: Boolean(opts.nextConfig.experimental.strictRouteTypes),
     typeCheckPreflight: false,
     tsconfigPath: opts.nextConfig.typescript.tsconfigPath,
     disableStaticImages: opts.nextConfig.images.disableStaticImages,

--- a/test/e2e/tsconfig-module-preserve/index.test.ts
+++ b/test/e2e/tsconfig-module-preserve/index.test.ts
@@ -2,6 +2,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
+const strictRouteTypes =
+  process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
+
 describe('tsconfig module: preserve', () => {
   const { next, skipped } = nextTestSetup({
     files: {
@@ -37,35 +40,70 @@ describe('tsconfig module: preserve', () => {
     expect(output).not.toContain('esModuleInterop')
     expect(output).not.toContain('resolveJsonModule')
 
-    expect(await next.readFile('tsconfig.json')).toMatchInlineSnapshot(`
-      "{
-        "compilerOptions": {
-          "module": "preserve",
-          "target": "ES2017",
-          "lib": [
-            "dom",
-            "dom.iterable",
-            "esnext"
-          ],
-          "allowJs": true,
-          "skipLibCheck": true,
-          "strict": false,
-          "noEmit": true,
-          "incremental": true,
-          "isolatedModules": true,
-          "jsx": "react-jsx"
-        },
-        "include": [
-          "next-env.d.ts",
-          "**/*.mts",
-          "**/*.ts",
-          "**/*.tsx"
-        ],
-        "exclude": [
-          "node_modules"
-        ]
-      }
-      "
-    `)
+    if (strictRouteTypes) {
+      expect(await next.readFile('tsconfig.json')).toMatchInlineSnapshot(`
+       "{
+         "compilerOptions": {
+           "module": "preserve",
+           "target": "ES2017",
+           "lib": [
+             "dom",
+             "dom.iterable",
+             "esnext"
+           ],
+           "allowJs": true,
+           "skipLibCheck": true,
+           "strict": false,
+           "noEmit": true,
+           "incremental": true,
+           "isolatedModules": true,
+           "jsx": "react-jsx"
+         },
+         "include": [
+           "next-env.d.ts",
+           ".next/types/**/*.ts",
+           ".next/dev/types/**/*.ts",
+           "**/*.mts",
+           "**/*.ts",
+           "**/*.tsx"
+         ],
+         "exclude": [
+           "node_modules"
+         ]
+       }
+       "
+      `)
+    } else {
+      expect(await next.readFile('tsconfig.json')).toMatchInlineSnapshot(`
+       "{
+         "compilerOptions": {
+           "module": "preserve",
+           "target": "ES2017",
+           "lib": [
+             "dom",
+             "dom.iterable",
+             "esnext"
+           ],
+           "allowJs": true,
+           "skipLibCheck": true,
+           "strict": false,
+           "noEmit": true,
+           "incremental": true,
+           "isolatedModules": true,
+           "jsx": "react-jsx"
+         },
+         "include": [
+           "next-env.d.ts",
+           "**/*.mts",
+           "**/*.ts",
+           "**/*.tsx"
+         ],
+         "exclude": [
+           "node_modules"
+         ]
+       }
+       "
+      `)
+    }
   })
 })


### PR DESCRIPTION
Flagged behind `experimental.strictRouteTypes`

Pages Router routes were only type-checked when App Router was also used. This adds an additional cliff when adding App Router pages. It also hid bugs in the typechecking for Pages Router routes (e.g. https://github.com/vercel/next.js/pull/87633)

Now we always typecheck all routes for all cominbations: pure Pages Router, pure App Router, hybrid Pages/App router.

 