### PR TITLE
fix(examples): use --watchAll in jest examples

### DIFF
--- a/examples/with-jest-babel/package.json
+++ b/examples/with-jest-babel/package.json
@@ -4,7 +4,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest --watch",
+    "test": "jest --watchAll",
     "test:ci": "jest --ci"
   },
   "dependencies": {

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -4,7 +4,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "jest --watch",
+    "test": "jest --watchAll",
     "test:ci": "jest --ci"
   },
   "dependencies": {


### PR DESCRIPTION
## What?
Replace `jest --watch` with `jest --watchAll` in jest example package.json files.

## Why?
`jest --watch` requires git to track changed files. In a freshly cloned example with no changes, it fails with an unhelpful error.

## How?
Use `--watchAll` which watches all files regardless of git status.

Fixes #69236