### PR TITLE
Respect __NEXT_NO_MIDDLEWARE_URL_NORMALIZE during adapter URL construction

### DIFF
--- a/packages/next/src/server/web/adapter.test.ts
+++ b/packages/next/src/server/web/adapter.test.ts
@@ -1,0 +1,26 @@
+import type { AdapterOptions } from './adapter'
+import { adapter } from './adapter'
+import { normalizeRscURL } from '../../shared/lib/router/utils/app-paths'
+jest.mock('../../shared/lib/router/utils/app-paths', () => ({
+  normalizeRscURL: jest.fn((url: string) => url),
+}))
+
+describe('adapter', () => {
+  it('does not normalize the URL when __NEXT_NO_MIDDLEWARE_URL_NORMALIZE is set', async () => {
+    process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE = '1'
+
+    await adapter({
+      page: '/',
+      bypassNextUrl: true,
+      handler: async () => new Response(null),
+      request: {
+        url: 'http://example.com/test.rsc',
+        method: 'GET',
+        headers: {},
+        nextConfig: {},
+      },
+    } as unknown as AdapterOptions)
+
+    expect(normalizeRscURL).not.toHaveBeenCalled()
+  })
+})

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -115,11 +115,12 @@ export async function adapter(
   const isEdgeRendering =
     typeof (globalThis as any).__BUILD_MANIFEST !== 'undefined'
 
-  params.request.url = normalizeRscURL(params.request.url)
-
+  const baseUrl: string = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE
+    ? params.request.url
+    : normalizeRscURL(params.request.url)
   const requestURL = params.bypassNextUrl
-    ? new URL(params.request.url)
-    : new NextURL(params.request.url, {
+    ? new URL(baseUrl)
+    : new NextURL(baseUrl, {
         headers: params.request.headers,
         nextConfig: params.request.nextConfig,
       })
@@ -168,16 +169,12 @@ export async function adapter(
     }
   }
 
-  const normalizeURL = process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE
-    ? new URL(params.request.url)
-    : requestURL
-
-  const rscHash = normalizeURL.searchParams.get(NEXT_RSC_UNION_QUERY)
+  const rscHash = requestURL.searchParams.get(NEXT_RSC_UNION_QUERY)
 
   const request = new NextRequestHint({
     page: params.page,
     // Strip internal query parameters off the request.
-    input: stripInternalSearchParams(normalizeURL).toString(),
+    input: stripInternalSearchParams(requestURL).toString(),
     init: {
       body: params.request.body,
       headers: requestHeaders,


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- Related issues linked using `fixes #number` (if applicable)
- Tests added
- No new errors introduced

---

## For Maintainers

### What?

Fixes an issue where `__NEXT_NO_MIDDLEWARE_URL_NORMALIZE` was ignored during adapter URL construction, causing request URLs to be normalized even when normalization was explicitly disabled.

### Why?

The adapter always normalized the request URL via `normalizeRscURL()` before checking the flag, making the flag ineffective and causing middleware to observe a mutated URL.

### How?

Stop mutating `params.request.url` and gate `normalizeRscURL()` at URL construction time so normalization only occurs when allowed.

Fixes #87779