### PR TITLE
[strict-route-types] Don't reject `number` in `config.api.bodyParser.sizeLimit` when validating route

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -574,7 +574,7 @@ export function generateValidatorFile(
   default: (req: any, res: any) => ReturnType<NextApiHandler>
   config?: {
     api?: {
-      bodyParser?: boolean | { sizeLimit?: string }
+      bodyParser?: boolean | { sizeLimit?: number | string }
       responseLimit?: string | number | boolean
       externalResolver?: boolean
     }
@@ -809,7 +809,7 @@ export function generateValidatorFileStrict(
   default: (req: any, res: any) => ReturnType<NextApiHandler>
   config?: {
     api?: {
-      bodyParser?: boolean | { sizeLimit?: string }
+      bodyParser?: boolean | { sizeLimit?: number | string }
       responseLimit?: string | number | boolean
       externalResolver?: boolean
     }


### PR DESCRIPTION
Not flagged behind `experimental.strictRouteTypes`. This is just a bug fix.

Got revealed once we typechecked routes in pure Pages Router apps e.g.
```
.next/types/validator.ts:76:11
Type error: Type 'typeof import("~/pages/api/hello")' does not satisfy the expected type 'ApiRouteConfig'.
  The types of 'config.api.bodyParser' are incompatible between these types.
    Type 'false | { sizeLimit?: SizeLimit; }' is not assignable to type 'boolean | { sizeLimit?: string; }'.
      Type '{ sizeLimit?: SizeLimit; }' is not assignable to type 'boolean | { sizeLimit?: string; }'.
        Type '{ sizeLimit?: SizeLimit; }' is not assignable to type '{ sizeLimit?: string; }'.
          Types of property 'sizeLimit' are incompatible.
            Type 'SizeLimit' is not assignable to type 'string'.
              Type 'number' is not assignable to type 'string'.
```
-- https://github.com/vercel/next.js/actions/runs/20427462435/job/58690778302?pr=87628#step:32:562

Closes https://linear.app/vercel/issue/NXT-121