### PR TITLE
fix: use RDC for server action requests

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -976,5 +976,6 @@
   "975": "Failed to find Server Action. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "976": "Decompressed resume data cache exceeded %s byte limit",
   "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")",
-  "978": "Next.js has blocked a javascript: URL as a security precaution."
+  "978": "Next.js has blocked a javascript: URL as a security precaution.",
+  "979": "invariant: expected %s bytes of postponed state but only received %s bytes"
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -51,6 +51,7 @@ import {
   HTML_CONTENT_TYPE_HEADER,
   NEXT_CACHE_TAGS_HEADER,
   NEXT_RESUME_HEADER,
+  NEXT_RESUME_STATE_LENGTH_HEADER,
 } from '../../lib/constants'
 import type { CacheControl } from '../../server/lib/cache-control'
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags'
@@ -218,6 +219,40 @@ export async function handler(
   const couldSupportPPR: boolean = checkIsAppPPREnabled(
     nextConfig.experimental.ppr
   )
+
+  // Stash postponed state for server actions when in minimal mode.
+  // We extract it here so the RDC is available for the re-render after the action completes.
+  const resumeStateLengthHeader = req.headers[NEXT_RESUME_STATE_LENGTH_HEADER]
+  if (
+    !getRequestMeta(req, 'postponed') &&
+    isMinimalMode &&
+    couldSupportPPR &&
+    isPossibleServerAction &&
+    resumeStateLengthHeader &&
+    typeof resumeStateLengthHeader === 'string'
+  ) {
+    const stateLength = parseInt(resumeStateLengthHeader, 10)
+    if (!isNaN(stateLength) && stateLength > 0) {
+      // Read the entire body
+      const bodyChunks: Array<Buffer> = []
+      for await (const chunk of req) {
+        bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+      }
+      const fullBody = Buffer.concat(bodyChunks)
+
+      if (fullBody.length >= stateLength) {
+        // Extract postponed state from the beginning
+        const postponedState = fullBody
+          .subarray(0, stateLength)
+          .toString('utf8')
+        addRequestMeta(req, 'postponed', postponedState)
+
+        // Store the remaining action body for the action handler
+        const actionBody = fullBody.subarray(stateLength)
+        addRequestMeta(req, 'actionBody', actionBody)
+      }
+    }
+  }
 
   if (
     !getRequestMeta(req, 'postponed') &&

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -256,17 +256,33 @@ export async function handler(
         return null
       }
 
-      // Read the entire body, tracking size
+      // Calculate max total body size to prevent buffering excessively large
+      // payloads before the action handler checks. We use stateLength (not
+      // maxPostponedStateSizeBytes) so the postponed state doesn't eat into
+      // the action body budget - it's already validated above.
+      const defaultActionBodySizeLimit = '1 MB'
+      const actionBodySizeLimit =
+        nextConfig.experimental.serverActions?.bodySizeLimit ??
+        defaultActionBodySizeLimit
+      const actionBodySizeLimitBytes =
+        actionBodySizeLimit !== defaultActionBodySizeLimit
+          ? (
+              require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
+            ).parse(actionBodySizeLimit)
+          : 1024 * 1024 // 1 MB
+      const maxTotalBodySize = stateLength + actionBodySizeLimitBytes
+
+      // Read the entire body, checking size as we go.
       const bodyChunks: Array<Buffer> = []
       let size = 0
       for await (const chunk of req) {
         const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
         size += buffer.byteLength
-        if (size > maxPostponedStateSizeBytes) {
+        if (size > maxTotalBodySize) {
           res.statusCode = 413
           res.end(
-            `Postponed state exceeded ${maxPostponedStateSize} limit. ` +
-              `To configure the limit, see: https://nextjs.org/docs/app/api-reference/config/next-config-js/max-postponed-state-size`
+            `Request body exceeded limit. ` +
+              `To configure the body size limit for Server Actions, see: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit`
           )
           ctx.waitUntil?.(Promise.resolve())
           return null
@@ -285,6 +301,10 @@ export async function handler(
         // Store the remaining action body for the action handler
         const actionBody = fullBody.subarray(stateLength)
         addRequestMeta(req, 'actionBody', actionBody)
+      } else {
+        throw new Error(
+          `invariant: expected ${stateLength} bytes of postponed state but only received ${fullBody.length} bytes`
+        )
       }
     }
   }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -57,7 +57,10 @@ import type { CacheControl } from '../../server/lib/cache-control'
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags'
 import { sendRenderResult } from '../../server/send-payload'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
-import { parseMaxPostponedStateSize } from '../../shared/lib/size-limit'
+import {
+  DEFAULT_MAX_POSTPONED_STATE_SIZE,
+  parseMaxPostponedStateSize,
+} from '../../shared/lib/size-limit'
 
 // These are injected by the loader afterwards.
 
@@ -232,11 +235,43 @@ export async function handler(
     typeof resumeStateLengthHeader === 'string'
   ) {
     const stateLength = parseInt(resumeStateLengthHeader, 10)
+    const maxPostponedStateSize =
+      nextConfig.experimental.maxPostponedStateSize ??
+      DEFAULT_MAX_POSTPONED_STATE_SIZE
+    const maxPostponedStateSizeBytes = parseMaxPostponedStateSize(
+      nextConfig.experimental.maxPostponedStateSize
+    )
+
     if (!isNaN(stateLength) && stateLength > 0) {
-      // Read the entire body
+      if (
+        maxPostponedStateSizeBytes === undefined ||
+        stateLength > maxPostponedStateSizeBytes
+      ) {
+        res.statusCode = 413
+        res.end(
+          `Postponed state exceeded ${maxPostponedStateSize} limit. ` +
+            `To configure the limit, see: https://nextjs.org/docs/app/api-reference/config/next-config-js/max-postponed-state-size`
+        )
+        ctx.waitUntil?.(Promise.resolve())
+        return null
+      }
+
+      // Read the entire body, tracking size
       const bodyChunks: Array<Buffer> = []
+      let size = 0
       for await (const chunk of req) {
-        bodyChunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+        size += buffer.byteLength
+        if (size > maxPostponedStateSizeBytes) {
+          res.statusCode = 413
+          res.end(
+            `Postponed state exceeded ${maxPostponedStateSize} limit. ` +
+              `To configure the limit, see: https://nextjs.org/docs/app/api-reference/config/next-config-js/max-postponed-state-size`
+          )
+          ctx.waitUntil?.(Promise.resolve())
+          return null
+        }
+        bodyChunks.push(buffer)
       }
       const fullBody = Buffer.concat(bodyChunks)
 

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -846,17 +846,20 @@ export async function handler(
           ? minimalPostponed
           : undefined
 
-      // If this is a dynamic RSC request, we should use the postponed data from
-      // the static render (if available). This ensures that we can utilize the
-      // resume data cache (RDC) from the static render to ensure that the data
-      // is consistent between the static and dynamic renders.
+      // If this is a dynamic RSC request or a server action request, we should
+      // use the postponed data from the static render (if available). This
+      // ensures that we can utilize the resume data cache (RDC) from the static
+      // render to ensure that the data is consistent between the static and
+      // dynamic renders (for navigations) or when re-rendering after a server
+      // action.
       if (
         // Only enable RDC for Navigations if the feature is enabled.
         supportsRDCForNavigations &&
         process.env.NEXT_RUNTIME !== 'edge' &&
         !isMinimalMode &&
         incrementalCache &&
-        isDynamicRSCRequest &&
+        // Include both dynamic RSC requests (navigations) and server actions
+        (isDynamicRSCRequest || isPossibleServerAction) &&
         // We don't typically trigger an on-demand revalidation for dynamic RSC
         // requests, as we're typically revalidating the page in the background
         // instead. However, if the cache entry is stale, we should trigger a

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -25,6 +25,7 @@ export const NEXT_CACHE_REVALIDATE_TAG_TOKEN_HEADER =
   'x-next-revalidate-tag-token'
 
 export const NEXT_RESUME_HEADER = 'next-resume'
+export const NEXT_RESUME_STATE_LENGTH_HEADER = 'x-next-resume-state-length'
 
 // if these change make sure we update the related
 // documentation as well

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2247,8 +2247,6 @@ async function renderToHTMLOrFlightImpl(
       }
 
       didExecuteServerAction = true
-      // Restore the resume data cache
-      requestStore.renderResumeDataCache = renderResumeDataCache
     }
 
     const options: RenderResultOptions = {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2201,9 +2201,6 @@ async function renderToHTMLOrFlightImpl(
     let didExecuteServerAction = false
     let formState: null | any = null
     if (isPossibleActionRequest) {
-      // For action requests, we don't want to use the resume data cache.
-      requestStore.renderResumeDataCache = null
-
       // For action requests, we handle them differently with a special render result.
       const actionRequestResult = await handleAction({
         req,

--- a/packages/next/src/server/lib/server-ipc/utils.ts
+++ b/packages/next/src/server/lib/server-ipc/utils.ts
@@ -48,6 +48,7 @@ const INTERNAL_HEADERS = [
   'x-middleware-next',
   'x-now-route-matches',
   'x-matched-path',
+  'x-next-resume-state-length',
 ]
 
 export const filterInternalHeaders = (

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -141,6 +141,13 @@ export interface RequestMeta {
   postponed?: string
 
   /**
+   * The action body extracted from a server action request when the postponed
+   * state was prepended to the body by the proxy. This allows the action
+   * handler to read the action payload without re-reading the consumed stream.
+   */
+  actionBody?: Buffer
+
+  /**
    * If provided, this will be called when a response cache entry was generated
    * or looked up in the cache.
    *

--- a/test/e2e/app-dir/resume-data-cache/app/actions.ts
+++ b/test/e2e/app-dir/resume-data-cache/app/actions.ts
@@ -1,0 +1,9 @@
+'use server'
+
+import { refresh } from 'next/cache'
+
+export async function refreshAction() {
+  // Simulate some IO before calling refresh
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  refresh()
+}

--- a/test/e2e/app-dir/resume-data-cache/app/revalidate-action/actions.ts
+++ b/test/e2e/app-dir/resume-data-cache/app/revalidate-action/actions.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { updateTag } from 'next/cache'
+
+export async function revalidateAction() {
+  updateTag('revalidate-action-test')
+}

--- a/test/e2e/app-dir/resume-data-cache/app/revalidate-action/page.tsx
+++ b/test/e2e/app-dir/resume-data-cache/app/revalidate-action/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { cacheTag } from 'next/cache'
+import { RevalidateButton } from './revalidate-button'
+
+async function getCachedRandom() {
+  'use cache'
+  cacheTag('revalidate-action-test')
+  return Math.random()
+}
+
+async function DynamicContent() {
+  // Make the page dynamic/PPR by accessing connection()
+  await connection()
+  // Generate uncached value after dynamic access
+  const uncachedValue = Math.random()
+  return <p id="uncached-value">{uncachedValue}</p>
+}
+
+export default async function Page() {
+  const cachedValue = await getCachedRandom()
+
+  return (
+    <div>
+      <p id="cached-value">{cachedValue}</p>
+      <Suspense fallback={<p id="uncached-value">Loading...</p>}>
+        <DynamicContent />
+      </Suspense>
+      <RevalidateButton />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/resume-data-cache/app/revalidate-action/revalidate-button.tsx
+++ b/test/e2e/app-dir/resume-data-cache/app/revalidate-action/revalidate-button.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { revalidateAction } from './actions'
+
+export function RevalidateButton() {
+  return (
+    <form action={revalidateAction}>
+      <button id="revalidate-button" type="submit">
+        Revalidate
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/resume-data-cache/app/revalidate-fetch-action/actions.ts
+++ b/test/e2e/app-dir/resume-data-cache/app/revalidate-fetch-action/actions.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { updateTag } from 'next/cache'
+
+export async function revalidateFetchAction() {
+  updateTag('revalidate-fetch-action-test')
+}

--- a/test/e2e/app-dir/resume-data-cache/app/revalidate-fetch-action/page.tsx
+++ b/test/e2e/app-dir/resume-data-cache/app/revalidate-fetch-action/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { RevalidateButton } from './revalidate-button'
+
+async function DynamicContent() {
+  // Make the page dynamic/PPR by accessing connection()
+  await connection()
+  // Generate uncached value after dynamic access
+  const uncachedValue = Math.random()
+  return <p id="uncached-value">{uncachedValue}</p>
+}
+
+export default async function Page() {
+  // Use fetch with cache and tags
+  const cachedValue = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random',
+    { cache: 'force-cache', next: { tags: ['revalidate-fetch-action-test'] } }
+  ).then((res) => res.text())
+
+  return (
+    <div>
+      <p id="cached-value">{cachedValue}</p>
+      <Suspense fallback={<p id="uncached-value">Loading...</p>}>
+        <DynamicContent />
+      </Suspense>
+      <RevalidateButton />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/resume-data-cache/app/revalidate-fetch-action/revalidate-button.tsx
+++ b/test/e2e/app-dir/resume-data-cache/app/revalidate-fetch-action/revalidate-button.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { revalidateFetchAction } from './actions'
+
+export function RevalidateButton() {
+  return (
+    <form action={revalidateFetchAction}>
+      <button id="revalidate-button" type="submit">
+        Revalidate
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/resume-data-cache/app/server-action/page.tsx
+++ b/test/e2e/app-dir/resume-data-cache/app/server-action/page.tsx
@@ -1,0 +1,40 @@
+import React, { Suspense } from 'react'
+import { cacheTag } from 'next/cache'
+import { refreshAction } from '../actions'
+
+async function getCachedRandomNumber() {
+  'use cache'
+  cacheTag('server-action-test')
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+
+  return Math.random()
+}
+
+async function getUncachedRandomNumber() {
+  // No 'use cache' - this will generate a new value on every render
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  return Math.random()
+}
+
+async function DynamicComponent() {
+  const uncachedNumber = await getUncachedRandomNumber()
+  return <p id="uncached-random">{uncachedNumber}</p>
+}
+
+export default async function Page() {
+  const cachedNumber = await getCachedRandomNumber()
+  return (
+    <>
+      <p id="cached-random">{cachedNumber}</p>
+      <form action={refreshAction}>
+        <button id="refresh-button" type="submit">
+          Refresh
+        </button>
+      </form>
+      <Suspense fallback={<p id="uncached-random">Loading...</p>}>
+        <DynamicComponent />
+      </Suspense>
+    </>
+  )
+}

--- a/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
+++ b/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
@@ -167,4 +167,86 @@ describe('resume-data-cache', () => {
       })
     })
   }
+
+  it('should see fresh data after updateTag in server action with use cache', async () => {
+    // This test verifies that when a server action calls updateTag(),
+    // the subsequent re-render sees fresh data instead of stale RDC data.
+    // This is the "read your own writes" behavior for 'use cache'.
+
+    const browser = await next.browser('/revalidate-action')
+
+    // Get the initial cached value from the page render
+    const initialCachedValue = await browser
+      .elementByCss('#cached-value')
+      .text()
+    const initialUncachedValue = await browser
+      .elementByCss('#uncached-value')
+      .text()
+
+    // Click the revalidate button to trigger the server action
+    await browser.elementByCss('#revalidate-button').click()
+
+    // Wait for the re-render and verify:
+    // 1. The uncached value should change (proves re-render happened)
+    // 2. The cached value should ALSO change (proves updateTag was respected)
+    await retry(async () => {
+      const cachedValueAfterAction = await browser
+        .elementByCss('#cached-value')
+        .text()
+      const uncachedValueAfterAction = await browser
+        .elementByCss('#uncached-value')
+        .text()
+
+      // Uncached value should change - this proves the action triggered a re-render
+      expect(uncachedValueAfterAction).not.toBe(initialUncachedValue)
+
+      // Cached value should also change, which proves that the RDC read respected
+      // pendingRevalidatedTags and fetched fresh data instead of returning
+      // the stale value from the RDC.
+      // If this fails, it means the RDC is not respecting updateTag()
+      // calls made during server actions
+      expect(cachedValueAfterAction).not.toBe(initialCachedValue)
+    })
+  })
+
+  it('should see fresh data after updateTag in server action with fetch cache', async () => {
+    // This test verifies that when a server action calls updateTag(),
+    // the subsequent re-render sees fresh data instead of stale RDC data.
+    // This is the "read your own writes" behavior for fetch cache.
+
+    const browser = await next.browser('/revalidate-fetch-action')
+
+    // Get the initial cached value from the page render
+    const initialCachedValue = await browser
+      .elementByCss('#cached-value')
+      .text()
+    const initialUncachedValue = await browser
+      .elementByCss('#uncached-value')
+      .text()
+
+    // Click the revalidate button to trigger the server action
+    await browser.elementByCss('#revalidate-button').click()
+
+    // Wait for the re-render and verify:
+    // 1. The uncached value should change (proves re-render happened)
+    // 2. The cached value should ALSO change (proves updateTag was respected)
+    await retry(async () => {
+      const cachedValueAfterAction = await browser
+        .elementByCss('#cached-value')
+        .text()
+      const uncachedValueAfterAction = await browser
+        .elementByCss('#uncached-value')
+        .text()
+
+      // Uncached value should change - this proves the action triggered a re-render
+      expect(uncachedValueAfterAction).not.toBe(initialUncachedValue)
+
+      // Cached value should also change, which proves that the RDC read respected
+      // pendingRevalidatedTags and fetched fresh data instead of returning
+      // the stale value from the RDC.
+      // If this fails, it means the RDC is not respecting updateTag()
+      // calls made during server actions
+      expect(cachedValueAfterAction).not.toBe(initialCachedValue)
+    })
+  })
 })

--- a/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
+++ b/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
@@ -131,4 +131,37 @@ describe('resume-data-cache', () => {
       // between the static and dynamic renders.
     }
   )
+
+  it('should use RDC for server action re-renders', async () => {
+    const browser = await next.browser('/server-action')
+
+    // Get the initial values
+    const initialCachedValue = await browser
+      .elementByCss('#cached-random')
+      .text()
+    const initialUncachedValue = await browser
+      .elementByCss('#uncached-random')
+      .text()
+
+    await browser.elementByCss('#refresh-button').click()
+
+    // Wait for the action to complete and verify:
+    // 1. The uncached value should change
+    // 2. The cached value should remain the same (proving RDC is being used)
+    await retry(async () => {
+      const cachedValueAfterAction = await browser
+        .elementByCss('#cached-random')
+        .text()
+      const uncachedValueAfterAction = await browser
+        .elementByCss('#uncached-random')
+        .text()
+
+      // Uncached value should have changed - this proves the action caused a re-render
+      expect(uncachedValueAfterAction).not.toBe(initialUncachedValue)
+
+      // Cached value should remain the same - this proves the RDC is being used
+      // to maintain consistency during server action re-renders
+      expect(cachedValueAfterAction).toBe(initialCachedValue)
+    })
+  })
 })

--- a/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
+++ b/test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts
@@ -3,7 +3,7 @@ import { retry } from 'next-test-utils'
 import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 describe('resume-data-cache', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -132,36 +132,39 @@ describe('resume-data-cache', () => {
     }
   )
 
-  it('should use RDC for server action re-renders', async () => {
-    const browser = await next.browser('/server-action')
+  // TODO: Re-enable this test once necessary upstream changes are merged to support this
+  if (!isNextDeploy) {
+    it('should use RDC for server action re-renders', async () => {
+      const browser = await next.browser('/server-action')
 
-    // Get the initial values
-    const initialCachedValue = await browser
-      .elementByCss('#cached-random')
-      .text()
-    const initialUncachedValue = await browser
-      .elementByCss('#uncached-random')
-      .text()
-
-    await browser.elementByCss('#refresh-button').click()
-
-    // Wait for the action to complete and verify:
-    // 1. The uncached value should change
-    // 2. The cached value should remain the same (proving RDC is being used)
-    await retry(async () => {
-      const cachedValueAfterAction = await browser
+      // Get the initial values
+      const initialCachedValue = await browser
         .elementByCss('#cached-random')
         .text()
-      const uncachedValueAfterAction = await browser
+      const initialUncachedValue = await browser
         .elementByCss('#uncached-random')
         .text()
 
-      // Uncached value should have changed - this proves the action caused a re-render
-      expect(uncachedValueAfterAction).not.toBe(initialUncachedValue)
+      await browser.elementByCss('#refresh-button').click()
 
-      // Cached value should remain the same - this proves the RDC is being used
-      // to maintain consistency during server action re-renders
-      expect(cachedValueAfterAction).toBe(initialCachedValue)
+      // Wait for the action to complete and verify:
+      // 1. The uncached value should change
+      // 2. The cached value should remain the same (proving RDC is being used)
+      await retry(async () => {
+        const cachedValueAfterAction = await browser
+          .elementByCss('#cached-random')
+          .text()
+        const uncachedValueAfterAction = await browser
+          .elementByCss('#uncached-random')
+          .text()
+
+        // Uncached value should have changed - this proves the action caused a re-render
+        expect(uncachedValueAfterAction).not.toBe(initialUncachedValue)
+
+        // Cached value should remain the same - this proves the RDC is being used
+        // to maintain consistency during server action re-renders
+        expect(cachedValueAfterAction).toBe(initialCachedValue)
+      })
     })
-  })
+  }
 })


### PR DESCRIPTION
When a server action triggers a re-render of the underlying page (eg by calling `refresh()`), cached data that was part of the Resume Data Cache (RDC) was not provided to the server action handler, and so those parts of the UI would update with new data. A subsequent refresh of the page would revert back to the ISR data, which means the server action causes the data to temporarily get into an "ahead" state that will never actually be reflected in the ISR shell. 

This provides the RDC data to the server action handler. For self-hosted deployments, Next.js can look up the cached entry directly since the cache and renderer are co-located. For deployments on Vercel, the caching layer and rendering layer are separate services, and server actions bypass the cache. This means the serverless function has no way to access the cached RDC on its own, so the underlying CDN must fetch it and pass it via the request body. The `x-next-resume-state-length` is sent to the serverless function so that it can determine how to split off the RDC data from the action body.

Fixes NAR-478
Fixes NAR-502