### PR TITLE
ci: run stats on canary pushes for historical trend tracking

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -680,37 +680,6 @@ jobs:
       - run: exit 1
         if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
 
-  releaseStats:
-    name: Release Stats
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
-    timeout-minutes: 25
-    needs: [publishRelease]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 25
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: next-swc-binaries-*
-          merge-multiple: true
-          path: packages/next-swc/native
-
-      - run: cp -r packages/next-swc/native .github/actions/next-stats-action/native
-
-      - run: ./scripts/release-stats.sh
-      - uses: ./.github/actions/next-stats-action
-        env:
-          PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
-          NEXT_SKIP_NATIVE_POSTINSTALL: 1
-          # This uses the webpack bundle analyzer and for consistent results we need to use webpack.
-          # Once there is an equivalent analyzer for turbopack, we can remove this.
-          IS_WEBPACK_TEST: 1
-
   upload_turbopack_bytesize:
     if: ${{ needs.deploy-target.outputs.value != 'automated-preview'}}
     name: Upload Turbopack Bytesize metrics to Datadog

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -1,8 +1,11 @@
 on:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches:
+      - canary
 
-name: Generate Pull Request Stats
+name: Generate Stats
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,7 +39,7 @@ jobs:
       uploadAnalyzerArtifacts: 'yes'
 
   stats:
-    name: PR Stats (${{ matrix.bundler }})
+    name: Stats (${{ matrix.bundler }})
     needs: build
     timeout-minutes: 25
     strategy:
@@ -85,7 +88,7 @@ jobs:
           retention-days: 1
 
   stats-aggregate:
-    name: Aggregate PR Stats
+    name: Aggregate Stats
     needs: stats
     if: always() && needs.stats.result != 'cancelled'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add push trigger for canary branch to `pull_request_stats.yml`
- Remove redundant `releaseStats` job from `build_and_deploy.yml`
- Rename workflow/jobs from "PR Stats" to "Stats"

## Background

The stats system was designed to save historical metrics to KV for trend tracking, but it wasn't working:

1. `releaseStats` job only ran on actual stable releases (rare)
2. When it did run, KV secrets were missing
3. PR stats had KV secrets but didn't save (because `isRelease=false`)

This change consolidates stats into one workflow that runs on both PRs and canary pushes.

## Behavior

**For PRs:**
- Compare PR branch vs canary HEAD
- Post comment to PR
- Don't save to KV

**For canary pushes:**
- Compare current canary vs last stable release tag
- Post comment to the commit
- Save stats to KV for historical trend tracking

## Test plan

- [ ] Verify workflow triggers on PR (existing behavior)
- [ ] Verify workflow triggers on canary push (new behavior)
- [ ] Verify stats are saved to KV on canary push
- [ ] Verify trend sparklines appear in PR comments (once history builds up)