### PR TITLE
Add path validation check to ouputFileTracingRoot, turbopack.root

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -973,5 +973,9 @@
   "972": "Failed to resolve pattern \"%s\": %s",
   "973": "Server Actions are not enabled for this application. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "974": "Failed to find Server Action%s. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
-  "975": "Failed to find Server Action. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action"
+  "975": "Failed to find Server Action. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
+  "976": "Specified outputFileTracingRoot is not a directory, received %s",
+  "977": "turbopack.root path provided does not exist, received %s",
+  "978": "Specified turbopack.root is not a directory, received %s",
+  "979": "outputFileTracingRoot path provided does not exist, received %s"
 }

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'fs'
+import { existsSync, statSync } from 'fs'
 import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
 import { pathToFileURL } from 'url'
 import findUp from 'next/dist/compiled/find-up'
@@ -895,23 +895,49 @@ function assignDefaultsAndValidate(
     silent
   )
 
-  if (
-    result?.outputFileTracingRoot &&
-    !isAbsolute(result.outputFileTracingRoot)
-  ) {
-    result.outputFileTracingRoot = resolve(result.outputFileTracingRoot)
-    if (!silent) {
-      Log.warn(
-        `outputFileTracingRoot should be absolute, using: ${result.outputFileTracingRoot}`
+  if (result?.outputFileTracingRoot) {
+    if (!isAbsolute(result.outputFileTracingRoot)) {
+      result.outputFileTracingRoot = resolve(result.outputFileTracingRoot)
+      if (!silent) {
+        Log.warn(
+          `outputFileTracingRoot should be absolute, using: ${result.outputFileTracingRoot}`
+        )
+      }
+    }
+
+    const tracingRoot = result.outputFileTracingRoot
+    if (!existsSync(tracingRoot)) {
+      throw new Error(
+        `outputFileTracingRoot path provided does not exist, received ${tracingRoot}`
+      )
+    }
+    if (!statSync(tracingRoot).isDirectory()) {
+      throw new Error(
+        `Specified outputFileTracingRoot is not a directory, received ${tracingRoot}`
       )
     }
   }
 
-  if (result?.turbopack?.root && !isAbsolute(result.turbopack.root)) {
-    result.turbopack.root = resolve(result.turbopack.root)
-    if (!silent) {
-      Log.warn(
-        `turbopack.root should be absolute, using: ${result.turbopack.root}`
+  if (result?.turbopack?.root) {
+    if (!isAbsolute(result.turbopack.root)) {
+      result.turbopack.root = resolve(result.turbopack.root)
+      if (!silent) {
+        Log.warn(
+          `turbopack.root should be absolute, using: ${result.turbopack.root}`
+        )
+      }
+    }
+
+    const turbopackRoot = result.turbopack.root
+    if (!existsSync(turbopackRoot)) {
+      throw new Error(
+        `turbopack.root path provided does not exist, received ${turbopackRoot}`
+      )
+    }
+
+    if (!statSync(turbopackRoot).isDirectory()) {
+      throw new Error(
+        `Specified turbopack.root is not a directory, received ${turbopackRoot}`
       )
     }
   }

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -174,45 +174,50 @@ describe('config', () => {
 
   describe('outputFileTracingRoot and turbopack.root consistency', () => {
     it('Should set both outputFileTracingRoot and turbopack.root to the same value when only outputFileTracingRoot is provided', async () => {
+      const validDir = join(__dirname, '_resolvedata', 'aa')
       const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
         customConfig: {
-          outputFileTracingRoot: '/custom/root',
+          outputFileTracingRoot: validDir,
         },
       })
-      expect(config.outputFileTracingRoot).toBe('/custom/root')
-      expect(config.turbopack.root).toBe('/custom/root')
+      expect(config.outputFileTracingRoot).toBe(validDir)
+      expect(config.turbopack.root).toBe(validDir)
     })
 
     it('Should set both outputFileTracingRoot and turbopack.root to the same value when only turbopack.root is provided', async () => {
+      const validDir = join(__dirname, '_resolvedata', 'bb')
       const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
         customConfig: {
-          turbopack: { root: '/custom/root' },
+          turbopack: { root: validDir },
         },
       })
-      expect(config.outputFileTracingRoot).toBe('/custom/root')
-      expect(config.turbopack.root).toBe('/custom/root')
+      expect(config.outputFileTracingRoot).toBe(validDir)
+      expect(config.turbopack.root).toBe(validDir)
     })
 
     it('Should use outputFileTracingRoot value when both are provided with different values', async () => {
+      const tracingDir = join(__dirname, '_resolvedata', 'aa')
+      const turboDir = join(__dirname, '_resolvedata', 'bb')
       const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
         customConfig: {
-          outputFileTracingRoot: '/tracing/root',
-          turbopack: { root: '/turbo/root' },
+          outputFileTracingRoot: tracingDir,
+          turbopack: { root: turboDir },
         },
       })
-      expect(config.outputFileTracingRoot).toBe('/tracing/root')
-      expect(config.turbopack.root).toBe('/tracing/root')
+      expect(config.outputFileTracingRoot).toBe(tracingDir)
+      expect(config.turbopack.root).toBe(tracingDir)
     })
 
     it('Should keep the same value when both are provided with matching values', async () => {
+      const sameDir = join(__dirname, '_resolvedata', 'cc')
       const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
         customConfig: {
-          outputFileTracingRoot: '/same/root',
-          turbopack: { root: '/same/root' },
+          outputFileTracingRoot: sameDir,
+          turbopack: { root: sameDir },
         },
       })
-      expect(config.outputFileTracingRoot).toBe('/same/root')
-      expect(config.turbopack.root).toBe('/same/root')
+      expect(config.outputFileTracingRoot).toBe(sameDir)
+      expect(config.turbopack.root).toBe(sameDir)
     })
 
     it('Should set both to findRootDir result when neither is provided', async () => {
@@ -221,6 +226,30 @@ describe('config', () => {
       })
       expect(config.outputFileTracingRoot).toBeDefined()
       expect(config.turbopack.root).toBe(config.outputFileTracingRoot)
+    })
+
+    it('Should throw when outputFileTracingRoot does not exist', async () => {
+      await expect(async () => {
+        await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {
+            outputFileTracingRoot: '/invalid/path',
+          },
+        })
+      }).rejects.toThrow(
+        /outputFileTracingRoot path provided does not exist, received \/invalid\/path/
+      )
+    })
+
+    it('Should throw when turbopack.root does not exist', async () => {
+      await expect(async () => {
+        await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {
+            turbopack: { root: '/invalid/path' },
+          },
+        })
+      }).rejects.toThrow(
+        /turbopack\.root path provided does not exist, received \/invalid\/path/
+      )
     })
   })
 })


### PR DESCRIPTION
### What?
Fix TurbopackInternalError on build due to misconfiguration of project root directory via outputFileTracingRoot or turbopack.root. Due to the straightforward nature of the error, a helpful link was not included.
 
### Why?
See #87881

### How?
Adding a check to assignDefaultsAndValidate that both values exist and are directories.

Closes NEXT-
Fixes #87881

### Tests
Added a test to `config.test.ts`. The existing implementation had two unit tests with fake paths that were now failing - these were updated to use real paths.