### PR TITLE
Turbopack: fix order of breadth first edges

### DIFF
--- a/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
@@ -136,12 +136,7 @@ where
     pub fn into_breadth_first_edges(self) -> IntoBreadthFirstEdges<T, E> {
         IntoBreadthFirstEdges {
             adjacency_map: self.adjacency_map,
-            queue: self
-                .roots
-                .into_iter()
-                .rev()
-                .map(|root| (None, root))
-                .collect(),
+            queue: self.roots.into_iter().map(|root| (None, root)).collect(),
             expanded: FxHashSet::default(),
         }
     }


### PR DESCRIPTION
### What?

It's a VecDeque and we are calling pop_front() so we don't want to reverse the roots