### PR TITLE
test: replace check() with retry() in production tests

### DIFF
--- a/test/production/app-dir-prefetch-non-iso-url/index.test.ts
+++ b/test/production/app-dir-prefetch-non-iso-url/index.test.ts
@@ -3,7 +3,7 @@ import { NextInstance } from 'e2e-utils'
 import { join } from 'path'
 import { Playwright } from 'next-webdriver'
 import webdriver from 'next-webdriver'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-dir-prefetch-non-iso-url', () => {
   let next: NextInstance
@@ -24,7 +24,13 @@ describe('app-dir-prefetch-non-iso-url', () => {
     try {
       browser = await webdriver(next.url, '/')
       await browser.elementByCss('#to-iso').click()
-      await check(() => browser.elementByCss('#page').text(), '/[slug]')
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toBe('/[slug]')
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -38,7 +44,13 @@ describe('app-dir-prefetch-non-iso-url', () => {
     try {
       browser = await webdriver(next.url, '/')
       await browser.elementByCss('#to-non-iso').click()
-      await check(() => browser.elementByCss('#page').text(), '/[slug]')
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toBe('/[slug]')
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()

--- a/test/production/custom-error-500/index.test.ts
+++ b/test/production/custom-error-500/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { renderViaHTTP, retry } from 'next-test-utils'
 
 describe('custom-error-500', () => {
   let next: NextInstance
@@ -54,7 +54,13 @@ describe('custom-error-500', () => {
     const html = await renderViaHTTP(next.url, '/')
     expect(html).toContain('pages/500')
 
-    await check(() => next.cliOutput, /called Error\.getInitialProps true/)
+    await retry(
+      () => {
+        expect(next.cliOutput).toMatch(/called Error\.getInitialProps true/)
+      },
+      30000,
+      1000
+    )
   })
 
   it('should work correctly with pages/404 present', async () => {
@@ -72,6 +78,12 @@ describe('custom-error-500', () => {
     const html = await renderViaHTTP(next.url, '/')
     expect(html).toContain('pages/500')
 
-    await check(() => next.cliOutput, /called Error\.getInitialProps true/)
+    await retry(
+      () => {
+        expect(next.cliOutput).toMatch(/called Error\.getInitialProps true/)
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/production/enoent-during-require/index.test.ts
+++ b/test/production/enoent-during-require/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { renderViaHTTP, retry } from 'next-test-utils'
 
 describe('ENOENT during require', () => {
   let next: NextInstance
@@ -41,14 +41,14 @@ describe('ENOENT during require', () => {
   afterAll(() => next.destroy())
 
   it('should show ENOENT error correctly', async () => {
-    await check(async () => {
-      await renderViaHTTP(next.url, '/')
-      console.error(next.cliOutput)
-
-      return next.cliOutput.includes('non-existent-folder')
-        ? 'success'
-        : next.cliOutput
-    }, 'success')
+    await retry(
+      async () => {
+        await renderViaHTTP(next.url, '/')
+        expect(next.cliOutput).toContain('non-existent-folder')
+      },
+      30000,
+      1000
+    )
 
     expect(next.cliOutput).not.toContain('Cannot destructure property')
   })

--- a/test/production/export/index.test.ts
+++ b/test/production/export/index.test.ts
@@ -3,8 +3,8 @@ import { nextTestSetup } from 'e2e-utils'
 import {
   renderViaHTTP,
   startStaticServer,
-  check,
   getBrowserBodyText,
+  retry,
 } from 'next-test-utils'
 import { AddressInfo, Server } from 'net'
 import cheerio from 'cheerio'
@@ -283,9 +283,14 @@ describe('static export', () => {
         .click()
         .waitForElementByCss('#dynamic-imports-page')
 
-      await check(
-        () => getBrowserBodyText(browser),
-        /Welcome to dynamic imports/
+      await retry(
+        async () => {
+          await expect(getBrowserBodyText(browser)).resolves.toMatch(
+            /Welcome to dynamic imports/
+          )
+        },
+        30000,
+        1000
       )
 
       await browser.close()
@@ -306,7 +311,13 @@ describe('static export', () => {
 
         expect(text).toBe('Vercel is awesome')
 
-        await check(() => browser.elementByCss('#hash').text(), /cool/)
+        await retry(
+          async () => {
+            expect(await browser.elementByCss('#hash').text()).toMatch(/cool/)
+          },
+          30000,
+          1000
+        )
       } finally {
         if (browser) {
           await browser.close()
@@ -363,9 +374,14 @@ describe('static export', () => {
           'document.getElementById("level1-home-page").click()'
         )
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is the Level1 home page/
+        await retry(
+          async () => {
+            await expect(getBrowserBodyText(browser)).resolves.toMatch(
+              /This is the Level1 home page/
+            )
+          },
+          30000,
+          1000
         )
 
         await browser.close()
@@ -378,9 +394,14 @@ describe('static export', () => {
           'document.getElementById("level1-about-page").click()'
         )
 
-        await check(
-          () => getBrowserBodyText(browser),
-          /This is the Level1 about page/
+        await retry(
+          async () => {
+            await expect(getBrowserBodyText(browser)).resolves.toMatch(
+              /This is the Level1 about page/
+            )
+          },
+          30000,
+          1000
         )
 
         await browser.close()

--- a/test/production/fatal-render-error/index.test.ts
+++ b/test/production/fatal-render-error/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP, waitFor } from 'next-test-utils'
+import { renderViaHTTP, waitFor, retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -40,7 +40,13 @@ describe('fatal-render-error', () => {
     await browser.eval('window.renderAttempts = 0')
 
     await browser.eval('window.next.router.push("/with-error")')
-    await check(() => browser.eval('location.pathname'), '/with-error')
+    await retry(
+      async () => {
+        expect(await browser.eval('location.pathname')).toBe('/with-error')
+      },
+      30000,
+      1000
+    )
 
     // wait a bit to see if we are rendering multiple times unexpectedly
     await waitFor(500)

--- a/test/production/pages-dir/production/test/dynamic.ts
+++ b/test/production/pages-dir/production/test/dynamic.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import webdriver from 'next-webdriver'
 import cheerio from 'cheerio'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 // These tests are similar to ../../basic/test/dynamic.js
@@ -45,7 +45,15 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/pagechange1')
-          await check(() => browser.elementByCss('body').text(), /PageChange1/)
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('body').text()
+              ).resolves.toMatch(/PageChange1/)
+            },
+            30000,
+            1000
+          )
           const firstElement = await browser.elementById('with-css')
           const css1 = await firstElement.getComputedCss('display')
           expect(css1).toBe('flex')
@@ -53,7 +61,15 @@ export default (next: NextInstance, render) => {
             // @ts-expect-error window.next exists
             window.next.router.push('/dynamic/pagechange2')
           })
-          await check(() => browser.elementByCss('body').text(), /PageChange2/)
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('body').text()
+              ).resolves.toMatch(/PageChange2/)
+            },
+            30000,
+            1000
+          )
           const secondElement = await browser.elementById('with-css')
           const css2 = await secondElement.getComputedCss('display')
           expect(css2).toBe(css1)
@@ -68,13 +84,23 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/shared-css-module')
-          await check(
-            () => browser.elementByCss('#with-css').getComputedCss('color'),
-            'rgb(0, 0, 0)'
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('#with-css').getComputedCss('color')
+              ).resolves.toBe('rgb(0, 0, 0)')
+            },
+            30000,
+            1000
           )
-          await check(
-            () => browser.elementByCss('#with-css-2').getComputedCss('color'),
-            'rgb(0, 0, 0)'
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('#with-css-2').getComputedCss('color')
+              ).resolves.toBe('rgb(0, 0, 0)')
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {
@@ -93,13 +119,23 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/no-chunk')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, normal/
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('body').text()
+              ).resolves.toMatch(/Welcome, normal/)
+            },
+            30000,
+            1000
           )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, dynamic/
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('body').text()
+              ).resolves.toMatch(/Welcome, dynamic/)
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {
@@ -118,9 +154,14 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/no-ssr')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('body').text()
+              ).resolves.toMatch(/Hello World 1/)
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {
@@ -140,9 +181,14 @@ export default (next: NextInstance, render) => {
         let browser
         try {
           browser = await webdriver(next.appPort, '/dynamic/ssr-true')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('body').text()
+              ).resolves.toMatch(/Hello World 1/)
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {
@@ -165,9 +211,14 @@ export default (next: NextInstance, render) => {
             next.appPort,
             '/dynamic/no-ssr-custom-loading'
           )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
+          await retry(
+            async () => {
+              await expect(
+                browser.elementByCss('body').text()
+              ).resolves.toMatch(/Hello World 1/)
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -6,8 +6,8 @@ import {
   renderViaHTTP,
   waitFor,
   getPageFileFromPagesManifest,
-  check,
   fetchViaHTTP,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import {
@@ -80,10 +80,16 @@ describe('Production Usage', () => {
           `/${search || ''}${hash || ''}`
         )
 
-        await check(
-          () =>
-            browser.eval('window.next.router.isReady ? "ready" : "not ready"'),
-          'ready'
+        await retry(
+          async () => {
+            expect(
+              await browser.eval(
+                'window.next.router.isReady ? "ready" : "not ready"'
+              )
+            ).toBe('ready')
+          },
+          30000,
+          1000
         )
         expect(await browser.eval('window.location.pathname')).toBe('/')
         expect(await browser.eval('window.location.hash')).toBe(hash || '')
@@ -1239,9 +1245,14 @@ describe('Production Usage', () => {
       })
     })()`)
 
-      await check(
-        () => browser.eval('document.documentElement.innerHTML'),
-        /page could not be found/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/page could not be found/)
+        },
+        30000,
+        1000
       )
 
       expect(await browser.eval('window.beforeNav')).toBeFalsy()
@@ -1264,9 +1275,14 @@ describe('Production Usage', () => {
 
     expect(await browser.eval('window.beforeNav')).toBe(1)
 
-    await check(
-      () => browser.elementByCss('img').getComputedCss('background-image'),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await browser.elementByCss('img').getComputedCss('background-image')
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
 
     await browser.eval(`(function() {
@@ -1284,12 +1300,16 @@ describe('Production Usage', () => {
 
     expect(await browser.eval('window.beforeNav')).toBe(1)
 
-    await check(
-      () =>
-        browser
-          .elementByCss('#static-image')
-          .getComputedCss('background-image'),
-      'none'
+    await retry(
+      async () => {
+        await expect(
+          browser
+            .elementByCss('#static-image')
+            .getComputedCss('background-image')
+        ).resolves.toBe('none')
+      },
+      30000,
+      1000
     )
 
     for (let i = 0; i < 5; i++) {

--- a/test/production/prerender-prefetch/index.test.ts
+++ b/test/production/prerender-prefetch/index.test.ts
@@ -1,12 +1,6 @@
 import { NextInstance } from 'e2e-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import {
-  check,
-  fetchViaHTTP,
-  renderViaHTTP,
-  retry,
-  waitFor,
-} from 'next-test-utils'
+import { fetchViaHTTP, renderViaHTTP, retry, waitFor } from 'next-test-utils'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import assert from 'assert'
@@ -63,11 +57,14 @@ describe('Prerender prefetch', () => {
 
       await browser.elementByCss('#to-blog-first').click()
 
-      await check(async () => {
-        const data = await getData()
-        assert.notDeepEqual(initialData, data)
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          const data = await getData()
+          assert.notDeepEqual(initialData, data)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should update cache using prefetch with unstable_skipClientCache', async () => {
@@ -88,7 +85,13 @@ describe('Prerender prefetch', () => {
       await browser.elementByCss('#to-blog-first').click()
       const outputIndex = next.cliOutput.length
 
-      await check(() => browser.elementByCss('#page').text(), 'blog/[slug]')
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toBe('blog/[slug]')
+        },
+        30000,
+        1000
+      )
 
       expect(JSON.parse(await browser.elementByCss('#props').text()).now).toBe(
         startTime
@@ -96,10 +99,16 @@ describe('Prerender prefetch', () => {
       await browser.back().waitForElementByCss('#to-blog-first')
 
       // trigger revalidation of /blog/first
-      await check(async () => {
-        await renderViaHTTP(next.url, '/blog/first')
-        return next.cliOutput.substring(outputIndex)
-      }, /revalidating \/blog first/)
+      await retry(
+        async () => {
+          await renderViaHTTP(next.url, '/blog/first')
+          expect(next.cliOutput.substring(outputIndex)).toMatch(
+            /revalidating \/blog first/
+          )
+        },
+        30000,
+        1000
+      )
 
       // wait for the revalidation to finish by comparing timestamps
       await retry(async () => {
@@ -121,10 +130,22 @@ describe('Prerender prefetch', () => {
       await browser.eval(
         'next.router.prefetch("/blog/first", undefined, { unstable_skipClientCache: true }).finally(() => { window.prefetchDone = "yes" })'
       )
-      await check(() => browser.eval('window.prefetchDone'), 'yes')
+      await retry(
+        async () => {
+          expect(await browser.eval('window.prefetchDone')).toBe('yes')
+        },
+        30000,
+        1000
+      )
 
       await browser.elementByCss('#to-blog-first').click()
-      await check(() => browser.elementByCss('#page').text(), 'blog/[slug]')
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toBe('blog/[slug]')
+        },
+        30000,
+        1000
+      )
 
       const newTime = JSON.parse(
         await browser.elementByCss('#props').text()
@@ -151,7 +172,13 @@ describe('Prerender prefetch', () => {
       await browser.elementByCss('#to-blog-first').click()
       const outputIndex = next.cliOutput.length
 
-      await check(() => browser.elementByCss('#page').text(), 'blog/[slug]')
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toBe('blog/[slug]')
+        },
+        30000,
+        1000
+      )
 
       expect(JSON.parse(await browser.elementByCss('#props').text()).now).toBe(
         startTime
@@ -159,10 +186,16 @@ describe('Prerender prefetch', () => {
       await browser.back().waitForElementByCss('#to-blog-first')
 
       // trigger revalidation of /blog/first
-      await check(async () => {
-        await renderViaHTTP(next.url, '/blog/first')
-        return next.cliOutput.substring(outputIndex)
-      }, /revalidating \/blog first/)
+      await retry(
+        async () => {
+          await renderViaHTTP(next.url, '/blog/first')
+          expect(next.cliOutput.substring(outputIndex)).toMatch(
+            /revalidating \/blog first/
+          )
+        },
+        30000,
+        1000
+      )
 
       // wait for the revalidation to finish by comparing timestamps
       await retry(async () => {
@@ -184,9 +217,21 @@ describe('Prerender prefetch', () => {
       await browser.eval(
         'next.router.push("/blog/first", undefined, { unstable_skipClientCache: true }).finally(() => { window.prefetchDone = "yes" })'
       )
-      await check(() => browser.eval('window.prefetchDone'), 'yes')
+      await retry(
+        async () => {
+          expect(await browser.eval('window.prefetchDone')).toBe('yes')
+        },
+        30000,
+        1000
+      )
 
-      await check(() => browser.elementByCss('#page').text(), 'blog/[slug]')
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toBe('blog/[slug]')
+        },
+        30000,
+        1000
+      )
 
       const newTime = JSON.parse(
         await browser.elementByCss('#props').text()
@@ -212,7 +257,15 @@ describe('Prerender prefetch', () => {
 
         // ensure stale data is used by default
         await browser.elementByCss('#to-blog-first').click()
-        await check(() => browser.elementByCss('#page').text(), 'blog/[slug]')
+        await retry(
+          async () => {
+            expect(await browser.elementByCss('#page').text()).toBe(
+              'blog/[slug]'
+            )
+          },
+          30000,
+          1000
+        )
 
         expect(
           JSON.parse(await browser.elementByCss('#props').text()).now
@@ -225,18 +278,22 @@ describe('Prerender prefetch', () => {
         })
 
         // now trigger cache update and navigate again
-        await check(async () => {
-          if (process.env.DEVICE_NAME) {
-            await browser.elementByCss('#to-blog-second').touchStart()
-            await browser.elementByCss('#to-blog-first').touchStart()
-          } else {
-            await browser.elementByCss('#to-blog-second').moveTo()
-            await browser.elementByCss('#to-blog-first').moveTo()
-          }
-          return requests.some((url) => url.includes('/blog/first.json'))
-            ? 'success'
-            : requests
-        }, 'success')
+        await retry(
+          async () => {
+            if (process.env.DEVICE_NAME) {
+              await browser.elementByCss('#to-blog-second').touchStart()
+              await browser.elementByCss('#to-blog-first').touchStart()
+            } else {
+              await browser.elementByCss('#to-blog-second').moveTo()
+              await browser.elementByCss('#to-blog-first').moveTo()
+            }
+            expect(
+              requests.some((url) => url.includes('/blog/first.json'))
+            ).toBe(true)
+          },
+          30000,
+          1000
+        )
       })
     } else {
       it('should not attempt client cache update on link hover/touch start', async () => {
@@ -247,15 +304,19 @@ describe('Prerender prefetch', () => {
           requests.push(req.url())
         })
 
-        await check(async () => {
-          const cacheKeys = await browser.eval(
-            'Object.keys(window.next.router.sdc)'
-          )
-          return cacheKeys.some((url) => url.includes('/blog/first')) &&
-            cacheKeys.some((url) => url.includes('/blog/second'))
-            ? 'success'
-            : JSON.stringify(requests, null, 2)
-        }, 'success')
+        await retry(
+          async () => {
+            const cacheKeys = await browser.eval(
+              'Object.keys(window.next.router.sdc)'
+            )
+            expect(
+              cacheKeys.some((url) => url.includes('/blog/first')) &&
+                cacheKeys.some((url) => url.includes('/blog/second'))
+            ).toBe(true)
+          },
+          30000,
+          1000
+        )
 
         requests = []
 

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -5,7 +5,6 @@ import { join } from 'path'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {
-  check,
   createNowRouteMatches,
   fetchViaHTTP,
   findPort,
@@ -14,6 +13,7 @@ import {
   renderViaHTTP,
   waitFor,
   withInvocationId,
+  retry,
 } from 'next-test-utils'
 import nodeFetch from 'node-fetch'
 import { ChildProcess } from 'child_process'
@@ -718,12 +718,12 @@ describe('required server files i18n', () => {
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
 
-    await check(
-      () =>
-        errors.join('').includes('gip hit an oops')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
+    await retry(
+      () => {
+        expect(errors.join('')).toContain('gip hit an oops')
+      },
+      30000,
+      1000
     )
   })
 
@@ -736,12 +736,12 @@ describe('required server files i18n', () => {
     )
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
-    await check(
-      () =>
-        errors.join('\n').includes('gssp hit an oops')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
+    await retry(
+      () => {
+        expect(errors.join('\n')).toContain('gssp hit an oops')
+      },
+      30000,
+      1000
     )
   })
 
@@ -754,12 +754,12 @@ describe('required server files i18n', () => {
     )
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
-    await check(
-      () =>
-        errors.join('\n').includes('gsp hit an oops')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
+    await retry(
+      () => {
+        expect(errors.join('\n')).toContain('gsp hit an oops')
+      },
+      30000,
+      1000
     )
   })
 
@@ -773,12 +773,12 @@ describe('required server files i18n', () => {
     )
     expect(res.status).toBe(500)
     expect(await res.text()).toBe('Internal Server Error')
-    await check(
-      () =>
-        errors.join('\n').includes('some error from /api/error')
-          ? 'success'
-          : errors.join('\n'),
-      'success'
+    await retry(
+      () => {
+        expect(errors.join('\n')).toContain('some error from /api/error')
+      },
+      30000,
+      1000
     )
   })
 

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -6,7 +6,6 @@ import { nanoid } from 'nanoid'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {
-  check,
   createNowRouteMatches,
   fetchViaHTTP,
   findPort,
@@ -214,7 +213,13 @@ describe('required server files', () => {
       )
 
       expect(res.status).toBe(500)
-      await check(() => stderr, /Invariant: failed to load static page/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/Invariant: failed to load static page/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await next.renameFile(`${toRename}.bak`, toRename)
     }
@@ -373,9 +378,14 @@ describe('required server files', () => {
     'should warn when "next" is imported directly',
     async () => {
       await renderViaHTTP(appPort, '/gssp', undefined, withInvocationId())
-      await check(
-        () => stderr,
-        /"next" should not be imported directly, imported in/
+      await retry(
+        () => {
+          expect(stderr).toMatch(
+            /"next" should not be imported directly, imported in/
+          )
+        },
+        30000,
+        1000
       )
     }
   )


### PR DESCRIPTION
### What?

Replace deprecated `check()` calls with `retry()` in production test files.

### Why?

The `check()` function is deprecated and will be removed. `retry()` provides:
- Better error messages (shows actual Jest/expect assertion failures)
- Configurable timeout and interval
- More idiomatic test patterns using `expect()` assertions

### How?

Migrated 10 production test files, replacing patterns like:

```ts
// Before
await check(() => browser.elementByCss('#page').text(), 'blog/[slug]')

// After
await retry(async () => {
  expect(await browser.elementByCss('#page').text()).toBe('blog/[slug]')
}, 30000, 1000)
```

NAR-701