### PR TITLE
perf: improve stats thresholds to reduce CI noise

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -680,37 +680,6 @@ jobs:
       - run: exit 1
         if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
 
-  releaseStats:
-    name: Release Stats
-    runs-on:
-      - 'self-hosted'
-      - 'linux'
-      - 'x64'
-      - 'metal'
-    timeout-minutes: 25
-    needs: [publishRelease]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 25
-
-      - uses: actions/download-artifact@v4
-        with:
-          pattern: next-swc-binaries-*
-          merge-multiple: true
-          path: packages/next-swc/native
-
-      - run: cp -r packages/next-swc/native .github/actions/next-stats-action/native
-
-      - run: ./scripts/release-stats.sh
-      - uses: ./.github/actions/next-stats-action
-        env:
-          PR_STATS_COMMENT_TOKEN: ${{ secrets.PR_STATS_COMMENT_TOKEN }}
-          NEXT_SKIP_NATIVE_POSTINSTALL: 1
-          # This uses the webpack bundle analyzer and for consistent results we need to use webpack.
-          # Once there is an equivalent analyzer for turbopack, we can remove this.
-          IS_WEBPACK_TEST: 1
-
   upload_turbopack_bytesize:
     if: ${{ needs.deploy-target.outputs.value != 'automated-preview'}}
     name: Upload Turbopack Bytesize metrics to Datadog

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -1,8 +1,11 @@
 on:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches:
+      - canary
 
-name: Generate Pull Request Stats
+name: Generate Stats
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,7 +39,7 @@ jobs:
       uploadAnalyzerArtifacts: 'yes'
 
   stats:
-    name: PR Stats (${{ matrix.bundler }})
+    name: Stats (${{ matrix.bundler }})
     needs: build
     timeout-minutes: 25
     strategy:
@@ -85,7 +88,7 @@ jobs:
           retention-days: 1
 
   stats-aggregate:
-    name: Aggregate PR Stats
+    name: Aggregate Stats
     needs: stats
     if: always() && needs.stats.result != 'cancelled'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add per-metric significance thresholds that account for variance.

**Time metrics** (high variance from CI):
- Dev boot: <100ms AND <15%, OR <3%
- Build times: <500ms AND <5%, OR <2%

**Size metrics** (deterministic):
- node_modules: <10KB AND <1%, OR <0.01%
- Bundle sizes: <2KB AND <1%, OR <0.1%

## Problem

Current thresholds flag insignificant changes as regressions:
- 3.45 KB change on 457 MB node_modules (0.0008%) was flagged as a regression

## Solution

Use per-metric thresholds with OR logic for very small percentage changes:
- Time metrics need more generous thresholds due to CI variance
- Size metrics can be tighter since they're deterministic

## Test plan

- Verify that 3.45 KB on 457 MB (0%) is now marked as insignificant
- Verify that real regressions (>0.1% for sizes, >3% for times) are still flagged

---

Stack:
- #88157
- **→ This PR**