### PR TITLE
docs: update link for search parameters documentation

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/page.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/page.mdx
@@ -65,7 +65,7 @@ export default async function Page({ params }) {
 
 #### `searchParams` (optional)
 
-A promise that resolves to an object containing the [search parameters](https://developer.mozilla.org/docs/Learn/Common_questions/What_is_a_URL#parameters) of the current URL. For example:
+A promise that resolves to an object containing the [search parameters](https://developer.mozilla.org/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL#parameters) of the current URL. For example:
 
 ```tsx filename="app/shop/page.tsx" switcher
 export default async function Page({


### PR DESCRIPTION
## What was done

The current link explaining what search parameters are results in a `Page not found` error on MDN. I've updated the link to reflect the new location of the article in the Mozilla website.

Old link:
- https://developer.mozilla.org/docs/Learn/Common_questions/What_is_a_URL#parameters

New link:
- https://developer.mozilla.org/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_URL#parameters