### PR TITLE
Update mdx.mdx

### DIFF
--- a/docs/01-app/02-guides/mdx.mdx
+++ b/docs/01-app/02-guides/mdx.mdx
@@ -292,7 +292,7 @@ export function generateStaticParams() {
   return [{ slug: 'welcome' }, { slug: 'about' }]
 }
 
-export const dynamicParams = false
+export const dynamicParams = false // not compatible nor necessary with cacheComponents
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher


### PR DESCRIPTION
Using `export const dynamicParams = false` with `cacheComponents` results in an error:

<img width="1680" height="985" alt="Screenshot 2025-12-23 at 5 27 00 PM" src="https://github.com/user-attachments/assets/b4d50f21-cfbe-4d9b-a788-6751dd62d61e" />
<br />
<br />
Seems unnecessary with `cacheComponents` as well.