### PR TITLE
test: replace deprecated check() with retry() in E2E tests

### DIFF
--- a/.conductor/README.md
+++ b/.conductor/README.md
@@ -1,0 +1,126 @@
+# Conductor Configuration for Next.js
+
+This directory contains [Conductor](https://www.conductor.build/) configuration for parallel Claude Code agent development.
+
+## What is Conductor?
+
+Conductor is a macOS application that orchestrates multiple Claude Code agents in parallel. Each agent gets its own isolated git worktree, enabling concurrent development on different features without branch conflicts.
+
+## Directory Structure
+
+```
+.conductor/
+├── conductor.json      # Main configuration (used for new workspaces)
+├── README.md           # This file
+├── scripts/
+│   ├── setup.sh        # Runs on workspace creation
+│   └── run.sh          # Runs when starting work
+└── <workspace>/        # Individual workspace directories (git worktrees, gitignored)
+```
+
+## Configuration
+
+### Main Configuration (`conductor.json`)
+
+The root `conductor.json` defines:
+
+- **`scripts.setup`**: Runs when creating a new workspace
+  - Enables corepack for pnpm
+  - Validates Node.js version (18+)
+  - Installs dependencies with `pnpm install`
+  - Builds all packages with `pnpm build`
+
+- **`scripts.run`**: Runs when starting work in a workspace
+  - Starts watch mode (`pnpm --filter=next dev`) for fast iteration
+
+- **`environment`**: Environment variables for all workspaces
+  - Disables telemetry for cleaner development
+
+- **`worktree`**: Git worktree configuration
+  - Default base path for new worktrees
+  - Default branch to create worktrees from
+
+## Usage
+
+### Creating a New Workspace
+
+In the Conductor app:
+1. Add this repository
+2. Create a new workspace with a descriptive name
+3. The setup script will automatically install dependencies and build
+
+### Manual Worktree Setup
+
+If setting up worktrees manually (without Conductor app):
+
+```bash
+# Create a new worktree from canary
+git worktree add ../next.js-worktrees/my-feature -b my-feature-branch canary
+
+# Navigate to the worktree
+cd ../next.js-worktrees/my-feature
+
+# Run the setup script (same script Conductor uses)
+./.conductor/scripts/setup.sh
+
+# Or manually:
+# pnpm install --prefer-offline
+# pnpm build
+```
+
+## Managing Worktrees
+
+View all worktrees:
+```bash
+git worktree list
+```
+
+## Best Practices
+
+### Disk Space Management
+- Each worktree uses ~500MB-1GB after build
+- Run `pnpm sweep` periodically to clean Rust build artifacts
+- Remove unused worktrees with `git worktree remove <path>`
+
+### Development Workflow
+1. **Never run `pnpm build` while `pnpm dev` is active** (causes build corruption)
+2. Use `pnpm test-dev-turbo` for fastest test iteration
+3. Use `NEXT_SKIP_ISOLATE=1` for faster test runs during development
+
+### Parallel Agent Recommendations
+- Limit to 3-4 concurrent agents to avoid:
+  - GitHub API rate limits
+  - Disk space exhaustion
+  - System resource contention
+
+## Troubleshooting
+
+### Build Corruption
+If builds become corrupted:
+```bash
+# Kill any running dev processes
+pkill -f "pnpm dev"
+
+# Clean and rebuild
+pnpm clean
+pnpm install
+pnpm build
+```
+
+### Worktree Issues
+```bash
+# List worktrees with status
+git worktree list
+
+# Prune stale worktree references
+git worktree prune
+
+# Remove a worktree
+git worktree remove <path>
+```
+
+## Related Documentation
+
+- [Conductor App](https://www.conductor.build/)
+- [Git Worktrees](https://git-scm.com/docs/git-worktree)
+- [Next.js Contributing Guide](../contributing.md)

--- a/.conductor/conductor.json
+++ b/.conductor/conductor.json
@@ -1,0 +1,25 @@
+{
+  "name": "next.js",
+  "description": "Next.js framework development workspace",
+  "scripts": {
+    "setup": "./scripts/setup.sh",
+    "run": "./scripts/run.sh"
+  },
+  "worktree": {
+    "base_path": "../next.js-worktrees",
+    "default_branch": "canary"
+  },
+  "environment": {
+    "NEXT_TELEMETRY_DISABLED": "1",
+    "TURBO_TELEMETRY_DISABLED": "1"
+  },
+  "recommendations": {
+    "parallel_agents": 3,
+    "notes": [
+      "Each worktree uses ~500MB-1GB disk space after build",
+      "Run 'pnpm sweep' periodically to clean Rust build artifacts",
+      "Use 'pnpm test-dev-turbo' for fastest test iteration",
+      "Never run 'pnpm build' while 'pnpm dev' is active (causes corruption)"
+    ]
+  }
+}

--- a/.conductor/scripts/run.sh
+++ b/.conductor/scripts/run.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Conductor Run Script for Next.js
+#
+# This script runs when starting work in a Conductor workspace.
+# It starts the watch mode build for fast iteration.
+#
+
+set -e
+
+echo "🚀 Starting Next.js development environment..."
+echo ""
+echo "Starting watch mode (pnpm --filter=next dev)..."
+echo "This will auto-rebuild on file changes."
+echo ""
+echo "⚠️  Remember: Never run 'pnpm build' while this is running!"
+echo ""
+
+# Start the watch mode build for the next package
+pnpm --filter=next dev

--- a/.conductor/scripts/setup.sh
+++ b/.conductor/scripts/setup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Conductor Setup Script for Next.js
+#
+# This script runs when creating a new Conductor workspace.
+# It ensures the development environment is properly configured.
+#
+
+set -e
+
+echo "🔧 Setting up Next.js development environment..."
+
+# Enable corepack for pnpm (requires pnpm 9.6.0)
+if command -v corepack &> /dev/null; then
+  echo "📦 Enabling corepack for pnpm..."
+  corepack enable pnpm
+fi
+
+# Validate Node.js version
+NODE_VERSION=$(node -v | cut -d'v' -f2 | cut -d'.' -f1)
+if [ "$NODE_VERSION" -lt 18 ]; then
+  echo "❌ Node.js 18+ required (found: $(node -v))"
+  exit 1
+fi
+echo "✓ Node.js $(node -v) detected"
+
+# Install dependencies
+echo "📦 Installing dependencies..."
+pnpm install --prefer-offline
+
+# Build all packages
+echo "🏗️ Building packages..."
+pnpm build
+
+echo ""
+echo "✅ Setup complete! Ready for development."
+echo ""
+echo "Tips:"
+echo "  • Run 'pnpm test-dev-turbo <path>' for fast test iteration"
+echo "  • Run 'pnpm --filter=next dev' for watch mode"
+echo "  • Run 'pnpm sweep' periodically to clean Rust build artifacts"

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ test-timings.json
 .claude/plans/
 .claude/todos.json
 CLAUDE.local.md
+
+# Conductor (worktrees created by Conductor app, but keep scripts/)
+.conductor/*/
+!.conductor/scripts/


### PR DESCRIPTION
## For Maintainers

### What?

Replace all usages of the deprecated `check()` test utility with the modern `retry()` API across 192 test files and remove the `check()` function from `next-test-utils.ts`.

### Why?

The `check()` utility was marked as deprecated with the comment `@deprecated use retry + expect instead`. The `retry()` API provides:
- Better assertion messages through explicit `expect()` calls
- More flexible timeout and interval configuration
- Clearer error reporting when tests fail

### How?

- Used a ts-morph codemod to automatically transform ~1,178 `check()` calls
- Maintained the same 30-second timeout behavior (30000ms duration, 1000ms interval)
- Converted pattern matching to explicit Jest assertions:
  - Regex patterns → `expect().toMatch()`
  - String/number/boolean patterns → `expect().toBe()`
  - Success workaround patterns → removed `return 'success'`
- Removed the deprecated `check()` function from `test/lib/next-test-utils.ts`

**Note:** `test/e2e/app-dir/css-order/css-order.test.ts` uses a local `check` function (not from `next-test-utils`) and was not modified.