### PR TITLE
Turbopack: handle invalid RSC imports via importmap

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -50,10 +50,7 @@ use crate::{
         get_next_client_resolved_map,
     },
     next_shared::{
-        resolve::{
-            ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin,
-            get_invalid_server_only_resolve_plugin,
-        },
+        resolve::{ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin},
         transforms::{
             emotion::get_emotion_transform_rule,
             react_remove_properties::get_react_remove_properties_transform_rule,
@@ -181,11 +178,6 @@ pub async fn get_client_resolve_options_context(
         browser: true,
         module: true,
         before_resolve_plugins: vec![
-            ResolvedVc::upcast(
-                get_invalid_server_only_resolve_plugin(project_path.clone())
-                    .to_resolved()
-                    .await?,
-            ),
             ResolvedVc::upcast(
                 ModuleFeatureReportResolvePlugin::new(project_path.clone())
                     .to_resolved()

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -27,10 +27,7 @@ use crate::{
     next_font::local::NextFontLocalResolvePlugin,
     next_import_map::{get_next_edge_and_server_fallback_import_map, get_next_edge_import_map},
     next_server::context::ServerContextType,
-    next_shared::resolve::{
-        ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin,
-        get_invalid_client_only_resolve_plugin, get_invalid_styled_jsx_resolve_plugin,
-    },
+    next_shared::resolve::{ModuleFeatureReportResolvePlugin, NextSharedRuntimeResolvePlugin},
     util::{
         NextRuntime, OptionEnvMap, defines, foreign_code_context_condition,
         free_var_references_with_vercel_system_env_warnings, worker_forwarded_globals,
@@ -129,25 +126,6 @@ pub async fn get_edge_resolve_options_context(
                 .await?,
         ));
     };
-
-    if matches!(
-        ty,
-        ServerContextType::AppRSC { .. }
-            | ServerContextType::AppRoute { .. }
-            | ServerContextType::Middleware { .. }
-            | ServerContextType::Instrumentation { .. }
-    ) {
-        before_resolve_plugins.push(ResolvedVc::upcast(
-            get_invalid_client_only_resolve_plugin(project_path.clone())
-                .to_resolved()
-                .await?,
-        ));
-        before_resolve_plugins.push(ResolvedVc::upcast(
-            get_invalid_styled_jsx_resolve_plugin(project_path.clone())
-                .to_resolved()
-                .await?,
-        ));
-    }
 
     let after_resolve_plugins = vec![ResolvedVc::upcast(
         NextSharedRuntimeResolvePlugin::new(project_path.clone())

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -10,7 +10,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     asset::AssetContent,
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
+    issue::{Issue, IssueSeverity, IssueStage, StyledString},
     reference_type::ReferenceType,
     resolve::{
         ResolveResult, ResolveResultItem, ResolveResultOption,
@@ -108,16 +108,12 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let font_fallbacks = &*get_font_fallbacks(lookup_path.clone(), options_vc).await?;
                 let font_fallbacks = match font_fallbacks {
                     FontFallbackResult::FontFileNotFound(err) => {
-                        FontResolvingIssue {
-                            origin_path: lookup_path.clone(),
-                            font_path: ResolvedVc::cell(err.0.clone()),
-                        }
-                        .resolved_cell()
-                        .emit();
-
                         return Ok(ResolveResultOption::some(
-                            ResolveResult::primary(ResolveResultItem::Error(ResolvedVc::cell(
-                                err.to_string().into(),
+                            ResolveResult::primary(ResolveResultItem::Error(ResolvedVc::upcast(
+                                FontResolvingIssue {
+                                    font_path: ResolvedVc::cell(err.0.clone()),
+                                }
+                                .resolved_cell(),
                             )))
                             .cell(),
                         ));
@@ -183,16 +179,12 @@ impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
                 let fallback = &*get_font_fallbacks(lookup_path.clone(), options).await?;
                 let fallback = match fallback {
                     FontFallbackResult::FontFileNotFound(err) => {
-                        FontResolvingIssue {
-                            origin_path: lookup_path.clone(),
-                            font_path: ResolvedVc::cell(err.0.clone()),
-                        }
-                        .resolved_cell()
-                        .emit();
-
                         return Ok(ResolveResultOption::some(
-                            ResolveResult::primary(ResolveResultItem::Error(ResolvedVc::cell(
-                                err.to_string().into(),
+                            ResolveResult::primary(ResolveResultItem::Error(ResolvedVc::upcast(
+                                FontResolvingIssue {
+                                    font_path: ResolvedVc::cell(err.0.clone()),
+                                }
+                                .resolved_cell(),
                             )))
                             .cell(),
                         ));
@@ -320,9 +312,6 @@ fn font_file_options_from_query_map(query: &RcStr) -> Result<NextFontLocalFontFi
 #[turbo_tasks::value(shared)]
 struct FontResolvingIssue {
     font_path: ResolvedVc<RcStr>,
-    // TODO(PACK-4879): The filepath is incorrect and there should be a fine grained source
-    // location pointing at the import/require
-    origin_path: FileSystemPath,
 }
 
 #[turbo_tasks::value_impl]
@@ -333,7 +322,7 @@ impl Issue for FontResolvingIssue {
 
     #[turbo_tasks::function]
     fn file_path(&self) -> Vc<FileSystemPath> {
-        self.origin_path.clone().cell()
+        panic!("FontResolvingIssue::file_path should not be called");
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -7,7 +7,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::{FileSystem, FileSystemPath, to_sys_path};
 use turbopack_core::{
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, StyledString},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
         AliasPattern, ExternalTraced, ExternalType, ResolveAliasMap, SubpathValue,
@@ -280,6 +280,8 @@ pub async fn get_next_client_import_map(
     insert_turbopack_dev_alias(&mut import_map).await?;
     insert_instrumentation_client_alias(&mut import_map, project_path).await?;
 
+    insert_server_only_error_alias(&mut import_map);
+
     Ok(import_map.cell())
 }
 
@@ -551,6 +553,16 @@ pub async fn get_next_edge_import_map(
         }
     }
 
+    if matches!(
+        ty,
+        ServerContextType::AppRSC { .. }
+            | ServerContextType::AppRoute { .. }
+            | ServerContextType::Middleware { .. }
+            | ServerContextType::Instrumentation { .. }
+    ) {
+        insert_client_only_error_alias(&mut import_map);
+    }
+
     Ok(import_map.cell())
 }
 
@@ -704,9 +716,7 @@ async fn insert_next_server_special_aliases(
     match &ty {
         ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {}
         // the logic closely follows the one in createRSCAliases in webpack-config.ts
-        ServerContextType::AppSSR { app_dir }
-        | ServerContextType::AppRSC { app_dir, .. }
-        | ServerContextType::AppRoute { app_dir, .. } => {
+        ServerContextType::AppSSR { app_dir } => {
             let next_package = get_next_package(app_dir.clone()).await?;
             import_map.insert_exact_alias(
                 rcstr!("styled-jsx"),
@@ -726,7 +736,10 @@ async fn insert_next_server_special_aliases(
             )
             .await?;
         }
-        ServerContextType::Middleware { .. } | ServerContextType::Instrumentation { .. } => {
+        ServerContextType::AppRSC { .. }
+        | ServerContextType::AppRoute { .. }
+        | ServerContextType::Middleware { .. }
+        | ServerContextType::Instrumentation { .. } => {
             rsc_aliases(
                 import_map,
                 project_path.clone(),
@@ -766,11 +779,11 @@ async fn insert_next_server_special_aliases(
                 project_path.clone(),
                 fxindexmap! {
                     rcstr!("server-only") => rcstr!("next/dist/compiled/server-only/empty"),
-                    rcstr!("client-only") => rcstr!("next/dist/compiled/client-only/error"),
                     rcstr!("next/dist/compiled/server-only") => rcstr!("next/dist/compiled/server-only/empty"),
                     rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/error"),
                 },
             );
+            insert_client_only_error_alias(import_map);
         }
         ServerContextType::AppSSR { .. } => {
             insert_exact_alias_map(
@@ -1456,6 +1469,113 @@ async fn insert_instrumentation_client_alias(
     );
 
     Ok(())
+}
+
+fn insert_client_only_error_alias(import_map: &mut ImportMap) {
+    import_map.insert_exact_alias(
+        rcstr!("client-only"),
+        ImportMapping::Error(ResolvedVc::upcast(
+            InvalidImportIssue {
+                title: StyledString::Line(vec![
+                    StyledString::Code(rcstr!("'client-only'")),
+                    StyledString::Text(rcstr!(
+                        " cannot be imported from a Server Component module"
+                    )),
+                ])
+                .resolved_cell(),
+                description: ResolvedVc::cell(Some(
+                    StyledString::Line(vec![StyledString::Text(
+                        "It should only be used from a Client Component.".into(),
+                    )])
+                    .resolved_cell(),
+                )),
+            }
+            .resolved_cell(),
+        ))
+        .resolved_cell(),
+    );
+
+    // styled-jsx imports client-only. So this is effectively the same as above but produces a nicer
+    // import trace.
+    let mapping = ImportMapping::Error(ResolvedVc::upcast(
+        InvalidImportIssue {
+            title: StyledString::Line(vec![
+                StyledString::Code(rcstr!("'styled-jsx'")),
+                StyledString::Text(rcstr!(" cannot be imported from a Server Component module")),
+            ])
+            .resolved_cell(),
+            description: ResolvedVc::cell(Some(
+                StyledString::Line(vec![StyledString::Text(
+                    "It only works in a Client Component but none of its parents are marked with \
+                     'use client', so they're Server Components by default."
+                        .into(),
+                )])
+                .resolved_cell(),
+            )),
+        }
+        .resolved_cell(),
+    ))
+    .resolved_cell();
+    import_map.insert_exact_alias(rcstr!("styled-jsx"), mapping);
+    import_map.insert_wildcard_alias(rcstr!("styled-jsx/"), mapping);
+}
+
+fn insert_server_only_error_alias(import_map: &mut ImportMap) {
+    import_map.insert_exact_alias(
+        rcstr!("server-only"),
+        ImportMapping::Error(ResolvedVc::upcast(
+            InvalidImportIssue {
+                title: StyledString::Line(vec![
+                    StyledString::Code(rcstr!("'server-only'")),
+                    StyledString::Text(rcstr!(
+                        " cannot be imported from a Client Component module"
+                    )),
+                ])
+                .resolved_cell(),
+                description: ResolvedVc::cell(Some(
+                    StyledString::Line(vec![StyledString::Text(
+                        "It should only be used from a Server Component.".into(),
+                    )])
+                    .resolved_cell(),
+                )),
+            }
+            .resolved_cell(),
+        ))
+        .resolved_cell(),
+    );
+}
+
+#[turbo_tasks::value(shared)]
+struct InvalidImportIssue {
+    title: ResolvedVc<StyledString>,
+    description: ResolvedVc<OptionStyledString>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for InvalidImportIssue {
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Error
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        panic!("InvalidImportIssue::file_path should not be called");
+    }
+
+    #[turbo_tasks::function]
+    fn stage(self: Vc<Self>) -> Vc<IssueStage> {
+        IssueStage::Resolve.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        *self.title
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        *self.description
+    }
 }
 
 // To alias e.g. both `import "next/link"` and `import "next/link.js"`

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -53,8 +53,7 @@ use crate::{
     next_shared::{
         resolve::{
             ModuleFeatureReportResolvePlugin, NextExternalResolvePlugin,
-            NextNodeSharedRuntimeResolvePlugin, get_invalid_client_only_resolve_plugin,
-            get_invalid_styled_jsx_resolve_plugin,
+            NextNodeSharedRuntimeResolvePlugin,
         },
         transforms::{
             EcmascriptTransformStage, emotion::get_emotion_transform_rule, get_ecma_transform_rule,
@@ -153,14 +152,6 @@ pub async fn get_server_resolve_options_context(
         ModuleFeatureReportResolvePlugin::new(project_path.clone())
             .to_resolved()
             .await?;
-    let invalid_client_only_resolve_plugin =
-        get_invalid_client_only_resolve_plugin(project_path.clone())
-            .to_resolved()
-            .await?;
-    let invalid_styled_jsx_client_only_resolve_plugin =
-        get_invalid_styled_jsx_resolve_plugin(project_path.clone())
-            .to_resolved()
-            .await?;
 
     // Always load these predefined packages as external.
     let mut external_packages: Vec<RcStr> = load_next_js_jsonc_file(
@@ -241,7 +232,7 @@ pub async fn get_server_resolve_options_context(
             .to_resolved()
             .await?;
 
-    let mut before_resolve_plugins = match &ty {
+    let before_resolve_plugins = match &ty {
         ServerContextType::Pages { .. }
         | ServerContextType::AppSSR { .. }
         | ServerContextType::AppRSC { .. } => {
@@ -287,32 +278,6 @@ pub async fn get_server_resolve_options_context(
             ]
         }
     };
-
-    // Inject resolve plugin to assert incorrect import to client|server-only for
-    // the corresponding context. Refer https://github.com/vercel/next.js/blob/ad15817f0368ba154bed6d85320335d4b67b7348/packages/next/src/build/webpack-config.ts#L1205-L1235
-    // how it is applied in the webpack config.
-    // Unlike webpack which alias client-only -> runtime code -> build-time error
-    // code, we use resolve plugin to detect original import directly. This
-    // means each resolve plugin must be injected only for the context where the
-    // alias resolves into the error. The alias lives in here: https://github.com/vercel/next.js/blob/0060de1c4905593ea875fa7250d4b5d5ce10897d/packages/next-swc/crates/next-core/src/next_import_map.rs#L534
-    match ty {
-        ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
-            //noop
-        }
-        ServerContextType::AppRSC { .. }
-        | ServerContextType::AppRoute { .. }
-        | ServerContextType::Middleware { .. }
-        | ServerContextType::Instrumentation { .. } => {
-            before_resolve_plugins.push(ResolvedVc::upcast(invalid_client_only_resolve_plugin));
-            before_resolve_plugins.push(ResolvedVc::upcast(
-                invalid_styled_jsx_client_only_resolve_plugin,
-            ));
-        }
-        ServerContextType::AppSSR { .. } => {
-            //[TODO] Build error in this context makes rsc-build-error.ts fail which expects runtime error code
-            // looks like webpack and turbopack have different order, webpack runs rsc transform first, turbopack triggers resolve plugin first.
-        }
-    }
 
     let resolve_options_context = ResolveOptionsContext {
         enable_node_modules: Some(root_dir.clone()),

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -11,7 +11,7 @@ use turbo_tasks_fs::{
 use turbopack_core::{
     diagnostics::DiagnosticExt,
     file_source::FileSource,
-    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
+    issue::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     reference_type::ReferenceType,
     resolve::{
         ExternalTraced, ExternalType, ResolveResult, ResolveResultItem, ResolveResultOption,
@@ -99,115 +99,6 @@ impl Issue for InvalidImportModuleIssue {
             .resolved_cell(),
         )))
     }
-}
-
-/// A resolver plugin emits an error when specific context imports
-/// specified import requests. It doesn't detect if the import is correctly
-/// aliased or not unlike webpack-config does; Instead it should be correctly
-/// configured when each context sets up its resolve options.
-#[turbo_tasks::value]
-pub(crate) struct InvalidImportResolvePlugin {
-    root: FileSystemPath,
-    invalid_import: RcStr,
-    message: Vec<RcStr>,
-}
-
-#[turbo_tasks::value_impl]
-impl InvalidImportResolvePlugin {
-    #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath, invalid_import: RcStr, message: Vec<RcStr>) -> Vc<Self> {
-        InvalidImportResolvePlugin {
-            root,
-            invalid_import,
-            message,
-        }
-        .cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl BeforeResolvePlugin for InvalidImportResolvePlugin {
-    #[turbo_tasks::function]
-    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_modules(Vc::cell(vec![self.invalid_import.clone()]))
-    }
-
-    #[turbo_tasks::function]
-    fn before_resolve(
-        &self,
-        lookup_path: FileSystemPath,
-        _reference_type: ReferenceType,
-        _request: Vc<Request>,
-    ) -> Vc<ResolveResultOption> {
-        InvalidImportModuleIssue {
-            file_path: lookup_path,
-            messages: self.message.clone(),
-            // styled-jsx specific resolve error has its own message
-            skip_context_message: self.invalid_import == "styled-jsx",
-        }
-        .resolved_cell()
-        .emit();
-
-        ResolveResultOption::some(
-            ResolveResult::primary(ResolveResultItem::Error(ResolvedVc::cell(
-                self.message.join("\n").into(),
-            )))
-            .cell(),
-        )
-    }
-}
-
-/// Returns a resolve plugin if context have imports to `client-only`.
-/// Only the contexts that aliases `client-only` to
-/// `next/dist/compiled/client-only/error` should use this.
-pub(crate) fn get_invalid_client_only_resolve_plugin(
-    root: FileSystemPath,
-) -> Vc<InvalidImportResolvePlugin> {
-    InvalidImportResolvePlugin::new(
-        root,
-        rcstr!("client-only"),
-        vec![
-            "'client-only' cannot be imported from a Server Component module. It should only be \
-             used from a Client Component."
-                .into(),
-        ],
-    )
-}
-
-/// Returns a resolve plugin if context have imports to `server-only`.
-/// Only the contexts that aliases `server-only` to
-/// `next/dist/compiled/server-only/index` should use this.
-pub(crate) fn get_invalid_server_only_resolve_plugin(
-    root: FileSystemPath,
-) -> Vc<InvalidImportResolvePlugin> {
-    InvalidImportResolvePlugin::new(
-        root,
-        rcstr!("server-only"),
-        vec![
-            "'server-only' cannot be imported from a Client Component module. It should only be \
-             used from a Server Component."
-                .into(),
-        ],
-    )
-}
-
-/// Returns a resolve plugin if context have imports to `styled-jsx`.
-pub(crate) fn get_invalid_styled_jsx_resolve_plugin(
-    root: FileSystemPath,
-) -> Vc<InvalidImportResolvePlugin> {
-    InvalidImportResolvePlugin::new(
-        root,
-        rcstr!("styled-jsx"),
-        vec![
-            "'client-only' cannot be imported from a Server Component module. It should only be \
-             used from a Client Component."
-                .into(),
-            "The error was caused by using 'styled-jsx'. It only works in a Client Component but \
-             none of its parents are marked with \"use client\", so they're Server Components by \
-             default."
-                .into(),
-        ],
-    )
 }
 
 #[turbo_tasks::value]

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -74,7 +74,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
         asset::Asset,
         module::Module,
         reference_type::{CommonJsReferenceSubType, ReferenceType},
-        resolve::{ResolveErrorMode, handle_resolve_error, parse::Request, resolve},
+        resolve::{ResolveErrorMode, error::handle_resolve_error, parse::Request, resolve},
     };
     use turbopack_ecmascript_plugins::transform::swc_ecma_transform_plugins::{
         SwcEcmaTransformPluginsTransformer, SwcPluginModule,

--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -66,10 +66,15 @@ describe('Error Overlay invalid imports', () => {
     await session.waitForRedbox()
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./app
-        Invalid import
-        'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.
-        The error was caused by using 'styled-jsx'. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default."
+       "./app/comp2.js
+       'styled-jsx' cannot be imported from a Server Component module
+       It only works in a Client Component but none of its parents are marked with 'use client', so they're Server Components by default.
+
+       Import trace:
+         Server Component:
+           ./app/comp2.js
+           ./app/comp1.js
+           ./app/page.js"
       `)
     } else if (process.env.NEXT_RSPACK) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
@@ -95,6 +100,75 @@ describe('Error Overlay invalid imports', () => {
               ./app/comp1.js
               ./app/page.js"
           `)
+    }
+  })
+
+  it('should show error when require-ing client-only in server component', async () => {
+    await using sandbox = await createSandbox(
+      next,
+      new Map([
+        [
+          'app/foo.js',
+          outdent`
+            require("client-only")
+          `,
+        ],
+        [
+          'app/page.js',
+          outdent`
+            'use client'
+            import './foo'
+
+            export default function Page() {
+              return "Hello"
+            }
+          `,
+        ],
+      ])
+    )
+    const { session } = sandbox
+    const pageFile = 'app/page.js'
+    const content = await next.readFile(pageFile)
+    const withoutUseClient = content.replace("'use client'", '')
+    await session.patch(pageFile, withoutUseClient)
+
+    await session.waitForRedbox()
+    if (process.env.IS_TURBOPACK_TEST) {
+      expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
+       "./app/foo.js (1:1)
+       'client-only' cannot be imported from a Server Component module
+       > 1 | require("client-only")
+           | ^^^^^^^^^^^^^^^^^^^^^^
+
+       It should only be used from a Client Component.
+
+       Import trace:
+         Server Component:
+           ./app/foo.js
+           ./app/page.js"
+      `)
+    } else if (process.env.NEXT_RSPACK) {
+      expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
+       "./app/foo.js
+         × 'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.
+         │ 
+         │ The error was caused by importing 'next/dist/compiled/client-only/error.js' in './app/foo.js'.
+         │ 
+         │ Import trace for requested module:
+       │   ./app/foo.js
+       │   ./app/page.js"
+      `)
+    } else {
+      expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
+       "./app/foo.js
+       'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.
+
+       The error was caused by importing 'next/dist/compiled/client-only/error.js' in './app/foo.js'.
+
+       Import trace for requested module:
+       ./app/foo.js
+       ./app/page.js"
+      `)
     }
   })
 
@@ -160,10 +234,19 @@ describe('Error Overlay invalid imports', () => {
     await session.waitForRedbox()
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./node_modules/client-only-package
-        Invalid import
-        'client-only' cannot be imported from a Server Component module. It should only be used from a Client Component.
-        The error was caused by importing 'node_modules/client-only-package'"
+       "./node_modules/client-only-package/index.js (1:1)
+       'client-only' cannot be imported from a Server Component module
+       > 1 | require("client-only")
+           | ^^^^^^^^^^^^^^^^^^^^^^
+
+       It should only be used from a Client Component.
+
+       Import trace:
+         Server Component:
+           ./node_modules/client-only-package/index.js
+           ./app/comp2.js
+           ./app/comp1.js
+           ./app/page.js"
       `)
     } else if (process.env.NEXT_RSPACK) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
@@ -252,10 +335,27 @@ describe('Error Overlay invalid imports', () => {
     await session.waitForRedbox()
     if (process.env.IS_TURBOPACK_TEST) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
-        "./node_modules/server-only-package
-        Invalid import
-        'server-only' cannot be imported from a Client Component module. It should only be used from a Server Component.
-        The error was caused by importing 'node_modules/server-only-package'"
+       "./node_modules/server-only-package/index.js (1:1)
+       'server-only' cannot be imported from a Client Component module
+       > 1 | require("server-only")
+           | ^^^^^^^^^^^^^^^^^^^^^^
+
+       It should only be used from a Server Component.
+
+       Import traces:
+         Client Component Browser:
+           ./node_modules/server-only-package/index.js [Client Component Browser]
+           ./app/comp2.js [Client Component Browser]
+           ./app/comp1.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+
+         Client Component SSR:
+           ./node_modules/server-only-package/index.js [Client Component SSR]
+           ./app/comp2.js [Client Component SSR]
+           ./app/comp1.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]"
       `)
     } else if (process.env.NEXT_RSPACK) {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -1,5 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
-import { waitForRedbox, getRedboxSource, retry } from 'next-test-utils'
+import {
+  waitForRedbox,
+  getRedboxSource,
+  retry,
+  waitForNoRedbox,
+} from 'next-test-utils'
 
 describe('module layer', () => {
   const { next, isNextStart, isNextDev } = nextTestSetup({
@@ -95,32 +100,30 @@ describe('module layer', () => {
 
   if (isNextDev) {
     describe('client packages in middleware', () => {
-      const middlewareFile = 'middleware.js'
-      let middlewareContent = ''
-
-      afterAll(async () => {
-        await next.patchFile(middlewareFile, middlewareContent)
-      })
-
       it('should error when import server packages in middleware', async () => {
         const browser = await next.browser('/')
 
-        middlewareContent = await next.readFile(middlewareFile)
-
         await next.patchFile(
-          middlewareFile,
-          middlewareContent
-            .replace("import 'server-only'", "// import 'server-only'")
-            .replace("// import './lib/mixed-lib'", "import './lib/mixed-lib'")
+          'middleware.js',
+          (c) =>
+            c
+              .replace("import 'server-only'", "// import 'server-only'")
+              .replace(
+                "// import './lib/mixed-lib'",
+                "import './lib/mixed-lib'"
+              ),
+          async () => {
+            await retry(async () => {
+              await waitForRedbox(browser)
+              const source = await getRedboxSource(browser)
+              expect(source).toContain(
+                `You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client"`
+              )
+            })
+          }
         )
 
-        await retry(async () => {
-          await waitForRedbox(browser)
-          const source = await getRedboxSource(browser)
-          expect(source).toContain(
-            `You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client"`
-          )
-        })
+        await waitForNoRedbox(browser)
       })
     })
   }

--- a/turbopack/crates/turbopack-core/src/resolve/error.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/error.rs
@@ -1,0 +1,246 @@
+use anyhow::Result;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{IntoTraitRef, PrettyPrintError, ResolvedVc, Vc};
+use turbo_tasks_fs::FileSystemPath;
+
+use crate::{
+    issue::{
+        Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
+        OptionStyledString, StyledString, resolve::ResolvingIssue,
+    },
+    reference_type::ReferenceType,
+    resolve::{
+        ModuleResolveResult, ResolveErrorMode, ResolveResult, options::ResolveOptions,
+        origin::ResolveOrigin, parse::Request,
+    },
+};
+
+pub async fn handle_resolve_error(
+    result: Vc<ModuleResolveResult>,
+    reference_type: ReferenceType,
+    origin: Vc<Box<dyn ResolveOrigin>>,
+    request: Vc<Request>,
+    resolve_options: Vc<ResolveOptions>,
+    error_mode: ResolveErrorMode,
+
+    source: Option<IssueSource>,
+) -> Result<Vc<ModuleResolveResult>> {
+    Ok(match result.await {
+        Ok(result_ref) => {
+            if result_ref.is_unresolvable_ref() {
+                emit_unresolvable_issue(
+                    error_mode,
+                    origin,
+                    reference_type,
+                    request,
+                    resolve_options,
+                    source,
+                )
+                .await?;
+            }
+
+            handle_item_issues(result_ref.errors(), origin, source).await?;
+
+            result
+        }
+        Err(err) => {
+            emit_resolve_error_issue(
+                error_mode,
+                origin,
+                reference_type,
+                request,
+                resolve_options,
+                err,
+                source,
+            )
+            .await?;
+            *ModuleResolveResult::unresolvable()
+        }
+    })
+}
+
+pub async fn handle_resolve_source_error(
+    result: Vc<ResolveResult>,
+    reference_type: ReferenceType,
+    origin: Vc<Box<dyn ResolveOrigin>>,
+    request: Vc<Request>,
+    resolve_options: Vc<ResolveOptions>,
+    error_mode: ResolveErrorMode,
+    source: Option<IssueSource>,
+) -> Result<Vc<ResolveResult>> {
+    Ok(match result.await {
+        Ok(result_ref) => {
+            if result_ref.is_unresolvable_ref() {
+                emit_unresolvable_issue(
+                    error_mode,
+                    origin,
+                    reference_type,
+                    request,
+                    resolve_options,
+                    source,
+                )
+                .await?;
+            }
+
+            handle_item_issues(result_ref.errors(), origin, source).await?;
+
+            result
+        }
+        Err(err) => {
+            emit_resolve_error_issue(
+                error_mode,
+                origin,
+                reference_type,
+                request,
+                resolve_options,
+                err,
+                source,
+            )
+            .await?;
+            ResolveResult::unresolvable().cell()
+        }
+    })
+}
+
+async fn handle_item_issues(
+    items: impl Iterator<Item = ResolvedVc<Box<dyn Issue>>>,
+    origin: Vc<Box<dyn ResolveOrigin>>,
+    source: Option<IssueSource>,
+) -> Result<()> {
+    let mut items = items.peekable();
+    if items.peek().is_some() {
+        let file_path = origin.origin_path().owned().await?;
+        for item in items {
+            ResolvingIssueWithLocation {
+                inner: item,
+                severity: item.into_trait_ref().await?.severity(),
+                file_path: file_path.clone(),
+                source,
+            }
+            .resolved_cell()
+            .emit();
+        }
+    }
+    Ok(())
+}
+
+async fn emit_resolve_error_issue(
+    error_mode: ResolveErrorMode,
+    origin: Vc<Box<dyn ResolveOrigin>>,
+    reference_type: ReferenceType,
+    request: Vc<Request>,
+    resolve_options: Vc<ResolveOptions>,
+    err: anyhow::Error,
+    source: Option<IssueSource>,
+) -> Result<()> {
+    if error_mode == ResolveErrorMode::Ignore {
+        return Ok(());
+    }
+    let severity = if error_mode == ResolveErrorMode::Warn || resolve_options.await?.loose_errors {
+        IssueSeverity::Warning
+    } else {
+        IssueSeverity::Error
+    };
+    ResolvingIssue {
+        severity,
+        file_path: origin.origin_path().owned().await?,
+        request_type: format!("{reference_type} request"),
+        request: request.to_resolved().await?,
+        resolve_options: resolve_options.to_resolved().await?,
+        error_message: Some(format!("{}", PrettyPrintError(&err))),
+        source,
+    }
+    .resolved_cell()
+    .emit();
+    Ok(())
+}
+
+async fn emit_unresolvable_issue(
+    error_mode: ResolveErrorMode,
+
+    origin: Vc<Box<dyn ResolveOrigin>>,
+    reference_type: ReferenceType,
+    request: Vc<Request>,
+    resolve_options: Vc<ResolveOptions>,
+    source: Option<IssueSource>,
+) -> Result<()> {
+    if error_mode == ResolveErrorMode::Ignore {
+        return Ok(());
+    }
+    let severity = if error_mode == ResolveErrorMode::Warn || resolve_options.await?.loose_errors {
+        IssueSeverity::Warning
+    } else {
+        IssueSeverity::Error
+    };
+    ResolvingIssue {
+        severity,
+        file_path: origin.origin_path().owned().await?,
+        request_type: format!("{reference_type} request"),
+        request: request.to_resolved().await?,
+        resolve_options: resolve_options.to_resolved().await?,
+        error_message: None,
+        source,
+    }
+    .resolved_cell()
+    .emit();
+    Ok(())
+}
+
+pub async fn resolve_error_severity(resolve_options: Vc<ResolveOptions>) -> Result<IssueSeverity> {
+    Ok(if resolve_options.await?.loose_errors {
+        IssueSeverity::Warning
+    } else {
+        IssueSeverity::Error
+    })
+}
+
+/// Delegates to the inner issue but overrides the file path and source information.
+#[turbo_tasks::value(shared)]
+pub struct ResolvingIssueWithLocation {
+    pub inner: ResolvedVc<Box<dyn Issue>>,
+    pub severity: IssueSeverity,
+    pub file_path: FileSystemPath,
+    pub source: Option<IssueSource>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for ResolvingIssueWithLocation {
+    fn severity(&self) -> IssueSeverity {
+        self.severity
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.file_path.clone().cell()
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        self.inner.stage()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        self.inner.title()
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        self.inner.description()
+    }
+
+    #[turbo_tasks::function]
+    fn detail(&self) -> Vc<OptionStyledString> {
+        self.inner.detail()
+    }
+
+    #[turbo_tasks::function]
+    fn documentation_link(&self) -> Vc<RcStr> {
+        self.inner.documentation_link()
+    }
+
+    #[turbo_tasks::function]
+    fn source(&self) -> Vc<OptionIssueSource> {
+        Vc::cell(self.source)
+    }
+}

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -17,8 +17,8 @@ use tracing::{Instrument, Level};
 use turbo_frozenmap::{FrozenMap, FrozenSet};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, PrettyPrintError, ReadRef, ResolvedVc, TaskInput,
-    TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
+    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt,
+    TryJoinIterExt, ValueToString, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 use turbo_unix_path::normalize_request;
@@ -28,7 +28,8 @@ use crate::{
     data_uri_source::DataUriSource,
     file_source::FileSource,
     issue::{
-        IssueExt, IssueSource, module::emit_unknown_module_type_error, resolve::ResolvingIssue,
+        Issue, IssueExt, IssueSource, module::emit_unknown_module_type_error,
+        resolve::ResolvingIssue,
     },
     module::{Module, Modules, OptionModule},
     output::{OutputAsset, OutputAssets},
@@ -37,6 +38,7 @@ use crate::{
     reference_type::ReferenceType,
     resolve::{
         alias_map::AliasKey,
+        error::{handle_resolve_error, resolve_error_severity},
         node::{node_cjs_resolve_options, node_esm_resolve_options},
         options::{
             ConditionValue, ImportMapResult, ResolveInPackage, ResolveIntoPackage, ResolveModules,
@@ -52,6 +54,7 @@ use crate::{
 };
 
 mod alias_map;
+pub mod error;
 pub mod node;
 pub mod options;
 pub mod origin;
@@ -64,8 +67,6 @@ pub use alias_map::{
     AliasMap, AliasMapIntoIter, AliasMapLookupIterator, AliasMatch, AliasPattern, AliasTemplate,
 };
 pub use remap::{ResolveAliasMap, SubpathValue};
-
-use crate::issue::IssueSeverity;
 
 /// Controls how resolve errors are handled.
 #[turbo_tasks::value(shared)]
@@ -98,8 +99,11 @@ pub enum ModuleResolveResultItem {
     },
     /// A module could not be created (according to the rules, e.g. no module type as assigned)
     Unknown(ResolvedVc<Box<dyn Source>>),
+    /// Completely ignore this reference.
     Ignore,
-    Error(ResolvedVc<RcStr>),
+    /// Emit the given issue, and generate a module which throws that issue's title at runtime.
+    Error(ResolvedVc<Box<dyn Issue>>),
+    /// Resolve the reference to an empty module.
     Empty,
     Custom(u8),
 }
@@ -298,6 +302,13 @@ impl ModuleResolveResult {
     pub fn is_unresolvable_ref(&self) -> bool {
         self.primary.is_empty()
     }
+
+    pub fn errors(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Issue>>> + '_ {
+        self.primary.iter().filter_map(|i| match &i.1 {
+            ModuleResolveResultItem::Error(e) => Some(*e),
+            _ => None,
+        })
+    }
 }
 
 pub struct ModuleResolveResultBuilder {
@@ -483,8 +494,11 @@ pub enum ResolveResultItem {
         /// root to be able to access potentially transitive dependencies.
         target: Option<FileSystemPath>,
     },
+    /// Completely ignore this reference.
     Ignore,
-    Error(ResolvedVc<RcStr>),
+    /// Emit the given issue, and generate a module which throws that issue's title at runtime.
+    Error(ResolvedVc<Box<dyn Issue>>),
+    /// Resolve the reference to an empty module.
     Empty,
     Custom(u8),
 }
@@ -664,6 +678,13 @@ impl ResolveResult {
             primary: vec![(request_key, ResolveResultItem::Source(source))].into_boxed_slice(),
             affecting_sources: affecting_sources.into_boxed_slice(),
         }
+    }
+
+    pub fn errors(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Issue>>> + '_ {
+        self.primary.iter().filter_map(|i| match &i.1 {
+            ResolveResultItem::Error(e) => Some(*e),
+            _ => None,
+        })
     }
 }
 
@@ -2004,7 +2025,7 @@ async fn resolve_internal_inline(
 
                 if !has_alias {
                     ResolvingIssue {
-                        severity: error_severity(options).await?,
+                        severity: resolve_error_severity(options).await?,
                         request_type: "server relative import: not implemented yet".to_string(),
                         request: relative.to_resolved().await?,
                         file_path: lookup_path.clone(),
@@ -2034,7 +2055,7 @@ async fn resolve_internal_inline(
             } => {
                 if !has_alias {
                     ResolvingIssue {
-                        severity: error_severity(options).await?,
+                        severity: resolve_error_severity(options).await?,
                         request_type: "windows import: not implemented yet".to_string(),
                         request: request.to_resolved().await?,
                         file_path: lookup_path.clone(),
@@ -2129,7 +2150,7 @@ async fn resolve_internal_inline(
             Request::Unknown { path } => {
                 if !has_alias {
                     ResolvingIssue {
-                        severity: error_severity(options).await?,
+                        severity: resolve_error_severity(options).await?,
                         request_type: format!("unknown import: `{}`", path.describe_as_string()),
                         request: request.to_resolved().await?,
                         file_path: lookup_path.clone(),
@@ -2669,7 +2690,7 @@ async fn apply_in_package(
         }
 
         ResolvingIssue {
-            severity: error_severity(options).await?,
+            severity: resolve_error_severity(options).await?,
             file_path: package_json_path.clone(),
             request_type: format!("alias field ({field})"),
             request: Request::parse(Pattern::Constant(request))
@@ -3036,6 +3057,9 @@ async fn resolve_import_map_result(
             Some(ResolveResultOrCell::Cell(merge_results(cells)))
         }
         ImportMapResult::NoEntry => None,
+        ImportMapResult::Error(issue) => Some(ResolveResultOrCell::Value(ResolveResult::primary(
+            ResolveResultItem::Error(*issue),
+        ))),
     })
 }
 
@@ -3271,7 +3295,7 @@ async fn resolve_package_internal_with_imports_field(
     // https://github.com/nodejs/node/blob/1b177932/lib/internal/modules/esm/resolve.js#L615-L619
     if specifier == "#" || specifier.starts_with("#/") || specifier.ends_with('/') {
         ResolvingIssue {
-            severity: error_severity(resolve_options).await?,
+            severity: resolve_error_severity(resolve_options).await?,
             file_path: file_path.clone(),
             request_type: format!("package imports request: `{specifier}`"),
             request: request.to_resolved().await?,
@@ -3301,160 +3325,6 @@ async fn resolve_package_internal_with_imports_field(
         RcStr::default(),
     )
     .await
-}
-
-pub async fn handle_resolve_error(
-    result: Vc<ModuleResolveResult>,
-    reference_type: ReferenceType,
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    request: Vc<Request>,
-    resolve_options: Vc<ResolveOptions>,
-    error_mode: ResolveErrorMode,
-    source: Option<IssueSource>,
-) -> Result<Vc<ModuleResolveResult>> {
-    Ok(match result.await {
-        Ok(result_ref) => {
-            if result_ref.is_unresolvable_ref() {
-                emit_unresolvable_issue(
-                    error_mode,
-                    origin,
-                    reference_type,
-                    request,
-                    resolve_options,
-                    source,
-                )
-                .await?;
-            }
-
-            result
-        }
-        Err(err) => {
-            emit_resolve_error_issue(
-                error_mode,
-                origin,
-                reference_type,
-                request,
-                resolve_options,
-                err,
-                source,
-            )
-            .await?;
-            *ModuleResolveResult::unresolvable()
-        }
-    })
-}
-
-pub async fn handle_resolve_source_error(
-    result: Vc<ResolveResult>,
-    reference_type: ReferenceType,
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    request: Vc<Request>,
-    resolve_options: Vc<ResolveOptions>,
-    error_mode: ResolveErrorMode,
-    source: Option<IssueSource>,
-) -> Result<Vc<ResolveResult>> {
-    async fn is_unresolvable(result: Vc<ResolveResult>) -> Result<bool> {
-        Ok(*result.resolve().await?.is_unresolvable().await?)
-    }
-    Ok(match is_unresolvable(result).await {
-        Ok(unresolvable) => {
-            if unresolvable {
-                emit_unresolvable_issue(
-                    error_mode,
-                    origin,
-                    reference_type,
-                    request,
-                    resolve_options,
-                    source,
-                )
-                .await?;
-            }
-
-            result
-        }
-        Err(err) => {
-            emit_resolve_error_issue(
-                error_mode,
-                origin,
-                reference_type,
-                request,
-                resolve_options,
-                err,
-                source,
-            )
-            .await?;
-            ResolveResult::unresolvable().cell()
-        }
-    })
-}
-
-async fn emit_resolve_error_issue(
-    error_mode: ResolveErrorMode,
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    reference_type: ReferenceType,
-    request: Vc<Request>,
-    resolve_options: Vc<ResolveOptions>,
-    err: anyhow::Error,
-    source: Option<IssueSource>,
-) -> Result<()> {
-    if error_mode == ResolveErrorMode::Ignore {
-        return Ok(());
-    }
-    let severity = if error_mode == ResolveErrorMode::Warn || resolve_options.await?.loose_errors {
-        IssueSeverity::Warning
-    } else {
-        IssueSeverity::Error
-    };
-    ResolvingIssue {
-        severity,
-        file_path: origin.origin_path().owned().await?,
-        request_type: format!("{reference_type} request"),
-        request: request.to_resolved().await?,
-        resolve_options: resolve_options.to_resolved().await?,
-        error_message: Some(format!("{}", PrettyPrintError(&err))),
-        source,
-    }
-    .resolved_cell()
-    .emit();
-    Ok(())
-}
-
-async fn emit_unresolvable_issue(
-    error_mode: ResolveErrorMode,
-    origin: Vc<Box<dyn ResolveOrigin>>,
-    reference_type: ReferenceType,
-    request: Vc<Request>,
-    resolve_options: Vc<ResolveOptions>,
-    source: Option<IssueSource>,
-) -> Result<()> {
-    if error_mode == ResolveErrorMode::Ignore {
-        return Ok(());
-    }
-    let severity = if error_mode == ResolveErrorMode::Warn || resolve_options.await?.loose_errors {
-        IssueSeverity::Warning
-    } else {
-        IssueSeverity::Error
-    };
-    ResolvingIssue {
-        severity,
-        file_path: origin.origin_path().owned().await?,
-        request_type: format!("{reference_type} request"),
-        request: request.to_resolved().await?,
-        resolve_options: resolve_options.to_resolved().await?,
-        error_message: None,
-        source,
-    }
-    .resolved_cell()
-    .emit();
-    Ok(())
-}
-
-async fn error_severity(resolve_options: Vc<ResolveOptions>) -> Result<IssueSeverity> {
-    Ok(if resolve_options.await?.loose_errors {
-        IssueSeverity::Warning
-    } else {
-        IssueSeverity::Error
-    })
 }
 
 /// ModulePart represents a part of a module.

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -9,12 +9,15 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
-use crate::resolve::{
-    AliasPattern, ExternalTraced, ExternalType, ResolveResult, ResolveResultItem,
-    alias_map::{AliasMap, AliasTemplate},
-    parse::Request,
-    pattern::Pattern,
-    plugin::{AfterResolvePlugin, BeforeResolvePlugin},
+use crate::{
+    issue::Issue,
+    resolve::{
+        AliasPattern, ExternalTraced, ExternalType, ResolveResult, ResolveResultItem,
+        alias_map::{AliasMap, AliasTemplate},
+        parse::Request,
+        pattern::Pattern,
+        plugin::{AfterResolvePlugin, BeforeResolvePlugin},
+    },
 };
 
 #[turbo_tasks::value(shared)]
@@ -112,8 +115,12 @@ pub enum ImportMapping {
     /// the original request if it fails. Useful for the tsconfig.json
     /// `compilerOptions.paths` option and Next aliases.
     PrimaryAlternative(RcStr, Option<FileSystemPath>),
+    /// See [`ResolveResultItem::Ignore`]
     Ignore,
+    /// See [`ResolveResultItem::Empty`]
     Empty,
+    /// See [`ResolveResultItem::Error`]
+    Error(ResolvedVc<Box<dyn Issue>>),
     Alternatives(Vec<ResolvedVc<ImportMapping>>),
     Dynamic(ResolvedVc<Box<dyn ImportMappingReplacement>>),
 }
@@ -141,6 +148,7 @@ pub enum ReplacedImportMapping {
     Empty,
     Alternatives(Vec<ResolvedVc<ReplacedImportMapping>>),
     Dynamic(ResolvedVc<Box<dyn ImportMappingReplacement>>),
+    Error(ResolvedVc<Box<dyn Issue>>),
 }
 
 impl ImportMapping {
@@ -219,6 +227,7 @@ impl AliasTemplate for Vc<ImportMapping> {
                         .await?,
                 ),
                 ImportMapping::Dynamic(replacement) => ReplacedImportMapping::Dynamic(*replacement),
+                ImportMapping::Error(issue) => ReplacedImportMapping::Error(*issue),
             }
             .resolved_cell())
         })
@@ -293,6 +302,7 @@ impl AliasTemplate for Vc<ImportMapping> {
                         .owned()
                         .await?
                 }
+                ImportMapping::Error(issue) => ReplacedImportMapping::Error(*issue),
             }
             .resolved_cell())
         })
@@ -415,6 +425,7 @@ pub enum ImportMapResult {
     Alias(ResolvedVc<Request>, Option<FileSystemPath>),
     Alternatives(Vec<ImportMapResult>),
     NoEntry,
+    Error(ResolvedVc<Box<dyn Issue>>),
 }
 
 async fn import_mapping_to_result(
@@ -489,6 +500,7 @@ async fn import_mapping_to_result(
         ReplacedImportMapping::Dynamic(replacement) => {
             replacement.result(lookup_path, request).owned().await?
         }
+        ReplacedImportMapping::Error(issue) => ImportMapResult::Error(*issue),
     })
 }
 
@@ -529,6 +541,9 @@ impl ValueToString for ImportMapResult {
                 Ok(Vc::cell(strings.join(" | ").into()))
             }
             ImportMapResult::NoEntry => Ok(Vc::cell(rcstr!("No import map entry"))),
+            ImportMapResult::Error(issue) => Ok(Vc::cell(
+                format!("error: {}", issue.title().await?.to_unstyled_string()).into(),
+            )),
         }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -18,7 +18,7 @@ use turbo_tasks::{
 use turbopack_core::{
     chunk::{ChunkableModule, ChunkingContext, ModuleChunkItemIdExt, ModuleId},
     issue::{
-        IssueExt, IssueSeverity, StyledString, code_gen::CodeGenerationIssue,
+        Issue, IssueExt, IssueSeverity, StyledString, code_gen::CodeGenerationIssue,
         module::emit_unknown_module_type_error,
     },
     resolve::{
@@ -324,8 +324,10 @@ async fn to_single_pattern_mapping(
                 "unknown module type".to_string(),
             ));
         }
-        ModuleResolveResultItem::Error(str) => {
-            return Ok(SinglePatternMapping::Unresolvable(str.await?.to_string()));
+        ModuleResolveResultItem::Error(issue) => {
+            return Ok(SinglePatternMapping::Unresolvable(
+                issue.title().await?.to_unstyled_string(),
+            ));
         }
         ModuleResolveResultItem::OutputAsset(_)
         | ModuleResolveResultItem::Empty

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -18,8 +18,9 @@ use turbopack_core::{
     reference::ModuleReference,
     reference_type::{ReferenceType, WorkerReferenceSubType},
     resolve::{
-        ModuleResolveResult, ModuleResolveResultItem, ResolveErrorMode, handle_resolve_error,
-        origin::ResolveOrigin, parse::Request, pattern::Pattern, resolve_raw, url_resolve,
+        ModuleResolveResult, ModuleResolveResultItem, ResolveErrorMode,
+        error::handle_resolve_error, origin::ResolveOrigin, parse::Request, pattern::Pattern,
+        resolve_raw, url_resolve,
     },
 };
 

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -5,8 +5,8 @@ use turbopack_core::{
     issue::IssueSource,
     reference_type::{CommonJsReferenceSubType, EcmaScriptModulesReferenceSubType, ReferenceType},
     resolve::{
-        ModuleResolveResult, ResolveErrorMode, ResolveResult, handle_resolve_error,
-        handle_resolve_source_error,
+        ModuleResolveResult, ResolveErrorMode, ResolveResult,
+        error::{handle_resolve_error, handle_resolve_source_error},
         options::{
             ConditionValue, ResolutionConditions, ResolveInPackage, ResolveIntoPackage,
             ResolveOptions,

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -15,7 +15,8 @@ use turbopack_core::{
     },
     reference_type::{ReferenceType, TypeScriptReferenceSubType},
     resolve::{
-        AliasPattern, ModuleResolveResult, RequestKey, ResolveErrorMode, handle_resolve_error,
+        AliasPattern, ModuleResolveResult, RequestKey, ResolveErrorMode,
+        error::handle_resolve_error,
         node::node_cjs_resolve_options,
         options::{
             ConditionValue, ImportMap, ImportMapping, ResolveIntoPackage, ResolveModules,


### PR DESCRIPTION
We have two lines of defense:
1. crates/next-custom-transforms/src/transforms/react_server_components.rs validates ESM imports of server-only and client-only and throws an issue if something is wrong. Notably, `require('server-only')` isn't caught by this
2. additionally, we had an `BeforeResolvePlugin` for server-only, client-only and styled-jsx. 

We should probably get rid of the first one completely for consistency (it's brittle)
https://github.com/vercel/next.js/blob/79040a318d29641eb3d96a5a47c92a5f8506e826/crates/next-custom-transforms/src/transforms/react_server_components.rs#L663-L674

This PR is about improving the second one:

The error message isn't ideal yet, but better than before (note: no import trace):

```
./bench/basic-app/app
Invalid import
'server-only' cannot be imported from a Client Component module. It should only be used from a Server Component.
The error was caused by importing 'bench/basic-app/app'
```

now

<img width="708" height="386" alt="Bildschirmfoto 2026-01-07 um 17 21 59" src="https://github.com/user-attachments/assets/4d49eff3-4959-4b70-aa47-6f3c10c75588" />
