### PR TITLE
Pass loading boundary as part of RSC data

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -424,6 +424,7 @@ function Router({
       parentCacheNode: cache,
       parentSegmentPath: null,
       parentParams: {},
+      parentLoadingData: null,
       // This is the <Activity> "name" that shows up in the Suspense DevTools.
       // It represents the root of the app.
       debugNameContext: '/',

--- a/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
+++ b/packages/next/src/client/components/router-reducer/reducers/find-head-in-cache.test.tsx
@@ -34,7 +34,6 @@ describe('findHeadInCache', () => {
       prefetchRsc: null,
       head: null,
       prefetchHead: null,
-      loading: null,
       parallelRoutes: new Map([
         [
           'children',
@@ -47,7 +46,6 @@ describe('findHeadInCache', () => {
                 prefetchRsc: null,
                 head: null,
                 prefetchHead: null,
-                loading: null,
                 parallelRoutes: new Map([
                   [
                     'children',
@@ -58,7 +56,6 @@ describe('findHeadInCache', () => {
                           navigatedAt,
                           head: null,
                           prefetchHead: null,
-                          loading: null,
                           parallelRoutes: new Map([
                             [
                               'children',
@@ -70,7 +67,6 @@ describe('findHeadInCache', () => {
                                     rsc: null,
                                     prefetchRsc: null,
                                     prefetchHead: null,
-                                    loading: null,
                                     parallelRoutes: new Map(),
                                     head: null,
                                   },

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -5,7 +5,6 @@ import type {
   InitialRSCPayload,
   DynamicParamTypesShort,
   HeadData,
-  LoadingModuleData,
 } from '../../shared/lib/app-router-types'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
@@ -68,7 +67,6 @@ export type TreePrefetch = {
 export type SegmentPrefetch = {
   buildId: string
   rsc: React.ReactNode | null
-  loading: LoadingModuleData | Promise<LoadingModuleData>
   isPartial: boolean
 }
 
@@ -243,13 +241,7 @@ async function PrefetchTreeData({
   // the client cache.
   segmentTasks.push(
     waitAtLeastOneReactRenderTask().then(() =>
-      renderSegmentPrefetch(
-        buildId,
-        head,
-        null,
-        HEAD_REQUEST_KEY,
-        clientModules
-      )
+      renderSegmentPrefetch(buildId, head, HEAD_REQUEST_KEY, clientModules)
     )
   )
 
@@ -316,13 +308,7 @@ function collectSegmentDataImpl(
       // Since we're already in the middle of a render, wait until after the
       // current task to escape the current rendering context.
       waitAtLeastOneReactRenderTask().then(() =>
-        renderSegmentPrefetch(
-          buildId,
-          seedData[0],
-          seedData[2],
-          requestKey,
-          clientModules
-        )
+        renderSegmentPrefetch(buildId, seedData[0], requestKey, clientModules)
       )
     )
   } else {
@@ -364,7 +350,6 @@ function collectSegmentDataImpl(
 async function renderSegmentPrefetch(
   buildId: string,
   rsc: React.ReactNode,
-  loading: LoadingModuleData | Promise<LoadingModuleData>,
   requestKey: SegmentRequestKey,
   clientModules: ManifestNode
 ): Promise<[SegmentRequestKey, Buffer]> {
@@ -374,7 +359,6 @@ async function renderSegmentPrefetch(
   const segmentPrefetch: SegmentPrefetch = {
     buildId,
     rsc,
-    loading,
     isPartial: await isPartialRSCData(rsc, clientModules),
   }
   // Since all we're doing is decoding and re-encoding a cached prerender, if

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -13,7 +13,10 @@ export { prerender } from 'react-server-dom-webpack/static'
 // TODO: Just re-export `* as ReactServer`
 export { captureOwnerStack, createElement, Fragment } from 'react'
 
-export { default as LayoutRouter } from '../../client/components/layout-router'
+export {
+  default as LayoutRouter,
+  LoadingBoundaryProvider,
+} from '../../client/components/layout-router'
 export { default as RenderFromTemplateContext } from '../../client/components/render-from-template-context'
 export { workAsyncStorage } from '../app-render/work-async-storage.external'
 export { workUnitAsyncStorage } from './work-unit-async-storage.external'

--- a/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/app-router-context.shared-runtime.ts
@@ -9,6 +9,7 @@ import type {
   FlightRouterState,
   FlightSegmentPath,
   CacheNode,
+  LoadingModuleData,
 } from './app-router-types'
 import React from 'react'
 
@@ -63,6 +64,7 @@ export const LayoutRouterContext = React.createContext<{
   parentCacheNode: CacheNode
   parentSegmentPath: FlightSegmentPath | null
   parentParams: Params
+  parentLoadingData: LoadingModuleData | null
   debugNameContext: string
   url: string
   isActive: boolean

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -48,8 +48,6 @@ export type CacheNode = {
 
   head: HeadData
 
-  loading: LoadingModuleData | Promise<LoadingModuleData>
-
   parallelRoutes: Map<string, ChildSegmentMap>
 
   /**
@@ -191,7 +189,8 @@ export type CacheNodeSeedData = [
   parallelRoutes: {
     [parallelRouterKey: string]: CacheNodeSeedData | null
   },
-  loading: LoadingModuleData | Promise<LoadingModuleData>,
+  // TODO: This field is no longer used. Remove it.
+  loading: null,
   isPartial: boolean,
   /** TODO: this doesn't feel like it belongs here, because it's only used during build, in `collectSegmentData` */
   hasRuntimePrefetch: boolean,

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -701,7 +701,7 @@ describe('opentelemetry', () => {
                       },
                       {
                         attributes: {
-                          'next.clientComponentLoadCount': isNextDev ? 7 : 6,
+                          'next.clientComponentLoadCount': isNextDev ? 8 : 7,
                           'next.span_type':
                             'NextNodeServer.clientComponentLoading',
                         },


### PR DESCRIPTION
Based on:

- https://github.com/vercel/next.js/pull/87203
- https://github.com/vercel/next.js/pull/87256
- https://github.com/vercel/next.js/pull/87293

---

Removes the `loading` as a separate field in the server response payload. Instead, it is passed as part of the component data (the `rsc` field).

This simplifies much of the logic on the client because, logically, they were already coupled. Unifying the fields removes the possibility that they'll get out of sync due to some implementation mistake.