### PR TITLE
chore: warn when running tests against stale build

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const createJestConfig = nextJest()
 const customJestConfig = {
   displayName: process.env.IS_WEBPACK_TEST ? 'webpack' : 'Turbopack',
   testMatch: ['**/*.test.js', '**/*.test.ts', '**/*.test.jsx', '**/*.test.tsx'],
+  globalSetup: '<rootDir>/jest-global-setup.ts',
   setupFilesAfterEnv: ['<rootDir>/jest-setup-after-env.ts'],
   verbose: true,
   rootDir: 'test',

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2684,6 +2684,16 @@ export async function build(task, opts) {
     ['precompile', 'compile', 'check_error_codes', 'generate_types'],
     opts
   )
+  // Write git commit hash to dist for stale build detection during tests
+  try {
+    const { stdout: commitHash } = await execa('git', ['rev-parse', 'HEAD'])
+    await fs.writeFile(
+      join(__dirname, 'dist', '.build-commit'),
+      commitHash.trim()
+    )
+  } catch (err) {
+    // Ignore errors (e.g., not in a git repo)
+  }
 }
 
 export async function generate_types(task, opts) {

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2692,7 +2692,7 @@ export async function build(task, opts) {
       commitHash.trim()
     )
   } catch (err) {
-    throw new Error(`Failed to write build commit hash: ${err.message}`)
+    console.warn(`Warning: Could not write build commit hash: ${err.message}`)
   }
 }
 

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2692,7 +2692,7 @@ export async function build(task, opts) {
       commitHash.trim()
     )
   } catch (err) {
-    // Ignore errors (e.g., not in a git repo)
+    throw new Error(`Failed to write build commit hash: ${err.message}`)
   }
 }
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -13,6 +13,7 @@ const glob = promisify(_glob)
 const exec = promisify(execOrig)
 const core = require('@actions/core')
 const { getTestFilter } = require('./test/get-test-filter')
+const { checkBuildFreshness } = require('./test/lib/check-build-freshness')
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
@@ -218,6 +219,9 @@ async function getTestTimings() {
 async function main() {
   // Ensure we have the arguments awaited from yargs.
   argv = await argv
+
+  // Check for stale or missing build
+  await checkBuildFreshness()
 
   // `.github/workflows/build_reusable.yml` sets this, we should use it unless
   // it's overridden by an explicit `--concurrency` argument.

--- a/test/jest-global-setup.ts
+++ b/test/jest-global-setup.ts
@@ -1,0 +1,5 @@
+import { checkBuildFreshness } from './lib/check-build-freshness'
+
+export default async function globalSetup() {
+  await checkBuildFreshness()
+}

--- a/test/lib/check-build-freshness.js
+++ b/test/lib/check-build-freshness.js
@@ -1,0 +1,59 @@
+const { existsSync } = require('fs')
+const fsp = require('fs/promises')
+const path = require('path')
+const { execSync } = require('child_process')
+
+const YELLOW = '\x1b[33m'
+const RESET = '\x1b[0m'
+
+/**
+ * Check if the Next.js build is fresh (matches current git HEAD).
+ * Prints warnings to console if build is missing or stale.
+ * @returns {Promise<void>}
+ */
+async function checkBuildFreshness() {
+  const distPath = path.join(__dirname, '../../packages/next/dist')
+  const buildCommitPath = path.join(distPath, '.build-commit')
+
+  if (!existsSync(distPath)) {
+    console.warn(`${YELLOW}⚠️  WARNING: No build found!${RESET}`)
+    console.warn(
+      `${YELLOW}   The packages/next/dist directory does not exist.${RESET}`
+    )
+    console.warn(
+      `${YELLOW}   Run \`pnpm build\` before running tests.\n${RESET}`
+    )
+    return
+  }
+
+  if (!existsSync(buildCommitPath)) {
+    console.warn(`${YELLOW}⚠️  WARNING: Build may be stale!${RESET}`)
+    console.warn(
+      `${YELLOW}   Unable to verify build freshness (no .build-commit marker).${RESET}`
+    )
+    console.warn(`${YELLOW}   Run \`pnpm build\` to rebuild.\n${RESET}`)
+    return
+  }
+
+  try {
+    const buildCommit = (await fsp.readFile(buildCommitPath, 'utf8')).trim()
+    const currentCommit = execSync('git rev-parse HEAD', {
+      encoding: 'utf8',
+    }).trim()
+
+    if (buildCommit !== currentCommit) {
+      console.warn(`${YELLOW}⚠️  WARNING: Build is stale!${RESET}`)
+      console.warn(
+        `${YELLOW}   Build was compiled at commit: ${buildCommit.slice(0, 8)}${RESET}`
+      )
+      console.warn(
+        `${YELLOW}   Current HEAD is at commit:    ${currentCommit.slice(0, 8)}${RESET}`
+      )
+      console.warn(`${YELLOW}   Run \`pnpm build\` to rebuild.\n${RESET}`)
+    }
+  } catch (err) {
+    // Ignore errors (e.g., git not available)
+  }
+}
+
+module.exports = { checkBuildFreshness }


### PR DESCRIPTION
i got bit by this often :p 

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
