### PR TITLE
metadata: use fixed segment in dynamic routes with static metadata files

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -251,7 +251,7 @@ impl AppPageLoaderTreeBuilder {
         let metadata_route = &*get_metadata_route_name(item.clone().into()).await?;
         writeln!(
             self.loader_tree_code,
-            "{s}  url: fillMetadataSegment({}, await props.params, {}) + \
+            "{s}  url: fillMetadataSegment({}, await props.params, {}, true) + \
              `?${{{identifier}.src.split(\"/\").splice(-1)[0]}}`,",
             StringifyJs(&pathname_prefix),
             StringifyJs(metadata_route),

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -74,7 +74,7 @@ async fn dynamic_image_metadata_with_generator_source(
 
             export default async function (props) {{
                 const {{ __metadata_id__: _, ...params }} = await props.params
-                const imageUrl = fillMetadataSegment({pathname_prefix}, params, {page_segment})
+                const imageUrl = fillMetadataSegment({pathname_prefix}, params, {page_segment}, false)
 
                 const {{ generateImageMetadata }} = imageModule
 
@@ -148,7 +148,7 @@ async fn dynamic_image_metadata_without_generator_source(
 
             export default async function (props) {{
                 const {{ __metadata_id__: _, ...params }} = await props.params
-                const imageUrl = fillMetadataSegment({pathname_prefix}, params, {page_segment})
+                const imageUrl = fillMetadataSegment({pathname_prefix}, params, {page_segment}, false)
 
                 function getImageMetadata(imageMetadata, idParam) {{
                     const data = {{

--- a/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-image-loader.ts
@@ -91,7 +91,7 @@ async function nextMetadataImageLoader(
     function getImageMetadata(imageMetadata, idParam, resolvedParams) {
       const imageUrl = fillMetadataSegment(${JSON.stringify(
         pathnamePrefix
-      )}, resolvedParams, ${JSON.stringify(pageSegment)})
+      )}, resolvedParams, ${JSON.stringify(pageSegment)}, false)
       const data = {
         alt: imageMetadata.alt,
         type: imageMetadata.contentType || 'image/png',
@@ -175,7 +175,7 @@ async function nextMetadataImageLoader(
     const imageData = ${JSON.stringify(imageData)}
     const imageUrl = fillMetadataSegment(${JSON.stringify(
       pathnamePrefix
-    )}, await props.params, ${JSON.stringify(pageSegment)})
+    )}, await props.params, ${JSON.stringify(pageSegment)}, true)
 
     return [{
       ...imageData,

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -52,19 +52,39 @@ function getMetadataRouteSuffix(page: string) {
  * Fill the dynamic segment in the metadata route
  *
  * Example:
- * fillMetadataSegment('/a/[slug]', { params: { slug: 'b' } }, 'open-graph') -> '/a/b/open-graph'
+ * fillMetadataSegment('/a/[slug]', { params: { slug: 'b' } }, 'open-graph', false) -> '/a/b/open-graph'
+ *
+ * When isStatic is true, all dynamic segments are filled with "-" placeholder
+ * since static metadata files have consistent responses regardless of params.
+ * Example:
+ * fillMetadataSegment('/a/[slug]', {}, 'icon.png', true) -> '/a/-/icon.png'
  *
  */
 export function fillMetadataSegment(
   segment: string,
   params: any,
-  lastSegment: string
+  lastSegment: string,
+  isStatic: boolean
 ) {
   const pathname = normalizeAppPath(segment)
   const routeRegex = getNamedRouteRegex(pathname, {
     prefixRouteKeys: false,
   })
-  const route = interpolateDynamicPath(pathname, params, routeRegex)
+
+  // For static metadata files, fill all dynamic segments with "-" placeholder
+  const routeParams = isStatic
+    ? Object.keys(routeRegex.groups).reduce(
+        (acc, key) => {
+          const { repeat } = routeRegex.groups[key]
+          // Use array for catch-all segments, string for regular segments
+          acc[key] = repeat ? ['-'] : '-'
+          return acc
+        },
+        {} as Record<string, string | string[]>
+      )
+    : params
+
+  const route = interpolateDynamicPath(pathname, routeParams, routeRegex)
   const { name, ext } = path.parse(lastSegment)
   const pagePath = path.posix.join(segment, name)
   const suffix = getMetadataRouteSuffix(pagePath)
@@ -125,4 +145,17 @@ export function normalizeMetadataPageToRoute(page: string, isDynamic: boolean) {
     : `${routePagePath}${metadataRouteExtension}`
 
   return mapped + (isRoute ? '/route' : '')
+}
+
+/**
+ * Normalize static metadata file path by replacing dynamic segments with "-" placeholder.
+ * This creates a consistent URL path for static files under dynamic routes.
+ *
+ * Example:
+ * normalizeStaticMetadataFilePath('/dynamic/[id]/icon.png') -> '/dynamic/-/icon.png'
+ * normalizeStaticMetadataFilePath('/[category]/[id]/opengraph-image.png') -> '/-/-/opengraph-image.png'
+ */
+export function normalizeStaticMetadataFilePath(page: string): string {
+  // Replace dynamic segments [param] or [...param] or [[...param]] with "-"
+  return page.replace(/\[(?:\[\.\.\.)?[^\]]+\]?\]/g, '-')
 }

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -146,16 +146,3 @@ export function normalizeMetadataPageToRoute(page: string, isDynamic: boolean) {
 
   return mapped + (isRoute ? '/route' : '')
 }
-
-/**
- * Normalize static metadata file path by replacing dynamic segments with "-" placeholder.
- * This creates a consistent URL path for static files under dynamic routes.
- *
- * Example:
- * normalizeStaticMetadataFilePath('/dynamic/[id]/icon.png') -> '/dynamic/-/icon.png'
- * normalizeStaticMetadataFilePath('/[category]/[id]/opengraph-image.png') -> '/-/-/opengraph-image.png'
- */
-export function normalizeStaticMetadataFilePath(page: string): string {
-  // Replace dynamic segments [param] or [...param] or [[...param]] with "-"
-  return page.replace(/\[(?:\[\.\.\.)?[^\]]+\]?\]/g, '-')
-}

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -66,8 +66,8 @@ import {
   isStaticMetadataFile,
 } from '../../../lib/metadata/is-metadata-route'
 import {
+  fillMetadataSegment,
   normalizeMetadataPageToRoute,
-  normalizeStaticMetadataFilePath,
 } from '../../../lib/metadata/get-metadata-route'
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 import { store as consoleStore } from '../../../build/output/store'
@@ -695,7 +695,14 @@ async function startWatcher(
             // Static metadata files will be served from filesystem.
             if (appDir && isStaticMetadataFile(fileName.replace(appDir, ''))) {
               // Use "-" placeholder for dynamic segments since static files have consistent content
-              const normalizedPath = normalizeStaticMetadataFilePath(pageName)
+              const segment = path.posix.dirname(pageName)
+              const lastSegment = path.posix.basename(pageName)
+              const normalizedPath = fillMetadataSegment(
+                segment,
+                {},
+                lastSegment,
+                true
+              )
               staticMetadataFiles.set(normalizedPath, fileName)
             } else {
               appFiles.add(pageName)

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -65,7 +65,10 @@ import {
   isMetadataRouteFile,
   isStaticMetadataFile,
 } from '../../../lib/metadata/is-metadata-route'
-import { normalizeMetadataPageToRoute } from '../../../lib/metadata/get-metadata-route'
+import {
+  normalizeMetadataPageToRoute,
+  normalizeStaticMetadataFilePath,
+} from '../../../lib/metadata/get-metadata-route'
 import { JsConfigPathsPlugin } from '../../../build/webpack/plugins/jsconfig-paths-plugin'
 import { store as consoleStore } from '../../../build/output/store'
 import {
@@ -691,7 +694,9 @@ async function startWatcher(
           if (useFileSystemPublicRoutes) {
             // Static metadata files will be served from filesystem.
             if (appDir && isStaticMetadataFile(fileName.replace(appDir, ''))) {
-              staticMetadataFiles.set(pageName, fileName)
+              // Use "-" placeholder for dynamic segments since static files have consistent content
+              const normalizedPath = normalizeStaticMetadataFilePath(pageName)
+              staticMetadataFiles.set(normalizedPath, fileName)
             } else {
               appFiles.add(pageName)
             }

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup } from 'e2e-utils'
+import { nextTestSetup, isNextStart } from 'e2e-utils'
 import { getCommonMetadataHeadTags } from './utils'
 
 describe('metadata-files-static-output-dynamic-route', () => {
@@ -147,4 +147,18 @@ describe('metadata-files-static-output-dynamic-route', () => {
       sitemap: actualSitemap,
     })
   })
+
+  if (isNextStart) {
+    it('should display static metadata files with "-" placeholder in build output', () => {
+      // Build output should show normalized paths with "-" for dynamic segments
+      expect(next.cliOutput).toContain('/dynamic/-/apple-icon.png')
+      expect(next.cliOutput).toContain('/dynamic/-/icon.png')
+      expect(next.cliOutput).toContain('/dynamic/-/opengraph-image.png')
+      expect(next.cliOutput).toContain('/dynamic/-/twitter-image.png')
+
+      // Should NOT show the dynamic segment pattern in output for static files
+      expect(next.cliOutput).not.toMatch(/\/dynamic\/\[id\]\/icon\.png/)
+      expect(next.cliOutput).not.toMatch(/\/dynamic\/\[id\]\/apple-icon\.png/)
+    })
+  }
 })

--- a/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
+++ b/test/e2e/app-dir/metadata-static-file/metadata-static-file-dynamic-route.test.ts
@@ -25,19 +25,21 @@ describe('metadata-files-static-output-dynamic-route', () => {
     return
   }
 
-  it('should have correct link tags for dynamic page', async () => {
+  it('should have correct link tags for dynamic page with static placeholder', async () => {
     const browser = await next.browser('/dynamic/123')
 
+    // Static metadata files under dynamic routes use "-" as placeholder
+    // since the file content is the same regardless of params
     expect(await getCommonMetadataHeadTags(browser)).toMatchInlineSnapshot(`
      {
        "links": [
          {
-           "href": "/dynamic/123/apple-icon.png",
+           "href": "/dynamic/-/apple-icon.png",
            "rel": "apple-touch-icon",
            "type": "image/png",
          },
          {
-           "href": "/dynamic/123/icon.png",
+           "href": "/dynamic/-/icon.png",
            "rel": "icon",
            "type": "image/png",
          },
@@ -87,7 +89,8 @@ describe('metadata-files-static-output-dynamic-route', () => {
     `)
   })
 
-  it('should serve static files when requested to its route for dynamic page', async () => {
+  it('should serve static files when requested with placeholder for dynamic page', async () => {
+    // Static metadata files use "-" as placeholder for dynamic segments
     const [
       appleIconRes,
       iconRes,
@@ -95,11 +98,11 @@ describe('metadata-files-static-output-dynamic-route', () => {
       twitterImageRes,
       sitemapRes,
     ] = await Promise.all([
-      next.fetch('/dynamic/123/apple-icon.png'),
-      next.fetch('/dynamic/123/icon.png'),
-      next.fetch('/dynamic/123/opengraph-image.png'),
-      next.fetch('/dynamic/123/twitter-image.png'),
-      next.fetch('/dynamic/123/sitemap.xml'),
+      next.fetch('/dynamic/-/apple-icon.png'),
+      next.fetch('/dynamic/-/icon.png'),
+      next.fetch('/dynamic/-/opengraph-image.png'),
+      next.fetch('/dynamic/-/twitter-image.png'),
+      next.fetch('/dynamic/-/sitemap.xml'),
     ])
 
     // Compare response content with actual files

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -597,8 +597,10 @@ describe('app dir - metadata', () => {
       const $dynamic = await next.render$('/icons/static/dynamic-routes/123')
       const $dynamicIcon = $dynamic('link[rel="icon"][type!="image/x-icon"]')
       const dynamicIconHref = $dynamicIcon.attr('href')
+      // Static icon files under dynamic routes use "-" as placeholder
+      // since the file content is the same regardless of params
       expect(dynamicIconHref).toMatch(
-        /\/icons\/static\/dynamic-routes\/123\/icon/
+        /\/icons\/static\/dynamic-routes\/-\/icon/
       )
       const dynamicIconRes = await next.fetch(dynamicIconHref)
       expect(dynamicIconRes.status).toBe(200)


### PR DESCRIPTION
Static metadata files (`icon.png`, `apple-icon.png`, `opengraph-image.png`, etc.) under dynamic routes now use a fixed - placeholder in the URL instead of the dynamic segment value.

| Before | After |
|---|---|
| `/dynamic/123/icon.png` | `/dynamic/-/icon.png` |
| `/dynamic/456/icon.png` | `/dynamic/-/icon.png` |
| `/catch-all/[...slug]/icon.png` | `/catch-all/-/icon.png` |
| `/catch-all/[[...slug]]/icon.png` | `/catch-all/-/icon.png` |
 
Since static image files return identical content regardless of the dynamic parameter, using a consistent URL improves cacheability and makes the behavior clearer. The build output
also reflects this change, showing `/dynamic/-/icon.png` instead of `/dynamic/[id]/icon.png`.

Dynamic metadata files (dynamic og image with .js or .ts extension) continue to use actual parameter values since their content can vary.

Close NEXT-4738
