### PR TITLE
feat(ci): add Datadog integration for flaky test detection

### DIFF
--- a/.github/actions/next-integration-stat/action.yml
+++ b/.github/actions/next-integration-stat/action.yml
@@ -19,6 +19,14 @@ inputs:
     default: 'false'
     description: 'Whether to include the full test failure message in the report. This is currently disabled as we have too many failed test cases, which would lead to massive comments.'
 
+  datadog_api_key:
+    description: 'Datadog API key for querying historical test data'
+    required: false
+
+  datadog_app_key:
+    description: 'Datadog Application key for querying historical test data'
+    required: false
+
 runs:
   using: node20
   main: dist/index.js

--- a/.github/actions/next-integration-stat/dist/index.js
+++ b/.github/actions/next-integration-stat/dist/index.js
@@ -56239,6 +56239,198 @@ function getCategoryKey(category) {
 function formatCategoryLabel(category) {
     return `\`${category.type}\` · \`${category.bundler}\` · \`${category.platform}\``;
 }
+function queryDatadogTestData(testNames, apiKey, appKey) {
+    var _a, _b, _c, _d, _e;
+    return __awaiter(this, void 0, void 0, function* () {
+        const testData = new Map();
+        if (!apiKey || !appKey) {
+            console.log('Datadog keys not provided, skipping test data query');
+            return testData;
+        }
+        console.log(`Querying Datadog for ${testNames.length} tests...`);
+        try {
+            // Query Datadog CI Visibility API for test events from the last 30 days
+            // We look for tests that have both passed and failed recently
+            const now = Math.floor(Date.now() / 1000);
+            const thirtyDaysAgo = now - 30 * 24 * 60 * 60;
+            // Build the query for all test names
+            // We need to batch this as URLs have length limits
+            const batchSize = 10;
+            for (let i = 0; i < testNames.length; i += batchSize) {
+                const batch = testNames.slice(i, i + batchSize);
+                for (const testName of batch) {
+                    try {
+                        // Normalize test name for query
+                        const normalizedName = testName
+                            .replace(/^.*?(test\/)/, 'test/')
+                            .replace(/^.*?(packages\/)/, 'packages/');
+                        // Query for this specific test's results
+                        const query = encodeURIComponent(`@git.repository.id:github.com/vercel/next.js ` +
+                            `@test.name:"${normalizedName}" ` +
+                            `@git.branch:canary`);
+                        const response = yield fetch(`https://api.datadoghq.com/api/v2/ci/tests/events?filter[query]=${query}&filter[from]=${thirtyDaysAgo}s&filter[to]=${now}s&page[limit]=100`, {
+                            headers: {
+                                'DD-API-KEY': apiKey,
+                                'DD-APPLICATION-KEY': appKey,
+                                'Content-Type': 'application/json',
+                            },
+                        });
+                        if (!response.ok) {
+                            console.log(`Datadog API error for ${normalizedName}: ${response.status}`);
+                            continue;
+                        }
+                        const data = yield response.json();
+                        const events = data.data || [];
+                        if (events.length === 0)
+                            continue;
+                        // Count passes, failures, and collect durations
+                        let passes = 0;
+                        let failures = 0;
+                        let isKnownFlaky = false;
+                        const durations = [];
+                        for (const event of events) {
+                            const status = (_b = (_a = event.attributes) === null || _a === void 0 ? void 0 : _a.test) === null || _b === void 0 ? void 0 : _b.status;
+                            const tags = ((_c = event.attributes) === null || _c === void 0 ? void 0 : _c.tags) || [];
+                            const duration = (_e = (_d = event.attributes) === null || _d === void 0 ? void 0 : _d.test) === null || _e === void 0 ? void 0 : _e.duration;
+                            if (status === 'pass')
+                                passes++;
+                            if (status === 'fail')
+                                failures++;
+                            // Collect duration in milliseconds (Datadog returns nanoseconds)
+                            if (typeof duration === 'number' && duration > 0) {
+                                durations.push(duration / 1000000); // Convert ns to ms
+                            }
+                            // Check for flaky tags
+                            if (tags.includes('is_flaky:true') || tags.includes('is_known_flaky:true')) {
+                                isKnownFlaky = true;
+                            }
+                        }
+                        const totalRuns = passes + failures;
+                        if (totalRuns > 0) {
+                            const flakeRate = totalRuns > 1 && passes > 0 && failures > 0
+                                ? Math.round((Math.min(passes, failures) / totalRuns) * 100)
+                                : 0;
+                            // Calculate duration baseline (p50)
+                            let baselineDurationMs;
+                            let baselineDurationP50Ms;
+                            if (durations.length >= 3) {
+                                durations.sort((a, b) => a - b);
+                                const p50Index = Math.floor(durations.length / 2);
+                                baselineDurationP50Ms = durations[p50Index];
+                                baselineDurationMs = durations.reduce((a, b) => a + b, 0) / durations.length;
+                            }
+                            // Store data for all tests that have history (for duration comparison)
+                            // or are flaky
+                            const isFlaky = isKnownFlaky || (passes > 0 && failures > 0 && flakeRate >= 10);
+                            if (isFlaky || durations.length >= 3) {
+                                testData.set(testName, {
+                                    testName,
+                                    isKnownFlaky: isKnownFlaky || flakeRate >= 30,
+                                    flakeRate,
+                                    recentFailures: failures,
+                                    recentRuns: totalRuns,
+                                    baselineDurationMs,
+                                    baselineDurationP50Ms,
+                                });
+                            }
+                        }
+                    }
+                    catch (err) {
+                        console.log(`Error querying Datadog for test: ${err}`);
+                    }
+                }
+                // Small delay between batches to avoid rate limiting
+                if (i + batchSize < testNames.length) {
+                    yield new Promise((resolve) => setTimeout(resolve, 100));
+                }
+            }
+            console.log(`Found ${testData.size} tests with historical data`);
+        }
+        catch (err) {
+            console.log('Error querying Datadog:', err);
+        }
+        return testData;
+    });
+}
+function formatFlakyTestsSection(flakyTests, testData, sha) {
+    var _a;
+    if (flakyTests.length === 0)
+        return '';
+    let content = `\n---\n\n### Known Flaky Tests (can likely ignore)\n\n`;
+    content += `> These tests have a history of flaky behavior on \`canary\`. They may not be caused by your changes.\n\n`;
+    content += `<details>\n`;
+    content += `<summary>${flakyTests.length} known flaky test${flakyTests.length > 1 ? 's' : ''}</summary>\n\n`;
+    content += `| Test | Flake Rate | Recent (30d) | Links |\n|------|-----------|--------------|-------|\n`;
+    for (const test of flakyTests) {
+        const shortPath = test.testPath
+            .replace(/^.*?(test\/)/, 'test/')
+            .replace(/^.*?(packages\/)/, 'packages/');
+        const testType = test.category.bundler === 'turbopack' ? 'turbopack' : 'nextjs';
+        const ddLink = createDatadogLink(sha, test.name, testType);
+        const data = testData.get(test.testPath) || testData.get(test.name);
+        const flakeRate = (_a = data === null || data === void 0 ? void 0 : data.flakeRate) !== null && _a !== void 0 ? _a : '?';
+        const recentStats = data ? `${data.recentFailures}/${data.recentRuns} failed` : '-';
+        // Truncate long names
+        const displayName = shortPath.length > 50 ? shortPath.substring(0, 47) + '...' : shortPath;
+        content += `| \`${displayName}\` | ${flakeRate}% | ${recentStats} | [DD](${ddLink}) [job](${test.jobUrl}) |\n`;
+    }
+    content += `\n</details>\n`;
+    return content;
+}
+function findSlowTestRegressions(tests, testData, thresholdPercent = 100 // Flag tests that are 2x slower (100% increase)
+) {
+    const slowTests = [];
+    for (const test of tests) {
+        if (!test.duration)
+            continue;
+        const data = testData.get(test.testPath) || testData.get(test.name);
+        if (!(data === null || data === void 0 ? void 0 : data.baselineDurationP50Ms))
+            continue;
+        const currentDurationMs = test.duration;
+        const baselineDurationMs = data.baselineDurationP50Ms;
+        const percentageIncrease = ((currentDurationMs - baselineDurationMs) / baselineDurationMs) * 100;
+        // Only flag significant slowdowns (above threshold and at least 5 seconds slower)
+        if (percentageIncrease >= thresholdPercent && (currentDurationMs - baselineDurationMs) >= 5000) {
+            slowTests.push({
+                test,
+                currentDurationMs,
+                baselineDurationMs,
+                percentageIncrease,
+            });
+        }
+    }
+    // Sort by percentage increase (worst first)
+    return slowTests.sort((a, b) => b.percentageIncrease - a.percentageIncrease);
+}
+function formatSlowTestsSection(slowTests, sha) {
+    if (slowTests.length === 0)
+        return '';
+    let content = `\n---\n\n### Slow Test Regressions\n\n`;
+    content += `> These tests are significantly slower than their historical baseline on \`canary\`.\n\n`;
+    content += `<details>\n`;
+    content += `<summary>${slowTests.length} test${slowTests.length > 1 ? 's' : ''} with duration regression</summary>\n\n`;
+    content += `| Test | Current | Baseline (p50) | Delta | Links |\n|------|---------|----------------|-------|-------|\n`;
+    for (const { test, currentDurationMs, baselineDurationMs, percentageIncrease } of slowTests) {
+        const shortPath = test.testPath
+            .replace(/^.*?(test\/)/, 'test/')
+            .replace(/^.*?(packages\/)/, 'packages/');
+        const testType = test.category.bundler === 'turbopack' ? 'turbopack' : 'nextjs';
+        const ddLink = createDatadogLink(sha, test.name, testType);
+        const formatDuration = (ms) => {
+            if (ms >= 60000)
+                return `${(ms / 60000).toFixed(1)}m`;
+            if (ms >= 1000)
+                return `${(ms / 1000).toFixed(1)}s`;
+            return `${Math.round(ms)}ms`;
+        };
+        const displayName = shortPath.length > 40 ? shortPath.substring(0, 37) + '...' : shortPath;
+        const delta = `+${Math.round(percentageIncrease)}%`;
+        content += `| \`${displayName}\` | ${formatDuration(currentDurationMs)} | ${formatDuration(baselineDurationMs)} | **${delta}** ⚠️ | [DD](${ddLink}) |\n`;
+    }
+    content += `\n> ℹ️ Baseline calculated from last 30 days of runs on \`canary\`\n\n`;
+    content += `</details>\n`;
+    return content;
+}
 function fetchOtherPRFailures(octokit, currentPRNumber) {
     return __awaiter(this, void 0, void 0, function* () {
         // Map of test path -> PR numbers where it's failing
@@ -56389,6 +56581,42 @@ function formatSummaryTable(sha, runId, runAttempt, totalFailures, passedOnRetry
     }
     for (const [label, count] of categoryGroups) {
         summary += `| ${label} | ${count} |\n`;
+    }
+    return summary;
+}
+function formatSummaryTableWithFlaky(sha, runId, runAttempt, totalFailures, needsInvestigationCount, knownFlakyCount, passedOnRetryCount, investigationGroups) {
+    const commitUrl = `https://github.com/vercel/next.js/commit/${sha}`;
+    const runUrl = `https://github.com/vercel/next.js/actions/runs/${runId}/attempts/${runAttempt}`;
+    const rerunUrl = `https://github.com/vercel/next.js/actions/runs/${runId}`;
+    const shortSha = sha.substring(0, 7);
+    let summary = `## Failing test suites ${BOT_COMMENT_MARKER}\n\n`;
+    // Header with commit info
+    summary += `| | |\n|---|---|\n`;
+    summary += `| **Tested Commit** | [\`${shortSha}\`](${commitUrl}) |\n`;
+    summary += `| **Workflow Run** | [#${runId}](${runUrl}) · Attempt ${runAttempt} |\n\n`;
+    summary += `[**Re-run failed jobs →**](${rerunUrl})\n\n`;
+    summary += `---\n\n`;
+    // Summary counts with flaky breakdown
+    summary += `| Summary | |\n|---------|---|\n`;
+    summary += `| Total Failed | ${totalFailures} |\n`;
+    if (knownFlakyCount > 0) {
+        summary += `| **Needs Investigation** | **${needsInvestigationCount}** |\n`;
+        summary += `| Known Flaky | ${knownFlakyCount} (can likely ignore) |\n`;
+    }
+    if (passedOnRetryCount > 0) {
+        summary += `| Passed on Retry | ${passedOnRetryCount} (likely flaky) |\n`;
+    }
+    // Group counts by category (only for needs investigation)
+    if (investigationGroups.length > 0) {
+        summary += `\n| Breakdown | |\n|---------|---|\n`;
+        const categoryGroups = new Map();
+        for (const group of investigationGroups) {
+            const label = formatCategoryLabel(group.category);
+            categoryGroups.set(label, (categoryGroups.get(label) || 0) + group.tests.length);
+        }
+        for (const [label, count] of categoryGroups) {
+            summary += `| ${label} | ${count} |\n`;
+        }
     }
     return summary;
 }
@@ -56819,23 +57047,66 @@ function run() {
             return;
         }
         // Process and categorize test results
-        const { groups, passedOnRetry } = processTestResults(jobResults.result, sha);
+        const { categorizedTests, groups, passedOnRetry } = processTestResults(jobResults.result, sha);
         const totalFailures = groups.reduce((sum, g) => sum + g.tests.length, 0);
         const runId = _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.runId;
         const runAttempt = parseInt(process.env.GITHUB_RUN_ATTEMPT || '1', 10);
+        // Query Datadog for test history (flaky detection + duration baselines)
+        const datadogApiKey = (0,_actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput)('datadog_api_key');
+        const datadogAppKey = (0,_actions_core__WEBPACK_IMPORTED_MODULE_1__.getInput)('datadog_app_key');
+        const testData = yield queryDatadogTestData(failedTestLists, datadogApiKey, datadogAppKey);
+        // Split tests into "needs investigation" vs "known flaky"
+        const flakyTests = [];
+        const needsInvestigation = [];
+        for (const test of categorizedTests) {
+            const data = testData.get(test.testPath) || testData.get(test.name);
+            if (data && data.isKnownFlaky) {
+                flakyTests.push(test);
+            }
+            else {
+                needsInvestigation.push(test);
+            }
+        }
+        // Find slow test regressions (tests that are 2x slower than baseline)
+        const slowTestRegressions = findSlowTestRegressions(categorizedTests, testData);
+        // Re-group the needs investigation tests
+        const investigationGroupMap = new Map();
+        for (const test of needsInvestigation) {
+            const key = getCategoryKey(test.category);
+            if (!investigationGroupMap.has(key)) {
+                investigationGroupMap.set(key, {
+                    key,
+                    category: test.category,
+                    tests: [],
+                    jobUrl: test.jobUrl,
+                });
+            }
+            investigationGroupMap.get(key).tests.push(test);
+        }
+        const investigationGroups = Array.from(investigationGroupMap.values()).sort((a, b) => b.tests.length - a.tests.length);
         // Check for cross-PR failures
         console.log('Checking for cross-PR failures...');
         const otherPRFailures = yield fetchOtherPRFailures(octokit, prNumber);
         const commonFailures = findCommonFailures(failedTestLists, otherPRFailures);
         console.log(`Found ${commonFailures.length} tests failing in other PRs`);
-        // Build comment
-        let commentBody = formatSummaryTable(sha, runId, runAttempt, totalFailures, passedOnRetry.length, groups);
+        // Build comment with updated summary
+        let commentBody = formatSummaryTableWithFlaky(sha, runId, runAttempt, totalFailures, needsInvestigation.length, flakyTests.length, passedOnRetry.length, investigationGroups);
         // Add cross-PR alert if applicable
         if (commonFailures.length > 0) {
             commentBody += formatCrossPRAlert(commonFailures, _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.repo.owner, _actions_github__WEBPACK_IMPORTED_MODULE_0__.context.repo.repo);
         }
-        for (const group of groups) {
-            commentBody += formatTestGroup(group, sha);
+        // Show "needs investigation" tests first (these are the important ones)
+        if (investigationGroups.length > 0) {
+            commentBody += `\n### Needs Investigation\n`;
+            for (const group of investigationGroups) {
+                commentBody += formatTestGroup(group, sha);
+            }
+        }
+        // Show known flaky tests (collapsed, less important)
+        commentBody += formatFlakyTestsSection(flakyTests, testData, sha);
+        // Show slow test regressions
+        if (slowTestRegressions.length > 0) {
+            commentBody += formatSlowTestsSection(slowTestRegressions, sha);
         }
         // Add passed on retry section
         commentBody += formatPassedOnRetrySection(passedOnRetry, sha);

--- a/.github/actions/next-integration-stat/src/index.ts
+++ b/.github/actions/next-integration-stat/src/index.ts
@@ -149,6 +149,268 @@ function formatCategoryLabel(category: TestCategory): string {
 }
 
 // =============================================================================
+// Datadog Flaky Test Detection
+// =============================================================================
+
+interface DatadogTestData {
+  testName: string
+  isKnownFlaky: boolean
+  flakeRate: number // 0-100
+  recentFailures: number
+  recentRuns: number
+  // Duration baseline (in milliseconds)
+  baselineDurationMs?: number
+  baselineDurationP50Ms?: number
+}
+
+async function queryDatadogTestData(
+  testNames: string[],
+  apiKey: string,
+  appKey: string
+): Promise<Map<string, DatadogTestData>> {
+  const testData = new Map<string, DatadogTestData>()
+
+  if (!apiKey || !appKey) {
+    console.log('Datadog keys not provided, skipping test data query')
+    return testData
+  }
+
+  console.log(`Querying Datadog for ${testNames.length} tests...`)
+
+  try {
+    // Query Datadog CI Visibility API for test events from the last 30 days
+    // We look for tests that have both passed and failed recently
+    const now = Math.floor(Date.now() / 1000)
+    const thirtyDaysAgo = now - 30 * 24 * 60 * 60
+
+    // Build the query for all test names
+    // We need to batch this as URLs have length limits
+    const batchSize = 10
+    for (let i = 0; i < testNames.length; i += batchSize) {
+      const batch = testNames.slice(i, i + batchSize)
+
+      for (const testName of batch) {
+        try {
+          // Normalize test name for query
+          const normalizedName = testName
+            .replace(/^.*?(test\/)/, 'test/')
+            .replace(/^.*?(packages\/)/, 'packages/')
+
+          // Query for this specific test's results
+          const query = encodeURIComponent(
+            `@git.repository.id:github.com/vercel/next.js ` +
+            `@test.name:"${normalizedName}" ` +
+            `@git.branch:canary`
+          )
+
+          const response = await fetch(
+            `https://api.datadoghq.com/api/v2/ci/tests/events?filter[query]=${query}&filter[from]=${thirtyDaysAgo}s&filter[to]=${now}s&page[limit]=100`,
+            {
+              headers: {
+                'DD-API-KEY': apiKey,
+                'DD-APPLICATION-KEY': appKey,
+                'Content-Type': 'application/json',
+              },
+            }
+          )
+
+          if (!response.ok) {
+            console.log(`Datadog API error for ${normalizedName}: ${response.status}`)
+            continue
+          }
+
+          const data = await response.json()
+          const events = data.data || []
+
+          if (events.length === 0) continue
+
+          // Count passes, failures, and collect durations
+          let passes = 0
+          let failures = 0
+          let isKnownFlaky = false
+          const durations: number[] = []
+
+          for (const event of events) {
+            const status = event.attributes?.test?.status
+            const tags = event.attributes?.tags || []
+            const duration = event.attributes?.test?.duration
+
+            if (status === 'pass') passes++
+            if (status === 'fail') failures++
+
+            // Collect duration in milliseconds (Datadog returns nanoseconds)
+            if (typeof duration === 'number' && duration > 0) {
+              durations.push(duration / 1000000) // Convert ns to ms
+            }
+
+            // Check for flaky tags
+            if (tags.includes('is_flaky:true') || tags.includes('is_known_flaky:true')) {
+              isKnownFlaky = true
+            }
+          }
+
+          const totalRuns = passes + failures
+          if (totalRuns > 0) {
+            const flakeRate = totalRuns > 1 && passes > 0 && failures > 0
+              ? Math.round((Math.min(passes, failures) / totalRuns) * 100)
+              : 0
+
+            // Calculate duration baseline (p50)
+            let baselineDurationMs: number | undefined
+            let baselineDurationP50Ms: number | undefined
+            if (durations.length >= 3) {
+              durations.sort((a, b) => a - b)
+              const p50Index = Math.floor(durations.length / 2)
+              baselineDurationP50Ms = durations[p50Index]
+              baselineDurationMs = durations.reduce((a, b) => a + b, 0) / durations.length
+            }
+
+            // Store data for all tests that have history (for duration comparison)
+            // or are flaky
+            const isFlaky = isKnownFlaky || (passes > 0 && failures > 0 && flakeRate >= 10)
+            if (isFlaky || durations.length >= 3) {
+              testData.set(testName, {
+                testName,
+                isKnownFlaky: isKnownFlaky || flakeRate >= 30,
+                flakeRate,
+                recentFailures: failures,
+                recentRuns: totalRuns,
+                baselineDurationMs,
+                baselineDurationP50Ms,
+              })
+            }
+          }
+        } catch (err) {
+          console.log(`Error querying Datadog for test: ${err}`)
+        }
+      }
+
+      // Small delay between batches to avoid rate limiting
+      if (i + batchSize < testNames.length) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+    }
+
+    console.log(`Found ${testData.size} tests with historical data`)
+  } catch (err) {
+    console.log('Error querying Datadog:', err)
+  }
+
+  return testData
+}
+
+function formatFlakyTestsSection(
+  flakyTests: CategorizedTest[],
+  testData: Map<string, DatadogTestData>,
+  sha: string
+): string {
+  if (flakyTests.length === 0) return ''
+
+  let content = `\n---\n\n### Known Flaky Tests (can likely ignore)\n\n`
+  content += `> These tests have a history of flaky behavior on \`canary\`. They may not be caused by your changes.\n\n`
+
+  content += `<details>\n`
+  content += `<summary>${flakyTests.length} known flaky test${flakyTests.length > 1 ? 's' : ''}</summary>\n\n`
+
+  content += `| Test | Flake Rate | Recent (30d) | Links |\n|------|-----------|--------------|-------|\n`
+
+  for (const test of flakyTests) {
+    const shortPath = test.testPath
+      .replace(/^.*?(test\/)/, 'test/')
+      .replace(/^.*?(packages\/)/, 'packages/')
+    const testType = test.category.bundler === 'turbopack' ? 'turbopack' : 'nextjs'
+    const ddLink = createDatadogLink(sha, test.name, testType)
+
+    const data = testData.get(test.testPath) || testData.get(test.name)
+    const flakeRate = data?.flakeRate ?? '?'
+    const recentStats = data ? `${data.recentFailures}/${data.recentRuns} failed` : '-'
+
+    // Truncate long names
+    const displayName = shortPath.length > 50 ? shortPath.substring(0, 47) + '...' : shortPath
+    content += `| \`${displayName}\` | ${flakeRate}% | ${recentStats} | [DD](${ddLink}) [job](${test.jobUrl}) |\n`
+  }
+
+  content += `\n</details>\n`
+
+  return content
+}
+
+interface SlowTestRegression {
+  test: CategorizedTest
+  currentDurationMs: number
+  baselineDurationMs: number
+  percentageIncrease: number
+}
+
+function findSlowTestRegressions(
+  tests: CategorizedTest[],
+  testData: Map<string, DatadogTestData>,
+  thresholdPercent: number = 100 // Flag tests that are 2x slower (100% increase)
+): SlowTestRegression[] {
+  const slowTests: SlowTestRegression[] = []
+
+  for (const test of tests) {
+    if (!test.duration) continue
+
+    const data = testData.get(test.testPath) || testData.get(test.name)
+    if (!data?.baselineDurationP50Ms) continue
+
+    const currentDurationMs = test.duration
+    const baselineDurationMs = data.baselineDurationP50Ms
+    const percentageIncrease = ((currentDurationMs - baselineDurationMs) / baselineDurationMs) * 100
+
+    // Only flag significant slowdowns (above threshold and at least 5 seconds slower)
+    if (percentageIncrease >= thresholdPercent && (currentDurationMs - baselineDurationMs) >= 5000) {
+      slowTests.push({
+        test,
+        currentDurationMs,
+        baselineDurationMs,
+        percentageIncrease,
+      })
+    }
+  }
+
+  // Sort by percentage increase (worst first)
+  return slowTests.sort((a, b) => b.percentageIncrease - a.percentageIncrease)
+}
+
+function formatSlowTestsSection(slowTests: SlowTestRegression[], sha: string): string {
+  if (slowTests.length === 0) return ''
+
+  let content = `\n---\n\n### Slow Test Regressions\n\n`
+  content += `> These tests are significantly slower than their historical baseline on \`canary\`.\n\n`
+
+  content += `<details>\n`
+  content += `<summary>${slowTests.length} test${slowTests.length > 1 ? 's' : ''} with duration regression</summary>\n\n`
+
+  content += `| Test | Current | Baseline (p50) | Delta | Links |\n|------|---------|----------------|-------|-------|\n`
+
+  for (const { test, currentDurationMs, baselineDurationMs, percentageIncrease } of slowTests) {
+    const shortPath = test.testPath
+      .replace(/^.*?(test\/)/, 'test/')
+      .replace(/^.*?(packages\/)/, 'packages/')
+    const testType = test.category.bundler === 'turbopack' ? 'turbopack' : 'nextjs'
+    const ddLink = createDatadogLink(sha, test.name, testType)
+
+    const formatDuration = (ms: number) => {
+      if (ms >= 60000) return `${(ms / 60000).toFixed(1)}m`
+      if (ms >= 1000) return `${(ms / 1000).toFixed(1)}s`
+      return `${Math.round(ms)}ms`
+    }
+
+    const displayName = shortPath.length > 40 ? shortPath.substring(0, 37) + '...' : shortPath
+    const delta = `+${Math.round(percentageIncrease)}%`
+
+    content += `| \`${displayName}\` | ${formatDuration(currentDurationMs)} | ${formatDuration(baselineDurationMs)} | **${delta}** ⚠️ | [DD](${ddLink}) |\n`
+  }
+
+  content += `\n> ℹ️ Baseline calculated from last 30 days of runs on \`canary\`\n\n`
+  content += `</details>\n`
+
+  return content
+}
+
+// =============================================================================
 // Cross-PR Failure Detection
 // =============================================================================
 
@@ -365,6 +627,62 @@ function formatSummaryTable(
 
   for (const [label, count] of categoryGroups) {
     summary += `| ${label} | ${count} |\n`
+  }
+
+  return summary
+}
+
+function formatSummaryTableWithFlaky(
+  sha: string,
+  runId: number,
+  runAttempt: number,
+  totalFailures: number,
+  needsInvestigationCount: number,
+  knownFlakyCount: number,
+  passedOnRetryCount: number,
+  investigationGroups: TestGroup[]
+): string {
+  const commitUrl = `https://github.com/vercel/next.js/commit/${sha}`
+  const runUrl = `https://github.com/vercel/next.js/actions/runs/${runId}/attempts/${runAttempt}`
+  const rerunUrl = `https://github.com/vercel/next.js/actions/runs/${runId}`
+  const shortSha = sha.substring(0, 7)
+
+  let summary = `## Failing test suites ${BOT_COMMENT_MARKER}\n\n`
+
+  // Header with commit info
+  summary += `| | |\n|---|---|\n`
+  summary += `| **Tested Commit** | [\`${shortSha}\`](${commitUrl}) |\n`
+  summary += `| **Workflow Run** | [#${runId}](${runUrl}) · Attempt ${runAttempt} |\n\n`
+
+  summary += `[**Re-run failed jobs →**](${rerunUrl})\n\n`
+
+  summary += `---\n\n`
+
+  // Summary counts with flaky breakdown
+  summary += `| Summary | |\n|---------|---|\n`
+  summary += `| Total Failed | ${totalFailures} |\n`
+
+  if (knownFlakyCount > 0) {
+    summary += `| **Needs Investigation** | **${needsInvestigationCount}** |\n`
+    summary += `| Known Flaky | ${knownFlakyCount} (can likely ignore) |\n`
+  }
+
+  if (passedOnRetryCount > 0) {
+    summary += `| Passed on Retry | ${passedOnRetryCount} (likely flaky) |\n`
+  }
+
+  // Group counts by category (only for needs investigation)
+  if (investigationGroups.length > 0) {
+    summary += `\n| Breakdown | |\n|---------|---|\n`
+    const categoryGroups = new Map<string, number>()
+    for (const group of investigationGroups) {
+      const label = formatCategoryLabel(group.category)
+      categoryGroups.set(label, (categoryGroups.get(label) || 0) + group.tests.length)
+    }
+
+    for (const [label, count] of categoryGroups) {
+      summary += `| ${label} | ${count} |\n`
+    }
   }
 
   return summary
@@ -990,7 +1308,7 @@ async function run() {
   }
 
   // Process and categorize test results
-  const { groups, passedOnRetry } = processTestResults(
+  const { categorizedTests, groups, passedOnRetry } = processTestResults(
     jobResults.result as Array<JobResult & { jobUrl?: string }>,
     sha
   )
@@ -999,22 +1317,75 @@ async function run() {
   const runId = context.runId
   const runAttempt = parseInt(process.env.GITHUB_RUN_ATTEMPT || '1', 10)
 
+  // Query Datadog for test history (flaky detection + duration baselines)
+  const datadogApiKey = getInput('datadog_api_key')
+  const datadogAppKey = getInput('datadog_app_key')
+  const testData = await queryDatadogTestData(failedTestLists, datadogApiKey, datadogAppKey)
+
+  // Split tests into "needs investigation" vs "known flaky"
+  const flakyTests: CategorizedTest[] = []
+  const needsInvestigation: CategorizedTest[] = []
+
+  for (const test of categorizedTests) {
+    const data = testData.get(test.testPath) || testData.get(test.name)
+    if (data && data.isKnownFlaky) {
+      flakyTests.push(test)
+    } else {
+      needsInvestigation.push(test)
+    }
+  }
+
+  // Find slow test regressions (tests that are 2x slower than baseline)
+  const slowTestRegressions = findSlowTestRegressions(categorizedTests, testData)
+
+  // Re-group the needs investigation tests
+  const investigationGroupMap = new Map<string, TestGroup>()
+  for (const test of needsInvestigation) {
+    const key = getCategoryKey(test.category)
+    if (!investigationGroupMap.has(key)) {
+      investigationGroupMap.set(key, {
+        key,
+        category: test.category,
+        tests: [],
+        jobUrl: test.jobUrl,
+      })
+    }
+    investigationGroupMap.get(key)!.tests.push(test)
+  }
+  const investigationGroups = Array.from(investigationGroupMap.values()).sort((a, b) => b.tests.length - a.tests.length)
+
   // Check for cross-PR failures
   console.log('Checking for cross-PR failures...')
   const otherPRFailures = await fetchOtherPRFailures(octokit, prNumber)
   const commonFailures = findCommonFailures(failedTestLists, otherPRFailures)
   console.log(`Found ${commonFailures.length} tests failing in other PRs`)
 
-  // Build comment
-  let commentBody = formatSummaryTable(sha, runId, runAttempt, totalFailures, passedOnRetry.length, groups)
+  // Build comment with updated summary
+  let commentBody = formatSummaryTableWithFlaky(
+    sha, runId, runAttempt,
+    totalFailures, needsInvestigation.length, flakyTests.length,
+    passedOnRetry.length, investigationGroups
+  )
 
   // Add cross-PR alert if applicable
   if (commonFailures.length > 0) {
     commentBody += formatCrossPRAlert(commonFailures, context.repo.owner, context.repo.repo)
   }
 
-  for (const group of groups) {
-    commentBody += formatTestGroup(group, sha)
+  // Show "needs investigation" tests first (these are the important ones)
+  if (investigationGroups.length > 0) {
+    commentBody += `\n### Needs Investigation\n`
+    for (const group of investigationGroups) {
+      commentBody += formatTestGroup(group, sha)
+    }
+  }
+
+  // Show known flaky tests (collapsed, less important)
+  commentBody += formatFlakyTestsSection(flakyTests, testData, sha)
+
+  // Show slow test regressions
+  if (slowTestRegressions.length > 0) {
+    commentBody += formatSlowTestsSection(slowTestRegressions, sha)
   }
 
   // Add passed on retry section

--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -177,6 +177,8 @@ jobs:
         uses: ./.github/actions/next-integration-stat
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          datadog_api_key: ${{ secrets.DATA_DOG_API_KEY }}
+          datadog_app_key: ${{ secrets.DD_APPLICATION_KEY }}
 
       - name: Store artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Adds Datadog CI Visibility API integration to identify known flaky tests and detect slow test regressions.

**Depends on:** #87974

### Changes

1. **Flaky test detection** — Queries Datadog for historical test data (30-day window) to identify tests with flaky behavior on `canary`. Separates "Needs Investigation" from "Known Flaky" tests.

2. **Slow test regression detection** — Flags tests that are 2x slower than their historical baseline (p50)

3. **Workflow integration** — Passes `DATA_DOG_API_KEY` and `DD_APPLICATION_KEY` secrets to the action

### Updated Comment Format

```
| Summary | |
|---------|---|
| Total Failed | 31 |
| **Needs Investigation** | **3** |
| Known Flaky | 28 (can likely ignore) |
| Passed on Retry | 5 (likely flaky) |

### Needs Investigation
[Tests that aren't known to be flaky]

### Known Flaky Tests (can likely ignore)
| Test | Flake Rate | Recent (30d) | Links |
|------|-----------|--------------|-------|
| `test/e2e/app-dir/...` | 45% | 12/27 failed | [DD](link) |

### Slow Test Regressions
| Test | Current | Baseline (p50) | Delta |
|------|---------|----------------|-------|
| `test/...` | 45s | 15s | **+200%** ⚠️ |
```

### Configuration

Uses existing secrets:
- `DATA_DOG_API_KEY` — Already configured for JUnit uploads
- `DD_APPLICATION_KEY` — Needs `ci_visibility_read` scope for querying test history

## Test Plan

- [ ] Verify Datadog API queries succeed (check workflow logs)
- [ ] Confirm known flaky tests are correctly identified
- [ ] Check slow test detection works when a test exceeds baseline