### PR TITLE
fix(types): apply AppType generic to top-level props #42846

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<any, any> & P
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
### Fixing a bug

- Related issues linked using `fixes #42846`
- This PR ensures that the generic type parameter `P` in `AppType` is applied to the top-level props instead of being nested inside `pageProps`. This allows developers to access custom props passed to the custom App component without TypeScript errors.

### Testing
- Verified by creating a test page in `examples/with-typescript` using a custom `AppType` with additional props.
- Ran `pnpm build` in the root directory and confirmed that all 14 tasks finished successfully.