### PR TITLE
feat: add --experimental-cpu-prof flag for dev, build, and start

### DIFF
--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -56,6 +56,7 @@ The following commands are available:
 | `--experimental-https-cert <path>`       | Path to a HTTPS certificate file.                                                                                                                    |
 | `--experimental-https-ca <path>`         | Path to a HTTPS certificate authority file.                                                                                                          |
 | `--experimental-upload-trace <traceUrl>` | Reports a subset of the debugging trace to a remote HTTP URL.                                                                                        |
+| `--experimental-cpu-prof`                | Enables CPU profiling using V8's inspector. Profiles are saved to `.next/cpu-profiles/` on exit.                                                     |
 
 ### `next build` options
 
@@ -87,6 +88,7 @@ The following options are available for the `next build` command:
 | `--experimental-build-mode [mode]` | Uses an experimental build mode. (choices: "compile", "generate", default: "default")                                                                                              |
 | `--debug-prerender`                | Debug prerender errors in development.                                                                                                                                             |
 | `--debug-build-paths=<patterns>`   | Build only specific routes for debugging.                                                                                                                                          |
+| `--experimental-cpu-prof`          | Enables CPU profiling using V8's inspector. Profiles are saved to `.next/cpu-profiles/` on exit.                                                                                   |
 
 ### `next start` options
 
@@ -101,6 +103,7 @@ The following options are available for the `next start` command:
 | `-p` or `--port <port>`                 | Specify a port number on which to start the application. (default: 3000, env: PORT)                             |
 | `-H` or `--hostname <hostname>`         | Specify a hostname on which to start the application (default: 0.0.0.0).                                        |
 | `--keepAliveTimeout <keepAliveTimeout>` | Specify the maximum amount of milliseconds to wait before closing the inactive connections.                     |
+| `--experimental-cpu-prof`               | Enables CPU profiling using V8's inspector. Profiles are saved to `.next/cpu-profiles/` on exit.                |
 
 ### `next info` options
 
@@ -333,6 +336,46 @@ NODE_OPTIONS='--throw-deprecation' next
 NODE_OPTIONS='-r esm' next
 NODE_OPTIONS='--inspect' next
 ```
+
+### CPU profiling
+
+You can capture CPU profiles to analyze performance bottlenecks in your Next.js application. The `--experimental-cpu-prof` flag enables V8's built-in CPU profiler and saves profiles to `.next/cpu-profiles/` when the process exits:
+
+```bash filename="Terminal"
+# Profile the build process
+next build --experimental-cpu-prof
+
+# Profile the dev server (profile saved on Ctrl+C or SIGTERM)
+next dev --experimental-cpu-prof
+
+# Profile the production server
+next start --experimental-cpu-prof
+```
+
+The generated `.cpuprofile` files can be opened in Chrome DevTools (Performance tab → Load profile) or other V8-compatible profiling tools.
+
+> **Good to know**: Profile files are named with a descriptive prefix and timestamp. The profiles generated depend on the command:
+>
+> **`next dev`:**
+>
+> - `dev-main-*` - Parent process (dev server orchestration)
+> - `dev-server-*` - Child server process (request handling and rendering) - this is typically what you want to analyze
+>
+> **`next build` (Turbopack):**
+>
+> - `build-main-*` - Main build orchestration process
+> - `build-turbopack-*` - Turbopack compilation worker
+>
+> **`next build` (Webpack):**
+>
+> - `build-main-*` - Main build orchestration process
+> - `build-webpack-client-*` - Client bundle compilation worker
+> - `build-webpack-server-*` - Server bundle compilation worker
+> - `build-webpack-edge-server-*` - Edge runtime compilation worker
+>
+> **`next start`:**
+>
+> - `start-main-*` - Production server process
 
 | Version   | Changes                                                                         |
 | --------- | ------------------------------------------------------------------------------- |

--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -1,3 +1,5 @@
+// Import cpu-profile to start profiling early if enabled
+import '../server/lib/cpu-profile'
 import { Span } from '../trace'
 import type { NextConfigComplete } from '../server/config-shared'
 

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -831,6 +831,15 @@ export function createStaticWorker(
     isolatedMemory: true,
     enableWorkerThreads: config.experimental.workerThreads,
     exposedMethods: staticWorkerExposedMethods,
+    forkOptions: process.env.NEXT_CPU_PROF
+      ? {
+          env: {
+            NEXT_CPU_PROF: '1',
+            NEXT_CPU_PROF_DIR: process.env.NEXT_CPU_PROF_DIR,
+            __NEXT_PRIVATE_CPU_PROFILE: 'build-static-worker',
+          },
+        }
+      : undefined,
   }) as StaticWorker
 }
 
@@ -1735,6 +1744,15 @@ export default async function build(
                     isolatedMemory: false,
                     numWorkers: 1,
                     exposedMethods: ['collectBuildTraces'],
+                    forkOptions: process.env.NEXT_CPU_PROF
+                      ? {
+                          env: {
+                            NEXT_CPU_PROF: '1',
+                            NEXT_CPU_PROF_DIR: process.env.NEXT_CPU_PROF_DIR,
+                            __NEXT_PRIVATE_CPU_PROFILE: 'build-trace-worker',
+                          },
+                        }
+                      : undefined,
                   }
                 ) as Worker & typeof import('./collect-build-traces')
 

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -1,3 +1,5 @@
+// Import cpu-profile first to start profiling early if enabled
+import { saveCpuProfile } from '../../server/lib/cpu-profile'
 import path from 'path'
 import { validateTurboNextConfig } from '../../lib/turbopack-warning'
 import { isFileSystemCacheEnabledForBuild } from '../../shared/lib/turbopack/utils'
@@ -261,6 +263,8 @@ export async function workerMain(workerData: {
   } finally {
     // Always flush telemetry before worker exits (waits for async operations like setTimeout in debug mode)
     await telemetry.flush()
+    // Save CPU profile before worker exits
+    await saveCpuProfile()
   }
 }
 

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -17,6 +17,13 @@ async function turbopackBuildWithWorker(): ReturnType<
       forkOptions: {
         env: {
           NEXT_PRIVATE_BUILD_WORKER: '1',
+          ...(process.env.NEXT_CPU_PROF
+            ? {
+                NEXT_CPU_PROF: '1',
+                NEXT_CPU_PROF_DIR: process.env.NEXT_CPU_PROF_DIR,
+                __NEXT_PRIVATE_CPU_PROFILE: 'build-turbopack',
+              }
+            : undefined),
         },
       },
     }) as Worker & typeof import('./impl')

--- a/packages/next/src/build/webpack-build/impl.ts
+++ b/packages/next/src/build/webpack-build/impl.ts
@@ -1,3 +1,5 @@
+// Import cpu-profile first to start profiling early if enabled
+import { saveCpuProfile } from '../../server/lib/cpu-profile'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import { stringBufferUtils } from 'next/dist/compiled/webpack-sources3'
 import { red } from '../../lib/picocolors'
@@ -415,6 +417,9 @@ export async function workerMain(workerData: {
   }
   NextBuildContext.nextBuildSpan.stop()
   await telemetry.flush()
+
+  // Save CPU profile before worker exits
+  await saveCpuProfile()
 
   return { ...result, debugTraceEvents: getTraceEvents() }
 }

--- a/packages/next/src/build/webpack-build/index.ts
+++ b/packages/next/src/build/webpack-build/index.ts
@@ -54,6 +54,13 @@ async function webpackBuildWithWorker(
       forkOptions: {
         env: {
           NEXT_PRIVATE_BUILD_WORKER: '1',
+          ...(process.env.NEXT_CPU_PROF
+            ? {
+                NEXT_CPU_PROF: '1',
+                NEXT_CPU_PROF_DIR: process.env.NEXT_CPU_PROF_DIR,
+                __NEXT_PRIVATE_CPU_PROFILE: `build-webpack-${compilerName}`,
+              }
+            : undefined),
         },
       },
     }) as Worker & typeof import('./impl')

--- a/packages/next/src/build/worker.ts
+++ b/packages/next/src/build/worker.ts
@@ -1,4 +1,6 @@
 import '../server/require-hook'
+// Import cpu-profile to start profiling early if enabled
+import '../server/lib/cpu-profile'
 
 export {
   getDefinedNamedExports,

--- a/packages/next/src/cli/next-analyze.ts
+++ b/packages/next/src/cli/next-analyze.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import '../server/lib/cpu-profile'
+import { saveCpuProfile } from '../server/lib/cpu-profile'
 import { existsSync } from 'fs'
 import { italic } from '../lib/picocolors'
 import analyze from '../build/analyze'
@@ -18,8 +19,14 @@ export type NextAnalyzeOptions = {
 }
 
 const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
-  process.on('SIGTERM', () => process.exit(143))
-  process.on('SIGINT', () => process.exit(130))
+  process.on('SIGTERM', async () => {
+    saveCpuProfile()
+    process.exit(143)
+  })
+  process.on('SIGINT', async () => {
+    saveCpuProfile()
+    process.exit(130)
+  })
 
   const { profile, mangling, experimentalAppOnly, output, port } = options
 

--- a/packages/next/src/cli/next-analyze.ts
+++ b/packages/next/src/cli/next-analyze.ts
@@ -19,11 +19,11 @@ export type NextAnalyzeOptions = {
 }
 
 const nextAnalyze = async (options: NextAnalyzeOptions, directory?: string) => {
-  process.on('SIGTERM', async () => {
+  process.on('SIGTERM', () => {
     saveCpuProfile()
     process.exit(143)
   })
-  process.on('SIGINT', async () => {
+  process.on('SIGINT', () => {
     saveCpuProfile()
     process.exit(130)
   })

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import '../server/lib/cpu-profile'
+import { saveCpuProfile } from '../server/lib/cpu-profile'
 import { existsSync } from 'fs'
 import { italic } from '../lib/picocolors'
 import build from '../build'
@@ -32,11 +32,18 @@ export type NextBuildOptions = {
   experimentalUploadTrace?: string
   experimentalNextConfigStripTypes?: boolean
   debugBuildPaths?: string
+  experimentalCpuProf?: boolean
 }
 
 const nextBuild = async (options: NextBuildOptions, directory?: string) => {
-  process.on('SIGTERM', () => process.exit(143))
-  process.on('SIGINT', () => process.exit(130))
+  process.on('SIGTERM', async () => {
+    saveCpuProfile()
+    process.exit(143)
+  })
+  process.on('SIGINT', async () => {
+    saveCpuProfile()
+    process.exit(130)
+  })
 
   const {
     experimentalAnalyze,
@@ -157,4 +164,4 @@ const nextBuild = async (options: NextBuildOptions, directory?: string) => {
     })
 }
 
-export { nextBuild }
+export { nextBuild, saveCpuProfile }

--- a/packages/next/src/cli/next-build.ts
+++ b/packages/next/src/cli/next-build.ts
@@ -36,11 +36,11 @@ export type NextBuildOptions = {
 }
 
 const nextBuild = async (options: NextBuildOptions, directory?: string) => {
-  process.on('SIGTERM', async () => {
+  process.on('SIGTERM', () => {
     saveCpuProfile()
     process.exit(143)
   })
-  process.on('SIGINT', async () => {
+  process.on('SIGINT', () => {
     saveCpuProfile()
     process.exit(130)
   })

--- a/packages/next/src/server/lib/cpu-profile.ts
+++ b/packages/next/src/server/lib/cpu-profile.ts
@@ -1,32 +1,67 @@
 const privateCpuProfileName = process.env.__NEXT_PRIVATE_CPU_PROFILE
 const isCpuProfileEnabled = process.env.NEXT_CPU_PROF || privateCpuProfileName
+const cpuProfileDir = process.env.NEXT_CPU_PROF_DIR
+
+let session: import('inspector').Session | null = null
+let profileSaved = false
 
 if (isCpuProfileEnabled) {
   const { Session } = require('inspector') as typeof import('inspector')
-  const fs = require('fs') as typeof import('fs')
 
-  const session = new Session()
+  session = new Session()
   session.connect()
 
   session.post('Profiler.enable')
   session.post('Profiler.start')
 
-  function saveProfile() {
-    session.post('Profiler.stop', (error, param) => {
-      if (error) {
-        console.error('Cannot generate CPU profiling:', error)
-        return
-      }
+  process.on('exit', () => {
+    saveCpuProfile()
+  })
+}
 
-      // Write profile to disk
-      const filename = `${
-        privateCpuProfileName || 'CPU.main'
-      }.${Date.now()}.cpuprofile`
-      fs.writeFileSync(`./${filename}`, JSON.stringify(param.profile))
-      process.exit(0)
-    })
+/**
+ * Save the CPU profile to disk.
+ *
+ * This is synchronous despite the callback-based API because inspector's
+ * session.post() executes its callback synchronously when connected to
+ * the same process (via session.connect()).
+ */
+export function saveCpuProfile(): void {
+  if (!session || profileSaved || !isCpuProfileEnabled) {
+    return
   }
-  process.on('SIGINT', saveProfile)
-  process.on('SIGTERM', saveProfile)
-  process.on('exit', saveProfile)
+  profileSaved = true
+
+  const fs = require('fs') as typeof import('fs')
+  const path = require('path') as typeof import('path')
+
+  session!.post('Profiler.stop', (error, param) => {
+    if (error) {
+      console.error('Cannot generate CPU profiling:', error)
+      return
+    }
+
+    const timestamp = new Date()
+      .toISOString()
+      .replace(/[:.]/g, '-')
+      .slice(0, 19)
+    const baseName = privateCpuProfileName || 'cpu-profile'
+    const filename = `${baseName}-${timestamp}.cpuprofile`
+
+    let outputPath: string
+    if (cpuProfileDir) {
+      if (!fs.existsSync(cpuProfileDir)) {
+        fs.mkdirSync(cpuProfileDir, { recursive: true })
+      }
+      outputPath = path.join(cpuProfileDir, filename)
+    } else {
+      outputPath = `./${filename}`
+    }
+
+    fs.writeFileSync(outputPath, JSON.stringify(param.profile))
+    const { green } =
+      require('../../lib/picocolors') as typeof import('../../lib/picocolors')
+    console.log(`\n${green('CPU profile saved:')} ${outputPath}`)
+    console.log('Open in Chrome DevTools → Performance tab → Load profile')
+  })
 }

--- a/test/e2e/cpu-profiling/app/layout.tsx
+++ b/test/e2e/cpu-profiling/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/cpu-profiling/app/page.tsx
+++ b/test/e2e/cpu-profiling/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Hello from CPU Profiling Test</h1>
+}

--- a/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
@@ -1,0 +1,57 @@
+import { nextTestSetup, isNextDeploy } from 'e2e-utils'
+import { pathExists, readdir } from 'fs-extra'
+import { join } from 'path'
+
+describe('CPU Profiling - next build', () => {
+  const { next, isNextDev, skipped, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    buildCommand: 'pnpm next build --experimental-cpu-prof',
+    dependencies: {},
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  // CPU profiling only works with local `next build`, not dev or deploy modes
+  if (isNextDev || isNextDeploy || skipped) {
+    it('skip for development/deploy mode', () => {})
+    return
+  }
+
+  beforeAll(async () => {
+    // Run the build with CPU profiling enabled
+    await next.build()
+  })
+
+  it('should create CPU profile files after build', async () => {
+    const profileDir = join(next.testDir, '.next', 'cpu-profiles')
+
+    const profileDirExists = await pathExists(profileDir)
+    expect(profileDirExists).toBe(true)
+
+    const files = await readdir(profileDir)
+    const cpuProfiles = files.filter((f: string) => f.endsWith('.cpuprofile'))
+
+    // Main profile should always exist
+    expect(cpuProfiles.some((f) => f.startsWith('build-main-'))).toBe(true)
+
+    if (isTurbopack) {
+      // Turbopack mode generates: build-main, build-turbopack
+      expect(cpuProfiles.length).toBe(2)
+      expect(cpuProfiles.some((f) => f.startsWith('build-turbopack-'))).toBe(
+        true
+      )
+    } else {
+      // Webpack mode generates: build-main, build-webpack-client, build-webpack-server, build-webpack-edge-server
+      expect(cpuProfiles.length).toBe(4)
+      expect(
+        cpuProfiles.some((f) => f.startsWith('build-webpack-client-'))
+      ).toBe(true)
+      expect(
+        cpuProfiles.some((f) => f.startsWith('build-webpack-server-'))
+      ).toBe(true)
+      expect(
+        cpuProfiles.some((f) => f.startsWith('build-webpack-edge-server-'))
+      ).toBe(true)
+    }
+  })
+})

--- a/test/e2e/cpu-profiling/cpu-profiling-dev.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling-dev.test.ts
@@ -1,0 +1,44 @@
+import { nextTestSetup } from 'e2e-utils'
+import { pathExists, readdir } from 'fs-extra'
+import { join } from 'path'
+
+describe('CPU Profiling - next dev', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+    startCommand: 'pnpm next dev --experimental-cpu-prof',
+    dependencies: {},
+  })
+
+  if (!isNextDev) {
+    it('skip for production mode', () => {})
+    return
+  }
+
+  it('should create CPU profile files on exit', async () => {
+    const profileDir = join(next.testDir, '.next', 'cpu-profiles')
+
+    // Make a request to ensure the server is running
+    const res = await next.fetch('/')
+    expect(res.status).toBe(200)
+
+    // Stop the server with SIGTERM to trigger profile save (SIGKILL doesn't allow cleanup)
+    await next.stop('SIGTERM')
+
+    // Wait for profile to be written
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const profileDirExists = await pathExists(profileDir)
+    expect(profileDirExists).toBe(true)
+
+    const files = await readdir(profileDir)
+    const cpuProfiles = files.filter((f: string) => f.endsWith('.cpuprofile'))
+    expect(cpuProfiles.length).toBeGreaterThanOrEqual(1)
+
+    // Verify profile names are meaningful
+    for (const profile of cpuProfiles) {
+      expect(profile).toMatch(
+        /^(dev-main|dev-server)-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.cpuprofile$/
+      )
+    }
+  })
+})

--- a/test/e2e/cpu-profiling/cpu-profiling-dev.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling-dev.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { pathExists, readdir } from 'fs-extra'
 import { join } from 'path'
+import { retry } from 'next-test-utils'
 
 describe('CPU Profiling - next dev', () => {
   const { next, isNextDev } = nextTestSetup({
@@ -24,15 +25,16 @@ describe('CPU Profiling - next dev', () => {
     // Stop the server with SIGTERM to trigger profile save (SIGKILL doesn't allow cleanup)
     await next.stop('SIGTERM')
 
-    // Wait for profile to be written
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    // Retry until profile files are written
+    const cpuProfiles = await retry(async () => {
+      const profileDirExists = await pathExists(profileDir)
+      expect(profileDirExists).toBe(true)
 
-    const profileDirExists = await pathExists(profileDir)
-    expect(profileDirExists).toBe(true)
-
-    const files = await readdir(profileDir)
-    const cpuProfiles = files.filter((f: string) => f.endsWith('.cpuprofile'))
-    expect(cpuProfiles.length).toBeGreaterThanOrEqual(1)
+      const files = await readdir(profileDir)
+      const profiles = files.filter((f: string) => f.endsWith('.cpuprofile'))
+      expect(profiles.length).toBeGreaterThanOrEqual(1)
+      return profiles
+    })
 
     // Verify profile names are meaningful
     for (const profile of cpuProfiles) {

--- a/test/e2e/cpu-profiling/cpu-profiling.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling.test.ts
@@ -1,0 +1,50 @@
+import { nextTestSetup, isNextDeploy } from 'e2e-utils'
+import { pathExists, readdir } from 'fs-extra'
+import { join } from 'path'
+
+describe('CPU Profiling - next start', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    startCommand: 'pnpm next start --experimental-cpu-prof',
+    dependencies: {},
+    skipStart: true, // Skip auto-start to avoid failure in dev/deploy mode
+  })
+
+  // CPU profiling only works with local `next start`, not dev or deploy modes
+  if (isNextDev || isNextDeploy || skipped) {
+    it('skip for development/deploy mode', () => {})
+    return
+  }
+
+  beforeAll(async () => {
+    await next.start()
+  })
+
+  it('should create CPU profile files on exit', async () => {
+    const profileDir = join(next.testDir, '.next', 'cpu-profiles')
+
+    // Make a request to ensure the server is running
+    const res = await next.fetch('/')
+    expect(res.status).toBe(200)
+
+    // Stop the server with SIGTERM to trigger profile save (SIGKILL doesn't allow cleanup)
+    await next.stop('SIGTERM')
+
+    // Wait for profile to be written
+    await new Promise((resolve) => setTimeout(resolve, 2000))
+
+    const profileDirExists = await pathExists(profileDir)
+    expect(profileDirExists).toBe(true)
+
+    const files = await readdir(profileDir)
+    const cpuProfiles = files.filter((f: string) => f.endsWith('.cpuprofile'))
+    expect(cpuProfiles.length).toBeGreaterThan(0)
+
+    // Verify profile name is meaningful (start-main)
+    for (const profile of cpuProfiles) {
+      expect(profile).toMatch(
+        /^start-main-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.cpuprofile$/
+      )
+    }
+  })
+})

--- a/test/e2e/cpu-profiling/cpu-profiling.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup, isNextDeploy } from 'e2e-utils'
 import { pathExists, readdir } from 'fs-extra'
 import { join } from 'path'
+import { retry } from 'next-test-utils'
 
 describe('CPU Profiling - next start', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
@@ -30,15 +31,16 @@ describe('CPU Profiling - next start', () => {
     // Stop the server with SIGTERM to trigger profile save (SIGKILL doesn't allow cleanup)
     await next.stop('SIGTERM')
 
-    // Wait for profile to be written
-    await new Promise((resolve) => setTimeout(resolve, 2000))
+    // Retry until profile files are written
+    const cpuProfiles = await retry(async () => {
+      const profileDirExists = await pathExists(profileDir)
+      expect(profileDirExists).toBe(true)
 
-    const profileDirExists = await pathExists(profileDir)
-    expect(profileDirExists).toBe(true)
-
-    const files = await readdir(profileDir)
-    const cpuProfiles = files.filter((f: string) => f.endsWith('.cpuprofile'))
-    expect(cpuProfiles.length).toBeGreaterThan(0)
+      const files = await readdir(profileDir)
+      const profiles = files.filter((f: string) => f.endsWith('.cpuprofile'))
+      expect(profiles.length).toBeGreaterThan(0)
+      return profiles
+    })
 
     // Verify profile name is meaningful (start-main)
     for (const profile of cpuProfiles) {

--- a/test/integration/cpu-profiling/fixtures/basic-app/app/layout.tsx
+++ b/test/integration/cpu-profiling/fixtures/basic-app/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/integration/cpu-profiling/fixtures/basic-app/app/page.tsx
+++ b/test/integration/cpu-profiling/fixtures/basic-app/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>Hello</h1>
+}

--- a/test/integration/cpu-profiling/fixtures/basic-app/tsconfig.json
+++ b/test/integration/cpu-profiling/fixtures/basic-app/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": true,
+    "module": "esnext",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "**/*.mts",
+    "**/*.ts",
+    "**/*.tsx"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/test/integration/cpu-profiling/test/index.test.ts
+++ b/test/integration/cpu-profiling/test/index.test.ts
@@ -1,0 +1,61 @@
+/* eslint-env jest */
+
+import { remove, pathExists, readdir } from 'fs-extra'
+import { nextBuild } from 'next-test-utils'
+import { join } from 'path'
+
+const fixturesDir = join(__dirname, '..', 'fixtures')
+const appDir = join(fixturesDir, 'basic-app')
+
+describe('CPU Profiling', () => {
+  beforeEach(async () => {
+    await remove(join(appDir, '.next'))
+  })
+
+  describe('next build --experimental-cpu-prof', () => {
+    it('should create CPU profile files with meaningful names', async () => {
+      const profileDir = join(appDir, '.next', 'cpu-profiles')
+
+      const { stdout } = await nextBuild(appDir, ['--experimental-cpu-prof'], {
+        stdout: true,
+        stderr: true,
+      })
+
+      expect(stdout).toContain('CPU profile saved')
+
+      const profileDirExists = await pathExists(profileDir)
+      expect(profileDirExists).toBe(true)
+
+      const files = await readdir(profileDir)
+      const cpuProfiles = files.filter((f) => f.endsWith('.cpuprofile'))
+      expect(cpuProfiles.length).toBeGreaterThan(0)
+
+      // Verify profile names are meaningful (not just random numbers)
+      for (const profile of cpuProfiles) {
+        // Profile names should contain descriptive prefixes like 'build-main', 'build-webpack-server', etc.
+        expect(profile).toMatch(
+          /^(build-main|build-webpack-(server|client|edge-server)|build-turbopack|build-static-worker|build-trace-worker)-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.cpuprofile$/
+        )
+      }
+    })
+
+    it('should create profiles for worker processes', async () => {
+      const profileDir = join(appDir, '.next', 'cpu-profiles')
+
+      await nextBuild(appDir, ['--experimental-cpu-prof'], {
+        stdout: true,
+        stderr: true,
+      })
+
+      const files = await readdir(profileDir)
+      const cpuProfiles = files.filter((f) => f.endsWith('.cpuprofile'))
+
+      // Should have at least main process profile and potentially worker profiles
+      expect(cpuProfiles.length).toBeGreaterThanOrEqual(1)
+
+      // Verify we have the main build profile
+      const mainProfile = cpuProfiles.find((f) => f.startsWith('build-main'))
+      expect(mainProfile).toBeDefined()
+    })
+  })
+})


### PR DESCRIPTION
## What

Adds a `--experimental-cpu-prof` flag to `next dev`, `next build`, and `next start` commands to capture V8 CPU profiles for debugging performance bottlenecks.

## Why

When investigating slow builds, slow dev server startups, or production server performance issues, having access to CPU profiles is invaluable. This provides a first-party way to capture these profiles without needing to manually set up the V8 inspector.

## How

- Adds `--experimental-cpu-prof` flag to CLI commands
- Uses V8's built-in CPU profiler via Node.js inspector module
- Profiles are saved to `.next/cpu-profiles/` with descriptive filenames
- Profiles are saved on process exit (Ctrl+C, SIGTERM, or normal exit)

### Profile files generated

**`next dev`:**
- `dev-main-*` - Parent process (dev server orchestration)
- `dev-server-*` - Child server process (request handling and rendering)

**`next build` (Turbopack):**
- `build-main-*` - Main build orchestration process
- `build-turbopack-*` - Turbopack compilation worker

**`next build` (Webpack):**
- `build-main-*` - Main build orchestration process
- `build-webpack-client-*` - Client bundle compilation worker
- `build-webpack-server-*` - Server bundle compilation worker
- `build-webpack-edge-server-*` - Edge runtime compilation worker

**`next start`:**
- `start-main-*` - Production server process

## Changes addressing PR review comments

- Removed signal handlers from `cpu-profile.ts` to prevent conflicts with CLI cleanup logic (telemetry, traces, etc.)
- Added synchronous exit handler for non-signal process exits (errors, `process.exit()` calls)
- CLI commands now explicitly call `saveCpuProfile()` as part of their cleanup before exiting
- Replaced raw ANSI escape codes with `picocolors` library
- Added comprehensive documentation about profile file naming for each command
- Added build profiling test that verifies correct profile generation for both Turbopack and Webpack modes