### PR TITLE
Turbopack: make GraphTraversal deterministically calling all nodes before erroring

### DIFF
--- a/turbopack/crates/turbo-tasks/src/graph/control_flow.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/control_flow.rs
@@ -8,6 +8,4 @@ pub enum VisitControlFlow {
     /// The edge is excluded, and the traversal should not continue on the outgoing edges of the
     /// given node.
     Exclude,
-    /// The traversal should abort and return immediately.
-    Abort,
 }


### PR DESCRIPTION
### What?

The graph traversal used to early exit when there are errors. This leads to cycles to continuously executing the graph traversal to discover more task one by one. This leads to bad incremental performance.