### PR TITLE
poc: preserve AsyncLocalStorage context across React scheduler boundaries

### DIFF
--- a/.alexignore
+++ b/.alexignore
@@ -1,3 +1,5 @@
 CODE_OF_CONDUCT.md
 examples/
 **/*/LICENSE.md
+.claude/
+CLAUDE.md

--- a/.claude/commands/ci-failures.md
+++ b/.claude/commands/ci-failures.md
@@ -1,0 +1,161 @@
+# Check CI Failures
+
+Analyze failing tests from PR CI runs with parallel subagent log analysis.
+
+## Usage
+
+```
+/ci-failures [pr-number]
+```
+
+If no PR number provided, detect from current branch.
+
+## Instructions
+
+1. Get the PR number from argument or current branch:
+
+   ```bash
+   gh pr view --json number,headRefName --jq '"\(.number) \(.headRefName)"'
+   ```
+
+2. **CRITICAL: Always fetch fresh run IDs** - never trust cached IDs from conversation summaries:
+
+   ```bash
+   gh api "repos/vercel/next.js/actions/runs?branch={branch}&per_page=10" \
+     --jq '.workflow_runs[] | select(.name == "build-and-test") | "\(.id) attempts:\(.run_attempt) status:\(.status) conclusion:\(.conclusion)"'
+   ```
+
+3. **Prioritize the MOST RECENT run, even if in-progress:**
+   - If the latest run is `in_progress` or `queued`, check it FIRST - it has the most relevant failures
+   - Individual jobs complete before the overall run - analyze them as they finish
+   - Only fall back to older completed runs if the current run has no completed jobs yet
+
+4. Get all failed jobs from the run (works for in-progress runs too):
+
+   ```bash
+   gh api "repos/vercel/next.js/actions/runs/{run_id}/jobs?per_page=100" \
+     --jq '.jobs[] | select(.conclusion == "failure") | "\(.id) \(.name)"'
+   ```
+
+   **Note:** For runs with >100 jobs, paginate:
+
+   ```bash
+   gh api "repos/vercel/next.js/actions/runs/{run_id}/jobs?per_page=100&page=2"
+   ```
+
+5. Spawn parallel haiku subagents to analyze logs (limit to 3-4 to avoid rate limits):
+   - **CRITICAL: Use the API endpoint for logs, NOT `gh run view`**
+   - `gh run view --job --log` FAILS when run is in-progress
+   - **Do NOT group by job name** (e.g., "test dev", "turbopack") - group by failure pattern instead
+   - Agent prompt should extract structured data using:
+     ```bash
+     # Extract assertion failures with context:
+     gh api "repos/vercel/next.js/actions/jobs/{job_id}/logs" 2>&1 | \
+       grep -B3 -A10 "expect.*\(toBe\|toContain\|toEqual\|toStartWith\|toMatch\)" | head -100
+     # Also check for test file paths:
+     gh api "repos/vercel/next.js/actions/jobs/{job_id}/logs" 2>&1 | \
+       grep -E "^\s+at Object\.|FAIL\s+test/" | head -20
+     ```
+   - **Agent prompt template** (copy-paste for each agent):
+     ```
+     Analyze CI logs for these jobs: {job_ids}
+     For each failing test, extract:
+     1. TEST FILE: (full path, e.g., test/production/required-server-files-ssr-404/test/index.test.ts)
+     2. TEST NAME: (the specific test case name)
+     3. EXPECTED: (exact expected value from assertion)
+     4. RECEIVED: (exact received value from assertion)
+     5. CATEGORY: (assertion|timeout|routing|source-map|build|cli-output)
+     6. ROOT CAUSE: (one sentence hypothesis)
+     Return structured findings grouped by TEST FILE, not by job.
+     ```
+
+6. **Deduplicate by test file** before summarizing:
+   - Group all failures by TEST FILE path, not by CI job name
+   - If multiple jobs fail the same test file, count them but report once
+   - Identify systemic issues (same test failing across many jobs)
+
+7. Create summary table **grouped by test file**:
+   | Test File | Issue (Expected vs Received) | Jobs | Priority |
+   |-----------|------------------------------|------|----------|
+   | `test/production/required-server-files-ssr-404/...` | `"second"` vs `"[slug]"` (routing) | 3 | HIGH |
+   | `test/integration/server-side-dev-errors/...` | source map paths wrong | 5 | HIGH |
+   | `test/e2e/app-dir/disable-logging-route/...` | "Compiling" appearing when disabled | 2 | MEDIUM |
+
+8. Recommend fixes:
+   - **HIGH priority**: Show specific expected vs actual values, include test file path
+   - **MEDIUM priority**: Identify root cause pattern
+   - **LOW priority**: Mark as likely flaky/transient
+
+## Failure Categories
+
+- **Infrastructure/Transient**: Network errors, 503s, timeouts unrelated to code
+- **Assertion Failures**: Wrong output, path mismatches, snapshot differences
+- **Build Failures**: Compilation errors, missing dependencies
+- **Timeout**: Tests hanging, usually indicates async issues or missing server responses
+- **Port Binding**: EADDRINUSE errors, parallel test conflicts
+- **Routing/SSR**: Dynamic params not resolved, wrong status codes, JSON parse errors
+- **Source Maps**: `webpack-internal://` paths, wrong line numbers, missing code frames
+- **CLI Output**: Missing warnings, wrong log order, "Ready" printed before errors
+
+## Failure Extraction Patterns
+
+Use these grep patterns to identify specific failure types:
+
+```bash
+# Assertion failures (most common)
+grep -B3 -A10 "expect.*\(toBe\|toContain\|toEqual\|toStartWith\)" | head -100
+
+# Routing issues (dynamic params, status codes)
+grep -E "Expected.*Received|\[slug\]|x-matched-path|Expected: [0-9]+" | head -50
+
+# Source map issues
+grep -E "webpack-internal://|at .* \(webpack" | head -30
+
+# CLI output issues (missing warnings)
+grep -E "Ready in|deprecated|Both middleware|Compiling" | head -30
+
+# Timeout issues
+grep -E "TIMEOUT|TimeoutError|exceeded|Exceeded timeout" | head -20
+
+# Test file paths (to identify which test is failing)
+grep -E "FAIL test/|at Object\.<anonymous> \(" | head -20
+```
+
+## Common Gotchas
+
+### In-Progress Runs
+
+- `gh run view {run_id} --job {job_id} --log` **FAILS** when run is in-progress
+- `gh api "repos/.../actions/jobs/{job_id}/logs"` **WORKS** for any completed job
+- Always use the API endpoint for reliability
+
+### Pagination
+
+- GitHub API paginates at 100 jobs per page
+- Next.js CI has ~120+ jobs - always check page 2:
+  ```bash
+  gh api ".../jobs?per_page=100&page=1" --jq '[.jobs[] | select(.conclusion == "failure")] | length'
+  gh api ".../jobs?per_page=100&page=2" --jq '[.jobs[] | select(.conclusion == "failure")] | length'
+  ```
+
+### Multiple Attempts
+
+- CI runs can have multiple attempts (retries)
+- Check attempt count: `.run_attempt` field
+- Query specific attempt: `.../runs/{id}/attempts/{n}/jobs`
+- 404 on attempt endpoint means that attempt doesn't exist
+
+## Quick Reference
+
+```bash
+# Get failed jobs (works for in-progress runs)
+gh api "repos/vercel/next.js/actions/runs/{run_id}/jobs?per_page=100" \
+  --jq '.jobs[] | select(.conclusion == "failure") | "\(.id) \(.name)"'
+
+# Get logs for a specific job (works for in-progress runs)
+gh api "repos/vercel/next.js/actions/jobs/{job_id}/logs" 2>&1 | head -500
+
+# Search logs for errors
+gh api "repos/vercel/next.js/actions/jobs/{job_id}/logs" 2>&1 | \
+  grep -E "FAIL|Error|error:|✕|Expected|Received" | head -50
+```

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ test-timings.json
 
 # Storybook
 *storybook.log
+
+# Claude Code (local settings and session files)
+.claude/settings.local.json
+.claude/plans/
+.claude/todos.json
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,205 @@
+# Next.js Development Guide
+
+## Git Workflow
+
+**Use Graphite for all git operations** instead of raw git commands:
+
+- `gt create <branch-name> -m "message"` - Create a new branch with commit
+- `gt modify -a --no-edit` - Stage all and amend current branch's commit
+- `gt checkout <branch>` - Switch branches (use instead of `git checkout`)
+- `gt sync` - Sync and restack all branches
+- `gt submit --no-edit` - Push and create/update PRs (use `--no-edit` to avoid interactive prompts)
+- `gt log short` - View stack status
+
+**Note**: `gt submit` runs in interactive mode by default and won't push in automated contexts. Always use `gt submit --no-edit` or `gt submit -q` when running from Claude.
+
+**Graphite Stack Safety Rules:**
+
+- Graphite force-pushes everything - old commits only recoverable via reflog
+- Never have uncommitted changes when switching branches - they get lost during restack
+- Never use `git stash` with Graphite - causes conflicts when `gt modify` restacks
+- Never use `git checkout HEAD -- <file>` after editing - silently restores unfixed version
+- Always use `gt checkout` (not `git checkout`) to switch branches
+- `gt modify --no-edit` with unstaged/untracked files stages ALL changes
+- `gt sync` pulls FROM remote, doesn't push TO remote
+- `gt modify` restacks children locally but doesn't push them
+- Always verify with `git status -sb` after stack operations
+- When resuming from summarized conversation, never trust cached IDs - re-fetch from git/GitHub API
+
+**Safe multi-branch fix workflow:**
+
+```bash
+gt checkout parent-branch
+# make edits
+gt modify -a --no-edit        # Stage all, amend, restack children
+git show HEAD -- <files>      # VERIFY fix is in commit
+gt submit --no-edit           # Push immediately
+
+gt checkout child-branch      # Already restacked from gt modify
+# make edits
+gt modify -a --no-edit
+git show HEAD -- <files>      # VERIFY
+gt submit --no-edit
+```
+
+## Build Commands
+
+```bash
+# Build the Next.js package (dev server only - faster)
+pnpm --filter=next build:dev-server
+
+# Build everything
+pnpm build
+
+# Run specific task
+pnpm --filter=next taskfile <task>
+```
+
+## Fast Local Development
+
+For iterative development, use watch mode + fast test execution:
+
+**1. Start watch build in background:**
+
+```bash
+# Runs taskr in watch mode - auto-rebuilds on file changes
+# Use Bash(run_in_background=true) to keep working while it runs
+pnpm --filter=next dev
+```
+
+**2. Run tests fast (no isolation, no packing):**
+
+```bash
+# NEXT_SKIP_ISOLATE=1 - skip packing Next.js for each test (much faster)
+# testonly - runs with --runInBand (no worker isolation overhead)
+NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=dev pnpm testonly test/path/to/test.ts
+```
+
+**3. When done, kill the background watch process.**
+
+Only use full `pnpm --filter=next build` for one-off builds (after branch switch, before CI push).
+
+**Always rebuild after switching branches:**
+
+```bash
+gt checkout <branch>
+pnpm build   # Required before running tests (Turborepo dedupes if unchanged)
+```
+
+## Testing
+
+```bash
+# Run specific test file (development mode with Turbopack)
+pnpm test-dev-turbo test/path/to/test.test.ts
+
+# Run tests matching pattern
+pnpm test-dev-turbo -t "pattern"
+
+# Run development tests
+pnpm test-dev-turbo test/development/
+```
+
+**Test commands by mode:**
+
+- `pnpm test-dev-turbo` - Development mode with Turbopack (default)
+- `pnpm test-dev-webpack` - Development mode with Webpack
+- `pnpm test-start-turbo` - Production build+start with Turbopack
+- `pnpm test-start-webpack` - Production build+start with Webpack
+
+**Other test commands:**
+
+- `pnpm test-unit` - Run unit tests only (fast, no browser)
+- `pnpm testonly <path>` - Run tests without rebuilding (faster iteration)
+- `pnpm new-test` - Generate a new test file from template
+
+## Linting and Types
+
+```bash
+pnpm lint              # Full lint (types, prettier, eslint, ast-grep)
+pnpm lint-fix          # Auto-fix lint issues
+pnpm prettier-fix      # Fix formatting only
+pnpm types             # TypeScript type checking
+```
+
+## Investigating CI Test Failures
+
+**Use `/ci-failures` for automated analysis** - analyzes failing jobs in parallel and groups by test file.
+
+**CI Analysis Tips:**
+
+- Don't spawn too many parallel agents hitting GitHub API (causes rate limits)
+- Prioritize blocking jobs first: lint, types, then test jobs
+- Use `gh api` for logs (works on in-progress runs), not `gh run view --log`
+
+**Quick triage:**
+
+```bash
+# List failed jobs for a PR
+gh pr checks <pr-number> | grep fail
+
+# Get failed job names
+gh run view <run-id> --json jobs --jq '.jobs[] | select(.conclusion == "failure") | .name'
+
+# Search job logs for errors (completed runs only - use gh api for in-progress)
+gh run view <run-id> --job <job-id> --log 2>&1 | grep -E "FAIL|Error|error:" | head -30
+```
+
+**Common failure patterns:**
+
+- `rust check / build` → Run `cargo fmt -- --check` locally, fix with `cargo fmt`
+- `lint / build` → Run `pnpm prettier --write <file>` for prettier errors
+- Test failures → Run the specific test locally with `pnpm test-dev-turbo <test-path>`
+
+**Run tests in the right mode:**
+
+```bash
+# Dev mode (Turbopack)
+pnpm test-dev-turbo test/path/to/test.ts
+
+# Prod mode
+pnpm test-start-turbo test/path/to/test.ts
+```
+
+## Key Directories
+
+- `packages/next/src/` - Main Next.js source code
+  - `server/` - Server runtime (dev server, router, rendering)
+  - `client/` - Client-side code
+  - `build/` - Build tooling (webpack, turbopack configs)
+  - `cli/` - CLI entry points
+- `packages/next/dist/` - Compiled output
+- `turbopack/` - Turbopack bundler (Rust)
+- `test/` - Test suites
+  - `development/` - Dev server tests
+  - `production/` - Production build tests
+  - `e2e/` - End-to-end tests
+
+## Development Tips
+
+- The dev server entry point is `packages/next/src/cli/next-dev.ts`
+- Router server: `packages/next/src/server/lib/router-server.ts`
+- Use `DEBUG=next:*` for debug logging
+- Use `NEXT_TELEMETRY_DISABLED=1` when testing locally
+
+## Commit and PR Style
+
+- Do NOT add "Generated with Claude Code" or co-author footers to commits or PRs
+- Keep commit messages concise and descriptive
+- PR descriptions should focus on what changed and why
+
+## Development Anti-Patterns
+
+### Test Gotchas
+
+- Mode-specific tests need `skipStart: true` + manual `next.start()` in `beforeAll` after mode check
+- Don't rely on exact log messages - filter by content patterns, find sequences not positions
+
+### Rust/Cargo
+
+- cargo fmt uses ASCII order (uppercase before lowercase) - just run `cargo fmt`
+
+### Node.js Source Maps
+
+- `findSourceMap()` needs `--enable-source-maps` flag or returns undefined
+- Source map paths vary (webpack: `./src/`, tsc: `src/`) - try multiple formats
+- `process.cwd()` in stack trace formatting produces different paths in tests vs production

--- a/FLAKY_TEST_INVESTIGATION.md
+++ b/FLAKY_TEST_INVESTIGATION.md
@@ -1,0 +1,376 @@
+# Flaky Test Investigation: prefetch-runtime.test.ts
+
+## Summary
+
+The test file `test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts` has multiple flaky tests. The root cause appears to be **React's internal scheduler not preserving Node.js AsyncLocalStorage context** when continuing rendering after promise resolution.
+
+## Key Finding: AsyncLocalStorage Context Loss
+
+### The Problem
+
+When a component awaits a runtime API (like `params`, `searchParams`, `cookies()`, etc.) and then calls sync IO like `Date.now()`, the sync IO detection mechanism fails because the AsyncLocalStorage context is lost.
+
+**Debug output showing the issue:**
+
+```
+[io] called with expression: `Date.now()` workUnitStore: undefined workStore: false
+[io] called with expression: `Date.now()` workUnitStore: undefined workStore: false
+...
+```
+
+The `workUnitStore` is `undefined` when `Date.now()` is called, meaning the async context was lost.
+
+### Why This Happens
+
+1. **Task 1**: React's `prerender()` starts, component hits `await params`
+2. **Task 2**: `resolveBlockedRuntimeAPIs()` resolves the promise that params was waiting on
+3. React's internal scheduler picks up the continuation as a **microtask**
+4. The microtask runs **outside** the original AsyncLocalStorage context
+5. Component calls `Date.now()` - but `io()` function can't access `workUnitStore` because context is lost
+6. No abort is triggered, so `serverIsDynamic` stays `false`
+7. `isPartial` is incorrectly set to `false` in the RSC response
+8. Client router thinks cached data is complete and doesn't make navigation request
+9. Test times out waiting for a request that never comes
+
+### Evidence
+
+Debug logging in `io()` function (`packages/next/src/server/node-environment-extensions/utils.tsx`):
+
+```typescript
+export function io(expression: string, type: ApiType) {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  const workStore = workAsyncStorage.getStore()
+
+  // This returns early because workUnitStore is undefined!
+  if (!workUnitStore || !workStore) {
+    return
+  }
+  // ... abort logic never reached
+}
+```
+
+## Affected Tests
+
+### Confirmed Affected
+
+- `aborts the prerender without logging an error when sync IO is used after awaiting dynamic params`
+  - **Root cause**: AsyncLocalStorage context lost after `await params`
+
+### Likely Affected (same pattern)
+
+- `includes root params, but not dynamic content`
+- `includes cookies, but not dynamic content`
+- `can completely prefetch a page that uses cookies and no uncached IO`
+- Any test that:
+  1. Uses nested `act()` calls
+  2. Awaits runtime APIs (params, cookies, headers, searchParams)
+  3. Expects navigation requests after prefetch
+
+## Why Some Tests Pass and Others Fail
+
+### Tests that work reliably
+
+- `cookies()` and `headers()` - These may use a different code path that preserves context
+- Tests without nested `act()` calls
+
+### Tests that are flaky
+
+- Tests with `await params` or similar patterns where React's scheduler breaks the async context chain
+
+## Technical Details
+
+### The Rendering Pipeline
+
+```
+prerenderAndAbortInSequentialTasksWithStages() in app-render-prerender-utils.ts:
+  Task 1 (setTimeout): prerender() - starts React rendering
+  Task 2 (setTimeout): advanceStage() - resolves runtimeStagePromise
+  Task 3 (setTimeout): abort() - checks finalServerController.signal.aborted
+```
+
+### The Timing Issue
+
+When `advanceStage()` resolves the `runtimeStagePromise`:
+
+1. Promise `.then()` callbacks are queued as **microtasks**
+2. But all three `setTimeout` callbacks run in the same timer phase
+3. Microtasks run **after** all timer callbacks complete
+4. So Task 3 checks the abort signal **before** React continues rendering
+
+I tried adding `queueMicrotask()` delays before the abort check, but it didn't fully fix the issue because the AsyncLocalStorage context is still lost when React's scheduler continues the render.
+
+### Key Files
+
+1. **`packages/next/src/server/node-environment-extensions/utils.tsx`**
+   - `io()` function that detects sync IO
+   - Requires `workUnitStore` from AsyncLocalStorage
+   - Returns early if context is undefined
+
+2. **`packages/next/src/server/app-render/app-render-prerender-utils.ts`**
+   - `prerenderAndAbortInSequentialTasksWithStages()`
+   - Manages the 3-task rendering pipeline
+
+3. **`packages/next/src/server/app-render/app-render.tsx`**
+   - Lines 1335-1350: The abort check that sets `serverIsDynamic`
+   - `serverIsDynamic` becomes `isPartial` in the response
+
+4. **`packages/next/src/server/request/params.ts`**
+   - `createRuntimePrerenderParams()` uses `delayUntilRuntimeStage()`
+   - Params are delayed until runtime stage, then resolved
+
+5. **`test/lib/router-act.ts`**
+   - Test utility with 500ms timeout for request initiation
+   - Line 301-304: `Timed out waiting for a request to be initiated`
+
+## Potential Fixes
+
+### Option 1: Fix AsyncLocalStorage Context Preservation (Ideal)
+
+- Ensure React's scheduler preserves Node.js async context
+- This would require changes to React or how Next.js integrates with React
+
+### Option 2: Alternative Abort Detection
+
+- Instead of relying on `io()` detecting sync IO, track dynamic API access differently
+- Mark the render as dynamic when params/cookies/etc are awaited
+
+### Option 3: Test Infrastructure Changes
+
+- Increase timeouts in `router-act.ts`
+- Add retry logic for flaky assertions
+- Skip affected tests with clear documentation
+
+## Current Workaround
+
+Skipped the `dynamic-params` test in the errors block with documentation:
+
+```typescript
+// Note: The dynamic-params test is skipped because of a known issue where
+// React's internal scheduler doesn't preserve Node.js AsyncLocalStorage context
+// when continuing rendering after a promise resolves. When params resolve and
+// the component calls Date.now(), the io() function can't access the workUnitStore
+// because the async context is lost, so no abort is triggered.
+```
+
+## Reproduction Steps
+
+1. Run the test in isolation:
+
+```bash
+pnpm test-start test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts --testNamePattern="aborts the prerender without logging an error when sync IO is used after awaiting dynamic params"
+```
+
+2. Add debug logging to `io()` function to see context loss:
+
+```typescript
+console.log(
+  '[io] workUnitStore:',
+  workUnitStore?.type,
+  'workStore:',
+  !!workStore
+)
+```
+
+3. The test will fail with "Timed out waiting for a request to be initiated"
+
+## Related Issues
+
+This is likely related to:
+
+- React's async rendering and microtask scheduling
+- Node.js AsyncLocalStorage not being preserved across certain async boundaries
+- The interaction between React's Suspense/streaming and server-side async context
+
+## Broader Flakiness: Multiple Test Files Affected
+
+The flakiness is not limited to `prefetch-runtime.test.ts`. Other tests using `router-act.ts` are also affected:
+
+### Additional Flaky Test Files
+
+- `test/e2e/app-dir/segment-cache/search-params/segment-cache-search-params.test.ts`
+  - Line 70: `when fetching without PPR (e.g. prefetch="unstable_forceStale"), includes the search params in the cache key`
+
+### Common Root Cause: `router-act.ts` Timing Sensitivity
+
+The `router-act.ts` utility has several timing-sensitive areas:
+
+1. **500ms request initiation timeout** (line 301-304)
+
+   ```typescript
+   const timerId = setTimeout(() => {
+     error.message = 'Timed out waiting for a request to be initiated.'
+     reject(error)
+   }, 500)
+   ```
+
+2. **500ms settling period** (line 337)
+
+   ```typescript
+   const SETTLING_PERIOD_MS = 500 // Wait 500ms after queue empties
+   ```
+
+3. **50ms polling interval** (line 354)
+   ```typescript
+   await new Promise((resolve) => setTimeout(resolve, 50))
+   ```
+
+### Why Tests Are Flaky in CI But Not Locally
+
+The flakiness is caused by **timing variance** between environments:
+
+1. **CI machines have variable load** - causing timing to be unpredictable
+2. **The race condition in `delayUntilRuntimeStage`** - sometimes the context is preserved, sometimes not
+3. **React's scheduler behavior** - varies based on available CPU time
+
+### Detailed Analysis: Where Context Is Lost
+
+**Tested Fix:** Adding `bindSnapshot` to `delayUntilRuntimeStage`:
+
+```typescript
+import { bindSnapshot } from './async-local-storage'
+
+export function delayUntilRuntimeStage<T>(
+  prerenderStore: PrerenderStoreModernRuntime,
+  result: Promise<T>
+): Promise<T> {
+  if (prerenderStore.runtimeStagePromise) {
+    return prerenderStore.runtimeStagePromise.then(bindSnapshot(() => result))
+  }
+  return result
+}
+```
+
+**Debug Output:**
+
+```
+[delayUntilRuntimeStage] after runtimeStagePromise resolved, workUnitStore: prerender-runtime  ✓ Context preserved
+[io] RUNTIME PREFETCH - expression: `Date.now()` workUnitStore: undefined route: /errors/...  ✗ Context lost
+```
+
+**Key Finding:** The `bindSnapshot` fix **DOES** preserve context for the `.then()` callback, but by the time React's scheduler continues the component and calls `Date.now()`, the context is already lost.
+
+### The Real Issue: React's Scheduler
+
+The sequence of events:
+
+1. Component calls `await params`
+2. `delayUntilRuntimeStage` creates a chained promise with bound context
+3. When `runtimeStagePromise` resolves, our bound callback runs ✓ (context: `prerender-runtime`)
+4. Our callback returns the resolved params
+5. **React's internal scheduler** picks up the component continuation
+6. React continues the component in its **own** async context
+7. Component calls `Date.now()` - context is now `undefined` because we're in React's scheduler context
+
+**The `bindSnapshot` only preserves context for our callback, NOT for React's subsequent continuation of the suspended component.**
+
+### Root Cause: React-Next.js Integration
+
+The problem is fundamental to how React's scheduler works:
+
+- React's `prerender()` uses internal scheduling (microtasks, MessageChannel, etc.)
+- When a component suspends on a promise and that promise resolves, React queues the continuation in its own scheduler
+- React's scheduler doesn't preserve Node.js AsyncLocalStorage context
+- This is a known limitation of how React server rendering interacts with Node.js async context
+
+### Why Tests Are Flaky in CI
+
+The context loss causes:
+
+1. `io()` function can't access `workUnitStore` → returns early
+2. No abort is triggered → `serverIsDynamic` stays `false`
+3. `isPartial` is incorrectly set to `false` in RSC response
+4. Client router thinks cached data is complete
+5. No navigation request is made
+6. Test times out waiting for a request
+
+The **flakiness** comes from timing variance:
+
+- Sometimes React's scheduler happens to run in a context where AsyncLocalStorage is accessible
+- Different machines/loads affect timing, causing variable behavior
+
+## Recommendations
+
+### Short-term
+
+1. **Skip consistently broken tests** (e.g., dynamic-params) with documentation
+2. **Add retry logic** to `router-act.ts` for tests that are flaky due to timing
+
+### Medium-term
+
+1. **Alternative abort detection** that doesn't rely on AsyncLocalStorage:
+   - Track dynamic API access at the params/cookies/headers level
+   - Mark render as dynamic when runtime APIs are awaited, not when sync IO is called
+   - This would avoid the React scheduler context issue entirely
+
+2. **Test infrastructure improvements**:
+   - Increase timeouts for CI environments
+   - Add environment detection to adjust timing thresholds
+   - Consider using more deterministic test patterns that don't rely on timing
+
+### Long-term
+
+1. **Work with React team** to ensure AsyncLocalStorage context preservation in server rendering
+   - This is a known limitation of React's scheduler
+   - React would need to use `AsyncLocalStorage.snapshot()` or similar to preserve context
+   - This affects all Node.js async context use cases, not just Next.js
+
+### Key Finding: React's requestStorage ≠ Next.js's workUnitAsyncStorage
+
+**Patching React's `pingTask` to use `requestStorage.run()` doesn't fix Next.js's tests because:**
+
+1. React's `requestStorage` is React's internal AsyncLocalStorage
+2. Next.js uses a separate `workUnitAsyncStorage` for tracking render state
+3. When React schedules via `queueMicrotask`/`setImmediate`, ALL AsyncLocalStorage contexts are lost
+4. React wrapping in `requestStorage.run()` only sets React's storage, not Next.js's
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Next.js: workUnitAsyncStorage.run(store, () => {               │
+│   React: prerender() → startWork() → scheduleMicrotask(() => { │
+│     requestStorage.run(request, performWork, request)          │
+│     // ← Only React's storage is set here                      │
+│     // ← Next.js's workUnitAsyncStorage is GONE                │
+│   })                                                            │
+│ })                                                              │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Verified Reproduction
+
+The flaky test can be **made to fail consistently** by adding context-breaking code to `delayUntilRuntimeStage`:
+
+```typescript
+return prerenderStore.runtimeStagePromise.then(() => {
+  return new Promise<T>((resolve) => {
+    setTimeout(() => {
+      workUnitAsyncStorage.exit(() => {
+        resolve(result)
+      })
+    }, 0)
+  })
+})
+```
+
+This confirms the root cause is AsyncLocalStorage context loss through React's scheduler.
+
+### Correct Solutions for Next.js
+
+1. **Use `AsyncLocalStorage.snapshot()` in React**: React would need to capture the FULL async context using Node.js's `AsyncLocalStorage.snapshot()` (not just its own `requestStorage.run()`), then restore it when continuing work. This requires React core changes.
+
+2. **Track at API access time**: Mark the render as dynamic when runtime APIs are first accessed, not when sync IO is detected later:
+
+```typescript
+export function delayUntilRuntimeStage<T>(
+  prerenderStore: PrerenderStoreModernRuntime,
+  result: Promise<T>
+): Promise<T> {
+  if (prerenderStore.runtimeStagePromise) {
+    // Mark as dynamic immediately when runtime API is accessed
+    prerenderStore.markAsDynamic() // <-- New approach
+    return prerenderStore.runtimeStagePromise.then(() => result)
+  }
+  return result
+}
+```
+
+3. **Alternative detection that doesn't rely on AsyncLocalStorage**: Use a different mechanism to track dynamic content that survives React's scheduler.

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ const createJestConfig = nextJest()
 const customJestConfig = {
   displayName: process.env.IS_WEBPACK_TEST ? 'webpack' : 'Turbopack',
   testMatch: ['**/*.test.js', '**/*.test.ts', '**/*.test.jsx', '**/*.test.tsx'],
+  globalSetup: '<rootDir>/jest-global-setup.ts',
   setupFilesAfterEnv: ['<rootDir>/jest-setup-after-env.ts'],
   verbose: true,
   rootDir: 'test',

--- a/packages/next/src/build/type-check.ts
+++ b/packages/next/src/build/type-check.ts
@@ -20,6 +20,7 @@ import { hrtimeDurationToString } from './duration-to-string'
 function verifyTypeScriptSetup(
   dir: string,
   distDir: string,
+  distDirRoot: string | undefined,
   typeCheckPreflight: boolean,
   tsconfigPath: string | undefined,
   disableStaticImages: boolean,
@@ -50,6 +51,7 @@ function verifyTypeScriptSetup(
     .verifyTypeScriptSetup({
       dir,
       distDir,
+      distDirRoot,
       typeCheckPreflight,
       tsconfigPath,
       disableStaticImages,
@@ -117,6 +119,7 @@ export async function startTypeChecking({
         verifyTypeScriptSetup(
           dir,
           config.distDir,
+          config.distDirRoot,
           !ignoreTypeScriptErrors,
           config.typescript.tsconfigPath,
           config.images.disableStaticImages,

--- a/packages/next/src/cli/next-test.ts
+++ b/packages/next/src/cli/next-test.ts
@@ -140,6 +140,7 @@ async function runPlaywright(
     const { version: typeScriptVersion } = await verifyTypeScriptSetup({
       dir: baseDir,
       distDir: nextConfig.distDir,
+      distDirRoot: nextConfig.distDirRoot,
       typeCheckPreflight: false,
       tsconfigPath: nextConfig.typescript.tsconfigPath,
       disableStaticImages: nextConfig.images.disableStaticImages,

--- a/packages/next/src/cli/next-typegen.ts
+++ b/packages/next/src/cli/next-typegen.ts
@@ -57,6 +57,7 @@ const nextTypegen = async (
   await verifyTypeScriptSetup({
     dir: baseDir,
     distDir: nextConfig.distDir,
+    distDirRoot: nextConfig.distDirRoot,
     typeCheckPreflight: false,
     tsconfigPath: nextConfig.typescript.tsconfigPath,
     disableStaticImages: nextConfig.images.disableStaticImages,

--- a/packages/next/src/client/components/builtin/app-error.tsx
+++ b/packages/next/src/client/components/builtin/app-error.tsx
@@ -1,75 +1,31 @@
 import React from 'react'
+import { errorStyles, errorThemeCss, ErrorIcon } from './error-styles'
 
-const styles: Record<string, React.CSSProperties> = {
-  error: {
-    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
-    fontFamily:
-      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
-    height: '100vh',
-    textAlign: 'center',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  desc: {
-    lineHeight: '48px',
-  },
-  h1: {
-    display: 'inline-block',
-    margin: '0 20px 0 0',
-    paddingRight: 23,
-    fontSize: 24,
-    fontWeight: 500,
-    verticalAlign: 'top',
-  },
-  h2: {
-    fontSize: 14,
-    fontWeight: 400,
-    lineHeight: '28px',
-  },
-  wrap: {
-    display: 'inline-block',
-  },
-} as const
-
-/* CSS minified from
-body { margin: 0; color: #000; background: #fff; }
-.next-error-h1 {
-  border-right: 1px solid rgba(0, 0, 0, .3);
-}
-@media (prefers-color-scheme: dark) {
-  body { color: #fff; background: #000; }
-  .next-error-h1 {
-    border-right: 1px solid rgba(255, 255, 255, .3);
-  }
-}
-*/
-const themeCss = `body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}
-@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}`
-
+// This is the static 500.html page for App Router apps.
+// Always a server error, rendered at build time.
 function AppError() {
-  const errorMessage = 'Internal Server Error.'
-  const title = `500: ${errorMessage}`
   return (
     <html id="__next_error__">
       <head>
-        <title>{title}</title>
+        <title>500: This page failed to load</title>
+        <style dangerouslySetInnerHTML={{ __html: errorThemeCss }} />
       </head>
       <body>
-        <div style={styles.error}>
-          <div style={styles.desc}>
-            <style
-              dangerouslySetInnerHTML={{
-                __html: themeCss,
-              }}
-            />
-            <h1 className="next-error-h1" style={styles.h1}>
-              500
-            </h1>
-            <div style={styles.wrap}>
-              <h2 style={styles.h2}>{errorMessage}</h2>
-            </div>
+        <div style={errorStyles.container}>
+          <div style={errorStyles.card}>
+            <ErrorIcon />
+            <h1 style={errorStyles.title}>This page failed to load</h1>
+            <p style={errorStyles.message}>
+              Something went wrong while loading this page.
+            </p>
+            <p style={errorStyles.messageHint}>
+              If this keeps happening, it may be a server issue.
+            </p>
+            <form>
+              <button type="submit" style={errorStyles.button}>
+                Reload page
+              </button>
+            </form>
           </div>
         </div>
       </body>

--- a/packages/next/src/client/components/builtin/error-styles.tsx
+++ b/packages/next/src/client/components/builtin/error-styles.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+
+export const errorStyles = {
+  container: {
+    fontFamily:
+      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
+    height: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  card: {
+    maxWidth: '420px',
+    padding: '32px 28px',
+    textAlign: 'left' as const,
+  },
+  icon: {
+    marginBottom: '16px',
+  },
+  title: {
+    fontSize: '17px',
+    fontWeight: 600,
+    letterSpacing: '-0.01em',
+    margin: '0 0 8px 0',
+    color: 'var(--next-error-title)',
+  },
+  message: {
+    fontSize: '14px',
+    fontWeight: 400,
+    lineHeight: 1.6,
+    margin: '0 0 6px 0',
+    color: 'var(--next-error-message)',
+  },
+  messageHint: {
+    fontSize: '13px',
+    fontWeight: 400,
+    lineHeight: 1.5,
+    margin: '0 0 20px 0',
+    color: 'var(--next-error-hint)',
+  },
+  buttonGroup: {
+    display: 'flex',
+    gap: '12px',
+    alignItems: 'center',
+  },
+  button: {
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    color: 'var(--next-error-btn-text)',
+    background: 'var(--next-error-btn-bg)',
+    border: 'var(--next-error-btn-border)',
+  },
+  buttonSecondary: {
+    padding: '10px 20px',
+    fontSize: '14px',
+    fontWeight: 500,
+    letterSpacing: '0.01em',
+    borderRadius: '6px',
+    cursor: 'pointer',
+    color: 'var(--next-error-btn-secondary-text)',
+    background: 'transparent',
+    border: 'none',
+  },
+  digestContainer: {
+    marginTop: '20px',
+    paddingTop: '16px',
+    borderTop: 'var(--next-error-digest-border)',
+  },
+  digest: {
+    fontSize: '12px',
+    fontWeight: 400,
+    margin: '0',
+    color: 'var(--next-error-digest)',
+  },
+  digestCode: {
+    fontFamily:
+      'ui-monospace,SFMono-Regular,"SF Mono",Menlo,Consolas,monospace',
+    fontSize: '11px',
+    color: 'var(--next-error-digest-code)',
+    userSelect: 'all' as const,
+  },
+} as const
+
+export const errorThemeCss = `
+:root {
+  --next-error-bg: #fff;
+  --next-error-text: #171717;
+  --next-error-title: #171717;
+  --next-error-message: #666;
+  --next-error-hint: #888;
+  --next-error-digest: #999;
+  --next-error-digest-code: #888;
+  --next-error-digest-border: 1px solid rgba(0,0,0,0.06);
+  --next-error-btn-text: #171717;
+  --next-error-btn-bg: #fff;
+  --next-error-btn-border: 1px solid #e5e5e5;
+  --next-error-btn-secondary-text: #666;
+  --next-error-icon-ring: #fecaca;
+  --next-error-icon-fill: #fef2f2;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --next-error-bg: #0a0a0a;
+    --next-error-text: #ededed;
+    --next-error-title: #ededed;
+    --next-error-message: #a0a0a0;
+    --next-error-hint: #707070;
+    --next-error-digest: #606060;
+    --next-error-digest-code: #707070;
+    --next-error-digest-border: 1px solid rgba(255,255,255,0.08);
+    --next-error-btn-text: #ededed;
+    --next-error-btn-bg: #1a1a1a;
+    --next-error-btn-border: 1px solid #333;
+    --next-error-btn-secondary-text: #a0a0a0;
+    --next-error-icon-ring: #5c2121;
+    --next-error-icon-fill: #2a1618;
+  }
+}
+body { margin: 0; color: var(--next-error-text); background: var(--next-error-bg); }
+`.replace(/\n\s*/g, '')
+
+export function ErrorIcon() {
+  return (
+    <svg
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
+      fill="none"
+      style={errorStyles.icon}
+    >
+      <circle
+        cx="20"
+        cy="20"
+        r="19"
+        stroke="var(--next-error-icon-ring)"
+        strokeWidth="2"
+      />
+      <circle cx="20" cy="20" r="16" fill="var(--next-error-icon-fill)" />
+      <path
+        d="M20 12v9"
+        stroke="#dc2626"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+      <circle cx="20" cy="27" r="1.5" fill="#dc2626" />
+    </svg>
+  )
+}

--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -1,46 +1,74 @@
 'use client'
 
 import { HandleISRError } from '../handle-isr-error'
-
-const styles = {
-  error: {
-    // https://github.com/sindresorhus/modern-normalize/blob/main/modern-normalize.css#L38-L52
-    fontFamily:
-      'system-ui,"Segoe UI",Roboto,Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji"',
-    height: '100vh',
-    textAlign: 'center',
-    display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  text: {
-    fontSize: '14px',
-    fontWeight: 400,
-    lineHeight: '28px',
-    margin: '0 8px',
-  },
-} as const
+import { errorStyles, errorThemeCss, ErrorIcon } from './error-styles'
 
 export type GlobalErrorComponent = React.ComponentType<{
   error: any
 }>
+
 function DefaultGlobalError({ error }: { error: any }) {
   const digest: string | undefined = error?.digest
+  const isServerError = !!digest
+
+  // Server error: "This page failed to load"
+  // Client error: "This page crashed"
+  const title = isServerError ? 'This page failed to load' : 'This page crashed'
+  const message = isServerError
+    ? 'Something went wrong while loading this page.'
+    : 'An error occurred while running this page.'
+  const hint = isServerError
+    ? 'If this keeps happening, it may be a server issue.'
+    : null
+
   return (
     <html id="__next_error__">
-      <head></head>
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: errorThemeCss }} />
+      </head>
       <body>
         <HandleISRError error={error} />
-        <div style={styles.error}>
-          <div>
-            <h2 style={styles.text}>
-              Application error: a {digest ? 'server' : 'client'}-side exception
-              has occurred while loading {window.location.hostname} (see the{' '}
-              {digest ? 'server logs' : 'browser console'} for more
-              information).
-            </h2>
-            {digest ? <p style={styles.text}>{`Digest: ${digest}`}</p> : null}
+        <div style={errorStyles.container}>
+          <div style={errorStyles.card}>
+            <ErrorIcon />
+            <h1 style={errorStyles.title}>{title}</h1>
+            <p style={errorStyles.message}>{message}</p>
+            {hint && <p style={errorStyles.messageHint}>{hint}</p>}
+            {!isServerError && (
+              <p style={errorStyles.messageHint}>
+                Reloading usually fixes this.
+              </p>
+            )}
+            <div style={errorStyles.buttonGroup}>
+              <form>
+                <button type="submit" style={errorStyles.button}>
+                  Reload page
+                </button>
+              </form>
+              {!isServerError && (
+                <button
+                  type="button"
+                  style={errorStyles.buttonSecondary}
+                  onClick={() => {
+                    if (window.history.length > 1) {
+                      window.history.back()
+                    } else {
+                      window.location.href = '/'
+                    }
+                  }}
+                >
+                  Go back
+                </button>
+              )}
+            </div>
+            {digest && (
+              <div style={errorStyles.digestContainer}>
+                <p style={errorStyles.digest}>
+                  Error reference:{' '}
+                  <code style={errorStyles.digestCode}>{digest}</code>
+                </p>
+              </div>
+            )}
           </div>
         </div>
       </body>

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -4218,11 +4218,13 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-        ? async_hooks.AsyncLocalStorage.snapshot()
-        : null;
       scheduleMicrotask(function () {
-        requestStorage.run(request, performWork, request);
+        requestStorage.run(request, function() {
+          request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+            ? async_hooks.AsyncLocalStorage.snapshot()
+            : null;
+          performWork(request);
+        });
       });
       setImmediate(function () {
         10 === request.status && (request.status = 11);

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -4218,8 +4218,8 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-        ? AsyncLocalStorage.snapshot()
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
         : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -1174,6 +1174,7 @@
       type = this.timeOrigin = performance.now();
       emitTimeOriginChunk(this, type + performance.timeOrigin);
       this.abortTime = -0;
+      this.asyncContextSnapshot = null;
       model = createTask(
         this,
         model,
@@ -2252,6 +2253,14 @@
         emitDebugChunk(request, task.id, alreadyForwardedDebugInfo),
         markOperationEndTime(request, task, node.end));
     }
+    function runInAsyncContext(request, fn) {
+      return function() {
+        if (request.asyncContextSnapshot) {
+          return request.asyncContextSnapshot(fn);
+        }
+        return fn();
+      };
+    }
     function pingTask(request, task) {
       task.timed = !0;
       var pingedTasks = request.pingedTasks;
@@ -2259,12 +2268,12 @@
       1 === pingedTasks.length &&
         ((request.flushScheduled = null !== request.destination),
         21 === request.type || 10 === request.status
-          ? scheduleMicrotask(function () {
+          ? scheduleMicrotask(runInAsyncContext(request, function () {
               return performWork(request);
-            })
-          : setImmediate(function () {
+            }))
+          : setImmediate(runInAsyncContext(request, function () {
               return performWork(request);
-            }));
+            })));
     }
     function createTask(
       request,
@@ -4206,6 +4215,9 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
+      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+        ? AsyncLocalStorage.snapshot()
+        : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);
       });

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2255,7 +2255,7 @@
     }
     function runInAsyncContext(request, fn) {
       return function() {
-        if (request.asyncContextSnapshot) {
+        if (request.asyncContextSnapshot && supportsRequestStorage) {
           return request.asyncContextSnapshot(fn);
         }
         return fn();
@@ -3058,6 +3058,7 @@
       request.cacheController.abort(
         Error("The render was aborted due to a fatal error.", { cause: error })
       );
+      request.asyncContextSnapshot = null;
     }
     function serializeErrorValue(request, error) {
       var name = "Error",
@@ -4206,12 +4207,14 @@
               (request.destination = null)),
             null !== request.debugDestination &&
               (request.debugDestination.end(),
-              (request.debugDestination = null)))
+              (request.debugDestination = null)),
+            (request.asyncContextSnapshot = null))
           : null !== importsChunks &&
             null !== request.destination &&
             ((request.status = CLOSED),
             request.destination.end(),
-            (request.destination = null)));
+            (request.destination = null),
+            (request.asyncContextSnapshot = null)));
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
@@ -5706,6 +5709,7 @@
         /^ {3} at (?:(.+) \((?:(.+):(\d+):(\d+)|<anonymous>)\)|(?:async )?(.+):(\d+):(\d+)|<anonymous>)$/,
       stackTraceCache = new WeakMap(),
       requestStorage = new async_hooks.AsyncLocalStorage(),
+      supportsRequestStorage = true,
       componentStorage = new async_hooks.AsyncLocalStorage(),
       TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
       proxyHandlers = {

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
@@ -524,6 +524,7 @@ function getChildFormatContext(parentContext, type, props) {
   }
 }
 var requestStorage = new async_hooks.AsyncLocalStorage(),
+  supportsRequestStorage = true,
   TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
   proxyHandlers = {
     get: function (target, name) {
@@ -1320,7 +1321,7 @@ function renderElement(request, task, type, key, ref, props) {
 }
 function runInAsyncContext(request, fn) {
   return function() {
-    if (request.asyncContextSnapshot) {
+    if (request.asyncContextSnapshot && supportsRequestStorage) {
       return request.asyncContextSnapshot(fn);
     }
     return fn();
@@ -1913,6 +1914,7 @@ function fatalError(request, error) {
   request.cacheController.abort(
     Error("The render was aborted due to a fatal error.", { cause: error })
   );
+  request.asyncContextSnapshot = null;
 }
 function emitErrorChunk(request, id, digest) {
   digest = { digest: digest };
@@ -2174,7 +2176,8 @@ function flushCompletedChunks(request) {
     null !== request.destination &&
       ((request.status = 14),
       request.destination.end(),
-      (request.destination = null)));
+      (request.destination = null)),
+    (request.asyncContextSnapshot = null));
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
@@ -915,6 +915,7 @@ function RequestInstance(
   this.identifierPrefix = identifierPrefix || "";
   this.identifierCount = 1;
   this.taintCleanupQueue = cleanupQueue;
+  this.asyncContextSnapshot = null;
   this.onError = void 0 === onError ? defaultErrorHandler : onError;
   this.onAllReady = onAllReady;
   this.onFatalError = onFatalError;
@@ -1317,18 +1318,26 @@ function renderElement(request, task, type, key, ref, props) {
   task = task.implicitSlot && null !== request ? [props] : props;
   return task;
 }
+function runInAsyncContext(request, fn) {
+  return function() {
+    if (request.asyncContextSnapshot) {
+      return request.asyncContextSnapshot(fn);
+    }
+    return fn();
+  };
+}
 function pingTask(request, task) {
   var pingedTasks = request.pingedTasks;
   pingedTasks.push(task);
   1 === pingedTasks.length &&
     ((request.flushScheduled = null !== request.destination),
     21 === request.type || 10 === request.status
-      ? scheduleMicrotask(function () {
+      ? scheduleMicrotask(runInAsyncContext(request, function () {
           return performWork(request);
-        })
-      : setImmediate(function () {
+        }))
+      : setImmediate(runInAsyncContext(request, function () {
           return performWork(request);
-        }));
+        })));
 }
 function createTask(
   request,
@@ -2169,6 +2178,9 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
+  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+    ? AsyncLocalStorage.snapshot()
+    : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);
   });

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2181,8 +2181,8 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-    ? AsyncLocalStorage.snapshot()
+  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+    ? async_hooks.AsyncLocalStorage.snapshot()
     : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2181,11 +2181,13 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-    ? async_hooks.AsyncLocalStorage.snapshot()
-    : null;
   scheduleMicrotask(function () {
-    requestStorage.run(request, performWork, request);
+    requestStorage.run(request, function() {
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
+        : null;
+      performWork(request);
+    });
   });
   setImmediate(function () {
     10 === request.status && (request.status = 11);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2237,9 +2237,6 @@
     }
     function runInAsyncContext(request, fn) {
       return function() {
-        if (request.asyncContextSnapshot) {
-          return request.asyncContextSnapshot(fn);
-        }
         return fn();
       };
     }
@@ -3028,6 +3025,7 @@
       request.cacheController.abort(
         Error("The render was aborted due to a fatal error.", { cause: error })
       );
+      request.asyncContextSnapshot = null;
     }
     function serializeErrorValue(request, error) {
       var name = "Error",
@@ -4160,12 +4158,14 @@
               (request.destination = null)),
             null !== request.debugDestination &&
               (request.debugDestination.end(),
-              (request.debugDestination = null)))
+              (request.debugDestination = null)),
+            (request.asyncContextSnapshot = null))
           : null !== importsChunks &&
             null !== request.destination &&
             ((request.status = CLOSED),
             request.destination.end(),
-            (request.destination = null)));
+            (request.destination = null),
+            (request.asyncContextSnapshot = null)));
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
@@ -5660,6 +5660,7 @@
         /^ {3} at (?:(.+) \((?:(.+):(\d+):(\d+)|<anonymous>)\)|(?:async )?(.+):(\d+):(\d+)|<anonymous>)$/,
       stackTraceCache = new WeakMap(),
       requestStorage = new async_hooks.AsyncLocalStorage(),
+      supportsRequestStorage = true,
       componentStorage = new async_hooks.AsyncLocalStorage(),
       TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
       proxyHandlers = {

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2237,7 +2237,7 @@
     }
     function runInAsyncContext(request, fn) {
       return function() {
-        if (request.asyncContextSnapshot) {
+        if (request.asyncContextSnapshot && supportsRequestStorage) {
           return request.asyncContextSnapshot(fn);
         }
         return fn();
@@ -4172,8 +4172,8 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-        ? AsyncLocalStorage.snapshot()
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
         : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -1156,6 +1156,7 @@
       type = this.timeOrigin = performance.now();
       emitTimeOriginChunk(this, type + performance.timeOrigin);
       this.abortTime = -0;
+      this.asyncContextSnapshot = null;
       model = createTask(
         this,
         model,
@@ -2234,6 +2235,14 @@
         emitDebugChunk(request, task.id, alreadyForwardedDebugInfo),
         markOperationEndTime(request, task, node.end));
     }
+    function runInAsyncContext(request, fn) {
+      return function() {
+        if (request.asyncContextSnapshot) {
+          return request.asyncContextSnapshot(fn);
+        }
+        return fn();
+      };
+    }
     function pingTask(request, task) {
       task.timed = !0;
       var pingedTasks = request.pingedTasks;
@@ -2241,12 +2250,12 @@
       1 === pingedTasks.length &&
         ((request.flushScheduled = null !== request.destination),
         21 === request.type || 10 === request.status
-          ? scheduleMicrotask(function () {
+          ? scheduleMicrotask(runInAsyncContext(request, function () {
               return performWork(request);
-            })
-          : setImmediate(function () {
+            }))
+          : setImmediate(runInAsyncContext(request, function () {
               return performWork(request);
-            }));
+            })));
     }
     function createTask(
       request,
@@ -4160,6 +4169,9 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
+      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+        ? AsyncLocalStorage.snapshot()
+        : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);
       });

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -2237,6 +2237,9 @@
     }
     function runInAsyncContext(request, fn) {
       return function() {
+        if (request.asyncContextSnapshot) {
+          return request.asyncContextSnapshot(fn);
+        }
         return fn();
       };
     }

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.development.js
@@ -4172,11 +4172,13 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-        ? async_hooks.AsyncLocalStorage.snapshot()
-        : null;
       scheduleMicrotask(function () {
-        requestStorage.run(request, performWork, request);
+        requestStorage.run(request, function() {
+          request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+            ? async_hooks.AsyncLocalStorage.snapshot()
+            : null;
+          performWork(request);
+        });
       });
       setImmediate(function () {
         10 === request.status && (request.status = 11);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2129,8 +2129,8 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-    ? AsyncLocalStorage.snapshot()
+  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+    ? async_hooks.AsyncLocalStorage.snapshot()
     : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
@@ -891,6 +891,7 @@ function RequestInstance(
   this.identifierPrefix = identifierPrefix || "";
   this.identifierCount = 1;
   this.taintCleanupQueue = [];
+  this.asyncContextSnapshot = null;
   this.onError = void 0 === onError ? defaultErrorHandler : onError;
   this.onAllReady = onAllReady;
   this.onFatalError = onFatalError;
@@ -1293,18 +1294,26 @@ function renderElement(request, task, type, key, ref, props) {
   task = task.implicitSlot && null !== request ? [props] : props;
   return task;
 }
+function runInAsyncContext(request, fn) {
+  return function() {
+    if (request.asyncContextSnapshot) {
+      return request.asyncContextSnapshot(fn);
+    }
+    return fn();
+  };
+}
 function pingTask(request, task) {
   var pingedTasks = request.pingedTasks;
   pingedTasks.push(task);
   1 === pingedTasks.length &&
     ((request.flushScheduled = null !== request.destination),
     21 === request.type || 10 === request.status
-      ? scheduleMicrotask(function () {
+      ? scheduleMicrotask(runInAsyncContext(request, function () {
           return performWork(request);
-        })
-      : setImmediate(function () {
+        }))
+      : setImmediate(runInAsyncContext(request, function () {
           return performWork(request);
-        }));
+        })));
 }
 function createTask(
   request,
@@ -2117,6 +2126,9 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
+  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+    ? AsyncLocalStorage.snapshot()
+    : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);
   });

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
@@ -524,6 +524,7 @@ function getChildFormatContext(parentContext, type, props) {
   }
 }
 var requestStorage = new async_hooks.AsyncLocalStorage(),
+  supportsRequestStorage = true,
   TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
   proxyHandlers = {
     get: function (target, name) {
@@ -1296,7 +1297,7 @@ function renderElement(request, task, type, key, ref, props) {
 }
 function runInAsyncContext(request, fn) {
   return function() {
-    if (request.asyncContextSnapshot) {
+    if (request.asyncContextSnapshot && supportsRequestStorage) {
       return request.asyncContextSnapshot(fn);
     }
     return fn();
@@ -1877,6 +1878,7 @@ function fatalError(request, error) {
   request.cacheController.abort(
     Error("The render was aborted due to a fatal error.", { cause: error })
   );
+  request.asyncContextSnapshot = null;
 }
 function emitErrorChunk(request, id, digest) {
   digest = { digest: digest };
@@ -2122,7 +2124,8 @@ function flushCompletedChunks(request) {
     null !== request.destination &&
       ((request.status = 14),
       request.destination.end(),
-      (request.destination = null)));
+      (request.destination = null)),
+    (request.asyncContextSnapshot = null));
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-server.node.production.js
@@ -2129,11 +2129,13 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-    ? async_hooks.AsyncLocalStorage.snapshot()
-    : null;
   scheduleMicrotask(function () {
-    requestStorage.run(request, performWork, request);
+    requestStorage.run(request, function() {
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
+        : null;
+      performWork(request);
+    });
   });
   setImmediate(function () {
     10 === request.status && (request.status = 11);

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -4218,11 +4218,13 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-        ? async_hooks.AsyncLocalStorage.snapshot()
-        : null;
       scheduleMicrotask(function () {
-        requestStorage.run(request, performWork, request);
+        requestStorage.run(request, function() {
+          request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+            ? async_hooks.AsyncLocalStorage.snapshot()
+            : null;
+          performWork(request);
+        });
       });
       setImmediate(function () {
         10 === request.status && (request.status = 11);

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -4218,8 +4218,8 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-        ? AsyncLocalStorage.snapshot()
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
         : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -1174,6 +1174,7 @@
       type = this.timeOrigin = performance.now();
       emitTimeOriginChunk(this, type + performance.timeOrigin);
       this.abortTime = -0;
+      this.asyncContextSnapshot = null;
       model = createTask(
         this,
         model,
@@ -2252,6 +2253,14 @@
         emitDebugChunk(request, task.id, alreadyForwardedDebugInfo),
         markOperationEndTime(request, task, node.end));
     }
+    function runInAsyncContext(request, fn) {
+      return function() {
+        if (request.asyncContextSnapshot) {
+          return request.asyncContextSnapshot(fn);
+        }
+        return fn();
+      };
+    }
     function pingTask(request, task) {
       task.timed = !0;
       var pingedTasks = request.pingedTasks;
@@ -2259,12 +2268,12 @@
       1 === pingedTasks.length &&
         ((request.flushScheduled = null !== request.destination),
         21 === request.type || 10 === request.status
-          ? scheduleMicrotask(function () {
+          ? scheduleMicrotask(runInAsyncContext(request, function () {
               return performWork(request);
-            })
-          : setImmediate(function () {
+            }))
+          : setImmediate(runInAsyncContext(request, function () {
               return performWork(request);
-            }));
+            })));
     }
     function createTask(
       request,
@@ -4206,6 +4215,9 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
+      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+        ? AsyncLocalStorage.snapshot()
+        : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);
       });

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.development.js
@@ -2255,7 +2255,7 @@
     }
     function runInAsyncContext(request, fn) {
       return function() {
-        if (request.asyncContextSnapshot) {
+        if (request.asyncContextSnapshot && supportsRequestStorage) {
           return request.asyncContextSnapshot(fn);
         }
         return fn();
@@ -3058,6 +3058,7 @@
       request.cacheController.abort(
         Error("The render was aborted due to a fatal error.", { cause: error })
       );
+      request.asyncContextSnapshot = null;
     }
     function serializeErrorValue(request, error) {
       var name = "Error",
@@ -4206,12 +4207,14 @@
               (request.destination = null)),
             null !== request.debugDestination &&
               (request.debugDestination.end(),
-              (request.debugDestination = null)))
+              (request.debugDestination = null)),
+            (request.asyncContextSnapshot = null))
           : null !== importsChunks &&
             null !== request.destination &&
             ((request.status = CLOSED),
             request.destination.end(),
-            (request.destination = null)));
+            (request.destination = null),
+            (request.asyncContextSnapshot = null)));
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
@@ -5709,6 +5712,7 @@
         /^ {3} at (?:(.+) \((?:(.+):(\d+):(\d+)|<anonymous>)\)|(?:async )?(.+):(\d+):(\d+)|<anonymous>)$/,
       stackTraceCache = new WeakMap(),
       requestStorage = new async_hooks.AsyncLocalStorage(),
+      supportsRequestStorage = true,
       componentStorage = new async_hooks.AsyncLocalStorage(),
       TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
       proxyHandlers = {

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
@@ -524,6 +524,7 @@ function getChildFormatContext(parentContext, type, props) {
   }
 }
 var requestStorage = new async_hooks.AsyncLocalStorage(),
+  supportsRequestStorage = true,
   TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
   proxyHandlers = {
     get: function (target, name) {
@@ -1320,7 +1321,7 @@ function renderElement(request, task, type, key, ref, props) {
 }
 function runInAsyncContext(request, fn) {
   return function() {
-    if (request.asyncContextSnapshot) {
+    if (request.asyncContextSnapshot && supportsRequestStorage) {
       return request.asyncContextSnapshot(fn);
     }
     return fn();
@@ -1913,6 +1914,7 @@ function fatalError(request, error) {
   request.cacheController.abort(
     Error("The render was aborted due to a fatal error.", { cause: error })
   );
+  request.asyncContextSnapshot = null;
 }
 function emitErrorChunk(request, id, digest) {
   digest = { digest: digest };
@@ -2174,7 +2176,8 @@ function flushCompletedChunks(request) {
     null !== request.destination &&
       ((request.status = 14),
       request.destination.end(),
-      (request.destination = null)));
+      (request.destination = null)),
+    (request.asyncContextSnapshot = null));
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
@@ -915,6 +915,7 @@ function RequestInstance(
   this.identifierPrefix = identifierPrefix || "";
   this.identifierCount = 1;
   this.taintCleanupQueue = cleanupQueue;
+  this.asyncContextSnapshot = null;
   this.onError = void 0 === onError ? defaultErrorHandler : onError;
   this.onAllReady = onAllReady;
   this.onFatalError = onFatalError;
@@ -1317,18 +1318,26 @@ function renderElement(request, task, type, key, ref, props) {
   task = task.implicitSlot && null !== request ? [props] : props;
   return task;
 }
+function runInAsyncContext(request, fn) {
+  return function() {
+    if (request.asyncContextSnapshot) {
+      return request.asyncContextSnapshot(fn);
+    }
+    return fn();
+  };
+}
 function pingTask(request, task) {
   var pingedTasks = request.pingedTasks;
   pingedTasks.push(task);
   1 === pingedTasks.length &&
     ((request.flushScheduled = null !== request.destination),
     21 === request.type || 10 === request.status
-      ? scheduleMicrotask(function () {
+      ? scheduleMicrotask(runInAsyncContext(request, function () {
           return performWork(request);
-        })
-      : setImmediate(function () {
+        }))
+      : setImmediate(runInAsyncContext(request, function () {
           return performWork(request);
-        }));
+        })));
 }
 function createTask(
   request,
@@ -2169,6 +2178,9 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
+  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+    ? AsyncLocalStorage.snapshot()
+    : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);
   });

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
@@ -2181,8 +2181,8 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-    ? AsyncLocalStorage.snapshot()
+  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+    ? async_hooks.AsyncLocalStorage.snapshot()
     : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-server.node.production.js
@@ -2181,11 +2181,13 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-    ? async_hooks.AsyncLocalStorage.snapshot()
-    : null;
   scheduleMicrotask(function () {
-    requestStorage.run(request, performWork, request);
+    requestStorage.run(request, function() {
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
+        : null;
+      performWork(request);
+    });
   });
   setImmediate(function () {
     10 === request.status && (request.status = 11);

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -1156,6 +1156,7 @@
       type = this.timeOrigin = performance.now();
       emitTimeOriginChunk(this, type + performance.timeOrigin);
       this.abortTime = -0;
+      this.asyncContextSnapshot = null;
       model = createTask(
         this,
         model,
@@ -2234,6 +2235,14 @@
         emitDebugChunk(request, task.id, alreadyForwardedDebugInfo),
         markOperationEndTime(request, task, node.end));
     }
+    function runInAsyncContext(request, fn) {
+      return function() {
+        if (request.asyncContextSnapshot) {
+          return request.asyncContextSnapshot(fn);
+        }
+        return fn();
+      };
+    }
     function pingTask(request, task) {
       task.timed = !0;
       var pingedTasks = request.pingedTasks;
@@ -2241,12 +2250,12 @@
       1 === pingedTasks.length &&
         ((request.flushScheduled = null !== request.destination),
         21 === request.type || 10 === request.status
-          ? scheduleMicrotask(function () {
+          ? scheduleMicrotask(runInAsyncContext(request, function () {
               return performWork(request);
-            })
-          : setImmediate(function () {
+            }))
+          : setImmediate(runInAsyncContext(request, function () {
               return performWork(request);
-            }));
+            })));
     }
     function createTask(
       request,
@@ -4160,6 +4169,9 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
+      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+        ? AsyncLocalStorage.snapshot()
+        : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);
       });

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -2237,7 +2237,7 @@
     }
     function runInAsyncContext(request, fn) {
       return function() {
-        if (request.asyncContextSnapshot) {
+        if (request.asyncContextSnapshot && supportsRequestStorage) {
           return request.asyncContextSnapshot(fn);
         }
         return fn();
@@ -3028,6 +3028,7 @@
       request.cacheController.abort(
         Error("The render was aborted due to a fatal error.", { cause: error })
       );
+      request.asyncContextSnapshot = null;
     }
     function serializeErrorValue(request, error) {
       var name = "Error",
@@ -4160,12 +4161,14 @@
               (request.destination = null)),
             null !== request.debugDestination &&
               (request.debugDestination.end(),
-              (request.debugDestination = null)))
+              (request.debugDestination = null)),
+            (request.asyncContextSnapshot = null))
           : null !== importsChunks &&
             null !== request.destination &&
             ((request.status = CLOSED),
             request.destination.end(),
-            (request.destination = null)));
+            (request.destination = null),
+            (request.asyncContextSnapshot = null)));
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
@@ -5663,6 +5666,7 @@
         /^ {3} at (?:(.+) \((?:(.+):(\d+):(\d+)|<anonymous>)\)|(?:async )?(.+):(\d+):(\d+)|<anonymous>)$/,
       stackTraceCache = new WeakMap(),
       requestStorage = new async_hooks.AsyncLocalStorage(),
+      supportsRequestStorage = true,
       componentStorage = new async_hooks.AsyncLocalStorage(),
       TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
       proxyHandlers = {

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -4172,8 +4172,8 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-        ? AsyncLocalStorage.snapshot()
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
         : null;
       scheduleMicrotask(function () {
         requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.development.js
@@ -4172,11 +4172,13 @@
     }
     function startWork(request) {
       request.flushScheduled = null !== request.destination;
-      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-        ? async_hooks.AsyncLocalStorage.snapshot()
-        : null;
       scheduleMicrotask(function () {
-        requestStorage.run(request, performWork, request);
+        requestStorage.run(request, function() {
+          request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+            ? async_hooks.AsyncLocalStorage.snapshot()
+            : null;
+          performWork(request);
+        });
       });
       setImmediate(function () {
         10 === request.status && (request.status = 11);

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -2129,8 +2129,8 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
-    ? AsyncLocalStorage.snapshot()
+  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+    ? async_hooks.AsyncLocalStorage.snapshot()
     : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -891,6 +891,7 @@ function RequestInstance(
   this.identifierPrefix = identifierPrefix || "";
   this.identifierCount = 1;
   this.taintCleanupQueue = [];
+  this.asyncContextSnapshot = null;
   this.onError = void 0 === onError ? defaultErrorHandler : onError;
   this.onAllReady = onAllReady;
   this.onFatalError = onFatalError;
@@ -1293,18 +1294,26 @@ function renderElement(request, task, type, key, ref, props) {
   task = task.implicitSlot && null !== request ? [props] : props;
   return task;
 }
+function runInAsyncContext(request, fn) {
+  return function() {
+    if (request.asyncContextSnapshot) {
+      return request.asyncContextSnapshot(fn);
+    }
+    return fn();
+  };
+}
 function pingTask(request, task) {
   var pingedTasks = request.pingedTasks;
   pingedTasks.push(task);
   1 === pingedTasks.length &&
     ((request.flushScheduled = null !== request.destination),
     21 === request.type || 10 === request.status
-      ? scheduleMicrotask(function () {
+      ? scheduleMicrotask(runInAsyncContext(request, function () {
           return performWork(request);
-        })
-      : setImmediate(function () {
+        }))
+      : setImmediate(runInAsyncContext(request, function () {
           return performWork(request);
-        }));
+        })));
 }
 function createTask(
   request,
@@ -2117,6 +2126,9 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
+  request.asyncContextSnapshot = typeof AsyncLocalStorage.snapshot === 'function'
+    ? AsyncLocalStorage.snapshot()
+    : null;
   scheduleMicrotask(function () {
     requestStorage.run(request, performWork, request);
   });

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -524,6 +524,7 @@ function getChildFormatContext(parentContext, type, props) {
   }
 }
 var requestStorage = new async_hooks.AsyncLocalStorage(),
+  supportsRequestStorage = true,
   TEMPORARY_REFERENCE_TAG = Symbol.for("react.temporary.reference"),
   proxyHandlers = {
     get: function (target, name) {
@@ -1296,7 +1297,7 @@ function renderElement(request, task, type, key, ref, props) {
 }
 function runInAsyncContext(request, fn) {
   return function() {
-    if (request.asyncContextSnapshot) {
+    if (request.asyncContextSnapshot && supportsRequestStorage) {
       return request.asyncContextSnapshot(fn);
     }
     return fn();
@@ -1877,6 +1878,7 @@ function fatalError(request, error) {
   request.cacheController.abort(
     Error("The render was aborted due to a fatal error.", { cause: error })
   );
+  request.asyncContextSnapshot = null;
 }
 function emitErrorChunk(request, id, digest) {
   digest = { digest: digest };
@@ -2122,7 +2124,8 @@ function flushCompletedChunks(request) {
     null !== request.destination &&
       ((request.status = 14),
       request.destination.end(),
-      (request.destination = null)));
+      (request.destination = null)),
+    (request.asyncContextSnapshot = null));
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-server.node.production.js
@@ -2129,11 +2129,13 @@ function flushCompletedChunks(request) {
 }
 function startWork(request) {
   request.flushScheduled = null !== request.destination;
-  request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
-    ? async_hooks.AsyncLocalStorage.snapshot()
-    : null;
   scheduleMicrotask(function () {
-    requestStorage.run(request, performWork, request);
+    requestStorage.run(request, function() {
+      request.asyncContextSnapshot = typeof async_hooks.AsyncLocalStorage.snapshot === 'function'
+        ? async_hooks.AsyncLocalStorage.snapshot()
+        : null;
+      performWork(request);
+    });
   });
   setImmediate(function () {
     10 === request.status && (request.status = 11);

--- a/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
+++ b/packages/next/src/lib/typescript/writeAppTypeDeclarations.ts
@@ -5,12 +5,15 @@ import { promises as fs } from 'fs'
 export async function writeAppTypeDeclarations({
   baseDir,
   distDir,
+  distDirRoot,
   imageImportsEnabled,
   hasPagesDir,
   hasAppDir,
 }: {
   baseDir: string
   distDir: string
+  /** The original distDir before any modifications (e.g., for isolatedDevBuild). Used for stable type imports. */
+  distDirRoot?: string
   imageImportsEnabled: boolean
   hasPagesDir: boolean
   hasAppDir: boolean
@@ -57,10 +60,12 @@ export async function writeAppTypeDeclarations({
     )
   }
 
-  const routeTypesPath = path.posix.join(
-    distDir.replaceAll(path.win32.sep, path.posix.sep),
-    'types/routes.d.ts'
+  // Use distDirRoot for stable path that doesn't change between dev/build modes
+  const stableDistDir = (distDirRoot ?? distDir).replaceAll(
+    path.win32.sep,
+    path.posix.sep
   )
+  const routeTypesPath = path.posix.join(stableDistDir, 'types/routes.d.ts')
 
   // Use ESM import instead of triple-slash reference for better ESLint compatibility
   directives.push(`import "./${routeTypesPath}";`)

--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -36,6 +36,7 @@ const requiredPackages = [
 export async function verifyTypeScriptSetup({
   dir,
   distDir,
+  distDirRoot,
   cacheDir,
   tsconfigPath,
   typeCheckPreflight,
@@ -49,6 +50,8 @@ export async function verifyTypeScriptSetup({
 }: {
   dir: string
   distDir: string
+  /** The original distDir before any modifications (e.g., for isolatedDevBuild). */
+  distDirRoot?: string
   cacheDir?: string
   tsconfigPath: string | undefined
   typeCheckPreflight: boolean
@@ -143,6 +146,7 @@ export async function verifyTypeScriptSetup({
     await writeAppTypeDeclarations({
       baseDir: dir,
       distDir,
+      distDirRoot,
       imageImportsEnabled: !disableStaticImages,
       hasPagesDir,
       hasAppDir,

--- a/packages/next/src/server/lib/router-utils/route-types-utils.ts
+++ b/packages/next/src/server/lib/router-utils/route-types-utils.ts
@@ -395,3 +395,28 @@ export async function writeValidatorFile(
       : generateValidatorFile(manifest)
   )
 }
+
+/**
+ * Writes a proxy routes.d.ts file at the stable path that re-exports from
+ * the actual dev types location. This allows next-env.d.ts to always reference
+ * the same stable path regardless of dev/build mode.
+ *
+ * @param stableTypesDir - The stable types directory (e.g., .next/types)
+ * @param devTypesRelativePath - Relative path from stable dir to dev types (e.g., ../dev/types/routes.d.ts)
+ */
+export async function writeRouteTypesProxy(
+  stableTypesDir: string,
+  devTypesRelativePath: string
+) {
+  if (!fs.existsSync(stableTypesDir)) {
+    await fs.promises.mkdir(stableTypesDir, { recursive: true })
+  }
+
+  const proxyFilePath = path.join(stableTypesDir, 'routes.d.ts')
+  const proxyContent = `// This file re-exports route types from the dev types location.
+// This provides a stable import path for next-env.d.ts across dev/build modes.
+export * from '${devTypesRelativePath}';
+`
+
+  await fs.promises.writeFile(proxyFilePath, proxyContent)
+}

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -85,6 +85,7 @@ import {
   createRouteTypesManifest,
   writeRouteTypesManifest,
   writeValidatorFile,
+  writeRouteTypesProxy,
 } from './route-types-utils'
 import { writeCacheLifeTypes } from './cache-life-type-utils'
 import { isParallelRouteSegment } from '../../../shared/lib/segment'
@@ -143,6 +144,7 @@ async function verifyTypeScript(opts: SetupOpts) {
   const verifyResult = await verifyTypeScriptSetup({
     dir: opts.dir,
     distDir: opts.nextConfig.distDir,
+    distDirRoot: opts.nextConfig.distDirRoot,
     typeCheckPreflight: false,
     tsconfigPath: opts.nextConfig.typescript.tsconfigPath,
     disableStaticImages: opts.nextConfig.images.disableStaticImages,
@@ -265,6 +267,17 @@ async function startWatcher(
     path.join(distTypesDir, 'routes.d.ts'),
     opts.nextConfig
   )
+
+  // When isolatedDevBuild is enabled, write a proxy file at the stable path
+  // that re-exports from the dev types location
+  if (opts.nextConfig.experimental.isolatedDevBuild) {
+    const stableTypesDir = path.join(
+      opts.dir,
+      opts.nextConfig.distDirRoot,
+      'types'
+    )
+    await writeRouteTypesProxy(stableTypesDir, '../dev/types/routes.d.ts')
+  }
 
   const routesManifestPath = path.join(distDir, ROUTES_MANIFEST)
   const routesManifest: DevRoutesManifest = {

--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -2684,6 +2684,16 @@ export async function build(task, opts) {
     ['precompile', 'compile', 'check_error_codes', 'generate_types'],
     opts
   )
+  // Write git commit hash to dist for stale build detection during tests
+  try {
+    const { stdout: commitHash } = await execa('git', ['rev-parse', 'HEAD'])
+    await fs.writeFile(
+      join(__dirname, 'dist', '.build-commit'),
+      commitHash.trim()
+    )
+  } catch (err) {
+    console.warn(`Warning: Could not write build commit hash: ${err.message}`)
+  }
 }
 
 export async function generate_types(task, opts) {

--- a/run-tests.js
+++ b/run-tests.js
@@ -13,6 +13,7 @@ const glob = promisify(_glob)
 const exec = promisify(execOrig)
 const core = require('@actions/core')
 const { getTestFilter } = require('./test/get-test-filter')
+const { checkBuildFreshness } = require('./test/lib/check-build-freshness')
 
 // Do not rename or format. sync-react script relies on this line.
 // prettier-ignore
@@ -218,6 +219,9 @@ async function getTestTimings() {
 async function main() {
   // Ensure we have the arguments awaited from yargs.
   argv = await argv
+
+  // Check for stale or missing build
+  await checkBuildFreshness()
 
   // `.github/workflows/build_reusable.yml` sets this, we should use it unless
   // it's overridden by an explicit `--concurrency` argument.

--- a/test/development/app-dir/isolated-dev-build/isolated-dev-build.test.ts
+++ b/test/development/app-dir/isolated-dev-build/isolated-dev-build.test.ts
@@ -23,4 +23,32 @@ describe('isolated-dev-build', () => {
       expect(await browser.elementByCss('p').text()).toBe('hello updated world')
     })
   })
+
+  it('should use stable path in next-env.d.ts that does not change between dev/build', async () => {
+    const nextEnvContent = await next.readFile('next-env.d.ts')
+    // Snapshot ensures next-env.d.ts content stays stable
+    expect(nextEnvContent).toMatchInlineSnapshot(`
+      "/// <reference types="next" />
+      /// <reference types="next/image-types/global" />
+      import "./.next/types/routes.d.ts";
+
+      // NOTE: This file should not be edited
+      // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.
+      "
+    `)
+  })
+
+  it('should create proxy routes.d.ts at stable path that re-exports from dev types', async () => {
+    // The proxy file should re-export from the dev types location
+    const proxyContent = await next.readFile('.next/types/routes.d.ts')
+    expect(proxyContent).toMatchInlineSnapshot(`
+      "// This file re-exports route types from the dev types location.
+      // This provides a stable import path for next-env.d.ts across dev/build modes.
+      export * from '../dev/types/routes.d.ts';
+      "
+    `)
+
+    // The actual dev types should exist
+    expect(await next.hasFile('.next/dev/types/routes.d.ts')).toBe(true)
+  })
 })

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -38,9 +38,7 @@ describe('serialize-circular-error', () => {
     `)
 
     const bodyText = await browser.elementByCss('body').text()
-    expect(bodyText).toContain(
-      'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
-    )
+    expect(bodyText).toContain('This page crashed')
 
     const output = next.cliOutput
     expect(output).toContain(

--- a/test/e2e/app-dir/default-error-page-ui/app/layout.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/default-error-page-ui/app/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/page.js
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home Page</div>
+}

--- a/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/server-error/page.js
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function ServerErrorContent() {
+  await connection()
+  throw new Error('Test server error')
+}
+
+export default function ServerErrorPage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ServerErrorContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/default-error-page-ui/app/trigger-error/page.js
+++ b/test/e2e/app-dir/default-error-page-ui/app/trigger-error/page.js
@@ -1,0 +1,20 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function TriggerErrorPage() {
+  const [shouldError, setShouldError] = useState(false)
+
+  if (shouldError) {
+    throw new Error('Test client error')
+  }
+
+  return (
+    <div>
+      <h1>Trigger Error Page</h1>
+      <button id="trigger-error" onClick={() => setShouldError(true)}>
+        Trigger Error
+      </button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
+++ b/test/e2e/app-dir/default-error-page-ui/default-error-page-ui.test.ts
@@ -1,0 +1,160 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('app dir - default error page UI', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render client error page with correct UI elements', async () => {
+    const browser = await next.browser('/trigger-error')
+
+    // Trigger a client-side error
+    await browser.elementByCss('#trigger-error').click()
+
+    // Skip UI checks in dev mode (redbox overlay covers the error page)
+    if (isNextDev) {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Test client error",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/trigger-error/page.js (9:11) @ TriggerErrorPage
+       >  9 |     throw new Error('Test client error')
+            |           ^",
+         "stack": [
+           "TriggerErrorPage app/trigger-error/page.js (9:11)",
+         ],
+       }
+      `)
+      return
+    }
+
+    // In production mode, verify the client error page UI elements
+
+    // Check that the SVG icon is present (40x40 size)
+    const svgIcon = await browser.elementByCss('svg')
+    expect(await svgIcon.getAttribute('width')).toBe('40')
+    expect(await svgIcon.getAttribute('height')).toBe('40')
+
+    // Check the error title - client errors show "This page crashed"
+    const title = await browser.elementByCss('h1')
+    expect(await title.text()).toBe('This page crashed')
+
+    // Check the error message - client errors show "An error occurred while running this page."
+    const message = await browser.elementByCss('p')
+    expect(await message.text()).toContain('An error occurred while running')
+
+    // Check the "Reload page" button exists
+    const buttons = await browser.elementsByCss('button')
+    expect(await buttons[0].innerText()).toBe('Reload page')
+
+    // Check "Go back" button exists for client errors
+    expect(await buttons[1].innerText()).toBe('Go back')
+
+    // Check the hint text about reloading
+    const html = await browser.eval('document.documentElement.innerHTML')
+    expect(html).toContain('Reloading usually fixes this')
+  })
+
+  it('should reload the page when Reload page button is clicked', async () => {
+    const browser = await next.browser('/trigger-error')
+
+    // Trigger a client-side error
+    await browser.elementByCss('#trigger-error').click()
+
+    // Skip in dev mode (redbox overlay)
+    if (isNextDev) {
+      return
+    }
+
+    // Get the current URL
+    const urlBefore = await browser.url()
+
+    // Click the Reload page button
+    await browser.elementByCss('button').click()
+
+    // Wait for page to reload (should be back to the trigger-error page)
+    await browser.waitForElementByCss('#trigger-error')
+
+    // Verify we're on the same page
+    const urlAfter = await browser.url()
+    expect(urlAfter).toBe(urlBefore)
+
+    // Verify the page content is showing (not the error)
+    const pageTitle = await browser.elementByCss('h1')
+    expect(await pageTitle.text()).toBe('Trigger Error Page')
+  })
+
+  it('should have proper styling in the default error page', async () => {
+    const browser = await next.browser('/trigger-error')
+
+    // Trigger a client-side error
+    await browser.elementByCss('#trigger-error').click()
+
+    // Skip in dev mode
+    if (isNextDev) {
+      return
+    }
+
+    // Check that the title has neutral dark color (not red)
+    const title = await browser.elementByCss('h1')
+    const titleColor = await title.getComputedCss('color')
+    // In light mode: #171717 = rgb(23, 23, 23)
+    expect(titleColor).toContain('23')
+
+    // Check that the button has neutral styling (white background with border)
+    const button = await browser.elementByCss('button')
+    const buttonBg = await button.getComputedCss('background-color')
+    // White = rgb(255, 255, 255)
+    expect(buttonBg).toContain('255')
+  })
+
+  it('should display server error page with Error reference', async () => {
+    const browser = await next.browser('/server-error')
+
+    // Skip in dev mode (redbox overlay)
+    if (isNextDev) {
+      await expect(browser).toDisplayRedbox(`
+       {
+         "description": "Test server error",
+         "environmentLabel": "Server",
+         "label": "Runtime Error",
+         "source": "app/server-error/page.js (6:9) @ ServerErrorContent
+       > 6 |   throw new Error('Test server error')
+           |         ^",
+         "stack": [
+           "ServerErrorContent app/server-error/page.js (6:9)",
+         ],
+       }
+      `)
+      return
+    }
+
+    // In production mode, verify the server error page
+    const html = await browser.eval('document.documentElement.innerHTML')
+
+    // Server errors show "This page failed to load"
+    expect(html).toContain('This page failed to load')
+
+    // Server errors show "Error reference:" with digest
+    expect(html).toContain('Error reference:')
+
+    // Server errors show hint about server issue
+    expect(html).toContain('it may be a server issue')
+  })
+
+  it('should have left-aligned text in error page', async () => {
+    const browser = await next.browser('/trigger-error')
+
+    await browser.elementByCss('#trigger-error').click()
+
+    if (isNextDev) {
+      return
+    }
+
+    // Check that the h1 has left text alignment
+    const title = await browser.elementByCss('h1')
+    const textAlign = await title.getComputedCss('text-align')
+    expect(textAlign).toBe('left')
+  })
+})

--- a/test/e2e/app-dir/errors/index.test.ts
+++ b/test/e2e/app-dir/errors/index.test.ts
@@ -189,10 +189,8 @@ describe('app-dir - errors', () => {
         `)
       } else {
         expect(
-          await browser.waitForElementByCss('body').elementByCss('h2').text()
-        ).toBe(
-          'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
-        )
+          await browser.waitForElementByCss('body').elementByCss('h1').text()
+        ).toBe('This page crashed')
       }
 
       expect(pageErrors).toEqual([
@@ -228,13 +226,11 @@ describe('app-dir - errors', () => {
         `)
       } else {
         expect(
-          await browser.waitForElementByCss('body').elementByCss('h2').text()
-        ).toBe(
-          'Application error: a server-side exception has occurred while loading localhost (see the server logs for more information).'
-        )
-        expect(
-          await browser.waitForElementByCss('body').elementByCss('p').text()
-        ).toMatch(/Digest: \w+/)
+          await browser.waitForElementByCss('body').elementByCss('h1').text()
+        ).toBe('This page failed to load')
+        // Check digest is displayed in error reference
+        const bodyText = await browser.waitForElementByCss('body').text()
+        expect(bodyText).toMatch(/Error reference:\s*\w+/)
       }
 
       expect(pageErrors).toEqual([

--- a/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
+++ b/test/e2e/app-dir/global-error/error-in-global-error/error-in-global-error.test.ts
@@ -31,10 +31,10 @@ describe('app dir - global-error - error-in-global-error', () => {
 
   it('should render fallback UI when error occurs in global-error', async () => {
     const browser = await next.browser('/?error-in-global-error=1')
-    const text = await browser.elementByCss('h2').text()
-    expect(text).toMatch(
-      /Application error: a client-side exception has occurred while loading [\w.-]+ \(see the browser console for more information\)./
-    )
+    // When the custom global-error throws, it falls back to the default global-error
+    // Client errors show "This page crashed"
+    const title = await browser.elementByCss('h1').text()
+    expect(title).toBe('This page crashed')
 
     if (isNextDev) {
       await waitForRedbox(browser)

--- a/test/e2e/app-dir/revalidatetag-rsc/revalidatetag-rsc.test.ts
+++ b/test/e2e/app-dir/revalidatetag-rsc/revalidatetag-rsc.test.ts
@@ -36,7 +36,7 @@ describe('revalidateTag-rsc', () => {
         await retry(async () => {
           expect(
             await browser.eval('document.documentElement.innerHTML')
-          ).toContain('Application error: a server-side exception has occurred')
+          ).toContain('This page failed to load')
         })
       }
 

--- a/test/e2e/app-dir/segment-cache/async-context-loss/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/async-context-loss/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/app/page.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>AsyncLocalStorage Context Loss Test</h1>
+      <p>
+        Click a link to trigger runtime prefetch and test context preservation:
+      </p>
+      <ul>
+        <li>
+          <Link href="/test-page/123">Test with params</Link>
+        </li>
+        <li>
+          <Link href="/test-cookies">Test with cookies()</Link>
+        </li>
+        <li>
+          <Link href="/test-headers">Test with headers()</Link>
+        </li>
+        <li>
+          <Link href="/test-generic-promise">Test with generic promise</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/async-context-loss/app/test-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/app/test-cookies/page.tsx
@@ -1,0 +1,53 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
+
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Cookies Context Loss Test</h1>
+      <Suspense fallback={<div>Loading...</div>}>
+        <TestComponent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function TestComponent() {
+  const contextBefore = workUnitAsyncStorage.getStore()
+  console.log(
+    '[COOKIES] CONTEXT_BEFORE_AWAIT:',
+    contextBefore?.type ?? 'undefined'
+  )
+
+  // Await cookies - triggers runtime stage delay
+  const cookieStore = await cookies()
+
+  const contextAfter = workUnitAsyncStorage.getStore()
+  console.log(
+    '[COOKIES] CONTEXT_AFTER_AWAIT:',
+    contextAfter?.type ?? 'undefined'
+  )
+
+  if (contextAfter === undefined) {
+    console.log('[COOKIES] CONTEXT_STATUS: LOST')
+  } else {
+    console.log('[COOKIES] CONTEXT_STATUS: PRESERVED')
+  }
+
+  const timestamp = Date.now()
+
+  return (
+    <div>
+      <p id="result">Cookies count: {cookieStore.getAll().length}</p>
+      <p>Timestamp: {timestamp}</p>
+      <p>Context Before: {contextBefore?.type ?? 'undefined'}</p>
+      <p>Context After: {contextAfter?.type ?? 'undefined'}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/async-context-loss/app/test-generic-promise/page.tsx
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/app/test-generic-promise/page.tsx
@@ -1,0 +1,66 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
+
+// A simple promise that resolves after a microtask
+// This demonstrates the issue is with React's scheduler, not specific to Next.js APIs
+function createDelayedPromise<T>(value: T): Promise<T> {
+  return new Promise((resolve) => {
+    queueMicrotask(() => resolve(value))
+  })
+}
+
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Generic Promise Context Loss Test</h1>
+      <Suspense fallback={<div>Loading...</div>}>
+        <TestComponent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function TestComponent() {
+  // First access cookies to make this a valid dynamic page
+  const cookieStore = await cookies()
+
+  const contextBefore = workUnitAsyncStorage.getStore()
+  console.log(
+    '[GENERIC] CONTEXT_BEFORE_AWAIT:',
+    contextBefore?.type ?? 'undefined'
+  )
+
+  // Await a generic promise AFTER the runtime API
+  const data = await createDelayedPromise({ message: 'Hello from promise' })
+
+  const contextAfter = workUnitAsyncStorage.getStore()
+  console.log(
+    '[GENERIC] CONTEXT_AFTER_AWAIT:',
+    contextAfter?.type ?? 'undefined'
+  )
+
+  if (contextAfter === undefined) {
+    console.log('[GENERIC] CONTEXT_STATUS: LOST')
+  } else {
+    console.log('[GENERIC] CONTEXT_STATUS: PRESERVED')
+  }
+
+  // Now Date.now() is valid because we already accessed cookies
+  const timestamp = Date.now()
+
+  return (
+    <div>
+      <p id="result">Message: {data.message}</p>
+      <p>Cookies: {cookieStore.getAll().length}</p>
+      <p>Timestamp: {timestamp}</p>
+      <p>Context Before: {contextBefore?.type ?? 'undefined'}</p>
+      <p>Context After: {contextAfter?.type ?? 'undefined'}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/async-context-loss/app/test-headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/app/test-headers/page.tsx
@@ -1,0 +1,55 @@
+import { Suspense } from 'react'
+import { headers } from 'next/headers'
+import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
+
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export default async function Page() {
+  return (
+    <main>
+      <h1>Headers Context Loss Test</h1>
+      <Suspense fallback={<div>Loading...</div>}>
+        <TestComponent />
+      </Suspense>
+    </main>
+  )
+}
+
+async function TestComponent() {
+  const contextBefore = workUnitAsyncStorage.getStore()
+  console.log(
+    '[HEADERS] CONTEXT_BEFORE_AWAIT:',
+    contextBefore?.type ?? 'undefined'
+  )
+
+  // Await headers - triggers runtime stage delay
+  const headerStore = await headers()
+
+  const contextAfter = workUnitAsyncStorage.getStore()
+  console.log(
+    '[HEADERS] CONTEXT_AFTER_AWAIT:',
+    contextAfter?.type ?? 'undefined'
+  )
+
+  if (contextAfter === undefined) {
+    console.log('[HEADERS] CONTEXT_STATUS: LOST')
+  } else {
+    console.log('[HEADERS] CONTEXT_STATUS: PRESERVED')
+  }
+
+  const timestamp = Date.now()
+
+  return (
+    <div>
+      <p id="result">
+        User-Agent: {headerStore.get('user-agent')?.slice(0, 20)}...
+      </p>
+      <p>Timestamp: {timestamp}</p>
+      <p>Context Before: {contextBefore?.type ?? 'undefined'}</p>
+      <p>Context After: {contextAfter?.type ?? 'undefined'}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/async-context-loss/app/test-page/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/app/test-page/[id]/page.tsx
@@ -1,0 +1,55 @@
+import { Suspense } from 'react'
+import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
+
+type Params = { id: string }
+
+export const unstable_prefetch = {
+  mode: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export default async function Page({ params }: { params: Promise<Params> }) {
+  return (
+    <main>
+      <h1>Params Context Loss Test</h1>
+      <Suspense fallback={<div>Loading...</div>}>
+        <TestComponent params={params} />
+      </Suspense>
+    </main>
+  )
+}
+
+async function TestComponent({ params }: { params: Promise<Params> }) {
+  const contextBefore = workUnitAsyncStorage.getStore()
+  console.log(
+    '[PARAMS] CONTEXT_BEFORE_AWAIT:',
+    contextBefore?.type ?? 'undefined'
+  )
+
+  // Await params - this triggers delayUntilRuntimeStage
+  // With the macrotask boundary fix, this will force context loss
+  const resolvedParams = await params
+
+  const contextAfter = workUnitAsyncStorage.getStore()
+  console.log(
+    '[PARAMS] CONTEXT_AFTER_AWAIT:',
+    contextAfter?.type ?? 'undefined'
+  )
+
+  if (contextAfter === undefined) {
+    console.log('[PARAMS] CONTEXT_STATUS: LOST')
+  } else {
+    console.log('[PARAMS] CONTEXT_STATUS: PRESERVED')
+  }
+
+  const timestamp = Date.now()
+
+  return (
+    <div>
+      <p id="result">Param ID: {resolvedParams.id}</p>
+      <p>Timestamp: {timestamp}</p>
+      <p>Context Before: {contextBefore?.type ?? 'undefined'}</p>
+      <p>Context After: {contextAfter?.type ?? 'undefined'}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/async-context-loss/async-context-loss.test.ts
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/async-context-loss.test.ts
@@ -1,0 +1,137 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+
+/**
+ * This test demonstrates the AsyncLocalStorage context loss issue
+ * when React's scheduler continues a suspended component.
+ *
+ * The test uses the same infrastructure as the flaky prefetch-runtime tests
+ * to ensure we're hitting the runtime prefetch code path.
+ */
+describe('AsyncLocalStorage context loss in React scheduler', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (isNextDev || skipped) {
+    test('skipped', () => {})
+    return
+  }
+
+  it('loses context after awaiting params in runtime prefetch', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Navigate to the params test page via prefetch
+    // This triggers runtime prefetch on the server
+    await act(
+      async () => {
+        // Navigate to the dynamic params page
+        await browser.elementByCss('a[href="/test-page/123"]').click()
+      },
+      {
+        // We expect the page to render with the result
+        includes: 'Param ID: 123',
+      }
+    )
+
+    // Check server logs for context status
+    const logs = next.cliOutput
+
+    // Look for the context logs during runtime prefetch
+    const hasContextLost = logs.includes('[PARAMS] CONTEXT_STATUS: LOST')
+    const hasContextPreserved = logs.includes(
+      '[PARAMS] CONTEXT_STATUS: PRESERVED'
+    )
+
+    console.log('Server logs contain CONTEXT_STATUS: LOST:', hasContextLost)
+    console.log(
+      'Server logs contain CONTEXT_STATUS: PRESERVED:',
+      hasContextPreserved
+    )
+
+    // If context is lost, this test fails - demonstrating the bug
+    if (hasContextLost) {
+      console.log('\n=== BUG CONFIRMED ===')
+      console.log('AsyncLocalStorage context is LOST after awaiting params')
+      console.log('This causes io() to fail to detect sync IO operations')
+      console.log('=====================\n')
+    }
+
+    expect(hasContextLost).toBe(false)
+    expect(hasContextPreserved).toBe(true)
+  })
+
+  it('loses context after awaiting cookies() in runtime prefetch', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/test-cookies"]').click()
+      },
+      {
+        includes: 'Cookies count:',
+      }
+    )
+
+    const logs = next.cliOutput
+    const hasContextLost = logs.includes('[COOKIES] CONTEXT_STATUS: LOST')
+    const hasContextPreserved = logs.includes(
+      '[COOKIES] CONTEXT_STATUS: PRESERVED'
+    )
+
+    console.log(
+      'COOKIES - Context Lost:',
+      hasContextLost,
+      'Preserved:',
+      hasContextPreserved
+    )
+
+    expect(hasContextLost).toBe(false)
+    expect(hasContextPreserved).toBe(true)
+  })
+
+  it('loses context after awaiting headers() in runtime prefetch', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/test-headers"]').click()
+      },
+      {
+        includes: 'User-Agent:',
+      }
+    )
+
+    const logs = next.cliOutput
+    const hasContextLost = logs.includes('[HEADERS] CONTEXT_STATUS: LOST')
+    const hasContextPreserved = logs.includes(
+      '[HEADERS] CONTEXT_STATUS: PRESERVED'
+    )
+
+    console.log(
+      'HEADERS - Context Lost:',
+      hasContextLost,
+      'Preserved:',
+      hasContextPreserved
+    )
+
+    expect(hasContextLost).toBe(false)
+    expect(hasContextPreserved).toBe(true)
+  })
+})

--- a/test/e2e/app-dir/segment-cache/async-context-loss/next.config.js
+++ b/test/e2e/app-dir/segment-cache/async-context-loss/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  experimental: {
+    dynamicIO: true,
+    clientSegmentCache: true,
+    cacheComponents: true,
+  },
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../../shared'
-import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
 
 type Params = { id: string }
 
@@ -25,11 +24,6 @@ export default async function Page({ params }: { params: Promise<Params> }) {
 }
 
 async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
-  const res = await params
-  console.log(
-    'RuntimePrefetchable :: awaited params',
-    res,
-    workUnitAsyncStorage.getStore()
-  )
+  await params
   return <div id="timestamp">Timestamp: {Date.now()}</div>
 }

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -28,8 +28,9 @@ describe('next-link', () => {
        }
       `)
     }
-    expect(await browser.elementByCss('body').text()).toMatchInlineSnapshot(
-      `"Application error: a client-side exception has occurred while loading localhost (see the browser console for more information)."`
+    // Client errors show "This page crashed"
+    expect(await browser.elementByCss('body').text()).toContain(
+      'This page crashed'
     )
   })
 
@@ -51,8 +52,9 @@ describe('next-link', () => {
          ],
        }
       `)
-      expect(await browser.elementByCss('body').text()).toMatchInlineSnapshot(
-        `"Application error: a client-side exception has occurred while loading localhost (see the browser console for more information)."`
+      // Client errors show "This page crashed"
+      expect(await browser.elementByCss('body').text()).toContain(
+        'This page crashed'
       )
     } else {
       expect(await browser.elementByCss('body').text()).toMatchInlineSnapshot(

--- a/test/e2e/opentelemetry/instrumentation/instrumentation-test.ts
+++ b/test/e2e/opentelemetry/instrumentation/instrumentation-test.ts
@@ -71,13 +71,13 @@ class TestExporter implements SpanExporter {
           code: ExportResultCode.FAILED,
           error: new Error(`http status ${response.status}`),
         })
+        return
       }
+      resultCallback({ code: ExportResultCode.SUCCESS })
     } catch (e) {
-      console.warn('WARN: TestExporterP: error:', e)
+      console.warn('WARN: TestExporter: error:', e)
       resultCallback({ code: ExportResultCode.FAILED, error: e })
     }
-
-    resultCallback({ code: ExportResultCode.SUCCESS })
   }
   shutdown(): Promise<void> {
     return Promise.resolve()

--- a/test/integration/custom-server-types/next-env.d.ts
+++ b/test/integration/custom-server-types/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/dev/types/routes.d.ts'
+import './.next/types/routes.d.ts'
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/test/integration/typescript-app-type-declarations/next-env.d.ts
+++ b/test/integration/typescript-app-type-declarations/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/test/jest-global-setup.ts
+++ b/test/jest-global-setup.ts
@@ -1,0 +1,5 @@
+import { checkBuildFreshness } from './lib/check-build-freshness'
+
+export default async function globalSetup() {
+  await checkBuildFreshness()
+}

--- a/test/lib/check-build-freshness.js
+++ b/test/lib/check-build-freshness.js
@@ -1,0 +1,59 @@
+const { existsSync } = require('fs')
+const fsp = require('fs/promises')
+const path = require('path')
+const { execSync } = require('child_process')
+
+const YELLOW = '\x1b[33m'
+const RESET = '\x1b[0m'
+
+/**
+ * Check if the Next.js build is fresh (matches current git HEAD).
+ * Prints warnings to console if build is missing or stale.
+ * @returns {Promise<void>}
+ */
+async function checkBuildFreshness() {
+  const distPath = path.join(__dirname, '../../packages/next/dist')
+  const buildCommitPath = path.join(distPath, '.build-commit')
+
+  if (!existsSync(distPath)) {
+    console.warn(`${YELLOW}⚠️  WARNING: No build found!${RESET}`)
+    console.warn(
+      `${YELLOW}   The packages/next/dist directory does not exist.${RESET}`
+    )
+    console.warn(
+      `${YELLOW}   Run \`pnpm build\` before running tests.\n${RESET}`
+    )
+    return
+  }
+
+  if (!existsSync(buildCommitPath)) {
+    console.warn(`${YELLOW}⚠️  WARNING: Build may be stale!${RESET}`)
+    console.warn(
+      `${YELLOW}   Unable to verify build freshness (no .build-commit marker).${RESET}`
+    )
+    console.warn(`${YELLOW}   Run \`pnpm build\` to rebuild.\n${RESET}`)
+    return
+  }
+
+  try {
+    const buildCommit = (await fsp.readFile(buildCommitPath, 'utf8')).trim()
+    const currentCommit = execSync('git rev-parse HEAD', {
+      encoding: 'utf8',
+    }).trim()
+
+    if (buildCommit !== currentCommit) {
+      console.warn(`${YELLOW}⚠️  WARNING: Build is stale!${RESET}`)
+      console.warn(
+        `${YELLOW}   Build was compiled at commit: ${buildCommit.slice(0, 8)}${RESET}`
+      )
+      console.warn(
+        `${YELLOW}   Current HEAD is at commit:    ${currentCommit.slice(0, 8)}${RESET}`
+      )
+      console.warn(`${YELLOW}   Run \`pnpm build\` to rebuild.\n${RESET}`)
+    }
+  } catch (err) {
+    // Ignore errors (e.g., git not available)
+  }
+}
+
+module.exports = { checkBuildFreshness }

--- a/test/production/500-page/app-router-only/app-router-only.test.ts
+++ b/test/production/500-page/app-router-only/app-router-only.test.ts
@@ -11,8 +11,8 @@ describe('500-page app-router-only', () => {
     it('should render app router 500 page when route error', async () => {
       const $ = await next.render$('/route-error')
       expect($('html').attr('id')).toBe('__next_error__')
-      expect($('body').text()).toContain('Internal Server Error.')
-      expect($('body').text()).toContain('500')
+      // Server errors show "This page failed to load"
+      expect($('body').text()).toContain('This page failed to load')
     })
   }
 
@@ -24,7 +24,8 @@ describe('500-page app-router-only', () => {
       )
       // Not use pages router to generate 500.html
       expect(html).toContain('__next_error__')
-      expect(html).toContain('Internal Server Error.')
+      // Server errors show "This page failed to load"
+      expect(html).toContain('This page failed to load')
       // global-error is not used in app router 500.html
       expect(html).not.toContain('app-router-global-error')
     })

--- a/test/production/app-dir/graceful-degrade/graceful-degrade-non-bot.test.ts
+++ b/test/production/app-dir/graceful-degrade/graceful-degrade-non-bot.test.ts
@@ -32,9 +32,8 @@ describe('graceful-degrade - non bot', () => {
     expect(await body.getAttribute('class')).not.toBe('body-cls')
 
     const bodyText = await body.text()
-    expect(bodyText).toMatch(
-      /Application error: a client-side exception has occurred while loading/
-    )
+    // Client errors show "This page crashed"
+    expect(bodyText).toMatch(/This page crashed/)
   })
 
   it('should show error boundary when browser errors when error boundary is defined', async () => {

--- a/test/production/app-dir/graceful-degrade/graceful-degrade.test.ts
+++ b/test/production/app-dir/graceful-degrade/graceful-degrade.test.ts
@@ -31,9 +31,7 @@ describe('graceful-degrade', () => {
 
     // Do not contain the global error boundary text
     const bodyText = await originBody.text()
-    expect(bodyText).not.toMatch(
-      /Application error: a client-side exception has occurred while loading/
-    )
+    expect(bodyText).not.toMatch(/This page crashed/)
   })
 
   it('should preserve the ssr html when browser errors for bot', async () => {
@@ -50,9 +48,7 @@ describe('graceful-degrade', () => {
     expect(errors).toMatch(/Error: boom/)
 
     const bodyText = await browser.elementByCss('body').text()
-    expect(bodyText).not.toMatch(
-      /Application error: a client-side exception has occurred while loading/
-    )
+    expect(bodyText).not.toMatch(/This page crashed/)
     expect(bodyText).toMatch(/fine/)
   })
 })

--- a/test/production/chunk-load-failure/chunk-load-failure.test.ts
+++ b/test/production/chunk-load-failure/chunk-load-failure.test.ts
@@ -41,9 +41,8 @@ describe('chunk-load-failure', () => {
 
     await retry(async () => {
       const body = await browser.elementByCss('body')
-      expect(await body.text()).toMatch(
-        /Application error: a client-side exception has occurred while loading/
-      )
+      // Client errors show "This page crashed"
+      expect(await body.text()).toMatch(/This page crashed/)
     })
 
     expect(pageError).toBeDefined()


### PR DESCRIPTION
> should not be merged. just a proof of concept that this [PR](https://github.com/facebook/react/pull/35436) in React work. We should wait for a sync

## Problem

When React's server-side renderer schedules work via microtasks or `setImmediate`, the Node.js AsyncLocalStorage context is lost. This causes Next.js's `workUnitAsyncStorage` to return `undefined` when components call sync IO APIs (like `Date.now()`) after awaiting runtime APIs (like `params`, `cookies()`, etc.).

This resulted in flaky tests in CI because:
1. The `io()` function couldn't detect sync IO access (context was lost)
2. No abort was triggered, so `serverIsDynamic` stayed `false`
3. `isPartial` was incorrectly set to `false` in RSC responses
4. Client router thought cached data was complete
5. Navigation requests weren't made, causing test timeouts

### Debug Evidence

```
[io] called with expression: `Date.now()` workUnitStore: undefined workStore: false
```

The `workUnitStore` was `undefined` when `Date.now()` was called, meaning the async context was lost.

## Solution

Use `AsyncLocalStorage.snapshot()` to capture the full async context when `startWork()` is called, then restore it when React's scheduler continues work via `pingTask()`. This ensures Next.js's AsyncLocalStorage contexts are preserved across React's scheduler boundaries.

### Changes Made to Vendored React Files

1. Added `asyncContextSnapshot` property to request object (initialized to `null`)
2. Capture snapshot in `startWork()` using `AsyncLocalStorage.snapshot()`
3. Added `runInAsyncContext()` helper to restore context when scheduling work
4. Wrapped `scheduleMicrotask` and `setImmediate` callbacks in `pingTask()` to use the captured snapshot

### Files Patched

- `react-server-dom-webpack` (dev & prod)
- `react-server-dom-webpack-experimental` (dev & prod)
- `react-server-dom-turbopack` (dev & prod)
- `react-server-dom-turbopack-experimental` (dev & prod)

## Testing

Tested locally with the previously flaky test:
- `aborts the prerender without logging an error when sync IO is used after awaiting dynamic params`
- All 7 "errors" block tests now pass reliably (ran 3+ times without failure)

## How It Works

```
┌─────────────────────────────────────────────────────────────────┐
│ Next.js: workUnitAsyncStorage.run(store, () => {               │
│   startWork(request) {                                         │
│     // Capture ALL AsyncLocalStorage contexts                  │
│     request.asyncContextSnapshot = AsyncLocalStorage.snapshot()│
│   }                                                            │
│   ...                                                          │
│   pingTask(request) {                                          │
│     // Restore context when scheduling continuation            │
│     scheduleMicrotask(runInAsyncContext(request, () => {       │
│       performWork(request) // Context is now available!        │
│     }))                                                        │
│   }                                                            │
│ })                                                              │
└─────────────────────────────────────────────────────────────────┘
```