### PR TITLE
Fix yarn command for creating a new Next.js app

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -28,7 +28,7 @@ npm run dev
 ```
 
 ```bash package="yarn"
-yarn create next-app@latest my-app --yes
+yarn create next-app my-app --yes
 cd my-app
 yarn dev
 ```


### PR DESCRIPTION
<img width="1056" height="404" alt="{7D0AFF4F-FC3D-4892-8B9C-B45800A1FDD1}" src="https://github.com/user-attachments/assets/402ee454-55ec-4ee7-b914-ba80390a4639" />

### What’s going wrong

Yarn **successfully installed** `create-next-app@16.1.1`, but when it tried to run it, Windows failed to resolve this command:

```
C:\Users\ThinkPad\AppData\Local\Yarn\bin\create-next-app@latest
```

### The problem:

* Windows treats `@latest` as **part of the executable name**
* That file **does not exist**
* Hence: *“is not recognized as an internal or external command”*

### The Fix:
Remove the `@latest` tag since yarn installs the latest already
