### PR TITLE
perf: improve stats action reliability and reduce CI noise

### DIFF
--- a/.github/actions/next-stats-action/action.yml
+++ b/.github/actions/next-stats-action/action.yml
@@ -1,0 +1,10 @@
+name: 'Next.js PR Stats'
+description: 'Compare PR stats with canary'
+inputs:
+  bundler:
+    description: 'Bundler to benchmark (webpack|turbopack|both)'
+    default: 'both'
+    required: false
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/.github/actions/next-stats-action/package.json
+++ b/.github/actions/next-stats-action/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "main": "src/index.js",
   "dependencies": {
+    "@vercel/kv": "^1.0.1",
     "async-sema": "^3.1.0",
     "execa": "2.0.3",
     "get-port": "^5.0.0",

--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -510,11 +510,13 @@ function generatePerformanceSection(mainStats, diffStats, history) {
 // Base group names (without bundler suffix)
 const BASE_BUNDLE_GROUPS = {
   client: [
-    'Client Bundles (main, webpack)',
+    'Client Bundles (main)',
     'Client Pages',
     'Legacy Client Bundles (polyfills)',
   ],
-  server: ['Next Runtimes', 'Edge SSR bundle Size', 'Middleware size'],
+  server: ['Edge SSR bundle Size', 'Middleware size'],
+  // Next Runtimes are built independently of Turbopack/Webpack
+  shared: ['Next Runtimes'],
   other: ['Client Build Manifests', 'Rendered Page Sizes', 'build cache'],
 }
 
@@ -588,7 +590,7 @@ function generateBundleGroup(groupKey, result, tableHead) {
 
   // Friendly names for groups
   const friendlyNames = {
-    'Client Bundles (main, webpack)': 'Main & Webpack',
+    'Client Bundles (main)': 'Main Bundles',
     'Legacy Client Bundles (polyfills)': 'Polyfills',
     'Client Pages': 'Pages',
     'Client Build Manifests': 'Build Manifests',
@@ -620,7 +622,7 @@ function generateBundleSizeSection(result, tableHead) {
 
   // Organize groups by bundler and category
   const bundlerGroups = {}
-  const nonBundlerGroups = { client: [], server: [], other: [] }
+  const nonBundlerGroups = { client: [], server: [], shared: [], other: [] }
 
   for (const groupKey of allGroupKeys) {
     if (groupKey === 'General' || groupKey === benchTitle) continue
@@ -639,6 +641,8 @@ function generateBundleSizeSection(result, tableHead) {
         nonBundlerGroups.client.push(groupKey)
       } else if (BASE_BUNDLE_GROUPS.server.includes(baseGroup)) {
         nonBundlerGroups.server.push(groupKey)
+      } else if (BASE_BUNDLE_GROUPS.shared.includes(baseGroup)) {
+        nonBundlerGroups.shared.push(groupKey)
       } else {
         nonBundlerGroups.other.push(groupKey)
       }
@@ -732,6 +736,7 @@ function generateBundleSizeSection(result, tableHead) {
       const titles = {
         client: '📦 Client',
         server: '🖥️ Server',
+        shared: '🔄 Shared (bundler-independent)',
         other: '🔧 Other',
       }
       content += `### ${titles[categoryKey]}\n\n${categoryContent}`

--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -238,14 +238,17 @@ function formatChange(mainVal, diffVal, type = 'bytes') {
   const percentChange = mainVal > 0 ? (diff / mainVal) * 100 : 0
 
   // Thresholds: filter CI noise while catching real regressions
-  // For time: <50ms AND <10% = not worth mentioning (with 9 iterations for stable median)
+  // For time:
+  //   - (<50ms AND <10%) = insignificant for short ops (dev boot ~300ms)
+  //   - OR <2% = insignificant for long ops (builds ~13s where 70ms is noise)
   // For size: <1KB AND <1% = not worth mentioning
   // If mainVal is 0 and diff is non-zero, always consider it significant
   const isInsignificant =
     mainVal === 0 && diff !== 0
       ? false
       : type === 'ms'
-        ? Math.abs(diff) < 50 && Math.abs(percentChange) < 10
+        ? (Math.abs(diff) < 50 && Math.abs(percentChange) < 10) ||
+          Math.abs(percentChange) < 2
         : Math.abs(diff) < 1024 && Math.abs(percentChange) < 1
 
   if (isInsignificant) {
@@ -450,7 +453,7 @@ function generateGlossary() {
 - **Cached** = With existing .next directory
 
 **Change Thresholds:**
-- Time: Changes < 50ms AND < 10% are insignificant
+- Time: Changes < 50ms AND < 10%, OR < 2% are insignificant
 - Size: Changes < 1KB AND < 1% are insignificant
 - All other changes are flagged to catch regressions
 

--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -36,17 +36,17 @@ const MAX_HISTORY_ENTRIES = 100
 // Human-readable labels for metrics
 const METRIC_LABELS = {
   // Dev boot metrics - Turbopack (Listen = port listening, First Request = HTTP responding)
-  'nextDevColdListenDurationTurbo (ms)': 'Cold (Listen)',
-  'nextDevColdReadyDurationTurbo (ms)': 'Cold (First Request)',
-  'nextDevWarmListenDurationTurbo (ms)': 'Warm (Listen)',
-  'nextDevWarmReadyDurationTurbo (ms)': 'Warm (First Request)',
+  nextDevColdListenDurationTurbo: 'Cold (Listen)',
+  nextDevColdReadyDurationTurbo: 'Cold (First Request)',
+  nextDevWarmListenDurationTurbo: 'Warm (Listen)',
+  nextDevWarmReadyDurationTurbo: 'Warm (First Request)',
   // Dev boot metrics - Webpack
-  'nextDevColdListenDurationWebpack (ms)': 'Webpack Cold (Listen)',
-  'nextDevColdReadyDurationWebpack (ms)': 'Webpack Cold (First Request)',
-  'nextDevWarmListenDurationWebpack (ms)': 'Webpack Warm (Listen)',
-  'nextDevWarmReadyDurationWebpack (ms)': 'Webpack Warm (First Request)',
+  nextDevColdListenDurationWebpack: 'Webpack Cold (Listen)',
+  nextDevColdReadyDurationWebpack: 'Webpack Cold (First Request)',
+  nextDevWarmListenDurationWebpack: 'Webpack Warm (Listen)',
+  nextDevWarmReadyDurationWebpack: 'Webpack Warm (First Request)',
   // Production metrics
-  'nextStartReadyDuration (ms)': 'Prod Start',
+  nextStartReadyDuration: 'Prod Start',
   // Build metrics - Webpack
   buildDurationWebpack: 'Webpack Build Time',
   buildDurationCachedWebpack: 'Webpack Build Time (cached)',
@@ -66,22 +66,22 @@ const METRIC_GROUPS = {
     metrics: [
       {
         label: 'Cold (Listen)',
-        key: 'nextDevColdListenDurationTurbo (ms)',
+        key: 'nextDevColdListenDurationTurbo',
         description: 'Time until TCP port accepts connections',
       },
       {
         label: 'Cold (First Request)',
-        key: 'nextDevColdReadyDurationTurbo (ms)',
+        key: 'nextDevColdReadyDurationTurbo',
         description: 'Time until first HTTP request succeeds',
       },
       {
         label: 'Warm (Listen)',
-        key: 'nextDevWarmListenDurationTurbo (ms)',
+        key: 'nextDevWarmListenDurationTurbo',
         description: 'Time until TCP port accepts connections (cached)',
       },
       {
         label: 'Warm (First Request)',
-        key: 'nextDevWarmReadyDurationTurbo (ms)',
+        key: 'nextDevWarmReadyDurationTurbo',
         description: 'Time until first HTTP request succeeds (cached)',
       },
     ],
@@ -95,22 +95,22 @@ const METRIC_GROUPS = {
     metrics: [
       {
         label: 'Cold (Listen)',
-        key: 'nextDevColdListenDurationWebpack (ms)',
+        key: 'nextDevColdListenDurationWebpack',
         description: 'Time until TCP port accepts connections',
       },
       {
         label: 'Cold (First Request)',
-        key: 'nextDevColdReadyDurationWebpack (ms)',
+        key: 'nextDevColdReadyDurationWebpack',
         description: 'Time until first HTTP request succeeds',
       },
       {
         label: 'Warm (Listen)',
-        key: 'nextDevWarmListenDurationWebpack (ms)',
+        key: 'nextDevWarmListenDurationWebpack',
         description: 'Time until TCP port accepts connections (cached)',
       },
       {
         label: 'Warm (First Request)',
-        key: 'nextDevWarmReadyDurationWebpack (ms)',
+        key: 'nextDevWarmReadyDurationWebpack',
         description: 'Time until first HTTP request succeeds (cached)',
       },
     ],
@@ -156,7 +156,7 @@ const METRIC_GROUPS = {
     metrics: [
       {
         label: 'Start (First Request)',
-        key: 'nextStartReadyDuration (ms)',
+        key: 'nextStartReadyDuration',
       },
     ],
   },
@@ -168,13 +168,16 @@ const METRIC_GROUPS = {
 
 async function loadHistory() {
   const kvClient = await getKV()
-  if (!kvClient) return { entries: [] }
+  if (!kvClient) {
+    logger('KV not configured - historical trends unavailable')
+    return { entries: [] }
+  }
 
   try {
     const data = await kvClient.lrange(KV_STATS_KEY, -MAX_HISTORY_ENTRIES, -1)
-    return {
-      entries: data.map((d) => (typeof d === 'string' ? JSON.parse(d) : d)),
-    }
+    const entries = data.map((d) => (typeof d === 'string' ? JSON.parse(d) : d))
+    logger(`Loaded ${entries.length} historical entries from KV`)
+    return { entries }
   } catch (e) {
     logger.error('Failed to load history from KV:', e)
     return { entries: [] }
@@ -223,7 +226,7 @@ const shortenLabel = (itemKey) =>
     : itemKey
 
 function getMetricLabel(key) {
-  return METRIC_LABELS[key] || shortenLabel(key.replace(/ \(ms\)$/, ''))
+  return METRIC_LABELS[key] || shortenLabel(key)
 }
 
 function formatChange(mainVal, diffVal, type = 'bytes') {
@@ -234,15 +237,15 @@ function formatChange(mainVal, diffVal, type = 'bytes') {
   const diff = diffVal - mainVal
   const percentChange = mainVal > 0 ? (diff / mainVal) * 100 : 0
 
-  // Thresholds: stricter for framework development to catch all regressions
-  // For time: <10ms AND <2% = not worth mentioning
+  // Thresholds: filter CI noise while catching real regressions
+  // For time: <50ms AND <10% = not worth mentioning (with 9 iterations for stable median)
   // For size: <1KB AND <1% = not worth mentioning
   // If mainVal is 0 and diff is non-zero, always consider it significant
   const isInsignificant =
     mainVal === 0 && diff !== 0
       ? false
       : type === 'ms'
-        ? Math.abs(diff) < 10 && Math.abs(percentChange) < 2
+        ? Math.abs(diff) < 50 && Math.abs(percentChange) < 10
         : Math.abs(diff) < 1024 && Math.abs(percentChange) < 1
 
   if (isInsignificant) {
@@ -306,7 +309,7 @@ function getHistoricalValues(history, metricKey, limit = 15) {
 
 // Determine if a metric is time-based (ms) or size-based (bytes)
 function getMetricType(metricKey) {
-  if (metricKey.includes('Duration') || metricKey.includes('(ms)')) {
+  if (metricKey.includes('Duration')) {
     return 'ms'
   }
   if (metricKey.includes('Size')) {
@@ -315,7 +318,7 @@ function getMetricType(metricKey) {
   return 'ms' // default to ms for performance metrics
 }
 
-function generateChangeSummary(mainStats, diffStats) {
+function generateChangeSummary(mainStats, diffStats, history) {
   // Collect all significant changes across all metrics
   const changes = []
 
@@ -330,11 +333,13 @@ function generateChangeSummary(mainStats, diffStats) {
     const change = formatChange(mainVal, diffVal, type)
 
     if (change.significant) {
+      const histValues = getHistoricalValues(history, key)
       changes.push({
         metric: getMetricLabel(key),
         mainVal: prettify(mainVal, type),
         diffVal: prettify(diffVal, type),
         change: change.text,
+        trend: generateTrendBar(histValues),
         improved: change.improved,
         regression: change.regression,
       })
@@ -365,12 +370,21 @@ function generateChangeSummary(mainStats, diffStats) {
     headline = `### 🟢 ${improvements.length} improvement${improvements.length > 1 ? 's' : ''}`
   }
 
+  const hasTrends = changes.some((c) => c.trend)
   let summary = `${headline}\n\n`
-  summary += `| Metric | Canary | PR | Change |\n`
-  summary += `|:-------|-------:|---:|-------:|\n`
 
-  for (const c of changes) {
-    summary += `| ${c.metric} | ${c.mainVal} | ${c.diffVal} | ${c.change} |\n`
+  if (hasTrends) {
+    summary += `| Metric | Canary | PR | Change | Trend |\n`
+    summary += `|:-------|-------:|---:|-------:|:-----:|\n`
+    for (const c of changes) {
+      summary += `| ${c.metric} | ${c.mainVal} | ${c.diffVal} | ${c.change} | ${c.trend} |\n`
+    }
+  } else {
+    summary += `| Metric | Canary | PR | Change |\n`
+    summary += `|:-------|-------:|---:|-------:|\n`
+    for (const c of changes) {
+      summary += `| ${c.metric} | ${c.mainVal} | ${c.diffVal} | ${c.change} |\n`
+    }
   }
 
   return summary + '\n'
@@ -391,7 +405,7 @@ function generateGlossary() {
 - **Cached** = With existing .next directory
 
 **Change Thresholds:**
-- Time: Changes < 10ms AND < 2% are insignificant
+- Time: Changes < 50ms AND < 10% are insignificant
 - Size: Changes < 1KB AND < 1% are insignificant
 - All other changes are flagged to catch regressions
 
@@ -794,7 +808,8 @@ module.exports = async function addComment(
     if (i === 0) {
       comment += generateChangeSummary(
         result.mainRepoStats,
-        result.diffRepoStats
+        result.diffRepoStats,
+        history
       )
     }
 

--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -304,6 +304,51 @@ function getHistoricalValues(history, metricKey, limit = 15) {
 }
 
 // ============================================================================
+// Bundle Size Aggregation
+// ============================================================================
+
+/**
+ * Compute aggregate totals for each bundle group for KV persistence.
+ * This allows tracking bundle size trends over time even when individual
+ * files can't be matched (Turbopack uses content-hash filenames).
+ */
+function computeBundleGroupTotals(stats) {
+  const totals = {}
+
+  for (const [groupKey, groupStats] of Object.entries(stats)) {
+    if (groupKey === 'General' || groupKey === benchTitle) continue
+    if (!groupStats || typeof groupStats !== 'object') continue
+
+    // Sum gzip values for each group
+    let total = 0
+    for (const [key, value] of Object.entries(groupStats)) {
+      if (key.endsWith(' gzip') && typeof value === 'number') {
+        total += value
+      }
+    }
+
+    // Create stable key from group name
+    // "Client Bundles (main) (Turbopack)" → "clientBundlesMainTurbopackTotal"
+    const stableKey =
+      groupKey
+        .replace(/[^a-zA-Z0-9]/g, ' ')
+        .trim()
+        .split(/\s+/)
+        .filter((w) => w.length > 0)
+        .map((w, i) =>
+          i === 0
+            ? w.toLowerCase()
+            : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()
+        )
+        .join('') + 'Total'
+
+    totals[stableKey] = total
+  }
+
+  return totals
+}
+
+// ============================================================================
 // Comment Generation
 // ============================================================================
 
@@ -422,15 +467,15 @@ function generateMetricsTable(
   history,
   isCollapsed = false
 ) {
-  let rows = ''
-  let hasAny = false
+  // Pre-compute all row data to check if we have any trends
+  const rowData = []
+  let hasTrends = false
 
   for (const metricDef of config.metrics) {
     const mainVal = mainGroup[metricDef.key]
     const diffVal = diffGroup[metricDef.key]
 
     if (mainVal === undefined && diffVal === undefined) continue
-    hasAny = true
 
     const metricType = metricDef.type || 'ms'
     const mainStr = prettify(mainVal, metricType)
@@ -439,15 +484,38 @@ function generateMetricsTable(
     const histValues = getHistoricalValues(history, metricDef.key)
     const sparkline = generateTrendBar(histValues)
 
-    rows += `| ${metricDef.label} | ${mainStr} | ${diffStr} | ${change.text} | ${sparkline} |\n`
+    if (sparkline) hasTrends = true
+
+    rowData.push({
+      label: metricDef.label,
+      mainStr,
+      diffStr,
+      changeText: change.text,
+      sparkline,
+    })
   }
 
-  if (!hasAny) return ''
+  if (rowData.length === 0) return ''
+
+  // Build rows with or without trend column
+  let rows = ''
+  for (const row of rowData) {
+    if (hasTrends) {
+      rows += `| ${row.label} | ${row.mainStr} | ${row.diffStr} | ${row.changeText} | ${row.sparkline} |\n`
+    } else {
+      rows += `| ${row.label} | ${row.mainStr} | ${row.diffStr} | ${row.changeText} |\n`
+    }
+  }
+
+  const header = hasTrends
+    ? `| Metric | Canary | PR | Change | Trend |
+|:-------|-------:|---:|-------:|:-----:|`
+    : `| Metric | Canary | PR | Change |
+|:-------|-------:|---:|-------:|`
 
   const table = `### ${config.icon} ${groupName}
 
-| Metric | Canary | PR | Change | Trend |
-|:-------|-------:|---:|-------:|:-----:|
+${header}
 ${rows}
 `
 
@@ -550,10 +618,33 @@ function generateBundleGroup(groupKey, result, tableHead) {
     ...Object.keys(diffRepoGroup),
   ])
 
+  // Detect pure-hash filenames (Turbopack uses content-hash only, can't be matched)
+  // Pattern: 16 hex chars followed by .js or .css (with optional .map or gzip suffix)
+  const pureHashPattern = /^[0-9a-f]{16}\.(js|css)/
+  let pureHashCount = 0
+  let totalGzipItems = 0
+
+  itemKeys.forEach((itemKey) => {
+    if (itemKey.endsWith('gzip')) {
+      totalGzipItems++
+      // Extract base filename (remove ' gzip' suffix)
+      const baseName = itemKey.replace(/ gzip$/, '')
+      if (pureHashPattern.test(baseName)) {
+        pureHashCount++
+      }
+    }
+  })
+
+  // If more than 50% of items are pure-hash files, show totals only
+  const isPureHashGroup =
+    totalGzipItems > 0 && pureHashCount / totalGzipItems > 0.5
+
   let groupTable = tableHead
   let mainRepoTotal = 0
   let diffRepoTotal = 0
   let hasItems = false
+  let matchedItems = 0
+  let unmatchedItems = 0
 
   itemKeys.forEach((itemKey) => {
     const isGzipItem = itemKey.endsWith('gzip')
@@ -565,14 +656,24 @@ function generateBundleGroup(groupKey, result, tableHead) {
     if (!isGzipItem && !groupKey.match(gzipIgnoreRegex)) return
 
     hasItems = true
-    const mainItemStr = prettify(mainItemVal, 'bytes')
-    const diffItemStr = prettify(diffItemVal, 'bytes')
-    const change = formatChange(mainItemVal, diffItemVal, 'bytes')
+
+    // Track matched vs unmatched items
+    if (typeof mainItemVal === 'number' && typeof diffItemVal === 'number') {
+      matchedItems++
+    } else {
+      unmatchedItems++
+    }
 
     if (typeof mainItemVal === 'number') mainRepoTotal += mainItemVal
     if (typeof diffItemVal === 'number') diffRepoTotal += diffItemVal
 
-    groupTable += `| ${shortenLabel(itemKey)} | ${mainItemStr} | ${diffItemStr} | ${change.text} |\n`
+    // Only add individual rows if not a pure-hash group
+    if (!isPureHashGroup) {
+      const mainItemStr = prettify(mainItemVal, 'bytes')
+      const diffItemStr = prettify(diffItemVal, 'bytes')
+      const change = formatChange(mainItemVal, diffItemVal, 'bytes')
+      groupTable += `| ${shortenLabel(itemKey)} | ${mainItemStr} | ${diffItemStr} | ${change.text} |\n`
+    }
   })
 
   if (!hasItems) return null
@@ -585,8 +686,6 @@ function generateBundleGroup(groupKey, result, tableHead) {
     const sign = totalChange > 0 ? '+' : '-'
     totalChangeStr = `${icon} ${sign}${prettyBytes(Math.abs(totalChange))}`
   }
-
-  groupTable += `| **Total** | **${prettyBytes(mainRepoTotal)}** | **${prettyBytes(diffRepoTotal)}** | ${totalChangeStr} |\n`
 
   // Friendly names for groups
   const friendlyNames = {
@@ -601,7 +700,21 @@ function generateBundleGroup(groupKey, result, tableHead) {
     'build cache': 'Build Cache',
   }
 
-  const displayName = friendlyNames[groupKey] || groupKey
+  const baseGroupName = getBaseGroupName(groupKey)
+  const displayName = friendlyNames[baseGroupName] || groupKey
+
+  // For pure-hash groups, show a simplified view with just totals
+  if (isPureHashGroup) {
+    return `<details>
+<summary>${displayName}: **${prettyBytes(mainRepoTotal)}** → **${prettyBytes(diffRepoTotal)}** ${totalChangeStr}</summary>
+
+*${totalGzipItems} files with content-based hashes (individual files not comparable between builds)*
+
+</details>
+`
+  }
+
+  groupTable += `| **Total** | **${prettyBytes(mainRepoTotal)}** | **${prettyBytes(diffRepoTotal)}** | ${totalChangeStr} |\n`
 
   return `<details>
 <summary>${displayName}</summary>
@@ -655,9 +768,18 @@ function generateBundleSizeSection(result, tableHead) {
     let hasAny = false
 
     // Organize bundler groups by category
+    // Skip shared groups - they'll be rendered in their own section
     const categorizedGroups = { client: [], server: [], other: [] }
     for (const groupKey of bundlerData.groups) {
       const baseGroup = getBaseGroupName(groupKey)
+      // Skip shared groups (like Next Runtimes) - they're bundler-independent
+      if (BASE_BUNDLE_GROUPS.shared.includes(baseGroup)) {
+        // Move to nonBundlerGroups.shared for unified rendering
+        if (!nonBundlerGroups.shared.includes(groupKey)) {
+          nonBundlerGroups.shared.push(groupKey)
+        }
+        continue
+      }
       if (BASE_BUNDLE_GROUPS.client.includes(baseGroup)) {
         categorizedGroups.client.push(groupKey)
       } else if (BASE_BUNDLE_GROUPS.server.includes(baseGroup)) {
@@ -717,14 +839,26 @@ function generateBundleSizeSection(result, tableHead) {
     }
   }
 
-  // Handle any non-bundler-specific groups (shouldn't happen but fallback)
+  // Handle any non-bundler-specific groups
   for (const [categoryKey, groups] of Object.entries(nonBundlerGroups)) {
     if (groups.length === 0) continue
 
     let categoryContent = ''
     let hasAny = false
 
+    // For shared groups, deduplicate by base name (e.g., "Next Runtimes (Turbopack)"
+    // and "Next Runtimes (Webpack)" should only show once)
+    const seenBaseGroups = new Set()
+
     for (const groupKey of groups) {
+      const baseGroup = getBaseGroupName(groupKey)
+
+      // Skip if we've already rendered this base group
+      if (categoryKey === 'shared' && seenBaseGroups.has(baseGroup)) {
+        continue
+      }
+      seenBaseGroups.add(baseGroup)
+
       const groupContent = generateBundleGroup(groupKey, result, tableHead)
       if (groupContent) {
         hasAny = true
@@ -847,10 +981,16 @@ module.exports = async function addComment(
   if (results.length > 0 && actionInfo.isRelease && actionInfo.commitId) {
     const mainStats = results[0].mainRepoStats
     if (mainStats?.General) {
+      // Compute aggregate totals for each bundle group
+      const bundleTotals = computeBundleGroupTotals(mainStats)
+
       const entry = {
         commitId: actionInfo.commitId,
         timestamp: new Date().toISOString(),
-        metrics: { ...mainStats.General },
+        metrics: {
+          ...mainStats.General, // Performance metrics
+          ...bundleTotals, // Bundle size totals
+        },
       }
       await saveToHistory(entry)
     }

--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -6,11 +6,210 @@ const logger = require('./util/logger')
 const prettyBytes = require('pretty-bytes')
 const { benchTitle } = require('./constants')
 
-const gzipIgnoreRegex = new RegExp(`(General|^Serverless|${benchTitle})`)
+// Try to load Vercel KV - may not be available in all environments
+let kv = null
+async function getKV() {
+  if (kv) return kv
+  if (!process.env.KV_REST_API_URL || !process.env.KV_REST_API_TOKEN) {
+    return null
+  }
+  try {
+    const { createClient } = require('@vercel/kv')
+    kv = createClient({
+      url: process.env.KV_REST_API_URL,
+      token: process.env.KV_REST_API_TOKEN,
+    })
+    return kv
+  } catch (e) {
+    logger.error('Failed to initialize Vercel KV:', e)
+    return null
+  }
+}
+
+const KV_STATS_KEY = 'next-stats-history'
+const MAX_HISTORY_ENTRIES = 100
+
+// ============================================================================
+// Metric Configuration
+// ============================================================================
+
+// Human-readable labels for metrics
+const METRIC_LABELS = {
+  // Dev boot metrics - Turbopack (Listen = port listening, First Request = HTTP responding)
+  'nextDevColdListenDurationTurbo (ms)': 'Cold (Listen)',
+  'nextDevColdReadyDurationTurbo (ms)': 'Cold (First Request)',
+  'nextDevWarmListenDurationTurbo (ms)': 'Warm (Listen)',
+  'nextDevWarmReadyDurationTurbo (ms)': 'Warm (First Request)',
+  // Dev boot metrics - Webpack
+  'nextDevColdListenDurationWebpack (ms)': 'Webpack Cold (Listen)',
+  'nextDevColdReadyDurationWebpack (ms)': 'Webpack Cold (First Request)',
+  'nextDevWarmListenDurationWebpack (ms)': 'Webpack Warm (Listen)',
+  'nextDevWarmReadyDurationWebpack (ms)': 'Webpack Warm (First Request)',
+  // Production metrics
+  'nextStartReadyDuration (ms)': 'Prod Start',
+  // Build metrics - Webpack
+  buildDurationWebpack: 'Webpack Build Time',
+  buildDurationCachedWebpack: 'Webpack Build Time (cached)',
+  // Build metrics - Turbopack
+  buildDurationTurbo: 'Turbo Build Time',
+  buildDurationCachedTurbo: 'Turbo Build Time (cached)',
+  // General metrics
+  nodeModulesSize: 'node_modules Size',
+}
+
+// Group configuration for organizing the comment
+const METRIC_GROUPS = {
+  'Dev Server': {
+    icon: '⚡',
+    description:
+      'Boot time for `next dev` (Turbopack). Cold = fresh build, Warm = with cache.',
+    metrics: [
+      {
+        label: 'Cold (Listen)',
+        key: 'nextDevColdListenDurationTurbo (ms)',
+        description: 'Time until TCP port accepts connections',
+      },
+      {
+        label: 'Cold (First Request)',
+        key: 'nextDevColdReadyDurationTurbo (ms)',
+        description: 'Time until first HTTP request succeeds',
+      },
+      {
+        label: 'Warm (Listen)',
+        key: 'nextDevWarmListenDurationTurbo (ms)',
+        description: 'Time until TCP port accepts connections (cached)',
+      },
+      {
+        label: 'Warm (First Request)',
+        key: 'nextDevWarmReadyDurationTurbo (ms)',
+        description: 'Time until first HTTP request succeeds (cached)',
+      },
+    ],
+    webpackGroup: 'Dev Server (Webpack)',
+  },
+  'Dev Server (Webpack)': {
+    icon: '📦',
+    isLegacy: true,
+    description:
+      'Boot time for `next dev` (Webpack). Cold = fresh build, Warm = with cache.',
+    metrics: [
+      {
+        label: 'Cold (Listen)',
+        key: 'nextDevColdListenDurationWebpack (ms)',
+        description: 'Time until TCP port accepts connections',
+      },
+      {
+        label: 'Cold (First Request)',
+        key: 'nextDevColdReadyDurationWebpack (ms)',
+        description: 'Time until first HTTP request succeeds',
+      },
+      {
+        label: 'Warm (Listen)',
+        key: 'nextDevWarmListenDurationWebpack (ms)',
+        description: 'Time until TCP port accepts connections (cached)',
+      },
+      {
+        label: 'Warm (First Request)',
+        key: 'nextDevWarmReadyDurationWebpack (ms)',
+        description: 'Time until first HTTP request succeeds (cached)',
+      },
+    ],
+  },
+  'Production Builds': {
+    icon: '⚡',
+    description: 'Time for `next build` (Turbopack).',
+    metrics: [
+      {
+        label: 'Fresh Build',
+        key: 'buildDurationTurbo',
+      },
+      {
+        label: 'Cached Build',
+        key: 'buildDurationCachedTurbo',
+      },
+    ],
+    webpackGroup: 'Production Builds (Webpack)',
+  },
+  'Production Builds (Webpack)': {
+    icon: '📦',
+    isLegacy: true,
+    description: 'Time for `next build --webpack`.',
+    metrics: [
+      {
+        label: 'Fresh Build',
+        key: 'buildDurationWebpack',
+      },
+      {
+        label: 'Cached Build',
+        key: 'buildDurationCachedWebpack',
+      },
+      {
+        label: 'node_modules Size',
+        key: 'nodeModulesSize',
+        type: 'bytes',
+      },
+    ],
+  },
+  'Production Runtime': {
+    icon: '🚀',
+    description: 'Boot time for `next start` (bundler-agnostic).',
+    metrics: [
+      {
+        label: 'Start (First Request)',
+        key: 'nextStartReadyDuration (ms)',
+      },
+    ],
+  },
+}
+
+// ============================================================================
+// Historical Data (Vercel KV)
+// ============================================================================
+
+async function loadHistory() {
+  const kvClient = await getKV()
+  if (!kvClient) return { entries: [] }
+
+  try {
+    const data = await kvClient.lrange(KV_STATS_KEY, -MAX_HISTORY_ENTRIES, -1)
+    return {
+      entries: data.map((d) => (typeof d === 'string' ? JSON.parse(d) : d)),
+    }
+  } catch (e) {
+    logger.error('Failed to load history from KV:', e)
+    return { entries: [] }
+  }
+}
+
+async function saveToHistory(entry) {
+  const kvClient = await getKV()
+  if (!kvClient) return
+
+  try {
+    await kvClient.rpush(KV_STATS_KEY, JSON.stringify(entry))
+    // Trim to keep only last N entries
+    await kvClient.ltrim(KV_STATS_KEY, -MAX_HISTORY_ENTRIES, -1)
+    logger('Saved stats to KV history')
+  } catch (e) {
+    logger.error('Failed to save to KV:', e)
+  }
+}
+
+// ============================================================================
+// Formatting Utilities
+// ============================================================================
+
+function prettifyTime(ms) {
+  if (typeof ms !== 'number') return 'N/A'
+  if (ms < 1000) {
+    return `${Math.round(ms)}ms`
+  }
+  return `${(ms / 1000).toFixed(3)}s`
+}
 
 const prettify = (val, type = 'bytes') => {
   if (typeof val !== 'number') return 'N/A'
-  return type === 'bytes' ? prettyBytes(val) : prettyMs(val)
+  return type === 'bytes' ? prettyBytes(val) : prettifyTime(val)
 }
 
 const round = (num, places) => {
@@ -23,202 +222,621 @@ const shortenLabel = (itemKey) =>
     ? `${itemKey.slice(0, 12)}..${itemKey.slice(-12)}`
     : itemKey
 
-const twoMB = 2 * 1024 * 1024
-const ONE_HUNDRED_BYTES = 100
-const ONE_HUNDRED_MS = 100
+function getMetricLabel(key) {
+  return METRIC_LABELS[key] || shortenLabel(key.replace(/ \(ms\)$/, ''))
+}
+
+function formatChange(mainVal, diffVal, type = 'bytes') {
+  if (typeof mainVal !== 'number' || typeof diffVal !== 'number') {
+    return { text: '-', significant: false, improved: false, regression: false }
+  }
+
+  const diff = diffVal - mainVal
+  const percentChange = mainVal > 0 ? (diff / mainVal) * 100 : 0
+
+  // Thresholds: stricter for framework development to catch all regressions
+  // For time: <10ms AND <2% = not worth mentioning
+  // For size: <1KB AND <1% = not worth mentioning
+  // If mainVal is 0 and diff is non-zero, always consider it significant
+  const isInsignificant =
+    mainVal === 0 && diff !== 0
+      ? false
+      : type === 'ms'
+        ? Math.abs(diff) < 10 && Math.abs(percentChange) < 2
+        : Math.abs(diff) < 1024 && Math.abs(percentChange) < 1
+
+  if (isInsignificant) {
+    return { text: '✓', significant: false, improved: false, regression: false }
+  }
+
+  const improved = diff < 0
+  const regression = diff > 0
+  // Clear icons: 🔴 regression, 🟢 improvement
+  const icon = improved ? '🟢' : '🔴'
+  const sign = diff > 0 ? '+' : ''
+  const formatted = prettify(Math.abs(diff), type)
+  const pct = `(${percentChange > 0 ? '+' : ''}${Math.round(percentChange)}%)`
+
+  return {
+    text: `${icon} ${sign}${formatted} ${pct}`.trim(),
+    significant: true,
+    improved,
+    regression,
+  }
+}
+
+function generateTrendBar(values) {
+  if (!values || values.length < 2) return ''
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min
+
+  if (range === 0) return '▁▁▁▁▁' // All values the same
+
+  // Unicode bar characters from short to tall
+  const bars = '▁▂▃▄▅▆▇█'
+
+  // Take last 5 values for a compact trend
+  const recent = values.slice(-5)
+
+  return recent
+    .map((v) => {
+      const normalized = (v - min) / range
+      const index = Math.min(
+        Math.floor(normalized * bars.length),
+        bars.length - 1
+      )
+      return bars[index]
+    })
+    .join('')
+}
+
+function getHistoricalValues(history, metricKey, limit = 15) {
+  if (!history?.entries?.length) return []
+  return history.entries
+    .slice(-limit)
+    .map((e) => e.metrics?.[metricKey])
+    .filter((v) => typeof v === 'number')
+}
+
+// ============================================================================
+// Comment Generation
+// ============================================================================
+
+// Determine if a metric is time-based (ms) or size-based (bytes)
+function getMetricType(metricKey) {
+  if (metricKey.includes('Duration') || metricKey.includes('(ms)')) {
+    return 'ms'
+  }
+  if (metricKey.includes('Size')) {
+    return 'bytes'
+  }
+  return 'ms' // default to ms for performance metrics
+}
+
+function generateChangeSummary(mainStats, diffStats) {
+  // Collect all significant changes across all metrics
+  const changes = []
+
+  // Check General metrics
+  const mainGeneral = mainStats?.General || {}
+  const diffGeneral = diffStats?.General || {}
+
+  for (const key of Object.keys({ ...mainGeneral, ...diffGeneral })) {
+    const mainVal = mainGeneral[key]
+    const diffVal = diffGeneral[key]
+    const type = getMetricType(key)
+    const change = formatChange(mainVal, diffVal, type)
+
+    if (change.significant) {
+      changes.push({
+        metric: getMetricLabel(key),
+        mainVal: prettify(mainVal, type),
+        diffVal: prettify(diffVal, type),
+        change: change.text,
+        improved: change.improved,
+        regression: change.regression,
+      })
+    }
+  }
+
+  if (changes.length === 0) {
+    return `### ✅ No significant changes detected\n\n`
+  }
+
+  // Sort: regressions first, then improvements
+  changes.sort((a, b) => {
+    if (a.regression !== b.regression) return a.regression ? -1 : 1
+    return 0
+  })
+
+  const regressions = changes.filter((c) => c.regression)
+  const improvements = changes.filter((c) => c.improved)
+
+  // Clear headline showing regressions
+  let headline = ''
+  if (regressions.length > 0) {
+    headline = `### 🔴 ${regressions.length} regression${regressions.length > 1 ? 's' : ''}`
+    if (improvements.length > 0) {
+      headline += `, ${improvements.length} improvement${improvements.length > 1 ? 's' : ''}`
+    }
+  } else {
+    headline = `### 🟢 ${improvements.length} improvement${improvements.length > 1 ? 's' : ''}`
+  }
+
+  let summary = `${headline}\n\n`
+  summary += `| Metric | Canary | PR | Change |\n`
+  summary += `|:-------|-------:|---:|-------:|\n`
+
+  for (const c of changes) {
+    summary += `| ${c.metric} | ${c.mainVal} | ${c.diffVal} | ${c.change} |\n`
+  }
+
+  return summary + '\n'
+}
+
+function generateGlossary() {
+  return `<details>
+<summary><strong>📖 Metrics Glossary</strong></summary>
+
+**Dev Server Metrics:**
+- **Listen** = TCP port starts accepting connections
+- **First Request** = HTTP server returns successful response
+- **Cold** = Fresh build (no cache)
+- **Warm** = With cached build artifacts
+
+**Build Metrics:**
+- **Fresh** = Clean build (no .next directory)
+- **Cached** = With existing .next directory
+
+**Change Thresholds:**
+- Time: Changes < 10ms AND < 2% are insignificant
+- Size: Changes < 1KB AND < 1% are insignificant
+- All other changes are flagged to catch regressions
+
+</details>
+
+`
+}
+
+function generateMetricsTable(
+  groupName,
+  config,
+  mainGroup,
+  diffGroup,
+  history,
+  isCollapsed = false
+) {
+  let rows = ''
+  let hasAny = false
+
+  for (const metricDef of config.metrics) {
+    const mainVal = mainGroup[metricDef.key]
+    const diffVal = diffGroup[metricDef.key]
+
+    if (mainVal === undefined && diffVal === undefined) continue
+    hasAny = true
+
+    const metricType = metricDef.type || 'ms'
+    const mainStr = prettify(mainVal, metricType)
+    const diffStr = prettify(diffVal, metricType)
+    const change = formatChange(mainVal, diffVal, metricType)
+    const histValues = getHistoricalValues(history, metricDef.key)
+    const sparkline = generateTrendBar(histValues)
+
+    rows += `| ${metricDef.label} | ${mainStr} | ${diffStr} | ${change.text} | ${sparkline} |\n`
+  }
+
+  if (!hasAny) return ''
+
+  const table = `### ${config.icon} ${groupName}
+
+| Metric | Canary | PR | Change | Trend |
+|:-------|-------:|---:|-------:|:-----:|
+${rows}
+`
+
+  // Wrap legacy/webpack tables in collapsible details
+  if (isCollapsed) {
+    return `<details>
+<summary><strong>${config.icon} ${groupName} (Legacy)</strong></summary>
+
+${table}
+</details>
+
+`
+  }
+
+  return table
+}
+
+function generatePerformanceSection(mainStats, diffStats, history) {
+  let content = ''
+
+  content += generateGlossary()
+
+  const mainGroup = mainStats?.General || {}
+  const diffGroup = diffStats?.General || {}
+
+  // Render groups in order: show Turbopack tables, then collapse Webpack tables
+  for (const [groupName, config] of Object.entries(METRIC_GROUPS)) {
+    // Skip legacy groups - they'll be rendered after their corresponding Turbopack group
+    if (config.isLegacy) continue
+
+    // Render Turbopack/main group prominently
+    content += generateMetricsTable(
+      groupName,
+      config,
+      mainGroup,
+      diffGroup,
+      history,
+      false
+    )
+
+    // If this group has a corresponding Webpack group, render it collapsed
+    if (config.webpackGroup) {
+      const webpackConfig = METRIC_GROUPS[config.webpackGroup]
+      if (webpackConfig) {
+        content += generateMetricsTable(
+          config.webpackGroup,
+          webpackConfig,
+          mainGroup,
+          diffGroup,
+          history,
+          true // collapsed
+        )
+      }
+    }
+  }
+
+  return content
+}
+
+// Base group names (without bundler suffix)
+const BASE_BUNDLE_GROUPS = {
+  client: [
+    'Client Bundles (main, webpack)',
+    'Client Pages',
+    'Legacy Client Bundles (polyfills)',
+  ],
+  server: ['Next Runtimes', 'Edge SSR bundle Size', 'Middleware size'],
+  other: ['Client Build Manifests', 'Rendered Page Sizes', 'build cache'],
+}
+
+// Bundler configuration
+const BUNDLERS_CONFIG = [
+  { name: 'Webpack', icon: '📦' },
+  { name: 'Turbopack', icon: '⚡' },
+]
+
+// Helper to check if a group name belongs to a bundler category
+function getBundlerFromGroupKey(groupKey) {
+  for (const bundler of BUNDLERS_CONFIG) {
+    if (groupKey.endsWith(`(${bundler.name})`)) {
+      return bundler
+    }
+  }
+  return null
+}
+
+// Helper to get the base group name (without bundler suffix)
+function getBaseGroupName(groupKey) {
+  return groupKey.replace(/ \((Webpack|Turbopack)\)$/, '')
+}
+
+function generateBundleGroup(groupKey, result, tableHead) {
+  const gzipIgnoreRegex = new RegExp(`(General|^Serverless|${benchTitle})`)
+  const mainRepoGroup = result.mainRepoStats[groupKey] || {}
+  const diffRepoGroup = result.diffRepoStats[groupKey] || {}
+  const itemKeys = new Set([
+    ...Object.keys(mainRepoGroup),
+    ...Object.keys(diffRepoGroup),
+  ])
+
+  let groupTable = tableHead
+  let mainRepoTotal = 0
+  let diffRepoTotal = 0
+  let hasItems = false
+
+  itemKeys.forEach((itemKey) => {
+    const isGzipItem = itemKey.endsWith('gzip')
+    const mainItemVal = mainRepoGroup[itemKey]
+    const diffItemVal = diffRepoGroup[itemKey]
+
+    // Skip non-gzip for most groups, skip gzip for serverless
+    if (groupKey.startsWith('Serverless') && isGzipItem) return
+    if (!isGzipItem && !groupKey.match(gzipIgnoreRegex)) return
+
+    hasItems = true
+    const mainItemStr = prettify(mainItemVal, 'bytes')
+    const diffItemStr = prettify(diffItemVal, 'bytes')
+    const change = formatChange(mainItemVal, diffItemVal, 'bytes')
+
+    if (typeof mainItemVal === 'number') mainRepoTotal += mainItemVal
+    if (typeof diffItemVal === 'number') diffRepoTotal += diffItemVal
+
+    groupTable += `| ${shortenLabel(itemKey)} | ${mainItemStr} | ${diffItemStr} | ${change.text} |\n`
+  })
+
+  if (!hasItems) return null
+
+  const totalChange = diffRepoTotal - mainRepoTotal
+  let totalChangeStr = '✓'
+
+  if (totalChange !== 0) {
+    const icon = totalChange > 0 ? '⚠️' : '✅'
+    const sign = totalChange > 0 ? '+' : '-'
+    totalChangeStr = `${icon} ${sign}${prettyBytes(Math.abs(totalChange))}`
+  }
+
+  groupTable += `| **Total** | **${prettyBytes(mainRepoTotal)}** | **${prettyBytes(diffRepoTotal)}** | ${totalChangeStr} |\n`
+
+  // Friendly names for groups
+  const friendlyNames = {
+    'Client Bundles (main, webpack)': 'Main & Webpack',
+    'Legacy Client Bundles (polyfills)': 'Polyfills',
+    'Client Pages': 'Pages',
+    'Client Build Manifests': 'Build Manifests',
+    'Rendered Page Sizes': 'HTML Output',
+    'Edge SSR bundle Size': 'Edge SSR',
+    'Middleware size': 'Middleware',
+    'Next Runtimes': 'Runtimes',
+    'build cache': 'Build Cache',
+  }
+
+  const displayName = friendlyNames[groupKey] || groupKey
+
+  return `<details>
+<summary>${displayName}</summary>
+
+${groupTable}
+</details>
+`
+}
+
+function generateBundleSizeSection(result, tableHead) {
+  let content = ''
+
+  // Collect all group keys from the result
+  const allGroupKeys = new Set([
+    ...Object.keys(result.mainRepoStats || {}),
+    ...Object.keys(result.diffRepoStats || {}),
+  ])
+
+  // Organize groups by bundler and category
+  const bundlerGroups = {}
+  const nonBundlerGroups = { client: [], server: [], other: [] }
+
+  for (const groupKey of allGroupKeys) {
+    if (groupKey === 'General' || groupKey === benchTitle) continue
+
+    const bundler = getBundlerFromGroupKey(groupKey)
+    const baseGroup = getBaseGroupName(groupKey)
+
+    if (bundler) {
+      if (!bundlerGroups[bundler.name]) {
+        bundlerGroups[bundler.name] = { icon: bundler.icon, groups: [] }
+      }
+      bundlerGroups[bundler.name].groups.push(groupKey)
+    } else {
+      // Categorize non-bundler groups
+      if (BASE_BUNDLE_GROUPS.client.includes(baseGroup)) {
+        nonBundlerGroups.client.push(groupKey)
+      } else if (BASE_BUNDLE_GROUPS.server.includes(baseGroup)) {
+        nonBundlerGroups.server.push(groupKey)
+      } else {
+        nonBundlerGroups.other.push(groupKey)
+      }
+    }
+  }
+
+  // Generate content for bundler-specific groups
+  for (const [bundlerName, bundlerData] of Object.entries(bundlerGroups)) {
+    let bundlerContent = ''
+    let hasAny = false
+
+    // Organize bundler groups by category
+    const categorizedGroups = { client: [], server: [], other: [] }
+    for (const groupKey of bundlerData.groups) {
+      const baseGroup = getBaseGroupName(groupKey)
+      if (BASE_BUNDLE_GROUPS.client.includes(baseGroup)) {
+        categorizedGroups.client.push(groupKey)
+      } else if (BASE_BUNDLE_GROUPS.server.includes(baseGroup)) {
+        categorizedGroups.server.push(groupKey)
+      } else {
+        categorizedGroups.other.push(groupKey)
+      }
+    }
+
+    // Client bundles
+    if (categorizedGroups.client.length > 0) {
+      let clientContent = ''
+      for (const groupKey of categorizedGroups.client) {
+        const groupContent = generateBundleGroup(groupKey, result, tableHead)
+        if (groupContent) {
+          hasAny = true
+          clientContent += groupContent
+        }
+      }
+      if (clientContent) {
+        bundlerContent += `**Client**\n${clientContent}\n`
+      }
+    }
+
+    // Server bundles
+    if (categorizedGroups.server.length > 0) {
+      let serverContent = ''
+      for (const groupKey of categorizedGroups.server) {
+        const groupContent = generateBundleGroup(groupKey, result, tableHead)
+        if (groupContent) {
+          hasAny = true
+          serverContent += groupContent
+        }
+      }
+      if (serverContent) {
+        bundlerContent += `**Server**\n${serverContent}\n`
+      }
+    }
+
+    // Other bundles (collapsed)
+    if (categorizedGroups.other.length > 0) {
+      let otherContent = ''
+      for (const groupKey of categorizedGroups.other) {
+        const groupContent = generateBundleGroup(groupKey, result, tableHead)
+        if (groupContent) {
+          hasAny = true
+          otherContent += groupContent
+        }
+      }
+      if (otherContent) {
+        bundlerContent += `<details>\n<summary><strong>Build Details</strong></summary>\n\n${otherContent}</details>\n\n`
+      }
+    }
+
+    if (hasAny) {
+      content += `### ${bundlerData.icon} ${bundlerName}\n\n${bundlerContent}`
+    }
+  }
+
+  // Handle any non-bundler-specific groups (shouldn't happen but fallback)
+  for (const [categoryKey, groups] of Object.entries(nonBundlerGroups)) {
+    if (groups.length === 0) continue
+
+    let categoryContent = ''
+    let hasAny = false
+
+    for (const groupKey of groups) {
+      const groupContent = generateBundleGroup(groupKey, result, tableHead)
+      if (groupContent) {
+        hasAny = true
+        categoryContent += groupContent
+      }
+    }
+
+    if (hasAny) {
+      const titles = {
+        client: '📦 Client',
+        server: '🖥️ Server',
+        other: '🔧 Other',
+      }
+      content += `### ${titles[categoryKey]}\n\n${categoryContent}`
+    }
+  }
+
+  return content ? `## Bundle Sizes\n\n${content}` : ''
+}
+
+function generateDiffsSection(result) {
+  if (!result.diffs || Object.keys(result.diffs).length === 0) return ''
+
+  const diffKeys = Object.keys(result.diffs)
+  const diffCount = diffKeys.length
+
+  // Just show count and list of changed files, keep diffs collapsed
+  let content = `<details>\n<summary><strong>📝 Changed Files</strong> (${diffCount} file${diffCount === 1 ? '' : 's'})</summary>\n\n`
+
+  // List files that changed
+  content += '**Files with changes:**\n'
+  for (const itemKey of diffKeys.slice(0, 20)) {
+    content += `- \`${shortenLabel(itemKey)}\`\n`
+  }
+  if (diffKeys.length > 20) {
+    content += `- ... and ${diffKeys.length - 20} more\n`
+  }
+
+  // Show actual diffs in nested collapsed sections
+  content += '\n<details>\n<summary>View diffs</summary>\n\n'
+  for (const [itemKey, diff] of Object.entries(result.diffs)) {
+    content += `<details>\n<summary>${shortenLabel(itemKey)}</summary>\n\n`
+    if (diff.length > 36000) {
+      content += 'Diff too large to display'
+    } else {
+      content += `\`\`\`diff\n${diff}\n\`\`\``
+    }
+    content += '\n</details>\n'
+  }
+  content += '</details>\n'
+
+  content += '</details>\n\n'
+  return content
+}
+
+// ============================================================================
+// Main Export
+// ============================================================================
+
+// Hidden marker to identify stats comments (invisible in rendered markdown)
+const STATS_COMMENT_MARKER = '<!-- __NEXT_STATS_COMMENT__ -->'
 
 module.exports = async function addComment(
   results = [],
   actionInfo,
   statsConfig
 ) {
-  let comment = `# ${
+  // Load historical data
+  const history = await loadHistory()
+
+  // Build the comment with hidden marker for identification
+  let comment = `${STATS_COMMENT_MARKER}\n## ${
     actionInfo.isRelease
       ? statsConfig.commentReleaseHeading || 'Stats from current release'
       : statsConfig.commentHeading || 'Stats from current PR'
   }\n\n`
 
-  const tableHead = `|  | ${statsConfig.mainRepo} ${statsConfig.mainBranch} ${
-    actionInfo.lastStableTag || ''
-  } | ${actionInfo.prRepo} ${actionInfo.prRef} | Change |\n| - | - | - | - |\n`
+  const tableHead = `| | Canary | PR | Change |\n|:--|--:|--:|--:|\n`
 
   for (let i = 0; i < results.length; i++) {
     const result = results[i]
     const isLastResult = i === results.length - 1
-    let resultHasIncrease = false
-    let resultHasDecrease = false
-    let resultContent = ''
 
-    Object.keys(result.mainRepoStats).forEach((groupKey) => {
-      const isBenchmark = groupKey === benchTitle
-      const mainRepoGroup = result.mainRepoStats[groupKey]
-      const diffRepoGroup = result.diffRepoStats[groupKey]
-      const itemKeys = new Set([
-        ...Object.keys(mainRepoGroup),
-        ...Object.keys(diffRepoGroup),
-      ])
-      let groupTable = tableHead
-      let mainRepoTotal = 0
-      let diffRepoTotal = 0
-      let totalChange = 0
-
-      itemKeys.forEach((itemKey) => {
-        const prettyType = itemKey.match(/(length|duration)/i) ? 'ms' : 'bytes'
-        const isGzipItem = itemKey.endsWith('gzip')
-        const mainItemVal = mainRepoGroup[itemKey]
-        const diffItemVal = diffRepoGroup[itemKey]
-        const useRawValue = isBenchmark && prettyType !== 'ms'
-        const mainItemStr = useRawValue
-          ? mainItemVal
-          : prettify(mainItemVal, prettyType)
-
-        const diffItemStr = useRawValue
-          ? diffItemVal
-          : prettify(diffItemVal, prettyType)
-
-        let change = '✓'
-
-        // Don't show gzip values for serverless as they aren't
-        // deterministic currently
-        if (groupKey.startsWith('Serverless') && isGzipItem) return
-        // otherwise only show gzip values
-        else if (!isGzipItem && !groupKey.match(gzipIgnoreRegex)) return
-
-        // calculate the change
-        if (mainItemVal !== diffItemVal) {
-          if (
-            typeof mainItemVal === 'number' &&
-            typeof diffItemVal === 'number'
-          ) {
-            const roundedValue = round(diffItemVal - mainItemVal, 2)
-
-            // check if there is still a change after rounding
-            if (
-              roundedValue !== 0 &&
-              ((prettyType === 'ms' && roundedValue > ONE_HUNDRED_MS) ||
-                (prettyType === 'bytes' && roundedValue > ONE_HUNDRED_BYTES))
-            ) {
-              change = roundedValue
-              const absChange = Math.abs(change)
-              const warnIfNegative = isBenchmark && itemKey.match(/req\/sec/)
-              const warn = warnIfNegative
-                ? change < 0
-                  ? '⚠️ '
-                  : ''
-                : change > 0
-                  ? '⚠️ '
-                  : ''
-              change = `${warn}${change < 0 ? '-' : '+'}${
-                useRawValue ? absChange : prettify(absChange, prettyType)
-              }`
-            } else {
-              change = 'N/A'
-            }
-          } else {
-            change = 'N/A'
-          }
-        }
-
-        if (
-          (change !== 'N/A' && !itemKey.startsWith('buildDuration')) ||
-          (isBenchmark && itemKey.match(/req\/sec/))
-        ) {
-          if (typeof mainItemVal === 'number') mainRepoTotal += mainItemVal
-          if (typeof diffItemVal === 'number') diffRepoTotal += diffItemVal
-        }
-
-        groupTable += `| ${
-          isBenchmark ? itemKey : shortenLabel(itemKey)
-        } | ${mainItemStr} | ${diffItemStr} | ${change} |\n`
-      })
-      let groupTotalChange = ''
-
-      totalChange = diffRepoTotal - mainRepoTotal
-
-      if (totalChange !== 0) {
-        if (totalChange < 0) {
-          resultHasDecrease = true
-          groupTotalChange = ` Overall decrease ${isBenchmark ? '⚠️' : '✓'}`
-        } else {
-          if (
-            (groupKey !== 'General' && totalChange > 5) ||
-            totalChange > twoMB
-          ) {
-            resultHasIncrease = true
-          }
-          groupTotalChange = ` Overall increase ${isBenchmark ? '✓' : '⚠️'}`
-        }
-      }
-
-      if (groupKey !== 'General' && groupKey !== benchTitle) {
-        let totalChangeSign = ''
-
-        if (totalChange === 0) {
-          totalChange = '✓'
-        } else {
-          totalChangeSign = totalChange < 0 ? '-' : '⚠️ +'
-        }
-        totalChange = `${totalChangeSign}${
-          typeof totalChange === 'number'
-            ? prettify(Math.abs(totalChange))
-            : totalChange
-        }`
-        groupTable += `| Overall change | ${prettyBytes(
-          round(mainRepoTotal, 2)
-        )} | ${prettyBytes(round(diffRepoTotal, 2))} | ${totalChange} |\n`
-      }
-
-      if (itemKeys.size > 0) {
-        resultContent += `<details>\n`
-        resultContent += `<summary><strong>${groupKey}</strong>${groupTotalChange}</summary>\n\n`
-        resultContent += groupTable
-        resultContent += `\n</details>\n\n`
-      }
-    })
-
-    // add diffs
-    if (result.diffs) {
-      let diffContent = ''
-
-      Object.keys(result.diffs).forEach((itemKey) => {
-        const curDiff = result.diffs[itemKey]
-        diffContent += `<details>\n`
-        diffContent += `<summary>Diff for <strong>${shortenLabel(
-          itemKey
-        )}</strong></summary>\n\n`
-
-        if (curDiff.length > 36 * 1000) {
-          diffContent += 'Diff too large to display'
-        } else {
-          diffContent += `\`\`\`diff\n${curDiff}\n\`\`\``
-        }
-        diffContent += `\n</details>\n`
-      })
-
-      if (diffContent.length > 0) {
-        resultContent += `<details>\n`
-        resultContent += `<summary><strong>Diff details</strong></summary>\n\n`
-        resultContent += diffContent
-        resultContent += `\n</details>\n\n`
-      }
-    }
-    let increaseDecreaseNote = ''
-
-    if (resultHasIncrease) {
-      increaseDecreaseNote = ' (Increase detected ⚠️)'
-    } else if (resultHasDecrease) {
-      increaseDecreaseNote = ' (Decrease detected ✓)'
+    // Add summary showing only significant changes (not collapsed)
+    if (i === 0) {
+      comment += generateChangeSummary(
+        result.mainRepoStats,
+        result.diffRepoStats
+      )
     }
 
-    comment += `<details open>\n`
-    comment += `<summary><strong>${result.title}</strong>${increaseDecreaseNote}</summary>\n\n<br/>\n\n`
-    comment += resultContent
-    comment += '</details>\n'
+    // Add performance section (collapsed by default)
+    const perfSection = generatePerformanceSection(
+      result.mainRepoStats,
+      result.diffRepoStats,
+      history
+    )
+    if (perfSection) {
+      comment += `<details>\n<summary><strong>📊 All Metrics</strong></summary>\n\n${perfSection}</details>\n\n`
+    }
+
+    // Add bundle sizes (collapsed by default)
+    const bundleSection = generateBundleSizeSection(result, tableHead)
+    if (bundleSection) {
+      comment += `<details>\n<summary><strong>📦 Bundle Sizes</strong></summary>\n\n${bundleSection}</details>\n\n`
+    }
+
+    // Add diffs (already collapsed)
+    comment += generateDiffsSection(result)
 
     if (!isLastResult) {
-      comment += `<hr/>\n`
+      comment += '<hr/>\n\n'
     }
   }
+
+  // Save canary stats to history (only for releases, not PR comparisons)
+  // This ensures we only track official canary metrics, not PR-specific data
+  if (results.length > 0 && actionInfo.isRelease && actionInfo.commitId) {
+    const mainStats = results[0].mainRepoStats
+    if (mainStats?.General) {
+      const entry = {
+        commitId: actionInfo.commitId,
+        timestamp: new Date().toISOString(),
+        metrics: { ...mainStats.General },
+      }
+      await saveToHistory(entry)
+    }
+  }
+
+  // Output locally or post to GitHub
   if (process.env.LOCAL_STATS) {
     const statsPath = path.resolve('pr-stats.md')
     await fs.writeFile(statsPath, comment)
@@ -231,8 +849,6 @@ module.exports = async function addComment(
     actionInfo.customCommentEndpoint ||
     (actionInfo.githubToken && actionInfo.commentEndpoint)
   ) {
-    logger(`Posting results to ${actionInfo.commentEndpoint}`)
-
     const body = {
       body: comment,
       ...(!actionInfo.githubToken
@@ -249,8 +865,61 @@ module.exports = async function addComment(
     }
 
     try {
-      const res = await fetch(actionInfo.commentEndpoint, {
-        method: 'POST',
+      // Try to find existing stats comment to update
+      let existingCommentId = null
+      const commentHeading =
+        statsConfig.commentHeading || 'Stats from current PR'
+
+      if (actionInfo.githubToken && actionInfo.commentEndpoint) {
+        try {
+          const existingRes = await fetch(actionInfo.commentEndpoint, {
+            headers: {
+              Authorization: `bearer ${actionInfo.githubToken}`,
+            },
+          })
+
+          if (existingRes.ok) {
+            const comments = await existingRes.json()
+            // Find comment with our hidden marker, or fall back to heading match
+            // The marker ensures we only update our own stats comments
+            const existing = comments.find(
+              (c) =>
+                c.body &&
+                (c.body.includes(STATS_COMMENT_MARKER) ||
+                  // Legacy fallback: match by heading (for comments before marker was added)
+                  ((c.body.startsWith(`## ${commentHeading}`) ||
+                    c.body.startsWith(`# ${commentHeading}`)) &&
+                    c.body.includes('Canary') &&
+                    c.body.includes('Change')))
+            )
+            if (existing) {
+              existingCommentId = existing.id
+              logger(`Found existing comment ${existingCommentId} to update`)
+            }
+          }
+        } catch (e) {
+          logger.error('Failed to fetch existing comments:', e)
+        }
+      }
+
+      // Update existing or create new
+      let endpoint = actionInfo.commentEndpoint
+      let method = 'POST'
+
+      if (existingCommentId && actionInfo.githubToken) {
+        // GitHub API: PATCH /repos/{owner}/{repo}/issues/comments/{comment_id}
+        endpoint = actionInfo.commentEndpoint.replace(
+          /\/issues\/\d+\/comments$/,
+          `/issues/comments/${existingCommentId}`
+        )
+        method = 'PATCH'
+        logger(`Updating existing comment at ${endpoint}`)
+      } else {
+        logger(`Creating new comment at ${endpoint}`)
+      }
+
+      const res = await fetch(endpoint, {
+        method,
         headers: {
           ...(actionInfo.githubToken
             ? {
@@ -264,14 +933,16 @@ module.exports = async function addComment(
       })
 
       if (!res.ok) {
-        logger.error(`Failed to post results ${res.status}`)
+        logger.error(`Failed to ${method} results ${res.status}`)
         try {
           logger.error(await res.text())
         } catch (_) {
           /* no-op */
         }
       } else {
-        logger('Successfully posted results')
+        logger(
+          `Successfully ${method === 'PATCH' ? 'updated' : 'posted'} results`
+        )
       }
     } catch (err) {
       logger.error(`Error occurred posting results`, err)

--- a/.github/actions/next-stats-action/src/aggregate-results.js
+++ b/.github/actions/next-stats-action/src/aggregate-results.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+/**
+ * Aggregates results from sharded stats runs and posts combined comment
+ *
+ * Usage: node aggregate-results.js <results-dir>
+ *
+ * Expects JSON files named pr-stats-*.json in the results directory
+ */
+
+const path = require('path')
+const fs = require('fs/promises')
+const { existsSync } = require('fs')
+const addComment = require('./add-comment')
+const logger = require('./util/logger')
+
+async function main() {
+  const resultsDir = process.argv[2] || process.cwd()
+
+  logger(`Aggregating results from: ${resultsDir}`)
+
+  // Find all pr-stats-*.json files
+  const files = await fs.readdir(resultsDir)
+  const statsFiles = files.filter(
+    (f) => f.startsWith('pr-stats-') && f.endsWith('.json')
+  )
+
+  if (statsFiles.length === 0) {
+    // This can happen for docs-only changes where stats jobs are skipped
+    logger('No pr-stats-*.json files found - this may be a docs-only change')
+    process.exit(0)
+  }
+
+  logger(`Found ${statsFiles.length} results files: ${statsFiles.join(', ')}`)
+
+  // Load all results
+  const allData = []
+  for (const file of statsFiles) {
+    const filePath = path.join(resultsDir, file)
+    try {
+      const content = await fs.readFile(filePath, 'utf8')
+      const data = JSON.parse(content)
+      allData.push(data)
+      logger(`Loaded ${file} successfully`)
+    } catch (err) {
+      logger(`Warning: Failed to load ${file}: ${err.message}`)
+    }
+  }
+
+  if (allData.length === 0) {
+    logger('No valid results files could be loaded')
+    process.exit(1)
+  }
+
+  // Use the first file's actionInfo and statsConfig
+  const { actionInfo, statsConfig } = allData[0]
+
+  // Re-inject the GitHub token from env (it's excluded from JSON serialization for security)
+  actionInfo.githubToken = process.env.PR_STATS_COMMENT_TOKEN
+
+  // Merge results from all files
+  // Each file has results array with {title, mainRepoStats, diffRepoStats, diffs}
+  // We need to merge stats objects by combining their keys
+  const mergedResults = []
+
+  // Assume all files have the same number of configs with same titles
+  const numConfigs = allData[0].results.length
+
+  for (let i = 0; i < numConfigs; i++) {
+    const title = allData[0].results[i].title
+    const mergedMainRepoStats = {}
+    const mergedDiffRepoStats = {}
+    let mergedDiffs = null
+
+    for (const data of allData) {
+      const result = data.results[i]
+
+      // Merge mainRepoStats
+      if (result.mainRepoStats) {
+        for (const [key, value] of Object.entries(result.mainRepoStats)) {
+          if (!mergedMainRepoStats[key]) {
+            mergedMainRepoStats[key] = {}
+          }
+          Object.assign(mergedMainRepoStats[key], value)
+        }
+      }
+
+      // Merge diffRepoStats
+      if (result.diffRepoStats) {
+        for (const [key, value] of Object.entries(result.diffRepoStats)) {
+          if (!mergedDiffRepoStats[key]) {
+            mergedDiffRepoStats[key] = {}
+          }
+          Object.assign(mergedDiffRepoStats[key], value)
+        }
+      }
+
+      // Merge diffs (just combine all diff objects)
+      if (result.diffs) {
+        if (!mergedDiffs) {
+          mergedDiffs = {}
+        }
+        Object.assign(mergedDiffs, result.diffs)
+      }
+    }
+
+    mergedResults.push({
+      title,
+      mainRepoStats: mergedMainRepoStats,
+      diffRepoStats: mergedDiffRepoStats,
+      diffs: mergedDiffs,
+    })
+  }
+
+  logger(
+    `Merged ${allData.length} result sets into ${mergedResults.length} configs`
+  )
+
+  // Post the combined comment
+  await addComment(mergedResults, actionInfo, statsConfig)
+
+  logger('Aggregation complete')
+}
+
+main().catch((err) => {
+  console.error('Error aggregating results:', err)
+  process.exit(1)
+})

--- a/.github/actions/next-stats-action/src/run/collect-stats.js
+++ b/.github/actions/next-stats-action/src/run/collect-stats.js
@@ -12,41 +12,10 @@ const { spawn } = require('../util/exec')
 const { parse: urlParse } = require('url')
 const benchmarkUrl = require('./benchmark-url')
 const { statsAppDir, diffingDir, benchTitle } = require('../constants')
+const { calcStats } = require('../util/stats')
 
 // Number of iterations for timing benchmarks to get stable median
-const BENCHMARK_ITERATIONS = 5
-
-// Calculate median of an array of numbers
-function median(arr) {
-  if (arr.length === 0) return null
-  const sorted = [...arr].sort((a, b) => a - b)
-  const mid = Math.floor(sorted.length / 2)
-  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
-}
-
-// Calculate stats summary for an array of numbers
-function calcStats(arr) {
-  if (arr.length === 0) return null
-  const sorted = [...arr].sort((a, b) => a - b)
-  const mid = Math.floor(sorted.length / 2)
-  const med =
-    sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
-  const min = sorted[0]
-  const max = sorted[sorted.length - 1]
-  const mean = arr.reduce((a, b) => a + b, 0) / arr.length
-  const variance =
-    arr.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / arr.length
-  const stddev = Math.sqrt(variance)
-  const cv = mean > 0 ? (stddev / mean) * 100 : 0 // coefficient of variation as %
-  return {
-    median: med,
-    min,
-    max,
-    mean: Math.round(mean),
-    stddev: Math.round(stddev),
-    cv: Math.round(cv),
-  }
-}
+const BENCHMARK_ITERATIONS = 9
 
 // Check if a port is accepting TCP connections
 function checkPort(port, timeout = 100) {
@@ -308,7 +277,7 @@ module.exports = async function collectStats(
       if (!orderedStats['General']) {
         orderedStats['General'] = {}
       }
-      orderedStats['General']['nextStartReadyDuration (ms)'] = readyStats.median
+      orderedStats['General']['nextStartReadyDuration'] = readyStats.median
     } else {
       logger(`  Prod Start: Failed to collect timing data`)
     }
@@ -458,14 +427,12 @@ module.exports = async function collectStats(
       )
 
       if (coldResult.listenTime !== null) {
-        orderedStats['General'][
-          `nextDevColdListenDuration${bundler.suffix} (ms)`
-        ] = coldResult.listenTime
+        orderedStats['General'][`nextDevColdListenDuration${bundler.suffix}`] =
+          coldResult.listenTime
       }
       if (coldResult.readyTime !== null) {
-        orderedStats['General'][
-          `nextDevColdReadyDuration${bundler.suffix} (ms)`
-        ] = coldResult.readyTime
+        orderedStats['General'][`nextDevColdReadyDuration${bundler.suffix}`] =
+          coldResult.readyTime
       }
 
       // 2. Warm up bytecode cache by running server for ~10 seconds
@@ -515,13 +482,12 @@ module.exports = async function collectStats(
 
         if (warmResult.listenTime !== null) {
           orderedStats['General'][
-            `nextDevWarmListenDuration${bundler.suffix} (ms)`
+            `nextDevWarmListenDuration${bundler.suffix}`
           ] = warmResult.listenTime
         }
         if (warmResult.readyTime !== null) {
-          orderedStats['General'][
-            `nextDevWarmReadyDuration${bundler.suffix} (ms)`
-          ] = warmResult.readyTime
+          orderedStats['General'][`nextDevWarmReadyDuration${bundler.suffix}`] =
+            warmResult.readyTime
         }
       }
     }

--- a/.github/actions/next-stats-action/src/run/collect-stats.js
+++ b/.github/actions/next-stats-action/src/run/collect-stats.js
@@ -1,14 +1,210 @@
 const path = require('path')
+const net = require('net')
 const fs = require('fs/promises')
+const { existsSync } = require('fs')
 const getPort = require('get-port')
 const fetch = require('node-fetch')
 const glob = require('../util/glob')
 const gzipSize = require('gzip-size')
 const logger = require('../util/logger')
+const exec = require('../util/exec')
 const { spawn } = require('../util/exec')
 const { parse: urlParse } = require('url')
 const benchmarkUrl = require('./benchmark-url')
 const { statsAppDir, diffingDir, benchTitle } = require('../constants')
+
+// Number of iterations for timing benchmarks to get stable median
+const BENCHMARK_ITERATIONS = 5
+
+// Calculate median of an array of numbers
+function median(arr) {
+  if (arr.length === 0) return null
+  const sorted = [...arr].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+}
+
+// Calculate stats summary for an array of numbers
+function calcStats(arr) {
+  if (arr.length === 0) return null
+  const sorted = [...arr].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  const med =
+    sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+  const min = sorted[0]
+  const max = sorted[sorted.length - 1]
+  const mean = arr.reduce((a, b) => a + b, 0) / arr.length
+  const variance =
+    arr.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / arr.length
+  const stddev = Math.sqrt(variance)
+  const cv = mean > 0 ? (stddev / mean) * 100 : 0 // coefficient of variation as %
+  return {
+    median: med,
+    min,
+    max,
+    mean: Math.round(mean),
+    stddev: Math.round(stddev),
+    cv: Math.round(cv),
+  }
+}
+
+// Check if a port is accepting TCP connections
+function checkPort(port, timeout = 100) {
+  return new Promise((resolve) => {
+    const socket = new net.Socket()
+    socket.setTimeout(timeout)
+    socket.once('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.once('timeout', () => {
+      socket.destroy()
+      resolve(false)
+    })
+    socket.once('error', () => {
+      socket.destroy()
+      resolve(false)
+    })
+    socket.connect(port, 'localhost')
+  })
+}
+
+// Wait for port to start accepting TCP connections
+async function waitForPort(port, timeoutMs = 60000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    if (await checkPort(port)) {
+      return Date.now() - start
+    }
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  return null
+}
+
+// Wait for HTTP server to respond
+async function waitForHttp(port, timeoutMs = 60000) {
+  const start = Date.now()
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(`http://localhost:${port}/`, { timeout: 2000 })
+      if (res.ok) {
+        return Date.now() - start
+      }
+    } catch (e) {
+      // Server not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 50))
+  }
+  return null
+}
+
+// Run a single dev server boot benchmark
+async function benchmarkDevBoot(appDevCommand, curDir, port, cleanBuild) {
+  // Clean .next directory for cold start
+  if (cleanBuild) {
+    const nextDir = path.join(curDir, '.next')
+    await fs.rm(nextDir, { recursive: true, force: true })
+  }
+
+  const startTime = Date.now()
+  const devChild = spawn(appDevCommand, {
+    cwd: curDir,
+    env: {
+      PORT: port,
+    },
+    stdio: 'pipe',
+  })
+
+  let exited = false
+  devChild.on('exit', () => {
+    exited = true
+  })
+
+  // Capture output for debugging
+  devChild.stdout.on('data', (data) => process.stdout.write(data))
+  devChild.stderr.on('data', (data) => process.stderr.write(data))
+
+  // Measure time to port listening (TCP level)
+  const listenTime = await waitForPort(port, 60000)
+
+  // Measure time to HTTP ready
+  let readyTime = null
+  if (listenTime !== null && !exited) {
+    readyTime = await waitForHttp(port, 60000)
+  }
+
+  devChild.kill()
+
+  // Wait for process to fully exit to avoid port conflicts on subsequent runs
+  if (!exited) {
+    await new Promise((resolve) => {
+      devChild.on('exit', resolve)
+      // Timeout after 5 seconds in case process doesn't exit cleanly
+      setTimeout(resolve, 5000)
+    })
+  }
+
+  return {
+    listenTime,
+    readyTime,
+  }
+}
+
+// Run multiple iterations of dev boot benchmark and return median times
+async function benchmarkDevBootWithIterations(
+  appDevCommand,
+  curDir,
+  port,
+  cleanBuild,
+  label
+) {
+  const listenTimes = []
+  const readyTimes = []
+
+  for (let i = 0; i < BENCHMARK_ITERATIONS; i++) {
+    // For cold start benchmarks, clean before EVERY iteration to get true cold times
+    logger(`  ${label} iteration ${i + 1}/${BENCHMARK_ITERATIONS}...`)
+
+    const result = await benchmarkDevBoot(
+      appDevCommand,
+      curDir,
+      port,
+      cleanBuild
+    )
+
+    if (result.listenTime !== null) {
+      listenTimes.push(result.listenTime)
+      logger(`    Boot: ${result.listenTime}ms`)
+    }
+    if (result.readyTime !== null) {
+      readyTimes.push(result.readyTime)
+      logger(`    Ready: ${result.readyTime}ms`)
+    }
+
+    // Small delay between iterations to let system settle
+    await new Promise((r) => setTimeout(r, 500))
+  }
+
+  const listenStats = calcStats(listenTimes)
+  const readyStats = calcStats(readyTimes)
+
+  // Log detailed stats for debugging
+  if (listenStats) {
+    logger(
+      `  ${label} Boot: median=${listenStats.median}ms, range=${listenStats.min}-${listenStats.max}ms, CV=${listenStats.cv}%`
+    )
+  }
+  if (readyStats) {
+    logger(
+      `  ${label} Ready: median=${readyStats.median}ms, range=${readyStats.min}-${readyStats.max}ms, CV=${readyStats.cv}%`
+    )
+  }
+
+  return {
+    listenTime: listenStats?.median ?? null,
+    readyTime: readyStats?.median ?? null,
+  }
+}
 
 async function defaultGetRequiredFiles(nextAppDir, fileName) {
   return [fileName]
@@ -17,7 +213,10 @@ async function defaultGetRequiredFiles(nextAppDir, fileName) {
 module.exports = async function collectStats(
   runConfig = {},
   statsConfig = {},
-  fromDiff = false
+  fromDiff = false,
+  bundlerSuffix = null,
+  benchmarkOnly = false,
+  bundlerFilter = null
 ) {
   const stats = {
     [benchTitle]: {},
@@ -27,18 +226,95 @@ module.exports = async function collectStats(
   }
   const curDir = fromDiff ? diffingDir : statsAppDir
 
+  // If bundlerSuffix is provided, we're collecting file sizes only (skip benchmarks)
+  // If benchmarkOnly is true, we're running benchmarks only (skip file sizes)
+  const collectFileSizes = !benchmarkOnly
+  const runBenchmarks = !bundlerSuffix
+
   const hasPagesToFetch =
     Array.isArray(runConfig.pagesToFetch) && runConfig.pagesToFetch.length > 0
 
   const hasPagesToBench =
     Array.isArray(runConfig.pagesToBench) && runConfig.pagesToBench.length > 0
 
+  // Run production start benchmark FIRST (before dev benchmark which cleans .next)
+  // Only run benchmarks when not collecting bundler-specific file sizes
+  // Skip production start in sharded mode (bundlerFilter set) as these metrics don't vary by bundler
   if (
+    runBenchmarks &&
     !fromDiff &&
+    !bundlerFilter &&
     statsConfig.appStartCommand &&
     (hasPagesToFetch || hasPagesToBench)
   ) {
     const port = await getPort()
+    const readyTimes = []
+
+    // Helper to run a single production start and measure time
+    async function runProdStartTiming() {
+      const startTime = Date.now()
+      const child = spawn(statsConfig.appStartCommand, {
+        cwd: curDir,
+        env: {
+          PORT: port,
+        },
+        stdio: 'pipe',
+      })
+
+      let serverReadyResolve
+      let serverReadyResolved = false
+      const serverReadyPromise = new Promise((resolve) => {
+        serverReadyResolve = resolve
+      })
+
+      child.stdout.on('data', (data) => {
+        if (data.toString().includes('- Local:') && !serverReadyResolved) {
+          serverReadyResolved = true
+          serverReadyResolve()
+        }
+      })
+
+      child.on('exit', () => {
+        if (!serverReadyResolved) {
+          serverReadyResolve()
+          serverReadyResolved = true
+        }
+      })
+
+      await serverReadyPromise
+      const readyTime = Date.now() - startTime
+      child.kill()
+      await new Promise((r) => setTimeout(r, 300)) // Let port release
+      return readyTime
+    }
+
+    // Run multiple timing iterations for stable median
+    logger(
+      `=== Production Start Benchmark (${BENCHMARK_ITERATIONS} iterations) ===`
+    )
+    for (let i = 0; i < BENCHMARK_ITERATIONS; i++) {
+      logger(`  Prod Start iteration ${i + 1}/${BENCHMARK_ITERATIONS}...`)
+      const readyTime = await runProdStartTiming()
+      readyTimes.push(readyTime)
+      logger(`    Ready: ${readyTime}ms`)
+    }
+
+    const readyStats = calcStats(readyTimes)
+    if (readyStats) {
+      logger(
+        `  Prod Start: median=${readyStats.median}ms, range=${readyStats.min}-${readyStats.max}ms, CV=${readyStats.cv}%`
+      )
+
+      if (!orderedStats['General']) {
+        orderedStats['General'] = {}
+      }
+      orderedStats['General']['nextStartReadyDuration (ms)'] = readyStats.median
+    } else {
+      logger(`  Prod Start: Failed to collect timing data`)
+    }
+
+    // Now run one more time to do page fetching/benchmarking
+    logger('=== Production Start for Page Fetching ===')
     const startTime = Date.now()
     const child = spawn(statsConfig.appStartCommand, {
       cwd: curDir,
@@ -74,11 +350,6 @@ module.exports = async function collectStats(
     })
 
     await serverReadyPromise
-    if (!orderedStats['General']) {
-      orderedStats['General'] = {}
-    }
-    orderedStats['General']['nextStartReadyDuration (ms)'] =
-      Date.now() - startTime
 
     if (exitCode !== null) {
       throw new Error(
@@ -139,43 +410,165 @@ module.exports = async function collectStats(
     child.kill()
   }
 
-  for (const fileGroup of runConfig.filesToTrack) {
-    const {
-      getRequiredFiles = defaultGetRequiredFiles,
-      name,
-      globs,
-    } = fileGroup
-    const groupStats = {}
-    const curFiles = new Set()
+  // Measure dev server boot time if configured
+  // Runs full matrix: (Turbopack + Webpack) x (Cold + Warm) x (Boot + Ready)
+  // Each timing uses median of BENCHMARK_ITERATIONS runs for stability
+  // NOTE: This runs AFTER the production start benchmark because it cleans the .next directory
+  // Only run benchmarks when not collecting bundler-specific file sizes
+  if (
+    runBenchmarks &&
+    !fromDiff &&
+    statsConfig.appDevCommand &&
+    statsConfig.measureDevBoot
+  ) {
+    const devPort = await getPort()
 
-    for (const pattern of globs) {
-      const results = await glob(pattern, { cwd: curDir, nodir: true })
-      results.forEach((result) => curFiles.add(result))
+    if (!orderedStats['General']) {
+      orderedStats['General'] = {}
     }
 
-    for (const file of curFiles) {
-      const fileKey = path.basename(file)
-      try {
-        let parsedSizeSum = 0
-        let gzipSizeSum = 0
-        for (const requiredFile of await getRequiredFiles(curDir, file)) {
-          const absPath = path.join(curDir, requiredFile)
-          const fileInfo = await fs.stat(absPath)
-          parsedSizeSum += fileInfo.size
-          gzipSizeSum += await gzipSize.file(absPath)
+    // Run benchmarks for selected bundler(s)
+    // Default is now turbopack, so we need --webpack for webpack
+    const allBundlers = [
+      { name: 'Turbopack', flag: '', suffix: 'Turbo' },
+      { name: 'Webpack', flag: '--webpack', suffix: 'Webpack' },
+    ]
+    const bundlers = bundlerFilter
+      ? allBundlers.filter((b) => b.name.toLowerCase() === bundlerFilter)
+      : allBundlers
+
+    for (const bundler of bundlers) {
+      logger(`\n=== ${bundler.name} Dev Server Benchmarks ===`)
+
+      // Build the command with the bundler flag
+      const devCommand = bundler.flag
+        ? `${statsConfig.appDevCommand} ${bundler.flag}`
+        : statsConfig.appDevCommand
+
+      // 1. Cold start benchmark (clean .next directory, multiple iterations)
+      logger(
+        `=== ${bundler.name} Cold Start (${BENCHMARK_ITERATIONS} iterations) ===`
+      )
+      const coldResult = await benchmarkDevBootWithIterations(
+        devCommand,
+        curDir,
+        devPort,
+        true, // clean .next before each iteration
+        `${bundler.name} Cold`
+      )
+
+      if (coldResult.listenTime !== null) {
+        orderedStats['General'][
+          `nextDevColdListenDuration${bundler.suffix} (ms)`
+        ] = coldResult.listenTime
+      }
+      if (coldResult.readyTime !== null) {
+        orderedStats['General'][
+          `nextDevColdReadyDuration${bundler.suffix} (ms)`
+        ] = coldResult.readyTime
+      }
+
+      // 2. Warm up bytecode cache by running server for ~10 seconds
+      if (coldResult.readyTime !== null) {
+        logger(`=== ${bundler.name} Warming up bytecode cache (10s) ===`)
+        const warmupChild = spawn(devCommand, {
+          cwd: curDir,
+          env: {
+            PORT: devPort,
+          },
+          stdio: 'pipe',
+        })
+
+        let warmupExited = false
+        warmupChild.on('exit', () => {
+          warmupExited = true
+        })
+
+        // Wait for server to be ready
+        await waitForHttp(devPort, 60000)
+
+        // Let it run for 10 seconds to warm bytecode cache
+        await new Promise((r) => setTimeout(r, 10000))
+
+        warmupChild.kill()
+
+        // Wait for warmup server to fully exit to avoid port conflicts
+        if (!warmupExited) {
+          await new Promise((resolve) => {
+            warmupChild.on('exit', resolve)
+            // Timeout after 5 seconds in case process doesn't exit cleanly
+            setTimeout(resolve, 5000)
+          })
         }
-        groupStats[fileKey] = parsedSizeSum
-        groupStats[`${fileKey} gzip`] = gzipSizeSum
-      } catch (err) {
-        logger.error('Failed to get file stats', err)
+
+        // 3. Warm start benchmark (keep .next directory, multiple iterations)
+        logger(
+          `=== ${bundler.name} Warm Start (${BENCHMARK_ITERATIONS} iterations) ===`
+        )
+        const warmResult = await benchmarkDevBootWithIterations(
+          devCommand,
+          curDir,
+          devPort,
+          false, // keep build
+          `${bundler.name} Warm`
+        )
+
+        if (warmResult.listenTime !== null) {
+          orderedStats['General'][
+            `nextDevWarmListenDuration${bundler.suffix} (ms)`
+          ] = warmResult.listenTime
+        }
+        if (warmResult.readyTime !== null) {
+          orderedStats['General'][
+            `nextDevWarmReadyDuration${bundler.suffix} (ms)`
+          ] = warmResult.readyTime
+        }
       }
     }
-    stats[name] = groupStats
+
+    logger('\n=== Dev Boot Benchmark Complete ===')
   }
 
-  for (const fileGroup of runConfig.filesToTrack) {
-    const { name } = fileGroup
-    orderedStats[name] = stats[name]
+  // Collect file sizes only when not in benchmark-only mode
+  if (collectFileSizes) {
+    for (const fileGroup of runConfig.filesToTrack) {
+      const {
+        getRequiredFiles = defaultGetRequiredFiles,
+        name,
+        globs,
+      } = fileGroup
+      const groupStats = {}
+      const curFiles = new Set()
+
+      for (const pattern of globs) {
+        const results = await glob(pattern, { cwd: curDir, nodir: true })
+        results.forEach((result) => curFiles.add(result))
+      }
+
+      for (const file of curFiles) {
+        const fileKey = path.basename(file)
+        try {
+          let parsedSizeSum = 0
+          let gzipSizeSum = 0
+          for (const requiredFile of await getRequiredFiles(curDir, file)) {
+            const absPath = path.join(curDir, requiredFile)
+            const fileInfo = await fs.stat(absPath)
+            parsedSizeSum += fileInfo.size
+            gzipSizeSum += await gzipSize.file(absPath)
+          }
+          groupStats[fileKey] = parsedSizeSum
+          groupStats[`${fileKey} gzip`] = gzipSizeSum
+        } catch (err) {
+          logger.error('Failed to get file stats', err)
+        }
+      }
+      stats[name] = groupStats
+    }
+
+    for (const fileGroup of runConfig.filesToTrack) {
+      const { name } = fileGroup
+      orderedStats[name] = stats[name]
+    }
   }
 
   if (stats[benchTitle]) {

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -121,7 +121,25 @@ async function runConfigs(
         )
         curStats.General[`buildDuration${bundler.suffix}`] = freshStats.median
 
-        // Apply renames to get deterministic output names (after last build)
+        // Run cached build iterations BEFORE renames (renames invalidate cache)
+        const cachedBuildTimes = []
+        logger(`  Cached build (${BUILD_BENCHMARK_ITERATIONS} iterations)...`)
+        for (let i = 0; i < BUILD_BENCHMARK_ITERATIONS; i++) {
+          const buildStart = Date.now()
+          console.log(await exec(`cd ${statsAppDir} && ${buildCommand}`, false))
+          const buildDuration = Date.now() - buildStart
+          cachedBuildTimes.push(buildDuration)
+          logger(`    Iteration ${i + 1}: ${buildDuration}ms`)
+        }
+
+        const cachedStats = calcStats(cachedBuildTimes)
+        logger(
+          `  Cached build: median=${cachedStats.median}ms, range=${cachedStats.min}-${cachedStats.max}ms`
+        )
+        curStats.General[`buildDurationCached${bundler.suffix}`] =
+          cachedStats.median
+
+        // Apply renames to get deterministic output names (after cached builds)
         for (const rename of config.renames) {
           const renameResults = await glob(rename.srcGlob, { cwd: statsAppDir })
           for (const result of renameResults) {
@@ -140,7 +158,7 @@ async function runConfigs(
           }
         }
 
-        // Collect file stats for this bundler (only once, after final build)
+        // Collect file stats for this bundler (after renames for deterministic names)
         const collectedStats = await collectStats(
           config,
           statsConfig,
@@ -157,24 +175,6 @@ async function runConfigs(
             collectedStats[key]
           )
         }
-
-        // Run multiple cached build iterations for stable timing
-        const cachedBuildTimes = []
-        logger(`  Cached build (${BUILD_BENCHMARK_ITERATIONS} iterations)...`)
-        for (let i = 0; i < BUILD_BENCHMARK_ITERATIONS; i++) {
-          const buildStart = Date.now()
-          console.log(await exec(`cd ${statsAppDir} && ${buildCommand}`, false))
-          const buildDuration = Date.now() - buildStart
-          cachedBuildTimes.push(buildDuration)
-          logger(`    Iteration ${i + 1}: ${buildDuration}ms`)
-        }
-
-        const cachedStats = calcStats(cachedBuildTimes)
-        logger(
-          `  Cached build: median=${cachedStats.median}ms, range=${cachedStats.min}-${cachedStats.max}ms`
-        )
-        curStats.General[`buildDurationCached${bundler.suffix}`] =
-          cachedStats.median
       }
 
       // Run benchmarks for selected bundler(s) - dev boot and prod start

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -7,28 +7,16 @@ const getDirSize = require('./get-dir-size')
 const collectStats = require('./collect-stats')
 const collectDiffs = require('./collect-diffs')
 const { statsAppDir, diffRepoDir } = require('../constants')
+const { calcStats } = require('../util/stats')
 
 // Number of iterations for build benchmarks to get stable median
-const BUILD_BENCHMARK_ITERATIONS = 3
+const BUILD_BENCHMARK_ITERATIONS = 5
 
 // Bundler configurations for dual-bundler benchmarking
 const BUNDLERS = [
   { name: 'Webpack', flag: '--webpack', suffix: 'Webpack' },
   { name: 'Turbopack', flag: '', suffix: 'Turbo' },
 ]
-
-// Calculate stats summary for an array of numbers
-function calcStats(arr) {
-  if (arr.length === 0) return null
-  const sorted = [...arr].sort((a, b) => a - b)
-  const mid = Math.floor(sorted.length / 2)
-  const med =
-    sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
-  const min = sorted[0]
-  const max = sorted[sorted.length - 1]
-  const mean = arr.reduce((a, b) => a + b, 0) / arr.length
-  return { median: med, min, max, mean: Math.round(mean) }
-}
 
 async function runConfigs(
   configs = [],

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -8,11 +8,54 @@ const collectStats = require('./collect-stats')
 const collectDiffs = require('./collect-diffs')
 const { statsAppDir, diffRepoDir } = require('../constants')
 
+// Number of iterations for build benchmarks to get stable median
+const BUILD_BENCHMARK_ITERATIONS = 3
+
+// Bundler configurations for dual-bundler benchmarking
+const BUNDLERS = [
+  { name: 'Webpack', flag: '--webpack', suffix: 'Webpack' },
+  { name: 'Turbopack', flag: '', suffix: 'Turbo' },
+]
+
+// Calculate stats summary for an array of numbers
+function calcStats(arr) {
+  if (arr.length === 0) return null
+  const sorted = [...arr].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  const med =
+    sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+  const min = sorted[0]
+  const max = sorted[sorted.length - 1]
+  const mean = arr.reduce((a, b) => a + b, 0) / arr.length
+  return { median: med, min, max, mean: Math.round(mean) }
+}
+
 async function runConfigs(
   configs = [],
-  { statsConfig, relativeStatsAppDir, mainRepoPkgPaths, diffRepoPkgPaths },
+  {
+    statsConfig,
+    relativeStatsAppDir,
+    mainRepoPkgPaths,
+    diffRepoPkgPaths,
+    bundlerFilter = null,
+  },
   diffing = false
 ) {
+  // Filter bundlers based on input
+  const bundlersToRun = bundlerFilter
+    ? BUNDLERS.filter((b) => b.name.toLowerCase() === bundlerFilter)
+    : BUNDLERS
+
+  if (bundlerFilter && bundlersToRun.length === 0) {
+    throw new Error(
+      `Invalid bundler filter: ${bundlerFilter}. Must be 'webpack' or 'turbopack'`
+    )
+  }
+
+  logger(
+    `Running benchmarks for bundlers: ${bundlersToRun.map((b) => b.name).join(', ')}`
+  )
+
   const results = []
 
   for (const config of configs) {
@@ -25,8 +68,6 @@ async function runConfigs(
     for (const pkgPaths of [mainRepoPkgPaths, diffRepoPkgPaths]) {
       let curStats = {
         General: {
-          buildDuration: null,
-          buildDurationCached: null,
           nodeModulesSize: null,
         },
       }
@@ -56,31 +97,109 @@ async function runConfigs(
         )
       }
 
-      const buildStart = Date.now()
-      console.log(
-        await exec(`cd ${statsAppDir} && ${statsConfig.appBuildCommand}`, false)
-      )
-      curStats.General.buildDuration = Date.now() - buildStart
+      // Run builds for selected bundler(s) and collect stats separately
+      for (const bundler of bundlersToRun) {
+        logger(`\n=== ${bundler.name} Production Build ===`)
 
-      // apply renames to get deterministic output names
-      for (const rename of config.renames) {
-        const results = await glob(rename.srcGlob, { cwd: statsAppDir })
-        for (const result of results) {
-          let dest = rename.removeHash
-            ? result.replace(/(\.|-)[0-9a-f]{16}(\.|-)/g, '$1HASH$2')
-            : rename.dest
-          if (result === dest) continue
-          await fs.rename(
-            path.join(statsAppDir, result),
-            path.join(statsAppDir, dest)
+        // Build base command without --webpack flag (we add it per bundler)
+        const baseBuildCommand = statsConfig.appBuildCommand.replace(
+          / --webpack/g,
+          ''
+        )
+        const buildCommand = bundler.flag
+          ? `${baseBuildCommand} ${bundler.flag}`
+          : baseBuildCommand
+
+        // Run multiple fresh build iterations for stable timing
+        const freshBuildTimes = []
+        logger(`  Fresh build (${BUILD_BENCHMARK_ITERATIONS} iterations)...`)
+        for (let i = 0; i < BUILD_BENCHMARK_ITERATIONS; i++) {
+          // Clean .next directory for fresh build
+          await fs.rm(path.join(statsAppDir, '.next'), {
+            recursive: true,
+            force: true,
+          })
+
+          const buildStart = Date.now()
+          console.log(await exec(`cd ${statsAppDir} && ${buildCommand}`, false))
+          const buildDuration = Date.now() - buildStart
+          freshBuildTimes.push(buildDuration)
+          logger(`    Iteration ${i + 1}: ${buildDuration}ms`)
+        }
+
+        const freshStats = calcStats(freshBuildTimes)
+        logger(
+          `  Fresh build: median=${freshStats.median}ms, range=${freshStats.min}-${freshStats.max}ms`
+        )
+        curStats.General[`buildDuration${bundler.suffix}`] = freshStats.median
+
+        // Apply renames to get deterministic output names (after last build)
+        for (const rename of config.renames) {
+          const renameResults = await glob(rename.srcGlob, { cwd: statsAppDir })
+          for (const result of renameResults) {
+            let dest = rename.removeHash
+              ? result.replace(/(\.|-)[0-9a-f]{16}(\.|-)/g, '$1HASH$2')
+              : rename.dest
+            if (result === dest) continue
+            try {
+              await fs.rename(
+                path.join(statsAppDir, result),
+                path.join(statsAppDir, dest)
+              )
+            } catch (e) {
+              // File may not exist for this bundler
+            }
+          }
+        }
+
+        // Collect file stats for this bundler (only once, after final build)
+        const collectedStats = await collectStats(
+          config,
+          statsConfig,
+          false,
+          bundler.suffix
+        )
+
+        for (const key of Object.keys(collectedStats)) {
+          // Prefix group names with bundler suffix (except General which is shared)
+          const groupKey = key === 'General' ? key : `${key} (${bundler.name})`
+          curStats[groupKey] = Object.assign(
+            {},
+            curStats[groupKey],
+            collectedStats[key]
           )
         }
+
+        // Run multiple cached build iterations for stable timing
+        const cachedBuildTimes = []
+        logger(`  Cached build (${BUILD_BENCHMARK_ITERATIONS} iterations)...`)
+        for (let i = 0; i < BUILD_BENCHMARK_ITERATIONS; i++) {
+          const buildStart = Date.now()
+          console.log(await exec(`cd ${statsAppDir} && ${buildCommand}`, false))
+          const buildDuration = Date.now() - buildStart
+          cachedBuildTimes.push(buildDuration)
+          logger(`    Iteration ${i + 1}: ${buildDuration}ms`)
+        }
+
+        const cachedStats = calcStats(cachedBuildTimes)
+        logger(
+          `  Cached build: median=${cachedStats.median}ms, range=${cachedStats.min}-${cachedStats.max}ms`
+        )
+        curStats.General[`buildDurationCached${bundler.suffix}`] =
+          cachedStats.median
       }
 
-      const collectedStats = await collectStats(config, statsConfig)
-
-      for (const key of Object.keys(collectedStats)) {
-        curStats[key] = Object.assign({}, curStats[key], collectedStats[key])
+      // Run benchmarks for selected bundler(s) - dev boot and prod start
+      const benchmarkStats = await collectStats(
+        config,
+        statsConfig,
+        false,
+        null,
+        true,
+        bundlerFilter
+      )
+      for (const key of Object.keys(benchmarkStats)) {
+        curStats[key] = Object.assign({}, curStats[key], benchmarkStats[key])
       }
 
       const applyRenames = (renames, stats) => {
@@ -130,6 +249,7 @@ async function runConfigs(
                   mainRepoPkgPaths,
                   diffRepoPkgPaths,
                   relativeStatsAppDir,
+                  bundlerFilter,
                 },
                 true
               )
@@ -150,12 +270,6 @@ async function runConfigs(
         /* eslint-disable-next-line */
         mainRepoStats = curStats
       }
-
-      const secondBuildStart = Date.now()
-      console.log(
-        await exec(`cd ${statsAppDir} && ${statsConfig.appBuildCommand}`, false)
-      )
-      curStats.General.buildDurationCached = Date.now() - secondBuildStart
     }
 
     logger(`Finished running: ${config.title}`)

--- a/.github/actions/next-stats-action/src/util/stats.js
+++ b/.github/actions/next-stats-action/src/util/stats.js
@@ -1,0 +1,35 @@
+/**
+ * Shared statistics utilities for benchmark measurements
+ */
+
+/**
+ * Calculate statistical summary for an array of numbers
+ * @param {number[]} arr - Array of numeric values
+ * @returns {Object|null} Stats object with median, min, max, mean, stddev, cv or null if empty
+ */
+function calcStats(arr) {
+  if (arr.length === 0) return null
+
+  const sorted = [...arr].sort((a, b) => a - b)
+  const mid = Math.floor(sorted.length / 2)
+  const median =
+    sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+  const min = sorted[0]
+  const max = sorted[sorted.length - 1]
+  const mean = arr.reduce((a, b) => a + b, 0) / arr.length
+  const variance =
+    arr.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) / arr.length
+  const stddev = Math.sqrt(variance)
+  const cv = mean > 0 ? (stddev / mean) * 100 : 0 // coefficient of variation as %
+
+  return {
+    median,
+    min,
+    max,
+    mean: Math.round(mean),
+    stddev: Math.round(stddev),
+    cv: Math.round(cv),
+  }
+}
+
+module.exports = { calcStats }

--- a/.github/actions/next-stats-action/test-local.js
+++ b/.github/actions/next-stats-action/test-local.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Test the stats action comment formatting locally
+ *
+ * Usage: node test-local.js [--with-history]
+ *
+ * This generates a sample PR comment using mock data so you can
+ * quickly verify formatting changes without running the full action.
+ *
+ * Options:
+ *   --with-history  Simulate KV history data to test trend sparklines
+ */
+
+const addComment = require('./src/add-comment')
+
+const withHistory = process.argv.includes('--with-history')
+
+// Mock data simulating real benchmark results
+const mockResults = [
+  {
+    title: 'Default Build',
+    mainRepoStats: {
+      General: {
+        nextDevColdListenDurationTurbo: 280,
+        nextDevColdReadyDurationTurbo: 450,
+        nextDevWarmListenDurationTurbo: 180,
+        nextDevWarmReadyDurationTurbo: 320,
+        nextDevColdListenDurationWebpack: 350,
+        nextDevColdReadyDurationWebpack: 1200,
+        nextDevWarmListenDurationWebpack: 250,
+        nextDevWarmReadyDurationWebpack: 800,
+        nextStartReadyDuration: 150,
+        buildDurationTurbo: 4500,
+        buildDurationCachedTurbo: 4200,
+        buildDurationWebpack: 14000,
+        buildDurationCachedWebpack: 13500,
+        nodeModulesSize: 250000000,
+      },
+    },
+    diffRepoStats: {
+      General: {
+        nextDevColdListenDurationTurbo: 290, // +10ms (insignificant)
+        nextDevColdReadyDurationTurbo: 520, // +70ms at 15% (significant regression)
+        nextDevWarmListenDurationTurbo: 175, // -5ms (insignificant)
+        nextDevWarmReadyDurationTurbo: 280, // -40ms at 12% (significant improvement)
+        nextDevColdListenDurationWebpack: 360,
+        nextDevColdReadyDurationWebpack: 1180,
+        nextDevWarmListenDurationWebpack: 245,
+        nextDevWarmReadyDurationWebpack: 790,
+        nextStartReadyDuration: 145,
+        buildDurationTurbo: 4400,
+        buildDurationCachedTurbo: 4250,
+        buildDurationWebpack: 13800,
+        buildDurationCachedWebpack: 13600,
+        nodeModulesSize: 251000000,
+      },
+    },
+    diffs: null,
+  },
+]
+
+const mockActionInfo = {
+  isRelease: false,
+  commitId: 'abc123',
+  issueId: 12345,
+}
+
+const mockStatsConfig = {
+  commentHeading: 'Stats from current PR',
+}
+
+// Run with LOCAL_STATS to output to file instead of posting
+process.env.LOCAL_STATS = 'true'
+
+// Mock the KV module to provide fake history if --with-history is passed
+if (withHistory) {
+  // Generate mock history entries showing a trend
+  const mockHistory = []
+  for (let i = 0; i < 10; i++) {
+    mockHistory.push({
+      commitId: `commit-${i}`,
+      timestamp: new Date(Date.now() - i * 86400000).toISOString(),
+      metrics: {
+        nextDevColdReadyDurationTurbo: 400 + Math.random() * 100, // varies 400-500
+        nextDevWarmReadyDurationTurbo: 300 + Math.random() * 50,
+        buildDurationTurbo: 4000 + Math.random() * 1000,
+      },
+    })
+  }
+
+  // Inject mock KV client
+  process.env.KV_REST_API_URL = 'mock://kv'
+  process.env.KV_REST_API_TOKEN = 'mock-token'
+
+  // Patch the require to intercept @vercel/kv
+  const Module = require('module')
+  const originalRequire = Module.prototype.require
+  Module.prototype.require = function (id) {
+    if (id === '@vercel/kv') {
+      return {
+        createClient: () => ({
+          lrange: async () => mockHistory,
+          rpush: async () => {},
+          ltrim: async () => {},
+        }),
+      }
+    }
+    return originalRequire.apply(this, arguments)
+  }
+
+  console.log('Running with mock history data (10 entries)')
+}
+
+addComment(mockResults, mockActionInfo, mockStatsConfig)
+  .then(() =>
+    console.log(
+      '\nGenerated pr-stats.md - open it to see the comment' +
+        (withHistory ? ' (with trend sparklines)' : '')
+    )
+  )
+  .catch(console.error)

--- a/.github/pnpm-lock.yaml
+++ b/.github/pnpm-lock.yaml
@@ -10,20 +10,20 @@ importers:
     dependencies:
       '@actions/core':
         specifier: 1.10.0
-        version: 1.11.1
+        version: 1.10.0
       '@actions/github':
         specifier: 5.1.1
-        version: 6.0.0
+        version: 5.1.1
     devDependencies:
       '@types/node':
         specifier: ^18.11.0
-        version: 22.10.2
+        version: 18.19.130
       '@vercel/ncc':
         specifier: 0.34.0
-        version: 0.38.3
+        version: 0.34.0
       typescript:
         specifier: 5.1.6
-        version: 5.7.2
+        version: 5.1.6
 
   actions/next-integration-stat:
     dependencies:
@@ -48,13 +48,13 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^18.11.18
-        version: 22.10.2
+        version: 18.19.130
       '@vercel/ncc':
         specifier: 0.34.0
-        version: 0.38.3
+        version: 0.34.0
       typescript:
         specifier: ^4.4.4
-        version: 5.7.2
+        version: 4.9.5
 
   actions/next-repo-actions:
     dependencies:
@@ -69,19 +69,19 @@ importers:
         version: 6.0.0
       '@ai-sdk/openai':
         specifier: ^0.0.67
-        version: 1.0.8(zod@3.24.1)
+        version: 0.0.67(zod@3.25.76)
       '@slack/web-api':
         specifier: ^7.6.0
         version: 7.8.0
       ai:
         specifier: ^3.4.14
-        version: 4.0.16(react@19.0.0)(zod@3.24.1)
+        version: 3.4.33(react@19.0.0)(sswr@2.2.0(svelte@5.46.1))(svelte@5.46.1)(vue@3.5.26(typescript@5.7.2))(zod@3.25.76)
       slack-block-builder:
         specifier: ^2.8.0
         version: 2.8.0
       zod:
-        specifier: ^3.23.8
-        version: 3.24.1
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@vercel/ncc':
         specifier: ^0.38.3
@@ -89,53 +89,56 @@ importers:
 
   actions/next-stats-action:
     dependencies:
+      '@vercel/kv':
+        specifier: ^1.0.1
+        version: 1.0.1
       async-sema:
         specifier: ^3.1.0
         version: 3.1.1
       execa:
         specifier: 2.0.3
-        version: 9.5.2
+        version: 2.0.3
       get-port:
         specifier: ^5.0.0
-        version: 7.1.0
+        version: 5.1.1
       glob:
         specifier: ^7.1.4
-        version: 11.0.0
+        version: 7.2.3
       gzip-size:
         specifier: ^5.1.1
-        version: 7.0.0
+        version: 5.1.1
       minimatch:
         specifier: ^3.0.4
-        version: 10.0.1
+        version: 3.1.2
       node-fetch:
         specifier: ^2.6.0
-        version: 3.3.2
+        version: 2.7.0
       prettier:
         specifier: ^2.8.4
-        version: 3.4.2
+        version: 2.8.8
       pretty-bytes:
         specifier: ^5.3.0
-        version: 6.1.1
+        version: 5.6.0
       pretty-ms:
         specifier: ^5.0.0
-        version: 9.2.0
+        version: 5.1.0
       semver:
         specifier: 7.3.4
-        version: 7.6.3
+        version: 7.3.4
     devDependencies:
       typescript:
         specifier: 5.1.6
-        version: 5.7.2
+        version: 5.1.6
 
   actions/upload-turboyet-data:
     dependencies:
       '@vercel/kv':
         specifier: ^0.2.3
-        version: 3.0.0
+        version: 0.2.4
     devDependencies:
       '@vercel/ncc':
         specifier: ^0.36.0
-        version: 0.38.3
+        version: 0.36.1
 
   actions/validate-docs-links:
     dependencies:
@@ -144,46 +147,52 @@ importers:
         version: 1.11.1
       '@actions/github':
         specifier: ^5.1.1
-        version: 6.0.0
+        version: 5.1.1
       github-slugger:
         specifier: 1.2.0
-        version: 2.0.0
+        version: 1.2.0
       gray-matter:
         specifier: 4.0.2
-        version: 4.0.3
+        version: 4.0.2
       rehype-raw:
         specifier: 4.0.1
-        version: 7.0.0
+        version: 4.0.1
       remark-parse:
         specifier: 7.0.1
-        version: 11.0.0
+        version: 7.0.1
       remark-rehype:
         specifier: 5.0.0
-        version: 11.1.1
+        version: 5.0.0
       unified:
         specifier: 8.4.1
-        version: 11.0.5
+        version: 8.4.1
       unist-util-visit:
         specifier: 2.0.0
-        version: 5.0.0
+        version: 2.0.0
     devDependencies:
       '@types/github-slugger':
         specifier: ^1.3.0
-        version: 2.0.0
+        version: 1.3.0
       '@vercel/ncc':
         specifier: 0.34.0
-        version: 0.38.3
+        version: 0.34.0
       typescript:
         specifier: 5.1.6
-        version: 5.7.2
+        version: 5.1.6
 
 packages:
+
+  '@actions/core@1.10.0':
+    resolution: {integrity: sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==}
 
   '@actions/core@1.11.1':
     resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
 
   '@actions/exec@1.1.1':
     resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
+  '@actions/github@5.1.1':
+    resolution: {integrity: sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==}
 
   '@actions/github@6.0.0':
     resolution: {integrity: sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==}
@@ -197,14 +206,14 @@ packages:
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
-  '@ai-sdk/openai@1.0.8':
-    resolution: {integrity: sha512-wcTHM9qgRWGYVO3WxPSTN/RwnZ9R5/17xyo61iUCCSCZaAuJyh6fKddO0/oamwDp3BG7g+4wbfAyuTo32H+fHw==}
+  '@ai-sdk/openai@0.0.67':
+    resolution: {integrity: sha512-LOvbQaKXuNdhlZ+Asinc4DGdh4v32wKTzFB8FIKvVYjPuXwMWAsK4ZjrS6sxwB37AjmyGLPTMVBUtwcHZdpk+A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
 
-  '@ai-sdk/provider-utils@2.0.4':
-    resolution: {integrity: sha512-GMhcQCZbwM6RoZCri0MWeEWXRt/T+uCxsmHEsTwNvEH3GDjNzchfX25C8ftry2MeEOOn6KfqCLSKomcgK6RoOg==}
+  '@ai-sdk/provider-utils@1.0.20':
+    resolution: {integrity: sha512-ngg/RGpnA00eNOWEtXHenpX1MsM2QshQh4QJFjUfwcqHpM5kTfG7je7Rc3HcEDP+OkRVv2GF+X4fC1Vfcnl8Ow==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -212,12 +221,25 @@ packages:
       zod:
         optional: true
 
-  '@ai-sdk/provider@1.0.2':
-    resolution: {integrity: sha512-YYtP6xWQyaAf5LiWLJ+ycGTOeBLWrED7LUrvc+SQIWhGaneylqbaGsyQL7VouQUeQ4JZ1qKYZuhmi3W56HADPA==}
+  '@ai-sdk/provider-utils@1.0.22':
+    resolution: {integrity: sha512-YHK2rpj++wnLVc9vPGzGFP3Pjeld2MwhKinetA0zKXOoHAT/Jit5O8kZsxcSlJPu9wvcGT1UGZEjZrtO7PfFOQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
+  '@ai-sdk/provider@0.0.24':
+    resolution: {integrity: sha512-XMsNGJdGO+L0cxhhegtqZ8+T6nn4EoShS819OvCgI2kLbYTIvk0GWFGD0AXJmxkxs3DrpsJxKAFukFR7bvTkgQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@1.0.6':
-    resolution: {integrity: sha512-8Hkserq0Ge6AEi7N4hlv2FkfglAGbkoAXEZ8YSp255c3PbnZz6+/5fppw+aROmZMOfNwallSRuy1i/iPa2rBpQ==}
+  '@ai-sdk/provider@0.0.26':
+    resolution: {integrity: sha512-dQkfBDs2lTYpKM8389oopPdQgIU007GQyCbuPPrV+K6MtSII3HBfE0stUIMXUb44L+LK1t6GXPP7wjSzjO6uKg==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@0.0.70':
+    resolution: {integrity: sha512-GnwbtjW4/4z7MleLiW+TOZC2M29eCg1tOUpuEiYFMmFNZK8mkrqM0PFZMo6UsYeUYMWqEOOcPOU9OQVJMJh7IQ==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -228,14 +250,58 @@ packages:
       zod:
         optional: true
 
-  '@ai-sdk/ui-utils@1.0.5':
-    resolution: {integrity: sha512-DGJSbDf+vJyWmFNexSPUsS1AAy7gtsmFmoSyNbNbJjwl9hRIf2dknfA1V0ahx6pg3NNklNYFm53L8Nphjovfvg==}
+  '@ai-sdk/solid@0.0.54':
+    resolution: {integrity: sha512-96KWTVK+opdFeRubqrgaJXoNiDP89gNxFRWUp0PJOotZW816AbhUf4EnDjBjXTLjXL1n0h8tGSE9sZsRkj9wQQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      solid-js: ^1.7.7
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  '@ai-sdk/svelte@0.0.57':
+    resolution: {integrity: sha512-SyF9ItIR9ALP9yDNAD+2/5Vl1IT6kchgyDH8xkmhysfJI6WrvJbtO1wdQ0nylvPLcsPoYu+cAlz1krU4lFHcYw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+
+  '@ai-sdk/ui-utils@0.0.50':
+    resolution: {integrity: sha512-Z5QYJVW+5XpSaJ4jYCCAVG7zIAuKOOdikhgpksneNmKvx61ACFaf98pmOd+xnjahl0pIlc/QIe6O4yVaJ1sEaw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@ai-sdk/vue@0.0.59':
+    resolution: {integrity: sha512-+ofYlnqdc8c4F6tM0IKF0+7NagZRAiqBJpGDJ+6EYhDW8FHLUP/JFBgu32SjxSxC6IKFZxEnl68ZoP/Z38EMlw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.3.4
+    peerDependenciesMeta:
+      vue:
+        optional: true
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.28.5':
+    resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.28.5':
+    resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
+    engines: {node: '>=6.9.0'}
 
   '@fastify/busboy@2.1.0':
     resolution: {integrity: sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==}
@@ -245,28 +311,60 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
-  '@isaacs/cliui@8.0.2':
-    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
-    engines: {node: '>=12'}
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@octokit/auth-token@2.5.0':
+    resolution: {integrity: sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==}
 
   '@octokit/auth-token@4.0.0':
     resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
     engines: {node: '>= 18'}
 
+  '@octokit/core@3.6.0':
+    resolution: {integrity: sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==}
+
   '@octokit/core@5.0.2':
     resolution: {integrity: sha512-cZUy1gUvd4vttMic7C0lwPed8IYXWYp8kHIMatyhY8t8n3Cpw2ILczkV5pGMPqef7v0bLo0pOHrEHarsau2Ydg==}
     engines: {node: '>= 18'}
+
+  '@octokit/endpoint@6.0.12':
+    resolution: {integrity: sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==}
 
   '@octokit/endpoint@9.0.4':
     resolution: {integrity: sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==}
     engines: {node: '>= 18'}
 
+  '@octokit/graphql@4.8.0':
+    resolution: {integrity: sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==}
+
   '@octokit/graphql@7.0.2':
     resolution: {integrity: sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==}
     engines: {node: '>= 18'}
 
+  '@octokit/openapi-types@12.11.0':
+    resolution: {integrity: sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==}
+
   '@octokit/openapi-types@19.1.0':
     resolution: {integrity: sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw==}
+
+  '@octokit/plugin-paginate-rest@2.21.3':
+    resolution: {integrity: sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==}
+    peerDependencies:
+      '@octokit/core': '>=2'
 
   '@octokit/plugin-paginate-rest@9.1.5':
     resolution: {integrity: sha512-WKTQXxK+bu49qzwv4qKbMMRXej1DU2gq017euWyKVudA6MldaSSQuxtz+vGbhxV4CjxpUxjZu6rM2wfc1FiWVg==}
@@ -280,9 +378,20 @@ packages:
     peerDependencies:
       '@octokit/core': '>=5'
 
+  '@octokit/plugin-rest-endpoint-methods@5.16.2':
+    resolution: {integrity: sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==}
+    peerDependencies:
+      '@octokit/core': '>=3'
+
+  '@octokit/request-error@2.1.0':
+    resolution: {integrity: sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==}
+
   '@octokit/request-error@5.0.1':
     resolution: {integrity: sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==}
     engines: {node: '>= 18'}
+
+  '@octokit/request@5.6.3':
+    resolution: {integrity: sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==}
 
   '@octokit/request@8.1.6':
     resolution: {integrity: sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==}
@@ -291,16 +400,12 @@ packages:
   '@octokit/types@12.4.0':
     resolution: {integrity: sha512-FLWs/AvZllw/AGVs+nJ+ELCDZZJk+kY0zMen118xhL2zD0s1etIUHm1odgjP7epxYU1ln7SZxEUWYop5bhsdgQ==}
 
+  '@octokit/types@6.41.0':
+    resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
-
-  '@sec-ant/readable-stream@0.4.1':
-    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
-
-  '@sindresorhus/merge-streams@4.0.0':
-    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
-    engines: {node: '>=18'}
 
   '@slack/logger@4.0.0':
     resolution: {integrity: sha512-Wz7QYfPAlG/DR+DfABddUZeNgoeY7d1J39OCR2jR+v7VBsB8ezulDK5szTnDDPDwLH5IWhLvXIHlCFZV7MSKgA==}
@@ -314,81 +419,120 @@ packages:
     resolution: {integrity: sha512-d4SdG+6UmGdzWw38a4sN3lF/nTEzsDxhzU13wm10ejOpPehtmRoqBKnPztQUfFiWbNvSb4czkWYJD4kt+5+Fuw==}
     engines: {node: '>= 18', npm: '>= 8.6.0'}
 
-  '@types/debug@4.1.12':
-    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+  '@sveltejs/acorn-typescript@1.0.8':
+    resolution: {integrity: sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==}
+    peerDependencies:
+      acorn: ^8.9.0
 
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
-  '@types/github-slugger@2.0.0':
-    resolution: {integrity: sha512-z/FaJhjFPk5mtrsZWeqyvaJdcZKw6CVCTuynEMrcXtgyozN3yMrtL13xWv8uQV2bWtwSXkdiNM37HEKkEj9x1Q==}
-    deprecated: This is a stub types definition. github-slugger provides its own type definitions, so you do not need this installed.
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/hast@3.0.4':
-    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+  '@types/github-slugger@1.3.0':
+    resolution: {integrity: sha512-J/rMZa7RqiH/rT29TEVZO4nBoDP9XJOjnbbIofg7GQKs4JIduEO3WLpte+6WeUz/TcrXKlY+bM7FYrp8yFB+3g==}
 
-  '@types/mdast@4.0.4':
-    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
-
-  '@types/ms@0.7.34':
-    resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
-
-  '@types/node@22.10.2':
-    resolution: {integrity: sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==}
-
-  '@types/node@22.7.6':
-    resolution: {integrity: sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==}
+  '@types/node@18.19.130':
+    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
 
-  '@types/unist@3.0.3':
-    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
-  '@ungap/structured-clone@1.2.1':
-    resolution: {integrity: sha512-fEzPV3hSkSMltkw152tJKNARhOupqbH96MZWyRjNaYZOMIzbrTeQDG+MTc6Mr2pgzFQzFxAfmhGDNP5QK++2ZA==}
+  '@upstash/redis@1.24.3':
+    resolution: {integrity: sha512-gw6d4IA1biB4eye5ESaXc0zOlVQI94aptsBvVcTghYWu1kRmOrJFoMFEDCa8p5uzluyYAOFCuY2GWLR6O4ZoIw==}
 
-  '@upstash/redis@1.34.3':
-    resolution: {integrity: sha512-VT25TyODGy/8ljl7GADnJoMmtmJ1F8d84UXfGonRRF8fWYJz7+2J6GzW+a6ETGtk4OyuRTt7FRSvFG5GvrfSdQ==}
+  '@upstash/redis@1.25.1':
+    resolution: {integrity: sha512-ACj0GhJ4qrQyBshwFgPod6XufVEfKX2wcaihsEvSdLYnY+m+pa13kGt1RXm/yTHKf4TQi/Dy2A8z/y6WUEOmlg==}
 
-  '@vercel/kv@3.0.0':
-    resolution: {integrity: sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==}
+  '@vercel/kv@0.2.4':
+    resolution: {integrity: sha512-wbIOOXhg6MzmNMzKFSWbbLAS65hCZcJN33z1coENzI1M0fOX55yE9v9LwVGqkzdItp3eZsv6pYvwcmGtllyLTw==}
     engines: {node: '>=14.6'}
+
+  '@vercel/kv@1.0.1':
+    resolution: {integrity: sha512-uTKddsqVYS2GRAM/QMNNXCTuw9N742mLoGRXoNDcyECaxEXvIHG0dEY+ZnYISV4Vz534VwJO+64fd9XeSggSKw==}
+    engines: {node: '>=14.6'}
+
+  '@vercel/ncc@0.34.0':
+    resolution: {integrity: sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==}
+    hasBin: true
+
+  '@vercel/ncc@0.36.1':
+    resolution: {integrity: sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==}
+    hasBin: true
 
   '@vercel/ncc@0.38.3':
     resolution: {integrity: sha512-rnK6hJBS6mwc+Bkab+PGPs9OiS0i/3kdTO+CkI8V0/VrW3vmz7O2Pxjw/owOlmo6PKEIxRSeZKv/kuL9itnpYA==}
     hasBin: true
 
-  ai@4.0.16:
-    resolution: {integrity: sha512-DdpyzTaJYwagQKkWNb1eYx/UcQoMNy+cZVRYYX3cb88r25EI46YjtjMuvDhd296FPgjJBFqbL4IvDHQBPaSwbw==}
+  '@vue/compiler-core@3.5.26':
+    resolution: {integrity: sha512-vXyI5GMfuoBCnv5ucIT7jhHKl55Y477yxP6fc4eUswjP8FG3FFVFd41eNDArR+Uk3QKn2Z85NavjaxLxOC19/w==}
+
+  '@vue/compiler-dom@3.5.26':
+    resolution: {integrity: sha512-y1Tcd3eXs834QjswshSilCBnKGeQjQXB6PqFn/1nxcQw4pmG42G8lwz+FZPAZAby6gZeHSt/8LMPfZ4Rb+Bd/A==}
+
+  '@vue/compiler-sfc@3.5.26':
+    resolution: {integrity: sha512-egp69qDTSEZcf4bGOSsprUr4xI73wfrY5oRs6GSgXFTiHrWj4Y3X5Ydtip9QMqiCMCPVwLglB9GBxXtTadJ3mA==}
+
+  '@vue/compiler-ssr@3.5.26':
+    resolution: {integrity: sha512-lZT9/Y0nSIRUPVvapFJEVDbEXruZh2IYHMk2zTtEgJSlP5gVOqeWXH54xDKAaFS4rTnDeDBQUYDtxKyoW9FwDw==}
+
+  '@vue/reactivity@3.5.26':
+    resolution: {integrity: sha512-9EnYB1/DIiUYYnzlnUBgwU32NNvLp/nhxLXeWRhHUEeWNTn1ECxX8aGO7RTXeX6PPcxe3LLuNBFoJbV4QZ+CFQ==}
+
+  '@vue/runtime-core@3.5.26':
+    resolution: {integrity: sha512-xJWM9KH1kd201w5DvMDOwDHYhrdPTrAatn56oB/LRG4plEQeZRQLw0Bpwih9KYoqmzaxF0OKSn6swzYi84e1/Q==}
+
+  '@vue/runtime-dom@3.5.26':
+    resolution: {integrity: sha512-XLLd/+4sPC2ZkN/6+V4O4gjJu6kSDbHAChvsyWgm1oGbdSO3efvGYnm25yCjtFm/K7rrSDvSfPDgN1pHgS4VNQ==}
+
+  '@vue/server-renderer@3.5.26':
+    resolution: {integrity: sha512-TYKLXmrwWKSodyVuO1WAubucd+1XlLg4set0YoV+Hu8Lo79mp/YMwWV5mC5FgtsDxX3qo1ONrxFaTP1OQgy1uA==}
+    peerDependencies:
+      vue: 3.5.26
+
+  '@vue/shared@3.5.26':
+    resolution: {integrity: sha512-7Z6/y3uFI5PRoKeorTOSXKcDj0MSasfNNltcslbFrPpcw6aXRUALq4IfJlaTRspiWIUOEZbrpM+iQGmCOiWe4A==}
+
+  acorn@8.15.0:
+    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ai@3.4.33:
+    resolution: {integrity: sha512-plBlrVZKwPoRTmM8+D1sJac9Bq8eaa2jiZlHLZIWekKWI1yMWYZvCCEezY9ASPwRhULYDJB2VhKOBUUeg3S5JQ==}
     engines: {node: '>=18'}
     peerDependencies:
+      openai: ^4.42.0
       react: ^18 || ^19 || ^19.0.0-rc
+      sswr: ^2.1.0
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
       zod: ^3.0.0
     peerDependenciesMeta:
+      openai:
+        optional: true
       react:
+        optional: true
+      sswr:
+        optional: true
+      svelte:
         optional: true
       zod:
         optional: true
-
-  ansi-regex@5.0.1:
-    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
-    engines: {node: '>=8'}
 
   ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
     engines: {node: '>=12'}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
-  ansi-styles@6.2.1:
-    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
-    engines: {node: '>=12'}
-
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   async-sema@3.1.1:
     resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
@@ -399,8 +543,12 @@ packages:
   axios@1.7.9:
     resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
-  bail@2.0.2:
-    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  bail@1.0.5:
+    resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -408,55 +556,58 @@ packages:
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
 
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
+  brace-expansion@1.1.12:
+    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  ccount@1.1.0:
+    resolution: {integrity: sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==}
 
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
-  character-entities@2.0.2:
-    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+  character-entities-legacy@1.1.4:
+    resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+
+  character-entities@1.2.4:
+    resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
+
+  character-reference-invalid@1.1.4:
+    resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
 
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+  collapse-white-space@1.0.6:
+    resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
 
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
 
-  comma-separated-tokens@2.0.3:
-    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+  comma-separated-tokens@1.0.8:
+    resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
 
-  cross-spawn@7.0.6:
-    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
-    engines: {node: '>= 8'}
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  cross-spawn@6.0.6:
+    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
+    engines: {node: '>=4.8'}
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
 
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  debug@4.4.0:
-    resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
-    engines: {node: '>=6.0'}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  decode-named-character-reference@1.0.2:
-    resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -465,12 +616,11 @@ packages:
   deprecation@2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
+  detab@2.0.4:
+    resolution: {integrity: sha512-8zdsQA5bIkoRECvCrNKPla84lyoR7DSAyf7p0YgXzBO9PDJx8KntPUay7NS6yp+KdxdVtiE5SpHKtbp2ZQyA9g==}
 
-  devlop@1.1.0:
-    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+  devalue@5.6.1:
+    resolution: {integrity: sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==}
 
   diff-match-patch@1.0.5:
     resolution: {integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==}
@@ -478,23 +628,29 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
-  eastasianwidth@0.2.0:
-    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+  emoji-regex@6.1.1:
+    resolution: {integrity: sha512-WfVwM9e+M9B/4Qjh9SRnPX2A74Tom3WlVfWF9QWJ8f2BPa1u+/q4aEp1tizZ3vBKAZTg7B6yxn3t9iMjT+dv4w==}
 
-  emoji-regex@8.0.0:
-    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
-  entities@4.5.0:
-    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+  entities@7.0.0:
+    resolution: {integrity: sha512-FDWG5cmEYf2Z00IkYRhbFrwIwvdFKH07uV8dvNy0omp/Qb1xcyCWp2UDtcwJF4QZZvk0sLudP6/hAu42TaqVhQ==}
     engines: {node: '>=0.12'}
+
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  esrap@2.2.1:
+    resolution: {integrity: sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
@@ -502,13 +658,13 @@ packages:
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
-  eventsource-parser@3.0.0:
-    resolution: {integrity: sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==}
-    engines: {node: '>=18.0.0'}
+  eventsource-parser@1.1.2:
+    resolution: {integrity: sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==}
+    engines: {node: '>=14.18'}
 
-  execa@9.5.2:
-    resolution: {integrity: sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==}
-    engines: {node: ^18.19.0 || >=20.5.0}
+  execa@2.0.3:
+    resolution: {integrity: sha512-iM124nlyGSrXmuyZF1EMe83ESY2chIYVyDRZKgmcDynid2Q2v/+GuE7gNMl6Sy9Niwf4MC0DDxagOxeMPjuLsw==}
+    engines: {node: ^8.12.0 || >=9.7.0}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -521,10 +677,6 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  figures@6.1.0:
-    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
-    engines: {node: '>=18'}
-
   follow-redirects@1.15.9:
     resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
@@ -534,10 +686,6 @@ packages:
       debug:
         optional: true
 
-  foreground-child@3.3.0:
-    resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
-    engines: {node: '>=14'}
-
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
@@ -546,51 +694,75 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
-  get-port@7.1.0:
-    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
-    engines: {node: '>=16'}
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  get-stream@9.0.1:
-    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
-    engines: {node: '>=18'}
+  get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
 
-  github-slugger@2.0.0:
-    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
-  glob@11.0.0:
-    resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
-    engines: {node: 20 || >=22}
-    hasBin: true
+  github-slugger@1.2.0:
+    resolution: {integrity: sha512-wIaa75k1vZhyPm9yWrD08A5Xnx/V+RmzGrpjQuLemGKSb77Qukiaei58Bogrl/LZSADDfPzKJX8jhLs4CRTl7Q==}
 
-  gray-matter@4.0.3:
-    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
+
+  gray-matter@4.0.2:
+    resolution: {integrity: sha512-7hB/+LxrOjq/dd8APlK0r24uL/67w7SkYnfwhNFwg/VDIGWGmduTDYf3WNstLW2fbbmRwrDGCVSJ2isuf2+4Hw==}
     engines: {node: '>=6.0'}
 
-  gzip-size@7.0.0:
-    resolution: {integrity: sha512-O1Ld7Dr+nqPnmGpdhzLmMTQ4vAsD+rHwMm1NLUmoUFFymBOMKxCCrtDxqdBRYXdeEPEi3SyoR4TizJLQrnKBNA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+  gzip-size@5.1.1:
+    resolution: {integrity: sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==}
+    engines: {node: '>=6'}
 
-  hast-util-from-parse5@8.0.2:
-    resolution: {integrity: sha512-SfMzfdAi/zAoZ1KkFEyyeXBn7u/ShQrfd675ZEE9M3qj+PMFX05xubzRyF76CCSJu8au9jgVxDV1+okFvgZU4A==}
+  hast-to-hyperscript@7.0.4:
+    resolution: {integrity: sha512-vmwriQ2H0RPS9ho4Kkbf3n3lY436QKLq6VaGA1pzBh36hBi3tm1DO9bR+kaJIbpT10UqaANDkMjxvjVfr+cnOA==}
 
-  hast-util-parse-selector@4.0.0:
-    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+  hast-util-from-parse5@5.0.3:
+    resolution: {integrity: sha512-gOc8UB99F6eWVWFtM9jUikjN7QkWxB3nY0df5Z0Zq1/Nkwl5V4hAAsl0tmwlgWl/1shlTF8DnNYLO8X6wRV9pA==}
 
-  hast-util-raw@9.1.0:
-    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+  hast-util-parse-selector@2.2.5:
+    resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
 
-  hast-util-to-parse5@8.0.0:
-    resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
+  hast-util-raw@5.0.2:
+    resolution: {integrity: sha512-3ReYQcIHmzSgMq8UrDZHFL0oGlbuVGdLKs8s/Fe8BfHFAyZDrdv1fy/AGn+Fim8ZuvAHcJ61NQhVMtyfHviT/g==}
 
-  hastscript@9.0.0:
-    resolution: {integrity: sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==}
+  hast-util-to-parse5@5.1.2:
+    resolution: {integrity: sha512-ZgYLJu9lYknMfsBY0rBV4TJn2xiwF1fXFFjbP6EE7S0s5mS8LIKBVWzhA1MeIs1SWW6GnnE4In6c3kPb+CWhog==}
 
-  html-void-elements@3.0.0:
-    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+  hastscript@5.1.2:
+    resolution: {integrity: sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==}
 
-  human-signals@8.0.0:
-    resolution: {integrity: sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==}
-    engines: {node: '>=18.18.0'}
+  html-void-elements@1.0.5:
+    resolution: {integrity: sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  inline-style-parser@0.1.1:
+    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+
+  is-alphabetical@1.0.4:
+    resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
+
+  is-alphanumerical@1.0.4:
+    resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
+  is-decimal@1.0.4:
+    resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
 
   is-electron@2.2.2:
     resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
@@ -599,32 +771,32 @@ packages:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
 
-  is-fullwidth-code-point@3.0.0:
-    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+  is-hexadecimal@1.0.4:
+    resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
 
-  is-plain-obj@4.1.0:
-    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
-    engines: {node: '>=12'}
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
+    engines: {node: '>=0.10.0'}
+
+  is-reference@3.0.3:
+    resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-stream@4.0.1:
-    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
-    engines: {node: '>=18'}
+  is-whitespace-character@1.0.4:
+    resolution: {integrity: sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==}
 
-  is-unicode-supported@2.1.0:
-    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
-    engines: {node: '>=18'}
+  is-word-character@1.0.4:
+    resolution: {integrity: sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  jackspeak@4.0.2:
-    resolution: {integrity: sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==}
-    engines: {node: 20 || >=22}
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
@@ -642,81 +814,30 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
-  lru-cache@11.0.2:
-    resolution: {integrity: sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==}
-    engines: {node: 20 || >=22}
+  locate-character@3.0.0:
+    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
-  mdast-util-from-markdown@2.0.2:
-    resolution: {integrity: sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==}
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
 
-  mdast-util-to-hast@13.2.0:
-    resolution: {integrity: sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==}
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  mdast-util-to-string@4.0.0:
-    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+  markdown-escapes@1.0.4:
+    resolution: {integrity: sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==}
 
-  micromark-core-commonmark@2.0.2:
-    resolution: {integrity: sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==}
+  mdast-util-definitions@1.2.5:
+    resolution: {integrity: sha512-CJXEdoLfiISCDc2JB6QLb79pYfI6+GcIH+W2ox9nMc7od0Pz+bovcHsiq29xAQY6ayqe/9CsK2VzkSJdg1pFYA==}
 
-  micromark-factory-destination@2.0.1:
-    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+  mdast-util-to-hast@6.0.2:
+    resolution: {integrity: sha512-GjcOimC9qHI0yNFAQdBesrZXzUkRdFleQlcoU8+TVNfDW6oLUazUx8MgUoTaUyCJzBOnE5AOgqhpURrSlf0QwQ==}
 
-  micromark-factory-label@2.0.1:
-    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+  mdurl@1.0.1:
+    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
 
-  micromark-factory-space@2.0.1:
-    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
-
-  micromark-factory-title@2.0.1:
-    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
-
-  micromark-factory-whitespace@2.0.1:
-    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
-
-  micromark-util-character@2.1.1:
-    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
-
-  micromark-util-chunked@2.0.1:
-    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
-
-  micromark-util-classify-character@2.0.1:
-    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
-
-  micromark-util-combine-extensions@2.0.1:
-    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
-
-  micromark-util-decode-numeric-character-reference@2.0.2:
-    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
-
-  micromark-util-decode-string@2.0.1:
-    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
-
-  micromark-util-encode@2.0.1:
-    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
-
-  micromark-util-html-tag-name@2.0.1:
-    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
-
-  micromark-util-normalize-identifier@2.0.1:
-    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
-
-  micromark-util-resolve-all@2.0.1:
-    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
-
-  micromark-util-sanitize-uri@2.0.1:
-    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
-
-  micromark-util-subtokenize@2.0.3:
-    resolution: {integrity: sha512-VXJJuNxYWSoYL6AJ6OQECCFGhIU2GGHMw8tahogePBrjkG8aCCas3ibkp7RnVOSTClg2is05/R7maAhF1XyQMg==}
-
-  micromark-util-symbol@2.0.1:
-    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
-
-  micromark-util-types@2.0.1:
-    resolution: {integrity: sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==}
-
-  micromark@4.0.1:
-    resolution: {integrity: sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==}
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -726,40 +847,70 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
-  minimatch@10.0.1:
-    resolution: {integrity: sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==}
-    engines: {node: 20 || >=22}
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@3.1.2:
+    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
-  ms@2.1.3:
-    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
 
   nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nice-try@1.0.5:
+    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  npm-run-path@6.0.0:
-    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
-    engines: {node: '>=18'}
+  npm-run-path@3.1.0:
+    resolution: {integrity: sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==}
+    engines: {node: '>=8'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   p-finally@1.0.0:
     resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
     engines: {node: '>=4'}
+
+  p-finally@2.0.1:
+    resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
+    engines: {node: '>=8'}
 
   p-queue@6.6.2:
     resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
@@ -773,59 +924,77 @@ packages:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
 
-  package-json-from-dist@1.0.1:
-    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+  parse-entities@1.2.2:
+    resolution: {integrity: sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==}
 
-  parse-ms@4.0.0:
-    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
-    engines: {node: '>=18'}
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
 
-  parse5@7.2.1:
-    resolution: {integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==}
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
+  path-key@2.0.1:
+    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
+    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  path-scurry@2.0.0:
-    resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
-    engines: {node: 20 || >=22}
+  pify@4.0.1:
+    resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
+    engines: {node: '>=6'}
 
-  prettier@3.4.2:
-    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
-    engines: {node: '>=14'}
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
+    engines: {node: '>=10.13.0'}
     hasBin: true
 
-  pretty-bytes@6.1.1:
-    resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
-    engines: {node: ^14.13.1 || >=16.0.0}
+  pretty-bytes@5.6.0:
+    resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
+    engines: {node: '>=6'}
 
-  pretty-ms@9.2.0:
-    resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
-    engines: {node: '>=18'}
+  pretty-ms@5.1.0:
+    resolution: {integrity: sha512-4gaK1skD2gwscCfkswYQRmddUb2GJZtzDGRjHWadVHtK/DIKFufa12MvES6/xu1tVbUYeia5bmLcwJtZJQUqnw==}
+    engines: {node: '>=8'}
 
-  property-information@6.5.0:
-    resolution: {integrity: sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==}
+  property-information@5.6.0:
+    resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
   react@19.0.0:
     resolution: {integrity: sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==}
     engines: {node: '>=0.10.0'}
 
-  rehype-raw@7.0.0:
-    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+  rehype-raw@4.0.1:
+    resolution: {integrity: sha512-g74dPCUWeB9EBfTfGF3lGOHSnZwFwN1ssc3Je9OwQO9f8yTkkAIrMqUVxT34h8zpi4ICU051tTLBZbOrzRWpxg==}
 
-  remark-parse@11.0.0:
-    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+  remark-parse@7.0.1:
+    resolution: {integrity: sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==}
 
-  remark-rehype@11.1.1:
-    resolution: {integrity: sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ==}
+  remark-rehype@5.0.0:
+    resolution: {integrity: sha512-tgo+AeOotuh9FnGMkEPbE6C3OfdARqqSxT0H/KNGAiTwJLiDoRSm6x/ytqPZTyYSiQ/exbi/kx7k6uUvqYL1wQ==}
+
+  repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -838,43 +1007,51 @@ packages:
   secure-json-parse@2.7.0:
     resolution: {integrity: sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==}
 
+  semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+
+  semver@7.3.4:
+    resolution: {integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.6.3:
     resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
-  shebang-command@2.0.0:
-    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
-    engines: {node: '>=8'}
+  shebang-command@1.2.0:
+    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
+    engines: {node: '>=0.10.0'}
 
-  shebang-regex@3.0.0:
-    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
-    engines: {node: '>=8'}
+  shebang-regex@1.0.0:
+    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
+    engines: {node: '>=0.10.0'}
 
-  signal-exit@4.1.0:
-    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
-    engines: {node: '>=14'}
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   slack-block-builder@2.8.0:
     resolution: {integrity: sha512-iisM+j99iKRuQFVfdWo0FiszDAl3r8Snq704oZH6C0RbDqvoVQStiptt6Y7kc6RX/5hSAqTqjhgvZ/di8cvaIA==}
 
-  space-separated-tokens@2.0.2:
-    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@1.1.5:
+    resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  string-width@4.2.3:
-    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
-    engines: {node: '>=8'}
+  sswr@2.2.0:
+    resolution: {integrity: sha512-clTszLPZkmycALTHD1mXGU+mOtA/MIoLgS1KGTTzFNVm9rytQVykgRaP+z1zl572cz0bTqj4rFVoC2N+IGK4Sg==}
+    peerDependencies:
+      svelte: ^4.0.0 || ^5.0.0
 
-  string-width@5.1.2:
-    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
-    engines: {node: '>=12'}
-
-  strip-ansi@6.0.1:
-    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
-    engines: {node: '>=8'}
+  state-toggle@1.0.3:
+    resolution: {integrity: sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==}
 
   strip-ansi@7.1.0:
     resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
@@ -884,8 +1061,15 @@ packages:
     resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
     engines: {node: '>=0.10.0'}
 
-  strip-final-newline@4.0.0:
-    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
+  style-to-object@0.2.3:
+    resolution: {integrity: sha512-1d/k4EY2N7jVLOqf2j04dTc37TPOv/hHxZmvpg8Pdh8UYydxeu/C1W1U4vD8alzf5V2Gt7rLsmkr4dxAlDm9ng==}
+
+  svelte@5.46.1:
+    resolution: {integrity: sha512-ynjfCHD3nP2el70kN5Pmg37sSi0EjOm9FgHYQdC4giWG/hzO3AatzXXJJgP305uIhGQxSufJLuYWtkY8uK/8RA==}
     engines: {node: '>=18'}
 
   swr@2.2.5:
@@ -893,30 +1077,55 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0
 
+  swrev@4.0.0:
+    resolution: {integrity: sha512-LqVcOHSB4cPGgitD1riJ1Hh4vdmITOp+BkmfmXRh4hSF/t7EnS4iD+SOTmq7w5pPm/SiPeto4ADbKS6dHUDWFA==}
+
+  swrv@1.1.0:
+    resolution: {integrity: sha512-pjllRDr2s0iTwiE5Isvip51dZGR7GjLH1gCSVyE8bQnbAx6xackXsFdojau+1O5u98yHF5V73HQGOFxKUXO9gQ==}
+    peerDependencies:
+      vue: '>=3.2.26 < 4'
+
   throttleit@2.1.0:
     resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
     engines: {node: '>=18'}
 
-  trim-lines@3.0.1:
-    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
-  trough@2.2.0:
-    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+  trim-lines@1.1.3:
+    resolution: {integrity: sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==}
+
+  trim-trailing-lines@1.1.4:
+    resolution: {integrity: sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==}
+
+  trim@0.0.1:
+    resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
+
+  trough@1.0.5:
+    resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
 
   tunnel@0.0.6:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
-  undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   undici@5.28.2:
     resolution: {integrity: sha512-wh1pHJHnUeQV5Xa8/kyQhO7WFa8M34l026L5P/+2TYiakvGy5Rdc8jWZVyG7ieht/0WgJLEd3kcU5gKx+6GC8w==}
@@ -926,27 +1135,44 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  unicorn-magic@0.3.0:
-    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
-    engines: {node: '>=18'}
+  unherit@1.1.3:
+    resolution: {integrity: sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==}
 
-  unified@11.0.5:
-    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+  unified@8.4.1:
+    resolution: {integrity: sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==}
 
-  unist-util-is@6.0.0:
-    resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
+  unist-builder@1.0.4:
+    resolution: {integrity: sha512-v6xbUPP7ILrT15fHGrNyHc1Xda8H3xVhP7/HAIotHOhVPjH5dCXA097C3Rry1Q2O+HbOLCao4hfPB+EYEjHgVg==}
 
-  unist-util-position@5.0.0:
-    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+  unist-util-generated@1.1.6:
+    resolution: {integrity: sha512-cln2Mm1/CZzN5ttGK7vkoGw+RZ8VcUH6BtGbq98DDtRGquAAOXig1mrBQYelOwMXYS8rK+vZDyyojSjp7JX+Lg==}
 
-  unist-util-stringify-position@4.0.0:
-    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+  unist-util-is@3.0.0:
+    resolution: {integrity: sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==}
 
-  unist-util-visit-parents@6.0.1:
-    resolution: {integrity: sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==}
+  unist-util-is@4.1.0:
+    resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
 
-  unist-util-visit@5.0.0:
-    resolution: {integrity: sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==}
+  unist-util-position@3.1.0:
+    resolution: {integrity: sha512-w+PkwCbYSFw8vpgWD0v7zRCl1FpY3fjDSQ3/N/wNd9Ffa4gPi8+4keqt99N3XW6F99t/mUzp2xAhNmfKWp95QA==}
+
+  unist-util-remove-position@1.1.4:
+    resolution: {integrity: sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==}
+
+  unist-util-stringify-position@2.0.3:
+    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
+
+  unist-util-visit-parents@2.1.2:
+    resolution: {integrity: sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==}
+
+  unist-util-visit-parents@3.1.1:
+    resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
+
+  unist-util-visit@1.4.1:
+    resolution: {integrity: sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==}
+
+  unist-util-visit@2.0.0:
+    resolution: {integrity: sha512-kiTpWKsF54u/78L/UU/i7lxrnqGiEWBgqCpaIZBYP0gwUC+Akq0Ajm4U8JiNIoQNfAioBdsyarnOcTEAb9mLeQ==}
 
   universal-user-agent@6.0.0:
     resolution: {integrity: sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==}
@@ -956,54 +1182,74 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  vfile-location@5.0.3:
-    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
 
-  vfile-message@4.0.2:
-    resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
+  vfile-location@2.0.6:
+    resolution: {integrity: sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==}
 
-  vfile@6.0.3:
-    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+  vfile-message@2.0.4:
+    resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
 
-  web-namespaces@2.0.1:
-    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+  vfile@4.2.1:
+    resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
+
+  vue@3.5.26:
+    resolution: {integrity: sha512-SJ/NTccVyAoNUJmkM9KUqPcYlY+u8OVL1X5EW9RIs3ch5H2uERxyyIUI4MRxVCSOiEcupX9xNGde1tL9ZKpimA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  web-namespaces@1.1.4:
+    resolution: {integrity: sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==}
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
-  which@2.0.2:
-    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
-    engines: {node: '>= 8'}
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which@1.3.1:
+    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
     hasBin: true
-
-  wrap-ansi@7.0.0:
-    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
-    engines: {node: '>=10'}
-
-  wrap-ansi@8.1.0:
-    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
-    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  yoctocolors@2.1.1:
-    resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
-    engines: {node: '>=18'}
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  zimmerframe@1.1.4:
+    resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
   zod-to-json-schema@3.24.1:
     resolution: {integrity: sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==}
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.24.1:
-    resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zwitch@2.0.4:
-    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+  zwitch@1.0.5:
+    resolution: {integrity: sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==}
 
 snapshots:
+
+  '@actions/core@1.10.0':
+    dependencies:
+      '@actions/http-client': 2.2.3
+      uuid: 8.3.2
 
   '@actions/core@1.11.1':
     dependencies:
@@ -1013,6 +1259,15 @@ snapshots:
   '@actions/exec@1.1.1':
     dependencies:
       '@actions/io': 1.1.3
+
+  '@actions/github@5.1.1':
+    dependencies:
+      '@actions/http-client': 2.2.3
+      '@octokit/core': 3.6.0
+      '@octokit/plugin-paginate-rest': 2.21.3(@octokit/core@3.6.0)
+      '@octokit/plugin-rest-endpoint-methods': 5.16.2(@octokit/core@3.6.0)
+    transitivePeerDependencies:
+      - encoding
 
   '@actions/github@6.0.0':
     dependencies:
@@ -1033,57 +1288,138 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@ai-sdk/openai@1.0.8(zod@3.24.1)':
+  '@ai-sdk/openai@0.0.67(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.0.2
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.24.1)
-      zod: 3.24.1
+      '@ai-sdk/provider': 0.0.24
+      '@ai-sdk/provider-utils': 1.0.20(zod@3.25.76)
+      zod: 3.25.76
 
-  '@ai-sdk/provider-utils@2.0.4(zod@3.24.1)':
+  '@ai-sdk/provider-utils@1.0.20(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.0.2
-      eventsource-parser: 3.0.0
+      '@ai-sdk/provider': 0.0.24
+      eventsource-parser: 1.1.2
+      nanoid: 3.3.6
+      secure-json-parse: 2.7.0
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@1.0.22(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      eventsource-parser: 1.1.2
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
     optionalDependencies:
-      zod: 3.24.1
+      zod: 3.25.76
 
-  '@ai-sdk/provider@1.0.2':
+  '@ai-sdk/provider@0.0.24':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.0.6(react@19.0.0)(zod@3.24.1)':
+  '@ai-sdk/provider@0.0.26':
     dependencies:
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.24.1)
-      '@ai-sdk/ui-utils': 1.0.5(zod@3.24.1)
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@0.0.70(react@19.0.0)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.76)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.76)
       swr: 2.2.5(react@19.0.0)
       throttleit: 2.1.0
     optionalDependencies:
       react: 19.0.0
-      zod: 3.24.1
+      zod: 3.25.76
 
-  '@ai-sdk/ui-utils@1.0.5(zod@3.24.1)':
+  '@ai-sdk/solid@0.0.54(zod@3.25.76)':
     dependencies:
-      '@ai-sdk/provider': 1.0.2
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.24.1)
-      zod-to-json-schema: 3.24.1(zod@3.24.1)
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.76)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.76)
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/svelte@0.0.57(svelte@5.46.1)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.76)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.76)
+      sswr: 2.2.0(svelte@5.46.1)
     optionalDependencies:
-      zod: 3.24.1
+      svelte: 5.46.1
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/ui-utils@0.0.50(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.76)
+      json-schema: 0.4.0
+      secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.24.1(zod@3.25.76)
+    optionalDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/vue@0.0.59(vue@3.5.26(typescript@5.7.2))(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.76)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.76)
+      swrv: 1.1.0(vue@3.5.26(typescript@5.7.2))
+    optionalDependencies:
+      vue: 3.5.26(typescript@5.7.2)
+    transitivePeerDependencies:
+      - zod
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.28.5':
+    dependencies:
+      '@babel/types': 7.28.5
+
+  '@babel/types@7.28.5':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@fastify/busboy@2.1.0': {}
 
   '@fastify/busboy@2.1.1': {}
 
-  '@isaacs/cliui@8.0.2':
+  '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      string-width: 5.1.2
-      string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.1.0
-      strip-ansi-cjs: strip-ansi@6.0.1
-      wrap-ansi: 8.1.0
-      wrap-ansi-cjs: wrap-ansi@7.0.0
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@octokit/auth-token@2.5.0':
+    dependencies:
+      '@octokit/types': 6.41.0
 
   '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@3.6.0':
+    dependencies:
+      '@octokit/auth-token': 2.5.0
+      '@octokit/graphql': 4.8.0
+      '@octokit/request': 5.6.3
+      '@octokit/request-error': 2.1.0
+      '@octokit/types': 6.41.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
 
   '@octokit/core@5.0.2':
     dependencies:
@@ -1095,10 +1431,24 @@ snapshots:
       before-after-hook: 2.2.3
       universal-user-agent: 6.0.0
 
+  '@octokit/endpoint@6.0.12':
+    dependencies:
+      '@octokit/types': 6.41.0
+      is-plain-object: 5.0.0
+      universal-user-agent: 6.0.0
+
   '@octokit/endpoint@9.0.4':
     dependencies:
       '@octokit/types': 12.4.0
       universal-user-agent: 6.0.0
+
+  '@octokit/graphql@4.8.0':
+    dependencies:
+      '@octokit/request': 5.6.3
+      '@octokit/types': 6.41.0
+      universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
 
   '@octokit/graphql@7.0.2':
     dependencies:
@@ -1106,7 +1456,14 @@ snapshots:
       '@octokit/types': 12.4.0
       universal-user-agent: 6.0.0
 
+  '@octokit/openapi-types@12.11.0': {}
+
   '@octokit/openapi-types@19.1.0': {}
+
+  '@octokit/plugin-paginate-rest@2.21.3(@octokit/core@3.6.0)':
+    dependencies:
+      '@octokit/core': 3.6.0
+      '@octokit/types': 6.41.0
 
   '@octokit/plugin-paginate-rest@9.1.5(@octokit/core@5.0.2)':
     dependencies:
@@ -1118,11 +1475,34 @@ snapshots:
       '@octokit/core': 5.0.2
       '@octokit/types': 12.4.0
 
+  '@octokit/plugin-rest-endpoint-methods@5.16.2(@octokit/core@3.6.0)':
+    dependencies:
+      '@octokit/core': 3.6.0
+      '@octokit/types': 6.41.0
+      deprecation: 2.3.1
+
+  '@octokit/request-error@2.1.0':
+    dependencies:
+      '@octokit/types': 6.41.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
   '@octokit/request-error@5.0.1':
     dependencies:
       '@octokit/types': 12.4.0
       deprecation: 2.3.1
       once: 1.4.0
+
+  '@octokit/request@5.6.3':
+    dependencies:
+      '@octokit/endpoint': 6.0.12
+      '@octokit/request-error': 2.1.0
+      '@octokit/types': 6.41.0
+      is-plain-object: 5.0.0
+      node-fetch: 2.7.0
+      universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
 
   '@octokit/request@8.1.6':
     dependencies:
@@ -1135,15 +1515,15 @@ snapshots:
     dependencies:
       '@octokit/openapi-types': 19.1.0
 
+  '@octokit/types@6.41.0':
+    dependencies:
+      '@octokit/openapi-types': 12.11.0
+
   '@opentelemetry/api@1.9.0': {}
-
-  '@sec-ant/readable-stream@0.4.1': {}
-
-  '@sindresorhus/merge-streams@4.0.0': {}
 
   '@slack/logger@4.0.0':
     dependencies:
-      '@types/node': 22.7.6
+      '@types/node': 18.19.130
 
   '@slack/types@2.14.0': {}
 
@@ -1151,7 +1531,7 @@ snapshots:
     dependencies:
       '@slack/logger': 4.0.0
       '@slack/types': 2.14.0
-      '@types/node': 22.7.6
+      '@types/node': 18.19.130
       '@types/retry': 0.12.0
       axios: 1.7.9
       eventemitter3: 5.0.1
@@ -1164,76 +1544,133 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@types/debug@4.1.12':
+  '@sveltejs/acorn-typescript@1.0.8(acorn@8.15.0)':
     dependencies:
-      '@types/ms': 0.7.34
+      acorn: 8.15.0
 
   '@types/diff-match-patch@1.0.36': {}
 
-  '@types/github-slugger@2.0.0':
-    dependencies:
-      github-slugger: 2.0.0
+  '@types/estree@1.0.8': {}
 
-  '@types/hast@3.0.4':
-    dependencies:
-      '@types/unist': 3.0.3
+  '@types/github-slugger@1.3.0': {}
 
-  '@types/mdast@4.0.4':
+  '@types/node@18.19.130':
     dependencies:
-      '@types/unist': 3.0.3
-
-  '@types/ms@0.7.34': {}
-
-  '@types/node@22.10.2':
-    dependencies:
-      undici-types: 6.20.0
-
-  '@types/node@22.7.6':
-    dependencies:
-      undici-types: 6.19.8
+      undici-types: 5.26.5
 
   '@types/retry@0.12.0': {}
 
-  '@types/unist@3.0.3': {}
+  '@types/unist@2.0.11': {}
 
-  '@ungap/structured-clone@1.2.1': {}
-
-  '@upstash/redis@1.34.3':
+  '@upstash/redis@1.24.3':
     dependencies:
       crypto-js: 4.2.0
 
-  '@vercel/kv@3.0.0':
+  '@upstash/redis@1.25.1':
     dependencies:
-      '@upstash/redis': 1.34.3
+      crypto-js: 4.2.0
+
+  '@vercel/kv@0.2.4':
+    dependencies:
+      '@upstash/redis': 1.24.3
+
+  '@vercel/kv@1.0.1':
+    dependencies:
+      '@upstash/redis': 1.25.1
+
+  '@vercel/ncc@0.34.0': {}
+
+  '@vercel/ncc@0.36.1': {}
 
   '@vercel/ncc@0.38.3': {}
 
-  ai@4.0.16(react@19.0.0)(zod@3.24.1):
+  '@vue/compiler-core@3.5.26':
     dependencies:
-      '@ai-sdk/provider': 1.0.2
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.24.1)
-      '@ai-sdk/react': 1.0.6(react@19.0.0)(zod@3.24.1)
-      '@ai-sdk/ui-utils': 1.0.5(zod@3.24.1)
+      '@babel/parser': 7.28.5
+      '@vue/shared': 3.5.26
+      entities: 7.0.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.26':
+    dependencies:
+      '@vue/compiler-core': 3.5.26
+      '@vue/shared': 3.5.26
+
+  '@vue/compiler-sfc@3.5.26':
+    dependencies:
+      '@babel/parser': 7.28.5
+      '@vue/compiler-core': 3.5.26
+      '@vue/compiler-dom': 3.5.26
+      '@vue/compiler-ssr': 3.5.26
+      '@vue/shared': 3.5.26
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.6
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.26':
+    dependencies:
+      '@vue/compiler-dom': 3.5.26
+      '@vue/shared': 3.5.26
+
+  '@vue/reactivity@3.5.26':
+    dependencies:
+      '@vue/shared': 3.5.26
+
+  '@vue/runtime-core@3.5.26':
+    dependencies:
+      '@vue/reactivity': 3.5.26
+      '@vue/shared': 3.5.26
+
+  '@vue/runtime-dom@3.5.26':
+    dependencies:
+      '@vue/reactivity': 3.5.26
+      '@vue/runtime-core': 3.5.26
+      '@vue/shared': 3.5.26
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.26(vue@3.5.26(typescript@5.7.2))':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.26
+      '@vue/shared': 3.5.26
+      vue: 3.5.26(typescript@5.7.2)
+
+  '@vue/shared@3.5.26': {}
+
+  acorn@8.15.0: {}
+
+  ai@3.4.33(react@19.0.0)(sswr@2.2.0(svelte@5.46.1))(svelte@5.46.1)(vue@3.5.26(typescript@5.7.2))(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/provider': 0.0.26
+      '@ai-sdk/provider-utils': 1.0.22(zod@3.25.76)
+      '@ai-sdk/react': 0.0.70(react@19.0.0)(zod@3.25.76)
+      '@ai-sdk/solid': 0.0.54(zod@3.25.76)
+      '@ai-sdk/svelte': 0.0.57(svelte@5.46.1)(zod@3.25.76)
+      '@ai-sdk/ui-utils': 0.0.50(zod@3.25.76)
+      '@ai-sdk/vue': 0.0.59(vue@3.5.26(typescript@5.7.2))(zod@3.25.76)
       '@opentelemetry/api': 1.9.0
+      eventsource-parser: 1.1.2
+      json-schema: 0.4.0
       jsondiffpatch: 0.6.0
-      zod-to-json-schema: 3.24.1(zod@3.24.1)
+      secure-json-parse: 2.7.0
+      zod-to-json-schema: 3.24.1(zod@3.25.76)
     optionalDependencies:
       react: 19.0.0
-      zod: 3.24.1
-
-  ansi-regex@5.0.1: {}
+      sswr: 2.2.0(svelte@5.46.1)
+      svelte: 5.46.1
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - solid-js
+      - vue
 
   ansi-regex@6.0.1: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
-
-  ansi-styles@6.2.1: {}
 
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  aria-query@5.3.2: {}
 
   async-sema@3.1.1: {}
 
@@ -1247,96 +1684,106 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  bail@2.0.2: {}
+  axobject-query@4.1.0: {}
+
+  bail@1.0.5: {}
 
   balanced-match@1.0.2: {}
 
   before-after-hook@2.2.3: {}
 
-  brace-expansion@2.0.1:
+  brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  ccount@1.1.0: {}
 
   chalk@5.3.0: {}
 
-  character-entities@2.0.2: {}
+  character-entities-legacy@1.1.4: {}
+
+  character-entities@1.2.4: {}
+
+  character-reference-invalid@1.1.4: {}
 
   client-only@0.0.1: {}
 
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
+  clsx@2.1.1: {}
 
-  color-name@1.1.4: {}
+  collapse-white-space@1.0.6: {}
 
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
-  comma-separated-tokens@2.0.3: {}
+  comma-separated-tokens@1.0.8: {}
 
-  cross-spawn@7.0.6:
+  concat-map@0.0.1: {}
+
+  cross-spawn@6.0.6:
     dependencies:
-      path-key: 3.1.1
-      shebang-command: 2.0.0
-      which: 2.0.2
+      nice-try: 1.0.5
+      path-key: 2.0.1
+      semver: 5.7.2
+      shebang-command: 1.2.0
+      which: 1.3.1
 
   crypto-js@4.2.0: {}
 
+  csstype@3.2.3: {}
+
   data-uri-to-buffer@4.0.1: {}
-
-  debug@4.4.0:
-    dependencies:
-      ms: 2.1.3
-
-  decode-named-character-reference@1.0.2:
-    dependencies:
-      character-entities: 2.0.2
 
   delayed-stream@1.0.0: {}
 
   deprecation@2.3.1: {}
 
-  dequal@2.0.3: {}
-
-  devlop@1.1.0:
+  detab@2.0.4:
     dependencies:
-      dequal: 2.0.3
+      repeat-string: 1.6.1
+
+  devalue@5.6.1: {}
 
   diff-match-patch@1.0.5: {}
 
   duplexer@0.1.2: {}
 
-  eastasianwidth@0.2.0: {}
+  emoji-regex@6.1.1: {}
 
-  emoji-regex@8.0.0: {}
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
-  emoji-regex@9.2.2: {}
+  entities@7.0.0: {}
 
-  entities@4.5.0: {}
+  esm-env@1.2.2: {}
 
   esprima@4.0.1: {}
+
+  esrap@2.2.1:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  estree-walker@2.0.2: {}
 
   eventemitter3@4.0.7: {}
 
   eventemitter3@5.0.1: {}
 
-  eventsource-parser@3.0.0: {}
+  eventsource-parser@1.1.2: {}
 
-  execa@9.5.2:
+  execa@2.0.3:
     dependencies:
-      '@sindresorhus/merge-streams': 4.0.0
-      cross-spawn: 7.0.6
-      figures: 6.1.0
-      get-stream: 9.0.1
-      human-signals: 8.0.0
-      is-plain-obj: 4.1.0
-      is-stream: 4.0.1
-      npm-run-path: 6.0.0
-      pretty-ms: 9.2.0
-      signal-exit: 4.1.0
-      strip-final-newline: 4.0.0
-      yoctocolors: 2.1.1
+      cross-spawn: 6.0.6
+      get-stream: 5.2.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 3.1.0
+      onetime: 5.1.2
+      p-finally: 2.0.1
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
 
   extend-shallow@2.0.1:
     dependencies:
@@ -1349,16 +1796,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  figures@6.1.0:
-    dependencies:
-      is-unicode-supported: 2.1.0
-
   follow-redirects@1.15.9: {}
-
-  foreground-child@3.3.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      signal-exit: 4.1.0
 
   form-data@4.0.1:
     dependencies:
@@ -1370,107 +1808,127 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  get-port@7.1.0: {}
+  fs.realpath@1.0.0: {}
 
-  get-stream@9.0.1:
+  get-port@5.1.1: {}
+
+  get-stream@5.2.0:
     dependencies:
-      '@sec-ant/readable-stream': 0.4.1
-      is-stream: 4.0.1
+      pump: 3.0.3
 
-  github-slugger@2.0.0: {}
-
-  glob@11.0.0:
+  github-slugger@1.2.0:
     dependencies:
-      foreground-child: 3.3.0
-      jackspeak: 4.0.2
-      minimatch: 10.0.1
-      minipass: 7.1.2
-      package-json-from-dist: 1.0.1
-      path-scurry: 2.0.0
+      emoji-regex: 6.1.1
 
-  gray-matter@4.0.3:
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  gray-matter@4.0.2:
     dependencies:
       js-yaml: 3.14.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
 
-  gzip-size@7.0.0:
+  gzip-size@5.1.1:
     dependencies:
       duplexer: 0.1.2
+      pify: 4.0.1
 
-  hast-util-from-parse5@8.0.2:
+  hast-to-hyperscript@7.0.4:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      devlop: 1.1.0
-      hastscript: 9.0.0
-      property-information: 6.5.0
-      vfile: 6.0.3
-      vfile-location: 5.0.3
-      web-namespaces: 2.0.1
+      comma-separated-tokens: 1.0.8
+      property-information: 5.6.0
+      space-separated-tokens: 1.1.5
+      style-to-object: 0.2.3
+      unist-util-is: 3.0.0
+      web-namespaces: 1.1.4
 
-  hast-util-parse-selector@4.0.0:
+  hast-util-from-parse5@5.0.3:
     dependencies:
-      '@types/hast': 3.0.4
+      ccount: 1.1.0
+      hastscript: 5.1.2
+      property-information: 5.6.0
+      web-namespaces: 1.1.4
+      xtend: 4.0.2
 
-  hast-util-raw@9.1.0:
+  hast-util-parse-selector@2.2.5: {}
+
+  hast-util-raw@5.0.2:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/unist': 3.0.3
-      '@ungap/structured-clone': 1.2.1
-      hast-util-from-parse5: 8.0.2
-      hast-util-to-parse5: 8.0.0
-      html-void-elements: 3.0.0
-      mdast-util-to-hast: 13.2.0
-      parse5: 7.2.1
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
-      vfile: 6.0.3
-      web-namespaces: 2.0.1
-      zwitch: 2.0.4
+      hast-util-from-parse5: 5.0.3
+      hast-util-to-parse5: 5.1.2
+      html-void-elements: 1.0.5
+      parse5: 5.1.1
+      unist-util-position: 3.1.0
+      web-namespaces: 1.1.4
+      xtend: 4.0.2
+      zwitch: 1.0.5
 
-  hast-util-to-parse5@8.0.0:
+  hast-util-to-parse5@5.1.2:
     dependencies:
-      '@types/hast': 3.0.4
-      comma-separated-tokens: 2.0.3
-      devlop: 1.1.0
-      property-information: 6.5.0
-      space-separated-tokens: 2.0.2
-      web-namespaces: 2.0.1
-      zwitch: 2.0.4
+      hast-to-hyperscript: 7.0.4
+      property-information: 5.6.0
+      web-namespaces: 1.1.4
+      xtend: 4.0.2
+      zwitch: 1.0.5
 
-  hastscript@9.0.0:
+  hastscript@5.1.2:
     dependencies:
-      '@types/hast': 3.0.4
-      comma-separated-tokens: 2.0.3
-      hast-util-parse-selector: 4.0.0
-      property-information: 6.5.0
-      space-separated-tokens: 2.0.2
+      comma-separated-tokens: 1.0.8
+      hast-util-parse-selector: 2.2.5
+      property-information: 5.6.0
+      space-separated-tokens: 1.1.5
 
-  html-void-elements@3.0.0: {}
+  html-void-elements@1.0.5: {}
 
-  human-signals@8.0.0: {}
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
+
+  inline-style-parser@0.1.1: {}
+
+  is-alphabetical@1.0.4: {}
+
+  is-alphanumerical@1.0.4:
+    dependencies:
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+
+  is-buffer@2.0.5: {}
+
+  is-decimal@1.0.4: {}
 
   is-electron@2.2.2: {}
 
   is-extendable@0.1.1: {}
 
-  is-fullwidth-code-point@3.0.0: {}
+  is-hexadecimal@1.0.4: {}
 
-  is-plain-obj@4.1.0: {}
+  is-plain-obj@2.1.0: {}
+
+  is-plain-object@5.0.0: {}
+
+  is-reference@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   is-stream@2.0.1: {}
 
-  is-stream@4.0.1: {}
+  is-whitespace-character@1.0.4: {}
 
-  is-unicode-supported@2.1.0: {}
+  is-word-character@1.0.4: {}
 
   isexe@2.0.0: {}
-
-  jackspeak@4.0.2:
-    dependencies:
-      '@isaacs/cliui': 8.0.2
 
   js-yaml@3.14.1:
     dependencies:
@@ -1487,173 +1945,39 @@ snapshots:
 
   kind-of@6.0.3: {}
 
-  lru-cache@11.0.2: {}
+  locate-character@3.0.0: {}
 
-  mdast-util-from-markdown@2.0.2:
+  lru-cache@6.0.0:
     dependencies:
-      '@types/mdast': 4.0.4
-      '@types/unist': 3.0.3
-      decode-named-character-reference: 1.0.2
-      devlop: 1.1.0
-      mdast-util-to-string: 4.0.0
-      micromark: 4.0.1
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-decode-string: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-      unist-util-stringify-position: 4.0.0
-    transitivePeerDependencies:
-      - supports-color
+      yallist: 4.0.0
 
-  mdast-util-to-hast@13.2.0:
+  magic-string@0.30.21:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      '@ungap/structured-clone': 1.2.1
-      devlop: 1.1.0
-      micromark-util-sanitize-uri: 2.0.1
-      trim-lines: 3.0.1
-      unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
-      vfile: 6.0.3
+      '@jridgewell/sourcemap-codec': 1.5.5
 
-  mdast-util-to-string@4.0.0:
+  markdown-escapes@1.0.4: {}
+
+  mdast-util-definitions@1.2.5:
     dependencies:
-      '@types/mdast': 4.0.4
+      unist-util-visit: 1.4.1
 
-  micromark-core-commonmark@2.0.2:
+  mdast-util-to-hast@6.0.2:
     dependencies:
-      decode-named-character-reference: 1.0.2
-      devlop: 1.1.0
-      micromark-factory-destination: 2.0.1
-      micromark-factory-label: 2.0.1
-      micromark-factory-space: 2.0.1
-      micromark-factory-title: 2.0.1
-      micromark-factory-whitespace: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-chunked: 2.0.1
-      micromark-util-classify-character: 2.0.1
-      micromark-util-html-tag-name: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-resolve-all: 2.0.1
-      micromark-util-subtokenize: 2.0.3
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
+      collapse-white-space: 1.0.6
+      detab: 2.0.4
+      mdast-util-definitions: 1.2.5
+      mdurl: 1.0.1
+      trim: 0.0.1
+      trim-lines: 1.1.3
+      unist-builder: 1.0.4
+      unist-util-generated: 1.1.6
+      unist-util-position: 3.1.0
+      unist-util-visit: 1.4.1
+      xtend: 4.0.2
 
-  micromark-factory-destination@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
+  mdurl@1.0.1: {}
 
-  micromark-factory-label@2.0.1:
-    dependencies:
-      devlop: 1.1.0
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-
-  micromark-factory-space@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-types: 2.0.1
-
-  micromark-factory-title@2.0.1:
-    dependencies:
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-
-  micromark-factory-whitespace@2.0.1:
-    dependencies:
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-
-  micromark-util-character@2.1.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-
-  micromark-util-chunked@2.0.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-classify-character@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-
-  micromark-util-combine-extensions@2.0.1:
-    dependencies:
-      micromark-util-chunked: 2.0.1
-      micromark-util-types: 2.0.1
-
-  micromark-util-decode-numeric-character-reference@2.0.2:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-decode-string@2.0.1:
-    dependencies:
-      decode-named-character-reference: 1.0.2
-      micromark-util-character: 2.1.1
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-encode@2.0.1: {}
-
-  micromark-util-html-tag-name@2.0.1: {}
-
-  micromark-util-normalize-identifier@2.0.1:
-    dependencies:
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-resolve-all@2.0.1:
-    dependencies:
-      micromark-util-types: 2.0.1
-
-  micromark-util-sanitize-uri@2.0.1:
-    dependencies:
-      micromark-util-character: 2.1.1
-      micromark-util-encode: 2.0.1
-      micromark-util-symbol: 2.0.1
-
-  micromark-util-subtokenize@2.0.3:
-    dependencies:
-      devlop: 1.1.0
-      micromark-util-chunked: 2.0.1
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-
-  micromark-util-symbol@2.0.1: {}
-
-  micromark-util-types@2.0.1: {}
-
-  micromark@4.0.1:
-    dependencies:
-      '@types/debug': 4.1.12
-      debug: 4.4.0
-      decode-named-character-reference: 1.0.2
-      devlop: 1.1.0
-      micromark-core-commonmark: 2.0.2
-      micromark-factory-space: 2.0.1
-      micromark-util-character: 2.1.1
-      micromark-util-chunked: 2.0.1
-      micromark-util-combine-extensions: 2.0.1
-      micromark-util-decode-numeric-character-reference: 2.0.2
-      micromark-util-encode: 2.0.1
-      micromark-util-normalize-identifier: 2.0.1
-      micromark-util-resolve-all: 2.0.1
-      micromark-util-sanitize-uri: 2.0.1
-      micromark-util-subtokenize: 2.0.3
-      micromark-util-symbol: 2.0.1
-      micromark-util-types: 2.0.1
-    transitivePeerDependencies:
-      - supports-color
+  merge-stream@2.0.0: {}
 
   mime-db@1.52.0: {}
 
@@ -1661,17 +1985,25 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  minimatch@10.0.1:
+  mimic-fn@2.1.0: {}
+
+  minimatch@3.1.2:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 1.1.12
 
-  minipass@7.1.2: {}
+  nanoid@3.3.11: {}
 
-  ms@2.1.3: {}
+  nanoid@3.3.6: {}
 
   nanoid@3.3.8: {}
 
+  nice-try@1.0.5: {}
+
   node-domexception@1.0.0: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-fetch@3.3.2:
     dependencies:
@@ -1679,16 +2011,23 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
-  npm-run-path@6.0.0:
+  npm-run-path@3.1.0:
     dependencies:
-      path-key: 4.0.0
-      unicorn-magic: 0.3.0
+      path-key: 3.1.1
+
+  object-assign@4.1.1: {}
 
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   p-finally@1.0.0: {}
+
+  p-finally@2.0.1: {}
 
   p-queue@6.6.2:
     dependencies:
@@ -1704,59 +2043,83 @@ snapshots:
     dependencies:
       p-finally: 1.0.0
 
-  package-json-from-dist@1.0.1: {}
-
-  parse-ms@4.0.0: {}
-
-  parse5@7.2.1:
+  parse-entities@1.2.2:
     dependencies:
-      entities: 4.5.0
+      character-entities: 1.2.4
+      character-entities-legacy: 1.1.4
+      character-reference-invalid: 1.1.4
+      is-alphanumerical: 1.0.4
+      is-decimal: 1.0.4
+      is-hexadecimal: 1.0.4
+
+  parse-ms@2.1.0: {}
+
+  parse5@5.1.1: {}
+
+  path-is-absolute@1.0.1: {}
+
+  path-key@2.0.1: {}
 
   path-key@3.1.1: {}
 
-  path-key@4.0.0: {}
+  picocolors@1.1.1: {}
 
-  path-scurry@2.0.0:
+  pify@4.0.1: {}
+
+  postcss@8.5.6:
     dependencies:
-      lru-cache: 11.0.2
-      minipass: 7.1.2
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
-  prettier@3.4.2: {}
+  prettier@2.8.8: {}
 
-  pretty-bytes@6.1.1: {}
+  pretty-bytes@5.6.0: {}
 
-  pretty-ms@9.2.0:
+  pretty-ms@5.1.0:
     dependencies:
-      parse-ms: 4.0.0
+      parse-ms: 2.1.0
 
-  property-information@6.5.0: {}
+  property-information@5.6.0:
+    dependencies:
+      xtend: 4.0.2
 
   proxy-from-env@1.1.0: {}
 
+  pump@3.0.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   react@19.0.0: {}
 
-  rehype-raw@7.0.0:
+  rehype-raw@4.0.1:
     dependencies:
-      '@types/hast': 3.0.4
-      hast-util-raw: 9.1.0
-      vfile: 6.0.3
+      hast-util-raw: 5.0.2
 
-  remark-parse@11.0.0:
+  remark-parse@7.0.1:
     dependencies:
-      '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2
-      micromark-util-types: 2.0.1
-      unified: 11.0.5
-    transitivePeerDependencies:
-      - supports-color
+      collapse-white-space: 1.0.6
+      is-alphabetical: 1.0.4
+      is-decimal: 1.0.4
+      is-whitespace-character: 1.0.4
+      is-word-character: 1.0.4
+      markdown-escapes: 1.0.4
+      parse-entities: 1.2.2
+      repeat-string: 1.6.1
+      state-toggle: 1.0.3
+      trim: 0.0.1
+      trim-trailing-lines: 1.1.4
+      unherit: 1.1.3
+      unist-util-remove-position: 1.1.4
+      vfile-location: 2.0.6
+      xtend: 4.0.2
 
-  remark-rehype@11.1.1:
+  remark-rehype@5.0.0:
     dependencies:
-      '@types/hast': 3.0.4
-      '@types/mdast': 4.0.4
-      mdast-util-to-hast: 13.2.0
-      unified: 11.0.5
-      vfile: 6.0.3
+      mdast-util-to-hast: 6.0.2
+
+  repeat-string@1.6.1: {}
 
   retry@0.13.1: {}
 
@@ -1767,37 +2130,36 @@ snapshots:
 
   secure-json-parse@2.7.0: {}
 
+  semver@5.7.2: {}
+
+  semver@7.3.4:
+    dependencies:
+      lru-cache: 6.0.0
+
   semver@7.6.3: {}
 
-  shebang-command@2.0.0:
+  shebang-command@1.2.0:
     dependencies:
-      shebang-regex: 3.0.0
+      shebang-regex: 1.0.0
 
-  shebang-regex@3.0.0: {}
+  shebang-regex@1.0.0: {}
 
-  signal-exit@4.1.0: {}
+  signal-exit@3.0.7: {}
 
   slack-block-builder@2.8.0: {}
 
-  space-separated-tokens@2.0.2: {}
+  source-map-js@1.2.1: {}
+
+  space-separated-tokens@1.1.5: {}
 
   sprintf-js@1.0.3: {}
 
-  string-width@4.2.3:
+  sswr@2.2.0(svelte@5.46.1):
     dependencies:
-      emoji-regex: 8.0.0
-      is-fullwidth-code-point: 3.0.0
-      strip-ansi: 6.0.1
+      svelte: 5.46.1
+      swrev: 4.0.0
 
-  string-width@5.1.2:
-    dependencies:
-      eastasianwidth: 0.2.0
-      emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
-
-  strip-ansi@6.0.1:
-    dependencies:
-      ansi-regex: 5.0.1
+  state-toggle@1.0.3: {}
 
   strip-ansi@7.1.0:
     dependencies:
@@ -1805,7 +2167,29 @@ snapshots:
 
   strip-bom-string@1.0.0: {}
 
-  strip-final-newline@4.0.0: {}
+  strip-final-newline@2.0.0: {}
+
+  style-to-object@0.2.3:
+    dependencies:
+      inline-style-parser: 0.1.1
+
+  svelte@5.46.1:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@sveltejs/acorn-typescript': 1.0.8(acorn@8.15.0)
+      '@types/estree': 1.0.8
+      acorn: 8.15.0
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      clsx: 2.1.1
+      devalue: 5.6.1
+      esm-env: 1.2.2
+      esrap: 2.2.1
+      is-reference: 3.0.3
+      locate-character: 3.0.0
+      magic-string: 0.30.21
+      zimmerframe: 1.1.4
 
   swr@2.2.5(react@19.0.0):
     dependencies:
@@ -1813,19 +2197,34 @@ snapshots:
       react: 19.0.0
       use-sync-external-store: 1.4.0(react@19.0.0)
 
+  swrev@4.0.0: {}
+
+  swrv@1.1.0(vue@3.5.26(typescript@5.7.2)):
+    dependencies:
+      vue: 3.5.26(typescript@5.7.2)
+
   throttleit@2.1.0: {}
 
-  trim-lines@3.0.1: {}
+  tr46@0.0.3: {}
 
-  trough@2.2.0: {}
+  trim-lines@1.1.3: {}
+
+  trim-trailing-lines@1.1.4: {}
+
+  trim@0.0.1: {}
+
+  trough@1.0.5: {}
 
   tunnel@0.0.6: {}
 
-  typescript@5.7.2: {}
+  typescript@4.9.5: {}
 
-  undici-types@6.19.8: {}
+  typescript@5.1.6: {}
 
-  undici-types@6.20.0: {}
+  typescript@5.7.2:
+    optional: true
+
+  undici-types@5.26.5: {}
 
   undici@5.28.2:
     dependencies:
@@ -1835,40 +2234,58 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  unicorn-magic@0.3.0: {}
-
-  unified@11.0.5:
+  unherit@1.1.3:
     dependencies:
-      '@types/unist': 3.0.3
-      bail: 2.0.2
-      devlop: 1.1.0
+      inherits: 2.0.4
+      xtend: 4.0.2
+
+  unified@8.4.1:
+    dependencies:
+      '@types/unist': 2.0.11
+      bail: 1.0.5
       extend: 3.0.2
-      is-plain-obj: 4.1.0
-      trough: 2.2.0
-      vfile: 6.0.3
+      is-plain-obj: 2.1.0
+      trough: 1.0.5
+      vfile: 4.2.1
 
-  unist-util-is@6.0.0:
+  unist-builder@1.0.4:
     dependencies:
-      '@types/unist': 3.0.3
+      object-assign: 4.1.1
 
-  unist-util-position@5.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
+  unist-util-generated@1.1.6: {}
 
-  unist-util-stringify-position@4.0.0:
-    dependencies:
-      '@types/unist': 3.0.3
+  unist-util-is@3.0.0: {}
 
-  unist-util-visit-parents@6.0.1:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
+  unist-util-is@4.1.0: {}
 
-  unist-util-visit@5.0.0:
+  unist-util-position@3.1.0: {}
+
+  unist-util-remove-position@1.1.4:
     dependencies:
-      '@types/unist': 3.0.3
-      unist-util-is: 6.0.0
-      unist-util-visit-parents: 6.0.1
+      unist-util-visit: 1.4.1
+
+  unist-util-stringify-position@2.0.3:
+    dependencies:
+      '@types/unist': 2.0.11
+
+  unist-util-visit-parents@2.1.2:
+    dependencies:
+      unist-util-is: 3.0.0
+
+  unist-util-visit-parents@3.1.1:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 4.1.0
+
+  unist-util-visit@1.4.1:
+    dependencies:
+      unist-util-visit-parents: 2.1.2
+
+  unist-util-visit@2.0.0:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-is: 4.1.0
+      unist-util-visit-parents: 3.1.1
 
   universal-user-agent@6.0.0: {}
 
@@ -1876,49 +2293,59 @@ snapshots:
     dependencies:
       react: 19.0.0
 
-  vfile-location@5.0.3:
-    dependencies:
-      '@types/unist': 3.0.3
-      vfile: 6.0.3
+  uuid@8.3.2: {}
 
-  vfile-message@4.0.2:
-    dependencies:
-      '@types/unist': 3.0.3
-      unist-util-stringify-position: 4.0.0
+  vfile-location@2.0.6: {}
 
-  vfile@6.0.3:
+  vfile-message@2.0.4:
     dependencies:
-      '@types/unist': 3.0.3
-      vfile-message: 4.0.2
+      '@types/unist': 2.0.11
+      unist-util-stringify-position: 2.0.3
 
-  web-namespaces@2.0.1: {}
+  vfile@4.2.1:
+    dependencies:
+      '@types/unist': 2.0.11
+      is-buffer: 2.0.5
+      unist-util-stringify-position: 2.0.3
+      vfile-message: 2.0.4
+
+  vue@3.5.26(typescript@5.7.2):
+    dependencies:
+      '@vue/compiler-dom': 3.5.26
+      '@vue/compiler-sfc': 3.5.26
+      '@vue/runtime-dom': 3.5.26
+      '@vue/server-renderer': 3.5.26(vue@3.5.26(typescript@5.7.2))
+      '@vue/shared': 3.5.26
+    optionalDependencies:
+      typescript: 5.7.2
+
+  web-namespaces@1.1.4: {}
 
   web-streams-polyfill@3.3.3: {}
 
-  which@2.0.2:
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
+  which@1.3.1:
     dependencies:
       isexe: 2.0.0
 
-  wrap-ansi@7.0.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
-  wrap-ansi@8.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      string-width: 5.1.2
-      strip-ansi: 7.1.0
-
   wrappy@1.0.2: {}
 
-  yoctocolors@2.1.1: {}
+  xtend@4.0.2: {}
 
-  zod-to-json-schema@3.24.1(zod@3.24.1):
+  yallist@4.0.0: {}
+
+  zimmerframe@1.1.4: {}
+
+  zod-to-json-schema@3.24.1(zod@3.25.76):
     dependencies:
-      zod: 3.24.1
+      zod: 3.25.76
 
-  zod@3.24.1: {}
+  zod@3.25.76: {}
 
-  zwitch@2.0.4: {}
+  zwitch@1.0.5: {}

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -36,9 +36,13 @@ jobs:
       uploadAnalyzerArtifacts: 'yes'
 
   stats:
-    name: PR Stats
+    name: PR Stats (${{ matrix.bundler }})
     needs: build
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        bundler: [webpack, turbopack]
     runs-on:
       - 'self-hosted'
       - 'linux'
@@ -64,7 +68,52 @@ jobs:
 
       - uses: ./.github/actions/next-stats-action
         if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        with:
+          bundler: ${{ matrix.bundler }}
         env:
-          # This uses the webpack bundle analyzer and for consistent results we need to use webpack.
-          # Once there is an equivalent analyzer for turbopack, we can remove this.
-          IS_WEBPACK_TEST: 1
+          PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
+          TURBO_TEAM: ${{ env.TURBO_TEAM }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_CACHE: ${{ env.TURBO_CACHE }}
+
+      - name: Upload stats results
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-stats-${{ matrix.bundler }}
+          path: pr-stats-${{ matrix.bundler }}.json
+          retention-days: 1
+
+  stats-aggregate:
+    name: Aggregate PR Stats
+    needs: stats
+    if: always() && needs.stats.result != 'cancelled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Download all stats artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pr-stats-*
+          path: stats-results
+          merge-multiple: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_LTS_VERSION }}
+
+      - name: Install dependencies
+        working-directory: .github/actions/next-stats-action
+        run: npm install
+
+      - name: Aggregate and post results
+        working-directory: .github/actions/next-stats-action
+        run: node src/aggregate-results.js ${{ github.workspace }}/stats-results
+        env:
+          PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
+          KV_REST_API_URL: ${{ secrets.KV_REST_API_URL }}
+          KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}

--- a/scripts/test-stats-benchmark.sh
+++ b/scripts/test-stats-benchmark.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+# Quick sanity check for stats benchmark config
+# Tests that the dev server can start with the new config
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== Stats Benchmark Config Test ==="
+
+# Check Next.js is built
+if [ ! -d "packages/next/dist" ]; then
+  echo "ERROR: Next.js not built. Run 'pnpm build' first."
+  exit 1
+fi
+
+# Create temp test app
+WORK_DIR=$(mktemp -d)
+trap "rm -rf $WORK_DIR" EXIT
+
+echo "Setting up test app in $WORK_DIR..."
+cp -r test/.stats-app/* "$WORK_DIR/"
+cd "$WORK_DIR"
+
+# Write the config that stats-config.js would write (with turbopack: {})
+cat > next.config.js << 'EOF'
+module.exports = {
+  generateBuildId: () => 'BUILD_ID',
+  turbopack: {},
+}
+EOF
+
+echo "Config:"
+cat next.config.js
+echo ""
+
+# Link local Next.js
+node -e "
+const fs = require('fs');
+const pkg = JSON.parse(fs.readFileSync('package.json'));
+pkg.dependencies.next = 'file:$REPO_ROOT/packages/next';
+fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+"
+echo "Installing dependencies..."
+pnpm install --ignore-scripts 2>/dev/null
+
+# Test Turbopack dev (the failing scenario)
+echo ""
+echo "=== Test 1: Turbopack dev (default, no flag) ==="
+PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
+
+rm -rf .next
+NEXT_TELEMETRY_DISABLED=1 timeout 30 pnpm next dev --port $PORT > /tmp/turbo.log 2>&1 &
+PID=$!
+sleep 12
+
+if kill -0 $PID 2>/dev/null; then
+  echo "OK: Turbopack dev server is running"
+  kill $PID 2>/dev/null || true
+  wait $PID 2>/dev/null || true
+else
+  wait $PID 2>/dev/null || CODE=$?
+  if [ "$CODE" = "1" ]; then
+    echo "FAIL: Turbopack dev crashed (exit 1)"
+    echo "Output:"
+    cat /tmp/turbo.log
+    exit 1
+  fi
+  echo "OK: Process exited (timeout or normal)"
+fi
+
+# Test Webpack dev
+echo ""
+echo "=== Test 2: Webpack dev (--webpack flag) ==="
+PORT=$(python3 -c "import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()")
+
+rm -rf .next
+NEXT_TELEMETRY_DISABLED=1 timeout 30 pnpm next dev --webpack --port $PORT > /tmp/webpack.log 2>&1 &
+PID=$!
+sleep 12
+
+if kill -0 $PID 2>/dev/null; then
+  echo "OK: Webpack dev server is running"
+  kill $PID 2>/dev/null || true
+  wait $PID 2>/dev/null || true
+else
+  echo "OK: Process exited (timeout or normal)"
+fi
+
+# Test Turbopack build
+echo ""
+echo "=== Test 3: Turbopack build ==="
+rm -rf .next
+if NEXT_TELEMETRY_DISABLED=1 pnpm next build 2>&1 | head -20; then
+  echo "OK: Turbopack build completed"
+else
+  echo "FAIL: Turbopack build failed"
+  exit 1
+fi
+
+# Test Webpack build
+echo ""
+echo "=== Test 4: Webpack build (--webpack flag) ==="
+rm -rf .next
+if NEXT_TELEMETRY_DISABLED=1 pnpm next build --webpack 2>&1 | head -20; then
+  echo "OK: Webpack build completed"
+else
+  echo "FAIL: Webpack build failed"
+  exit 1
+fi
+
+echo ""
+echo "=== All tests passed ==="

--- a/test/.stats-app/stats-config.js
+++ b/test/.stats-app/stats-config.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const clientGlobs = [
   {
-    name: 'Client Bundles (main, webpack)',
+    name: 'Client Bundles (main)',
     globs: [
       '.next/static/runtime/+(main|webpack)-*',
       '.next/static/chunks/!(polyfills*)',
@@ -109,9 +109,10 @@ const renames = [
 module.exports = {
   commentHeading: 'Stats from current PR',
   commentReleaseHeading: 'Stats from current release',
-  appBuildCommand: 'NEXT_TELEMETRY_DISABLED=1 pnpm next build',
+  appBuildCommand: 'NEXT_TELEMETRY_DISABLED=1 pnpm next build --webpack',
   appStartCommand: 'NEXT_TELEMETRY_DISABLED=1 pnpm next start --port $PORT',
-  appDevCommand: 'NEXT_TELEMETRY_DISABLED=1 pnpm next --port $PORT',
+  appDevCommand: 'NEXT_TELEMETRY_DISABLED=1 pnpm next dev --port $PORT',
+  measureDevBoot: true,
   mainRepo: 'vercel/next.js',
   mainBranch: 'canary',
   autoMergeMain: true,
@@ -125,6 +126,7 @@ module.exports = {
           content: `
             module.exports = {
               generateBuildId: () => 'BUILD_ID',
+              turbopack: {},
               webpack(config) {
                 config.optimization.minimize = false
                 config.optimization.minimizer = undefined
@@ -141,7 +143,8 @@ module.exports = {
           path: 'next.config.js',
           content: `
           module.exports = {
-              generateBuildId: () => 'BUILD_ID'
+              generateBuildId: () => 'BUILD_ID',
+              turbopack: {},
             }
           `,
         },


### PR DESCRIPTION
## Summary

Comprehensive improvements to the PR stats action for more reliable benchmarks and reduced CI noise.

### Vercel KV Integration
- Add `@vercel/kv` for historical data persistence
- Track metrics over time with `loadHistory()` / `saveToHistory()`
- Display trend sparklines in comments when history is available

### Comment Generation Refactor
- New `METRIC_LABELS` and `METRIC_GROUPS` configuration system
- Organized metrics by category (Dev Server, Production Builds, Production Runtime)
- Better formatting utilities (`prettifyTime`, `formatChange`, `generateTrendBar`)
- Bundle group totals for KV persistence

### Noise Reduction
- Significance thresholds: `50ms AND 10%` for time, `1KB AND 1%` for size
- Additional `<2%` filter for long-running operations (builds)
- Filters typical CI variance while catching real regressions

### Stats Config Updates
- Add `measureDevBoot: true` to enable dev boot benchmarks
- Fix `appDevCommand` to include `dev` subcommand
- Add `--webpack` flag to `appBuildCommand`
- Rename "Client Bundles (main, webpack)" to "Client Bundles (main)"
- Add `turbopack: {}` to test configs

### GitHub Actions Updates
- New `action.yml` with bundler input parameter
- Workflow improvements in `pull_request_stats.yml`

### New Files
- `scripts/test-stats-benchmark.sh` - Local testing script
- `.github/actions/next-stats-action/src/util/stats.js` - Shared stats utilities
- `.github/actions/next-stats-action/test-local.js` - Local comment testing

## Test Plan
```bash
cd .github/actions/next-stats-action
node test-local.js              # Basic test
node test-local.js --with-history  # Test with trend sparklines
```