### PR TITLE
test: reduce flakiness in opentelemetry test for prod mode

### DIFF
--- a/test/e2e/opentelemetry/instrumentation/instrumentation-test.ts
+++ b/test/e2e/opentelemetry/instrumentation/instrumentation-test.ts
@@ -71,13 +71,13 @@ class TestExporter implements SpanExporter {
           code: ExportResultCode.FAILED,
           error: new Error(`http status ${response.status}`),
         })
+        return
       }
+      resultCallback({ code: ExportResultCode.SUCCESS })
     } catch (e) {
-      console.warn('WARN: TestExporterP: error:', e)
+      console.warn('WARN: TestExporter: error:', e)
       resultCallback({ code: ExportResultCode.FAILED, error: e })
     }
-
-    resultCallback({ code: ExportResultCode.SUCCESS })
   }
   shutdown(): Promise<void> {
     return Promise.resolve()


### PR DESCRIPTION
## Summary

Reduces flakiness in the OpenTelemetry e2e test (`test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts`) for production mode.

### Root Cause
In production mode, Next.js generates additional spans from:
- RSC prefetch requests (with `?_rsc` query param)
- Edge runtime boundary spans

These extra root spans cause `toMatchObject` assertions to fail because they receive more spans than expected.

### Changes

1. **Filter spans by expected `http.target`** in `expectTrace()`:
   - Extract expected `http.target` values from the match object
   - Filter root spans to only include those with matching targets
   - This excludes RSC prefetch and edge boundary spans that aren't part of the test assertion

2. **Fix TestExporter callback bug** in `instrumentation-test.ts`:
   - The success callback was called unconditionally (even after errors)
   - Added early `return` after error callback
   - Moved success callback inside the success path

## Test Plan
- [x] All 34 tests pass in production mode (`NEXT_TEST_MODE=start`)
- [ ] CI passes