### PR TITLE
fix(examples): resolve hydration mismatch in blog-starter

### DIFF
--- a/examples/blog-starter/src/app/layout.tsx
+++ b/examples/blog-starter/src/app/layout.tsx
@@ -23,7 +23,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link
           rel="apple-touch-icon"


### PR DESCRIPTION
## What?
Add `suppressHydrationWarning` to the `<html>` element in the blog-starter example.

## Why?
The ThemeSwitcher script runs before React hydration and adds `dark` class and `data-mode` attribute to the `<html>` element, causing a hydration mismatch error.

## How?
Add `suppressHydrationWarning` to the `<html>` element to tell React this mismatch is intentional.

Fixes #74586