### PR TITLE
Redesign default error pages with cleaner, more user-friendly UI

### DIFF
--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -74,8 +74,6 @@ const themeCss = `
   :root {
     --next-error-bg: #0a0a0a;
     --next-error-text: #ededed;
-    --next-error-card-bg: rgba(255,255,255,0.04);
-    --next-error-card-border: 1px solid rgba(255,255,255,0.08);
     --next-error-title: #ededed;
     --next-error-message: #a0a0a0;
     --next-error-hint: #707070;

--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -21,14 +21,14 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '18px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#dc2626',
+    color: '#e5484d', // --color-red-700
     margin: '0 0 12px 0',
   },
   message: {
     fontSize: '15px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#64748b',
+    color: '#666666', // --color-gray-900
     margin: '0 0 24px 0',
   },
   button: {
@@ -37,30 +37,32 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     letterSpacing: '0.01em',
     color: '#fff',
-    backgroundColor: '#dc2626',
+    backgroundColor: '#e5484d', // --color-red-700
     border: 'none',
-    borderRadius: '8px',
+    borderRadius: '6px',
     cursor: 'pointer',
   },
   devHint: {
     fontSize: '12px',
     fontWeight: 400,
-    color: '#9ca3af',
+    color: '#8f8f8f', // --color-gray-700
     margin: '24px 0 0 0',
   },
 }
 
 /* CSS minified from
-body { margin: 0; color: #000; background: #fff; }
+body { margin: 0; color: #171717; background: #fff; }
 @media (prefers-color-scheme: dark) {
-  body { color: #fff; background: #0a0a0a; }
-  .next-error-message { color: #a1a1aa; }
-  .next-error-dev-hint { color: #71717a; }
-  .next-error-icon-ring { stroke: #7f1d1d; }
-  .next-error-icon-fill { fill: #1c1917; }
+  body { color: #ededed; background: #0a0a0a; }
+  .next-error-title { color: #ff6369; }
+  .next-error-message { color: #a0a0a0; }
+  .next-error-dev-hint { color: #878787; }
+  .next-error-icon-ring { stroke: #822025; }
+  .next-error-icon-fill { fill: #2a1314; }
+  .next-error-button { background: #e5484d; }
 }
 */
-const themeCss = `body{margin:0;color:#000;background:#fff}@media(prefers-color-scheme:dark){body{color:#fff;background:#0a0a0a}.next-error-message{color:#a1a1aa}.next-error-dev-hint{color:#71717a}.next-error-icon-ring{stroke:#7f1d1d}.next-error-icon-fill{fill:#1c1917}}`
+const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-title{color:#ff6369}.next-error-message{color:#a0a0a0}.next-error-dev-hint{color:#878787}.next-error-icon-ring{stroke:#822025}.next-error-icon-fill{fill:#2a1314}.next-error-button{background:#e5484d}}`
 
 function ErrorIcon() {
   return (
@@ -107,12 +109,18 @@ function AppError() {
         <div style={styles.container}>
           <div style={styles.content}>
             <ErrorIcon />
-            <h1 style={styles.title}>Internal Server Error</h1>
+            <h1 className="next-error-title" style={styles.title}>
+              Internal Server Error
+            </h1>
             <p className="next-error-message" style={styles.message}>
               The server encountered an error. Please try again later.
             </p>
             <form>
-              <button type="submit" style={styles.button}>
+              <button
+                className="next-error-button"
+                type="submit"
+                style={styles.button}
+              >
                 Try Again
               </button>
             </form>

--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -13,8 +13,9 @@ const styles = {
     maxWidth: '420px',
     padding: '32px 28px',
     textAlign: 'left' as const,
-    backgroundColor: 'rgba(255,255,255,0.03)',
     borderRadius: '12px',
+    background: 'var(--next-error-card-bg)',
+    border: 'var(--next-error-card-border)',
   },
   icon: {
     marginBottom: '16px',
@@ -23,50 +24,70 @@ const styles = {
     fontSize: '17px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#171717',
     margin: '0 0 8px 0',
+    color: 'var(--next-error-title)',
   },
   message: {
     fontSize: '14px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#666666',
     margin: '0 0 6px 0',
+    color: 'var(--next-error-message)',
   },
   messageHint: {
     fontSize: '13px',
     fontWeight: 400,
     lineHeight: 1.5,
-    color: '#8f8f8f',
     margin: '0 0 20px 0',
+    color: 'var(--next-error-hint)',
   },
   button: {
     padding: '10px 20px',
     fontSize: '14px',
     fontWeight: 500,
     letterSpacing: '0.01em',
-    color: '#171717',
-    backgroundColor: '#fff',
-    border: '1px solid #e5e5e5',
     borderRadius: '6px',
     cursor: 'pointer',
+    color: 'var(--next-error-btn-text)',
+    background: 'var(--next-error-btn-bg)',
+    border: 'var(--next-error-btn-border)',
   },
 }
 
-/* CSS minified from
-body { margin: 0; color: #171717; background: #fff; }
-@media (prefers-color-scheme: dark) {
-  body { color: #ededed; background: #0a0a0a; }
-  .next-error-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
-  .next-error-title { color: #ededed; }
-  .next-error-message { color: #a0a0a0; }
-  .next-error-message-hint { color: #707070; }
-  .next-error-icon-ring { stroke: #5c2121; }
-  .next-error-icon-fill { fill: #2a1618; }
-  .next-error-button { background: #1a1a1a; color: #ededed; border-color: #333; }
+/* CSS variables for theming */
+const themeCss = `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-card-bg: transparent;
+  --next-error-card-border: none;
+  --next-error-title: #171717;
+  --next-error-message: #666;
+  --next-error-hint: #888;
+  --next-error-btn-text: #171717;
+  --next-error-btn-bg: #fff;
+  --next-error-btn-border: 1px solid #e5e5e5;
+  --next-error-icon-ring: #fecaca;
+  --next-error-icon-fill: #fef2f2;
 }
-*/
-const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)}.next-error-title{color:#ededed}.next-error-message{color:#a0a0a0}.next-error-message-hint{color:#707070}.next-error-icon-ring{stroke:#5c2121}.next-error-icon-fill{fill:#2a1618}.next-error-button{background:#1a1a1a;color:#ededed;border-color:#333}}`
+@media (prefers-color-scheme: dark) {
+  :root {
+    --next-error-bg: #0a0a0a;
+    --next-error-text: #ededed;
+    --next-error-card-bg: rgba(255,255,255,0.04);
+    --next-error-card-border: 1px solid rgba(255,255,255,0.08);
+    --next-error-title: #ededed;
+    --next-error-message: #a0a0a0;
+    --next-error-hint: #707070;
+    --next-error-btn-text: #ededed;
+    --next-error-btn-bg: #1a1a1a;
+    --next-error-btn-border: 1px solid #333;
+    --next-error-icon-ring: #5c2121;
+    --next-error-icon-fill: #2a1618;
+  }
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, '')
 
 function ErrorIcon() {
   return (
@@ -78,20 +99,13 @@ function ErrorIcon() {
       style={styles.icon}
     >
       <circle
-        className="next-error-icon-ring"
         cx="20"
         cy="20"
         r="19"
-        stroke="#fecaca"
+        stroke="var(--next-error-icon-ring)"
         strokeWidth="2"
       />
-      <circle
-        className="next-error-icon-fill"
-        cx="20"
-        cy="20"
-        r="16"
-        fill="#fef2f2"
-      />
+      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
       <path
         d="M20 11v10M20 25v3"
         stroke="#dc2626"
@@ -111,24 +125,16 @@ function AppError() {
       </head>
       <body>
         <div style={styles.container}>
-          <div className="next-error-card" style={styles.card}>
+          <div style={styles.card}>
             <ErrorIcon />
-            <h1 className="next-error-title" style={styles.title}>
-              Something went wrong
-            </h1>
-            <p className="next-error-message" style={styles.message}>
-              The server encountered an error.
-            </p>
-            <p className="next-error-message-hint" style={styles.messageHint}>
+            <h1 style={styles.title}>Something went wrong</h1>
+            <p style={styles.message}>The server encountered an error.</p>
+            <p style={styles.messageHint}>
               Reloading usually fixes this. If it keeps happening, the page may
               be temporarily unavailable.
             </p>
             <form>
-              <button
-                className="next-error-button"
-                type="submit"
-                style={styles.button}
-              >
+              <button type="submit" style={styles.button}>
                 Reload page
               </button>
             </form>

--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -1,75 +1,125 @@
 import React from 'react'
 
 const styles: Record<string, React.CSSProperties> = {
-  error: {
-    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
+  container: {
     fontFamily:
       'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
     height: '100vh',
-    textAlign: 'center',
     display: 'flex',
-    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    textAlign: 'center',
   },
-  desc: {
-    lineHeight: '48px',
+  content: {
+    maxWidth: '420px',
+    padding: '0 24px',
   },
-  h1: {
-    display: 'inline-block',
-    margin: '0 20px 0 0',
-    paddingRight: 23,
-    fontSize: 24,
-    fontWeight: 500,
-    verticalAlign: 'top',
+  icon: {
+    marginBottom: '20px',
   },
-  h2: {
-    fontSize: 14,
+  title: {
+    fontSize: '18px',
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+    color: '#dc2626',
+    margin: '0 0 12px 0',
+  },
+  message: {
+    fontSize: '15px',
     fontWeight: 400,
-    lineHeight: '28px',
+    lineHeight: 1.6,
+    color: '#64748b',
+    margin: '0 0 24px 0',
   },
-  wrap: {
-    display: 'inline-block',
+  button: {
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    color: '#fff',
+    backgroundColor: '#dc2626',
+    border: 'none',
+    borderRadius: '8px',
+    cursor: 'pointer',
   },
-} as const
+  devHint: {
+    fontSize: '12px',
+    fontWeight: 400,
+    color: '#9ca3af',
+    margin: '24px 0 0 0',
+  },
+}
 
 /* CSS minified from
 body { margin: 0; color: #000; background: #fff; }
-.next-error-h1 {
-  border-right: 1px solid rgba(0, 0, 0, .3);
-}
 @media (prefers-color-scheme: dark) {
-  body { color: #fff; background: #000; }
-  .next-error-h1 {
-    border-right: 1px solid rgba(255, 255, 255, .3);
-  }
+  body { color: #fff; background: #0a0a0a; }
+  .next-error-message { color: #a1a1aa; }
+  .next-error-dev-hint { color: #71717a; }
+  .next-error-icon-ring { stroke: #7f1d1d; }
+  .next-error-icon-fill { fill: #1c1917; }
 }
 */
-const themeCss = `body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}
-@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}`
+const themeCss = `body{margin:0;color:#000;background:#fff}@media(prefers-color-scheme:dark){body{color:#fff;background:#0a0a0a}.next-error-message{color:#a1a1aa}.next-error-dev-hint{color:#71717a}.next-error-icon-ring{stroke:#7f1d1d}.next-error-icon-fill{fill:#1c1917}}`
+
+function ErrorIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      style={styles.icon}
+    >
+      <circle
+        className="next-error-icon-ring"
+        cx="24"
+        cy="24"
+        r="23"
+        stroke="#fecaca"
+        strokeWidth="2"
+      />
+      <circle
+        className="next-error-icon-fill"
+        cx="24"
+        cy="24"
+        r="20"
+        fill="#fef2f2"
+      />
+      <path
+        d="M24 14v12M24 30v4"
+        stroke="#dc2626"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
 
 function AppError() {
-  const errorMessage = 'Internal Server Error.'
-  const title = `500: ${errorMessage}`
   return (
     <html id="__next_error__">
       <head>
-        <title>{title}</title>
+        <title>500: Internal Server Error</title>
+        <style dangerouslySetInnerHTML={{ __html: themeCss }} />
       </head>
       <body>
-        <div style={styles.error}>
-          <div style={styles.desc}>
-            <style
-              dangerouslySetInnerHTML={{
-                __html: themeCss,
-              }}
-            />
-            <h1 className="next-error-h1" style={styles.h1}>
-              500
-            </h1>
-            <div style={styles.wrap}>
-              <h2 style={styles.h2}>{errorMessage}</h2>
-            </div>
+        <div style={styles.container}>
+          <div style={styles.content}>
+            <ErrorIcon />
+            <h1 style={styles.title}>Internal Server Error</h1>
+            <p className="next-error-message" style={styles.message}>
+              The server encountered an error. Please try again later.
+            </p>
+            <button
+              style={styles.button}
+              onClick={() => window.location.reload()}
+            >
+              Try Again
+            </button>
+            <p className="next-error-dev-hint" style={styles.devHint}>
+              Developers: Check your server logs for details.
+            </p>
           </div>
         </div>
       </body>

--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const styles: Record<string, React.CSSProperties> = {
+const styles = {
   container: {
     fontFamily:
       'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
@@ -8,45 +8,48 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    textAlign: 'center',
   },
-  content: {
+  card: {
     maxWidth: '420px',
-    padding: '0 24px',
+    padding: '32px 28px',
+    textAlign: 'left' as const,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderRadius: '12px',
   },
   icon: {
-    marginBottom: '20px',
+    marginBottom: '16px',
   },
   title: {
-    fontSize: '18px',
+    fontSize: '17px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#e5484d', // --color-red-700
-    margin: '0 0 12px 0',
+    color: '#171717',
+    margin: '0 0 8px 0',
   },
   message: {
-    fontSize: '15px',
+    fontSize: '14px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#666666', // --color-gray-900
-    margin: '0 0 24px 0',
+    color: '#666666',
+    margin: '0 0 6px 0',
+  },
+  messageHint: {
+    fontSize: '13px',
+    fontWeight: 400,
+    lineHeight: 1.5,
+    color: '#8f8f8f',
+    margin: '0 0 20px 0',
   },
   button: {
     padding: '10px 20px',
     fontSize: '14px',
     fontWeight: 500,
     letterSpacing: '0.01em',
-    color: '#fff',
-    backgroundColor: '#e5484d', // --color-red-700
-    border: 'none',
+    color: '#171717',
+    backgroundColor: '#fff',
+    border: '1px solid #e5e5e5',
     borderRadius: '6px',
     cursor: 'pointer',
-  },
-  devHint: {
-    fontSize: '12px',
-    fontWeight: 400,
-    color: '#8f8f8f', // --color-gray-700
-    margin: '24px 0 0 0',
   },
 }
 
@@ -54,44 +57,45 @@ const styles: Record<string, React.CSSProperties> = {
 body { margin: 0; color: #171717; background: #fff; }
 @media (prefers-color-scheme: dark) {
   body { color: #ededed; background: #0a0a0a; }
-  .next-error-title { color: #ff6369; }
+  .next-error-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
+  .next-error-title { color: #ededed; }
   .next-error-message { color: #a0a0a0; }
-  .next-error-dev-hint { color: #878787; }
-  .next-error-icon-ring { stroke: #822025; }
-  .next-error-icon-fill { fill: #2a1314; }
-  .next-error-button { background: #e5484d; }
+  .next-error-message-hint { color: #707070; }
+  .next-error-icon-ring { stroke: #5c2121; }
+  .next-error-icon-fill { fill: #2a1618; }
+  .next-error-button { background: #1a1a1a; color: #ededed; border-color: #333; }
 }
 */
-const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-title{color:#ff6369}.next-error-message{color:#a0a0a0}.next-error-dev-hint{color:#878787}.next-error-icon-ring{stroke:#822025}.next-error-icon-fill{fill:#2a1314}.next-error-button{background:#e5484d}}`
+const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)}.next-error-title{color:#ededed}.next-error-message{color:#a0a0a0}.next-error-message-hint{color:#707070}.next-error-icon-ring{stroke:#5c2121}.next-error-icon-fill{fill:#2a1618}.next-error-button{background:#1a1a1a;color:#ededed;border-color:#333}}`
 
 function ErrorIcon() {
   return (
     <svg
-      width="48"
-      height="48"
-      viewBox="0 0 48 48"
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
       fill="none"
       style={styles.icon}
     >
       <circle
         className="next-error-icon-ring"
-        cx="24"
-        cy="24"
-        r="23"
+        cx="20"
+        cy="20"
+        r="19"
         stroke="#fecaca"
         strokeWidth="2"
       />
       <circle
         className="next-error-icon-fill"
-        cx="24"
-        cy="24"
-        r="20"
+        cx="20"
+        cy="20"
+        r="16"
         fill="#fef2f2"
       />
       <path
-        d="M24 14v12M24 30v4"
+        d="M20 11v10M20 25v3"
         stroke="#dc2626"
-        strokeWidth="3"
+        strokeWidth="2.5"
         strokeLinecap="round"
       />
     </svg>
@@ -107,13 +111,17 @@ function AppError() {
       </head>
       <body>
         <div style={styles.container}>
-          <div style={styles.content}>
+          <div className="next-error-card" style={styles.card}>
             <ErrorIcon />
             <h1 className="next-error-title" style={styles.title}>
-              Internal Server Error
+              Something went wrong
             </h1>
             <p className="next-error-message" style={styles.message}>
-              The server encountered an error. Please try again later.
+              The server encountered an error.
+            </p>
+            <p className="next-error-message-hint" style={styles.messageHint}>
+              Reloading usually fixes this. If it keeps happening, the page may
+              be temporarily unavailable.
             </p>
             <form>
               <button
@@ -121,12 +129,9 @@ function AppError() {
                 type="submit"
                 style={styles.button}
               >
-                Try Again
+                Reload page
               </button>
             </form>
-            <p className="next-error-dev-hint" style={styles.devHint}>
-              Developers: Check your server logs for details.
-            </p>
           </div>
         </div>
       </body>

--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -111,12 +111,11 @@ function AppError() {
             <p className="next-error-message" style={styles.message}>
               The server encountered an error. Please try again later.
             </p>
-            <button
-              style={styles.button}
-              onClick={() => window.location.reload()}
-            >
-              Try Again
-            </button>
+            <form>
+              <button type="submit" style={styles.button}>
+                Try Again
+              </button>
+            </form>
             <p className="next-error-dev-hint" style={styles.devHint}>
               Developers: Check your server logs for details.
             </p>

--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -1,138 +1,28 @@
 import React from 'react'
+import { errorStyles, errorThemeCss, ErrorIcon } from './error-styles'
 
-const styles = {
-  container: {
-    fontFamily:
-      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
-    height: '100vh',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  card: {
-    maxWidth: '420px',
-    padding: '32px 28px',
-    textAlign: 'left' as const,
-    borderRadius: '12px',
-    background: 'var(--next-error-card-bg)',
-    border: 'var(--next-error-card-border)',
-  },
-  icon: {
-    marginBottom: '16px',
-  },
-  title: {
-    fontSize: '17px',
-    fontWeight: 600,
-    letterSpacing: '-0.01em',
-    margin: '0 0 8px 0',
-    color: 'var(--next-error-title)',
-  },
-  message: {
-    fontSize: '14px',
-    fontWeight: 400,
-    lineHeight: 1.6,
-    margin: '0 0 6px 0',
-    color: 'var(--next-error-message)',
-  },
-  messageHint: {
-    fontSize: '13px',
-    fontWeight: 400,
-    lineHeight: 1.5,
-    margin: '0 0 20px 0',
-    color: 'var(--next-error-hint)',
-  },
-  button: {
-    padding: '10px 20px',
-    fontSize: '14px',
-    fontWeight: 500,
-    letterSpacing: '0.01em',
-    borderRadius: '6px',
-    cursor: 'pointer',
-    color: 'var(--next-error-btn-text)',
-    background: 'var(--next-error-btn-bg)',
-    border: 'var(--next-error-btn-border)',
-  },
-}
-
-/* CSS variables for theming */
-const themeCss = `
-:root {
-  --next-error-bg: #fff;
-  --next-error-text: #171717;
-  --next-error-card-bg: transparent;
-  --next-error-card-border: none;
-  --next-error-title: #171717;
-  --next-error-message: #666;
-  --next-error-hint: #888;
-  --next-error-btn-text: #171717;
-  --next-error-btn-bg: #fff;
-  --next-error-btn-border: 1px solid #e5e5e5;
-  --next-error-icon-ring: #fecaca;
-  --next-error-icon-fill: #fef2f2;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --next-error-bg: #0a0a0a;
-    --next-error-text: #ededed;
-    --next-error-title: #ededed;
-    --next-error-message: #a0a0a0;
-    --next-error-hint: #707070;
-    --next-error-btn-text: #ededed;
-    --next-error-btn-bg: #1a1a1a;
-    --next-error-btn-border: 1px solid #333;
-    --next-error-icon-ring: #5c2121;
-    --next-error-icon-fill: #2a1618;
-  }
-}
-body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
-`.replace(/\n\s*/g, '')
-
-function ErrorIcon() {
-  return (
-    <svg
-      width="40"
-      height="40"
-      viewBox="0 0 40 40"
-      fill="none"
-      style={styles.icon}
-    >
-      <circle
-        cx="20"
-        cy="20"
-        r="19"
-        stroke="var(--next-error-icon-ring)"
-        strokeWidth="2"
-      />
-      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
-      <path
-        d="M20 11v10M20 25v3"
-        stroke="#dc2626"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-      />
-    </svg>
-  )
-}
-
+// This is the static 500.html page for App Router apps.
+// Always a server error, rendered at build time.
 function AppError() {
   return (
     <html id="__next_error__">
       <head>
-        <title>500: Internal Server Error</title>
-        <style dangerouslySetInnerHTML={{ __html: themeCss }} />
+        <title>500: This page failed to load</title>
+        <style dangerouslySetInnerHTML={{ __html: errorThemeCss }} />
       </head>
       <body>
-        <div style={styles.container}>
-          <div style={styles.card}>
+        <div style={errorStyles.container}>
+          <div style={errorStyles.card}>
             <ErrorIcon />
-            <h1 style={styles.title}>Something went wrong</h1>
-            <p style={styles.message}>The server encountered an error.</p>
-            <p style={styles.messageHint}>
-              Reloading usually fixes this. If it keeps happening, the page may
-              be temporarily unavailable.
+            <h1 style={errorStyles.title}>This page failed to load</h1>
+            <p style={errorStyles.message}>
+              Something went wrong while loading this page.
+            </p>
+            <p style={errorStyles.messageHint}>
+              If this keeps happening, it may be a server issue.
             </p>
             <form>
-              <button type="submit" style={styles.button}>
+              <button type="submit" style={errorStyles.button}>
                 Reload page
               </button>
             </form>

--- a/packages/next/src/client/components/builtin/error-styles.tsx
+++ b/packages/next/src/client/components/builtin/error-styles.tsx
@@ -1,0 +1,151 @@
+import React from 'react'
+
+export const errorStyles = {
+  container: {
+    fontFamily:
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+    height: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  card: {
+    maxWidth: '420px',
+    padding: '32px 28px',
+    textAlign: 'left' as const,
+  },
+  icon: {
+    marginBottom: '16px',
+  },
+  title: {
+    fontSize: '17px',
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+    margin: '0 0 8px 0',
+    color: 'var(--next-error-title)',
+  },
+  message: {
+    fontSize: '14px',
+    fontWeight: 400,
+    lineHeight: 1.6,
+    margin: '0 0 6px 0',
+    color: 'var(--next-error-message)',
+  },
+  messageHint: {
+    fontSize: '13px',
+    fontWeight: 400,
+    lineHeight: 1.5,
+    margin: '0 0 20px 0',
+    color: 'var(--next-error-hint)',
+  },
+  buttonGroup: {
+    display: 'flex',
+    gap: '12px',
+    alignItems: 'center',
+  },
+  button: {
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    color: 'var(--next-error-btn-text)',
+    background: 'var(--next-error-btn-bg)',
+    border: 'var(--next-error-btn-border)',
+  },
+  buttonSecondary: {
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    color: 'var(--next-error-btn-secondary-text)',
+    background: 'transparent',
+    border: 'none',
+  },
+  digestContainer: {
+    marginTop: '20px',
+    paddingTop: '16px',
+    borderTop: 'var(--next-error-digest-border)',
+  },
+  digest: {
+    fontSize: '12px',
+    fontWeight: 400,
+    margin: '0',
+    color: 'var(--next-error-digest)',
+  },
+  digestCode: {
+    fontFamily:
+      'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
+    fontSize: '11px',
+    color: 'var(--next-error-digest-code)',
+    userSelect: 'all' as const,
+  },
+} as const
+
+export const errorThemeCss = `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-title: #171717;
+  --next-error-message: #666;
+  --next-error-hint: #888;
+  --next-error-digest: #999;
+  --next-error-digest-code: #888;
+  --next-error-digest-border: 1px solid rgba(0,0,0,0.06);
+  --next-error-btn-text: #171717;
+  --next-error-btn-bg: #fff;
+  --next-error-btn-border: 1px solid #e5e5e5;
+  --next-error-btn-secondary-text: #666;
+  --next-error-icon-ring: #fecaca;
+  --next-error-icon-fill: #fef2f2;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --next-error-bg: #0a0a0a;
+    --next-error-text: #ededed;
+    --next-error-title: #ededed;
+    --next-error-message: #a0a0a0;
+    --next-error-hint: #707070;
+    --next-error-digest: #606060;
+    --next-error-digest-code: #707070;
+    --next-error-digest-border: 1px solid rgba(255,255,255,0.08);
+    --next-error-btn-text: #ededed;
+    --next-error-btn-bg: #1a1a1a;
+    --next-error-btn-border: 1px solid #333;
+    --next-error-btn-secondary-text: #a0a0a0;
+    --next-error-icon-ring: #5c2121;
+    --next-error-icon-fill: #2a1618;
+  }
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, '')
+
+export function ErrorIcon() {
+  return (
+    <svg
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
+      fill="none"
+      style={errorStyles.icon}
+    >
+      <circle
+        cx="20"
+        cy="20"
+        r="19"
+        stroke="var(--next-error-icon-ring)"
+        strokeWidth="2"
+      />
+      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
+      <path
+        d="M20 11v10M20 25v3"
+        stroke="#dc2626"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}

--- a/packages/next/src/client/components/builtin/error-styles.tsx
+++ b/packages/next/src/client/components/builtin/error-styles.tsx
@@ -141,11 +141,12 @@ export function ErrorIcon() {
       />
       <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
       <path
-        d="M20 11v10M20 25v3"
+        d="M20 12v9"
         stroke="#dc2626"
         strokeWidth="2.5"
         strokeLinecap="round"
       />
+      <circle cx="20" cy="27" r="1.5" fill="#dc2626" />
     </svg>
   )
 }

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -10,53 +10,72 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    textAlign: 'center',
   },
-  content: {
+  card: {
     maxWidth: '420px',
-    padding: '0 24px',
+    padding: '32px 28px',
+    textAlign: 'left' as const,
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderRadius: '12px',
   },
   icon: {
-    marginBottom: '20px',
+    marginBottom: '16px',
   },
   title: {
-    fontSize: '18px',
+    fontSize: '17px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#e5484d', // --color-red-700
-    margin: '0 0 12px 0',
+    color: '#171717',
+    margin: '0 0 8px 0',
   },
   message: {
-    fontSize: '15px',
+    fontSize: '14px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#666666', // --color-gray-900
-    margin: '0 0 16px 0',
+    color: '#666666',
+    margin: '0 0 6px 0',
   },
-  digest: {
+  messageHint: {
     fontSize: '13px',
     fontWeight: 400,
-    color: '#8f8f8f', // --color-gray-700
-    margin: '0 0 24px 0',
-    fontFamily:
-      'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
+    lineHeight: 1.5,
+    color: '#8f8f8f',
+    margin: '0 0 20px 0',
   },
   button: {
     padding: '10px 20px',
     fontSize: '14px',
     fontWeight: 500,
     letterSpacing: '0.01em',
-    color: '#fff',
-    backgroundColor: '#e5484d', // --color-red-700
-    border: 'none',
+    color: '#171717',
+    backgroundColor: '#fff',
+    border: '1px solid #e5e5e5',
     borderRadius: '6px',
     cursor: 'pointer',
   },
-  devHint: {
+  digestContainer: {
+    marginTop: '20px',
+    paddingTop: '16px',
+    borderTop: '1px solid rgba(0,0,0,0.06)',
+  },
+  digest: {
     fontSize: '12px',
     fontWeight: 400,
-    color: '#8f8f8f', // --color-gray-700
-    margin: '24px 0 0 0',
+    color: '#a0a0a0',
+    margin: '0 0 2px 0',
+  },
+  digestCode: {
+    fontFamily:
+      'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
+    fontSize: '11px',
+    color: '#8f8f8f',
+    userSelect: 'all' as const,
+  },
+  digestHint: {
+    fontSize: '11px',
+    fontWeight: 400,
+    color: '#b0b0b0',
+    margin: '4px 0 0 0',
   },
 } as const
 
@@ -64,45 +83,49 @@ const styles = {
 body { margin: 0; color: #171717; background: #fff; }
 @media (prefers-color-scheme: dark) {
   body { color: #ededed; background: #0a0a0a; }
-  .next-error-title { color: #ff6369; }
+  .next-error-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
+  .next-error-title { color: #ededed; }
   .next-error-message { color: #a0a0a0; }
-  .next-error-digest { color: #878787; }
-  .next-error-dev-hint { color: #878787; }
-  .next-error-icon-ring { stroke: #822025; }
-  .next-error-icon-fill { fill: #2a1314; }
-  .next-error-button { background: #e5484d; }
+  .next-error-message-hint { color: #707070; }
+  .next-error-digest { color: #606060; }
+  .next-error-digest-code { color: #707070; }
+  .next-error-digest-hint { color: #505050; }
+  .next-error-digest-container { border-color: rgba(255,255,255,0.08); }
+  .next-error-icon-ring { stroke: #5c2121; }
+  .next-error-icon-fill { fill: #2a1618; }
+  .next-error-button { background: #1a1a1a; color: #ededed; border-color: #333; }
 }
 */
-const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-title{color:#ff6369}.next-error-message{color:#a0a0a0}.next-error-digest{color:#878787}.next-error-dev-hint{color:#878787}.next-error-icon-ring{stroke:#822025}.next-error-icon-fill{fill:#2a1314}.next-error-button{background:#e5484d}}`
+const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)}.next-error-title{color:#ededed}.next-error-message{color:#a0a0a0}.next-error-message-hint{color:#707070}.next-error-digest{color:#606060}.next-error-digest-code{color:#707070}.next-error-digest-hint{color:#505050}.next-error-digest-container{border-color:rgba(255,255,255,0.08)}.next-error-icon-ring{stroke:#5c2121}.next-error-icon-fill{fill:#2a1618}.next-error-button{background:#1a1a1a;color:#ededed;border-color:#333}}`
 
 function ErrorIcon() {
   return (
     <svg
-      width="48"
-      height="48"
-      viewBox="0 0 48 48"
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
       fill="none"
       style={styles.icon}
     >
       <circle
         className="next-error-icon-ring"
-        cx="24"
-        cy="24"
-        r="23"
+        cx="20"
+        cy="20"
+        r="19"
         stroke="#fecaca"
         strokeWidth="2"
       />
       <circle
         className="next-error-icon-fill"
-        cx="24"
-        cy="24"
-        r="20"
+        cx="20"
+        cy="20"
+        r="16"
         fill="#fef2f2"
       />
       <path
-        d="M24 14v12M24 30v4"
+        d="M20 11v10M20 25v3"
         stroke="#dc2626"
-        strokeWidth="3"
+        strokeWidth="2.5"
         strokeLinecap="round"
       />
     </svg>
@@ -115,7 +138,6 @@ export type GlobalErrorComponent = React.ComponentType<{
 
 function DefaultGlobalError({ error }: { error: any }) {
   const digest: string | undefined = error?.digest
-  const isServerError = !!digest
 
   return (
     <html id="__next_error__">
@@ -125,32 +147,46 @@ function DefaultGlobalError({ error }: { error: any }) {
       <body>
         <HandleISRError error={error} />
         <div style={styles.container}>
-          <div style={styles.content}>
+          <div className="next-error-card" style={styles.card}>
             <ErrorIcon />
             <h1 className="next-error-title" style={styles.title}>
-              An Error Occurred
+              Something went wrong
             </h1>
             <p className="next-error-message" style={styles.message}>
-              Something went wrong. Please try again.
+              This page failed to load.
             </p>
-            {digest && (
-              <p className="next-error-digest" style={styles.digest}>
-                Error ID: {digest}
-              </p>
-            )}
+            <p className="next-error-message-hint" style={styles.messageHint}>
+              Reloading usually fixes this. If it keeps happening, the page may
+              be temporarily unavailable.
+            </p>
             <form>
               <button
                 className="next-error-button"
                 type="submit"
                 style={styles.button}
               >
-                Try Again
+                Reload page
               </button>
             </form>
-            <p className="next-error-dev-hint" style={styles.devHint}>
-              Developers: Check your{' '}
-              {isServerError ? 'server logs' : 'browser console'} for details.
-            </p>
+            {digest && (
+              <div
+                className="next-error-digest-container"
+                style={styles.digestContainer}
+              >
+                <p className="next-error-digest" style={styles.digest}>
+                  Error reference:{' '}
+                  <code
+                    className="next-error-digest-code"
+                    style={styles.digestCode}
+                  >
+                    {digest}
+                  </code>
+                </p>
+                <p className="next-error-digest-hint" style={styles.digestHint}>
+                  Include this if you contact support.
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </body>

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -1,144 +1,7 @@
 'use client'
 
 import { HandleISRError } from '../handle-isr-error'
-
-const styles = {
-  container: {
-    fontFamily:
-      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
-    height: '100vh',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  card: {
-    maxWidth: '420px',
-    padding: '32px 28px',
-    textAlign: 'left' as const,
-    borderRadius: '12px',
-    background: 'var(--next-error-card-bg)',
-    border: 'var(--next-error-card-border)',
-  },
-  icon: {
-    marginBottom: '16px',
-  },
-  title: {
-    fontSize: '17px',
-    fontWeight: 600,
-    letterSpacing: '-0.01em',
-    margin: '0 0 8px 0',
-    color: 'var(--next-error-title)',
-  },
-  message: {
-    fontSize: '14px',
-    fontWeight: 400,
-    lineHeight: 1.6,
-    margin: '0 0 6px 0',
-    color: 'var(--next-error-message)',
-  },
-  messageHint: {
-    fontSize: '13px',
-    fontWeight: 400,
-    lineHeight: 1.5,
-    margin: '0 0 20px 0',
-    color: 'var(--next-error-hint)',
-  },
-  button: {
-    padding: '10px 20px',
-    fontSize: '14px',
-    fontWeight: 500,
-    letterSpacing: '0.01em',
-    borderRadius: '6px',
-    cursor: 'pointer',
-    color: 'var(--next-error-btn-text)',
-    background: 'var(--next-error-btn-bg)',
-    border: 'var(--next-error-btn-border)',
-  },
-  digestContainer: {
-    marginTop: '20px',
-    paddingTop: '16px',
-    borderTop: 'var(--next-error-digest-border)',
-  },
-  digest: {
-    fontSize: '12px',
-    fontWeight: 400,
-    margin: '0',
-    color: 'var(--next-error-digest)',
-  },
-  digestCode: {
-    fontFamily:
-      'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
-    fontSize: '11px',
-    color: 'var(--next-error-digest-code)',
-    userSelect: 'all' as const,
-  },
-} as const
-
-/* CSS variables for theming */
-const themeCss = `
-:root {
-  --next-error-bg: #fff;
-  --next-error-text: #171717;
-  --next-error-card-bg: transparent;
-  --next-error-card-border: none;
-  --next-error-title: #171717;
-  --next-error-message: #666;
-  --next-error-hint: #888;
-  --next-error-digest: #999;
-  --next-error-digest-code: #888;
-  --next-error-digest-border: 1px solid rgba(0,0,0,0.06);
-  --next-error-btn-text: #171717;
-  --next-error-btn-bg: #fff;
-  --next-error-btn-border: 1px solid #e5e5e5;
-  --next-error-icon-ring: #fecaca;
-  --next-error-icon-fill: #fef2f2;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --next-error-bg: #0a0a0a;
-    --next-error-text: #ededed;
-    --next-error-title: #ededed;
-    --next-error-message: #a0a0a0;
-    --next-error-hint: #707070;
-    --next-error-digest: #606060;
-    --next-error-digest-code: #707070;
-    --next-error-digest-border: 1px solid rgba(255,255,255,0.08);
-    --next-error-btn-text: #ededed;
-    --next-error-btn-bg: #1a1a1a;
-    --next-error-btn-border: 1px solid #333;
-    --next-error-icon-ring: #5c2121;
-    --next-error-icon-fill: #2a1618;
-  }
-}
-body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
-`.replace(/\n\s*/g, '')
-
-function ErrorIcon() {
-  return (
-    <svg
-      width="40"
-      height="40"
-      viewBox="0 0 40 40"
-      fill="none"
-      style={styles.icon}
-    >
-      <circle
-        cx="20"
-        cy="20"
-        r="19"
-        stroke="var(--next-error-icon-ring)"
-        strokeWidth="2"
-      />
-      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
-      <path
-        d="M20 11v10M20 25v3"
-        stroke="#dc2626"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-      />
-    </svg>
-  )
-}
+import { errorStyles, errorThemeCss, ErrorIcon } from './error-styles'
 
 export type GlobalErrorComponent = React.ComponentType<{
   error: any
@@ -146,33 +9,63 @@ export type GlobalErrorComponent = React.ComponentType<{
 
 function DefaultGlobalError({ error }: { error: any }) {
   const digest: string | undefined = error?.digest
+  const isServerError = !!digest
+
+  // Server error: "This page failed to load"
+  // Client error: "This page crashed"
+  const title = isServerError ? 'This page failed to load' : 'This page crashed'
+  const message = isServerError
+    ? 'Something went wrong while loading this page.'
+    : 'An error occurred while running this page.'
+  const hint = isServerError
+    ? 'If this keeps happening, it may be a server issue.'
+    : null
 
   return (
     <html id="__next_error__">
       <head>
-        <style dangerouslySetInnerHTML={{ __html: themeCss }} />
+        <style dangerouslySetInnerHTML={{ __html: errorThemeCss }} />
       </head>
       <body>
         <HandleISRError error={error} />
-        <div style={styles.container}>
-          <div style={styles.card}>
+        <div style={errorStyles.container}>
+          <div style={errorStyles.card}>
             <ErrorIcon />
-            <h1 style={styles.title}>Something went wrong</h1>
-            <p style={styles.message}>This page failed to load.</p>
-            <p style={styles.messageHint}>
-              Reloading usually fixes this. If it keeps happening, the page may
-              be temporarily unavailable.
-            </p>
-            <form>
-              <button type="submit" style={styles.button}>
-                Reload page
-              </button>
-            </form>
+            <h1 style={errorStyles.title}>{title}</h1>
+            <p style={errorStyles.message}>{message}</p>
+            {hint && <p style={errorStyles.messageHint}>{hint}</p>}
+            {!isServerError && (
+              <p style={errorStyles.messageHint}>
+                Reloading usually fixes this.
+              </p>
+            )}
+            <div style={errorStyles.buttonGroup}>
+              <form>
+                <button type="submit" style={errorStyles.button}>
+                  Reload page
+                </button>
+              </form>
+              {!isServerError && (
+                <button
+                  type="button"
+                  style={errorStyles.buttonSecondary}
+                  onClick={() => {
+                    if (window.history.length > 1) {
+                      window.history.back()
+                    } else {
+                      window.location.href = '/'
+                    }
+                  }}
+                >
+                  Go back
+                </button>
+              )}
+            </div>
             {digest && (
-              <div style={styles.digestContainer}>
-                <p style={styles.digest}>
+              <div style={errorStyles.digestContainer}>
+                <p style={errorStyles.digest}>
                   Error reference:{' '}
-                  <code style={styles.digestCode}>{digest}</code>
+                  <code style={errorStyles.digestCode}>{digest}</code>
                 </p>
               </div>
             )}

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -23,20 +23,20 @@ const styles = {
     fontSize: '18px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#dc2626',
+    color: '#e5484d', // --color-red-700
     margin: '0 0 12px 0',
   },
   message: {
     fontSize: '15px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#64748b',
+    color: '#666666', // --color-gray-900
     margin: '0 0 16px 0',
   },
   digest: {
     fontSize: '13px',
     fontWeight: 400,
-    color: '#94a3b8',
+    color: '#8f8f8f', // --color-gray-700
     margin: '0 0 24px 0',
     fontFamily:
       'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
@@ -47,31 +47,33 @@ const styles = {
     fontWeight: 500,
     letterSpacing: '0.01em',
     color: '#fff',
-    backgroundColor: '#dc2626',
+    backgroundColor: '#e5484d', // --color-red-700
     border: 'none',
-    borderRadius: '8px',
+    borderRadius: '6px',
     cursor: 'pointer',
   },
   devHint: {
     fontSize: '12px',
     fontWeight: 400,
-    color: '#9ca3af',
+    color: '#8f8f8f', // --color-gray-700
     margin: '24px 0 0 0',
   },
 } as const
 
 /* CSS minified from
-body { margin: 0; color: #000; background: #fff; }
+body { margin: 0; color: #171717; background: #fff; }
 @media (prefers-color-scheme: dark) {
-  body { color: #fff; background: #0a0a0a; }
-  .next-error-message { color: #a1a1aa; }
-  .next-error-digest { color: #71717a; }
-  .next-error-dev-hint { color: #71717a; }
-  .next-error-icon-ring { stroke: #7f1d1d; }
-  .next-error-icon-fill { fill: #1c1917; }
+  body { color: #ededed; background: #0a0a0a; }
+  .next-error-title { color: #ff6369; }
+  .next-error-message { color: #a0a0a0; }
+  .next-error-digest { color: #878787; }
+  .next-error-dev-hint { color: #878787; }
+  .next-error-icon-ring { stroke: #822025; }
+  .next-error-icon-fill { fill: #2a1314; }
+  .next-error-button { background: #e5484d; }
 }
 */
-const themeCss = `body{margin:0;color:#000;background:#fff}@media(prefers-color-scheme:dark){body{color:#fff;background:#0a0a0a}.next-error-message{color:#a1a1aa}.next-error-digest{color:#71717a}.next-error-dev-hint{color:#71717a}.next-error-icon-ring{stroke:#7f1d1d}.next-error-icon-fill{fill:#1c1917}}`
+const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-title{color:#ff6369}.next-error-message{color:#a0a0a0}.next-error-digest{color:#878787}.next-error-dev-hint{color:#878787}.next-error-icon-ring{stroke:#822025}.next-error-icon-fill{fill:#2a1314}.next-error-button{background:#e5484d}}`
 
 function ErrorIcon() {
   return (
@@ -125,7 +127,9 @@ function DefaultGlobalError({ error }: { error: any }) {
         <div style={styles.container}>
           <div style={styles.content}>
             <ErrorIcon />
-            <h1 style={styles.title}>An Error Occurred</h1>
+            <h1 className="next-error-title" style={styles.title}>
+              An Error Occurred
+            </h1>
             <p className="next-error-message" style={styles.message}>
               Something went wrong. Please try again.
             </p>
@@ -135,7 +139,11 @@ function DefaultGlobalError({ error }: { error: any }) {
               </p>
             )}
             <form>
-              <button type="submit" style={styles.button}>
+              <button
+                className="next-error-button"
+                type="submit"
+                style={styles.button}
+              >
                 Try Again
               </button>
             </form>

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -3,44 +3,146 @@
 import { HandleISRError } from '../handle-isr-error'
 
 const styles = {
-  error: {
-    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
+  container: {
     fontFamily:
       'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
     height: '100vh',
-    textAlign: 'center',
     display: 'flex',
-    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    textAlign: 'center',
   },
-  text: {
-    fontSize: '14px',
+  content: {
+    maxWidth: '420px',
+    padding: '0 24px',
+  },
+  icon: {
+    marginBottom: '20px',
+  },
+  title: {
+    fontSize: '18px',
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+    color: '#dc2626',
+    margin: '0 0 12px 0',
+  },
+  message: {
+    fontSize: '15px',
     fontWeight: 400,
-    lineHeight: '28px',
-    margin: '0 8px',
+    lineHeight: 1.6,
+    color: '#64748b',
+    margin: '0 0 16px 0',
+  },
+  digest: {
+    fontSize: '13px',
+    fontWeight: 400,
+    color: '#94a3b8',
+    margin: '0 0 24px 0',
+    fontFamily:
+      'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
+  },
+  button: {
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    color: '#fff',
+    backgroundColor: '#dc2626',
+    border: 'none',
+    borderRadius: '8px',
+    cursor: 'pointer',
+  },
+  devHint: {
+    fontSize: '12px',
+    fontWeight: 400,
+    color: '#9ca3af',
+    margin: '24px 0 0 0',
   },
 } as const
+
+/* CSS minified from
+body { margin: 0; color: #000; background: #fff; }
+@media (prefers-color-scheme: dark) {
+  body { color: #fff; background: #0a0a0a; }
+  .next-error-message { color: #a1a1aa; }
+  .next-error-digest { color: #71717a; }
+  .next-error-dev-hint { color: #71717a; }
+  .next-error-icon-ring { stroke: #7f1d1d; }
+  .next-error-icon-fill { fill: #1c1917; }
+}
+*/
+const themeCss = `body{margin:0;color:#000;background:#fff}@media(prefers-color-scheme:dark){body{color:#fff;background:#0a0a0a}.next-error-message{color:#a1a1aa}.next-error-digest{color:#71717a}.next-error-dev-hint{color:#71717a}.next-error-icon-ring{stroke:#7f1d1d}.next-error-icon-fill{fill:#1c1917}}`
+
+function ErrorIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      style={styles.icon}
+    >
+      <circle
+        className="next-error-icon-ring"
+        cx="24"
+        cy="24"
+        r="23"
+        stroke="#fecaca"
+        strokeWidth="2"
+      />
+      <circle
+        className="next-error-icon-fill"
+        cx="24"
+        cy="24"
+        r="20"
+        fill="#fef2f2"
+      />
+      <path
+        d="M24 14v12M24 30v4"
+        stroke="#dc2626"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
+}
 
 export type GlobalErrorComponent = React.ComponentType<{
   error: any
 }>
+
 function DefaultGlobalError({ error }: { error: any }) {
   const digest: string | undefined = error?.digest
+  const isServerError = !!digest
+
   return (
     <html id="__next_error__">
-      <head></head>
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: themeCss }} />
+      </head>
       <body>
         <HandleISRError error={error} />
-        <div style={styles.error}>
-          <div>
-            <h2 style={styles.text}>
-              Application error: a {digest ? 'server' : 'client'}-side exception
-              has occurred while loading {window.location.hostname} (see the{' '}
-              {digest ? 'server logs' : 'browser console'} for more
-              information).
-            </h2>
-            {digest ? <p style={styles.text}>{`Digest: ${digest}`}</p> : null}
+        <div style={styles.container}>
+          <div style={styles.content}>
+            <ErrorIcon />
+            <h1 style={styles.title}>An Error Occurred</h1>
+            <p className="next-error-message" style={styles.message}>
+              Something went wrong. Please try again.
+            </p>
+            {digest && (
+              <p className="next-error-digest" style={styles.digest}>
+                Error ID: {digest}
+              </p>
+            )}
+            <button
+              style={styles.button}
+              onClick={() => window.location.reload()}
+            >
+              Try Again
+            </button>
+            <p className="next-error-dev-hint" style={styles.devHint}>
+              Developers: Check your {isServerError ? 'server logs' : 'browser console'} for details.
+            </p>
           </div>
         </div>
       </body>

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -15,8 +15,9 @@ const styles = {
     maxWidth: '420px',
     padding: '32px 28px',
     textAlign: 'left' as const,
-    backgroundColor: 'rgba(255,255,255,0.03)',
     borderRadius: '12px',
+    background: 'var(--next-error-card-bg)',
+    border: 'var(--next-error-card-border)',
   },
   icon: {
     marginBottom: '16px',
@@ -25,78 +26,94 @@ const styles = {
     fontSize: '17px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#171717',
     margin: '0 0 8px 0',
+    color: 'var(--next-error-title)',
   },
   message: {
     fontSize: '14px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#666666',
     margin: '0 0 6px 0',
+    color: 'var(--next-error-message)',
   },
   messageHint: {
     fontSize: '13px',
     fontWeight: 400,
     lineHeight: 1.5,
-    color: '#8f8f8f',
     margin: '0 0 20px 0',
+    color: 'var(--next-error-hint)',
   },
   button: {
     padding: '10px 20px',
     fontSize: '14px',
     fontWeight: 500,
     letterSpacing: '0.01em',
-    color: '#171717',
-    backgroundColor: '#fff',
-    border: '1px solid #e5e5e5',
     borderRadius: '6px',
     cursor: 'pointer',
+    color: 'var(--next-error-btn-text)',
+    background: 'var(--next-error-btn-bg)',
+    border: 'var(--next-error-btn-border)',
   },
   digestContainer: {
     marginTop: '20px',
     paddingTop: '16px',
-    borderTop: '1px solid rgba(0,0,0,0.06)',
+    borderTop: 'var(--next-error-digest-border)',
   },
   digest: {
     fontSize: '12px',
     fontWeight: 400,
-    color: '#a0a0a0',
-    margin: '0 0 2px 0',
+    margin: '0',
+    color: 'var(--next-error-digest)',
   },
   digestCode: {
     fontFamily:
       'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
     fontSize: '11px',
-    color: '#8f8f8f',
+    color: 'var(--next-error-digest-code)',
     userSelect: 'all' as const,
-  },
-  digestHint: {
-    fontSize: '11px',
-    fontWeight: 400,
-    color: '#b0b0b0',
-    margin: '4px 0 0 0',
   },
 } as const
 
-/* CSS minified from
-body { margin: 0; color: #171717; background: #fff; }
-@media (prefers-color-scheme: dark) {
-  body { color: #ededed; background: #0a0a0a; }
-  .next-error-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
-  .next-error-title { color: #ededed; }
-  .next-error-message { color: #a0a0a0; }
-  .next-error-message-hint { color: #707070; }
-  .next-error-digest { color: #606060; }
-  .next-error-digest-code { color: #707070; }
-  .next-error-digest-hint { color: #505050; }
-  .next-error-digest-container { border-color: rgba(255,255,255,0.08); }
-  .next-error-icon-ring { stroke: #5c2121; }
-  .next-error-icon-fill { fill: #2a1618; }
-  .next-error-button { background: #1a1a1a; color: #ededed; border-color: #333; }
+/* CSS variables for theming */
+const themeCss = `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-card-bg: transparent;
+  --next-error-card-border: none;
+  --next-error-title: #171717;
+  --next-error-message: #666;
+  --next-error-hint: #888;
+  --next-error-digest: #999;
+  --next-error-digest-code: #888;
+  --next-error-digest-border: 1px solid rgba(0,0,0,0.06);
+  --next-error-btn-text: #171717;
+  --next-error-btn-bg: #fff;
+  --next-error-btn-border: 1px solid #e5e5e5;
+  --next-error-icon-ring: #fecaca;
+  --next-error-icon-fill: #fef2f2;
 }
-*/
-const themeCss = `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)}.next-error-title{color:#ededed}.next-error-message{color:#a0a0a0}.next-error-message-hint{color:#707070}.next-error-digest{color:#606060}.next-error-digest-code{color:#707070}.next-error-digest-hint{color:#505050}.next-error-digest-container{border-color:rgba(255,255,255,0.08)}.next-error-icon-ring{stroke:#5c2121}.next-error-icon-fill{fill:#2a1618}.next-error-button{background:#1a1a1a;color:#ededed;border-color:#333}}`
+@media (prefers-color-scheme: dark) {
+  :root {
+    --next-error-bg: #0a0a0a;
+    --next-error-text: #ededed;
+    --next-error-card-bg: rgba(255,255,255,0.04);
+    --next-error-card-border: 1px solid rgba(255,255,255,0.08);
+    --next-error-title: #ededed;
+    --next-error-message: #a0a0a0;
+    --next-error-hint: #707070;
+    --next-error-digest: #606060;
+    --next-error-digest-code: #707070;
+    --next-error-digest-border: 1px solid rgba(255,255,255,0.08);
+    --next-error-btn-text: #ededed;
+    --next-error-btn-bg: #1a1a1a;
+    --next-error-btn-border: 1px solid #333;
+    --next-error-icon-ring: #5c2121;
+    --next-error-icon-fill: #2a1618;
+  }
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, '')
 
 function ErrorIcon() {
   return (
@@ -108,20 +125,13 @@ function ErrorIcon() {
       style={styles.icon}
     >
       <circle
-        className="next-error-icon-ring"
         cx="20"
         cy="20"
         r="19"
-        stroke="#fecaca"
+        stroke="var(--next-error-icon-ring)"
         strokeWidth="2"
       />
-      <circle
-        className="next-error-icon-fill"
-        cx="20"
-        cy="20"
-        r="16"
-        fill="#fef2f2"
-      />
+      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
       <path
         d="M20 11v10M20 25v3"
         stroke="#dc2626"
@@ -147,43 +157,24 @@ function DefaultGlobalError({ error }: { error: any }) {
       <body>
         <HandleISRError error={error} />
         <div style={styles.container}>
-          <div className="next-error-card" style={styles.card}>
+          <div style={styles.card}>
             <ErrorIcon />
-            <h1 className="next-error-title" style={styles.title}>
-              Something went wrong
-            </h1>
-            <p className="next-error-message" style={styles.message}>
-              This page failed to load.
-            </p>
-            <p className="next-error-message-hint" style={styles.messageHint}>
+            <h1 style={styles.title}>Something went wrong</h1>
+            <p style={styles.message}>This page failed to load.</p>
+            <p style={styles.messageHint}>
               Reloading usually fixes this. If it keeps happening, the page may
               be temporarily unavailable.
             </p>
             <form>
-              <button
-                className="next-error-button"
-                type="submit"
-                style={styles.button}
-              >
+              <button type="submit" style={styles.button}>
                 Reload page
               </button>
             </form>
             {digest && (
-              <div
-                className="next-error-digest-container"
-                style={styles.digestContainer}
-              >
-                <p className="next-error-digest" style={styles.digest}>
+              <div style={styles.digestContainer}>
+                <p style={styles.digest}>
                   Error reference:{' '}
-                  <code
-                    className="next-error-digest-code"
-                    style={styles.digestCode}
-                  >
-                    {digest}
-                  </code>
-                </p>
-                <p className="next-error-digest-hint" style={styles.digestHint}>
-                  Include this if you contact support.
+                  <code style={styles.digestCode}>{digest}</code>
                 </p>
               </div>
             )}

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -97,8 +97,6 @@ const themeCss = `
   :root {
     --next-error-bg: #0a0a0a;
     --next-error-text: #ededed;
-    --next-error-card-bg: rgba(255,255,255,0.04);
-    --next-error-card-border: 1px solid rgba(255,255,255,0.08);
     --next-error-title: #ededed;
     --next-error-message: #a0a0a0;
     --next-error-hint: #707070;

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -134,14 +134,14 @@ function DefaultGlobalError({ error }: { error: any }) {
                 Error ID: {digest}
               </p>
             )}
-            <button
-              style={styles.button}
-              onClick={() => window.location.reload()}
-            >
-              Try Again
-            </button>
+            <form>
+              <button type="submit" style={styles.button}>
+                Try Again
+              </button>
+            </form>
             <p className="next-error-dev-hint" style={styles.devHint}>
-              Developers: Check your {isServerError ? 'server logs' : 'browser console'} for details.
+              Developers: Check your{' '}
+              {isServerError ? 'server logs' : 'browser console'} for details.
             </p>
           </div>
         </div>

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -70,14 +70,14 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '18px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#dc2626',
+    color: '#e5484d', // --color-red-700
     margin: '0 0 12px 0',
   },
   message: {
     fontSize: '15px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#64748b',
+    color: '#666666', // --color-gray-900
     margin: '0 0 24px 0',
   },
   button: {
@@ -86,15 +86,15 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     letterSpacing: '0.01em',
     color: '#fff',
-    backgroundColor: '#dc2626',
+    backgroundColor: '#e5484d', // --color-red-700
     border: 'none',
-    borderRadius: '8px',
+    borderRadius: '6px',
     cursor: 'pointer',
   },
   devHint: {
     fontSize: '12px',
     fontWeight: 400,
-    color: '#9ca3af',
+    color: '#8f8f8f', // --color-gray-700
     margin: '24px 0 0 0',
   },
 }
@@ -151,18 +151,20 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
     const isClientError = !statusCode
 
     /* CSS minified from
-      body { margin: 0; color: #000; background: #fff; }
+      body { margin: 0; color: #171717; background: #fff; }
       @media (prefers-color-scheme: dark) {
-        body { color: #fff; background: #0a0a0a; }
-        .next-error-message { color: #a1a1aa; }
-        .next-error-dev-hint { color: #71717a; }
-        .next-error-icon-ring { stroke: #7f1d1d; }
-        .next-error-icon-fill { fill: #1c1917; }
+        body { color: #ededed; background: #0a0a0a; }
+        .next-error-title { color: #ff6369; }
+        .next-error-message { color: #a0a0a0; }
+        .next-error-dev-hint { color: #878787; }
+        .next-error-icon-ring { stroke: #822025; }
+        .next-error-icon-fill { fill: #2a1314; }
+        .next-error-button { background: #e5484d; }
       }
     */
     const themeCss = withDarkMode
-      ? `body{margin:0;color:#000;background:#fff}@media(prefers-color-scheme:dark){body{color:#fff;background:#0a0a0a}.next-error-message{color:#a1a1aa}.next-error-dev-hint{color:#71717a}.next-error-icon-ring{stroke:#7f1d1d}.next-error-icon-fill{fill:#1c1917}}`
-      : `body{margin:0;color:#000;background:#fff}`
+      ? `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-title{color:#ff6369}.next-error-message{color:#a0a0a0}.next-error-dev-hint{color:#878787}.next-error-icon-ring{stroke:#822025}.next-error-icon-fill{fill:#2a1314}.next-error-button{background:#e5484d}}`
+      : `body{margin:0;color:#171717;background:#fff}`
 
     return (
       <div style={styles.container}>
@@ -174,12 +176,18 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
         <style dangerouslySetInnerHTML={{ __html: themeCss }} />
         <div style={styles.content}>
           <ErrorIcon />
-          <h1 style={styles.title}>{title}</h1>
+          <h1 className="next-error-title" style={styles.title}>
+            {title}
+          </h1>
           <p className="next-error-message" style={styles.message}>
             {message}
           </p>
           <form>
-            <button type="submit" style={styles.button}>
+            <button
+              className="next-error-button"
+              type="submit"
+              style={styles.button}
+            >
               Try Again
             </button>
           </form>

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -9,6 +9,13 @@ const statusCodes: { [code: number]: string } = {
   500: 'Internal Server Error',
 }
 
+const statusMessages: { [code: number]: string } = {
+  400: 'The request could not be understood by the server.',
+  404: 'The page you are looking for does not exist.',
+  405: 'The request method is not supported.',
+  500: 'The server encountered an error. Please try again later.',
+}
+
 export type ErrorProps = {
   statusCode: number
   hostname?: string
@@ -43,36 +50,87 @@ function _getInitialProps({
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  error: {
-    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
+  container: {
     fontFamily:
       'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
     height: '100vh',
-    textAlign: 'center',
     display: 'flex',
-    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
+    textAlign: 'center',
   },
-  desc: {
-    lineHeight: '48px',
+  content: {
+    maxWidth: '420px',
+    padding: '0 24px',
   },
-  h1: {
-    display: 'inline-block',
-    margin: '0 20px 0 0',
-    paddingRight: 23,
-    fontSize: 24,
-    fontWeight: 500,
-    verticalAlign: 'top',
+  icon: {
+    marginBottom: '20px',
   },
-  h2: {
-    fontSize: 14,
+  title: {
+    fontSize: '18px',
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+    color: '#dc2626',
+    margin: '0 0 12px 0',
+  },
+  message: {
+    fontSize: '15px',
     fontWeight: 400,
-    lineHeight: '28px',
+    lineHeight: 1.6,
+    color: '#64748b',
+    margin: '0 0 24px 0',
   },
-  wrap: {
-    display: 'inline-block',
+  button: {
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    color: '#fff',
+    backgroundColor: '#dc2626',
+    border: 'none',
+    borderRadius: '8px',
+    cursor: 'pointer',
   },
+  devHint: {
+    fontSize: '12px',
+    fontWeight: 400,
+    color: '#9ca3af',
+    margin: '24px 0 0 0',
+  },
+}
+
+function ErrorIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      style={styles.icon}
+    >
+      <circle
+        className="next-error-icon-ring"
+        cx="24"
+        cy="24"
+        r="23"
+        stroke="#fecaca"
+        strokeWidth="2"
+      />
+      <circle
+        className="next-error-icon-fill"
+        cx="24"
+        cy="24"
+        r="20"
+        fill="#fef2f2"
+      />
+      <path
+        d="M24 14v12M24 30v4"
+        stroke="#dc2626"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+    </svg>
+  )
 }
 
 /**
@@ -84,71 +142,60 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   static getInitialProps = _getInitialProps
   static origGetInitialProps = _getInitialProps
 
+  handleRetry = () => {
+    if (typeof window !== 'undefined') {
+      window.location.reload()
+    }
+  }
+
   render() {
     const { statusCode, withDarkMode = true } = this.props
     const title =
       this.props.title ||
       statusCodes[statusCode] ||
-      'An unexpected error has occurred'
+      'An Error Occurred'
+    const message =
+      statusMessages[statusCode] ||
+      'Something went wrong. Please try again.'
+    const isClientError = !statusCode
+
+    /* CSS minified from
+      body { margin: 0; color: #000; background: #fff; }
+      @media (prefers-color-scheme: dark) {
+        body { color: #fff; background: #0a0a0a; }
+        .next-error-message { color: #a1a1aa; }
+        .next-error-dev-hint { color: #71717a; }
+        .next-error-icon-ring { stroke: #7f1d1d; }
+        .next-error-icon-fill { fill: #1c1917; }
+      }
+    */
+    const themeCss = withDarkMode
+      ? `body{margin:0;color:#000;background:#fff}@media(prefers-color-scheme:dark){body{color:#fff;background:#0a0a0a}.next-error-message{color:#a1a1aa}.next-error-dev-hint{color:#71717a}.next-error-icon-ring{stroke:#7f1d1d}.next-error-icon-fill{fill:#1c1917}}`
+      : `body{margin:0;color:#000;background:#fff}`
 
     return (
-      <div style={styles.error}>
+      <div style={styles.container}>
         <Head>
           <title>
             {statusCode
               ? `${statusCode}: ${title}`
-              : 'Application error: a client-side exception has occurred'}
+              : 'An Error Occurred'}
           </title>
         </Head>
-        <div style={styles.desc}>
-          <style
-            dangerouslySetInnerHTML={{
-              /* CSS minified from
-                body { margin: 0; color: #000; background: #fff; }
-                .next-error-h1 {
-                  border-right: 1px solid rgba(0, 0, 0, .3);
-                }
-
-                ${
-                  withDarkMode
-                    ? `@media (prefers-color-scheme: dark) {
-                  body { color: #fff; background: #000; }
-                  .next-error-h1 {
-                    border-right: 1px solid rgba(255, 255, 255, .3);
-                  }
-                }`
-                    : ''
-                }
-               */
-              __html: `body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}${
-                withDarkMode
-                  ? '@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}'
-                  : ''
-              }`,
-            }}
-          />
-
-          {statusCode ? (
-            <h1 className="next-error-h1" style={styles.h1}>
-              {statusCode}
-            </h1>
-          ) : null}
-          <div style={styles.wrap}>
-            <h2 style={styles.h2}>
-              {this.props.title || statusCode ? (
-                title
-              ) : (
-                <>
-                  Application error: a client-side exception has occurred{' '}
-                  {Boolean(this.props.hostname) && (
-                    <>while loading {this.props.hostname}</>
-                  )}{' '}
-                  (see the browser console for more information)
-                </>
-              )}
-              .
-            </h2>
-          </div>
+        <style dangerouslySetInnerHTML={{ __html: themeCss }} />
+        <div style={styles.content}>
+          <ErrorIcon />
+          <h1 style={styles.title}>{title}</h1>
+          <p className="next-error-message" style={styles.message}>
+            {message}
+          </p>
+          <button style={styles.button} onClick={this.handleRetry}>
+            Try Again
+          </button>
+          <p className="next-error-dev-hint" style={styles.devHint}>
+            Developers: Check your{' '}
+            {isClientError ? 'browser console' : 'server logs'} for details.
+          </p>
         </div>
       </div>
     )

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -13,7 +13,7 @@ const statusMessages: { [code: number]: string } = {
   400: 'The request could not be understood by the server.',
   404: 'The page you are looking for does not exist.',
   405: 'The request method is not supported.',
-  500: 'The server encountered an error. Please try again later.',
+  500: 'The server encountered an error.',
 }
 
 export type ErrorProps = {
@@ -57,76 +57,79 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    textAlign: 'center',
   },
-  content: {
+  card: {
     maxWidth: '420px',
-    padding: '0 24px',
+    padding: '32px 28px',
+    textAlign: 'left',
+    backgroundColor: 'rgba(255,255,255,0.03)',
+    borderRadius: '12px',
   },
   icon: {
-    marginBottom: '20px',
+    marginBottom: '16px',
   },
   title: {
-    fontSize: '18px',
+    fontSize: '17px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#e5484d', // --color-red-700
-    margin: '0 0 12px 0',
+    color: '#171717',
+    margin: '0 0 8px 0',
   },
   message: {
-    fontSize: '15px',
+    fontSize: '14px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#666666', // --color-gray-900
-    margin: '0 0 24px 0',
+    color: '#666666',
+    margin: '0 0 6px 0',
+  },
+  messageHint: {
+    fontSize: '13px',
+    fontWeight: 400,
+    lineHeight: 1.5,
+    color: '#8f8f8f',
+    margin: '0 0 20px 0',
   },
   button: {
     padding: '10px 20px',
     fontSize: '14px',
     fontWeight: 500,
     letterSpacing: '0.01em',
-    color: '#fff',
-    backgroundColor: '#e5484d', // --color-red-700
-    border: 'none',
+    color: '#171717',
+    backgroundColor: '#fff',
+    border: '1px solid #e5e5e5',
     borderRadius: '6px',
     cursor: 'pointer',
-  },
-  devHint: {
-    fontSize: '12px',
-    fontWeight: 400,
-    color: '#8f8f8f', // --color-gray-700
-    margin: '24px 0 0 0',
   },
 }
 
 function ErrorIcon() {
   return (
     <svg
-      width="48"
-      height="48"
-      viewBox="0 0 48 48"
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
       fill="none"
       style={styles.icon}
     >
       <circle
         className="next-error-icon-ring"
-        cx="24"
-        cy="24"
-        r="23"
+        cx="20"
+        cy="20"
+        r="19"
         stroke="#fecaca"
         strokeWidth="2"
       />
       <circle
         className="next-error-icon-fill"
-        cx="24"
-        cy="24"
-        r="20"
+        cx="20"
+        cy="20"
+        r="16"
         fill="#fef2f2"
       />
       <path
-        d="M24 14v12M24 30v4"
+        d="M20 11v10M20 25v3"
         stroke="#dc2626"
-        strokeWidth="3"
+        strokeWidth="2.5"
         strokeLinecap="round"
       />
     </svg>
@@ -145,36 +148,35 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   render() {
     const { statusCode, withDarkMode = true } = this.props
     const title =
-      this.props.title || statusCodes[statusCode] || 'An Error Occurred'
-    const message =
-      statusMessages[statusCode] || 'Something went wrong. Please try again.'
-    const isClientError = !statusCode
+      this.props.title || statusCodes[statusCode] || 'Something went wrong'
+    const message = statusMessages[statusCode] || 'This page failed to load.'
 
     /* CSS minified from
       body { margin: 0; color: #171717; background: #fff; }
       @media (prefers-color-scheme: dark) {
         body { color: #ededed; background: #0a0a0a; }
-        .next-error-title { color: #ff6369; }
+        .next-error-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
+        .next-error-title { color: #ededed; }
         .next-error-message { color: #a0a0a0; }
-        .next-error-dev-hint { color: #878787; }
-        .next-error-icon-ring { stroke: #822025; }
-        .next-error-icon-fill { fill: #2a1314; }
-        .next-error-button { background: #e5484d; }
+        .next-error-message-hint { color: #707070; }
+        .next-error-icon-ring { stroke: #5c2121; }
+        .next-error-icon-fill { fill: #2a1618; }
+        .next-error-button { background: #1a1a1a; color: #ededed; border-color: #333; }
       }
     */
     const themeCss = withDarkMode
-      ? `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-title{color:#ff6369}.next-error-message{color:#a0a0a0}.next-error-dev-hint{color:#878787}.next-error-icon-ring{stroke:#822025}.next-error-icon-fill{fill:#2a1314}.next-error-button{background:#e5484d}}`
+      ? `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)}.next-error-title{color:#ededed}.next-error-message{color:#a0a0a0}.next-error-message-hint{color:#707070}.next-error-icon-ring{stroke:#5c2121}.next-error-icon-fill{fill:#2a1618}.next-error-button{background:#1a1a1a;color:#ededed;border-color:#333}}`
       : `body{margin:0;color:#171717;background:#fff}`
 
     return (
       <div style={styles.container}>
         <Head>
           <title>
-            {statusCode ? `${statusCode}: ${title}` : 'An Error Occurred'}
+            {statusCode ? `${statusCode}: ${title}` : 'Something went wrong'}
           </title>
         </Head>
         <style dangerouslySetInnerHTML={{ __html: themeCss }} />
-        <div style={styles.content}>
+        <div className="next-error-card" style={styles.card}>
           <ErrorIcon />
           <h1 className="next-error-title" style={styles.title}>
             {title}
@@ -182,19 +184,19 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
           <p className="next-error-message" style={styles.message}>
             {message}
           </p>
+          <p className="next-error-message-hint" style={styles.messageHint}>
+            Reloading usually fixes this. If it keeps happening, the page may be
+            temporarily unavailable.
+          </p>
           <form>
             <button
               className="next-error-button"
               type="submit"
               style={styles.button}
             >
-              Try Again
+              Reload page
             </button>
           </form>
-          <p className="next-error-dev-hint" style={styles.devHint}>
-            Developers: Check your{' '}
-            {isClientError ? 'browser console' : 'server logs'} for details.
-          </p>
         </div>
       </div>
     )

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -166,8 +166,6 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   :root {
     --next-error-bg: #0a0a0a;
     --next-error-text: #ededed;
-    --next-error-card-bg: rgba(255,255,255,0.04);
-    --next-error-card-border: 1px solid rgba(255,255,255,0.08);
     --next-error-title: #ededed;
     --next-error-message: #a0a0a0;
     --next-error-hint: #707070;

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -9,13 +9,6 @@ const statusCodes: { [code: number]: string } = {
   500: 'Internal Server Error',
 }
 
-const statusMessages: { [code: number]: string } = {
-  400: 'The request could not be understood by the server.',
-  404: 'The page you are looking for does not exist.',
-  405: 'The request method is not supported.',
-  500: 'The server encountered an error.',
-}
-
 export type ErrorProps = {
   statusCode: number
   hostname?: string
@@ -50,84 +43,36 @@ function _getInitialProps({
 }
 
 const styles: Record<string, React.CSSProperties> = {
-  container: {
+  error: {
+    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
     fontFamily:
       'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
     height: '100vh',
+    textAlign: 'center',
     display: 'flex',
+    flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
   },
-  card: {
-    maxWidth: '420px',
-    padding: '32px 28px',
-    textAlign: 'left',
-    borderRadius: '12px',
-    background: 'var(--next-error-card-bg)',
-    border: 'var(--next-error-card-border)',
+  desc: {
+    lineHeight: '48px',
   },
-  icon: {
-    marginBottom: '16px',
-  },
-  title: {
-    fontSize: '17px',
-    fontWeight: 600,
-    letterSpacing: '-0.01em',
-    margin: '0 0 8px 0',
-    color: 'var(--next-error-title)',
-  },
-  message: {
-    fontSize: '14px',
-    fontWeight: 400,
-    lineHeight: 1.6,
-    margin: '0 0 6px 0',
-    color: 'var(--next-error-message)',
-  },
-  messageHint: {
-    fontSize: '13px',
-    fontWeight: 400,
-    lineHeight: 1.5,
-    margin: '0 0 20px 0',
-    color: 'var(--next-error-hint)',
-  },
-  button: {
-    padding: '10px 20px',
-    fontSize: '14px',
+  h1: {
+    display: 'inline-block',
+    margin: '0 20px 0 0',
+    paddingRight: 23,
+    fontSize: 24,
     fontWeight: 500,
-    letterSpacing: '0.01em',
-    borderRadius: '6px',
-    cursor: 'pointer',
-    color: 'var(--next-error-btn-text)',
-    background: 'var(--next-error-btn-bg)',
-    border: 'var(--next-error-btn-border)',
+    verticalAlign: 'top',
   },
-}
-
-function ErrorIcon() {
-  return (
-    <svg
-      width="40"
-      height="40"
-      viewBox="0 0 40 40"
-      fill="none"
-      style={styles.icon}
-    >
-      <circle
-        cx="20"
-        cy="20"
-        r="19"
-        stroke="var(--next-error-icon-ring)"
-        strokeWidth="2"
-      />
-      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
-      <path
-        d="M20 11v10M20 25v3"
-        stroke="#dc2626"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-      />
-    </svg>
-  )
+  h2: {
+    fontSize: 14,
+    fontWeight: 400,
+    lineHeight: '28px',
+  },
+  wrap: {
+    display: 'inline-block',
+  },
 }
 
 /**
@@ -142,81 +87,68 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   render() {
     const { statusCode, withDarkMode = true } = this.props
     const title =
-      this.props.title || statusCodes[statusCode] || 'Something went wrong'
-    const message = statusMessages[statusCode] || 'This page failed to load.'
-
-    /* CSS variables for theming */
-    const themeCss = withDarkMode
-      ? `
-:root {
-  --next-error-bg: #fff;
-  --next-error-text: #171717;
-  --next-error-card-bg: transparent;
-  --next-error-card-border: none;
-  --next-error-title: #171717;
-  --next-error-message: #666;
-  --next-error-hint: #888;
-  --next-error-btn-text: #171717;
-  --next-error-btn-bg: #fff;
-  --next-error-btn-border: 1px solid #e5e5e5;
-  --next-error-icon-ring: #fecaca;
-  --next-error-icon-fill: #fef2f2;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --next-error-bg: #0a0a0a;
-    --next-error-text: #ededed;
-    --next-error-title: #ededed;
-    --next-error-message: #a0a0a0;
-    --next-error-hint: #707070;
-    --next-error-btn-text: #ededed;
-    --next-error-btn-bg: #1a1a1a;
-    --next-error-btn-border: 1px solid #333;
-    --next-error-icon-ring: #5c2121;
-    --next-error-icon-fill: #2a1618;
-  }
-}
-body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
-`.replace(/\n\s*/g, '')
-      : `
-:root {
-  --next-error-bg: #fff;
-  --next-error-text: #171717;
-  --next-error-card-bg: transparent;
-  --next-error-card-border: none;
-  --next-error-title: #171717;
-  --next-error-message: #666;
-  --next-error-hint: #888;
-  --next-error-btn-text: #171717;
-  --next-error-btn-bg: #fff;
-  --next-error-btn-border: 1px solid #e5e5e5;
-  --next-error-icon-ring: #fecaca;
-  --next-error-icon-fill: #fef2f2;
-}
-body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
-`.replace(/\n\s*/g, '')
+      this.props.title ||
+      statusCodes[statusCode] ||
+      'An unexpected error has occurred'
 
     return (
-      <div style={styles.container}>
+      <div style={styles.error}>
         <Head>
           <title>
-            {statusCode ? `${statusCode}: ${title}` : 'Something went wrong'}
+            {statusCode
+              ? `${statusCode}: ${title}`
+              : 'Application error: a client-side exception has occurred'}
           </title>
         </Head>
-        <style dangerouslySetInnerHTML={{ __html: themeCss }} />
-        <div style={styles.card}>
-          <ErrorIcon />
-          <h1 style={styles.title}>{title}</h1>
-          <p style={styles.message}>{message}</p>
-          <p style={styles.messageHint}>
-            Reloading usually fixes this. If it keeps happening, the page may be
-            temporarily unavailable.
-          </p>
-          <form>
-            <button type="submit" style={styles.button}>
-              Reload page
-            </button>
-          </form>
+        <div style={styles.desc}>
+          <style
+            dangerouslySetInnerHTML={{
+              /* CSS minified from
+                body { margin: 0; color: #000; background: #fff; }
+                .next-error-h1 {
+                  border-right: 1px solid rgba(0, 0, 0, .3);
+                }
+
+                ${
+                  withDarkMode
+                    ? `@media (prefers-color-scheme: dark) {
+                  body { color: #fff; background: #000; }
+                  .next-error-h1 {
+                    border-right: 1px solid rgba(255, 255, 255, .3);
+                  }
+                }`
+                    : ''
+                }
+               */
+              __html: `body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}${
+                withDarkMode
+                  ? '@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}'
+                  : ''
+              }`,
+            }}
+          />
+
+          {statusCode ? (
+            <h1 className="next-error-h1" style={styles.h1}>
+              {statusCode}
+            </h1>
+          ) : null}
+          <div style={styles.wrap}>
+            <h2 style={styles.h2}>
+              {this.props.title || statusCode ? (
+                title
+              ) : (
+                <>
+                  Application error: a client-side exception has occurred{' '}
+                  {Boolean(this.props.hostname) && (
+                    <>while loading {this.props.hostname}</>
+                  )}{' '}
+                  (see the browser console for more information)
+                </>
+              )}
+              .
+            </h2>
+          </div>
         </div>
       </div>
     )

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -62,8 +62,9 @@ const styles: Record<string, React.CSSProperties> = {
     maxWidth: '420px',
     padding: '32px 28px',
     textAlign: 'left',
-    backgroundColor: 'rgba(255,255,255,0.03)',
     borderRadius: '12px',
+    background: 'var(--next-error-card-bg)',
+    border: 'var(--next-error-card-border)',
   },
   icon: {
     marginBottom: '16px',
@@ -72,33 +73,33 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '17px',
     fontWeight: 600,
     letterSpacing: '-0.01em',
-    color: '#171717',
     margin: '0 0 8px 0',
+    color: 'var(--next-error-title)',
   },
   message: {
     fontSize: '14px',
     fontWeight: 400,
     lineHeight: 1.6,
-    color: '#666666',
     margin: '0 0 6px 0',
+    color: 'var(--next-error-message)',
   },
   messageHint: {
     fontSize: '13px',
     fontWeight: 400,
     lineHeight: 1.5,
-    color: '#8f8f8f',
     margin: '0 0 20px 0',
+    color: 'var(--next-error-hint)',
   },
   button: {
     padding: '10px 20px',
     fontSize: '14px',
     fontWeight: 500,
     letterSpacing: '0.01em',
-    color: '#171717',
-    backgroundColor: '#fff',
-    border: '1px solid #e5e5e5',
     borderRadius: '6px',
     cursor: 'pointer',
+    color: 'var(--next-error-btn-text)',
+    background: 'var(--next-error-btn-bg)',
+    border: 'var(--next-error-btn-border)',
   },
 }
 
@@ -112,20 +113,13 @@ function ErrorIcon() {
       style={styles.icon}
     >
       <circle
-        className="next-error-icon-ring"
         cx="20"
         cy="20"
         r="19"
-        stroke="#fecaca"
+        stroke="var(--next-error-icon-ring)"
         strokeWidth="2"
       />
-      <circle
-        className="next-error-icon-fill"
-        cx="20"
-        cy="20"
-        r="16"
-        fill="#fef2f2"
-      />
+      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
       <path
         d="M20 11v10M20 25v3"
         stroke="#dc2626"
@@ -151,22 +145,58 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
       this.props.title || statusCodes[statusCode] || 'Something went wrong'
     const message = statusMessages[statusCode] || 'This page failed to load.'
 
-    /* CSS minified from
-      body { margin: 0; color: #171717; background: #fff; }
-      @media (prefers-color-scheme: dark) {
-        body { color: #ededed; background: #0a0a0a; }
-        .next-error-card { background: rgba(255,255,255,0.04); border: 1px solid rgba(255,255,255,0.08); }
-        .next-error-title { color: #ededed; }
-        .next-error-message { color: #a0a0a0; }
-        .next-error-message-hint { color: #707070; }
-        .next-error-icon-ring { stroke: #5c2121; }
-        .next-error-icon-fill { fill: #2a1618; }
-        .next-error-button { background: #1a1a1a; color: #ededed; border-color: #333; }
-      }
-    */
+    /* CSS variables for theming */
     const themeCss = withDarkMode
-      ? `body{margin:0;color:#171717;background:#fff}@media(prefers-color-scheme:dark){body{color:#ededed;background:#0a0a0a}.next-error-card{background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08)}.next-error-title{color:#ededed}.next-error-message{color:#a0a0a0}.next-error-message-hint{color:#707070}.next-error-icon-ring{stroke:#5c2121}.next-error-icon-fill{fill:#2a1618}.next-error-button{background:#1a1a1a;color:#ededed;border-color:#333}}`
-      : `body{margin:0;color:#171717;background:#fff}`
+      ? `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-card-bg: transparent;
+  --next-error-card-border: none;
+  --next-error-title: #171717;
+  --next-error-message: #666;
+  --next-error-hint: #888;
+  --next-error-btn-text: #171717;
+  --next-error-btn-bg: #fff;
+  --next-error-btn-border: 1px solid #e5e5e5;
+  --next-error-icon-ring: #fecaca;
+  --next-error-icon-fill: #fef2f2;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --next-error-bg: #0a0a0a;
+    --next-error-text: #ededed;
+    --next-error-card-bg: rgba(255,255,255,0.04);
+    --next-error-card-border: 1px solid rgba(255,255,255,0.08);
+    --next-error-title: #ededed;
+    --next-error-message: #a0a0a0;
+    --next-error-hint: #707070;
+    --next-error-btn-text: #ededed;
+    --next-error-btn-bg: #1a1a1a;
+    --next-error-btn-border: 1px solid #333;
+    --next-error-icon-ring: #5c2121;
+    --next-error-icon-fill: #2a1618;
+  }
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, '')
+      : `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-card-bg: transparent;
+  --next-error-card-border: none;
+  --next-error-title: #171717;
+  --next-error-message: #666;
+  --next-error-hint: #888;
+  --next-error-btn-text: #171717;
+  --next-error-btn-bg: #fff;
+  --next-error-btn-border: 1px solid #e5e5e5;
+  --next-error-icon-ring: #fecaca;
+  --next-error-icon-fill: #fef2f2;
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, '')
 
     return (
       <div style={styles.container}>
@@ -176,24 +206,16 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
           </title>
         </Head>
         <style dangerouslySetInnerHTML={{ __html: themeCss }} />
-        <div className="next-error-card" style={styles.card}>
+        <div style={styles.card}>
           <ErrorIcon />
-          <h1 className="next-error-title" style={styles.title}>
-            {title}
-          </h1>
-          <p className="next-error-message" style={styles.message}>
-            {message}
-          </p>
-          <p className="next-error-message-hint" style={styles.messageHint}>
+          <h1 style={styles.title}>{title}</h1>
+          <p style={styles.message}>{message}</p>
+          <p style={styles.messageHint}>
             Reloading usually fixes this. If it keeps happening, the page may be
             temporarily unavailable.
           </p>
           <form>
-            <button
-              className="next-error-button"
-              type="submit"
-              style={styles.button}
-            >
+            <button type="submit" style={styles.button}>
               Reload page
             </button>
           </form>

--- a/packages/next/src/pages/_error.tsx
+++ b/packages/next/src/pages/_error.tsx
@@ -142,21 +142,12 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
   static getInitialProps = _getInitialProps
   static origGetInitialProps = _getInitialProps
 
-  handleRetry = () => {
-    if (typeof window !== 'undefined') {
-      window.location.reload()
-    }
-  }
-
   render() {
     const { statusCode, withDarkMode = true } = this.props
     const title =
-      this.props.title ||
-      statusCodes[statusCode] ||
-      'An Error Occurred'
+      this.props.title || statusCodes[statusCode] || 'An Error Occurred'
     const message =
-      statusMessages[statusCode] ||
-      'Something went wrong. Please try again.'
+      statusMessages[statusCode] || 'Something went wrong. Please try again.'
     const isClientError = !statusCode
 
     /* CSS minified from
@@ -177,9 +168,7 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
       <div style={styles.container}>
         <Head>
           <title>
-            {statusCode
-              ? `${statusCode}: ${title}`
-              : 'An Error Occurred'}
+            {statusCode ? `${statusCode}: ${title}` : 'An Error Occurred'}
           </title>
         </Head>
         <style dangerouslySetInnerHTML={{ __html: themeCss }} />
@@ -189,9 +178,11 @@ export default class Error<P = {}> extends React.Component<P & ErrorProps> {
           <p className="next-error-message" style={styles.message}>
             {message}
           </p>
-          <button style={styles.button} onClick={this.handleRetry}>
-            Try Again
-          </button>
+          <form>
+            <button type="submit" style={styles.button}>
+              Try Again
+            </button>
+          </form>
           <p className="next-error-dev-hint" style={styles.devHint}>
             Developers: Check your{' '}
             {isClientError ? 'browser console' : 'server logs'} for details.

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -38,9 +38,7 @@ describe('serialize-circular-error', () => {
     `)
 
     const bodyText = await browser.elementByCss('body').text()
-    expect(bodyText).toContain(
-      'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
-    )
+    expect(bodyText).toContain('This page crashed')
 
     const output = next.cliOutput
     expect(output).toContain(

--- a/test/e2e/app-dir/default-error-page-ui/app/layout.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/default-error-page-ui/app/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/page.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home Page</div>
+}

--- a/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
@@ -1,0 +1,3 @@
+export default function ServerErrorPage() {
+  throw new Error('Test server error')
+}

--- a/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
@@ -1,3 +1,6 @@
-export default function ServerErrorPage() {
+import { connection } from 'next/server'
+
+export default async function ServerErrorPage() {
+  await connection()
   throw new Error('Test server error')
 }

--- a/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
@@ -1,6 +1,15 @@
+import { Suspense } from 'react'
 import { connection } from 'next/server'
 
-export default async function ServerErrorPage() {
+async function ServerErrorContent() {
   await connection()
   throw new Error('Test server error')
+}
+
+export default function ServerErrorPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ServerErrorContent />
+    </Suspense>
+  )
 }

--- a/test/e2e/app-dir/default-error-page-ui/app/trigger-error/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/trigger-error/page.js
@@ -1,0 +1,20 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function TriggerErrorPage() {
+  const [shouldError, setShouldError] = useState(false)
+
+  if (shouldError) {
+    throw new Error('Test client error')
+  }
+
+  return (
+    <div>
+      <h1>Trigger Error Page</h1>
+      <button id="trigger-error" onClick={() => setShouldError(true)}>
+        Trigger Error
+      </button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+++ b/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
@@ -5,7 +5,7 @@ describe('app dir - default error page UI', () => {
     files: __dirname,
   })
 
-  it('should render the redesigned default error page with all UI elements', async () => {
+  it('should render client error page with correct UI elements', async () => {
     const browser = await next.browser('/trigger-error')
 
     // Trigger a client-side error
@@ -29,24 +29,27 @@ describe('app dir - default error page UI', () => {
       return
     }
 
-    // In production mode, verify the new error page UI elements
+    // In production mode, verify the client error page UI elements
 
     // Check that the SVG icon is present (40x40 size)
     const svgIcon = await browser.elementByCss('svg')
     expect(await svgIcon.getAttribute('width')).toBe('40')
     expect(await svgIcon.getAttribute('height')).toBe('40')
 
-    // Check the error title
+    // Check the error title - client errors show "This page crashed"
     const title = await browser.elementByCss('h1')
-    expect(await title.text()).toBe('Something went wrong')
+    expect(await title.text()).toBe('This page crashed')
 
-    // Check the error message
+    // Check the error message - client errors show "An error occurred while running this page."
     const message = await browser.elementByCss('p')
-    expect(await message.text()).toContain('failed to load')
+    expect(await message.text()).toContain('An error occurred while running')
 
     // Check the "Reload page" button exists
-    const button = await browser.elementByCss('button')
-    expect(await button.text()).toBe('Reload page')
+    const buttons = await browser.elementsByCss('button')
+    expect(await buttons[0].innerText()).toBe('Reload page')
+
+    // Check "Go back" button exists for client errors
+    expect(await buttons[1].innerText()).toBe('Go back')
 
     // Check the hint text about reloading
     const html = await browser.eval('document.documentElement.innerHTML')
@@ -106,7 +109,7 @@ describe('app dir - default error page UI', () => {
     expect(buttonBg).toContain('255')
   })
 
-  it('should display Error reference for server-side errors', async () => {
+  it('should display server error page with Error reference', async () => {
     const browser = await next.browser('/server-error')
 
     // Skip in dev mode (redbox overlay)
@@ -116,23 +119,31 @@ describe('app dir - default error page UI', () => {
          "description": "Test server error",
          "environmentLabel": "Server",
          "label": "Runtime Error",
-         "source": "app/server-error/page.js (2:9) @ ServerErrorPage
-       > 2 |   throw new Error('Test server error')
+         "source": "app/server-error/page.js (5:9) @ ServerErrorPage
+       > 5 |   throw new Error('Test server error')
            |         ^",
          "stack": [
-           "ServerErrorPage app/server-error/page.js (2:9)",
+           "ServerErrorPage app/server-error/page.js (5:9)",
          ],
        }
       `)
       return
     }
 
-    // In production mode, verify the error page shows Error reference
+    // In production mode, verify the server error page
     const html = await browser.eval('document.documentElement.innerHTML')
+
+    // Server errors show "This page failed to load"
+    expect(html).toContain('This page failed to load')
+
+    // Server errors show "Error reference:" with digest
     expect(html).toContain('Error reference:')
+
+    // Server errors show hint about server issue
+    expect(html).toContain('it may be a server issue')
   })
 
-  it('should have left-aligned text inside centered container', async () => {
+  it('should have left-aligned text in error page', async () => {
     const browser = await next.browser('/trigger-error')
 
     await browser.elementByCss('#trigger-error').click()
@@ -141,9 +152,9 @@ describe('app dir - default error page UI', () => {
       return
     }
 
-    // Check that the card has left text alignment
-    const card = await browser.elementByCss('.next-error-card')
-    const textAlign = await card.getComputedCss('text-align')
+    // Check that the h1 has left text alignment
+    const title = await browser.elementByCss('h1')
+    const textAlign = await title.getComputedCss('text-align')
     expect(textAlign).toBe('left')
   })
 })

--- a/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+++ b/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
@@ -119,11 +119,11 @@ describe('app dir - default error page UI', () => {
          "description": "Test server error",
          "environmentLabel": "Server",
          "label": "Runtime Error",
-         "source": "app/server-error/page.js (5:9) @ ServerErrorPage
-       > 5 |   throw new Error('Test server error')
+         "source": "app/server-error/page.js (6:9) @ ServerErrorContent
+       > 6 |   throw new Error('Test server error')
            |         ^",
          "stack": [
-           "ServerErrorPage app/server-error/page.js (5:9)",
+           "ServerErrorContent app/server-error/page.js (6:9)",
          ],
        }
       `)

--- a/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+++ b/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
@@ -31,30 +31,29 @@ describe('app dir - default error page UI', () => {
 
     // In production mode, verify the new error page UI elements
 
-    // Check that the SVG icon is present
+    // Check that the SVG icon is present (40x40 size)
     const svgIcon = await browser.elementByCss('svg')
-    expect(await svgIcon.getAttribute('width')).toBe('48')
-    expect(await svgIcon.getAttribute('height')).toBe('48')
+    expect(await svgIcon.getAttribute('width')).toBe('40')
+    expect(await svgIcon.getAttribute('height')).toBe('40')
 
     // Check the error title
     const title = await browser.elementByCss('h1')
-    expect(await title.text()).toBe('An Error Occurred')
+    expect(await title.text()).toBe('Something went wrong')
 
     // Check the error message
     const message = await browser.elementByCss('p')
-    expect(await message.text()).toContain('Something went wrong')
+    expect(await message.text()).toContain('failed to load')
 
-    // Check the "Try Again" button exists
+    // Check the "Reload page" button exists
     const button = await browser.elementByCss('button')
-    expect(await button.text()).toBe('Try Again')
+    expect(await button.text()).toBe('Reload page')
 
-    // Check the developer hint
+    // Check the hint text about reloading
     const html = await browser.eval('document.documentElement.innerHTML')
-    expect(html).toContain('Developers:')
-    expect(html).toContain('browser console')
+    expect(html).toContain('Reloading usually fixes this')
   })
 
-  it('should reload the page when Try Again button is clicked', async () => {
+  it('should reload the page when Reload page button is clicked', async () => {
     const browser = await next.browser('/trigger-error')
 
     // Trigger a client-side error
@@ -68,7 +67,7 @@ describe('app dir - default error page UI', () => {
     // Get the current URL
     const urlBefore = await browser.url()
 
-    // Click the Try Again button
+    // Click the Reload page button
     await browser.elementByCss('button').click()
 
     // Wait for page to reload (should be back to the trigger-error page)
@@ -94,21 +93,20 @@ describe('app dir - default error page UI', () => {
       return
     }
 
-    // Check that the title has red color
+    // Check that the title has neutral dark color (not red)
     const title = await browser.elementByCss('h1')
     const titleColor = await title.getComputedCss('color')
-    // #e5484d = rgb(229, 72, 77)
-    expect(titleColor).toContain('229')
-    expect(titleColor).toContain('72')
+    // In light mode: #171717 = rgb(23, 23, 23)
+    expect(titleColor).toContain('23')
 
-    // Check that the button has red background
+    // Check that the button has neutral styling (white background with border)
     const button = await browser.elementByCss('button')
     const buttonBg = await button.getComputedCss('background-color')
-    expect(buttonBg).toContain('229')
-    expect(buttonBg).toContain('72')
+    // White = rgb(255, 255, 255)
+    expect(buttonBg).toContain('255')
   })
 
-  it('should display Error ID for server-side errors', async () => {
+  it('should display Error reference for server-side errors', async () => {
     const browser = await next.browser('/server-error')
 
     // Skip in dev mode (redbox overlay)
@@ -129,32 +127,24 @@ describe('app dir - default error page UI', () => {
       return
     }
 
-    // In production mode, verify the error page shows Error ID
+    // In production mode, verify the error page shows Error reference
     const html = await browser.eval('document.documentElement.innerHTML')
-    expect(html).toContain('Error ID:')
-    expect(html).toContain('server logs')
+    expect(html).toContain('Error reference:')
+    expect(html).toContain('contact support')
   })
 
-  it('should show correct developer hint based on error type', async () => {
-    // Client-side error should mention "browser console"
-    const clientBrowser = await next.browser('/trigger-error')
-    await clientBrowser.elementByCss('#trigger-error').click()
+  it('should have left-aligned text inside centered container', async () => {
+    const browser = await next.browser('/trigger-error')
 
-    if (!isNextDev) {
-      const clientHtml = await clientBrowser.eval(
-        'document.documentElement.innerHTML'
-      )
-      expect(clientHtml).toContain('browser console')
+    await browser.elementByCss('#trigger-error').click()
+
+    if (isNextDev) {
+      return
     }
 
-    // Server-side error should mention "server logs"
-    const serverBrowser = await next.browser('/server-error')
-
-    if (!isNextDev) {
-      const serverHtml = await serverBrowser.eval(
-        'document.documentElement.innerHTML'
-      )
-      expect(serverHtml).toContain('server logs')
-    }
+    // Check that the card has left text alignment
+    const card = await browser.elementByCss('.next-error-card')
+    const textAlign = await card.getComputedCss('text-align')
+    expect(textAlign).toBe('left')
   })
 })

--- a/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+++ b/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
@@ -49,7 +49,7 @@ describe('app dir - default error page UI', () => {
     expect(await button.text()).toBe('Try Again')
 
     // Check the developer hint
-    const html = await browser.html()
+    const html = await browser.eval('document.documentElement.innerHTML')
     expect(html).toContain('Developers:')
     expect(html).toContain('browser console')
   })
@@ -97,15 +97,15 @@ describe('app dir - default error page UI', () => {
     // Check that the title has red color
     const title = await browser.elementByCss('h1')
     const titleColor = await title.getComputedCss('color')
-    // #dc2626 = rgb(220, 38, 38)
-    expect(titleColor).toContain('220')
-    expect(titleColor).toContain('38')
+    // #e5484d = rgb(229, 72, 77)
+    expect(titleColor).toContain('229')
+    expect(titleColor).toContain('72')
 
     // Check that the button has red background
     const button = await browser.elementByCss('button')
     const buttonBg = await button.getComputedCss('background-color')
-    expect(buttonBg).toContain('220')
-    expect(buttonBg).toContain('38')
+    expect(buttonBg).toContain('229')
+    expect(buttonBg).toContain('72')
   })
 
   it('should display Error ID for server-side errors', async () => {
@@ -130,7 +130,7 @@ describe('app dir - default error page UI', () => {
     }
 
     // In production mode, verify the error page shows Error ID
-    const html = await browser.html()
+    const html = await browser.eval('document.documentElement.innerHTML')
     expect(html).toContain('Error ID:')
     expect(html).toContain('server logs')
   })
@@ -141,7 +141,9 @@ describe('app dir - default error page UI', () => {
     await clientBrowser.elementByCss('#trigger-error').click()
 
     if (!isNextDev) {
-      const clientHtml = await clientBrowser.html()
+      const clientHtml = await clientBrowser.eval(
+        'document.documentElement.innerHTML'
+      )
       expect(clientHtml).toContain('browser console')
     }
 
@@ -149,7 +151,9 @@ describe('app dir - default error page UI', () => {
     const serverBrowser = await next.browser('/server-error')
 
     if (!isNextDev) {
-      const serverHtml = await serverBrowser.html()
+      const serverHtml = await serverBrowser.eval(
+        'document.documentElement.innerHTML'
+      )
       expect(serverHtml).toContain('server logs')
     }
   })

--- a/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+++ b/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
@@ -1,0 +1,156 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app dir - default error page UI', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render the redesigned default error page with all UI elements', async () => {
+    const browser = await next.browser('/trigger-error')
+
+    // Trigger a client-side error
+    await browser.elementByCss('#trigger-error').click()
+
+    // Skip UI checks in dev mode (redbox overlay covers the error page)
+    if (isNextDev) {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Test client error",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/trigger-error/page.js (9:11) @ TriggerErrorPage
+       >  9 |     throw new Error('Test client error')
+            |           ^",
+         "stack": [
+           "TriggerErrorPage app/trigger-error/page.js (9:11)",
+         ],
+       }
+      `)
+      return
+    }
+
+    // In production mode, verify the new error page UI elements
+
+    // Check that the SVG icon is present
+    const svgIcon = await browser.elementByCss('svg')
+    expect(await svgIcon.getAttribute('width')).toBe('48')
+    expect(await svgIcon.getAttribute('height')).toBe('48')
+
+    // Check the error title
+    const title = await browser.elementByCss('h1')
+    expect(await title.text()).toBe('An Error Occurred')
+
+    // Check the error message
+    const message = await browser.elementByCss('p')
+    expect(await message.text()).toContain('Something went wrong')
+
+    // Check the "Try Again" button exists
+    const button = await browser.elementByCss('button')
+    expect(await button.text()).toBe('Try Again')
+
+    // Check the developer hint
+    const html = await browser.html()
+    expect(html).toContain('Developers:')
+    expect(html).toContain('browser console')
+  })
+
+  it('should reload the page when Try Again button is clicked', async () => {
+    const browser = await next.browser('/trigger-error')
+
+    // Trigger a client-side error
+    await browser.elementByCss('#trigger-error').click()
+
+    // Skip in dev mode (redbox overlay)
+    if (isNextDev) {
+      return
+    }
+
+    // Get the current URL
+    const urlBefore = await browser.url()
+
+    // Click the Try Again button
+    await browser.elementByCss('button').click()
+
+    // Wait for page to reload (should be back to the trigger-error page)
+    await browser.waitForElementByCss('#trigger-error')
+
+    // Verify we're on the same page
+    const urlAfter = await browser.url()
+    expect(urlAfter).toBe(urlBefore)
+
+    // Verify the page content is showing (not the error)
+    const pageTitle = await browser.elementByCss('h1')
+    expect(await pageTitle.text()).toBe('Trigger Error Page')
+  })
+
+  it('should have proper styling in the default error page', async () => {
+    const browser = await next.browser('/trigger-error')
+
+    // Trigger a client-side error
+    await browser.elementByCss('#trigger-error').click()
+
+    // Skip in dev mode
+    if (isNextDev) {
+      return
+    }
+
+    // Check that the title has red color
+    const title = await browser.elementByCss('h1')
+    const titleColor = await title.getComputedCss('color')
+    // #dc2626 = rgb(220, 38, 38)
+    expect(titleColor).toContain('220')
+    expect(titleColor).toContain('38')
+
+    // Check that the button has red background
+    const button = await browser.elementByCss('button')
+    const buttonBg = await button.getComputedCss('background-color')
+    expect(buttonBg).toContain('220')
+    expect(buttonBg).toContain('38')
+  })
+
+  it('should display Error ID for server-side errors', async () => {
+    const browser = await next.browser('/server-error')
+
+    // Skip in dev mode (redbox overlay)
+    if (isNextDev) {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Test server error",
+         "environmentLabel": "Server",
+         "label": "Runtime Error",
+         "source": "app/server-error/page.js (2:9) @ ServerErrorPage
+       > 2 |   throw new Error('Test server error')
+           |         ^",
+         "stack": [
+           "ServerErrorPage app/server-error/page.js (2:9)",
+         ],
+       }
+      `)
+      return
+    }
+
+    // In production mode, verify the error page shows Error ID
+    const html = await browser.html()
+    expect(html).toContain('Error ID:')
+    expect(html).toContain('server logs')
+  })
+
+  it('should show correct developer hint based on error type', async () => {
+    // Client-side error should mention "browser console"
+    const clientBrowser = await next.browser('/trigger-error')
+    await clientBrowser.elementByCss('#trigger-error').click()
+
+    if (!isNextDev) {
+      const clientHtml = await clientBrowser.html()
+      expect(clientHtml).toContain('browser console')
+    }
+
+    // Server-side error should mention "server logs"
+    const serverBrowser = await next.browser('/server-error')
+
+    if (!isNextDev) {
+      const serverHtml = await serverBrowser.html()
+      expect(serverHtml).toContain('server logs')
+    }
+  })
+})

--- a/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+++ b/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
@@ -130,7 +130,6 @@ describe('app dir - default error page UI', () => {
     // In production mode, verify the error page shows Error reference
     const html = await browser.eval('document.documentElement.innerHTML')
     expect(html).toContain('Error reference:')
-    expect(html).toContain('contact support')
   })
 
   it('should have left-aligned text inside centered container', async () => {

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -189,10 +189,8 @@ describe('app-dir - errors', () => {
         `)
       } else {
         expect(
-          await browser.waitForElementByCss('body').elementByCss('h2').text()
-        ).toBe(
-          'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
-        )
+          await browser.waitForElementByCss('body').elementByCss('h1').text()
+        ).toBe('This page crashed')
       }
 
       expect(pageErrors).toEqual([
@@ -228,13 +226,11 @@ describe('app-dir - errors', () => {
         `)
       } else {
         expect(
-          await browser.waitForElementByCss('body').elementByCss('h2').text()
-        ).toBe(
-          'Application error: a server-side exception has occurred while loading localhost (see the server logs for more information).'
-        )
-        expect(
-          await browser.waitForElementByCss('body').elementByCss('p').text()
-        ).toMatch(/Digest: \w+/)
+          await browser.waitForElementByCss('body').elementByCss('h1').text()
+        ).toBe('This page failed to load')
+        // Check digest is displayed in error reference
+        const bodyText = await browser.waitForElementByCss('body').text()
+        expect(bodyText).toMatch(/Error reference:\s*\w+/)
       }
 
       expect(pageErrors).toEqual([

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -31,10 +31,10 @@ describe('app dir - global-error - error-in-global-error', () => {
 
   it('should render fallback UI when error occurs in global-error', async () => {
     const browser = await next.browser('/?error-in-global-error=1')
-    const text = await browser.elementByCss('h2').text()
-    expect(text).toMatch(
-      /Application error: a client-side exception has occurred while loading [\w.-]+ \(see the browser console for more information\)./
-    )
+    // When the custom global-error throws, it falls back to the default global-error
+    // Client errors show "This page crashed"
+    const title = await browser.elementByCss('h1').text()
+    expect(title).toBe('This page crashed')
 
     if (isNextDev) {
       await waitForRedbox(browser)

--- a/test/e2e/app-dir/revalidatetag-rsc/revalidatetag-rsc.test.ts
+++ b/test/e2e/app-dir/revalidatetag-rsc/revalidatetag-rsc.test.ts
@@ -36,7 +36,7 @@ describe('revalidateTag-rsc', () => {
         await retry(async () => {
           expect(
             await browser.eval('document.documentElement.innerHTML')
-          ).toContain('Application error: a server-side exception has occurred')
+          ).toContain('This page failed to load')
         })
       }
 

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -28,8 +28,9 @@ describe('next-link', () => {
        }
       `)
     }
-    expect(await browser.elementByCss('body').text()).toMatchInlineSnapshot(
-      `"Application error: a client-side exception has occurred while loading localhost (see the browser console for more information)."`
+    // Client errors show "This page crashed"
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page crashed'
     )
   })
 
@@ -51,8 +52,9 @@ describe('next-link', () => {
          ],
        }
       `)
-      expect(await browser.elementByCss('body').text()).toMatchInlineSnapshot(
-        `"Application error: a client-side exception has occurred while loading localhost (see the browser console for more information)."`
+      // Client errors show "This page crashed"
+      expect(await browser.elementByCss('body').text()).toContain(
+        'This page crashed'
       )
     } else {
       expect(await browser.elementByCss('body').text()).toMatchInlineSnapshot(

--- a/test/production/500-page/app-router-only/app-router-only.test.ts
+++ b/test/production/500-page/app-router-only/app-router-only.test.ts
@@ -11,8 +11,8 @@ describe('500-page app-router-only', () => {
     it('should render app router 500 page when route error', async () => {
       const $ = await next.render$('/route-error')
       expect($('html').attr('id')).toBe('__next_error__')
-      expect($('body').text()).toContain('Internal Server Error.')
-      expect($('body').text()).toContain('500')
+      // Server errors show "This page failed to load"
+      expect($('body').text()).toContain('This page failed to load')
     })
   }
 
@@ -24,7 +24,8 @@ describe('500-page app-router-only', () => {
       )
       // Not use pages router to generate 500.html
       expect(html).toContain('__next_error__')
-      expect(html).toContain('Internal Server Error.')
+      // Server errors show "This page failed to load"
+      expect(html).toContain('This page failed to load')
       // global-error is not used in app router 500.html
       expect(html).not.toContain('app-router-global-error')
     })

--- a/test/production/app-dir/graceful-degrade/graceful-degrade-non-bot.test.ts
+++ b/test/production/app-dir/graceful-degrade/graceful-degrade-non-bot.test.ts
@@ -32,9 +32,8 @@ describe('graceful-degrade - non bot', () => {
     expect(await body.getAttribute('class')).not.toBe('body-cls')
 
     const bodyText = await body.text()
-    expect(bodyText).toMatch(
-      /Application error: a client-side exception has occurred while loading/
-    )
+    // Client errors show "This page crashed"
+    expect(bodyText).toMatch(/This page crashed/)
   })
 
   it('should show error boundary when browser errors when error boundary is defined', async () => {

--- a/test/production/app-dir/graceful-degrade/graceful-degrade.test.ts
+++ b/test/production/app-dir/graceful-degrade/graceful-degrade.test.ts
@@ -31,9 +31,7 @@ describe('graceful-degrade', () => {
 
     // Do not contain the global error boundary text
     const bodyText = await originBody.text()
-    expect(bodyText).not.toMatch(
-      /Application error: a client-side exception has occurred while loading/
-    )
+    expect(bodyText).not.toMatch(/This page crashed/)
   })
 
   it('should preserve the ssr html when browser errors for bot', async () => {
@@ -50,9 +48,7 @@ describe('graceful-degrade', () => {
     expect(errors).toMatch(/Error: boom/)
 
     const bodyText = await browser.elementByCss('body').text()
-    expect(bodyText).not.toMatch(
-      /Application error: a client-side exception has occurred while loading/
-    )
+    expect(bodyText).not.toMatch(/This page crashed/)
     expect(bodyText).toMatch(/fine/)
   })
 })

--- a/test/production/chunk-load-failure/chunk-load-failure.test.ts
+++ b/test/production/chunk-load-failure/chunk-load-failure.test.ts
@@ -41,9 +41,8 @@ describe('chunk-load-failure', () => {
 
     await retry(async () => {
       const body = await browser.elementByCss('body')
-      expect(await body.text()).toMatch(
-        /Application error: a client-side exception has occurred while loading/
-      )
+      // Client errors show "This page crashed"
+      expect(await body.text()).toMatch(/This page crashed/)
     })
 
     expect(pageError).toBeDefined()


### PR DESCRIPTION
- redesigns the default global + default error boundaries. removing the WSOD forever :/ 
- adds dark mode support
- unifies a bit of the styling
- add the digest for the server error
- adds a return button on the client errors

<img width="3328" height="1914" alt="CleanShot 2026-01-02 at 09 46 36@2x" src="https://github.com/user-attachments/assets/9994eb37-c22b-4847-9a18-e9acf0ae6236" />

<img width="2144" height="1242" alt="CleanShot 2026-01-02 at 09 47 01@2x" src="https://github.com/user-attachments/assets/9b3bcf39-63f6-4c8d-85c5-2976c25f5b7b" />


<img width="2238" height="1632" alt="CleanShot 2026-01-02 at 09 47 17@2x" src="https://github.com/user-attachments/assets/436433d7-9873-496a-9c96-536e070be9d7" />
<img width="1708" height="1260" alt="CleanShot 2026-01-02 at 09 47 23@2x" src="https://github.com/user-attachments/assets/1ec42402-dbd9-41a3-801b-4745a4f128f7" />
