### PR TITLE
feat(native): Add native support for Android ARM64

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -374,6 +374,13 @@ jobs:
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}
 
+      - name: Cache on ${{ github.ref_name }}
+        uses: ijjk/rust-cache@turbo-cache-v1.0.9
+        with:
+          save-if: 'true'
+          cache-provider: 'turbo'
+          shared-key: build-${{ matrix.settings.target }}-${{ hashFiles('.cargo/config.toml') }}
+
       - name: Clear native build
         run: rm -rf packages/next-swc/native
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -300,21 +300,12 @@ jobs:
           - host: ubuntu-latest
             target: 'aarch64-linux-android'
             build: |
-              # 1. Setup Environment Variables
               export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
               export CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
-              
-              # 2. Set Rust Flags
               export RUSTFLAGS="--cfg tokio_unstable -Zshare-generics=y -Csymbol-mangling-version=v0 -Clink-arg=--sysroot=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
-
-              # 3. Install CLI tools
               npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
-              
-              # 4. Build
               cd packages/next-swc
               npm run build-native-release -- --target aarch64-linux-android
-              
-              # 5. Strip the binary
               $ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip native/next-swc.*.node
 
     name: stable - ${{ matrix.settings.target }} - node@16

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -345,7 +345,6 @@ jobs:
           npm i -g corepack@0.31
           corepack enable
 
-      # [ADD THIS BLOCK] Install Android NDK only if the target is Android
       - name: Setup Android NDK
         if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
         uses: nttld/setup-ndk@v1

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -297,6 +297,26 @@ jobs:
               npm run build-native-release -- --target aarch64-unknown-linux-musl
               llvm-strip -x native/next-swc.*.node
 
+          - host: ubuntu-latest
+            target: 'aarch64-linux-android'
+            build: |
+              # 1. Setup Environment Variables
+              export CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
+              export CARGO_TARGET_AARCH64_LINUX_ANDROID_AR=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-ar
+              
+              # 2. Set Rust Flags
+              export RUSTFLAGS="--cfg tokio_unstable -Zshare-generics=y -Csymbol-mangling-version=v0 -Clink-arg=--sysroot=$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/sysroot"
+
+              # 3. Install CLI tools
+              npm i -g "@napi-rs/cli@${NAPI_CLI_VERSION}"
+              
+              # 4. Build
+              cd packages/next-swc
+              npm run build-native-release -- --target aarch64-linux-android
+              
+              # 5. Strip the binary
+              $ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip native/next-swc.*.node
+
     name: stable - ${{ matrix.settings.target }} - node@16
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 45
@@ -333,6 +353,13 @@ jobs:
         run: |
           npm i -g corepack@0.31
           corepack enable
+
+      # [ADD THIS BLOCK] Install Android NDK only if the target is Android
+      - name: Setup Android NDK
+        if: ${{ matrix.settings.target == 'aarch64-linux-android' }}
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r28c
 
       # we always want to run this to set environment variables
       - name: Install Rust

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -374,13 +374,6 @@ jobs:
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}
 
-      - name: Cache on ${{ github.ref_name }}
-        uses: ijjk/rust-cache@turbo-cache-v1.0.9
-        with:
-          save-if: 'true'
-          cache-provider: 'github'
-          shared-key: build-${{ matrix.settings.target }}-${{ hashFiles('.cargo/config.toml') }}
-
       - name: Clear native build
         run: rm -rf packages/next-swc/native
 

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -378,7 +378,7 @@ jobs:
         uses: ijjk/rust-cache@turbo-cache-v1.0.9
         with:
           save-if: 'true'
-          cache-provider: 'turbo'
+          cache-provider: 'github'
           shared-key: build-${{ matrix.settings.target }}-${{ hashFiles('.cargo/config.toml') }}
 
       - name: Clear native build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,6 +2328,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,6 +4456,7 @@ dependencies = [
  "dhat",
  "either",
  "flate2",
+ "fs2",
  "futures-util",
  "getrandom 0.2.15",
  "iana-time-zone",

--- a/crates/napi/Cargo.toml
+++ b/crates/napi/Cargo.toml
@@ -55,6 +55,8 @@ ignored = [
 ]
 
 [dependencies]
+[target.'cfg(target_os = "android")'.dependencies]
+fs2 = "0.4"
 anyhow = { workspace = true }
 bincode = { workspace = true }
 console-subscriber = { workspace = true, optional = true }

--- a/crates/napi/src/lockfile.rs
+++ b/crates/napi/src/lockfile.rs
@@ -8,6 +8,10 @@ use anyhow::Context;
 use napi::bindgen_prelude::External;
 use napi_derive::napi;
 
+#[cfg(target_os = "android")]
+use fs2::FileExt;
+
+
 /// A wrapper around [`File`] that is passed to JS, and is set to `None` when [`lockfile_unlock`] is
 /// called.
 ///
@@ -59,7 +63,7 @@ pub fn lockfile_try_acquire_sync(path: String) -> napi::Result<Option<External<J
         }
     };
 
-    #[cfg(not(windows))]
+    #[cfg(all(not(windows), not(target_os = "android")))]
     return {
         use std::fs::TryLockError;
 
@@ -73,6 +77,32 @@ pub fn lockfile_try_acquire_sync(path: String) -> napi::Result<Option<External<J
             )))))),
             Err(TryLockError::WouldBlock) => Ok(None),
             Err(TryLockError::Error(err)) => Err(err.into()),
+        }
+    };
+
+    #[cfg(target_os = "android")]
+    return {
+        let file = open_options.open(&path)?;
+        println!("Trying to lock file at {:?}", path);
+
+        match file.try_lock_exclusive() {
+            Ok(_) => {
+                println!("Lock succeeded!");
+                Ok(Some(External::new(Mutex::new(ManuallyDrop::new(Some(
+                    LockfileInner {
+                        file,
+                        path: path.into(),
+                    },
+                ))))))
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                println!("Lock would block, lock held elsewhere.");
+                Ok(None)
+            }
+            Err(e) => {
+                println!("Actual lock error: {:?}", e);
+                Err(e.into())
+            }
         }
     };
 }

--- a/crates/napi/src/lockfile.rs
+++ b/crates/napi/src/lockfile.rs
@@ -83,11 +83,9 @@ pub fn lockfile_try_acquire_sync(path: String) -> napi::Result<Option<External<J
     #[cfg(target_os = "android")]
     return {
         let file = open_options.open(&path)?;
-        println!("Trying to lock file at {:?}", path);
 
         match file.try_lock_exclusive() {
             Ok(_) => {
-                println!("Lock succeeded!");
                 Ok(Some(External::new(Mutex::new(ManuallyDrop::new(Some(
                     LockfileInner {
                         file,
@@ -96,11 +94,9 @@ pub fn lockfile_try_acquire_sync(path: String) -> napi::Result<Option<External<J
                 ))))))
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                println!("Lock would block, lock held elsewhere.");
                 Ok(None)
             }
             Err(e) => {
-                println!("Actual lock error: {:?}", e);
                 Err(e.into())
             }
         }

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -31,7 +31,8 @@
         "x86_64-unknown-linux-musl",
         "aarch64-unknown-linux-musl",
         "aarch64-pc-windows-msvc",
-        "wasm32-wasip1-threads"
+        "wasm32-wasip1-threads",
+        "aarch64-linux-android"
       ]
     }
   },

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -127,8 +127,7 @@
     }
   },
   "optionalDependencies": {
-    "sharp": "^0.34.4",
-    "@next/swc-android-arm64": "16.1.1-canary.11"
+    "sharp": "^0.34.4"
   },
   "devDependencies": {
     "@babel/code-frame": "7.26.2",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -127,7 +127,8 @@
     }
   },
   "optionalDependencies": {
-    "sharp": "^0.34.4"
+    "sharp": "^0.34.4",
+    "@next/swc-android-arm64": "16.1.1-canary.11"
   },
   "devDependencies": {
     "@babel/code-frame": "7.26.2",

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -145,7 +145,6 @@ function checkVersionMismatch(pkgData: any) {
 // we'll not include native bindings for these platform at all.
 const knownDefaultWasmFallbackTriples = [
   'x86_64-unknown-freebsd',
-  //'aarch64-linux-android',
   'arm-linux-androideabi',
   'armv7-unknown-linux-gnueabihf',
   'i686-pc-windows-msvc',

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -145,7 +145,7 @@ function checkVersionMismatch(pkgData: any) {
 // we'll not include native bindings for these platform at all.
 const knownDefaultWasmFallbackTriples = [
   'x86_64-unknown-freebsd',
-  'aarch64-linux-android',
+  //'aarch64-linux-android',
   'arm-linux-androideabi',
   'armv7-unknown-linux-gnueabihf',
   'i686-pc-windows-msvc',

--- a/turbopack/crates/turbo-tasks-malloc/src/counter.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/counter.rs
@@ -6,6 +6,9 @@ use std::{
 
 use crate::AllocationCounters;
 
+#[cfg(target_os = "android")]
+use crate::IS_THREAD_EXITING_FLAG;
+
 /// Tracks the current total amount of memory allocated through all the [ThreadLocalCounter]
 /// instances.  This is an overestimate as individual threads 'preallocate' a [TARGET_BUFFER] bytes
 /// to reduce the number of global synchronizations.  This means at any given time this might
@@ -27,6 +30,21 @@ struct ThreadLocalCounter {
     /// value.
     buffer: usize,
     allocation_counters: AllocationCounters,
+}
+
+#[cfg(target_os = "android")]
+fn atomic_sub(atomic: &AtomicUsize, val: usize) {
+    let mut current = atomic.load(Ordering::Relaxed);
+    loop {
+        let new = current.saturating_sub(val);
+        match atomic.compare_exchange_weak(
+            current, new,
+            Ordering::Relaxed, Ordering::Relaxed,
+        ) {
+            Ok(_) => break,
+            Err(x) => current = x,
+        }
+    }
 }
 
 impl ThreadLocalCounter {
@@ -55,7 +73,12 @@ impl ThreadLocalCounter {
         if self.buffer > MAX_BUFFER {
             let offset = self.buffer - TARGET_BUFFER;
             self.buffer = TARGET_BUFFER;
+
+            #[cfg(not(target_os = "android"))]
             ALLOCATED.fetch_sub(offset, Ordering::Relaxed);
+
+            #[cfg(target_os = "android")]
+            atomic_sub(&ALLOCATED, offset);
         }
     }
 
@@ -82,7 +105,12 @@ impl ThreadLocalCounter {
                 if self.buffer > MAX_BUFFER {
                     let offset = self.buffer - TARGET_BUFFER;
                     self.buffer = TARGET_BUFFER;
+                    
+                    #[cfg(not(target_os = "android"))]
                     ALLOCATED.fetch_sub(offset, Ordering::Relaxed);
+
+                    #[cfg(target_os = "android")]
+                    atomic_sub(&ALLOCATED, offset);
                 }
             }
         }
@@ -90,15 +118,48 @@ impl ThreadLocalCounter {
 
     fn unload(&mut self) {
         if self.buffer > 0 {
+
+            #[cfg(not(target_os = "android"))]
             ALLOCATED.fetch_sub(self.buffer, Ordering::Relaxed);
+
+            #[cfg(target_os = "android")]
+            atomic_sub(&ALLOCATED, self.buffer);
+
             self.buffer = 0;
         }
         self.allocation_counters = AllocationCounters::default();
     }
 }
 
+#[cfg(target_os = "android")]
+struct CounterGuard(ThreadLocalCounter);
+
+#[cfg(target_os = "android")]
+impl Drop for CounterGuard {
+    fn drop(&mut self) {
+        unsafe {
+            *IS_THREAD_EXITING_FLAG.get() = true;
+        }
+    }
+}
+
+#[cfg(target_os = "android")]
+impl CounterGuard {
+    const fn new() -> Self {
+        Self(ThreadLocalCounter::new())
+    }
+}
+
+#[cfg(target_os = "android")]
+type InnerCounter = CounterGuard;
+
+#[cfg(not(target_os = "android"))]
+type InnerCounter = ThreadLocalCounter;
+
 thread_local! {
-  static LOCAL_COUNTER: UnsafeCell<ThreadLocalCounter> = const {UnsafeCell::new(ThreadLocalCounter::new())};
+    static LOCAL_COUNTER: UnsafeCell<InnerCounter> = const {
+        UnsafeCell::new(InnerCounter::new())
+    };
 }
 
 pub fn get() -> usize {
@@ -118,7 +179,14 @@ fn with_local_counter<T>(f: impl FnOnce(&mut ThreadLocalCounter) -> T) -> T {
         let ptr = local.get();
         // SAFETY: This is a thread local.
         let mut local = unsafe { NonNull::new_unchecked(ptr) };
-        f(unsafe { local.as_mut() })
+
+        #[cfg(target_os = "android")]
+        let inner = unsafe { &mut local.as_mut().0 };
+
+        #[cfg(not(target_os = "android"))]
+        let inner = unsafe { local.as_mut() };
+
+        f(inner)
     })
 }
 

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(thread_local)]
+
 mod counter;
 
 use std::{
@@ -6,7 +8,30 @@ use std::{
     ops::{Add, AddAssign},
 };
 
+#[cfg(target_os = "android")]
+use std::cell::UnsafeCell;
+
 use self::counter::{add, flush, get, remove, update};
+
+#[cfg(target_os = "android")]
+#[thread_local]
+static mut IN_ALLOCATOR: bool = false;
+
+#[cfg(target_os = "android")]
+#[thread_local]
+pub(crate) static IS_THREAD_EXITING_FLAG: UnsafeCell<bool> = UnsafeCell::new(false);
+
+#[cfg(target_os = "android")]
+#[inline(always)]
+fn should_bypass() -> bool {
+    unsafe { IN_ALLOCATOR || *IS_THREAD_EXITING_FLAG.get() }
+}
+
+#[cfg(not(target_os = "android"))]
+#[inline(always)]
+fn should_bypass() -> bool {
+    false
+}
 
 #[derive(Default, Clone, Debug)]
 pub struct AllocationInfo {
@@ -100,6 +125,11 @@ impl TurboMalloc {
 
     pub fn thread_stop() {
         flush();
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            *IS_THREAD_EXITING_FLAG.get() = true;
+        }
     }
 
     pub fn allocation_counters() -> AllocationCounters {
@@ -142,30 +172,91 @@ unsafe fn base_alloc_size(ptr: *const u8, layout: Layout) -> usize {
 
 unsafe impl GlobalAlloc for TurboMalloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+
+        #[cfg(target_os = "android")]
+        if should_bypass() {
+            return unsafe { base_alloc().alloc(layout) };
+        }
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            IN_ALLOCATOR = true;
+        }
+
         let ret = unsafe { base_alloc().alloc(layout) };
         if !ret.is_null() {
             let size = unsafe { base_alloc_size(ret, layout) };
             add(size);
         }
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            IN_ALLOCATOR = false;
+        }
+
         ret
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+
+        #[cfg(target_os = "android")]
+        if should_bypass() {
+            return unsafe { base_alloc().dealloc(ptr, layout) };
+        }
+
+        #[cfg(target_os = "android")]
+        unsafe{
+            IN_ALLOCATOR = true;
+        }
+
         let size = unsafe { base_alloc_size(ptr, layout) };
         unsafe { base_alloc().dealloc(ptr, layout) };
         remove(size);
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            IN_ALLOCATOR = false;
+        }
     }
 
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+
+        #[cfg(target_os = "android")]
+        if should_bypass() {
+            return unsafe { base_alloc().alloc_zeroed(layout) };
+        }
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            IN_ALLOCATOR = true;
+        }
+
         let ret = unsafe { base_alloc().alloc_zeroed(layout) };
         if !ret.is_null() {
             let size = unsafe { base_alloc_size(ret, layout) };
             add(size);
         }
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            IN_ALLOCATOR = false;
+        }
+
         ret
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+
+        #[cfg(target_os = "android")]
+        if should_bypass() {
+            return unsafe { base_alloc().realloc(ptr, layout, new_size) };
+        }
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            IN_ALLOCATOR = true;
+        }
+
         let old_size = unsafe { base_alloc_size(ptr, layout) };
         let ret = unsafe { base_alloc().realloc(ptr, layout, new_size) };
         if !ret.is_null() {
@@ -175,6 +266,12 @@ unsafe impl GlobalAlloc for TurboMalloc {
             let new_size = unsafe { base_alloc_size(ret, new_layout) };
             update(old_size, new_size);
         }
+
+        #[cfg(target_os = "android")]
+        unsafe {
+            IN_ALLOCATOR = false;
+        }
+
         ret
     }
 }


### PR DESCRIPTION
### Summary
This PR enables full native support for `android-arm64` targets, allowing Next.js to run natively on Android devices (e.g., via Termux) with native SWC performance.

Previously, running Next.js on Android required slow WASM fallbacks or failed entirely with platform incompatibility errors. This PR adds the necessary build infrastructure to cross-compile `next-swc` for Android using the NDK.

### Changes
- **Build Configuration:** Added `aarch64-linux-android` to `napi.triples` in `packages/next-swc/package.json`.
- **Dependencies:** Added `@next/swc-android-arm64` to `optionalDependencies` in `packages/next/package.json`.
- **Loader Logic:** Updated `packages/next/src/build/swc/index.ts` to recognize Android and load the native binary instead of forcing WASM.
- **CI/CD:** Updated `.github/workflows/build_and_deploy.yml` to include a cross-compilation job using Android NDK r28c.
- **Stability:** Implemented `fs2` based file-locking for Android in `crates/napi/src/lockfile.rs` (as standard `flock` behaves differently on Android) and fixed a malloc re-entrancy crash in `turbo-tasks-malloc`.

### Verification
- **CI:** The `build-native` workflow successfully cross-compiled the binary (`next-swc.android-arm64.node`) on GitHub Actions (Ubuntu runner + NDK).
- **Manual Test:** I manually verified the binary on a native Android (Termux) environment. The dev server starts successfully, and compilation performance matches local native speeds.

### Related Issues
Fixes #58483
Related to #58015