### PR TITLE
fix: correct quotes in dev script filter in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "lerna clean -y && lerna bootstrap && lerna run clean && lerna exec 'node ../../scripts/rm.mjs dist'",
     "build": "turbo run build --remote-cache-timeout 60 --summarize true",
     "lerna": "lerna",
-    "dev": "turbo run dev --parallel --filter='!@next/bundle-analyzer-ui'",
+    "dev": "turbo run dev --parallel --filter=\"!@next/bundle-analyzer-ui\"",
     "pack-next": "tsx scripts/pack-next.ts",
     "test-types": "tsc",
     "test-unit": "jest test/unit/ packages/next/ packages/font",


### PR DESCRIPTION
### What?
Fixes a pnpm workspace resolution error where the `dev` script attempted to
filter `@next/bundle-analyzer-ui`, which is not defined as a workspace package,
resulting in:

`No package found with name '@next/bundle-analyzer-ui' in workspace`

### Why?
When running `pnpm dev`, Turbo tries to resolve all filtered packages.
Referencing a non-existent workspace causes pnpm to fail early, breaking
local development.

### How?
Updates the `dev` script to explicitly exclude `@next/bundle-analyzer-ui`
from the Turbo dev task, preventing pnpm from attempting to resolve a
non-workspace package.

No functional behavior is changed beyond avoiding the resolution error.

Fixes #87636 
