### PR TITLE
fix(examples): fix warnings in jest tests

### DIFF
--- a/examples/with-jest-babel/package.json
+++ b/examples/with-jest-babel/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "5.16.4",
-    "@testing-library/react": "13.2.0",
+    "@testing-library/react": "14.3.0",
     "@testing-library/user-event": "14.2.0",
     "@types/jest": "29.5.5",
     "@types/react": "18.2.8",

--- a/examples/with-jest/package.json
+++ b/examples/with-jest/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.1.5",
-    "@testing-library/react": "14.1.2",
+    "@testing-library/react": "14.3.0",
     "@types/jest": "29.5.11",
     "@types/react": "18.2.45",
     "jest": "29.7.0",


### PR DESCRIPTION
Suppresses the following warnings:

    $ # in examples/with-jest/ or examples/with-jest-babel/
    $ pnpm jest
     PASS  app/utils/add.test.ts
     PASS  app/page.test.tsx
      ● Console

        console.error
          Warning: `ReactDOMTestUtils.act` is deprecated in favor of `React.act`. Import `act` from `react` instead of `react-dom/test-utils`. See https://react.dev/warnings/react-dom-test-utils for more info.

           6 |
           7 | it("App Router: Works with Server Components", () => {
        >  8 |   render(<Page />);
             |         ^
           9 |   expect(screen.getByRole("heading")).toHaveTextContent("App Router");
          10 | });
          11 |

          at printWarning (node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom/cjs/react-dom-test-utils.development.js:71:30)
          at Object.<anonymous> (app/page.test.tsx:8:9)
    ...

This was fixed in @testing-library/react v14.3.0:
https://github.com/testing-library/react-testing-library/compare/v14.2.2...v14.3.0#diff-a4177cd5406a6c3f32827e85977bfadba791088e113656085bf736a5000ff8d2L3-R4
