### PR TITLE
perf(turbopack): use trace_span in tracing::intrument

### DIFF
--- a/crates/napi/src/next_api/endpoint.rs
+++ b/crates/napi/src/next_api/endpoint.rs
@@ -122,7 +122,7 @@ async fn get_written_endpoint_with_issues_operation(
     .cell())
 }
 
-#[tracing::instrument(level = "info", name = "write endpoint to disk", skip_all)]
+#[tracing::instrument(level = "trace", name = "write endpoint to disk", skip_all)]
 #[napi]
 pub async fn endpoint_write_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
@@ -156,7 +156,7 @@ pub async fn endpoint_write_to_disk(
     })
 }
 
-#[tracing::instrument(level = "info", name = "get server-side endpoint changes", skip_all)]
+#[tracing::instrument(level = "trace", name = "get server-side endpoint changes", skip_all)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_server_changed_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
@@ -175,7 +175,7 @@ pub fn endpoint_server_changed_subscribe(
                 result.effects.apply().await?;
                 Ok(result)
             }
-            .instrument(tracing::info_span!("server changes subscription"))
+            .instrument(tracing::trace_span!("server changes subscription"))
         },
         |ctx| {
             let EndpointIssuesAndDiags {
@@ -247,7 +247,7 @@ async fn subscribe_issues_and_diags_operation(
     }
 }
 
-#[tracing::instrument(level = "info", name = "get client-side endpoint changes", skip_all)]
+#[tracing::instrument(level = "trace", name = "get client-side endpoint changes", skip_all)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn endpoint_client_changed_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Endpoint\" }")] endpoint: External<ExternalEndpoint>,
@@ -270,7 +270,7 @@ pub fn endpoint_client_changed_subscribe(
                 let _ = changed_op.read_strongly_consistent().await?;
                 Ok(())
             }
-            .instrument(tracing::info_span!("client changes subscription"))
+            .instrument(tracing::trace_span!("client changes subscription"))
         },
         |_| {
             Ok(vec![TurbopackResult {

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -554,7 +554,7 @@ pub fn project_new(
                             println!("Failed to benchmark file I/O: {err}");
                         }
                     }
-                    .instrument(tracing::info_span!("benchmark file I/O"))
+                    .instrument(tracing::trace_span!("benchmark file I/O"))
                 });
             }
 
@@ -564,7 +564,7 @@ pub fn project_new(
                 exit_receiver: tokio::sync::Mutex::new(Some(exit_receiver)),
             }))
         }
-        .instrument(tracing::info_span!("create project")),
+        .instrument(tracing::trace_span!("create project")),
     )
 }
 
@@ -638,7 +638,9 @@ async fn benchmark_file_io(turbo_tasks: NextTurboTasks, directory: FileSystemPat
         }
         anyhow::Ok(())
     }
-    .instrument(tracing::info_span!("benchmark file IO (measurement)", path = %temp_path.display()))
+    .instrument(
+        tracing::trace_span!("benchmark file IO (measurement)", path = %temp_path.display()),
+    )
     .await?;
 
     let duration = Instant::now().duration_since(start);
@@ -652,7 +654,7 @@ async fn benchmark_file_io(turbo_tasks: NextTurboTasks, directory: FileSystemPat
     Ok(())
 }
 
-#[tracing::instrument(level = "info", name = "update project", skip_all)]
+#[tracing::instrument(level = "trace", name = "update project", skip_all)]
 #[napi]
 pub async fn project_update(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -715,7 +717,7 @@ async fn project_on_exit_internal(project: &ProjectInstance) {
 /// This is used in builds where it's important that we completely persist turbo-tasks to disk, but
 /// it's skipped in the development server (`project_on_exit` is used instead with a short timeout),
 /// where we prioritize fast exit and user responsiveness over all else.
-#[tracing::instrument(level = "info", name = "shutdown project", skip_all)]
+#[tracing::instrument(level = "trace", name = "shutdown project", skip_all)]
 #[napi]
 pub async fn project_shutdown(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -964,7 +966,7 @@ struct AllWrittenEntrypointsWithIssues {
     effects: Arc<Effects>,
 }
 
-#[tracing::instrument(level = "info", name = "write all entrypoints to disk", skip_all)]
+#[tracing::instrument(level = "trace", name = "write all entrypoints to disk", skip_all)]
 #[napi]
 pub async fn project_write_all_entrypoints_to_disk(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1081,7 +1083,7 @@ async fn output_assets_operation(
     ))
 }
 
-#[tracing::instrument(level = "info", name = "get entrypoints", skip_all)]
+#[tracing::instrument(level = "trace", name = "get entrypoints", skip_all)]
 #[napi]
 pub async fn project_entrypoints(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1124,7 +1126,7 @@ pub async fn project_entrypoints(
     })
 }
 
-#[tracing::instrument(level = "info", name = "subscribe to entrypoints", skip_all)]
+#[tracing::instrument(level = "trace", name = "subscribe to entrypoints", skip_all)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_entrypoints_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1150,7 +1152,7 @@ pub fn project_entrypoints_subscribe(
                 effects.apply().await?;
                 Ok((entrypoints.clone(), issues.clone(), diagnostics.clone()))
             }
-            .instrument(tracing::info_span!("entrypoints subscription"))
+            .instrument(tracing::trace_span!("entrypoints subscription"))
         },
         move |ctx| {
             let (entrypoints, issues, diags) = ctx.value;
@@ -1211,7 +1213,7 @@ fn project_hmr_update_operation(
     project.hmr_update(identifier, *state)
 }
 
-#[tracing::instrument(level = "info", name = "get HMR events", skip(project, func))]
+#[tracing::instrument(level = "trace", name = "get HMR events", skip(project, func))]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_hmr_events(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1334,7 +1336,7 @@ fn project_container_hmr_identifiers_operation(
     container.hmr_identifiers()
 }
 
-#[tracing::instrument(level = "info", name = "get HMR identifiers", skip_all)]
+#[tracing::instrument(level = "trace", name = "get HMR identifiers", skip_all)]
 #[napi(ts_return_type = "{ __napiType: \"RootTask\" }")]
 pub fn project_hmr_identifiers_subscribe(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1711,7 +1713,7 @@ pub async fn project_trace_source_operation(
     })))
 }
 
-#[tracing::instrument(level = "info", name = "apply SourceMap to stack frame", skip_all)]
+#[tracing::instrument(level = "trace", name = "apply SourceMap to stack frame", skip_all)]
 #[napi]
 pub async fn project_trace_source(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1738,7 +1740,7 @@ pub async fn project_trace_source(
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
-#[tracing::instrument(level = "info", name = "get source content for asset", skip_all)]
+#[tracing::instrument(level = "trace", name = "get source content for asset", skip_all)]
 #[napi]
 pub async fn project_get_source_for_asset(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
@@ -1772,7 +1774,7 @@ pub async fn project_get_source_for_asset(
         .map_err(|e| napi::Error::from_reason(PrettyPrintError(&e.into()).to_string()))
 }
 
-#[tracing::instrument(level = "info", name = "get SourceMap for asset", skip_all)]
+#[tracing::instrument(level = "trace", name = "get SourceMap for asset", skip_all)]
 #[napi]
 pub async fn project_get_source_map(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -986,7 +986,7 @@ impl AppProject {
                 }
                 .cell())
             }
-            .instrument(tracing::info_span!("module graph for endpoint"))
+            .instrument(tracing::trace_span!("module graph for endpoint"))
             .await
         } else {
             Ok(self.project.whole_app_module_graphs())
@@ -1947,19 +1947,19 @@ impl Endpoint for AppEndpoint {
                 ty: AppPageEndpointType::Html,
                 ..
             } => {
-                tracing::info_span!("app endpoint HTML", name = page_name)
+                tracing::trace_span!("app endpoint HTML", name = page_name)
             }
             AppEndpointType::Page {
                 ty: AppPageEndpointType::Rsc,
                 ..
             } => {
-                tracing::info_span!("app endpoint RSC", name = page_name)
+                tracing::trace_span!("app endpoint RSC", name = page_name)
             }
             AppEndpointType::Route { .. } => {
-                tracing::info_span!("app endpoint route", name = page_name)
+                tracing::trace_span!("app endpoint route", name = page_name)
             }
             AppEndpointType::Metadata { .. } => {
-                tracing::info_span!("app endpoint metadata", name = page_name)
+                tracing::trace_span!("app endpoint metadata", name = page_name)
             }
         };
 

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -203,7 +203,7 @@ impl InstrumentationEndpoint {
 impl Endpoint for InstrumentationEndpoint {
     #[turbo_tasks::function]
     async fn output(self: ResolvedVc<Self>) -> Result<Vc<EndpointOutput>> {
-        let span = tracing::info_span!("instrumentation endpoint");
+        let span = tracing::trace_span!("instrumentation endpoint");
         async move {
             let this = self.await?;
             let output_assets = self.output_assets();

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -334,7 +334,7 @@ impl MiddlewareEndpoint {
 impl Endpoint for MiddlewareEndpoint {
     #[turbo_tasks::function]
     async fn output(self: ResolvedVc<Self>) -> Result<Vc<EndpointOutput>> {
-        let span = tracing::info_span!("middleware endpoint");
+        let span = tracing::trace_span!("middleware endpoint");
         async move {
             let this = self.await?;
             let output_assets = self.output_assets();
@@ -348,7 +348,7 @@ impl Endpoint for MiddlewareEndpoint {
                 let client_paths = all_paths_in_root(output_assets, client_relative_root)
                     .into_future()
                     .owned()
-                    .instrument(tracing::info_span!("client_paths"))
+                    .instrument(tracing::trace_span!("client_paths"))
                     .await?;
                 (server_paths, client_paths)
             } else {

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -62,7 +62,7 @@ impl NextDynamicGraphs {
                 .try_join()
                 .await
         }
-        .instrument(tracing::info_span!("generating next/dynamic graphs"))
+        .instrument(tracing::trace_span!("generating next/dynamic graphs"))
         .await?;
         Ok(Self(next_dynamic).cell())
     }
@@ -89,7 +89,7 @@ impl NextDynamicGraphs {
         &self,
         entry: Vc<Box<dyn Module>>,
     ) -> Result<Vc<DynamicImportEntriesWithImporter>> {
-        let span = tracing::info_span!("collect all next/dynamic imports for endpoint");
+        let span = tracing::trace_span!("collect all next/dynamic imports for endpoint");
         async move {
             if let [graph] = &self.0[..] {
                 // Just a single graph, no need to merge results
@@ -148,7 +148,7 @@ impl NextDynamicGraph {
         &self,
         entry: ResolvedVc<Box<dyn Module>>,
     ) -> Result<Vc<DynamicImportEntriesWithImporter>> {
-        let span = tracing::info_span!("collect next/dynamic imports for endpoint");
+        let span = tracing::trace_span!("collect next/dynamic imports for endpoint");
         async move {
             let data = &*self.data.await?;
             let graph = self.graph.read().await?;
@@ -259,7 +259,7 @@ impl ServerActionsGraphs {
                 .try_join()
                 .await
         }
-        .instrument(tracing::info_span!("generating server actions graphs"))
+        .instrument(tracing::trace_span!("generating server actions graphs"))
         .await?;
         Ok(Self(server_actions).cell())
     }
@@ -286,7 +286,7 @@ impl ServerActionsGraphs {
         entry: Vc<Box<dyn Module>>,
         rsc_asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<AllActions>> {
-        let span = tracing::info_span!("collect all server actions for endpoint");
+        let span = tracing::trace_span!("collect all server actions for endpoint");
         async move {
             if let [graph] = &self.0[..] {
                 // Just a single graph, no need to merge results
@@ -335,7 +335,7 @@ impl ServerActionsGraph {
         entry: ResolvedVc<Box<dyn Module>>,
         rsc_asset_context: Vc<Box<dyn AssetContext>>,
     ) -> Result<Vc<AllActions>> {
-        let span = tracing::info_span!("collect server actions for endpoint");
+        let span = tracing::trace_span!("collect server actions for endpoint");
         async move {
             let data = &*self.data.await?;
             let data = if self.is_single_page {
@@ -433,7 +433,7 @@ impl ClientReferencesGraphs {
                 .try_join()
                 .await
         }
-        .instrument(tracing::info_span!("generating client references graphs"))
+        .instrument(tracing::trace_span!("generating client references graphs"))
         .await?;
         Ok(Self(client_references).cell())
     }
@@ -462,7 +462,7 @@ impl ClientReferencesGraphs {
         include_traced: bool,
         include_binding_usage: bool,
     ) -> Result<Vc<ClientReferenceGraphResult>> {
-        let span = tracing::info_span!("collect all client references for endpoint");
+        let span = tracing::trace_span!("collect all client references for endpoint");
         async move {
             let result = if let [graph] = &self.0[..] {
                 // Just a single graph, no need to merge results  This also naturally aggregates
@@ -536,7 +536,7 @@ impl ClientReferencesGraph {
         &self,
         entry: ResolvedVc<Box<dyn Module>>,
     ) -> Result<Vc<ClientReferenceGraphResult>> {
-        let span = tracing::info_span!("collect client references for endpoint");
+        let span = tracing::trace_span!("collect client references for endpoint");
         async move {
             let data = &*self.data.await?;
             let graph = self.graph.read().await?;
@@ -763,7 +763,7 @@ type FxModuleNameMap = FxIndexMap<ResolvedVc<Box<dyn Module>>, RcStr>;
 #[turbo_tasks::value(transparent)]
 struct ModuleNameMap(#[bincode(with = "turbo_bincode::indexmap")] pub FxModuleNameMap);
 
-#[tracing::instrument(level = "info", name = "validate pages css imports", skip_all)]
+#[tracing::instrument(level = "trace", name = "validate pages css imports", skip_all)]
 #[turbo_tasks::function]
 async fn validate_pages_css_imports_individual(
     graph: SingleModuleGraphWithBindingUsage,

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -145,7 +145,7 @@ impl Asset for NftJsonAsset {
     #[turbo_tasks::function]
     async fn content(self: Vc<Self>) -> Result<Vc<AssetContent>> {
         let this = &*self.await?;
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "output file tracing",
             path = display(self.path().to_string().await?)
         );

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -792,7 +792,7 @@ impl PageEndpoint {
 
             Ok(client_chunk_group)
         }
-        .instrument(tracing::info_span!("page client side rendering"))
+        .instrument(tracing::trace_span!("page client side rendering"))
         .await
     }
 
@@ -1101,9 +1101,9 @@ impl PageEndpoint {
             }
         }
         .instrument(match ty {
-            SsrChunkType::Page => tracing::info_span!("page server side rendering"),
-            SsrChunkType::Data => tracing::info_span!("server side data"),
-            SsrChunkType::Api => tracing::info_span!("server side api"),
+            SsrChunkType::Page => tracing::trace_span!("page server side rendering"),
+            SsrChunkType::Data => tracing::trace_span!("server side data"),
+            SsrChunkType::Api => tracing::trace_span!("server side api"),
         })
         .await
     }
@@ -1575,16 +1575,16 @@ impl Endpoint for PageEndpoint {
         let span = {
             match &this.ty {
                 PageEndpointType::Html => {
-                    tracing::info_span!("page endpoint HTML", name = display(original_name))
+                    tracing::trace_span!("page endpoint HTML", name = display(original_name))
                 }
                 PageEndpointType::Data => {
-                    tracing::info_span!("page endpoint data", name = display(original_name))
+                    tracing::trace_span!("page endpoint data", name = display(original_name))
                 }
                 PageEndpointType::Api => {
-                    tracing::info_span!("page endpoint API", name = display(original_name))
+                    tracing::trace_span!("page endpoint API", name = display(original_name))
                 }
                 PageEndpointType::SsrOnly => {
-                    tracing::info_span!("page endpoint SSR", name = display(original_name))
+                    tracing::trace_span!("page endpoint SSR", name = display(original_name))
                 }
             }
         };

--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -53,7 +53,7 @@ pub async fn all_server_paths(
     assets: Vc<OutputAssets>,
     node_root: FileSystemPath,
 ) -> Result<Vc<ServerPaths>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "collect all server paths",
         assets_count = tracing::field::Empty,
         server_assets_count = tracing::field::Empty

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -330,7 +330,7 @@ fn output_fs_operation(project: ResolvedVc<Project>) -> Vc<DiskFileSystem> {
 }
 
 impl ProjectContainer {
-    #[tracing::instrument(level = "info", name = "initialize project", skip_all)]
+    #[tracing::instrument(level = "trace", name = "initialize project", skip_all)]
     pub async fn initialize(self: ResolvedVc<Self>, options: ProjectOptions) -> Result<()> {
         let watch = options.watch;
 
@@ -359,7 +359,7 @@ impl ProjectContainer {
         Ok(())
     }
 
-    #[tracing::instrument(level = "info", name = "update project options", skip_all)]
+    #[tracing::instrument(level = "trace", name = "update project options", skip_all)]
     pub async fn update(self: Vc<Self>, options: PartialProjectOptions) -> Result<()> {
         let PartialProjectOptions {
             root_path,
@@ -1126,7 +1126,7 @@ impl Project {
 
             Ok(module_graphs_vc)
         }
-        .instrument(tracing::info_span!("module graph for app"))
+        .instrument(tracing::trace_span!("module graph for app"))
         .await
     }
 
@@ -1781,7 +1781,7 @@ impl Project {
         self: Vc<Self>,
         output_assets: OperationVc<OutputAssets>,
     ) -> Result<()> {
-        let span = tracing::info_span!("emitting");
+        let span = tracing::trace_span!("emitting");
         async move {
             let all_output_assets = all_assets_from_entries_operation(output_assets);
 

--- a/crates/next-api/src/webpack_stats.rs
+++ b/crates/next-api/src/webpack_stats.rs
@@ -14,7 +14,7 @@ use turbopack_core::{
     output::{OutputAsset, OutputAssetsReference},
 };
 
-#[instrument(level = "info", name = "generate webpack stats", skip_all)]
+#[instrument(level = "trace", name = "generate webpack stats", skip_all)]
 pub async fn generate_webpack_stats<I>(
     module_graph: Vc<ModuleGraph>,
     entry_name: RcStr,

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -245,7 +245,7 @@ async fn get_directory_tree(
     dir: FileSystemPath,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<DirectoryTree>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "read app directory tree",
         name = display(dir.value_to_string().await?)
     );
@@ -1435,7 +1435,7 @@ async fn directory_tree_to_entrypoints_internal(
     root_layouts: ResolvedVc<FileSystemPathVec>,
     root_params: ResolvedVc<RootParamVecOption>,
 ) -> Result<Vc<Entrypoints>> {
-    let span = tracing::info_span!("build layout trees", name = display(&app_page));
+    let span = tracing::trace_span!("build layout trees", name = display(&app_page));
     directory_tree_to_entrypoints_internal_untraced(
         app_dir,
         global_metadata,

--- a/crates/next-core/src/emit.rs
+++ b/crates/next-core/src/emit.rs
@@ -54,7 +54,8 @@ pub async fn emit_assets(
 
             async move {
                 let path = asset.path().owned().await?;
-                let span = tracing::info_span!("emit asset", name = %path.value_to_string().await?);
+                let span =
+                    tracing::trace_span!("emit asset", name = %path.value_to_string().await?);
                 async move {
                     Ok(if path.is_inside_ref(&node_root) {
                         Some(emit(*asset).as_side_effect().await?)

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -213,7 +213,7 @@ pub async fn get_app_client_references_chunks(
                     && let Some(ssr_chunking_context) = ssr_chunking_context
                 {
                     let availability_info = current_ssr_chunk_group.await?.availability_info;
-                    let _span = tracing::info_span!(
+                    let _span = tracing::trace_span!(
                         "server side rendering",
                         layout_segment = display(&server_component_path),
                     )
@@ -251,7 +251,7 @@ pub async fn get_app_client_references_chunks(
                     .await?;
                 let client_chunk_group = if !client_modules.is_empty() {
                     let availability_info = current_client_chunk_group.await?.availability_info;
-                    let _span = tracing::info_span!(
+                    let _span = tracing::trace_span!(
                         "client side rendering",
                         layout_segment = display(&server_component_path),
                     )
@@ -329,6 +329,6 @@ pub async fn get_app_client_references_chunks(
             .cell())
         }
     }
-    .instrument(tracing::info_span!("process client references"))
+    .instrument(tracing::trace_span!("process client references"))
     .await
 }

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -125,7 +125,7 @@ pub async fn find_server_entries(
         }
         .cell())
     }
-    .instrument(tracing::info_span!("find server entries"))
+    .instrument(tracing::trace_span!("find server entries"))
     .await
 }
 
@@ -265,16 +265,16 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
         }
         match node {
             FindServerEntriesNode::ClientReference => {
-                tracing::info_span!("client reference")
+                tracing::trace_span!("client reference")
             }
             FindServerEntriesNode::Internal(_, name) => {
-                tracing::info_span!("module", name = display(name.as_ref().unwrap()))
+                tracing::trace_span!("module", name = display(name.as_ref().unwrap()))
             }
             FindServerEntriesNode::ServerUtilEntry(_, name) => {
-                tracing::info_span!("server util", name = display(name.as_ref().unwrap()))
+                tracing::trace_span!("server util", name = display(name.as_ref().unwrap()))
             }
             FindServerEntriesNode::ServerComponentEntry(_, name) => {
-                tracing::info_span!("layout segment", name = display(name.as_ref().unwrap()))
+                tracing::trace_span!("layout segment", name = display(name.as_ref().unwrap()))
             }
         }
     }

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -160,7 +160,7 @@ async fn build_manifest(
         runtime,
         mode,
     } = &*manifest.await?;
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "build client reference manifest",
         entry_name = display(&entry_name)
     );

--- a/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
+++ b/crates/next-core/src/next_shared/transforms/debug_fn_name.rs
@@ -28,7 +28,7 @@ struct DebugFnNameTransformer {}
 
 #[async_trait]
 impl CustomTransformer for DebugFnNameTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "debug_fn_name", skip_all)]
+    #[tracing::instrument(level = "trace", name = "debug_fn_name", skip_all)]
     async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         program.visit_mut_with(&mut debug_fn_name());
         Ok(())

--- a/crates/next-core/src/next_shared/transforms/modularize_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/modularize_imports.rs
@@ -117,7 +117,7 @@ impl ModularizeImportsTransformer {
 
 #[async_trait]
 impl CustomTransformer for ModularizeImportsTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "modularize_imports", skip_all)]
+    #[tracing::instrument(level = "trace", name = "modularize_imports", skip_all)]
     async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(modularize_imports(&self.config));
 

--- a/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
+++ b/crates/next-core/src/next_shared/transforms/next_cjs_optimizer.rs
@@ -68,7 +68,7 @@ struct NextCjsOptimizer {
 
 #[async_trait]
 impl CustomTransformer for NextCjsOptimizer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_cjs_optimizer", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_cjs_optimizer", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let mut visitor = cjs_optimizer(
             self.config.clone(),

--- a/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
+++ b/crates/next-core/src/next_shared/transforms/next_disallow_re_export_all_in_page.rs
@@ -31,7 +31,7 @@ struct NextDisallowReExportAllInPage;
 
 #[async_trait]
 impl CustomTransformer for NextDisallowReExportAllInPage {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_disallow_reexport_all", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_disallow_reexport_all", skip_all)]
     async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(disallow_re_export_all_in_page(true));
         Ok(())

--- a/crates/next-core/src/next_shared/transforms/next_dynamic.rs
+++ b/crates/next-core/src/next_shared/transforms/next_dynamic.rs
@@ -44,7 +44,7 @@ struct NextJsDynamic {
 
 #[async_trait]
 impl CustomTransformer for NextJsDynamic {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_dynamic", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_dynamic", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(next_dynamic(
             self.mode.is_development(),

--- a/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_edge_node_api_assert.rs
@@ -39,7 +39,7 @@ struct NextEdgeNodeApiAssert {
 
 #[async_trait]
 impl CustomTransformer for NextEdgeNodeApiAssert {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_edge_node_api_assert", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_edge_node_api_assert", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let mut visitor = warn_for_edge_runtime(
             ctx.source_map.clone(),

--- a/crates/next-core/src/next_shared/transforms/next_font.rs
+++ b/crates/next-core/src/next_shared/transforms/next_font.rs
@@ -42,7 +42,7 @@ struct NextJsFont {
 
 #[async_trait]
 impl CustomTransformer for NextJsFont {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_font", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_font", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let mut next_font = next_font_loaders(Config {
             font_loaders: self.font_loaders.clone(),

--- a/crates/next-core/src/next_shared/transforms/next_lint.rs
+++ b/crates/next-core/src/next_shared/transforms/next_lint.rs
@@ -21,7 +21,7 @@ struct LintTransformer {}
 
 #[async_trait]
 impl CustomTransformer for LintTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_custom_lint", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_custom_lint", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         program.visit_with(&mut lint_codemod_comments(ctx.comments));
 

--- a/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
+++ b/crates/next-core/src/next_shared/transforms/next_middleware_dynamic_assert.rs
@@ -27,7 +27,7 @@ struct NextMiddlewareDynamicAssert {}
 
 #[async_trait]
 impl CustomTransformer for NextMiddlewareDynamicAssert {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_middleware_dynamic_assert", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_middleware_dynamic_assert", skip_all)]
     async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         let mut visitor = next_middleware_dynamic();
         program.visit_mut_with(&mut visitor);

--- a/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
+++ b/crates/next-core/src/next_shared/transforms/next_optimize_server_react.rs
@@ -34,7 +34,7 @@ struct NextOptimizeServerReact {
 
 #[async_trait]
 impl CustomTransformer for NextOptimizeServerReact {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_optimize_server_react", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_optimize_server_react", skip_all)]
     async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(optimize_server_react(Config {
             optimize_use_state: self.optimize_use_state,

--- a/crates/next-core/src/next_shared/transforms/next_pure.rs
+++ b/crates/next-core/src/next_shared/transforms/next_pure.rs
@@ -26,7 +26,7 @@ struct NextPure {}
 
 #[async_trait]
 impl CustomTransformer for NextPure {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_pure", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_pure", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         program.visit_mut_with(&mut pure_magic(ctx.comments.clone()));
         Ok(())

--- a/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
+++ b/crates/next-core/src/next_shared/transforms/next_react_server_components.rs
@@ -74,7 +74,7 @@ impl NextJsReactServerComponents {
 
 #[async_trait]
 impl CustomTransformer for NextJsReactServerComponents {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_react_server_components", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_react_server_components", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let file_name = if ctx.file_path_str.is_empty() {
             FileName::Anon

--- a/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_strip_page_exports.rs
@@ -57,7 +57,7 @@ struct NextJsStripPageExports {
 
 #[async_trait]
 impl CustomTransformer for NextJsStripPageExports {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_strip_page_exports", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_strip_page_exports", skip_all)]
     async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         // TODO(alexkirsz) Connect the eliminated_packages to telemetry.
         let eliminated_packages = Default::default();

--- a/crates/next-core/src/next_shared/transforms/next_track_dynamic_imports.rs
+++ b/crates/next-core/src/next_shared/transforms/next_track_dynamic_imports.rs
@@ -21,7 +21,7 @@ struct NextTrackDynamicImports {}
 
 #[async_trait]
 impl CustomTransformer for NextTrackDynamicImports {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "next_track_dynamic_imports", skip_all)]
+    #[tracing::instrument(level = "trace", name = "next_track_dynamic_imports", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(track_dynamic_imports(ctx.unresolved_mark));
         Ok(())

--- a/crates/next-core/src/next_shared/transforms/react_remove_properties.rs
+++ b/crates/next-core/src/next_shared/transforms/react_remove_properties.rs
@@ -51,7 +51,7 @@ struct ReactRemovePropertiesTransformer {
 
 #[async_trait]
 impl CustomTransformer for ReactRemovePropertiesTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "react_remove_properties", skip_all)]
+    #[tracing::instrument(level = "trace", name = "react_remove_properties", skip_all)]
     async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(react_remove_properties::react_remove_properties(
             self.config.clone(),

--- a/crates/next-core/src/next_shared/transforms/remove_console.rs
+++ b/crates/next-core/src/next_shared/transforms/remove_console.rs
@@ -54,7 +54,7 @@ struct RemoveConsoleTransformer {
 
 #[async_trait]
 impl CustomTransformer for RemoveConsoleTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "remove_console", skip_all)]
+    #[tracing::instrument(level = "trace", name = "remove_console", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(remove_console::remove_console(
             self.config.clone(),

--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -58,7 +58,7 @@ struct NextServerActions {
 
 #[async_trait]
 impl CustomTransformer for NextServerActions {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "server_actions", skip_all)]
+    #[tracing::instrument(level = "trace", name = "server_actions", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         let actions = server_actions(
             &FileName::Real(ctx.file_path_str.into()),

--- a/crates/next-core/src/pages_structure.rs
+++ b/crates/next-core/src/pages_structure.rs
@@ -328,7 +328,7 @@ async fn get_pages_structure_for_directory(
     position: u32,
     page_extensions: Vc<Vec<RcStr>>,
 ) -> Result<Vc<PagesDirectoryStructure>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "analyze pages structure",
         name = display(project_path.value_to_string().await?)
     );

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -176,7 +176,7 @@ impl ChunkItem for RawEcmascriptChunkItem {
 impl EcmascriptChunkItem for RawEcmascriptChunkItem {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "code generation raw module",
             name = display(self.module.ident().to_string().await?)
         );

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, hash_map},
+    collections::{hash_map, BTreeMap},
     convert::{TryFrom, TryInto},
     mem::{replace, take},
     path::{Path, PathBuf},
@@ -16,23 +16,23 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
 use swc_core::{
-    atoms::{Atom, Wtf8Atom, atom},
+    atoms::{atom, Atom, Wtf8Atom},
     common::{
-        BytePos, DUMMY_SP, FileName, Mark, SourceMap, Span, SyntaxContext,
         comments::{Comment, CommentKind, Comments, SingleThreadedComments},
         errors::HANDLER,
-        source_map::{PURE_SP, SourceMapGenConfig},
+        source_map::{SourceMapGenConfig, PURE_SP},
         util::take::Take,
+        BytePos, FileName, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        codegen::{self, Emitter, text_writer::JsWriter},
-        utils::{ExprFactory, private_ident, quote_ident},
-        visit::{VisitMut, VisitMutWith, noop_visit_mut_type, visit_mut_pass},
+        codegen::{self, text_writer::JsWriter, Emitter},
+        utils::{private_ident, quote_ident, ExprFactory},
+        visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
     },
     quote,
 };
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::{rcstr, RcStr};
 
 use crate::FxIndexMap;
 

--- a/crates/next-custom-transforms/src/transforms/server_actions.rs
+++ b/crates/next-custom-transforms/src/transforms/server_actions.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::RefCell,
-    collections::{hash_map, BTreeMap},
+    collections::{BTreeMap, hash_map},
     convert::{TryFrom, TryInto},
     mem::{replace, take},
     path::{Path, PathBuf},
@@ -16,23 +16,23 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use serde::Deserialize;
 use sha1::{Digest, Sha1};
 use swc_core::{
-    atoms::{atom, Atom, Wtf8Atom},
+    atoms::{Atom, Wtf8Atom, atom},
     common::{
+        BytePos, DUMMY_SP, FileName, Mark, SourceMap, Span, SyntaxContext,
         comments::{Comment, CommentKind, Comments, SingleThreadedComments},
         errors::HANDLER,
-        source_map::{SourceMapGenConfig, PURE_SP},
+        source_map::{PURE_SP, SourceMapGenConfig},
         util::take::Take,
-        BytePos, FileName, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        codegen::{self, text_writer::JsWriter, Emitter},
-        utils::{private_ident, quote_ident, ExprFactory},
-        visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith},
+        codegen::{self, Emitter, text_writer::JsWriter},
+        utils::{ExprFactory, private_ident, quote_ident},
+        visit::{VisitMut, VisitMutWith, noop_visit_mut_type, visit_mut_pass},
     },
     quote,
 };
-use turbo_rcstr::{rcstr, RcStr};
+use turbo_rcstr::{RcStr, rcstr};
 
 use crate::FxIndexMap;
 
@@ -138,7 +138,7 @@ enum ServerActionsErrorKind {
     },
 }
 
-#[tracing::instrument(level = tracing::Level::TRACE, skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn server_actions<C: Comments>(
     file_name: &FileName,
     file_query: Option<RcStr>,

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -386,7 +386,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     }
 
     /// Reads and decompresses a blob file. This is not backed by any cache.
-    #[tracing::instrument(level = "info", name = "reading database blob", skip_all)]
+    #[tracing::instrument(level = "trace", name = "reading database blob", skip_all)]
     fn read_blob(&self, seq: u32) -> Result<ArcSlice<u8>> {
         let path = self.path.join(format!("{seq:08}.blob"));
         let mmap = unsafe { Mmap::map(&File::open(&path)?)? };
@@ -517,7 +517,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
         new_meta_files.sort_unstable_by_key(|(seq, _)| *seq);
 
-        let sync_span = tracing::info_span!("sync new files").entered();
+        let sync_span = tracing::trace_span!("sync new files").entered();
         let mut new_meta_files = self
             .parallel_scheduler
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(new_meta_files, |(seq, file)| {
@@ -757,7 +757,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         if self.read_only {
             bail!("Compaction is not allowed on a read only database");
         }
-        let _span = tracing::info_span!("compact database").entered();
+        let _span = tracing::trace_span!("compact database").entered();
         if self
             .active_write_operation
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -335,7 +335,7 @@ impl StaticSortedFile {
     }
 
     /// Reads a block from the file.
-    #[tracing::instrument(level = "info", name = "reading database block", skip_all)]
+    #[tracing::instrument(level = "trace", name = "reading database block", skip_all)]
     fn read_block(
         &self,
         block_index: u16,

--- a/turbopack/crates/turbo-tasks-backend/benches/dependency_stress.rs
+++ b/turbopack/crates/turbo-tasks-backend/benches/dependency_stress.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use criterion::{BenchmarkId, Criterion};
+use turbo_tasks::{TryJoinIterExt, TurboTasks, Vc};
+use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
+
+pub fn dependency_stress(c: &mut Criterion) {
+    let mut group = c.benchmark_group("turbo_tasks_backend_dependency_stress");
+    group.sample_size(20);
+
+    for size in [100, 1000, 5000] {
+        group.throughput(criterion::Throughput::Elements(size as u64));
+        group.bench_with_input(BenchmarkId::new("many_readers", size), &size, |b, size| {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            let size = *size;
+
+            b.to_async(rt).iter_with_large_drop(move || {
+                let tt = TurboTasks::new(TurboTasksBackend::new(
+                    BackendOptions {
+                        storage_mode: None,
+                        ..Default::default()
+                    },
+                    noop_backing_storage(),
+                ));
+                async move {
+                    tt.run(async move {
+                        let root = root_task();
+                        (0..size).map(|_| dependent_task(root)).try_join().await?;
+                        Ok(())
+                    })
+                    .await
+                    .unwrap();
+                }
+            });
+        });
+    }
+}
+
+#[turbo_tasks::value(transparent)]
+struct Empty(());
+
+#[turbo_tasks::function]
+fn root_task() -> Vc<Empty> {
+    Empty(()).cell()
+}
+
+#[turbo_tasks::function]
+async fn dependent_task(root: Vc<Empty>) -> Result<Vc<Empty>> {
+    root.await?;
+    Ok(Empty(()).cell())
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1001,7 +1001,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let suspended_operations;
         {
-            let _span = tracing::info_span!("blocking").entered();
+            let _span = tracing::trace_span!("blocking").entered();
             let mut snapshot_request = self.snapshot_request.lock();
             snapshot_request.snapshot_requested = true;
             let active_operations = self
@@ -1200,7 +1200,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             return Some((snapshot_time, false));
         }
 
-        let _span = tracing::info_span!(parent: parent_span, "persist", reason = reason).entered();
+        let _span = tracing::trace_span!(parent: parent_span, "persist", reason = reason).entered();
         {
             if let Err(err) = self.backing_storage.save_snapshot(
                 suspended_operations,
@@ -1276,7 +1276,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         if matches!(self.options.storage_mode, Some(StorageMode::ReadWrite)) {
             // Schedule the snapshot job
             let _span = trace_span!("persisting background job").entered();
-            let _span = tracing::info_span!("thread").entered();
+            let _span = tracing::trace_span!("thread").entered();
             turbo_tasks.schedule_backend_background_job(TurboTasksBackendJob::InitialSnapshot);
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -270,7 +270,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
             > + Send
             + Sync,
     {
-        let _span = tracing::info_span!("save snapshot", operations = operations.len()).entered();
+        let _span = tracing::trace_span!("save snapshot", operations = operations.len()).entered();
         let mut batch = self.inner.database.write_batch()?;
 
         // these buffers should be large, because they're temporary and re-used.

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -375,7 +375,7 @@ impl DiskFileSystemInner {
     }
 
     fn invalidate(&self) {
-        let _span = tracing::info_span!("invalidate filesystem", name = &*self.root).entered();
+        let _span = tracing::trace_span!("invalidate filesystem", name = &*self.root).entered();
         let invalidator_map = take(&mut *self.invalidator_map.lock().unwrap());
         let dir_invalidator_map = take(&mut *self.dir_invalidator_map.lock().unwrap());
         let invalidators = invalidator_map
@@ -393,7 +393,7 @@ impl DiskFileSystemInner {
         &self,
         reason: impl Fn(&Path) -> R + Sync,
     ) {
-        let _span = tracing::info_span!("invalidate filesystem", name = &*self.root).entered();
+        let _span = tracing::trace_span!("invalidate filesystem", name = &*self.root).entered();
         let invalidator_map = take(&mut *self.invalidator_map.lock().unwrap());
         let dir_invalidator_map = take(&mut *self.dir_invalidator_map.lock().unwrap());
         let invalidators = invalidator_map
@@ -434,7 +434,7 @@ impl DiskFileSystemInner {
         }
     }
 
-    #[tracing::instrument(level = "info", name = "start filesystem watching", skip_all, fields(path = %self.root))]
+    #[tracing::instrument(level = "trace", name = "start filesystem watching", skip_all, fields(path = %self.root))]
     async fn start_watching_internal(
         self: &Arc<Self>,
         report_invalidation_reason: bool,
@@ -445,7 +445,7 @@ impl DiskFileSystemInner {
         // create the directory for the filesystem on disk, if it doesn't exist
         retry_blocking(root_path.clone(), move |path| {
             let _tracing =
-                tracing::info_span!("create root directory", name = display(path.display()))
+                tracing::trace_span!("create root directory", name = display(path.display()))
                     .entered();
 
             std::fs::create_dir_all(path)
@@ -468,7 +468,7 @@ impl DiskFileSystemInner {
             let func = |p: &Path| std::fs::create_dir_all(p);
             retry_blocking(directory.to_path_buf(), func)
                 .concurrency_limited(&self.write_semaphore)
-                .instrument(tracing::info_span!(
+                .instrument(tracing::trace_span!(
                     "create directory",
                     name = display(directory.display())
                 ))
@@ -681,7 +681,7 @@ impl FileSystem for DiskFileSystem {
         let _lock = self.inner.lock_path(&full_path).await;
         let content = match retry_blocking(full_path.clone(), |path: &Path| File::from_path(path))
             .concurrency_limited(&self.inner.read_semaphore)
-            .instrument(tracing::info_span!(
+            .instrument(tracing::trace_span!(
                 "read file",
                 name = display(full_path.display())
             ))
@@ -714,7 +714,7 @@ impl FileSystem for DiskFileSystem {
         // node-file-trace
         let read_dir = match retry_blocking(full_path.clone(), |path| {
             let _span =
-                tracing::info_span!("read directory", name = display(path.display())).entered();
+                tracing::trace_span!("read directory", name = display(path.display())).entered();
             std::fs::read_dir(path)
         })
         .concurrency_limited(&self.inner.read_semaphore)
@@ -807,7 +807,7 @@ impl FileSystem for DiskFileSystem {
         let link_path =
             match retry_blocking(full_path.clone(), |path: &Path| std::fs::read_link(path))
                 .concurrency_limited(&self.inner.read_semaphore)
-                .instrument(tracing::info_span!(
+                .instrument(tracing::trace_span!(
                     "read symlink",
                     name = display(full_path.display())
                 ))
@@ -929,7 +929,7 @@ impl FileSystem for DiskFileSystem {
             let compare = content
                 .streaming_compare(&full_path)
                 .concurrency_limited(&inner.read_semaphore)
-                .instrument(tracing::info_span!(
+                .instrument(tracing::trace_span!(
                     "read file before write",
                     name = display(full_path.display())
                 ))
@@ -997,7 +997,7 @@ impl FileSystem for DiskFileSystem {
                         Ok::<(), io::Error>(())
                     })
                     .concurrency_limited(&inner.write_semaphore)
-                    .instrument(tracing::info_span!(
+                    .instrument(tracing::trace_span!(
                         "write file",
                         name = display(full_path.display())
                     ))
@@ -1009,7 +1009,7 @@ impl FileSystem for DiskFileSystem {
                         std::fs::remove_file(path)
                     })
                     .concurrency_limited(&inner.write_semaphore)
-                    .instrument(tracing::info_span!(
+                    .instrument(tracing::trace_span!(
                         "remove file",
                         name = display(full_path.display())
                     ))
@@ -1112,7 +1112,7 @@ impl FileSystem for DiskFileSystem {
                 std::fs::read_link(path)
             })
             .concurrency_limited(&inner.read_semaphore)
-            .instrument(tracing::info_span!(
+            .instrument(tracing::trace_span!(
                 "read symlink before write",
                 name = display(full_path.display())
             ))
@@ -1175,7 +1175,7 @@ impl FileSystem for DiskFileSystem {
                     }
 
                     retry_blocking(target.clone(), move |target_path| {
-                        let _span = tracing::info_span!(
+                        let _span = tracing::trace_span!(
                             "write symlink",
                             name = display(target_path.display())
                         )
@@ -1244,7 +1244,7 @@ impl FileSystem for DiskFileSystem {
         let _lock = self.inner.lock_path(&full_path).await;
         let meta = retry_blocking(full_path.clone(), |path| std::fs::metadata(path))
             .concurrency_limited(&self.inner.read_semaphore)
-            .instrument(tracing::info_span!(
+            .instrument(tracing::trace_span!(
                 "read metadata",
                 name = display(full_path.display())
             ))

--- a/turbopack/crates/turbo-tasks-fs/src/watcher.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/watcher.rs
@@ -402,7 +402,7 @@ impl DiskWatcher {
         //
         // Best is to start_watching before starting to read
         {
-            let _span = tracing::info_span!("invalidate filesystem").entered();
+            let _span = tracing::trace_span!("invalidate filesystem").entered();
             let invalidator_map = take(&mut *fs_inner.invalidator_map.lock().unwrap());
             let dir_invalidator_map = take(&mut *fs_inner.dir_invalidator_map.lock().unwrap());
             let iter = invalidator_map.into_iter().chain(dir_invalidator_map);
@@ -744,7 +744,7 @@ impl DiskWatcher {
 
 #[instrument(
     parent = None,
-    level = "info",
+    level = "trace",
     name = "file change",
     skip_all,
     fields(name = %path.display())

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -158,7 +158,7 @@ pub async fn apply_effects(source: impl CollectiblesSource) -> Result<()> {
     if effects.is_empty() {
         return Ok(());
     }
-    let span = tracing::info_span!("apply effects", count = effects.len());
+    let span = tracing::trace_span!("apply effects", count = effects.len());
     APPLY_EFFECTS_CONTEXT
         .scope(Default::default(), async move {
             // Limit the concurrency of effects
@@ -242,7 +242,7 @@ impl Eq for Effects {}
 impl Effects {
     /// Applies all effects that have been captured by this struct.
     pub async fn apply(&self) -> Result<()> {
-        let span = tracing::info_span!("apply effects", count = self.effects.len());
+        let span = tracing::trace_span!("apply effects", count = self.effects.len());
         APPLY_EFFECTS_CONTEXT
             .scope(Default::default(), async move {
                 // Limit the concurrency of effects

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1225,12 +1225,12 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
 }
 
 impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
-    #[instrument(level = "info", skip_all, name = "invalidate")]
+    #[instrument(level = "trace", skip_all, name = "invalidate")]
     fn invalidate(&self, task: TaskId) {
         self.backend.invalidate_task(task, self);
     }
 
-    #[instrument(level = "info", skip_all, name = "invalidate", fields(name = display(&reason)))]
+    #[instrument(level = "trace", skip_all, name = "invalidate", fields(name = display(&reason)))]
     fn invalidate_with_reason(&self, task: TaskId, reason: StaticOrArc<dyn InvalidationReason>) {
         {
             let (_, reason_set) = &mut *self.aggregated_update.lock().unwrap();

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -59,7 +59,7 @@ impl ScopeInner {
             return;
         }
 
-        let _span = info_span!("blocking").entered();
+        let _span = trace_span!("blocking").entered();
 
         // Park up to 1ms without block_in_place to avoid the overhead.
         const TIMEOUT: Duration = Duration::from_millis(1);

--- a/turbopack/crates/turbo-tasks/src/scope.rs
+++ b/turbopack/crates/turbo-tasks/src/scope.rs
@@ -16,7 +16,7 @@ use std::{
 use once_cell::sync::Lazy;
 use parking_lot::{Condvar, Mutex};
 use tokio::{runtime::Handle, task::block_in_place};
-use tracing::{Span, info_span};
+use tracing::{Span, trace_span};
 
 use crate::{TurboTasksApi, manager::try_turbo_tasks, turbo_tasks_scope};
 

--- a/turbopack/crates/turbo-tasks/src/spawn.rs
+++ b/turbopack/crates/turbo-tasks/src/spawn.rs
@@ -72,7 +72,7 @@ pub fn spawn_blocking<T: Send + 'static>(
 /// is not accounted towards the current turbo-tasks function.
 pub fn spawn_thread(func: impl FnOnce() + Send + 'static) {
     let handle = Handle::current();
-    let span = info_span!("thread").or_current();
+    let span = trace_span!("thread").or_current();
     let turbo_tasks = turbo_tasks();
     thread::spawn(move || {
         let _span = span.entered();
@@ -98,7 +98,7 @@ where
 pub fn block_for_future<T: Send>(future: impl Future<Output = T> + Send + 'static) -> T {
     let handle = Handle::current();
     block_in_place(|| {
-        let _span = info_span!("blocking").entered();
+        let _span = trace_span!("blocking").entered();
         handle.block_on(future)
     })
 }

--- a/turbopack/crates/turbo-tasks/src/spawn.rs
+++ b/turbopack/crates/turbo-tasks/src/spawn.rs
@@ -8,7 +8,7 @@ use std::{
 use anyhow::Result;
 use futures::{FutureExt, ready};
 use tokio::runtime::Handle;
-use tracing::{Instrument, Span, info_span};
+use tracing::{Instrument, Span, trace_span};
 
 use crate::{
     TurboTasksPanic, capture_future::CaptureFuture, manager::turbo_tasks_future_scope, turbo_tasks,

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -684,7 +684,7 @@ impl ChunkingContext for BrowserChunkingContext {
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = tracing::info_span!("chunking", name = display(ident.to_string().await?));
+        let span = tracing::trace_span!("chunking", name = display(ident.to_string().await?));
         async move {
             let this = self.await?;
             let entries = chunk_group.entries();
@@ -747,7 +747,7 @@ impl ChunkingContext for BrowserChunkingContext {
         module_graph: Vc<ModuleGraph>,
         input_availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "chunking",
             name = display(ident.to_string().await?),
             chunking_type = "evaluated",

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -301,7 +301,7 @@ async fn build_internal(
             .try_join()
             .await
     }
-    .instrument(tracing::info_span!("resolve entries"))
+    .instrument(tracing::trace_span!("resolve entries"))
     .await?;
 
     let mut module_graph = ModuleGraph::from_modules(
@@ -497,7 +497,7 @@ async fn build_internal(
         }
         anyhow::Ok(all_assets)
     }
-    .instrument(tracing::info_span!("list chunks"))
+    .instrument(tracing::trace_span!("list chunks"))
     .await?;
 
     all_assets

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/production.rs
@@ -22,7 +22,7 @@ pub async fn make_production_chunks(
     chunking_config: &ChunkingConfig,
     mut split_context: SplitContext<'_>,
 ) -> Result<()> {
-    let span_outer = tracing::info_span!(
+    let span_outer = tracing::trace_span!(
         "make production chunks",
         chunk_items = chunk_items.len(),
         chunks_before_limits = Empty,

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -20,7 +20,7 @@ pub async fn make_style_production_chunks(
     chunking_config: &ChunkingConfig,
     mut split_context: SplitContext<'_>,
 ) -> Result<()> {
-    let span_outer = tracing::info_span!(
+    let span_outer = tracing::trace_span!(
         "make style production chunks",
         chunk_items = chunk_items.len(),
     );

--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -86,7 +86,7 @@ pub async fn compute_binding_usage_info(
     graph: ResolvedVc<ModuleGraph>,
     remove_unused_imports: bool,
 ) -> Result<Vc<BindingUsageInfo>> {
-    let span_outer = tracing::info_span!(
+    let span_outer = tracing::trace_span!(
         "compute bindung usage info",
         visit_count = tracing::field::Empty,
         unused_reference_count = tracing::field::Empty

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -373,7 +373,7 @@ impl Ord for TraversalPriority {
 }
 
 pub async fn compute_chunk_group_info(graph: &ModuleGraphRef) -> Result<Vc<ChunkGroupInfo>> {
-    let span_outer = tracing::info_span!(
+    let span_outer = tracing::trace_span!(
         "compute chunk group info",
         module_count = tracing::field::Empty,
         visit_count = tracing::field::Empty,

--- a/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/merged_modules.rs
@@ -62,7 +62,7 @@ impl MergedModuleInfo {
 /// - if a merged module has an incoming edge not contained in the group, it has to expose its
 ///   exports into the module cache.
 pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<MergedModuleInfo>> {
-    let span_outer = tracing::info_span!(
+    let span_outer = tracing::trace_span!(
         "compute merged modules",
         module_count = tracing::field::Empty,
         visit_count = tracing::field::Empty,
@@ -89,7 +89,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
 
         // First, compute the depth for each module in the graph
         let module_depth = {
-            let _inner_span = tracing::info_span!("compute depth").entered();
+            let _inner_span = tracing::trace_span!("compute depth").entered();
 
             let mut module_depth =
                 FxHashMap::with_capacity_and_hasher(module_count, Default::default());
@@ -117,7 +117,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         let mut entry_modules =
             FxHashSet::with_capacity_and_hasher(module_count, Default::default());
 
-        let inner_span = tracing::info_span!("collect mergeable modules");
+        let inner_span = tracing::trace_span!("collect mergeable modules");
         let mergeable = graphs
             .iter()
             .flat_map(|g| g.iter_nodes())
@@ -136,7 +136,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
             .into_iter()
             .collect::<FxHashSet<_>>();
 
-        let inner_span = tracing::info_span!("fixed point traversal").entered();
+        let inner_span = tracing::trace_span!("fixed point traversal").entered();
 
         let mut next_index = 0u32;
         let visit_count = module_graph.traverse_edges_fixed_point_with_priority(
@@ -229,7 +229,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         )?;
 
         drop(inner_span);
-        let inner_span = tracing::info_span!("chunk group collection").entered();
+        let inner_span = tracing::trace_span!("chunk group collection").entered();
 
         span.record("visit_count", visit_count);
 
@@ -286,7 +286,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
                     FxIndexSet<ResolvedVc<Box<dyn Module>>>,
                 >,
             }
-            let span = tracing::info_span!("map chunk groups").entered();
+            let span = tracing::trace_span!("map chunk groups").entered();
 
             let result = turbo_tasks::parallel::map_collect_chunked_owned::<_, _, Result<Vec<_>>>(
                 // TODO without collect
@@ -411,7 +411,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
             )?;
 
             drop(span);
-            let _span = tracing::info_span!("merging chunk group lists").entered();
+            let _span = tracing::trace_span!("merging chunk group lists").entered();
 
             lists_reverse_indices
                 .reserve_exact(result.iter().map(|r| r.lists_reverse_indices.len()).sum());
@@ -451,7 +451,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         }
 
         drop(inner_span);
-        let inner_span = tracing::info_span!("exposed computation").entered();
+        let inner_span = tracing::trace_span!("exposed computation").entered();
 
         // We use list.pop() below, so reverse order using negation
         lists_reverse_indices
@@ -517,7 +517,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         )?;
 
         drop(inner_span);
-        let inner_span = tracing::info_span!("reconciliation").entered();
+        let inner_span = tracing::trace_span!("reconciliation").entered();
         while let Some((_, common_occurrences)) = lists_reverse_indices.pop() {
             if common_occurrences.len() < 2 {
                 // Module exists only in one list, no need to split
@@ -671,7 +671,7 @@ pub async fn compute_merged_modules(module_graph: Vc<ModuleGraph>) -> Result<Vc<
         let lists = lists.into_iter().flatten().collect::<FxHashSet<_>>();
 
         drop(inner_span);
-        let inner_span = tracing::info_span!("merging");
+        let inner_span = tracing::trace_span!("merging");
         // Call MergeableModule impl to merge the modules.
         let result = lists
             .into_iter()

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -302,7 +302,7 @@ impl SingleModuleGraph {
         let mut modules: FxHashMap<ResolvedVc<Box<dyn Module>>, NodeIndex> =
             FxHashMap::with_capacity_and_hasher(node_count, Default::default());
         {
-            let _span = tracing::info_span!("build module graph").entered();
+            let _span = tracing::trace_span!("build module graph").entered();
             for (parent, current) in children_nodes_iter.into_breadth_first_edges() {
                 let (module, graph_node, count) = match current {
                     SingleModuleGraphBuilderNode::Module { module, ident: _ } => {
@@ -815,7 +815,7 @@ impl ModuleGraph {
             result_op.drop_collectibles::<Box<dyn Issue>>();
             anyhow::Ok(*result_vc)
         }
-        .instrument(tracing::info_span!("compute async module info"))
+        .instrument(tracing::trace_span!("compute async module info"))
         .await
     }
 
@@ -1702,10 +1702,10 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
             SingleModuleGraphBuilderNode::Module {
                 ident: Some(ident), ..
             } => {
-                tracing::info_span!("module", name = display(ident))
+                tracing::trace_span!("module", name = display(ident))
             }
             SingleModuleGraphBuilderNode::VisitedModule { .. } => {
-                tracing::info_span!("visited module")
+                tracing::trace_span!("visited module")
             }
             _ => unreachable!(),
         };
@@ -1718,15 +1718,15 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
                 } => {}
                 ChunkingType::Traced => {
                     let _span = span.entered();
-                    span = tracing::info_span!("traced reference");
+                    span = tracing::trace_span!("traced reference");
                 }
                 ChunkingType::Async => {
                     let _span = span.entered();
-                    span = tracing::info_span!("async reference");
+                    span = tracing::trace_span!("async reference");
                 }
                 ChunkingType::Isolated { _ty: ty, merge_tag } => {
                     let _span = span.entered();
-                    span = tracing::info_span!(
+                    span = tracing::trace_span!(
                         "isolated reference",
                         ty = debug(&ty),
                         merge_tag = debug(&merge_tag)
@@ -1737,7 +1737,7 @@ impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'
                     merge_tag,
                 } => {
                     let _span = span.entered();
-                    span = tracing::info_span!("shared reference", merge_tag = debug(&merge_tag));
+                    span = tracing::trace_span!("shared reference", merge_tag = debug(&merge_tag));
                 }
             };
         }

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -337,7 +337,7 @@ pub async fn compute_module_batches(
     module_graph: Vc<ModuleGraph>,
     _config: &BatchingConfig,
 ) -> Result<Vc<ModuleBatchesGraph>> {
-    let outer_span = tracing::info_span!(
+    let outer_span = tracing::trace_span!(
         "compute module batches",
         initial_pre_batch_items = tracing::field::Empty,
         initial_pre_batches = tracing::field::Empty,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1583,7 +1583,7 @@ pub async fn resolve_inline(
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "resolving",
         lookup_path = display(lookup_path.value_to_string().await?),
         name = tracing::field::Empty,
@@ -1794,7 +1794,7 @@ async fn resolve_internal_inline(
     request: Vc<Request>,
     options: Vc<ResolveOptions>,
 ) -> Result<Vc<ResolveResult>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "internal resolving",
         lookup_path = display(lookup_path.value_to_string().await?),
         name = tracing::field::Empty

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -352,7 +352,7 @@ pub async fn parse_css(
     ty: CssModuleAssetType,
     environment: Option<ResolvedVc<Environment>>,
 ) -> Result<Vc<ParseCssResult>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "parse css",
         name = display(source.ident().to_string().await?)
     );

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -30,7 +30,7 @@ use hyper::{
 use parking_lot::Mutex;
 use socket2::{Domain, Protocol, Socket, Type};
 use tokio::task::JoinHandle;
-use tracing::{Instrument, Level, Span, event, info_span};
+use tracing::{Instrument, Level, Span, event, trace_span};
 use turbo_tasks::{
     NonLocalValue, OperationVc, TurboTasksApi, Vc, apply_effects, run_once_with_reason,
     trace::TraceRawVcs, util::FormatDuration,
@@ -128,7 +128,7 @@ impl DevServerBuilder {
             let ongoing_side_effects = ongoing_side_effects.clone();
             async move {
                 let handler = move |request: Request<hyper::Body>| {
-                    let request_span = info_span!(parent: None, "request", name = ?request.uri());
+                    let request_span = trace_span!(parent: None, "request", name = ?request.uri());
                     let start = Instant::now();
                     let tt = tt.clone();
                     let get_issue_reporter = get_issue_reporter.clone();

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/directives/client.rs
@@ -19,7 +19,7 @@ impl ClientDirectiveTransformer {
 
 #[async_trait]
 impl CustomTransformer for ClientDirectiveTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "client_directive", skip_all)]
+    #[tracing::instrument(level = "trace", name = "client_directive", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         if is_client_module(program) {
             *program = create_proxy_module(

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/emotion.rs
@@ -147,7 +147,7 @@ impl EmotionTransformer {
 
 #[async_trait]
 impl CustomTransformer for EmotionTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "emotion", skip_all)]
+    #[tracing::instrument(level = "trace", name = "emotion", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         #[cfg(feature = "transform_emotion")]
         {

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/relay.rs
@@ -60,7 +60,7 @@ impl RelayTransformer {
 
 #[async_trait]
 impl CustomTransformer for RelayTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "relay", skip_all)]
+    #[tracing::instrument(level = "trace", name = "relay", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         // If user supplied artifact_directory, it should be resolvable already.
         // Otherwise, supply default relative path (./__generated__)

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_components.rs
@@ -85,7 +85,7 @@ impl StyledComponentsTransformer {
 
 #[async_trait]
 impl CustomTransformer for StyledComponentsTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "styled_components", skip_all)]
+    #[tracing::instrument(level = "trace", name = "styled_components", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(styled_components::styled_components(
             Some(ctx.file_path_str),

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/styled_jsx.rs
@@ -19,7 +19,7 @@ impl StyledJsxTransformer {
 
 #[async_trait]
 impl CustomTransformer for StyledJsxTransformer {
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "styled_jsx", skip_all)]
+    #[tracing::instrument(level = "trace", name = "styled_jsx", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         program.mutate(styled_jsx::visitor::styled_jsx(
             ctx.source_map.clone(),

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -116,7 +116,7 @@ impl SwcEcmaTransformPluginsTransformer {
 #[async_trait]
 impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
     #[cfg_attr(not(feature = "swc_ecma_transform_plugin"), allow(unused))]
-    #[tracing::instrument(level = tracing::Level::TRACE, name = "swc_ecma_transform_plugin", skip_all)]
+    #[tracing::instrument(level = "trace", name = "swc_ecma_transform_plugin", skip_all)]
     async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
         #[cfg(feature = "swc_ecma_transform_plugin")]
         {

--- a/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/async_chunk/chunk_item.rs
@@ -67,7 +67,7 @@ impl AsyncLoaderChunkItem {
     #[turbo_tasks::function]
     async fn chunks_data(self: Vc<Self>) -> Result<Vc<ChunksData>> {
         let this = self.await?;
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "compute async chunks",
             name = this.module.ident().to_string().await?.as_str()
         );

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -924,7 +924,7 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         async_module_info: Option<Vc<AsyncModuleInfo>>,
         _estimated: bool,
     ) -> Result<Vc<EcmascriptChunkItemContent>> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "code generation",
             name = display(self.asset_ident().to_string().await?)
         );
@@ -1065,7 +1065,7 @@ impl EcmascriptModuleContentOptions {
                     .collect(),
             )
         }
-        .instrument(tracing::info_span!("precompute code generation"))
+        .instrument(tracing::trace_span!("precompute code generation"))
         .await
     }
 }
@@ -1242,10 +1242,10 @@ impl EcmascriptModuleContent {
                 .into();
 
             emit_content(content, additional_ids)
-                .instrument(tracing::info_span!("emit code"))
+                .instrument(tracing::trace_span!("emit code"))
                 .await
         }
-        .instrument(tracing::info_span!(
+        .instrument(tracing::trace_span!(
             "generate merged code",
             modules = module_options.len()
         ))

--- a/turbopack/crates/turbopack-ecmascript/src/minify.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/minify.rs
@@ -32,7 +32,7 @@ use turbopack_core::{
 
 use crate::parse::generate_js_source_map;
 
-#[instrument(level = "info", name = "minify ecmascript code", skip_all)]
+#[instrument(level = "trace", name = "minify ecmascript code", skip_all)]
 pub fn minify(code: Code, source_maps: bool, mangle: Option<MangleType>) -> Result<Code> {
     // Pass None for the debug ID so we don't needlessly compute it for the pre-minified content, it
     // will be added by the Code object returned from this function

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -75,7 +75,7 @@ pub enum ParseResult {
 
 /// `original_source_maps_complete` indicates whether the `original_source_maps` cover the whole
 /// map, i.e. whether every module that ended up in `mappings` had an original sourcemap.
-#[instrument(level = "info", name = "generate source map", skip_all)]
+#[instrument(level = "trace", name = "generate source map", skip_all)]
 pub fn generate_js_source_map<'a>(
     files_map: &impl Files,
     mappings: Vec<(BytePos, LineCol)>,
@@ -170,7 +170,7 @@ pub async fn parse(
     is_external_tracing: bool,
     inline_helpers: bool,
 ) -> Result<Vc<ParseResult>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "parse ecmascript",
         name = display(source.ident().to_string().await?),
         ty = display(&ty)

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -520,7 +520,7 @@ pub async fn analyze_ecmascript_module(
     module: ResolvedVc<EcmascriptModuleAsset>,
     part: Option<ModulePart>,
 ) -> Result<Vc<AnalyzeEcmascriptModuleResult>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "analyze ecmascript module",
         name = display(module.ident().to_string().await?)
     );

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -94,7 +94,7 @@ impl FilePathModuleReference {
 impl ModuleReference for FilePathModuleReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "trace module",
             pattern = display(self.path.to_string().await?)
         );

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -49,7 +49,7 @@ impl FileSourceReference {
 impl ModuleReference for FileSourceReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "trace file",
             pattern = display(self.path.to_string().await?)
         );
@@ -198,7 +198,7 @@ async fn resolve_reference_from_dir(
 impl ModuleReference for DirAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "trace directory",
             pattern = display(self.path.to_string().await?)
         );

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -463,7 +463,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         module_graph: Vc<ModuleGraph>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<ChunkGroupResult>> {
-        let span = tracing::info_span!("chunking", name = display(ident.to_string().await?));
+        let span = tracing::trace_span!("chunking", name = display(ident.to_string().await?));
         async move {
             let modules = chunk_group.entries();
             let MakeChunkGroupResult {
@@ -507,7 +507,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         extra_referenced_assets: Vc<OutputAssets>,
         availability_info: AvailabilityInfo,
     ) -> Result<Vc<EntryChunkGroupResult>> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "chunking",
             name = display(path.value_to_string().await?),
             chunking_type = "entry",

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -17,7 +17,7 @@ use turbopack_ecmascript::async_chunk::module::AsyncLoaderModule;
 pub async fn get_global_module_id_strategy(
     module_graph: ResolvedVc<ModuleGraph>,
 ) -> Result<Vc<GlobalModuleIdStrategy>> {
-    let span = tracing::info_span!("compute module id map");
+    let span = tracing::trace_span!("compute module id map");
     async move {
         let module_graph = module_graph.read_graphs().await?;
         let graphs = &module_graph.graphs;

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -485,7 +485,7 @@ async fn process_default(
     reference_type: ReferenceType,
     processed_rules: Vec<usize>,
 ) -> Result<Vc<ProcessResult>> {
-    let span = tracing::info_span!(
+    let span = tracing::trace_span!(
         "process module",
         name = %source.ident().to_string().await?,
         layer = Empty,


### PR DESCRIPTION
Replace `info_span` to `trace_span` in `tracing::instrument`, this will reduce some overhead.

<img width="3386" height="1032" alt="image" src="https://github.com/user-attachments/assets/8087e2ff-f097-4b68-a562-4e3bedac8af9" />
