### PR TITLE
docs: clarify development server startup in installation guide

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -12,7 +12,7 @@ Create a new Next.js app and run it locally.
 ## Quick start
 
 1. Create a new Next.js app named `my-app`
-2. `cd my-app` and start the dev server.
+2. `cd my-app` and start the development server by running `npm run dev`.
 3. Visit `http://localhost:3000`.
 
 ```bash package="pnpm"

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -14,13 +14,13 @@ Welcome to the Next.js documentation!
 
 Next.js is a React framework for building full-stack web applications. You use React Components to build user interfaces, and Next.js for additional features and optimizations.
 
-It also automatically configures lower-level tools like bundlers and compilers. You can instead focus on building your product and shipping quickly.
+It also automatically configures lower-level tools, such as bundlers and compilers. You can instead focus on building your product and shipping quickly.
 
 Whether you're an individual developer or part of a larger team, Next.js can help you build interactive, dynamic, and fast React applications.
 
 ## How to use the docs
 
-The docs are organized into 3 sections:
+The docs are organized into three sections:
 
 - [Getting Started](/docs/app/getting-started): Step-by-step tutorials to help you create a new application and learn the core Next.js features.
 - [Guides](/docs/app/guides): Tutorials on specific use cases, choose what's relevant to you.


### PR DESCRIPTION
### Summary

- Clarifies how to start the development server in the Quick start section.
- Improves beginner readability without changing behavior.

### Notes

This change is limited to documentation only.