### PR TITLE
Fix pack-next script for next-swc

### DIFF
--- a/scripts/pack-util.ts
+++ b/scripts/pack-util.ts
@@ -168,11 +168,11 @@ export async function packageFiles(path: string): Promise<string[]> {
     // We add the full path, but check for parent directories too.
     // This catches the case where the whole directory is added and then a single file from the directory.
     // The sorting before ensures that the directory comes before the files inside of the directory.
-    set.add(f)
     while (f.includes('/')) {
-      f = f.replace(/\/[^/]+$/, '')
+      f = f.replace(/\/[^/]*$/, '')
       if (set.has(f)) return false
     }
+    set.add(f)
     return true
   })
 }


### PR DESCRIPTION
Specifying a folder in `files` didn't work:
https://github.com/vercel/next.js/blob/3bbb2e61d54c46df2b5bb0a4ecd7f0765ff93a72/packages/next-swc/package.json#L6

Previously, that folder wasn't in the tar:
```
tar -tf /Users/niklas/code/next.js-other/tarballs/next-swc.tar                                       
./README.md
./package.json
```