### PR TITLE
Upgrade to rustc 2026-01-04

### DIFF
--- a/.devcontainer/rust/devcontainer-feature.json
+++ b/.devcontainer/rust/devcontainer-feature.json
@@ -5,7 +5,7 @@
   "dependsOn": {
     "ghcr.io/devcontainers/features/rust:1": {
       // this should match the `rust-toolchain.toml`
-      "version": "nightly-2025-09-21",
+      "version": "nightly-2026-01-04",
       "profile": "minimal",
       "components": "rustfmt,clippy,rust-analyzer"
     }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,8 +3209,7 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 [[package]]
 name = "include_dir"
 version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+source = "git+https://github.com/vercel-labs/include_dir?branch=turbopack#0f23fcc20e37577a75a02d39ec55abfaf015faa3"
 dependencies = [
  "include_dir_macros",
 ]
@@ -3218,8 +3217,7 @@ dependencies = [
 [[package]]
 name = "include_dir_macros"
 version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+source = "git+https://github.com/vercel-labs/include_dir?branch=turbopack#0f23fcc20e37577a75a02d39ec55abfaf015faa3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,18 +3208,18 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "include_dir"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
 dependencies = [
  "include_dir_macros",
 ]
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b139284b5cf57ecfa712bcc66950bb635b31aff41c188e8a4cfc758eca374a3f"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -484,4 +484,7 @@ webbrowser = "1.0.6"
 [patch.crates-io]
 bincode = { git = "https://github.com/bgw/bincode.git", branch = "bgw/patches" }
 virtue = { git = "https://github.com/bgw/virtue.git", branch = "bgw/fix-generic-default-parsing" }
+# We have to very frequently bump the swc major version of mdxjs-rs
 mdxjs = { git = "https://github.com/vercel-labs/mdxjs-rs-turbopack.git", branch = "turbopack" }
+# Doesn't compile on recent nightly versions because of https://github.com/Michael-F-Bryan/include_dir/pull/117
+include_dir = { git = "https://github.com/vercel-labs/include_dir", branch = "turbopack" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
 [toolchain]
-channel = "nightly-2025-10-27"
+channel = "nightly-2026-01-04"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -32,7 +32,7 @@ concurrent-queue = { workspace = true }
 dashmap = { workspace = true }
 dunce = { workspace = true }
 futures = { workspace = true }
-include_dir = { version = "0.7.3" }
+include_dir = { version = "0.7.3", features = ["nightly"] }
 indexmap = { workspace = true }
 jsonc-parser = { version = "0.26.3", features = ["serde"] }
 mime = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -32,7 +32,7 @@ concurrent-queue = { workspace = true }
 dashmap = { workspace = true }
 dunce = { workspace = true }
 futures = { workspace = true }
-include_dir = { version = "0.7.2", features = ["nightly"] }
+include_dir = { version = "0.7.3" }
 indexmap = { workspace = true }
 jsonc-parser = { version = "0.26.3", features = ["serde"] }
 mime = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -8,6 +8,7 @@
 // stdlib into our source tree
 #![feature(normalize_lexically)]
 #![feature(trivial_bounds)]
+#![feature(downcast_unchecked)]
 // Junction points are used on Windows. We could use a third-party crate for this if the junction
 // API isn't eventually stabilized.
 #![cfg_attr(windows, feature(junction_point))]

--- a/turbopack/crates/turbo-tasks/src/effect.rs
+++ b/turbopack/crates/turbo-tasks/src/effect.rs
@@ -298,7 +298,7 @@ impl ApplyEffectsContext {
                 .get_mut(&TypeId::of::<T>())
                 .map(|value| {
                     // Safety: the map is keyed by TypeId
-                    unsafe { value.downcast_mut_unchecked() }
+                    unsafe { value.downcast_unchecked_mut() }
                 })
                 .map(f)
         })
@@ -315,7 +315,7 @@ impl ApplyEffectsContext {
             });
             f(
                 // Safety: the map is keyed by TypeId
-                unsafe { value.downcast_mut_unchecked() },
+                unsafe { value.downcast_unchecked_mut() },
             )
         })
     }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -37,7 +37,6 @@
 #![feature(downcast_unchecked)]
 #![feature(ptr_metadata)]
 #![feature(sync_unsafe_cell)]
-#![feature(vec_into_raw_parts)]
 #![feature(async_fn_traits)]
 
 pub mod backend;


### PR DESCRIPTION
~~`include_dir`'s `nightly` feature broke: https://github.com/Michael-F-Bryan/include_dir/issues/118 https://github.com/Michael-F-Bryan/include_dir/pull/117, we might want to fix that first:~~ forked the crate for now
> `nightly` - enables nightly APIs like `track_path` and  `proc_macro_tracked_env`. This gives the compiler more information about what is accessed by the procedural macro, enabling better caching. Functionality behind this feature flag is unstable and may change or stop compiling at any time.

