### PR TITLE
test: replace check() with retry() in development tests

### DIFF
--- a/test/development/acceptance-app/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance-app/ReactRefreshRegression.test.ts
@@ -2,7 +2,7 @@
 import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 
 describe('ReactRefreshRegression app', () => {
@@ -174,16 +174,26 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '0'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('0')
+      },
+      30000,
+      1000
     )
 
     await session.evaluate(() => document.querySelector('button').click())
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '1'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
 
     await session.patch(
@@ -205,16 +215,26 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      'Count: 1'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('Count: 1')
+      },
+      30000,
+      1000
     )
 
     await session.evaluate(() => document.querySelector('button').click())
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      'Count: 2'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('Count: 2')
+      },
+      30000,
+      1000
     )
   })
 
@@ -256,9 +276,14 @@ describe('ReactRefreshRegression app', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '0'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('0')
+      },
+      30000,
+      1000
     )
 
     await session.evaluate(() => document.querySelector('button').click())

--- a/test/development/acceptance-app/editor-links.test.ts
+++ b/test/development/acceptance-app/editor-links.test.ts
@@ -1,4 +1,4 @@
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import type { Playwright } from 'next-webdriver'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
@@ -88,7 +88,13 @@ describe('Error overlay - editor links', () => {
 
     await session.waitForRedbox()
     await clickSourceFile(browser)
-    await check(() => editorRequestsCount, /1/)
+    await retry(
+      () => {
+        expect(editorRequestsCount).toBe(1)
+      },
+      30000,
+      1000
+    )
   })
   ;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
     'opening links in import traces',
@@ -131,7 +137,13 @@ describe('Error overlay - editor links', () => {
 
         await session.waitForRedbox()
         await clickImportTraceFiles(browser)
-        await check(() => editorRequestsCount, /4/)
+        await retry(
+          () => {
+            expect(editorRequestsCount).toBe(4)
+          },
+          30000,
+          1000
+        )
       })
 
       it('should be possible to open import trace files on module not found error', async () => {
@@ -172,7 +184,13 @@ describe('Error overlay - editor links', () => {
 
         await session.waitForRedbox()
         await clickImportTraceFiles(browser)
-        await check(() => editorRequestsCount, /3/)
+        await retry(
+          () => {
+            expect(editorRequestsCount).toBe(3)
+          },
+          30000,
+          1000
+        )
       })
     }
   )

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import path from 'path'
 import { outdent } from 'outdent'
 
@@ -115,9 +115,14 @@ describe('Error recovery app', () => {
 
     await session.waitForNoRedbox()
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      /Count: 1/
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toMatch(/Count: 1/)
+      },
+      30000,
+      1000
     )
   })
 
@@ -198,9 +203,14 @@ describe('Error recovery app', () => {
         `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      'Hello world 2'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('Hello world 2')
+      },
+      30000,
+      1000
     )
   })
 
@@ -282,9 +292,14 @@ describe('Error recovery app', () => {
         `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      'Hello world 2'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('Hello world 2')
+      },
+      30000,
+      1000
     )
   })
 

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -2,7 +2,7 @@
 import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 
 describe('Error Overlay for server components', () => {
@@ -35,16 +35,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
@@ -89,16 +92,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
@@ -143,16 +149,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'createContext only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/context-in-server-component'
@@ -178,16 +187,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'useRef only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -211,16 +223,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'experimental_useOptimistic only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'experimental_useOptimistic only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'experimental_useOptimistic only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -244,11 +259,14 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        expect(html).toContain('experimental_useOptimistic')
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          expect(html).toContain('experimental_useOptimistic')
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain('experimental_useOptimistic')
     })
@@ -288,16 +306,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'useState only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -339,16 +360,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'useEffect only works in Client Components. Add the "use client" directive at the top of the file to use it. Read more: https://nextjs.org/docs/messages/react-client-hook-in-server-component'
@@ -375,16 +399,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'This might be caused by a React Class Component being rendered in a Server Component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'This might be caused by a React Class Component being rendered in a Server Component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'
@@ -427,16 +454,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'This might be caused by a React Class Component being rendered in a Server Component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'This might be caused by a React Class Component being rendered in a Server Component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'
@@ -479,16 +509,19 @@ describe('Error Overlay for server components', () => {
         ])
       )
       const { browser } = sandbox
-      await check(async () => {
-        expect(
-          await browser
-            .waitForElementByCss('#nextjs__container_errors_desc')
-            .text()
-        ).toContain(
-          'This might be caused by a React Class Component being rendered in a Server Component'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(
+            await browser
+              .waitForElementByCss('#nextjs__container_errors_desc')
+              .text()
+          ).toContain(
+            'This might be caused by a React Class Component being rendered in a Server Component'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(next.cliOutput).toContain(
         'This might be caused by a React Class Component being rendered in a Server Component'

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 import path from 'path'
 
@@ -228,9 +228,14 @@ describe('ReactRefreshRegression', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      '0'
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toBe('0')
+      },
+      30000,
+      1000
     )
 
     await session.evaluate(() => document.querySelector('button').click())

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 import { createSandbox } from 'development-sandbox'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { outdent } from 'outdent'
 import path from 'path'
 
@@ -115,9 +115,14 @@ describe('pages/ error recovery', () => {
       `
     )
 
-    await check(
-      () => session.evaluate(() => document.querySelector('p').textContent),
-      /Count: 1/
+    await retry(
+      async () => {
+        expect(
+          await session.evaluate(() => document.querySelector('p').textContent)
+        ).toMatch(/Count: 1/)
+      },
+      30000,
+      1000
     )
 
     await session.waitForNoRedbox()

--- a/test/development/app-dir/app-routes-error/index.test.ts
+++ b/test/development/app-dir/app-routes-error/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-dir - app routes errors', () => {
   const { next } = nextTestSetup({
@@ -20,18 +20,21 @@ describe('app-dir - app routes errors', () => {
       async (method: string) => {
         await next.fetch('/lowercase/' + method)
 
-        await check(() => {
-          expect(next.cliOutput).toContain(
-            `Detected lowercase method '${method}' in`
-          )
-          expect(next.cliOutput).toContain(
-            `Export the uppercase '${method.toUpperCase()}' method name to fix this error.`
-          )
-          expect(next.cliOutput).toMatch(
-            /Detected lowercase method '.+' in '.+\/route\.js'\. Export the uppercase '.+' method name to fix this error\./
-          )
-          return 'yes'
-        }, 'yes')
+        await retry(
+          () => {
+            expect(next.cliOutput).toContain(
+              `Detected lowercase method '${method}' in`
+            )
+            expect(next.cliOutput).toContain(
+              `Export the uppercase '${method.toUpperCase()}' method name to fix this error.`
+            )
+            expect(next.cliOutput).toMatch(
+              /Detected lowercase method '.+' in '.+\/route\.js'\. Export the uppercase '.+' method name to fix this error\./
+            )
+          },
+          30000,
+          1000
+        )
       }
     )
   })

--- a/test/development/app-dir/strict-mode-enabled-by-default/strict-mode-enabled-by-default.test.ts
+++ b/test/development/app-dir/strict-mode-enabled-by-default/strict-mode-enabled-by-default.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('Strict Mode enabled by default', () => {
   const { next } = nextTestSetup({
@@ -8,10 +8,14 @@ describe('Strict Mode enabled by default', () => {
   // TODO: modern StrictMode does not double invoke effects during hydration: https://github.com/facebook/react/pull/28951
   it.skip('should work using browser', async () => {
     const browser = await next.browser('/')
-    await check(async () => {
-      const text = await browser.elementByCss('p').text()
-      // FIXME: Bug in React. Strict Effects no longer work in current beta.
-      return text === '1' ? 'success' : `failed: ${text}`
-    }, 'success')
+    await retry(
+      async () => {
+        const text = await browser.elementByCss('p').text()
+        // FIXME: Bug in React. Strict Effects no longer work in current beta.
+        expect(text).toBe('1')
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/development/app-dir/watch-config-file/index.test.ts
+++ b/test/development/app-dir/watch-config-file/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('app-dir watch-config-file', () => {
@@ -8,12 +8,19 @@ describe('app-dir watch-config-file', () => {
   })
 
   it('should output config file change and restart server for app router', async () => {
-    await check(async () => next.cliOutput, /ready/i)
+    await retry(
+      async () => {
+        expect(next.cliOutput).toMatch(/ready/i)
+      },
+      30000,
+      1000
+    )
 
-    await check(async () => {
-      await next.patchFile(
-        'next.config.js',
-        `
+    await retry(
+      async () => {
+        await next.patchFile(
+          'next.config.js',
+          `
             console.log(${Date.now()})
             const nextConfig = {
               reactStrictMode: true,
@@ -28,10 +35,22 @@ describe('app-dir watch-config-file', () => {
                 },
             }
             module.exports = nextConfig`
-      )
-      return next.cliOutput
-    }, /Found a change in next\.config\.js\. Restarting the server to apply the changes\.\.\./)
+        )
+        expect(next.cliOutput).toMatch(
+          /Found a change in next\.config\.js\. Restarting the server to apply the changes\.\.\./
+        )
+      },
+      30000,
+      1000
+    )
 
-    await check(() => next.fetch('/about').then((res) => res.status), 200)
+    await retry(
+      async () => {
+        const res = await next.fetch('/about')
+        expect(res.status).toBe(200)
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/development/basic/asset-prefix/asset-prefix.test.ts
+++ b/test/development/basic/asset-prefix/asset-prefix.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('asset-prefix', () => {
   const { next } = nextTestSetup({
@@ -13,13 +13,17 @@ describe('asset-prefix', () => {
 
     expect(await browser.elementByCss('#text').text()).toBe('Hello World')
 
-    await check(async () => {
-      const logs = await browser.log()
-      const hasError = logs.some((log) =>
-        log.message.includes('Failed to fetch')
-      )
-      return hasError ? 'error' : 'success'
-    }, 'success')
+    await retry(
+      async () => {
+        const logs = await browser.log()
+        const hasError = logs.some((log) =>
+          log.message.includes('Failed to fetch')
+        )
+        expect(hasError).toBe(false)
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.eval(`window.__v`)).toBe(1)
   })

--- a/test/development/basic/define-class-fields/define-class-fields.test.ts
+++ b/test/development/basic/define-class-fields/define-class-fields.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('useDefineForClassFields SWC option', () => {
   const { next } = nextTestSetup({
@@ -17,9 +17,14 @@ describe('useDefineForClassFields SWC option', () => {
   it('tsx should compile with useDefineForClassFields enabled', async () => {
     const browser = await next.browser('/')
     await browser.elementByCss('#action').click()
-    await check(
-      () => browser.elementByCss('#name').text(),
-      /this is my name: next/
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#name').text()).toMatch(
+          /this is my name: next/
+        )
+      },
+      30000,
+      1000
     )
   })
 

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -3,7 +3,7 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { waitForNoRedbox, check } from 'next-test-utils'
+import { waitForNoRedbox, retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 const installCheckVisible = (browser) => {
@@ -38,7 +38,13 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
   it('should not reload page when client-side is changed too GSP', async () => {
     const browser = await webdriver(next.url, '/gsp-blog/first')
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#change').text()).toBe('change me')
+      },
+      30000,
+      1000
+    )
     await browser.eval(`window.beforeChange = 'hi'`)
 
     const props = JSON.parse(await browser.elementByCss('#props').text())
@@ -47,14 +53,26 @@ describe('GS(S)P Server-Side Change Reloading', () => {
     const originalContent = await next.readFile(page)
     await next.patchFile(page, originalContent.replace('change me', 'changed'))
 
-    await check(() => browser.elementByCss('#change').text(), 'changed')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#change').text()).toBe('changed')
+      },
+      30000,
+      1000
+    )
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
 
     const props2 = JSON.parse(await browser.elementByCss('#props').text())
     expect(props).toEqual(props2)
 
     await next.patchFile(page, originalContent)
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#change').text()).toBe('change me')
+      },
+      30000,
+      1000
+    )
   })
 
   it('should update page when getStaticProps is changed only', async () => {
@@ -71,18 +89,26 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('2')
+      },
+      30000,
+      1000
     )
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
     await next.patchFile(page, originalContent)
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
   })
 
@@ -101,19 +127,27 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('2')
+      },
+      30000,
+      1000
     )
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
     expect(await browser.eval(`window.showedBuilder`)).toBe(true)
 
     await next.patchFile(page, originalContent)
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
   })
 
@@ -167,10 +201,14 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('2')
+      },
+      30000,
+      1000
     )
     expect(await browser.eval('window.beforeChange')).toBe('hi')
     await next.patchFile(page, originalContent)
@@ -196,10 +234,14 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('2')
+      },
+      30000,
+      1000
     )
     expect(await browser.eval('window.beforeChange')).toBe('hi')
     expect(await browser.eval('document.documentElement.scrollTop')).toBe(
@@ -210,7 +252,13 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
   it('should not reload page when client-side is changed too GSSP', async () => {
     const browser = await webdriver(next.url, '/gssp-blog/first')
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#change').text()).toBe('change me')
+      },
+      30000,
+      1000
+    )
     await browser.eval(`window.beforeChange = 'hi'`)
 
     const props = JSON.parse(await browser.elementByCss('#props').text())
@@ -219,22 +267,38 @@ describe('GS(S)P Server-Side Change Reloading', () => {
     const originalContent = await next.readFile(page)
     await next.patchFile(page, originalContent.replace('change me', 'changed'))
 
-    await check(() => browser.elementByCss('#change').text(), 'changed')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#change').text()).toBe('changed')
+      },
+      30000,
+      1000
+    )
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
 
     const props2 = JSON.parse(await browser.elementByCss('#props').text())
     expect(props).toEqual(props2)
 
     await next.patchFile(page, originalContent)
-    await check(() => browser.elementByCss('#change').text(), 'change me')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#change').text()).toBe('change me')
+      },
+      30000,
+      1000
+    )
   })
 
   it('should update page when getServerSideProps is changed only', async () => {
     const browser = await webdriver(next.url, '/gssp-blog/first')
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
     await browser.eval(`window.beforeChange = 'hi'`)
 
@@ -248,18 +312,26 @@ describe('GS(S)P Server-Side Change Reloading', () => {
       originalContent.replace('count = 1', 'count = 2')
     )
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '2'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('2')
+      },
+      30000,
+      1000
     )
     expect(await browser.eval(`window.beforeChange`)).toBe('hi')
     await next.patchFile(page, originalContent)
 
-    await check(
-      async () =>
-        JSON.parse(await browser.elementByCss('#props').text()).count + '',
-      '1'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(await browser.elementByCss('#props').text()).count + ''
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
   })
 
@@ -352,21 +424,29 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
     try {
       await next.patchFile(page, JSON.stringify({ hello: 'replaced!!' }))
-      await check(async () => {
-        const props = JSON.parse(await browser.elementByCss('#props').text())
-        return props.count === 1 && props.data.hello === 'replaced!!'
-          ? 'success'
-          : JSON.stringify(props)
-      }, 'success')
+      await retry(
+        async () => {
+          const props = JSON.parse(await browser.elementByCss('#props').text())
+          if (props.count !== 1 || props.data.hello !== 'replaced!!') {
+            throw new Error(`Condition not met: ${JSON.stringify(props)}`)
+          }
+        },
+        30000,
+        1000
+      )
       expect(await browser.eval('window.beforeChange')).toBe('hi')
 
       await next.patchFile(page, originalContent)
-      await check(async () => {
-        const props = JSON.parse(await browser.elementByCss('#props').text())
-        return props.count === 1 && props.data.hello === 'world'
-          ? 'success'
-          : JSON.stringify(props)
-      }, 'success')
+      await retry(
+        async () => {
+          const props = JSON.parse(await browser.elementByCss('#props').text())
+          if (props.count !== 1 || props.data.hello !== 'world') {
+            throw new Error(`Condition not met: ${JSON.stringify(props)}`)
+          }
+        },
+        30000,
+        1000
+      )
     } finally {
       await next.patchFile(page, originalContent)
     }

--- a/test/development/basic/legacy-decorators.test.ts
+++ b/test/development/basic/legacy-decorators.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('Legacy decorators SWC option', () => {
   describe('with extended tsconfig', () => {
@@ -34,9 +34,14 @@ describe('Legacy decorators SWC option', () => {
         const text = await browser.elementByCss('#count').text()
         expect(text).toBe('Current number: 0')
         await browser.elementByCss('#increase').click()
-        await check(
-          () => browser.elementByCss('#count').text(),
-          /Current number: 1/
+        await retry(
+          async () => {
+            expect(await browser.elementByCss('#count').text()).toMatch(
+              /Current number: 1/
+            )
+          },
+          30000,
+          1000
         )
       } finally {
         if (browser) {
@@ -71,9 +76,14 @@ describe('Legacy decorators SWC option', () => {
         const text = await browser.elementByCss('#count').text()
         expect(text).toBe('Current number: 0')
         await browser.elementByCss('#increase').click()
-        await check(
-          () => browser.elementByCss('#count').text(),
-          /Current number: 1/
+        await retry(
+          async () => {
+            expect(await browser.elementByCss('#count').text()).toMatch(
+              /Current number: 1/
+            )
+          },
+          30000,
+          1000
         )
       } finally {
         if (browser) {

--- a/test/development/basic/next-dynamic/next-dynamic.test.ts
+++ b/test/development/basic/next-dynamic/next-dynamic.test.ts
@@ -2,7 +2,7 @@ import { join } from 'path'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
 import { createNext, FileRef } from 'e2e-utils'
-import { waitForNoRedbox, renderViaHTTP, check } from 'next-test-utils'
+import { waitForNoRedbox, renderViaHTTP, retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 const customDocumentGipContent = `\
@@ -88,13 +88,23 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/no-chunk')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, normal/
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /Welcome, normal/
+              )
+            },
+            30000,
+            1000
           )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Welcome, dynamic/
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /Welcome, dynamic/
+              )
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {
@@ -115,11 +125,32 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/nested')
-          await check(() => browser.elementByCss('body').text(), /Nested 1/)
-          await check(() => browser.elementByCss('body').text(), /Nested 2/)
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Browser hydrated/
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /Nested 1/
+              )
+            },
+            30000,
+            1000
+          )
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /Nested 2/
+              )
+            },
+            30000,
+            1000
+          )
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /Browser hydrated/
+              )
+            },
+            30000,
+            1000
           )
 
           if ((global as any).browserName === 'chrome') {
@@ -142,7 +173,13 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/head')
-          await check(() => browser.elementByCss('body').text(), /test/)
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(/test/)
+            },
+            30000,
+            1000
+          )
           const backgroundColor = await browser
             .elementByCss('.dynamic-style')
             .getComputedCss('background-color')
@@ -169,7 +206,15 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/no-ssr')
-          await check(() => browser.elementByCss('body').text(), /navigator/)
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /navigator/
+              )
+            },
+            30000,
+            1000
+          )
           await waitForNoRedbox(browser)
         } finally {
           if (browser) {
@@ -182,7 +227,15 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/no-ssr-esm')
-          await check(() => browser.elementByCss('body').text(), /esm.mjs/)
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /esm.mjs/
+              )
+            },
+            30000,
+            1000
+          )
           await waitForNoRedbox(browser)
         } finally {
           if (browser) {
@@ -203,9 +256,14 @@ describe('next/dynamic', () => {
         let browser
         try {
           browser = await webdriver(next.url, basePath + '/dynamic/ssr-true')
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /Hello World 1/
+              )
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {
@@ -240,9 +298,14 @@ describe('next/dynamic', () => {
               next.url,
               basePath + '/dynamic/chunkfilename'
             )
-            await check(
-              () => browser.elementByCss('body').text(),
-              /test chunkfilename/
+            await retry(
+              async () => {
+                expect(await browser.elementByCss('body').text()).toMatch(
+                  /test chunkfilename/
+                )
+              },
+              30000,
+              1000
             )
           } finally {
             if (browser) {
@@ -266,9 +329,14 @@ describe('next/dynamic', () => {
             next.url,
             basePath + '/dynamic/no-ssr-custom-loading'
           )
-          await check(
-            () => browser.elementByCss('body').text(),
-            /Hello World 1/
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('body').text()).toMatch(
+                /Hello World 1/
+              )
+            },
+            30000,
+            1000
           )
         } finally {
           if (browser) {

--- a/test/development/basic/project-directory-rename.test.ts
+++ b/test/development/basic/project-directory-rename.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
-import { waitForNoRedbox, check, findPort } from 'next-test-utils'
+import { waitForNoRedbox, findPort, retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 import { createNext } from 'e2e-utils'
 import stripAnsi from 'strip-ansi'
@@ -35,13 +35,22 @@ describe.skip('Project Directory Renaming', () => {
 
     next.testDir = newTestDir
 
-    await check(
-      () => stripAnsi(next.cliOutput),
-      /Detected project directory rename, restarting in new location/
+    await retry(
+      () => {
+        expect(stripAnsi(next.cliOutput)).toMatch(
+          /Detected project directory rename, restarting in new location/
+        )
+      },
+      30000,
+      1000
     )
-    await check(async () => {
-      return (await browser.eval('window.beforeNav')) === 1 ? 'pending' : 'done'
-    }, 'done')
+    await retry(
+      async () => {
+        expect((await browser.eval('window.beforeNav')) === 1).toBeFalsy()
+      },
+      30000,
+      1000
+    )
     await waitForNoRedbox(browser)
 
     try {
@@ -53,12 +62,18 @@ describe.skip('Project Directory Renaming', () => {
           'hello again'
         )
       )
-      await check(async () => {
-        if (!(await browser.eval('!!window.next'))) {
-          await browser.refresh()
-        }
-        return browser.eval('document.documentElement.innerHTML')
-      }, /hello again/)
+      await retry(
+        async () => {
+          if (!(await browser.eval('!!window.next'))) {
+            await browser.refresh()
+          }
+          expect(
+            await browser.eval('document.documentElement.innerHTML')
+          ).toMatch(/hello again/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await next.patchFile(
         'pages/index.js',

--- a/test/development/basic/tailwind-jit.test.ts
+++ b/test/development/basic/tailwind-jit.test.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import webdriver, { Playwright } from 'next-webdriver'
 import { FileRef, nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 // [TODO]: It is unclear why turbopack takes longer to run this test
 // remove once it's fixed
@@ -49,9 +49,14 @@ describe('TailwindCSS JIT', () => {
       // change the content
       try {
         await next.patchFile(aboutPagePath, editedContent)
-        await check(
-          () => browser.elementByCss('#test-link').getComputedCss('color'),
-          /rgb\(220, 38, 38\)/
+        await retry(
+          async () => {
+            expect(
+              await browser.elementByCss('#test-link').getComputedCss('color')
+            ).toMatch(/rgb\(220, 38, 38\)/)
+          },
+          30000,
+          1000
         )
         expect(await browser.eval('window.REAL_HMR')).toBe(1)
       } finally {

--- a/test/development/correct-tsconfig-defaults/index.test.ts
+++ b/test/development/correct-tsconfig-defaults/index.test.ts
@@ -1,5 +1,5 @@
 import { createNext } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { NextInstance } from 'e2e-utils'
 
 describe('correct tsconfig.json defaults', () => {
@@ -30,10 +30,14 @@ describe('correct tsconfig.json defaults', () => {
 
       let content: string
       // wait for tsconfig to be written
-      await check(async () => {
-        content = await next.readFile('tsconfig.json')
-        return content && content !== '{}' ? 'ready' : 'retry'
-      }, 'ready')
+      await retry(
+        async () => {
+          content = await next.readFile('tsconfig.json')
+          expect(content && content !== '{}').toBeTruthy()
+        },
+        30000,
+        1000
+      )
 
       const tsconfig = JSON.parse(content)
       expect(next.cliOutput).not.toContain('moduleResolution')

--- a/test/development/enoent-during-require/index.test.ts
+++ b/test/development/enoent-during-require/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('ENOENT during require', () => {
   const { next } = nextTestSetup({
@@ -9,11 +9,15 @@ describe('ENOENT during require', () => {
   it('should show ENOENT error correctly', async () => {
     await next.fetch('/')
 
-    await check(() => {
-      expect(next.cliOutput).toContain(
-        "ENOENT: no such file or directory, open 'does-not-exist.txt'"
-      )
-      return 'yes'
-    }, 'yes')
+    await retry(
+      () => {
+        expect(next.cliOutput).toContain(
+          "ENOENT: no such file or directory, open 'does-not-exist.txt'"
+        )
+        expect('yes').toBe('yes')
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/development/jsconfig-path-reloading/index.test.ts
+++ b/test/development/jsconfig-path-reloading/index.test.ts
@@ -3,9 +3,9 @@ import { NextInstance } from 'e2e-utils'
 import {
   waitForRedbox,
   waitForNoRedbox,
-  check,
   renderViaHTTP,
   getRedboxSource,
+  retry,
 } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
@@ -113,13 +113,23 @@ describe('jsconfig-path-reloading', () => {
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
-          const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('id="first-data"') &&
-            !html3.includes('second-data')
-            ? 'success'
-            : html3
-        }, 'success')
+        await retry(
+          async () => {
+            const html3 = await browser.eval(
+              'document.documentElement.innerHTML'
+            )
+            if (
+              !html3.includes('id="first-data"') ||
+              html3.includes('second-data')
+            ) {
+              throw new Error(
+                'Expected html to contain first-data but not second-data'
+              )
+            }
+          },
+          30000,
+          1000
+        )
       }
     })
 
@@ -160,24 +170,39 @@ describe('jsconfig-path-reloading', () => {
 
         await waitForNoRedbox(browser)
 
-        await check(async () => {
-          const html2 = await browser.eval('document.documentElement.innerHTML')
-          expect(html2).toContain('first button')
-          expect(html2).not.toContain('second button')
-          expect(html2).toContain('third button')
-          expect(html2).toContain('first-data')
-          return 'success'
-        }, 'success')
+        await retry(
+          async () => {
+            const html2 = await browser.eval(
+              'document.documentElement.innerHTML'
+            )
+            expect(html2).toContain('first button')
+            expect(html2).not.toContain('second button')
+            expect(html2).toContain('third button')
+            expect(html2).toContain('first-data')
+          },
+          30000,
+          1000
+        )
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
-          const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('first button') &&
-            !html3.includes('third button')
-            ? 'success'
-            : html3
-        }, 'success')
+        await retry(
+          async () => {
+            const html3 = await browser.eval(
+              'document.documentElement.innerHTML'
+            )
+            if (
+              !html3.includes('first button') ||
+              html3.includes('third button')
+            ) {
+              throw new Error(
+                'Expected html to contain first button but not third button'
+              )
+            }
+          },
+          30000,
+          1000
+        )
       }
     })
   }

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -1,4 +1,4 @@
-import { waitForNoRedbox, check, getDistDir, retry } from 'next-test-utils'
+import { waitForNoRedbox, getDistDir, retry } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -413,9 +413,14 @@ describe('middleware - development errors', () => {
 
     it('logs the error correctly', async () => {
       await next.fetch('/')
-      await check(
-        () => stripAnsi(next.cliOutput),
-        new RegExp(`unhandledRejection: Error: you shall see me`, 'm')
+      await retry(
+        () => {
+          expect(stripAnsi(next.cliOutput)).toMatch(
+            new RegExp(`unhandledRejection: Error: you shall see me`, 'm')
+          )
+        },
+        30000,
+        1000
       )
       // expect(output).not.toContain(
       //   'webpack-internal:///(middleware)/./middleware.js'
@@ -448,12 +453,17 @@ describe('middleware - development errors', () => {
     it('logs the error correctly', async () => {
       await next.fetch('/')
       const output = stripAnsi(next.cliOutput)
-      await check(
-        () => stripAnsi(next.cliOutput),
-        new RegExp(
-          ` uncaughtException: Error: This file asynchronously fails while loading`,
-          'm'
-        )
+      await retry(
+        () => {
+          expect(stripAnsi(next.cliOutput)).toMatch(
+            new RegExp(
+              ` uncaughtException: Error: This file asynchronously fails while loading`,
+              'm'
+            )
+          )
+        },
+        30000,
+        1000
       )
       expect(output).not.toContain(
         'webpack-internal:///(middleware)/./middleware.js'
@@ -476,14 +486,16 @@ describe('middleware - development errors', () => {
 
     it('logs the error correctly', async () => {
       await next.fetch('/')
-      await check(async () => {
-        expect(next.cliOutput).toContain(`Expected '{', got '}'`)
-        expect(
-          next.cliOutput.split(`Expected '{', got '}'`).length
-        ).toBeGreaterThanOrEqual(2)
-
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(next.cliOutput).toContain(`Expected '{', got '}'`)
+          expect(
+            next.cliOutput.split(`Expected '{', got '}'`).length
+          ).toBeGreaterThanOrEqual(2)
+        },
+        30000,
+        1000
+      )
     })
 
     it('renders the error correctly and recovers', async () => {
@@ -558,13 +570,16 @@ describe('middleware - development errors', () => {
       await next.patchFile('middleware.js', `export default function () }`)
       await next.fetch('/')
 
-      await check(() => {
-        expect(next.cliOutput).toContain(`Expected '{', got '}'`)
-        expect(
-          next.cliOutput.split(`Expected '{', got '}'`).length
-        ).toBeGreaterThanOrEqual(2)
-        return 'success'
-      }, 'success')
+      await retry(
+        () => {
+          expect(next.cliOutput).toContain(`Expected '{', got '}'`)
+          expect(
+            next.cliOutput.split(`Expected '{', got '}'`).length
+          ).toBeGreaterThanOrEqual(2)
+        },
+        30000,
+        1000
+      )
     })
 
     it('renders the error correctly and recovers', async () => {

--- a/test/development/next-config-ts/hmr/index.test.ts
+++ b/test/development/next-config-ts/hmr/index.test.ts
@@ -1,18 +1,25 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('next-config-ts - dev-hmr', () => {
   const { next } = nextTestSetup({
     files: __dirname,
   })
   it('should output config file change', async () => {
-    await check(async () => next.cliOutput, /ready/i)
+    await retry(
+      async () => {
+        expect(next.cliOutput).toMatch(/ready/i)
+      },
+      30000,
+      1000
+    )
 
-    await check(async () => {
-      await next.patchFile('next.config.ts', (content) => {
-        return content.replace(
-          '// target',
-          `async redirects() {
+    await retry(
+      async () => {
+        await next.patchFile('next.config.ts', (content) => {
+          return content.replace(
+            '// target',
+            `async redirects() {
             return [
               {
                 source: '/about',
@@ -21,11 +28,23 @@ describe('next-config-ts - dev-hmr', () => {
               },
             ]
           },`
+          )
+        })
+        expect(next.cliOutput).toMatch(
+          /Found a change in next\.config\.ts\. Restarting the server to apply the changes\.\.\./
         )
-      })
-      return next.cliOutput
-    }, /Found a change in next\.config\.ts\. Restarting the server to apply the changes\.\.\./)
+      },
+      30000,
+      1000
+    )
 
-    await check(() => next.fetch('/about').then((res) => res.status), 200)
+    await retry(
+      async () => {
+        const res = await next.fetch('/about')
+        expect(res.status).toBe(200)
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/development/next-font/deprecated-package.test.ts
+++ b/test/development/next-font/deprecated-package.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('Deprecated @next/font warning', () => {
   const { next, skipped } = nextTestSetup({
@@ -16,10 +16,21 @@ describe('Deprecated @next/font warning', () => {
 
   it('should warn if @next/font is in deps', async () => {
     await next.start()
-    await check(() => next.cliOutput, /ready/i)
-    await check(
-      () => next.cliOutput,
-      new RegExp('please use the built-in `next/font` instead')
+    await retry(
+      () => {
+        expect(next.cliOutput).toMatch(/ready/i)
+      },
+      30000,
+      1000
+    )
+    await retry(
+      () => {
+        expect(next.cliOutput).toMatch(
+          new RegExp('please use the built-in `next/font` instead')
+        )
+      },
+      30000,
+      1000
     )
 
     await next.stop()
@@ -33,7 +44,13 @@ describe('Deprecated @next/font warning', () => {
     await next.patchFile('package.json', JSON.stringify(packageJson))
 
     await next.start()
-    await check(() => next.cliOutput, /ready/i)
+    await retry(
+      () => {
+        expect(next.cliOutput).toMatch(/ready/i)
+      },
+      30000,
+      1000
+    )
     expect(next.cliOutput).not.toInclude(
       'please use the built-in `next/font` instead'
     )

--- a/test/development/pages-dir/client-navigation/as-path.test.ts
+++ b/test/development/pages-dir/client-navigation/as-path.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -57,18 +57,28 @@ describe('Client navigation with asPath', () => {
     it('should navigate an absolute url on push', async () => {
       const browser = await next.browser(`/absolute-url?port=${next.appPort}`)
       await browser.waitForElementByCss('#router-push').click()
-      await check(
-        () => browser.eval(() => window.location.origin),
-        'https://vercel.com'
+      await retry(
+        async () => {
+          expect(await browser.eval(() => window.location.origin)).toBe(
+            'https://vercel.com'
+          )
+        },
+        30000,
+        1000
       )
     })
 
     it('should navigate an absolute url on replace', async () => {
       const browser = await next.browser(`/absolute-url?port=${next.appPort}`)
       await browser.waitForElementByCss('#router-replace').click()
-      await check(
-        () => browser.eval(() => window.location.origin),
-        'https://vercel.com'
+      await retry(
+        async () => {
+          expect(await browser.eval(() => window.location.origin)).toBe(
+            'https://vercel.com'
+          )
+        },
+        30000,
+        1000
       )
     })
 

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -1,11 +1,6 @@
 /* eslint-env jest */
 
-import {
-  waitFor,
-  check,
-  retry,
-  getRedboxTotalErrorCount,
-} from 'next-test-utils'
+import { waitFor, retry, getRedboxTotalErrorCount } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -461,10 +456,14 @@ describe('Client Navigation', () => {
       window.next.router.push('#third')
     })()`)
 
-    await check(async () => {
-      const errorCount = await browser.eval('window.routeErrors.length')
-      return errorCount > 0 ? 'success' : errorCount
-    }, 'success')
+    await retry(
+      async () => {
+        const errorCount = await browser.eval('window.routeErrors.length')
+        expect(errorCount).toBeGreaterThan(0)
+      },
+      30000,
+      1000
+    )
   })
 
   it('should navigate to paths relative to the current page', async () => {

--- a/test/development/pages-dir/client-navigation/link.test.ts
+++ b/test/development/pages-dir/client-navigation/link.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { waitFor, check } from 'next-test-utils'
+import { waitFor, retry } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -74,9 +74,14 @@ describe('Client Navigation with <Link/>', () => {
   it('should navigate an absolute url', async () => {
     const browser = await next.browser(`/absolute-url?port=${next.appPort}`)
     await browser.waitForElementByCss('#absolute-link').click()
-    await check(
-      () => browser.eval(() => window.location.origin),
-      'https://vercel.com'
+    await retry(
+      async () => {
+        expect(await browser.eval(() => window.location.origin)).toBe(
+          'https://vercel.com'
+        )
+      },
+      30000,
+      1000
     )
   })
 

--- a/test/development/pages-dir/client-navigation/querystring.test.ts
+++ b/test/development/pages-dir/client-navigation/querystring.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -45,21 +45,39 @@ describe('Client navigation querystring', () => {
       const browser = await next.browser('/nav/query-only')
       await browser.elementByCss('#link').click()
 
-      await check(() => browser.waitForElementByCss('#prop').text(), 'foo')
+      await retry(
+        async () => {
+          expect(await browser.waitForElementByCss('#prop').text()).toBe('foo')
+        },
+        30000,
+        1000
+      )
     })
 
     it('should work with router.push', async () => {
       const browser = await next.browser('/nav/query-only')
       await browser.elementByCss('#router-push').click()
 
-      await check(() => browser.waitForElementByCss('#prop').text(), 'bar')
+      await retry(
+        async () => {
+          expect(await browser.waitForElementByCss('#prop').text()).toBe('bar')
+        },
+        30000,
+        1000
+      )
     })
 
     it('should work with router.replace', async () => {
       const browser = await next.browser('/nav/query-only')
       await browser.elementByCss('#router-replace').click()
 
-      await check(() => browser.waitForElementByCss('#prop').text(), 'baz')
+      await retry(
+        async () => {
+          expect(await browser.waitForElementByCss('#prop').text()).toBe('baz')
+        },
+        30000,
+        1000
+      )
     })
 
     it('router.replace with shallow=true shall not throw route cancelled errors', async () => {
@@ -68,9 +86,14 @@ describe('Client navigation querystring', () => {
       // the error occurs on every replace() after the first one
       await browser.elementByCss('#router-replace').click()
 
-      await check(
-        () => browser.waitForElementByCss('#routeState').text(),
-        '{"completed":2,"errors":0}'
+      await retry(
+        async () => {
+          expect(await browser.waitForElementByCss('#routeState').text()).toBe(
+            '{"completed":2,"errors":0}'
+          )
+        },
+        30000,
+        1000
       )
     })
   })

--- a/test/development/pages-dir/client-navigation/scroll.test.ts
+++ b/test/development/pages-dir/client-navigation/scroll.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 
@@ -97,9 +97,13 @@ describe('Client navigation scroll', () => {
     expect(scrollPosition).toBeGreaterThan(3000)
 
     await browser.elementByCss('#increaseWithScroll').click()
-    await check(async () => {
-      const newScrollPosition = await browser.eval('window.pageYOffset')
-      return newScrollPosition === 0 ? 'success' : 'fail'
-    }, 'success')
+    await retry(
+      async () => {
+        const newScrollPosition = await browser.eval('window.pageYOffset')
+        expect(newScrollPosition).toBe(0)
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/development/pages-dir/custom-app-hmr/index.test.ts
+++ b/test/development/pages-dir/custom-app-hmr/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('custom-app-hmr', () => {
   const { next } = nextTestSetup({
@@ -17,27 +17,31 @@ describe('custom-app-hmr', () => {
     )
     await next.patchFile(customAppFilePath, newCustomAppContent)
 
-    await check(async () => {
-      const pText = await browser.elementByCss('h1').text()
-      expect(pText).toBe('hmr text changed')
+    await retry(
+      async () => {
+        const pText = await browser.elementByCss('h1').text()
+        expect(pText).toBe('hmr text changed')
 
-      // Should keep the value on window, which indicates there's no full reload
-      const hmrConstantValue = await browser.eval('window.hmrConstantValue')
-      expect(hmrConstantValue).toBe('should-not-change')
-
-      return 'success'
-    }, 'success')
+        // Should keep the value on window, which indicates there's no full reload
+        const hmrConstantValue = await browser.eval('window.hmrConstantValue')
+        expect(hmrConstantValue).toBe('should-not-change')
+      },
+      30000,
+      1000
+    )
 
     await next.patchFile(customAppFilePath, customAppContent)
-    await check(async () => {
-      const pText = await browser.elementByCss('h1').text()
-      expect(pText).toBe('hmr text origin')
+    await retry(
+      async () => {
+        const pText = await browser.elementByCss('h1').text()
+        expect(pText).toBe('hmr text origin')
 
-      // Should keep the value on window, which indicates there's no full reload
-      const hmrConstantValue = await browser.eval('window.hmrConstantValue')
-      expect(hmrConstantValue).toBe('should-not-change')
-
-      return 'success'
-    }, 'success')
+        // Should keep the value on window, which indicates there's no full reload
+        const hmrConstantValue = await browser.eval('window.hmrConstantValue')
+        expect(hmrConstantValue).toBe('should-not-change')
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/development/tsconfig-path-reloading/index.test.ts
+++ b/test/development/tsconfig-path-reloading/index.test.ts
@@ -3,9 +3,9 @@ import { NextInstance } from 'e2e-utils'
 import {
   waitForRedbox,
   waitForNoRedbox,
-  check,
   renderViaHTTP,
   getRedboxSource,
+  retry,
 } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
@@ -113,13 +113,23 @@ describe('tsconfig-path-reloading', () => {
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
-          const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('id="first-data"') &&
-            !html3.includes('id="second-data"')
-            ? 'success'
-            : html3
-        }, 'success')
+        await retry(
+          async () => {
+            const html3 = await browser.eval(
+              'document.documentElement.innerHTML'
+            )
+            if (
+              !html3.includes('id="first-data"') ||
+              html3.includes('id="second-data"')
+            ) {
+              throw new Error(
+                'Expected html to contain first-data but not second-data'
+              )
+            }
+          },
+          30000,
+          1000
+        )
       }
     })
 
@@ -160,24 +170,39 @@ describe('tsconfig-path-reloading', () => {
 
         await waitForNoRedbox(browser)
 
-        await check(async () => {
-          const html2 = await browser.eval('document.documentElement.innerHTML')
-          expect(html2).toContain('first button')
-          expect(html2).not.toContain('second button')
-          expect(html2).toContain('third button')
-          expect(html2).toContain('first-data')
-          return 'success'
-        }, 'success')
+        await retry(
+          async () => {
+            const html2 = await browser.eval(
+              'document.documentElement.innerHTML'
+            )
+            expect(html2).toContain('first button')
+            expect(html2).not.toContain('second button')
+            expect(html2).toContain('third button')
+            expect(html2).toContain('first-data')
+          },
+          30000,
+          1000
+        )
       } finally {
         await next.patchFile(indexPage, indexContent)
         await next.patchFile(tsConfigFile, tsconfigContent)
-        await check(async () => {
-          const html3 = await browser.eval('document.documentElement.innerHTML')
-          return html3.includes('first button') &&
-            !html3.includes('third button')
-            ? 'success'
-            : html3
-        }, 'success')
+        await retry(
+          async () => {
+            const html3 = await browser.eval(
+              'document.documentElement.innerHTML'
+            )
+            if (
+              !html3.includes('first button') ||
+              html3.includes('third button')
+            ) {
+              throw new Error(
+                'Expected html to contain first button but not third button'
+              )
+            }
+          },
+          30000,
+          1000
+        )
       }
     })
   }

--- a/test/development/typescript-auto-install/index.test.ts
+++ b/test/development/typescript-auto-install/index.test.ts
@@ -1,6 +1,6 @@
 import { createNext } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
-import { check, renderViaHTTP } from 'next-test-utils'
+import { renderViaHTTP, retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'
 
@@ -40,29 +40,49 @@ describe('typescript-auto-install', () => {
     const browser = await webdriver(next.url, '/')
     const pageContent = await next.readFile('pages/index.js')
 
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /hello world/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/hello world/)
+      },
+      30000,
+      1000
     )
     await next.renameFile('pages/index.js', 'pages/index.tsx')
 
-    await check(
-      () => stripAnsi(next.cliOutput),
-      /We detected TypeScript in your project and created a tsconfig\.json file for you/i
+    await retry(
+      () => {
+        expect(stripAnsi(next.cliOutput)).toMatch(
+          /We detected TypeScript in your project and created a tsconfig\.json file for you/i
+        )
+      },
+      30000,
+      1000
     )
 
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /hello world/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/hello world/)
+      },
+      30000,
+      1000
     )
     await next.patchFile(
       'pages/index.tsx',
       pageContent.replace('hello world', 'hello again')
     )
 
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /hello again/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/hello again/)
+      },
+      30000,
+      1000
     )
   })
 })

--- a/test/development/watch-config-file/index.test.ts
+++ b/test/development/watch-config-file/index.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 
 describe('watch-config-file', () => {
@@ -7,12 +7,19 @@ describe('watch-config-file', () => {
     files: join(__dirname, 'fixture'),
   })
   it('should output config file change', async () => {
-    await check(async () => next.cliOutput, /ready/i)
+    await retry(
+      async () => {
+        expect(next.cliOutput).toMatch(/ready/i)
+      },
+      30000,
+      1000
+    )
 
-    await check(async () => {
-      await next.patchFile(
-        'next.config.js',
-        `
+    await retry(
+      async () => {
+        await next.patchFile(
+          'next.config.js',
+          `
             console.log(${Date.now()})
             const nextConfig = {
               reactStrictMode: true,
@@ -27,10 +34,21 @@ describe('watch-config-file', () => {
                 },
             }
             module.exports = nextConfig`
-      )
-      return next.cliOutput
-    }, /Found a change in next\.config\.js\. Restarting the server to apply the changes\.\.\./)
+        )
+        expect(next.cliOutput).toMatch(
+          /Found a change in next\.config\.js\. Restarting the server to apply the changes\.\.\./
+        )
+      },
+      30000,
+      1000
+    )
 
-    await check(() => next.fetch('/about').then((res) => res.status), 200)
+    await retry(
+      async () => {
+        expect(await next.fetch('/about').then((res) => res.status)).toBe(200)
+      },
+      30000,
+      1000
+    )
   })
 })


### PR DESCRIPTION
### What?

Replace deprecated `check()` calls with `retry()` in development test files.

### Why?

The `check()` function is deprecated and will be removed. `retry()` provides:
- Better error messages (shows actual Jest/expect assertion failures)
- Configurable timeout and interval
- More idiomatic test patterns using `expect()` assertions

### How?

Migrated 31 development test files, converting `check()` patterns to use `retry()` with `expect()` assertions.

NAR-700