### PR TITLE
fix: Full prefetch strategy in export ouput mode

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1732,7 +1732,17 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
   }
 
   try {
-    const response = await fetchPrefetchResponse(url, headers)
+    const requestUrl = isOutputExportMode
+      ? // In output: "export" mode, we need to fetch from the pre-generated
+        // static file instead of making a dynamic request to the page URL.
+        // The static export generates a __next._full.txt file that contains
+        // the full RSC payload for each page.
+        addSegmentPathToUrlInOutputExportMode(
+          url,
+          '/_full' as SegmentRequestKey
+        )
+      : url
+    const response = await fetchPrefetchResponse(requestUrl, headers)
     if (!response || !response.ok || !response.body) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.

--- a/test/e2e/app-dir/segment-cache/export/app/blog/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/blog/[slug]/page.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+export function generateStaticParams() {
+  return [{ slug: 'post-1' }, { slug: 'post-2' }, { slug: 'post-3' }]
+}
+
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return (
+    <div id="blog-post">
+      <h1>Blog: {slug}</h1>
+      <p>This is the content for {slug}</p>
+      <Link href="/">Back to home</Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/export/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/export/app/page.tsx
@@ -1,4 +1,5 @@
 import { LinkAccordion } from '../components/link-accordion'
+import { MultiPrefetchLinks } from '../components/multi-prefetch-links'
 
 export default function OutputExport() {
   return (
@@ -32,6 +33,17 @@ export default function OutputExport() {
           <LinkAccordion href="/redirect-to-target-page">
             Redirect to target page
           </LinkAccordion>
+        </li>
+      </ul>
+      <p>
+        Test for issue #88032: multiple Links with same href but different
+        prefetch values
+      </p>
+      <ul>
+        <li>
+          <MultiPrefetchLinks href="/blog/post-1">
+            Blog post 1
+          </MultiPrefetchLinks>
         </li>
       </ul>
     </>

--- a/test/e2e/app-dir/segment-cache/export/components/multi-prefetch-links.tsx
+++ b/test/e2e/app-dir/segment-cache/export/components/multi-prefetch-links.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import Link from 'next/link'
+import { useState } from 'react'
+
+/**
+ * This component renders two Links to the same href but with different prefetch
+ * values. This tests the fix for https://github.com/vercel/next.js/issues/88032
+ * where having multiple Links with different prefetch values could cause
+ * navigation to fail in output: "export" mode.
+ */
+export function MultiPrefetchLinks({ href, children }) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-multi-prefetch-accordion={href}
+      />
+      {isVisible ? (
+        <div>
+          {/* Link with default prefetch (auto/PPR strategy) */}
+          <Link href={href} data-link-default>
+            {children} (default prefetch)
+          </Link>
+          <br />
+          {/* Link with prefetch={true} (Full strategy) */}
+          <Link href={href} prefetch={true} data-link-force-prefetch>
+            {children} (force prefetch)
+          </Link>
+        </div>
+      ) : (
+        `${children} (links are hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
+++ b/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
@@ -160,4 +160,89 @@ describe('segment cache (output: "export")', () => {
       }
     )
   })
+
+  // Test for https://github.com/vercel/next.js/issues/88032
+  // Multiple Links with the same href but different prefetch values should
+  // all work correctly in output: "export" mode.
+  it('navigate using link with prefetch={true} when another link with default prefetch exists', async () => {
+    let act
+    const browser = await webdriver(port, '/', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Make both links visible (one with default prefetch, one with prefetch={true})
+    // The RSC response contains "Blog: " and "post-1" as separate elements
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-multi-prefetch-accordion="/blog/post-1"]'
+        )
+        await checkbox.click()
+      },
+      {
+        includes: 'blog-post',
+      }
+    )
+
+    // Navigate using the link with prefetch={true}
+    // This should work correctly even though there's another link with default prefetch
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[data-link-force-prefetch][href="/blog/post-1"]'
+        )
+        await link.click()
+
+        // The page should be navigated to
+        const div = await browser.elementById('blog-post')
+        expect(await div.text()).toContain('Blog: post-1')
+      },
+      {
+        // Should have prefetched the home page
+        includes: 'Demonstrates that per-segment prefetching works',
+      }
+    )
+  })
+
+  it('navigate using link with default prefetch when another link with prefetch={true} exists', async () => {
+    let act
+    const browser = await webdriver(port, '/', {
+      beforePageLoad(p: Playwright.Page) {
+        act = createRouterAct(p)
+      },
+    })
+
+    // Make both links visible
+    await act(
+      async () => {
+        const checkbox = await browser.elementByCss(
+          '[data-multi-prefetch-accordion="/blog/post-1"]'
+        )
+        await checkbox.click()
+      },
+      {
+        includes: 'blog-post',
+      }
+    )
+
+    // Navigate using the link with default prefetch
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[data-link-default][href="/blog/post-1"]'
+        )
+        await link.click()
+
+        // The page should be navigated to
+        const div = await browser.elementById('blog-post')
+        expect(await div.text()).toContain('Blog: post-1')
+      },
+      {
+        // Should have prefetched the home page
+        includes: 'Demonstrates that per-segment prefetching works',
+      }
+    )
+  })
 })


### PR DESCRIPTION
- Fix navigation failure when multiple `Link` components with different prefetch values point to the same href in static export mode
- `fetchSegmentPrefetchesUsingDynamicRequest` now fetches from `__next._full.txt` instead of the page URL in output export mode

Closes #88032