### PR TITLE
test: replace check() with retry() in integration tests

### DIFF
--- a/test/integration/404-page/test/index.test.ts
+++ b/test/integration/404-page/test/index.test.ts
@@ -12,7 +12,7 @@ import {
   fetchViaHTTP,
   waitFor,
   getPageFileFromPagesManifest,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -116,7 +116,13 @@ describe('404 Page Support', () => {
       })
       await renderViaHTTP(appPort, '/abc')
       try {
-        await check(() => stderr, gip404Err)
+        await retry(
+          () => {
+            expect(stderr).toMatch(gip404Err)
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app)
 

--- a/test/integration/api-support/test/index.test.ts
+++ b/test/integration/api-support/test/index.test.ts
@@ -14,7 +14,7 @@ import {
   nextStart,
   getPageFileFromBuildManifest,
   getPageFileFromPagesManifest,
-  check,
+  retry,
 } from 'next-test-utils'
 import json from '../big.json'
 
@@ -89,9 +89,14 @@ function runTests(dev = false) {
     expect(res2.headers.get('transfer-encoding')).toBe(null)
 
     if (dev) {
-      await check(
-        () => stderr.slice(stderrIdx),
-        /A body was attempted to be set with a 204 statusCode/
+      await retry(
+        () => {
+          expect(stderr.slice(stderrIdx)).toMatch(
+            /A body was attempted to be set with a 204 statusCode/
+          )
+        },
+        30000,
+        1000
       )
     }
   })
@@ -342,23 +347,30 @@ function runTests(dev = false) {
   it('should show friendly error for invalid redirect', async () => {
     await fetchViaHTTP(appPort, '/api/redirect-error', null, {})
 
-    await check(() => {
-      expect(stderr).toContain(
-        `Invalid redirect arguments. Please use a single argument URL, e.g. res.redirect('/destination') or use a status code and URL, e.g. res.redirect(307, '/destination').`
-      )
-      return 'yes'
-    }, 'yes')
+    await retry(
+      () => {
+        expect(stderr).toContain(
+          `Invalid redirect arguments. Please use a single argument URL, e.g. res.redirect('/destination') or use a status code and URL, e.g. res.redirect(307, '/destination').`
+        )
+        expect('yes').toBe('yes')
+      },
+      30000,
+      1000
+    )
   })
 
   it('should show friendly error in case of passing null as first argument redirect', async () => {
     await fetchViaHTTP(appPort, '/api/redirect-null', null, {})
 
-    check(() => {
-      expect(stderr).toContain(
-        `Invalid redirect arguments. Please use a single argument URL, e.g. res.redirect('/destination') or use a status code and URL, e.g. res.redirect(307, '/destination').`
-      )
-      return 'yes'
-    }, 'yes')
+    await retry(
+      () => {
+        expect(stderr).toContain(
+          `Invalid redirect arguments. Please use a single argument URL, e.g. res.redirect('/destination') or use a status code and URL, e.g. res.redirect(307, '/destination').`
+        )
+      },
+      30000,
+      1000
+    )
   })
 
   it('should redirect with status code 307', async () => {
@@ -527,28 +539,34 @@ function runTests(dev = false) {
   })
 
   it('should not warn if response body is larger than 4MB with responseLimit config = false', async () => {
-    await check(async () => {
-      let res = await fetchViaHTTP(appPort, '/api/large-response-with-config')
-      expect(res.ok).toBeTruthy()
-      expect(stderr).not.toContain(
-        'API response for /api/large-response-with-config exceeds 4MB. API Routes are meant to respond quickly.'
-      )
-      return 'success'
-    }, 'success')
+    await retry(
+      async () => {
+        let res = await fetchViaHTTP(appPort, '/api/large-response-with-config')
+        expect(res.ok).toBeTruthy()
+        expect(stderr).not.toContain(
+          'API response for /api/large-response-with-config exceeds 4MB. API Routes are meant to respond quickly.'
+        )
+      },
+      30000,
+      1000
+    )
   })
 
   it('should warn with configured size if response body is larger than configured size', async () => {
-    await check(async () => {
-      let res = await fetchViaHTTP(
-        appPort,
-        '/api/large-response-with-config-size'
-      )
-      expect(res.ok).toBeTruthy()
-      expect(stderr).toContain(
-        'API response for /api/large-response-with-config-size exceeds 5MB. API Routes are meant to respond quickly.'
-      )
-      return 'success'
-    }, 'success')
+    await retry(
+      async () => {
+        let res = await fetchViaHTTP(
+          appPort,
+          '/api/large-response-with-config-size'
+        )
+        expect(res.ok).toBeTruthy()
+        expect(stderr).toContain(
+          'API response for /api/large-response-with-config-size exceeds 5MB. API Routes are meant to respond quickly.'
+        )
+      },
+      30000,
+      1000
+    )
   })
 
   if (dev) {
@@ -571,9 +589,14 @@ function runTests(dev = false) {
         signal: controller.signal,
       }).catch(() => {})
 
-      await check(
-        () => stderr,
-        /API resolved without sending a response for \/api\/test-no-end, this may result in stalled requests/
+      await retry(
+        () => {
+          expect(stderr).toMatch(
+            /API resolved without sending a response for \/api\/test-no-end, this may result in stalled requests/
+          )
+        },
+        30000,
+        1000
       )
     })
 
@@ -590,12 +613,15 @@ function runTests(dev = false) {
       const req = await fetchViaHTTP(appPort, apiURL)
       expect(await req.text()).toBe('hello world')
 
-      check(() => {
-        expect(stderr).toContain(
-          `API resolved without sending a response for ${apiURL}, this may result in stalled requests.`
-        )
-        return 'yes'
-      }, 'yes')
+      await retry(
+        () => {
+          expect(stderr).toContain(
+            `API resolved without sending a response for ${apiURL}, this may result in stalled requests.`
+          )
+        },
+        30000,
+        1000
+      )
     })
 
     it('should not show warning if using externalResolver flag', async () => {

--- a/test/integration/app-document-add-hmr/test/index.test.ts
+++ b/test/integration/app-document-add-hmr/test/index.test.ts
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { killApp, findPort, launchApp, check } from 'next-test-utils'
+import { killApp, findPort, launchApp, retry } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
 const appPage = join(appDir, 'pages/_app.js')
@@ -41,20 +41,28 @@ describe('_app/_document add HMR', () => {
       `
       )
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('custom _app') && html.includes('index page')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('custom _app') && html.includes('index page')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
     } finally {
       await fs.remove(appPage)
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return !html.includes('custom _app') && html.includes('index page')
-          ? 'restored'
-          : html
-      }, 'restored')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          expect(
+            !html.includes('custom _app') && html.includes('index page')
+          ).toBeTruthy()
+        },
+        30000,
+        1000
+      )
     }
   })
 
@@ -96,20 +104,29 @@ describe('_app/_document add HMR', () => {
       `
       )
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('custom _document') && html.includes('index page')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('custom _document') &&
+            html.includes('index page')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
     } finally {
       await fs.remove(documentPage)
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return !html.includes('custom _document') && html.includes('index page')
-          ? 'restored'
-          : html
-      }, 'restored')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          expect(
+            !html.includes('custom _document') && html.includes('index page')
+          ).toBeTruthy()
+        },
+        30000,
+        1000
+      )
     }
   })
 })

--- a/test/integration/app-document-remove-hmr/test/index.test.ts
+++ b/test/integration/app-document-remove-hmr/test/index.test.ts
@@ -3,7 +3,7 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { killApp, findPort, launchApp, check } from 'next-test-utils'
+import { killApp, findPort, launchApp, retry } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
 const appPage = join(appDir, 'pages/_app.js')
@@ -30,12 +30,16 @@ describe('_app removal HMR', () => {
 
       await fs.rename(appPage, appPage + '.bak')
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page') && !html.includes('custom _app')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('index page') && !html.includes('custom _app')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
 
       await fs.writeFile(
         indexPage,
@@ -46,23 +50,31 @@ describe('_app removal HMR', () => {
       `
       )
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          !html.includes('custom _app')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('index page updated') &&
+            !html.includes('custom _app')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
 
       await fs.rename(appPage + '.bak', appPage)
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          html.includes('custom _app')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('index page updated') &&
+            html.includes('custom _app')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
     } finally {
       await fs.writeFile(indexPage, indexContent)
 
@@ -82,12 +94,17 @@ describe('_app removal HMR', () => {
 
       await fs.rename(documentPage, documentPage + '.bak')
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page') && !html.includes('custom _document')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('index page') &&
+            !html.includes('custom _document')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
 
       await fs.writeFile(
         indexPage,
@@ -98,23 +115,31 @@ describe('_app removal HMR', () => {
       `
       )
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          !html.includes('custom _document')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('index page updated') &&
+            !html.includes('custom _document')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
 
       await fs.rename(documentPage + '.bak', documentPage)
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.includes('index page updated') &&
-          html.includes('custom _document')
-          ? 'success'
-          : html
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          return html.includes('index page updated') &&
+            html.includes('custom _document')
+            ? 'success'
+            : html
+        },
+        30000,
+        1000
+      )
     } finally {
       await fs.writeFile(indexPage, indexContent)
 

--- a/test/integration/auto-export/test/index.test.ts
+++ b/test/integration/auto-export/test/index.test.ts
@@ -8,7 +8,7 @@ import {
   findPort,
   killApp,
   launchApp,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
@@ -34,16 +34,29 @@ const runTests = () => {
 
   it('Refreshes query on mount', async () => {
     const browser = await webdriver(appPort, '/post-1')
-    await check(() => browser.eval('document.body.innerHTML'), /post.*post-1/)
+    await retry(
+      async () => {
+        expect(await browser.eval('document.body.innerHTML')).toMatch(
+          /post.*post-1/
+        )
+      },
+      30000,
+      1000
+    )
     const html = await browser.eval('document.body.innerHTML')
     expect(html).toMatch(/nextExport/)
   })
 
   it('should update asPath after mount', async () => {
     const browser = await webdriver(appPort, '/zeit/cmnt-2')
-    await check(
-      () => browser.eval(`document.documentElement.innerHTML`),
-      /\/zeit\/cmnt-2/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.documentElement.innerHTML`)
+        ).toMatch(/\/zeit\/cmnt-2/)
+      },
+      30000,
+      1000
     )
   })
 

--- a/test/integration/cli/test/index.test.ts
+++ b/test/integration/cli/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   launchApp,
@@ -72,7 +71,13 @@ const testExitSignal = async (
     },
   }).catch((err) => expect.fail(err.message))
 
-  await check(() => output, readyRegex)
+  await retry(
+    () => {
+      expect(output).toMatch(readyRegex)
+    },
+    30000,
+    1000
+  )
   instance.kill(killSignal)
 
   const { code, signal } = await cmdPromise
@@ -193,7 +198,13 @@ describe('CLI Usage', () => {
           })
 
           try {
-            await check(() => stderr, /both `sass` and `node-sass` installed/)
+            await retry(
+              () => {
+                expect(stderr).toMatch(/both `sass` and `node-sass` installed/)
+              },
+              30000,
+              1000
+            )
           } finally {
             await killApp(instance).catch(() => {})
           }
@@ -493,7 +504,13 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, /- Local:/i)
+        await retry(
+          () => {
+            expect(output).toMatch(/- Local:/i)
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app)
       }
@@ -512,10 +529,21 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
-        await check(
-          () => output,
-          /Network:\s*http:\/\/[\d]{1,}\.[\d]{1,}\.[\d]{1,}/
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(output).toMatch(
+              /Network:\s*http:\/\/[\d]{1,}\.[\d]{1,}\.[\d]{1,}/
+            )
+          },
+          30000,
+          1000
         )
       } finally {
         await killApp(app)
@@ -535,10 +563,21 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
-        await check(
-          () => output,
-          /Network:\s*http:\/\/[\d]{1,}\.[\d]{1,}\.[\d]{1,}/
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(output).toMatch(
+              /Network:\s*http:\/\/[\d]{1,}\.[\d]{1,}\.[\d]{1,}/
+            )
+          },
+          30000,
+          1000
         )
       } finally {
         await killApp(app)
@@ -563,7 +602,13 @@ describe('CLI Usage', () => {
         },
       })
       try {
-        await check(() => output, /- Local:/)
+        await retry(
+          () => {
+            expect(output).toMatch(/- Local:/)
+          },
+          30000,
+          1000
+        )
         // without --hostname, do not log Network: xxx
         const matches = /Network:\s*http:\/\/\[::\]:(\d+)/.exec(output)
         const _port = parseInt('' + matches)
@@ -594,9 +639,27 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
-        await check(() => output, /- Debugger port:\s+\d+/)
-        await check(() => errOutput, /Debugger listening on/)
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(output).toMatch(/- Debugger port:\s+\d+/)
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(errOutput).toMatch(/Debugger listening on/)
+          },
+          30000,
+          1000
+        )
         expect(errOutput).not.toContain('address already in use')
       } finally {
         await killApp(app)
@@ -620,9 +683,27 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
-        await check(() => output, /- Debugger port:\s+9229/)
-        await check(() => errOutput, /Debugger listening on/)
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(output).toMatch(/- Debugger port:\s+9229/)
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(errOutput).toMatch(/Debugger listening on/)
+          },
+          30000,
+          1000
+        )
         expect(errOutput).not.toContain('address already in use')
       } finally {
         await killApp(app)
@@ -646,9 +727,27 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
-        await check(() => output, /- Debugger port:\s+\d+/)
-        await check(() => errOutput, /Debugger listening on/)
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(output).toMatch(/- Debugger port:\s+\d+/)
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(errOutput).toMatch(/Debugger listening on/)
+          },
+          30000,
+          1000
+        )
         expect(errOutput).not.toContain('address already in use')
       } finally {
         await killApp(app)
@@ -672,9 +771,27 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
-        await check(() => output, /- Debugger port:\s+9230/)
-        await check(() => errOutput, /Debugger listening on/)
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(output).toMatch(/- Debugger port:\s+9230/)
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(errOutput).toMatch(/Debugger listening on/)
+          },
+          30000,
+          1000
+        )
         expect(errOutput).not.toContain('address already in use')
       } finally {
         await killApp(app)
@@ -699,9 +816,27 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
-        await check(() => output, /- Debugger port:\s+\d+/)
-        await check(() => errOutput, /Debugger listening on/)
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(output).toMatch(/- Debugger port:\s+\d+/)
+          },
+          30000,
+          1000
+        )
+        await retry(
+          () => {
+            expect(errOutput).toMatch(/Debugger listening on/)
+          },
+          30000,
+          1000
+        )
         expect(errOutput).not.toContain('address already in use')
         expect(errOutput).toContain('Debugger listening on')
         console.log(output)
@@ -732,7 +867,13 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
         expect(output).toContain(
           'FILE_WITH_SPACES_TO_REQUIRE_WITH_NODE_REQUIRE_OPTION'
         )
@@ -764,7 +905,13 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
         expect(output).toContain(
           'FILE_WITH_SPACES_TO_REQUIRE_WITH_NODE_REQUIRE_OPTION'
         )
@@ -788,7 +935,13 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, new RegExp(`http://localhost:${port}`))
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app)
       }
@@ -852,11 +1005,22 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(
-          () => output,
-          new RegExp(`Network:\\s*http://0.0.0.0:${port}`)
+        await retry(
+          () => {
+            expect(output).toMatch(
+              new RegExp(`Network:\\s*http://0.0.0.0:${port}`)
+            )
+          },
+          30000,
+          1000
         )
-        await check(() => output, new RegExp(`http://localhost:${port}`))
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app)
       }
@@ -875,11 +1039,22 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(
-          () => output,
-          new RegExp(`Network:\\s*http://0.0.0.0:${port}`)
+        await retry(
+          () => {
+            expect(output).toMatch(
+              new RegExp(`Network:\\s*http://0.0.0.0:${port}`)
+            )
+          },
+          30000,
+          1000
         )
-        await check(() => output, new RegExp(`http://localhost:${port}`))
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://localhost:${port}`))
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app)
       }
@@ -943,7 +1118,13 @@ describe('CLI Usage', () => {
         }
       )
       try {
-        await check(() => output, /https:\/\/localhost:(\d+)/)
+        await retry(
+          () => {
+            expect(output).toMatch(/https:\/\/localhost:(\d+)/)
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app)
       }
@@ -963,11 +1144,22 @@ describe('CLI Usage', () => {
       )
       try {
         // Only display when hostname is provided
-        await check(
-          () => output,
-          new RegExp(`Network:\\s*\\http://\\[::\\]:${port}`)
+        await retry(
+          () => {
+            expect(output).toMatch(
+              new RegExp(`Network:\\s*\\http://\\[::\\]:${port}`)
+            )
+          },
+          30000,
+          1000
         )
-        await check(() => output, new RegExp(`http://\\[::1\\]:${port}`))
+        await retry(
+          () => {
+            expect(output).toMatch(new RegExp(`http://\\[::1\\]:${port}`))
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app).catch(() => {})
       }

--- a/test/integration/client-404/test/index.test.ts
+++ b/test/integration/client-404/test/index.test.ts
@@ -12,7 +12,6 @@ import {
   getClientBuildManifestLoaderChunkUrlPath,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
-import { check } from 'next-test-utils'
 
 const clientNavigation = (context, isProd = false) => {
   describe('Client Navigation 404', () => {
@@ -40,7 +39,15 @@ const clientNavigation = (context, isProd = false) => {
       const browser = await webdriver(context.appPort, '/invalid-link')
       await browser.eval(() => ((window as any).beforeNav = 'hi'))
       await browser.elementByCss('#to-nonexistent').click()
-      await check(() => browser.elementByCss('#errorStatusCode').text(), /404/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#errorStatusCode').text()).toMatch(
+            /404/
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.eval(() => (window as any).beforeNav)).not.toBe('hi')
     })
 

--- a/test/integration/client-shallow-routing/test/index.test.ts
+++ b/test/integration/client-shallow-routing/test/index.test.ts
@@ -8,8 +8,8 @@ import {
   killApp,
   nextBuild,
   nextStart,
-  check,
   waitFor,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -38,7 +38,13 @@ const runTests = () => {
     await browser.elementByCss('#to-another').click()
     await waitFor(1000)
 
-    await check(() => browser.elementByCss('#props').text(), /another/)
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#props').text()).toMatch(/another/)
+      },
+      30000,
+      1000
+    )
 
     const props4 = JSON.parse(await browser.elementByCss('#props').text())
     expect(props4.params).toEqual({ slug: 'another' })

--- a/test/integration/create-next-app/prompts.test.ts
+++ b/test/integration/create-next-app/prompts.test.ts
@@ -1,4 +1,4 @@
-import { check } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 import { join } from 'path'
 import { createNextApp, projectFilesShouldExist, useTempDir } from './utils'
 
@@ -164,7 +164,15 @@ describe('create-next-app prompts', () => {
         // cursor forward, choose 'Yes' for custom import alias
         childProcess.stdin.write('\u001b[C\n')
         // used check here since it needs to wait for the prompt
-        await check(() => output, /What import alias would you like configured/)
+        await retry(
+          () => {
+            expect(output).toMatch(
+              /What import alias would you like configured/
+            )
+          },
+          30000,
+          1000
+        )
         childProcess.stdin.write('@/something/*\n')
       })
 
@@ -298,7 +306,13 @@ describe('create-next-app prompts', () => {
         childProcess.stdin.write('\u001b[B\n')
 
         // Wait for the prompt to appear with "reuse previous settings"
-        await check(() => output, /No, reuse previous settings/)
+        await retry(
+          () => {
+            expect(output).toMatch(/No, reuse previous settings/)
+          },
+          30000,
+          1000
+        )
 
         childProcess.on('exit', async (exitCode) => {
           expect(exitCode).toBe(0)
@@ -340,15 +354,25 @@ describe('create-next-app prompts', () => {
           output += data
           process.stdout.write(data)
         })
-        await check(
-          () => output,
-          /Would you like to reset the saved preferences/
+        await retry(
+          () => {
+            expect(output).toMatch(
+              /Would you like to reset the saved preferences/
+            )
+          },
+          30000,
+          1000
         )
         // cursor forward, choose 'Yes' for reset preferences
         childProcess.stdin.write('\u001b[C\n')
-        await check(
-          () => output,
-          /The preferences have been reset successfully/
+        await retry(
+          () => {
+            expect(output).toMatch(
+              /The preferences have been reset successfully/
+            )
+          },
+          30000,
+          1000
         )
       })
     })

--- a/test/integration/css/test/css-modules.test.ts
+++ b/test/integration/css/test/css-modules.test.ts
@@ -2,7 +2,6 @@
 import cheerio from 'cheerio'
 import { readFile, remove } from 'fs-extra'
 import {
-  check,
   File,
   findPort,
   killApp,
@@ -11,6 +10,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -283,19 +283,27 @@ useLightningcss: ${useLightningcss}
         const cssFile = new File(join(appDir, 'pages/index.module.css'))
         try {
           cssFile.replace('color: yellow;', 'color: rgb(1, 1, 1);')
-          await check(
-            () =>
-              browser.eval(
-                `window.getComputedStyle(document.querySelector('#yellowText')).color`
-              ),
-            'rgb(1, 1, 1)'
+          await retry(
+            async () => {
+              expect(
+                await browser.eval(
+                  `window.getComputedStyle(document.querySelector('#yellowText')).color`
+                )
+              ).toBe('rgb(1, 1, 1)')
+            },
+            30000,
+            1000
           )
-          await check(
-            () =>
-              browser.eval(
-                `window.getComputedStyle(document.querySelector('#blueText')).color`
-              ),
-            'rgb(0, 0, 255)'
+          await retry(
+            async () => {
+              expect(
+                await browser.eval(
+                  `window.getComputedStyle(document.querySelector('#blueText')).color`
+                )
+              ).toBe('rgb(0, 0, 255)')
+            },
+            30000,
+            1000
           )
         } finally {
           cssFile.restore()

--- a/test/integration/css/test/css-rendering.test.ts
+++ b/test/integration/css/test/css-rendering.test.ts
@@ -1,13 +1,13 @@
 /* eslint-env jest */
 import { pathExists, readFile, readJSON, remove } from 'fs-extra'
 import {
-  check,
   findPort,
   File,
   killApp,
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -272,9 +272,14 @@ module.exports = {
 
               // Navigate to other:
               await browser.waitForElementByCss('#link-other').click()
-              await check(
-                () => browser.eval(`document.body.innerText`),
-                'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
+              await retry(
+                async () => {
+                  expect(await browser.eval(`document.body.innerText`)).toBe(
+                    'Application error: a client-side exception has occurred while loading localhost (see the browser console for more information).'
+                  )
+                },
+                30000,
+                1000
               )
 
               const newPageStyles = await browser.eval(
@@ -435,9 +440,14 @@ module.exports = {
           const browser = await webdriver(appPort, '/')
           try {
             await checkBlackTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
+            await retry(
+              async () => {
+                expect(
+                  await browser.eval(`document.querySelector('p').innerText`)
+                ).toBe('mounted')
+              },
+              30000,
+              1000
             )
           } finally {
             await browser.close()
@@ -448,9 +458,14 @@ module.exports = {
           const browser = await webdriver(appPort, '/client')
           try {
             await checkRedTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
+            await retry(
+              async () => {
+                expect(
+                  await browser.eval(`document.querySelector('p').innerText`)
+                ).toBe('mounted')
+              },
+              30000,
+              1000
             )
           } finally {
             await browser.close()
@@ -461,15 +476,25 @@ module.exports = {
           const browser = await webdriver(appPort, '/')
           try {
             await checkBlackTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
+            await retry(
+              async () => {
+                expect(
+                  await browser.eval(`document.querySelector('p').innerText`)
+                ).toBe('mounted')
+              },
+              30000,
+              1000
             )
             await browser.eval(`document.querySelector('#link-client').click()`)
             await checkRedTitle(browser)
-            await check(
-              () => browser.eval(`document.querySelector('p').innerText`),
-              'mounted'
+            await retry(
+              async () => {
+                expect(
+                  await browser.eval(`document.querySelector('p').innerText`)
+                ).toBe('mounted')
+              },
+              30000,
+              1000
             )
           } finally {
             await browser.close()

--- a/test/integration/css/test/dev-css-handling.test.ts
+++ b/test/integration/css/test/dev-css-handling.test.ts
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 import { remove } from 'fs-extra'
 import {
-  check,
   File,
   findPort,
   killApp,
   launchApp,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -50,12 +50,16 @@ describe('Can hot reload CSS without losing state', () => {
       try {
         cssFile.replace('color: red', 'color: purple')
 
-        await check(
-          () =>
-            browser.eval(
-              `window.getComputedStyle(document.querySelector('.red-text')).color`
-            ),
-          'rgb(128, 0, 128)'
+        await retry(
+          async () => {
+            expect(
+              await browser.eval(
+                `window.getComputedStyle(document.querySelector('.red-text')).color`
+              )
+            ).toBe('rgb(128, 0, 128)')
+          },
+          30000,
+          1000
         )
 
         // ensure text remained

--- a/test/integration/custom-error-page-exception/test/index.test.ts
+++ b/test/integration/custom-error-page-exception/test/index.test.ts
@@ -2,7 +2,7 @@
 
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import { nextBuild, nextStart, findPort, killApp, check } from 'next-test-utils'
+import { nextBuild, nextStart, findPort, killApp, retry } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
 const nodeArgs = ['-r', join(appDir, '../../lib/react-channel-require-hook.js')]
@@ -29,9 +29,14 @@ describe.skip('Custom error page exception', () => {
         const browser = await webdriver(appPort, '/')
         await browser.waitForElementByCss(navSel).elementByCss(navSel).click()
 
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /Application error: a client-side exception has occurred/
+        await retry(
+          async () => {
+            expect(
+              await browser.eval('document.documentElement.innerHTML')
+            ).toMatch(/Application error: a client-side exception has occurred/)
+          },
+          30000,
+          1000
         )
       })
     }

--- a/test/integration/custom-routes-i18n/test/index.test.ts
+++ b/test/integration/custom-routes-i18n/test/index.test.ts
@@ -12,7 +12,7 @@ import {
   nextStart,
   File,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -92,19 +92,23 @@ const runTests = () => {
 
       await browser.elementByCss('#to-about').click()
 
-      await check(async () => {
-        const data = JSON.parse(
-          cheerio
-            .load(await browser.eval('document.documentElement.innerHTML'))(
-              '#data'
-            )
-            .text()
-        )
-        console.log(data)
-        return data.url === `${expectedIndex ? '/fr' : ''}/about`
-          ? 'success'
-          : 'fail'
-      }, 'success')
+      await retry(
+        async () => {
+          const data = JSON.parse(
+            cheerio
+              .load(await browser.eval('document.documentElement.innerHTML'))(
+                '#data'
+              )
+              .text()
+          )
+          console.log(data)
+          return data.url === `${expectedIndex ? '/fr' : ''}/about`
+            ? 'success'
+            : 'fail'
+        },
+        30000,
+        1000
+      )
 
       await browser
         .back()
@@ -112,19 +116,23 @@ const runTests = () => {
         .elementByCss('#to-catch-all')
         .click()
 
-      await check(async () => {
-        const data = JSON.parse(
-          cheerio
-            .load(await browser.eval('document.documentElement.innerHTML'))(
-              '#data'
-            )
-            .text()
-        )
-        console.log(data)
-        return data.url === `${expectedIndex ? '/fr' : ''}/hello`
-          ? 'success'
-          : 'fail'
-      }, 'success')
+      await retry(
+        async () => {
+          const data = JSON.parse(
+            cheerio
+              .load(await browser.eval('document.documentElement.innerHTML'))(
+                '#data'
+              )
+              .text()
+          )
+          console.log(data)
+          return data.url === `${expectedIndex ? '/fr' : ''}/hello`
+            ? 'success'
+            : 'fail'
+        },
+        30000,
+        1000
+      )
 
       await browser.back().waitForElementByCss('#links')
 
@@ -132,14 +140,27 @@ const runTests = () => {
 
       await browser.elementByCss('#to-index').click()
 
-      await check(() => browser.eval('window.location.pathname'), locale || '/')
+      await retry(
+        async () => {
+          expect(await browser.eval('window.location.pathname')).toBe(
+            locale || '/'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.eval('window.beforeNav')).toBe(1)
 
       await browser.elementByCss('#to-links').click()
 
-      await check(
-        () => browser.eval('window.location.pathname'),
-        `${locale}/links`
+      await retry(
+        async () => {
+          expect(await browser.eval('window.location.pathname')).toBe(
+            `${locale}/links`
+          )
+        },
+        30000,
+        1000
       )
       expect(await browser.eval('window.beforeNav')).toBe(1)
     }

--- a/test/integration/custom-routes/test/index.test.ts
+++ b/test/integration/custom-routes/test/index.test.ts
@@ -20,8 +20,8 @@ import {
   getBrowserBodyText,
   waitFor,
   normalizeRegEx,
-  check,
   normalizeManifest,
+  retry,
 } from 'next-test-utils'
 
 let appDir = join(__dirname, '..')
@@ -92,9 +92,10 @@ const runTests = (isDev = false) => {
       })
     })
 
-    await check(
+    await retry(
       () => (messages.length > 0 ? 'success' : JSON.stringify(messages)),
-      'success'
+      30000,
+      1000
     )
     ws.close()
     expect([...externalServerHits]).toEqual(['/_next/webpack-hmr?page=/about'])
@@ -192,9 +193,14 @@ const runTests = (isDev = false) => {
 
     const browser = await webdriver(appPort, '/nav')
     await browser.elementByCss('#to-before-files-overridden').click()
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /Example Domain/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/Example Domain/)
+      },
+      30000,
+      1000
     )
   })
 
@@ -211,9 +217,14 @@ const runTests = (isDev = false) => {
     const browser = await webdriver(appPort, '/nav')
     await browser.eval('window.beforeNav = 1')
     await browser.elementByCss('#to-before-files-dynamic').click()
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /_sport\/\[slug\]/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/_sport\/\[slug\]/)
+      },
+      30000,
+      1000
     )
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       slug: 'nfl',
@@ -237,9 +248,14 @@ const runTests = (isDev = false) => {
     const browser = await webdriver(appPort, '/nav')
     await browser.eval('window.beforeNav = 1')
     await browser.elementByCss('#to-before-files-dynamic-again').click()
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /_sport\/\[slug\]\/test/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/_sport\/\[slug\]\/test/)
+      },
+      30000,
+      1000
     )
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       slug: 'nfl',
@@ -326,9 +342,14 @@ const runTests = (isDev = false) => {
 
   it('should parse params correctly for rewrite to auto-export dynamic page', async () => {
     const browser = await webdriver(appPort, '/rewriting-to-auto-export')
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /auto-export.*?hello/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => document.documentElement.innerHTML)
+        ).toMatch(/auto-export.*?hello/)
+      },
+      30000,
+      1000
     )
     expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual({
       rewrite: '1',
@@ -2636,9 +2657,14 @@ describe('Custom routes', () => {
 
     it('should not error for no-op rewrite and auto export dynamic route', async () => {
       const browser = await webdriver(appPort, '/auto-export/my-slug')
-      await check(
-        () => browser.eval(() => document.documentElement.innerHTML),
-        /auto-export.*?my-slug/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(() => document.documentElement.innerHTML)
+          ).toMatch(/auto-export.*?my-slug/)
+        },
+        30000,
+        1000
       )
     })
   })

--- a/test/integration/custom-server/test/index.test.ts
+++ b/test/integration/custom-server/test/index.test.ts
@@ -10,9 +10,9 @@ import {
   killApp,
   renderViaHTTP,
   fetchViaHTTP,
-  check,
   File,
   nextBuild,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -198,7 +198,15 @@ describe.each([
 
           indexPg.replace('Asset', 'Asset!!')
 
-          await check(() => browser.elementByCss('#go-asset').text(), /Asset!!/)
+          await retry(
+            async () => {
+              expect(await browser.elementByCss('#go-asset').text()).toMatch(
+                /Asset!!/
+              )
+            },
+            30000,
+            1000
+          )
         } finally {
           if (browser) {
             await browser.close()
@@ -299,7 +307,13 @@ describe.each([
         }
       )
       await fetchViaHTTP(nextUrl, '/unhandled-rejection', undefined, { agent })
-      await check(() => stderr, /unhandledRejection/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/unhandledRejection/)
+        },
+        30000,
+        1000
+      )
       expect(stderr).toContain('unhandledRejection: Error: unhandled rejection')
       expect(stderr).toMatch(/\/server\.js:\d+\d+/)
     })

--- a/test/integration/data-fetching-errors/test/index.test.ts
+++ b/test/integration/data-fetching-errors/test/index.test.ts
@@ -8,7 +8,7 @@ import {
   nextBuild,
   renderViaHTTP,
   nextStart,
-  check,
+  retry,
 } from 'next-test-utils'
 import { join } from 'path'
 import {
@@ -167,10 +167,14 @@ describe('GS(S)P Page Errors', () => {
               stderr += msg || ''
             },
           })
-          await check(async () => {
-            await renderViaHTTP(appPort, '/')
-            return stderr
-          }, /error: oops/i)
+          await retry(
+            async () => {
+              await renderViaHTTP(appPort, '/')
+              expect(stderr).toMatch(/error: oops/i)
+            },
+            30000,
+            1000
+          )
 
           expect(stderr).toContain('Error: Oops')
         } finally {

--- a/test/integration/dynamic-optional-routing-root-fallback/test/index.test.ts
+++ b/test/integration/dynamic-optional-routing-root-fallback/test/index.test.ts
@@ -2,12 +2,12 @@
 
 import fs from 'fs-extra'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -21,7 +21,13 @@ function runTests() {
     const browser = await webdriver(appPort, '/')
     try {
       await browser.waitForElementByCss('#success')
-      await check(() => browser.elementByCss('#success').text(), /yay/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#success').text()).toMatch(/yay/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }
@@ -31,7 +37,13 @@ function runTests() {
     const browser = await webdriver(appPort, '/one')
     try {
       await browser.waitForElementByCss('#success')
-      await check(() => browser.elementByCss('#success').text(), /one/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#success').text()).toMatch(/one/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }
@@ -41,7 +53,15 @@ function runTests() {
     const browser = await webdriver(appPort, '/one/two')
     try {
       await browser.waitForElementByCss('#success')
-      await check(() => browser.elementByCss('#success').text(), /one,two/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#success').text()).toMatch(
+            /one,two/
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }

--- a/test/integration/dynamic-optional-routing/test/index.test.ts
+++ b/test/integration/dynamic-optional-routing/test/index.test.ts
@@ -10,7 +10,7 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 import { join } from 'path'
 
@@ -187,9 +187,14 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(
-        () => stderr,
-        /You cannot define a route with the same specificity as a optional catch-all route/
+      await retry(
+        () => {
+          expect(stderr).toMatch(
+            /You cannot define a route with the same specificity as a optional catch-all route/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       await fs.unlink(invalidRoute)
@@ -201,9 +206,14 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(
-        () => stderr,
-        /You cannot define a route with the same specificity as a optional catch-all route/
+      await retry(
+        () => {
+          expect(stderr).toMatch(
+            /You cannot define a route with the same specificity as a optional catch-all route/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       await fs.unlink(invalidRoute)
@@ -215,7 +225,13 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(() => stderr, /You cannot use both .+ at the same level/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/You cannot use both .+ at the same level/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await fs.unlink(invalidRoute)
     }
@@ -226,9 +242,14 @@ function runInvalidPagesTests(buildFn) {
     try {
       await fs.outputFile(invalidRoute, DUMMY_PAGE, 'utf-8')
       await buildFn(appDir)
-      await check(
-        () => stderr,
-        /Optional route parameters are not yet supported/
+      await retry(
+        () => {
+          expect(stderr).toMatch(
+            /Optional route parameters are not yet supported/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       await fs.unlink(invalidRoute)

--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -14,9 +14,9 @@ import {
   nextBuild,
   nextStart,
   normalizeRegEx,
-  check,
   getRedboxHeader,
   normalizeManifest,
+  retry,
 } from 'next-test-utils'
 import cheerio from 'cheerio'
 
@@ -139,21 +139,25 @@ function runTests({ dev }) {
         })
       })()`)
       const curFrames = [...(await browser.websocketFrames())]
-      await check(async () => {
-        const frames = await browser.websocketFrames()
-        const newFrames = frames.slice(curFrames.length)
-        // console.error({newFrames, curFrames, frames});
+      await retry(
+        async () => {
+          const frames = await browser.websocketFrames()
+          const newFrames = frames.slice(curFrames.length)
+          // console.error({newFrames, curFrames, frames});
 
-        return newFrames.some((frame) => {
-          try {
-            const data = JSON.parse('' + frame.payload)
-            return data.event === 'pong'
-          } catch (_) {}
-          return false
-        })
-          ? 'success'
-          : JSON.stringify(newFrames)
-      }, 'success')
+          return newFrames.some((frame) => {
+            try {
+              const data = JSON.parse('' + frame.payload)
+              return data.event === 'pong'
+            } catch (_) {}
+            return false
+          })
+            ? 'success'
+            : JSON.stringify(newFrames)
+        },
+        30000,
+        1000
+      )
       expect(await browser.eval('window.uncaughtErrs.length')).toBe(0)
     })
   }
@@ -245,7 +249,15 @@ function runTests({ dev }) {
 
       await browser.eval('window.beforeNav = 1')
       await browser.elementByCss(`#${id}`).click()
-      await check(() => browser.eval('window.location.pathname'), pathname)
+      await retry(
+        async () => {
+          expect(await browser.eval('window.location.pathname')).toMatch(
+            pathname
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(JSON.parse(await browser.elementByCss('#query').text())).toEqual(
         navQuery
@@ -1017,9 +1029,14 @@ function runTests({ dev }) {
     expect(html).toMatch(/onmpost:.*pending/)
 
     const browser = await webdriver(appPort, '/on-mount/post-1')
-    await check(
-      () => browser.eval(`document.body.innerHTML`),
-      /onmpost:.*post-1/
+    await retry(
+      async () => {
+        expect(await browser.eval(`document.body.innerHTML`)).toMatch(
+          /onmpost:.*post-1/
+        )
+      },
+      30000,
+      1000
     )
   })
 
@@ -1030,18 +1047,28 @@ function runTests({ dev }) {
 
   it('should update with a hash in the URL', async () => {
     const browser = await webdriver(appPort, '/on-mount/post-1#abc')
-    await check(
-      () => browser.eval(`document.body.innerHTML`),
-      /onmpost:.*post-1/
+    await retry(
+      async () => {
+        expect(await browser.eval(`document.body.innerHTML`)).toMatch(
+          /onmpost:.*post-1/
+        )
+      },
+      30000,
+      1000
     )
   })
 
   it('should scroll to a hash on mount', async () => {
     const browser = await webdriver(appPort, '/on-mount/post-1#item-400')
 
-    await check(
-      () => browser.eval(`document.body.innerHTML`),
-      /onmpost:.*post-1/
+    await retry(
+      async () => {
+        expect(await browser.eval(`document.body.innerHTML`)).toMatch(
+          /onmpost:.*post-1/
+        )
+      },
+      30000,
+      1000
     )
 
     const elementPosition = await browser.eval(
@@ -1166,35 +1193,39 @@ function runTests({ dev }) {
         }
       `
       )
-      await check(async () => {
-        const response = await fetchViaHTTP(
-          appPort,
-          '/_next/static/development/_devPagesManifest.json',
-          undefined,
-          {
-            // @ts-expect-error -- node-fetch doesn't have this as a top-level but whatwg fetch does.
-            credentials: 'same-origin',
-          }
-        )
+      await retry(
+        async () => {
+          const response = await fetchViaHTTP(
+            appPort,
+            '/_next/static/development/_devPagesManifest.json',
+            undefined,
+            {
+              // @ts-expect-error -- node-fetch doesn't have this as a top-level but whatwg fetch does.
+              credentials: 'same-origin',
+            }
+          )
 
-        // Check if the response was successful (status code in the range 200-299)
-        if (!response.ok) {
-          return 'fail'
-        }
+          // Check if the response was successful (status code in the range 200-299)
+          expect(response.ok).toBe(true)
 
-        const contents = await response.text()
-        const containsAddedLater = contents.includes('added-later')
+          const contents = await response.text()
+          expect(contents).toContain('added-later')
+        },
+        30000,
+        1000
+      )
 
-        return containsAddedLater ? 'success' : 'fail'
-      }, 'success')
-
-      await check(async () => {
-        const contents = await renderViaHTTP(
-          appPort,
-          '/_next/static/development/_devPagesManifest.json'
-        )
-        return contents.includes('added-later') ? 'success' : 'fail'
-      }, 'success')
+      await retry(
+        async () => {
+          const contents = await renderViaHTTP(
+            appPort,
+            '/_next/static/development/_devPagesManifest.json'
+          )
+          expect(contents).toContain('added-later')
+        },
+        30000,
+        1000
+      )
 
       await browser.elementByCss('#added-later-link').click()
       await browser.waitForElementByCss('#added-later')

--- a/test/integration/edge-runtime-module-errors/test/index.test.ts
+++ b/test/integration/edge-runtime-module-errors/test/index.test.ts
@@ -3,7 +3,6 @@
 import { remove } from 'fs-extra'
 import { join } from 'path'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   killApp,
@@ -183,14 +182,17 @@ describe('Edge runtime code with imports', () => {
             )
             const res = await fetchViaHTTP(context.appPort, url)
             expect(res.status).toBe(500)
-            await check(async () => {
-              expectUnsupportedModuleDevError(
-                moduleName,
-                importStatement,
-                await res.text()
-              )
-              return 'success'
-            }, 'success')
+            await retry(
+              async () => {
+                expectUnsupportedModuleDevError(
+                  moduleName,
+                  importStatement,
+                  await res.text()
+                )
+              },
+              30000,
+              1000
+            )
           })
         }
       )
@@ -260,10 +262,13 @@ describe('Edge runtime code with imports', () => {
       expect(res.status).toBe(500)
 
       const text = await res.text()
-      await check(async () => {
-        expectModuleNotFoundDevError(moduleName, importStatement, text)
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expectModuleNotFoundDevError(moduleName, importStatement, text)
+        },
+        30000,
+        1000
+      )
     })
     ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
       'production mode',

--- a/test/integration/edge-runtime-streaming-error/test/index.test.ts
+++ b/test/integration/edge-runtime-streaming-error/test/index.test.ts
@@ -1,6 +1,5 @@
 import stripAnsi from 'next/dist/compiled/strip-ansi'
 import {
-  check,
   fetchViaHTTP,
   findPort,
   killApp,
@@ -8,6 +7,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import path from 'path'
 import { remove } from 'fs-extra'
@@ -20,12 +20,17 @@ function test(context: ReturnType<typeof createContext>) {
     expect(await res.text()).toEqual('hello')
     expect(res.status).toBe(200)
     await waitFor(200)
-    await check(
-      () => stripAnsi(context.output),
-      new RegExp(
-        `The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type boolean`,
-        'm'
-      )
+    await retry(
+      () => {
+        expect(stripAnsi(context.output)).toMatch(
+          new RegExp(
+            `The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received type boolean`,
+            'm'
+          )
+        )
+      },
+      30000,
+      1000
     )
     expect(stripAnsi(context.output)).not.toContain('webpack-internal:')
   }

--- a/test/integration/empty-object-getInitialProps/test/index.test.ts
+++ b/test/integration/empty-object-getInitialProps/test/index.test.ts
@@ -8,7 +8,7 @@ import {
   launchApp,
   killApp,
   waitFor,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -60,10 +60,14 @@ describe('Empty Project', () => {
         }
         window.next.router.replace('/another')
       })()`)
-      await check(async () => {
-        const gotWarn = await browser.eval(`window.gotWarn`)
-        return gotWarn ? 'pass' : 'fail'
-      }, 'pass')
+      await retry(
+        async () => {
+          const gotWarn = await browser.eval(`window.gotWarn`)
+          expect(gotWarn).toBeTruthy()
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }

--- a/test/integration/env-config/test/index.test.ts
+++ b/test/integration/env-config/test/index.test.ts
@@ -12,7 +12,7 @@ import {
   launchApp,
   killApp,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -195,9 +195,13 @@ describe('Env Config', () => {
               await fs.writeFile(filePath, content + `\n${toUpdate.toAdd}`)
             }
           }
-          await check(() => {
-            return output.substring(outputIndex)
-          }, /Reload env:/)
+          await retry(
+            () => {
+              expect(output.substring(outputIndex)).toMatch(/Reload env:/)
+            },
+            30000,
+            1000
+          )
         })
         afterAll(async () => {
           for (const { file, content } of originalContents) {
@@ -231,21 +235,32 @@ describe('Env Config', () => {
             )
 
             // we should only log we loaded new env from .env
-            await check(() => output.substring(outputIdx), /Reload env:/)
+            await retry(
+              () => {
+                expect(output.substring(outputIdx)).toMatch(/Reload env:/)
+              },
+              30000,
+              1000
+            )
             expect(
               [...output.substring(outputIdx).matchAll(/Reload env:/g)].length
             ).toBe(1)
             expect(output.substring(outputIdx)).not.toContain('.env.local')
 
-            await check(async () => {
-              html = await fetchViaHTTP(appPort, '/').then((res) => res.text())
-              renderedEnv = JSON.parse(cheerio.load(html)('p').text())
-              expect(renderedEnv['ENV_FILE_KEY']).toBe('env-updated')
-              expect(renderedEnv['ENV_FILE_LOCAL_OVERRIDE_TEST']).toBe(
-                'localenv'
-              )
-              return 'success'
-            }, 'success')
+            await retry(
+              async () => {
+                html = await fetchViaHTTP(appPort, '/').then((res) =>
+                  res.text()
+                )
+                renderedEnv = JSON.parse(cheerio.load(html)('p').text())
+                expect(renderedEnv['ENV_FILE_KEY']).toBe('env-updated')
+                expect(renderedEnv['ENV_FILE_LOCAL_OVERRIDE_TEST']).toBe(
+                  'localenv'
+                )
+              },
+              30000,
+              1000
+            )
 
             outputIdx = output.length
 
@@ -258,21 +273,32 @@ describe('Env Config', () => {
             )
 
             // we should only log we loaded new env from .env
-            await check(() => output.substring(outputIdx), /Reload env:/)
+            await retry(
+              () => {
+                expect(output.substring(outputIdx)).toMatch(/Reload env:/)
+              },
+              30000,
+              1000
+            )
             expect(
               [...output.substring(outputIdx).matchAll(/Reload env:/g)].length
             ).toBe(1)
             expect(output.substring(outputIdx)).toContain('.env.local')
 
-            await check(async () => {
-              html = await fetchViaHTTP(appPort, '/').then((res) => res.text())
-              renderedEnv = JSON.parse(cheerio.load(html)('p').text())
-              expect(renderedEnv['ENV_FILE_KEY']).toBe('env-updated')
-              expect(renderedEnv['ENV_FILE_LOCAL_OVERRIDE_TEST']).toBe(
-                'localenv-updated'
-              )
-              return 'success'
-            }, 'success')
+            await retry(
+              async () => {
+                html = await fetchViaHTTP(appPort, '/').then((res) =>
+                  res.text()
+                )
+                renderedEnv = JSON.parse(cheerio.load(html)('p').text())
+                expect(renderedEnv['ENV_FILE_KEY']).toBe('env-updated')
+                expect(renderedEnv['ENV_FILE_LOCAL_OVERRIDE_TEST']).toBe(
+                  'localenv-updated'
+                )
+              },
+              30000,
+              1000
+            )
           } finally {
             await fs.writeFile(envFile, envContent)
             await fs.writeFile(envLocalFile, envLocalContent)
@@ -305,15 +331,26 @@ describe('Env Config', () => {
               )
             )
             // we should only log we loaded new env from .env
-            await check(() => output.substring(outputIdx), /Reload env:/)
+            await retry(
+              () => {
+                expect(output.substring(outputIdx)).toMatch(/Reload env:/)
+              },
+              30000,
+              1000
+            )
             expect(
               [...output.substring(outputIdx).matchAll(/Reload env:/g)].length
             ).toBe(1)
             expect(output.substring(outputIdx)).not.toContain('.env.local')
 
-            await check(
-              () => browser.waitForElementByCss('#global-value').text(),
-              'replaced'
+            await retry(
+              async () => {
+                expect(
+                  await browser.waitForElementByCss('#global-value').text()
+                ).toBe('replaced')
+              },
+              30000,
+              1000
             )
 
             outputIdx = output.length
@@ -323,28 +360,51 @@ describe('Env Config', () => {
               envLocalContent + `\nNEXT_PUBLIC_TEST_DEST=overridden`
             )
             // we should only log we loaded new env from .env
-            await check(() => output.substring(outputIdx), /Reload env:/)
+            await retry(
+              () => {
+                expect(output.substring(outputIdx)).toMatch(/Reload env:/)
+              },
+              30000,
+              1000
+            )
             expect(
               [...output.substring(outputIdx).matchAll(/Reload env:/g)].length
             ).toBe(1)
             expect(output.substring(outputIdx)).toContain('.env.local')
 
-            await check(
-              () => browser.waitForElementByCss('#global-value').text(),
-              'overridden'
+            await retry(
+              async () => {
+                expect(
+                  await browser.waitForElementByCss('#global-value').text()
+                ).toBe('overridden')
+              },
+              30000,
+              1000
             )
 
             outputIdx = output.length
 
             await fs.writeFile(envLocalFile, envLocalContent)
             // we should only log we loaded new env from .env
-            await check(() => output.substring(outputIdx), /Reload env:/)
+            await retry(
+              () => {
+                expect(output.substring(outputIdx)).toMatch(/Reload env:/)
+              },
+              30000,
+              1000
+            )
             expect(
               [...output.substring(outputIdx).matchAll(/Reload env:/g)].length
             ).toBe(1)
             expect(output.substring(outputIdx)).toContain('.env.local')
 
-            await check(() => browser.elementByCss('p').text(), 'replaced')
+            await retry(
+              async () => {
+                expect(await browser.elementByCss('p').text()).toBe('replaced')
+              },
+              30000,
+              1000
+            )
           } finally {
             await fs.writeFile(envFile, envContent)
             await fs.writeFile(envLocalFile, envLocalContent)

--- a/test/integration/error-load-fail/test/index.test.ts
+++ b/test/integration/error-load-fail/test/index.test.ts
@@ -7,8 +7,8 @@ import {
   nextStart,
   findPort,
   killApp,
-  check,
   getClientBuildManifestLoaderChunkUrlPath,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -39,11 +39,17 @@ describe('Failing to load _error', () => {
         await browser.eval(`window.beforeNavigate = true`)
         await browser.elementByCss('#to-broken').click()
 
-        await check(async () => {
-          return !(await browser.eval('window.beforeNavigate'))
-            ? 'reloaded'
-            : 'fail'
-        }, /reloaded/)
+        await retry(
+          async () => {
+            expect(
+              !(await browser.eval('window.beforeNavigate'))
+                ? 'reloaded'
+                : 'fail'
+            ).toMatch(/reloaded/)
+          },
+          30000,
+          1000
+        )
       })
     }
   )

--- a/test/integration/gssp-redirect-base-path/test/index.test.ts
+++ b/test/integration/gssp-redirect-base-path/test/index.test.ts
@@ -9,7 +9,7 @@ import {
   nextBuild,
   nextStart,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -55,9 +55,14 @@ const runTests = (isDev: boolean) => {
 
     const browser = await webdriver(appPort, `${basePath}`)
     await browser.eval(`next.router.push('/gssp-blog/redirect-1-no-basepath-')`)
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /oops not found/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/oops not found/)
+      },
+      30000,
+      1000
     )
 
     const parsedUrl2 = new URL(await browser.eval('window.location.href'))
@@ -215,9 +220,14 @@ const runTests = (isDev: boolean) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /oops not found/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => document.documentElement.innerHTML)
+        ).toMatch(/oops not found/)
+      },
+      30000,
+      1000
     )
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
@@ -237,9 +247,14 @@ const runTests = (isDev: boolean) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
+    await retry(
+      async () => {
+        expect(await browser.eval(() => document.location.hostname)).toBe(
+          'example.vercel.sh'
+        )
+      },
+      30000,
+      1000
     )
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
@@ -255,9 +270,14 @@ const runTests = (isDev: boolean) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
+    await retry(
+      async () => {
+        expect(await browser.eval(() => document.location.hostname)).toBe(
+          'example.vercel.sh'
+        )
+      },
+      30000,
+      1000
     )
 
     const initialHref = await browser.eval(() => (window as any).initialHref)

--- a/test/integration/gssp-redirect-with-rewrites/test/index.test.ts
+++ b/test/integration/gssp-redirect-with-rewrites/test/index.test.ts
@@ -6,7 +6,7 @@ import {
   findPort,
   launchApp,
   killApp,
-  check,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -51,9 +51,13 @@ describe('getServerSideProps redirects', () => {
     await browser.elementByCss('#link-unknown-url').click()
 
     // Wait until the page has be reloaded
-    await check(async () => {
-      const val = await browser.eval('window.__SAME_PAGE')
-      return val ? 'fail' : 'success'
-    }, 'success')
+    await retry(
+      async () => {
+        const val = await browser.eval('window.__SAME_PAGE')
+        return val ? 'fail' : 'success'
+      },
+      30000,
+      1000
+    )
   })
 })

--- a/test/integration/gssp-redirect/test/index.test.ts
+++ b/test/integration/gssp-redirect/test/index.test.ts
@@ -9,7 +9,7 @@ import {
   nextBuild,
   nextStart,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -256,9 +256,14 @@ const runTests = (isDev: boolean) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /oops not found/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => document.documentElement.innerHTML)
+        ).toMatch(/oops not found/)
+      },
+      30000,
+      1000
     )
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
@@ -278,9 +283,14 @@ const runTests = (isDev: boolean) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
+    await retry(
+      async () => {
+        expect(await browser.eval(() => document.location.hostname)).toBe(
+          'example.vercel.sh'
+        )
+      },
+      30000,
+      1000
     )
 
     const initialHref = await browser.eval(() => (window as any).initialHref)
@@ -296,9 +306,14 @@ const runTests = (isDev: boolean) => {
       }
     )
 
-    await check(
-      () => browser.eval(() => document.location.hostname),
-      'example.vercel.sh'
+    await retry(
+      async () => {
+        expect(await browser.eval(() => document.location.hostname)).toBe(
+          'example.vercel.sh'
+        )
+      },
+      30000,
+      1000
     )
 
     const initialHref = await browser.eval(() => (window as any).initialHref)

--- a/test/integration/hydration/test/index.test.ts
+++ b/test/integration/hydration/test/index.test.ts
@@ -9,7 +9,7 @@ import {
   findPort,
   killApp,
   launchApp,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
@@ -31,9 +31,14 @@ const runTests = () => {
     const browser = await webdriver(appPort, '//')
     await browser.eval('window.beforeNav = true')
     await browser.eval('window.next.router.push("/details")')
-    await check(
-      () => browser.eval('document.documentElement.innerHTML'),
-      /details/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval('document.documentElement.innerHTML')
+        ).toMatch(/details/)
+      },
+      30000,
+      1000
     )
     expect(await browser.eval('window.beforeNav')).toBe(true)
   })

--- a/test/integration/i18n-support-catchall/test/index.test.ts
+++ b/test/integration/i18n-support-catchall/test/index.test.ts
@@ -11,7 +11,7 @@ import {
   launchApp,
   nextBuild,
   nextStart,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -80,7 +80,13 @@ function runTests(isDev: boolean) {
 
     await browser.elementByCss('#to-locale-index').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/nl-NL')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.pathname')).toBe('/nl-NL')
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('nl-NL')
     expect(await browser.elementByCss('#router-default-locale').text()).toBe(
@@ -102,7 +108,15 @@ function runTests(isDev: boolean) {
 
     await browser.back()
 
-    await check(() => browser.elementByCss('#router-locale').text(), 'en-US')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#router-locale').text()).toBe(
+          'en-US'
+        )
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en-US')
     expect(await browser.elementByCss('#router-default-locale').text()).toBe(
@@ -128,9 +142,14 @@ function runTests(isDev: boolean) {
 
     await browser.elementByCss('#to-locale-another').click()
 
-    await check(
-      () => browser.eval('window.location.pathname'),
-      '/nl-NL/another'
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.pathname')).toBe(
+          '/nl-NL/another'
+        )
+      },
+      30000,
+      1000
     )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('nl-NL')
@@ -157,7 +176,15 @@ function runTests(isDev: boolean) {
 
     await browser.back()
 
-    await check(() => browser.elementByCss('#router-locale').text(), 'en-US')
+    await retry(
+      async () => {
+        expect(await browser.elementByCss('#router-locale').text()).toBe(
+          'en-US'
+        )
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en-US')
     expect(await browser.elementByCss('#router-default-locale').text()).toBe(
@@ -191,27 +218,31 @@ function runTests(isDev: boolean) {
         document.querySelector('#to-fr-locale-index').scrollIntoView()
       })()`)
 
-      await check(async () => {
-        const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
-        hrefs.sort()
-
-        console.log({ hrefs })
-
-        assert.deepEqual(
-          hrefs.map((href) =>
-            new URL(href).pathname.replace(/^\/_next\/data\/[^/]+/, '')
-          ),
-          [
-            '/en-US.json',
-            '/en-US/another.json',
-            '/fr.json',
-            '/fr/another.json',
-            '/nl-NL.json',
-            '/nl-NL/another.json',
-          ]
-        )
-        return 'yes'
-      }, 'yes')
+      await retry(
+        async () => {
+          const hrefs = await browser.eval(
+            `Object.keys(window.next.router.sdc)`
+          )
+          hrefs.sort()
+          console.log({ hrefs })
+          assert.deepEqual(
+            hrefs.map((href) =>
+              new URL(href).pathname.replace(/^\/_next\/data\/[^/]+/, '')
+            ),
+            [
+              '/en-US.json',
+              '/en-US/another.json',
+              '/fr.json',
+              '/fr/another.json',
+              '/nl-NL.json',
+              '/nl-NL/another.json',
+            ]
+          )
+          expect('yes').toBe('yes')
+        },
+        30000,
+        1000
+      )
     })
   }
 }

--- a/test/integration/i18n-support-index-rewrite/test/index.test.ts
+++ b/test/integration/i18n-support-index-rewrite/test/index.test.ts
@@ -11,7 +11,7 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -57,18 +57,21 @@ const runTests = () => {
         window.next.router.push('/')
       })()`)
 
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        const props = JSON.parse(cheerio.load(html)('#props').text())
-        assert.deepEqual(props, {
-          params: {
-            slug: ['company', 'about-us'],
-          },
-          locale,
-          hello: 'world',
-        })
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          const props = JSON.parse(cheerio.load(html)('#props').text())
+          assert.deepEqual(props, {
+            params: {
+              slug: ['company', 'about-us'],
+            },
+            locale,
+            hello: 'world',
+          })
+        },
+        30000,
+        1000
+      )
 
       expect(await browser.eval('window.beforeNav')).toBe(1)
     }

--- a/test/integration/i18n-support-same-page-hash-change/test/index.test.ts
+++ b/test/integration/i18n-support-same-page-hash-change/test/index.test.ts
@@ -8,7 +8,7 @@ import {
   findPort,
   nextBuild,
   nextStart,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -21,16 +21,40 @@ const runTests = () => {
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/fr/about')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.pathname')).toBe('/fr/about')
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.hash')).toBe('#hash')
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('fr')
     expect(await browser.elementByCss('#props-locale').text()).toBe('fr')
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/about')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.pathname')).toBe('/about')
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.hash')).toBe('#hash')
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en')
     expect(await browser.elementByCss('#props-locale').text()).toBe('en')
@@ -41,16 +65,42 @@ const runTests = () => {
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/fr/posts/a')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.pathname')).toBe(
+          '/fr/posts/a'
+        )
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.hash')).toBe('#hash')
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('fr')
     expect(await browser.elementByCss('#props-locale').text()).toBe('fr')
 
     await browser.elementByCss('#change-locale').click()
 
-    await check(() => browser.eval('window.location.pathname'), '/posts/a')
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.pathname')).toBe('/posts/a')
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.hash')).toBe('#hash')
+      },
+      30000,
+      1000
+    )
 
     expect(await browser.elementByCss('#router-locale').text()).toBe('en')
     expect(await browser.elementByCss('#props-locale').text()).toBe('en')
@@ -59,14 +109,38 @@ const runTests = () => {
   it('should trigger hash change events', async () => {
     const browser = await webdriver(appPort, `/about#hash`)
 
-    await check(() => browser.eval('window.location.hash'), '#hash')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.hash')).toBe('#hash')
+      },
+      30000,
+      1000
+    )
 
     await browser.elementByCss('#hash-change').click()
 
-    await check(() => browser.eval('window.hashChangeStart'), 'yes')
-    await check(() => browser.eval('window.hashChangeComplete'), 'yes')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.hashChangeStart')).toBe('yes')
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        expect(await browser.eval('window.hashChangeComplete')).toBe('yes')
+      },
+      30000,
+      1000
+    )
 
-    await check(() => browser.eval('window.location.hash'), '#newhash')
+    await retry(
+      async () => {
+        expect(await browser.eval('window.location.hash')).toBe('#newhash')
+      },
+      30000,
+      1000
+    )
   })
 }
 

--- a/test/integration/i18n-support/test/index.test.ts
+++ b/test/integration/i18n-support/test/index.test.ts
@@ -12,7 +12,7 @@ import {
   fetchViaHTTP,
   File,
   launchApp,
-  check,
+  retry,
 } from 'next-test-utils'
 import assert from 'assert'
 
@@ -231,23 +231,31 @@ describe('i18n Support', () => {
             document.querySelector('#to-gsp-fr').scrollIntoView()
           })()`)
 
-          await check(async () => {
-            const hrefs = await browser.eval(
-              `Object.keys(window.next.router.sdc)`
-            )
-            hrefs.sort()
-
-            const baseURL = await browser.url()
-            assert.deepEqual(
-              hrefs.map((href) =>
-                new URL(href, baseURL).pathname
-                  .replace(ctx.basePath, '')
-                  .replace(/^\/_next\/data\/[^/]+/, '')
-              ),
-              ['/en-US/gsp.json', '/fr.json', '/fr/gsp.json', '/nl-NL/gsp.json']
-            )
-            return 'yes'
-          }, 'yes')
+          await retry(
+            async () => {
+              const hrefs = await browser.eval(
+                `Object.keys(window.next.router.sdc)`
+              )
+              hrefs.sort()
+              const baseURL = await browser.url()
+              assert.deepEqual(
+                hrefs.map((href) =>
+                  new URL(href, baseURL).pathname
+                    .replace(ctx.basePath, '')
+                    .replace(/^\/_next\/data\/[^/]+/, '')
+                ),
+                [
+                  '/en-US/gsp.json',
+                  '/fr.json',
+                  '/fr/gsp.json',
+                  '/nl-NL/gsp.json',
+                ]
+              )
+              expect('yes').toBe('yes')
+            },
+            30000,
+            1000
+          )
         })
 
         it('should have correct locale domain hrefs', async () => {

--- a/test/integration/i18n-support/test/shared.ts
+++ b/test/integration/i18n-support/test/shared.ts
@@ -12,7 +12,7 @@ import {
   renderViaHTTP,
   waitFor,
   normalizeRegEx,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const domainLocales = ['go', 'go-BE', 'do', 'do-BE']
@@ -366,7 +366,15 @@ export function runTests(ctx) {
       )
     })()`)
 
-    await check(() => browser.eval('window.location.hostname'), /example\.com/)
+    await retry(
+      async () => {
+        await expect(browser.eval('window.location.hostname')).resolves.toMatch(
+          /example\.com/
+        )
+      },
+      30000,
+      1000
+    )
     expect(await browser.eval('window.location.pathname')).toBe(
       ctx.basePath || '/'
     )
@@ -387,7 +395,15 @@ export function runTests(ctx) {
       )
     })()`)
 
-    await check(() => browser.eval('window.location.hostname'), /example\.com/)
+    await retry(
+      async () => {
+        await expect(browser.eval('window.location.hostname')).resolves.toMatch(
+          /example\.com/
+        )
+      },
+      30000,
+      1000
+    )
     expect(await browser.eval('window.location.pathname')).toBe(
       `${ctx.basePath || ''}/go-BE/gssp`
     )
@@ -533,7 +549,15 @@ export function runTests(ctx) {
       )
     })()`)
 
-    await check(() => browser.elementByCss('#router-locale').text(), 'nl')
+    await retry(
+      async () => {
+        await expect(
+          browser.elementByCss('#router-locale').text()
+        ).resolves.toBe('nl')
+      },
+      30000,
+      1000
+    )
     expect(await browser.eval('window.beforeNav')).toBe(1)
 
     await browser.eval(`(function() {
@@ -542,18 +566,21 @@ export function runTests(ctx) {
       )
     })()`)
 
-    await check(async () => {
-      const html = await browser.eval('document.documentElement.innerHTML')
-      const props = JSON.parse(cheerio.load(html)('#props').text())
+    await retry(
+      async () => {
+        const html = await browser.eval('document.documentElement.innerHTML')
+        const props = JSON.parse(cheerio.load(html)('#props').text())
 
-      assert.deepEqual(props, {
-        locale: 'nl',
-        locales,
-        defaultLocale: 'en-US',
-        query: { page: '1' },
-      })
-      return 'success'
-    }, 'success')
+        assert.deepEqual(props, {
+          locale: 'nl',
+          locales,
+          defaultLocale: 'en-US',
+          query: { page: '1' },
+        })
+      },
+      30000,
+      1000
+    )
 
     await browser
       .back()
@@ -619,25 +646,30 @@ export function runTests(ctx) {
         document.querySelector('#to-gsp-default').scrollIntoView()
       })()`)
 
-      await check(async () => {
-        const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
-        hrefs.sort()
-
-        assert.deepEqual(
-          hrefs.map((href) =>
-            new URL(href).pathname
-              .replace(ctx.basePath, '')
-              .replace(/^\/_next\/data\/[^/]+/, '')
-          ),
-          [
-            '/en-US/gsp.json',
-            '/fr/gsp.json',
-            '/fr/gsp/fallback/first.json',
-            '/fr/gsp/fallback/hello.json',
-          ]
-        )
-        return 'yes'
-      }, 'yes')
+      await retry(
+        async () => {
+          const hrefs = await browser.eval(
+            `Object.keys(window.next.router.sdc)`
+          )
+          hrefs.sort()
+          assert.deepEqual(
+            hrefs.map((href) =>
+              new URL(href).pathname
+                .replace(ctx.basePath, '')
+                .replace(/^\/_next\/data\/[^/]+/, '')
+            ),
+            [
+              '/en-US/gsp.json',
+              '/fr/gsp.json',
+              '/fr/gsp/fallback/first.json',
+              '/fr/gsp/fallback/hello.json',
+            ]
+          )
+          expect('yes').toBe('yes')
+        },
+        30000,
+        1000
+      )
     }
 
     expect(await browser.eval('window.beforeNav')).toBe(1)
@@ -664,20 +696,25 @@ export function runTests(ctx) {
         document.querySelector('#to-gsp-fr').scrollIntoView()
       })()`)
 
-      await check(async () => {
-        const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
-        hrefs.sort()
-
-        assert.deepEqual(
-          hrefs.map((href) =>
-            new URL(href).pathname
-              .replace(ctx.basePath, '')
-              .replace(/^\/_next\/data\/[^/]+/, '')
-          ),
-          ['/en-US/gsp.json', '/fr.json', '/fr/gsp.json', '/nl-NL/gsp.json']
-        )
-        return 'yes'
-      }, 'yes')
+      await retry(
+        async () => {
+          const hrefs = await browser.eval(
+            `Object.keys(window.next.router.sdc)`
+          )
+          hrefs.sort()
+          assert.deepEqual(
+            hrefs.map((href) =>
+              new URL(href).pathname
+                .replace(ctx.basePath, '')
+                .replace(/^\/_next\/data\/[^/]+/, '')
+            ),
+            ['/en-US/gsp.json', '/fr.json', '/fr/gsp.json', '/nl-NL/gsp.json']
+          )
+          expect('yes').toBe('yes')
+        },
+        30000,
+        1000
+      )
     })
   }
 
@@ -2152,24 +2189,29 @@ export function runTests(ctx) {
         document.querySelector('#to-no-fallback-first').scrollIntoView()
       })()`)
 
-      await check(async () => {
-        const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
-        hrefs.sort()
-
-        assert.deepEqual(
-          hrefs.map((href) =>
-            new URL(href).pathname
-              .replace(ctx.basePath, '')
-              .replace(/^\/_next\/data\/[^/]+/, '')
-          ),
-          [
-            '/fr/gsp.json',
-            '/fr/gsp/fallback/first.json',
-            '/fr/gsp/fallback/hello.json',
-          ]
-        )
-        return 'yes'
-      }, 'yes')
+      await retry(
+        async () => {
+          const hrefs = await browser.eval(
+            `Object.keys(window.next.router.sdc)`
+          )
+          hrefs.sort()
+          assert.deepEqual(
+            hrefs.map((href) =>
+              new URL(href).pathname
+                .replace(ctx.basePath, '')
+                .replace(/^\/_next\/data\/[^/]+/, '')
+            ),
+            [
+              '/fr/gsp.json',
+              '/fr/gsp/fallback/first.json',
+              '/fr/gsp/fallback/hello.json',
+            ]
+          )
+          expect('yes').toBe('yes')
+        },
+        30000,
+        1000
+      )
     }
 
     expect(await browser.elementByCss('#router-pathname').text()).toBe('/links')
@@ -2367,25 +2409,30 @@ export function runTests(ctx) {
         document.querySelector('#to-no-fallback-first').scrollIntoView()
       })()`)
 
-      await check(async () => {
-        const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
-        hrefs.sort()
-
-        assert.deepEqual(
-          hrefs.map((href) =>
-            new URL(href).pathname
-              .replace(ctx.basePath, '')
-              .replace(/^\/_next\/data\/[^/]+/, '')
-          ),
-          [
-            '/en-US/gsp.json',
-            '/fr/gsp.json',
-            '/fr/gsp/fallback/first.json',
-            '/fr/gsp/fallback/hello.json',
-          ]
-        )
-        return 'yes'
-      }, 'yes')
+      await retry(
+        async () => {
+          const hrefs = await browser.eval(
+            `Object.keys(window.next.router.sdc)`
+          )
+          hrefs.sort()
+          assert.deepEqual(
+            hrefs.map((href) =>
+              new URL(href).pathname
+                .replace(ctx.basePath, '')
+                .replace(/^\/_next\/data\/[^/]+/, '')
+            ),
+            [
+              '/en-US/gsp.json',
+              '/fr/gsp.json',
+              '/fr/gsp/fallback/first.json',
+              '/fr/gsp/fallback/hello.json',
+            ]
+          )
+          expect('yes').toBe('yes')
+        },
+        30000,
+        1000
+      )
     }
 
     expect(await browser.elementByCss('#router-pathname').text()).toBe(

--- a/test/integration/image-optimizer/test/index.test.ts
+++ b/test/integration/image-optimizer/test/index.test.ts
@@ -1,6 +1,5 @@
 /* eslint-env jest */
 import {
-  check,
   fetchViaHTTP,
   File,
   findPort,
@@ -740,23 +739,27 @@ describe('Image Optimizer', () => {
             `attachment; filename="test.webp"`
           )
 
-          await check(async () => {
-            const files = await fsToJson(imagesDir)
+          await retry(
+            async () => {
+              const files = await fsToJson(imagesDir)
 
-            let found = false
-            const maxAge = '14400'
+              let found = false
+              const maxAge = '14400'
 
-            Object.keys(files).forEach((dir) => {
-              if (
-                Object.keys(files[dir]).some((file) =>
-                  file.includes(`${maxAge}.`)
-                )
-              ) {
-                found = true
-              }
-            })
-            return found ? 'success' : 'failed'
-          }, 'success')
+              Object.keys(files).forEach((dir) => {
+                if (
+                  Object.keys(files[dir]).some((file) =>
+                    file.includes(`${maxAge}.`)
+                  )
+                ) {
+                  found = true
+                }
+              })
+              expect(found).toBe(true)
+            },
+            30000,
+            1000
+          )
         })
 
         it('should not set max-age header when not matching next.config.js', async () => {
@@ -910,23 +913,27 @@ describe('Image Optimizer', () => {
             `attachment; filename="next-js-bg.webp"`
           )
 
-          await check(async () => {
-            const files = await fsToJson(imagesDir)
+          await retry(
+            async () => {
+              const files = await fsToJson(imagesDir)
 
-            let found = false
-            const maxAge = '31536000'
+              let found = false
+              const maxAge = '31536000'
 
-            Object.keys(files).forEach((dir) => {
-              if (
-                Object.keys(files[dir]).some((file) =>
-                  file.includes(`${maxAge}.`)
-                )
-              ) {
-                found = true
-              }
-            })
-            return found ? 'success' : 'failed'
-          }, 'success')
+              Object.keys(files).forEach((dir) => {
+                if (
+                  Object.keys(files[dir]).some((file) =>
+                    file.includes(`${maxAge}.`)
+                  )
+                ) {
+                  found = true
+                }
+              })
+              expect(found).toBe(true)
+            },
+            30000,
+            1000
+          )
           await expectWidth(res, 64)
         })
       }

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -1,10 +1,8 @@
 import http from 'http'
 import fs from 'fs-extra'
 import { join } from 'path'
-import assert from 'assert'
 import sizeOf from 'image-size'
 import {
-  check,
   fetchViaHTTP,
   File,
   findPort,
@@ -14,6 +12,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import isAnimated from 'next/dist/compiled/is-animated'
 import type { RequestInit } from 'node-fetch'
@@ -1006,14 +1005,20 @@ export function runTests(ctx: RunTestsCtx) {
 
       let json1
 
-      await check(async () => {
-        json1 = await fsToJson(ctx.imagesDir)
-        return Object.keys(json1).some((dir) => {
-          return Object.keys(json1[dir]).some((file) => file.includes(etagOne))
-        })
-          ? 'success'
-          : 'fail'
-      }, 'success')
+      await retry(
+        async () => {
+          json1 = await fsToJson(ctx.imagesDir)
+          expect(
+            Object.keys(json1).some((dir) => {
+              return Object.keys(json1[dir]).some((file) =>
+                file.includes(etagOne)
+              )
+            })
+          ).toBe(true)
+        },
+        30000,
+        1000
+      )
 
       const two = await fetchWithDuration(
         ctx.appPort,
@@ -1055,15 +1060,15 @@ export function runTests(ctx: RunTestsCtx) {
           `${contentDispositionType}; filename="slow.webp"`
         )
 
-        await check(async () => {
-          const json4 = await fsToJson(ctx.imagesDir)
-          try {
-            assert.deepStrictEqual(json4, json1)
-            return 'fail'
-          } catch (err) {
-            return 'success'
-          }
-        }, 'success')
+        await retry(
+          async () => {
+            const json4 = await fsToJson(ctx.imagesDir)
+            // Wait for the cache to be updated (json4 should differ from json1)
+            expect(json4).not.toStrictEqual(json1)
+          },
+          30000,
+          1000
+        )
 
         const five = await fetchWithDuration(
           ctx.appPort,
@@ -1078,15 +1083,15 @@ export function runTests(ctx: RunTestsCtx) {
         expect(five.res.headers.get('Content-Disposition')).toBe(
           `${contentDispositionType}; filename="slow.webp"`
         )
-        await check(async () => {
-          const json5 = await fsToJson(ctx.imagesDir)
-          try {
-            assert.deepStrictEqual(json5, json1)
-            return 'fail'
-          } catch (err) {
-            return 'success'
-          }
-        }, 'success')
+        await retry(
+          async () => {
+            const json5 = await fsToJson(ctx.imagesDir)
+            // Wait for the cache to be updated (json5 should differ from json1)
+            expect(json5).not.toStrictEqual(json1)
+          },
+          30000,
+          1000
+        )
       }
     })
   }
@@ -1228,14 +1233,20 @@ export function runTests(ctx: RunTestsCtx) {
     const etagOne = one.res.headers.get('etag')
 
     let json1
-    await check(async () => {
-      json1 = await fsToJson(ctx.imagesDir)
-      return Object.keys(json1).some((dir) => {
-        return Object.keys(json1[dir]).some((file) => file.includes(etagOne))
-      })
-        ? 'success'
-        : 'fail'
-    }, 'success')
+    await retry(
+      async () => {
+        json1 = await fsToJson(ctx.imagesDir)
+        expect(
+          Object.keys(json1).some((dir) => {
+            return Object.keys(json1[dir]).some((file) =>
+              file.includes(etagOne)
+            )
+          })
+        ).toBe(true)
+      },
+      30000,
+      1000
+    )
 
     const two = await fetchWithDuration(
       ctx.appPort,
@@ -1274,15 +1285,15 @@ export function runTests(ctx: RunTestsCtx) {
       expect(four.res.headers.get('Content-Disposition')).toBe(
         `${contentDispositionType}; filename="test.webp"`
       )
-      await check(async () => {
-        const json3 = await fsToJson(ctx.imagesDir)
-        try {
-          assert.deepStrictEqual(json3, json1)
-          return 'fail'
-        } catch (err) {
-          return 'success'
-        }
-      }, 'success')
+      await retry(
+        async () => {
+          const json3 = await fsToJson(ctx.imagesDir)
+          // Wait for the cache to be updated (json3 should differ from json1)
+          expect(json3).not.toStrictEqual(json1)
+        },
+        30000,
+        1000
+      )
 
       const five = await fetchWithDuration(
         ctx.appPort,
@@ -1297,15 +1308,15 @@ export function runTests(ctx: RunTestsCtx) {
       expect(five.res.headers.get('Content-Disposition')).toBe(
         `${contentDispositionType}; filename="test.webp"`
       )
-      await check(async () => {
-        const json5 = await fsToJson(ctx.imagesDir)
-        try {
-          assert.deepStrictEqual(json5, json1)
-          return 'fail'
-        } catch (err) {
-          return 'success'
-        }
-      }, 'success')
+      await retry(
+        async () => {
+          const json5 = await fsToJson(ctx.imagesDir)
+          // Wait for the cache to be updated (json5 should differ from json1)
+          expect(json5).not.toStrictEqual(json1)
+        },
+        30000,
+        1000
+      )
     }
   })
 
@@ -1326,14 +1337,20 @@ export function runTests(ctx: RunTestsCtx) {
       const etagOne = res1.headers.get('etag')
 
       let json1
-      await check(async () => {
-        json1 = await fsToJson(ctx.imagesDir)
-        return Object.keys(json1).some((dir) => {
-          return Object.keys(json1[dir]).some((file) => file.includes(etagOne))
-        })
-          ? 'success'
-          : 'fail'
-      }, 'success')
+      await retry(
+        async () => {
+          json1 = await fsToJson(ctx.imagesDir)
+          expect(
+            Object.keys(json1).some((dir) => {
+              return Object.keys(json1[dir]).some((file) =>
+                file.includes(etagOne)
+              )
+            })
+          ).toBe(true)
+        },
+        30000,
+        1000
+      )
 
       const res2 = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
       expect(res2.status).toBe(200)
@@ -1365,10 +1382,14 @@ export function runTests(ctx: RunTestsCtx) {
     )
 
     let json1
-    await check(async () => {
-      json1 = await fsToJson(ctx.imagesDir)
-      return Object.keys(json1).length === 1 ? 'success' : 'fail'
-    }, 'success')
+    await retry(
+      async () => {
+        json1 = await fsToJson(ctx.imagesDir)
+        expect(Object.keys(json1).length).toBe(1)
+      },
+      30000,
+      1000
+    )
 
     const res2 = await fetchViaHTTP(ctx.appPort, '/_next/image', query, opts)
     expect(res2.status).toBe(200)
@@ -1459,14 +1480,14 @@ export function runTests(ctx: RunTestsCtx) {
       expect(json1).toEqual({})
       expect(await fsToJson(ctx.imagesDir)).toEqual({})
     } else {
-      await check(async () => {
-        try {
-          assert.deepStrictEqual(await fsToJson(ctx.imagesDir), json1)
-          return 'expected change, but matched'
-        } catch (_) {
-          return 'success'
-        }
-      }, 'success')
+      await retry(
+        async () => {
+          // Wait for the cache to be updated (should differ from json1)
+          expect(await fsToJson(ctx.imagesDir)).not.toStrictEqual(json1)
+        },
+        30000,
+        1000
+      )
     }
   })
 
@@ -1582,10 +1603,14 @@ export function runTests(ctx: RunTestsCtx) {
       const length =
         ctx.nextConfigExperimental?.isrFlushToDisk === false ? 0 : 1
 
-      await check(async () => {
-        const json1 = await fsToJson(ctx.imagesDir)
-        return Object.keys(json1).length === length ? 'success' : 'fail'
-      }, 'success')
+      await retry(
+        async () => {
+          const json1 = await fsToJson(ctx.imagesDir)
+          expect(Object.keys(json1).length).toBe(length)
+        },
+        30000,
+        1000
+      )
 
       const xCache = [res1, res2, res3]
         .map((r) => r.headers.get('X-Nextjs-Cache'))

--- a/test/integration/index-index/test/index.test.ts
+++ b/test/integration/index-index/test/index.test.ts
@@ -10,8 +10,8 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -45,7 +45,13 @@ function runTests(testMode: 'start' | 'dev') {
     try {
       await browser.elementByCss('#link1').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('#page').text(), /^index$/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toMatch(/^index$/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }
@@ -73,7 +79,15 @@ function runTests(testMode: 'start' | 'dev') {
     try {
       await browser.elementByCss('#link2').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('#page').text(), /^index > index$/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toMatch(
+            /^index > index$/
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }
@@ -101,7 +115,15 @@ function runTests(testMode: 'start' | 'dev') {
     try {
       await browser.elementByCss('#link5').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('#page').text(), /^index > user$/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toMatch(
+            /^index > user$/
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }
@@ -129,9 +151,14 @@ function runTests(testMode: 'start' | 'dev') {
     try {
       await browser.elementByCss('#link6').click()
       await waitFor(1000)
-      await check(
-        () => browser.elementByCss('#page').text(),
-        /^index > project$/
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toMatch(
+            /^index > project$/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       await browser.close()
@@ -160,9 +187,14 @@ function runTests(testMode: 'start' | 'dev') {
     try {
       await browser.elementByCss('#link3').click()
       await waitFor(1000)
-      await check(
-        () => browser.elementByCss('#page').text(),
-        /^index > index > index$/
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#page').text()).toMatch(
+            /^index > index > index$/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       await browser.close()
@@ -179,7 +211,13 @@ function runTests(testMode: 'start' | 'dev') {
     try {
       await browser.elementByCss('#link4').click()
       await waitFor(1000)
-      await check(() => browser.elementByCss('h1').text(), /404/)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('h1').text()).toMatch(/404/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }

--- a/test/integration/invalid-href/test/index.test.ts
+++ b/test/integration/invalid-href/test/index.test.ts
@@ -9,8 +9,8 @@ import {
   nextBuild,
   nextStart,
   waitFor,
-  check,
   fetchViaHTTP,
+  retry,
 } from 'next-test-utils'
 import cheerio from 'cheerio'
 import webdriver from 'next-webdriver'
@@ -44,10 +44,14 @@ const showsError = async (pathname, regex, click = false, isWarn = false) => {
       await waitFor(500)
     }
     if (isWarn) {
-      await check(async () => {
-        const warnLogs = await browser.eval('window.warnLogs')
-        return warnLogs.join('\n')
-      }, regex)
+      await retry(
+        async () => {
+          const warnLogs = await browser.eval('window.warnLogs')
+          expect(warnLogs.join('\n')).toMatch(regex)
+        },
+        30000,
+        1000
+      )
     } else {
       await waitForRedbox(browser)
       const errorContent = await getRedboxHeader(browser)

--- a/test/integration/invalid-revalidate-values/test/index.test.ts
+++ b/test/integration/invalid-revalidate-values/test/index.test.ts
@@ -7,8 +7,8 @@ import {
   File,
   launchApp,
   renderViaHTTP,
-  check,
   waitFor,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -64,9 +64,14 @@ describe('Invalid revalidate values', () => {
     pageFile.replace('revalidate: 1', 'revalidate: "1"')
 
     try {
-      await check(
-        () => renderViaHTTP(appPort, '/ssg'),
-        /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
+      await retry(
+        async () => {
+          await expect(renderViaHTTP(appPort, '/ssg')).resolves.toMatch(
+            /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       pageFile.restore()
@@ -77,9 +82,14 @@ describe('Invalid revalidate values', () => {
     pageFile.replace('revalidate: 1', 'revalidate: null')
 
     try {
-      await check(
-        () => renderViaHTTP(appPort, '/ssg'),
-        /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
+      await retry(
+        async () => {
+          await expect(renderViaHTTP(appPort, '/ssg')).resolves.toMatch(
+            /A page's revalidate option must be seconds expressed as a natural number. Mixed numbers and strings cannot be used. Received/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       pageFile.restore()
@@ -90,9 +100,14 @@ describe('Invalid revalidate values', () => {
     pageFile.replace('revalidate: 1', 'revalidate: 1.1')
 
     try {
-      await check(
-        () => renderViaHTTP(appPort, '/ssg'),
-        /A page's revalidate option must be seconds expressed as a natural number for \/ssg. Mixed numbers, such as/
+      await retry(
+        async () => {
+          await expect(renderViaHTTP(appPort, '/ssg')).resolves.toMatch(
+            /A page's revalidate option must be seconds expressed as a natural number for \/ssg. Mixed numbers, such as/
+          )
+        },
+        30000,
+        1000
       )
     } finally {
       pageFile.restore()

--- a/test/integration/link-with-encoding/test/index.test.ts
+++ b/test/integration/link-with-encoding/test/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import { findPort, killApp, launchApp, waitFor, check } from 'next-test-utils'
+import { findPort, killApp, launchApp, waitFor, retry } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
 
@@ -40,9 +40,14 @@ describe('Link Component with Encoding', () => {
             { pathname: encodeURI('/single/hello world ') }
           )`
         )
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello world "}"`)
@@ -56,9 +61,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-spaces').click()
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello world "}"`)
@@ -89,9 +99,14 @@ describe('Link Component with Encoding', () => {
             { pathname: encodeURI('/single/hello%world') }
           )`
         )
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello%world"}"`)
@@ -105,9 +120,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-percent').click()
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello%world"}"`)
@@ -141,9 +161,14 @@ describe('Link Component with Encoding', () => {
             { pathname: '/single/hello${encodeURIComponent('/')}world' }
           )`
         )
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello/world"}"`)
@@ -157,9 +182,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-slash').click()
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello/world"}"`)
@@ -197,9 +227,14 @@ describe('Link Component with Encoding', () => {
             { pathname: '/single/hello${encodeURIComponent('"')}world' }
           )`
         )
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(JSON.parse(text)).toMatchInlineSnapshot(`
@@ -217,9 +252,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-double-quote').click()
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(JSON.parse(text)).toMatchInlineSnapshot(`
@@ -257,9 +297,14 @@ describe('Link Component with Encoding', () => {
             { pathname: '/single/hello${encodeURIComponent(':')}world' }
           )`
         )
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello:world"}"`)
@@ -273,9 +318,14 @@ describe('Link Component with Encoding', () => {
       try {
         await waitFor(2000)
         await browser.elementByCss('#single-colon').click()
-        await check(
-          () => browser.hasElementByCssSelector('#query-content'),
-          true
+        await retry(
+          async () => {
+            expect(
+              await browser.hasElementByCssSelector('#query-content')
+            ).toBe(true)
+          },
+          30000,
+          1000
         )
         const text = await browser.elementByCss('#query-content').text()
         expect(text).toMatchInlineSnapshot(`"{"slug":"hello:world"}"`)

--- a/test/integration/middleware-dev-update/test/index.test.ts
+++ b/test/integration/middleware-dev-update/test/index.test.ts
@@ -1,5 +1,4 @@
 import {
-  check,
   fetchViaHTTP,
   File,
   findPort,
@@ -42,14 +41,17 @@ describe('Middleware development errors', () => {
   })
 
   async function assertMiddlewareFetch(hasMiddleware, path = '/') {
-    await check(async () => {
-      const res = await fetchViaHTTP(appPort, path)
-      expect(res.status).toBe(200)
-      expect(res.headers.get('x-from-middleware')).toBe(
-        hasMiddleware ? 'true' : null
-      )
-      return 'success'
-    }, 'success')
+    await retry(
+      async () => {
+        const res = await fetchViaHTTP(appPort, path)
+        expect(res.status).toBe(200)
+        expect(res.headers.get('x-from-middleware')).toBe(
+          hasMiddleware ? 'true' : null
+        )
+      },
+      30000,
+      1000
+    )
   }
 
   async function assertMiddlewareRender(hasMiddleware, path = '/') {

--- a/test/integration/middleware-prefetch/tests/index.test.ts
+++ b/test/integration/middleware-prefetch/tests/index.test.ts
@@ -4,12 +4,12 @@ import { join } from 'path'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
 import {
-  check,
   findPort,
   killApp,
   nextBuild,
   nextStart,
   getClientBuildManifestLoaderChunkUrlPath,
+  retry,
 } from 'next-test-utils'
 
 jest.setTimeout(1000 * 60 * 2)
@@ -60,33 +60,43 @@ describe('Middleware Production Prefetch', () => {
       it(`prefetch correctly for unexistent routes`, async () => {
         const browser = await webdriver(appPort, `/`)
         await browser.elementByCss('#made-up-link').moveTo()
-        await check(async () => {
-          const scripts = await browser.elementsByCss('script')
-          const attrs = await Promise.all(
-            scripts.map((script) => script.getAttribute('src'))
-          )
-          let chunk = getClientBuildManifestLoaderChunkUrlPath(
-            context.appDir,
-            '/ssg-page'
-          )
-          return attrs.find((src) => src.includes(chunk)) ? 'yes' : 'nope'
-        }, 'yes')
+        await retry(
+          async () => {
+            const scripts = await browser.elementsByCss('script')
+            const attrs = await Promise.all(
+              scripts.map((script) => script.getAttribute('src'))
+            )
+            let chunk = getClientBuildManifestLoaderChunkUrlPath(
+              context.appDir,
+              '/ssg-page'
+            )
+            expect(attrs.find((src) => src.includes(chunk))).toBeTruthy()
+          },
+          30000,
+          1000
+        )
       })
 
       it(`does not prefetch provided path if it will be rewritten`, async () => {
         const browser = await webdriver(appPort, `/`)
         await browser.elementByCss('#ssg-page-2').moveTo()
-        await check(async () => {
-          const scripts = await browser.elementsByCss('script')
-          const attrs = await Promise.all(
-            scripts.map((script) => script.getAttribute('src'))
-          )
-          return attrs.find((src) =>
-            src.includes('/ssg-page-2' + (process.env.NEXT_RSPACK ? '-' : ''))
-          )
-            ? 'nope'
-            : 'yes'
-        }, 'yes')
+        await retry(
+          async () => {
+            const scripts = await browser.elementsByCss('script')
+            const attrs = await Promise.all(
+              scripts.map((script) => script.getAttribute('src'))
+            )
+            expect(
+              attrs.find((src) =>
+                src.includes(
+                  '/ssg-page-2' + (process.env.NEXT_RSPACK ? '-' : '')
+                )
+              )
+            ).toBeFalsy()
+          },
+          30000,
+          1000
+        )
       })
     }
   )

--- a/test/integration/missing-document-component-error/test/index.test.ts
+++ b/test/integration/missing-document-component-error/test/index.test.ts
@@ -6,8 +6,8 @@ import {
   findPort,
   killApp,
   launchApp,
-  check,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -28,8 +28,20 @@ const checkMissing = async (missing = [], docContent) => {
 
   await renderViaHTTP(appPort, '/')
 
-  await check(() => stderr, new RegExp(`missing-document-component`))
-  await check(() => stderr, new RegExp(`${missing.join(', ')}`))
+  await retry(
+    () => {
+      expect(stderr).toMatch(new RegExp(`missing-document-component`))
+    },
+    30000,
+    1000
+  )
+  await retry(
+    () => {
+      expect(stderr).toMatch(new RegExp(`${missing.join(', ')}`))
+    },
+    30000,
+    1000
+  )
 
   await killApp(app)
   await fs.remove(docPath)

--- a/test/integration/next-image-legacy/base-path/test/index.test.ts
+++ b/test/integration/next-image-legacy/base-path/test/index.test.ts
@@ -3,7 +3,6 @@
 import {
   waitForRedbox,
   waitForNoRedbox,
-  check,
   findPort,
   getRedboxHeader,
   killApp,
@@ -11,6 +10,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -64,17 +64,19 @@ function runTests(mode) {
   it('should load the images', async () => {
     let browser = await webdriver(appPort, '/docs')
     try {
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       expect(
         await hasImageMatchingUrl(
@@ -90,16 +92,26 @@ function runTests(mode) {
   it('should update the image on src change', async () => {
     let browser = await webdriver(appPort, '/docs/update')
     try {
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.jpg/)
+        },
+        30000,
+        1000
       )
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.png/)
+        },
+        30000,
+        1000
       )
     } finally {
       await browser.close()
@@ -109,16 +121,19 @@ function runTests(mode) {
   it('should work when using flexbox', async () => {
     let browser = await webdriver(appPort, '/docs/flex')
     try {
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').width`
-        )
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').width`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
     } finally {
       await browser.close()
     }
@@ -163,12 +178,15 @@ function runTests(mode) {
       const delta = 250
       const id = 'intrinsic1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1x, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 2x'
       )
@@ -204,12 +222,15 @@ function runTests(mode) {
       const delta = 250
       const id = 'responsive1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -245,12 +266,15 @@ function runTests(mode) {
       const delta = 150
       const id = 'fill1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -286,12 +310,15 @@ function runTests(mode) {
       const height = await getComputed(browser, id, 'height')
       await browser.eval(`document.getElementById("${id}").scrollIntoView()`)
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -337,12 +364,15 @@ function runTests(mode) {
       const delta = 250
       const id = 'sizes1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=32&q=75 32w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=48&q=75 48w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=64&q=75 64w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=96&q=75 96w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=128&q=75 128w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=256&q=75 256w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=384&q=75 384w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -378,9 +408,15 @@ function runTests(mode) {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "src" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show invalid src error', async () => {
@@ -411,17 +447,19 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-        )
-
-        if (result < 1) {
-          throw new Error('Image not ready')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+          )
+          if (result < 1) {
+            throw new Error('Image not ready')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       await waitFor(1000)
 
@@ -441,17 +479,19 @@ function runTests(mode) {
         const id = 'exif-rotation-image'
 
         // Wait for image to load:
-        await check(async () => {
-          const result = await browser.eval(
-            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-          )
-
-          if (result < 1) {
-            throw new Error('Image not ready')
-          }
-
-          return 'result-correct'
-        }, /result-correct/)
+        await retry(
+          async () => {
+            const result = await browser.eval(
+              `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+            )
+            if (result < 1) {
+              throw new Error('Image not ready')
+            }
+            expect('result-correct').toMatch(/result-correct/)
+          },
+          30000,
+          1000
+        )
 
         await waitFor(1000)
 

--- a/test/integration/next-image-legacy/basic/test/index.test.ts
+++ b/test/integration/next-image-legacy/basic/test/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -136,13 +136,27 @@ function lazyLoadingTests() {
       `window.scrollTo(0, ${topOfMidImage - (viewportHeight + buffer)})`
     )
 
-    await check(() => {
-      return browser.elementById('lazy-mid').getAttribute('src')
-    }, 'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024')
+    await retry(
+      async () => {
+        expect(await browser.elementById('lazy-mid').getAttribute('src')).toBe(
+          'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024'
+        )
+      },
+      30000,
+      1000
+    )
 
-    await check(() => {
-      return browser.elementById('lazy-mid').getAttribute('srcset')
-    }, 'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=480 1x, https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024 2x')
+    await retry(
+      async () => {
+        expect(
+          await browser.elementById('lazy-mid').getAttribute('srcset')
+        ).toBe(
+          'https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=480 1x, https://example.com/myaccount/lazy2.jpg?auto=format&fit=max&w=1024 2x'
+        )
+      },
+      30000,
+      1000
+    )
   })
   it('should not have loaded the third image after scrolling down', async () => {
     expect(await browser.elementById('lazy-bottom').getAttribute('src')).toBe(
@@ -220,17 +234,33 @@ function lazyLoadingTests() {
       `window.scrollTo(0, ${topOfBottomImage - (viewportHeight + buffer)})`
     )
 
-    await check(() => {
-      return browser.eval(
-        'document.querySelector("#lazy-boundary").getAttribute("src")'
-      )
-    }, 'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600')
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            'document.querySelector("#lazy-boundary").getAttribute("src")'
+          )
+        ).toBe(
+          'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600'
+        )
+      },
+      30000,
+      1000
+    )
 
-    await check(() => {
-      return browser.eval(
-        'document.querySelector("#lazy-boundary").getAttribute("srcset")'
-      )
-    }, 'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1024 1x, https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600 2x')
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            'document.querySelector("#lazy-boundary").getAttribute("srcset")'
+          )
+        ).toBe(
+          'https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1024 1x, https://example.com/myaccount/lazy6.jpg?auto=format&fit=max&w=1600 2x'
+        )
+      },
+      30000,
+      1000
+    )
   })
 }
 

--- a/test/integration/next-image-legacy/default/test/index.test.ts
+++ b/test/integration/next-image-legacy/default/test/index.test.ts
@@ -5,7 +5,6 @@ import validateHTML from 'html-validator'
 import {
   waitForRedbox,
   waitForNoRedbox,
-  check,
   fetchViaHTTP,
   findPort,
   getRedboxHeader,
@@ -15,6 +14,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -77,17 +77,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       expect(
         await hasImageMatchingUrl(
@@ -107,17 +109,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/priority')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -229,16 +233,26 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/update')
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.jpg/)
+        },
+        30000,
+        1000
       )
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.png/)
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -256,80 +270,163 @@ function runTests(mode) {
         `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
       )
 
-      await check(
-        () => browser.eval(`document.getElementById("img1").currentSrc`),
-        /test(.*)jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("img1").currentSrc`)
+          ).toMatch(/test(.*)jpg/)
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("img2").currentSrc`),
-        /test(.*).png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("img2").currentSrc`)
+          ).toMatch(/test(.*).png/)
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("img3").currentSrc`),
-        /test\.svg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("img3").currentSrc`)
+          ).toMatch(/test\.svg/)
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("img4").currentSrc`),
-        /test(.*)ico/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("img4").currentSrc`)
+          ).toMatch(/test(.*)ico/)
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg1").textContent`),
-        'loaded 1 img1 with dimensions 128x128'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg1").textContent`)
+          ).toBe('loaded 1 img1 with dimensions 128x128')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg2").textContent`),
-        'loaded 1 img2 with dimensions 400x400'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg2").textContent`)
+          ).toBe('loaded 1 img2 with dimensions 400x400')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg3").textContent`),
-        'loaded 1 img3 with dimensions 266x266'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg3").textContent`)
+          ).toBe('loaded 1 img3 with dimensions 266x266')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg4").textContent`),
-        'loaded 1 img4 with dimensions 21x21'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg4").textContent`)
+          ).toBe('loaded 1 img4 with dimensions 21x21')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg5").textContent`),
-        'loaded 1 img5 with dimensions 3x5'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg5").textContent`)
+          ).toBe('loaded 1 img5 with dimensions 3x5')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg6").textContent`),
-        'loaded 1 img6 with dimensions 3x5'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg6").textContent`)
+          ).toBe('loaded 1 img6 with dimensions 3x5')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg7").textContent`),
-        'loaded 1 img7 with dimensions 400x400'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg7").textContent`)
+          ).toBe('loaded 1 img7 with dimensions 400x400')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("msg8").textContent`),
-        'loaded 1 img8 with dimensions 640x373'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg8").textContent`)
+          ).toBe('loaded 1 img8 with dimensions 640x373')
+        },
+        30000,
+        1000
       )
-      await check(
-        () =>
-          browser.eval(
-            `document.getElementById("img8").getAttribute("data-nimg")`
-          ),
-        'intrinsic'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              `document.getElementById("img8").getAttribute("data-nimg")`
+            )
+          ).toBe('intrinsic')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("img8").currentSrc`),
-        /wide.png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("img8").currentSrc`)
+          ).toMatch(/wide.png/)
+        },
+        30000,
+        1000
       )
       await browser.eval('document.getElementById("toggle").click()')
-      await check(
-        () => browser.eval(`document.getElementById("msg8").textContent`),
-        'loaded 2 img8 with dimensions 400x300'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("msg8").textContent`)
+          ).toBe('loaded 2 img8 with dimensions 400x300')
+        },
+        30000,
+        1000
       )
-      await check(
-        () =>
-          browser.eval(
-            `document.getElementById("img8").getAttribute("data-nimg")`
-          ),
-        'fixed'
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              `document.getElementById("img8").getAttribute("data-nimg")`
+            )
+          ).toBe('fixed')
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("img8").currentSrc`),
-        /test-rect.jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("img8").currentSrc`)
+          ).toMatch(/test-rect.jpg/)
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -345,92 +442,179 @@ function runTests(mode) {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").currentSrc`)
+        ).toMatch(/test(.*).png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img3").currentSrc`)
+        ).toMatch(/test\.svg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img4").currentSrc`)
+        ).toMatch(/test(.*)ico/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded 1 img1 with native onLoad'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('loaded 1 img1 with native onLoad')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded 1 img2 with native onLoad'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('loaded 1 img2 with native onLoad')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded 1 img3 with native onLoad'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toBe('loaded 1 img3 with native onLoad')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded 1 img4 with native onLoad'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toBe('loaded 1 img4 with native onLoad')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 1 img8 with native onLoad'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toBe('loaded 1 img8 with native onLoad')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      'intrinsic'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          )
+        ).toBe('intrinsic')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /wide.png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/wide.png/)
+      },
+      30000,
+      1000
     )
     await browser.eval('document.getElementById("toggle").click()')
     // The normal `onLoad()` is triggered by lazy placeholder image
     // so ideally this would be "2" instead of "3" count
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 3 img8 with native onLoad'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toBe('loaded 3 img8 with native onLoad')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      'fixed'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          )
+        ).toBe('fixed')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /test-rect.jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/test-rect.jpg/)
+      },
+      30000,
+      1000
     )
   })
 
   it('should callback native onError when error occurred while loading image', async () => {
     let browser = await webdriver(appPort, '/on-error')
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test\.png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").currentSrc`)
+        ).toMatch(/test\.png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      //This is an empty data url
-      /nonexistent-img\.png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").currentSrc`)
+        ).toMatch(/nonexistent-img\.png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'no error occurred'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('no error occurred')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'error occurred while loading img2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('error occurred while loading img2')
+      },
+      30000,
+      1000
     )
   })
 
@@ -439,13 +623,23 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/blob')
 
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").src`),
-        /^blob:/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("blob-image").src`)
+          ).toMatch(/^blob:/)
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").srcset`),
-        ''
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("blob-image").srcset`)
+          ).toBe('')
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -458,16 +652,19 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/flex')
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').width`
-        )
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').width`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -484,12 +681,15 @@ function runTests(mode) {
       const delta = 250
       const id = 'fixed1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x'
       )
@@ -522,12 +722,15 @@ function runTests(mode) {
       const delta = 250
       const id = 'intrinsic1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x'
       )
@@ -566,12 +769,15 @@ function runTests(mode) {
       const delta = 250
       const id = 'responsive1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -610,12 +816,15 @@ function runTests(mode) {
       const delta = 150
       const id = 'fill1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -654,18 +863,29 @@ function runTests(mode) {
       const height = await getComputed(browser, id, 'height')
       await browser.eval(`document.getElementById("${id}").scrollIntoView()`)
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
 
-      await check(() => {
-        return browser.eval(
-          `document.querySelector('#${id}').getAttribute('srcset')`
-        )
-      }, '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              `document.querySelector('#${id}').getAttribute('srcset')`
+            )
+          ).toBe(
+            '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+          )
+        },
+        30000,
+        1000
+      )
 
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       expect(await getComputed(browser, id, 'width')).toBe(width)
@@ -697,18 +917,34 @@ function runTests(mode) {
       expect(objectFit).toBe('cover')
       expect(objectPosition).toBe('left center')
       await browser.eval(`document.getElementById("fill3").scrollIntoView()`)
-      await check(() => {
-        return browser.eval(
-          `document.querySelector('#fill3').getAttribute('srcset')`
-        )
-      }, '/_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              `document.querySelector('#fill3').getAttribute('srcset')`
+            )
+          ).toBe(
+            '/_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+          )
+        },
+        30000,
+        1000
+      )
 
       await browser.eval(`document.getElementById("fill4").scrollIntoView()`)
-      await check(() => {
-        return browser.eval(
-          `document.querySelector('#fill4').getAttribute('srcset')`
-        )
-      }, '/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              `document.querySelector('#fill4').getAttribute('srcset')`
+            )
+          ).toBe(
+            '/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -725,12 +961,15 @@ function runTests(mode) {
       const delta = 250
       const id = 'sizes1'
 
-      await check(async () => {
-        expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
-        )
-        return 'success'
-      }, 'success')
+      await retry(
+        async () => {
+          expect(await getSrc(browser, id)).toBe(
+            '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          )
+        },
+        30000,
+        1000
+      )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
         '/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
       )
@@ -816,9 +1055,15 @@ function runTests(mode) {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "src" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show invalid src error', async () => {
@@ -872,9 +1117,17 @@ function runTests(mode) {
     it('should warn when img with layout=responsive is inside flex container', async () => {
       const browser = await webdriver(appPort, '/layout-responsive-inside-flex')
       await browser.eval(`document.getElementById("img").scrollIntoView()`)
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image with src (.*)jpg(.*) may not render properly as a child of a flex container. Consider wrapping the image with a div to configure the width/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(
+            /Image with src (.*)jpg(.*) may not render properly as a child of a flex container. Consider wrapping the image with a div to configure the width/gm
+          )
+        },
+        30000,
+        1000
+      )
       await waitForNoRedbox(browser)
     })
 
@@ -944,15 +1197,19 @@ function runTests(mode) {
       let browser = await webdriver(appPort, '/priority-missing-warning')
       try {
         // Wait for image to load:
-        await check(async () => {
-          const result = await browser.eval(
-            `document.getElementById('responsive').naturalWidth`
-          )
-          if (result < 1) {
-            throw new Error('Image not ready')
-          }
-          return 'done'
-        }, 'done')
+        await retry(
+          async () => {
+            const result = await browser.eval(
+              `document.getElementById('responsive').naturalWidth`
+            )
+            if (result < 1) {
+              throw new Error('Image not ready')
+            }
+            expect('done').toBe('done')
+          },
+          30000,
+          1000
+        )
         await waitFor(1000)
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1044,15 +1301,19 @@ function runTests(mode) {
         `document.querySelector("button").textContent`
       )
       expect(count).toBe('Count: 2')
-      await check(async () => {
-        const result = await browser.eval(
-          'document.getElementById("w").naturalWidth'
-        )
-        if (result < 1) {
-          throw new Error('Image not loaded')
-        }
-        return 'done'
-      }, 'done')
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            'document.getElementById("w").naturalWidth'
+          )
+          if (result < 1) {
+            throw new Error('Image not loaded')
+          }
+          expect('done').toBe('done')
+        },
+        30000,
+        1000
+      )
       await waitFor(1000)
       const warnings = (await browser.log())
         .map((log) => log.message)
@@ -1086,17 +1347,19 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-        )
-
-        if (result < 1) {
-          throw new Error('Image not ready')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+          )
+          if (result < 1) {
+            throw new Error('Image not ready')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       await waitFor(1000)
 
@@ -1152,8 +1415,24 @@ function runTests(mode) {
 
   it('should apply filter style after image loads', async () => {
     const browser = await webdriver(appPort, '/style-filter')
-    await check(() => getSrc(browser, 'img-plain'), /^\/_next\/image/)
-    await check(() => getSrc(browser, 'img-blur'), /^\/_next\/image/)
+    await retry(
+      async () => {
+        await expect(getSrc(browser, 'img-plain')).resolves.toMatch(
+          /^\/_next\/image/
+        )
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        await expect(getSrc(browser, 'img-blur')).resolves.toMatch(
+          /^\/_next\/image/
+        )
+      },
+      30000,
+      1000
+    )
     await waitFor(1000)
 
     expect(await getComputedStyle(browser, 'img-plain', 'filter')).toBe(
@@ -1201,17 +1480,19 @@ function runTests(mode) {
         const id = 'exif-rotation-image'
 
         // Wait for image to load:
-        await check(async () => {
-          const result = await browser.eval(
-            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-          )
-
-          if (result < 1) {
-            throw new Error('Image not ready')
-          }
-
-          return 'result-correct'
-        }, /result-correct/)
+        await retry(
+          async () => {
+            const result = await browser.eval(
+              `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+            )
+            if (result < 1) {
+              throw new Error('Image not ready')
+            }
+            expect('result-correct').toMatch(/result-correct/)
+          },
+          30000,
+          1000
+        )
 
         await waitFor(1000)
 
@@ -1265,14 +1546,18 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/blurry-placeholder')
-      await check(
-        async () =>
-          await getComputedStyle(
-            browser,
-            'blurry-placeholder',
-            'background-image'
-          ),
-        'none'
+      await retry(
+        async () => {
+          expect(
+            await getComputedStyle(
+              browser,
+              'blurry-placeholder',
+              'background-image'
+            )
+          ).toBe('none')
+        },
+        30000,
+        1000
       )
 
       expect(
@@ -1287,14 +1572,18 @@ function runTests(mode) {
 
       await browser.eval('document.getElementById("spacer").remove()')
 
-      await check(
-        async () =>
-          await getComputedStyle(
-            browser,
-            'blurry-placeholder-with-lazy',
-            'background-image'
-          ),
-        'none'
+      await retry(
+        async () => {
+          expect(
+            await getComputedStyle(
+              browser,
+              'blurry-placeholder-with-lazy',
+              'background-image'
+            )
+          ).toBe('none')
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -1308,17 +1597,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/lazy-src-change')
       // image should not be loaded as it is out of viewport
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result >= 400) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result >= 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       // Move image into viewport
       await browser.eval(
@@ -1326,21 +1617,30 @@ function runTests(mode) {
       )
 
       // image should be loaded by now
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result < 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
-        if (result < 400) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(
-        () => browser.eval(`document.getElementById("basic-image").currentSrc`),
-        /test\.jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              `document.getElementById("basic-image").currentSrc`
+            )
+          ).toMatch(/test\.jpg/)
+        },
+        30000,
+        1000
       )
 
       // Make image out of viewport again
@@ -1352,38 +1652,49 @@ function runTests(mode) {
         'document.getElementById("button-change-image-src").click()'
       )
       // "new" image should be lazy loaded
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result >= 400) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result >= 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       // Move image into viewport again
       await browser.eval(
         'document.getElementById("spacer").style.display = "none"'
       )
       // "new" image should be loaded by now
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result < 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
-        if (result < 400) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(
-        () => browser.eval(`document.getElementById("basic-image").currentSrc`),
-        /test\.png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              `document.getElementById("basic-image").currentSrc`
+            )
+          ).toMatch(/test\.png/)
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -1396,53 +1707,61 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/lazy-withref')
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('myImage1').naturalWidth`
-        )
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('myImage1').naturalWidth`
+          )
+          if (result >= 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
-        if (result >= 400) {
-          throw new Error('Incorrectly loaded image')
-        }
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('myImage4').naturalWidth`
+          )
+          if (result >= 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('myImage2').naturalWidth`
+          )
+          if (result < 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('myImage4').naturalWidth`
-        )
-
-        if (result >= 400) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('myImage2').naturalWidth`
-        )
-
-        if (result < 400) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
-
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('myImage3').naturalWidth`
-        )
-
-        if (result < 400) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('myImage3').naturalWidth`
+          )
+          if (result < 400) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       expect(
         await hasImageMatchingUrl(

--- a/test/integration/next-image-legacy/no-intersection-observer-fallback/test/index.test.ts
+++ b/test/integration/next-image-legacy/no-intersection-observer-fallback/test/index.test.ts
@@ -1,10 +1,10 @@
 import {
-  check,
   findPort,
   killApp,
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -30,9 +30,15 @@ describe('Image Component No IntersectionObserver test', () => {
           browser = await webdriver(appPort, '/no-observer')
 
           // Make sure the IntersectionObserver is mocked to null during the test
-          await check(() => {
-            return browser.eval('IntersectionObserver')
-          }, /null/)
+          await retry(
+            async () => {
+              await expect(
+                browser.eval('IntersectionObserver')
+              ).resolves.toBeNull()
+            },
+            30000,
+            1000
+          )
 
           expect(
             await browser.elementById('lazy-no-observer').getAttribute('src')
@@ -52,9 +58,15 @@ describe('Image Component No IntersectionObserver test', () => {
           browser = await webdriver(appPort, '/')
 
           // Make sure the IntersectionObserver is mocked to null during the test
-          await check(() => {
-            return browser.eval('IntersectionObserver')
-          }, /null/)
+          await retry(
+            async () => {
+              await expect(
+                browser.eval('IntersectionObserver')
+              ).resolves.toBeNull()
+            },
+            30000,
+            1000
+          )
 
           await browser.waitForElementByCss('#link-no-observer').click()
 

--- a/test/integration/next-image-legacy/trailing-slash/test/index.test.ts
+++ b/test/integration/next-image-legacy/trailing-slash/test/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -62,15 +62,18 @@ describe('Image Component Trailing Slash Tests', () => {
         try {
           browser = await webdriver(appPort, '/')
           const id = 'test1'
-          await check(async () => {
-            const srcImage = await browser.eval(
-              `document.getElementById('${id}').src`
-            )
-            expect(srcImage).toMatch(
-              /\/_next\/image\/\?url=%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=828&q=75/
-            )
-            return 'success'
-          }, 'success')
+          await retry(
+            async () => {
+              const srcImage = await browser.eval(
+                `document.getElementById('${id}').src`
+              )
+              expect(srcImage).toMatch(
+                /\/_next\/image\/\?url=%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=828&q=75/
+              )
+            },
+            30000,
+            1000
+          )
         } finally {
           if (browser) {
             await browser.close()

--- a/test/integration/next-image-legacy/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-legacy/unoptimized/test/index.test.ts
@@ -2,12 +2,12 @@
 
 import { join } from 'path'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -45,42 +45,72 @@ function runTests() {
       await browser.elementById('eager-image').getAttribute('srcset')
     ).toBeNull()
 
-    await check(async () => {
-      await browser.eval(
-        `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
-      )
-      return browser.eval(
-        `document.getElementById("external-image").currentSrc`
-      )
-    }, 'https://image-optimization-test.vercel.app/test.jpg')
+    await retry(
+      async () => {
+        await browser.eval(
+          `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
+        )
+        expect(
+          await browser.eval(
+            `document.getElementById("external-image").currentSrc`
+          )
+        ).toBe('https://image-optimization-test.vercel.app/test.jpg')
+      },
+      30000,
+      1000
+    )
 
-    await check(async () => {
-      await browser.eval(
-        `window.scrollTo(0, 0); document.getElementById("internal-image").scrollIntoView()`
-      )
-      return browser.elementById('internal-image').getAttribute('src')
-    }, '/test.png')
+    await retry(
+      async () => {
+        await browser.eval(
+          `window.scrollTo(0, 0); document.getElementById("internal-image").scrollIntoView()`
+        )
+        expect(
+          await browser.elementById('internal-image').getAttribute('src')
+        ).toBe('/test.png')
+      },
+      30000,
+      1000
+    )
 
-    await check(async () => {
-      await browser.eval(
-        `window.scrollTo(0, 0); document.getElementById("static-image").scrollIntoView()`
-      )
-      return browser.elementById('static-image').getAttribute('src')
-    }, /test(.*)jpg/)
+    await retry(
+      async () => {
+        await browser.eval(
+          `window.scrollTo(0, 0); document.getElementById("static-image").scrollIntoView()`
+        )
+        expect(
+          await browser.elementById('static-image').getAttribute('src')
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
+    )
 
-    await check(async () => {
-      await browser.eval(
-        `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
-      )
-      return browser.elementById('external-image').getAttribute('src')
-    }, 'https://image-optimization-test.vercel.app/test.jpg')
+    await retry(
+      async () => {
+        await browser.eval(
+          `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
+        )
+        expect(
+          await browser.elementById('external-image').getAttribute('src')
+        ).toBe('https://image-optimization-test.vercel.app/test.jpg')
+      },
+      30000,
+      1000
+    )
 
-    await check(async () => {
-      await browser.eval(
-        `window.scrollTo(0, 0); document.getElementById("eager-image").scrollIntoView()`
-      )
-      return browser.elementById('eager-image').getAttribute('src')
-    }, '/test.webp')
+    await retry(
+      async () => {
+        await browser.eval(
+          `window.scrollTo(0, 0); document.getElementById("eager-image").scrollIntoView()`
+        )
+        expect(
+          await browser.elementById('eager-image').getAttribute('src')
+        ).toBe('/test.webp')
+      },
+      30000,
+      1000
+    )
 
     expect(
       await browser.elementById('internal-image').getAttribute('srcset')

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -5,7 +5,6 @@ import validateHTML from 'html-validator'
 import {
   waitForRedbox,
   waitForNoRedbox,
-  check,
   fetchViaHTTP,
   findPort,
   getImagesManifest,
@@ -79,17 +78,19 @@ function runTests(mode: 'dev' | 'server') {
     try {
       browser = await webdriver(appPort, '/')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       expect(
         await hasImageMatchingUrl(
@@ -109,17 +110,19 @@ function runTests(mode: 'dev' | 'server') {
     try {
       browser = await webdriver(appPort, '/priority')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -260,17 +263,19 @@ function runTests(mode: 'dev' | 'server') {
     try {
       browser = await webdriver(appPort, '/preload')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -432,16 +437,26 @@ function runTests(mode: 'dev' | 'server') {
     try {
       browser = await webdriver(appPort, '/update')
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.jpg/)
+        },
+        30000,
+        1000
       )
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.png/)
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -457,84 +472,172 @@ function runTests(mode: 'dev' | 'server') {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").currentSrc`)
+        ).toMatch(/test(.*).png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img3").currentSrc`)
+        ).toMatch(/test\.svg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img4").currentSrc`)
+        ).toMatch(/test(.*)ico/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded 1 img1 with dimensions 128x128'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('loaded 1 img1 with dimensions 128x128')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded 1 img2 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('loaded 1 img2 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded 1 img3 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toBe('loaded 1 img3 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded 1 img4 with dimensions 32x32'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toBe('loaded 1 img4 with dimensions 32x32')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded 1 img5 with dimensions 3x5'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg5").textContent`)
+        ).toBe('loaded 1 img5 with dimensions 3x5')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded 1 img6 with dimensions 3x5'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg6").textContent`)
+        ).toBe('loaded 1 img6 with dimensions 3x5')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg7").textContent`),
-      'loaded 1 img7 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg7").textContent`)
+        ).toBe('loaded 1 img7 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 1 img8 with dimensions 640x373'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toBe('loaded 1 img8 with dimensions 640x373')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          )
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /wide.png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/wide.png/)
+      },
+      30000,
+      1000
     )
     await browser.eval('document.getElementById("toggle").click()')
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 2 img8 with dimensions 400x300'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toBe('loaded 2 img8 with dimensions 400x300')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          )
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /test-rect.jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/test-rect.jpg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg9").textContent`),
-      'loaded 1 img9 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg9").textContent`)
+        ).toBe('loaded 1 img9 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
 
     if (mode === 'dev') {
@@ -554,88 +657,184 @@ function runTests(mode: 'dev' | 'server') {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('loaded img1 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('loaded img2 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toBe('loaded img3 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toBe('loaded img4 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg5").textContent`)
+        ).toBe('loaded img5 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg6").textContent`)
+        ).toBe('loaded img6 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img5").getAttribute("data-nimg")`
-        ),
-      '1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img5").getAttribute("data-nimg")`
+          )
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
 
     await browser.eval('document.getElementById("toggle").click()')
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('loaded img1 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('loaded img2 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toBe('loaded img3 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toBe('loaded img4 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg5").textContent`)
+        ).toBe('loaded img5 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg6").textContent`)
+        ).toBe('loaded img6 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").currentSrc`)
+        ).toMatch(/test(.*).png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img3").currentSrc`)
+        ).toMatch(/test\.svg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img4").currentSrc`)
+        ).toMatch(/test(.*)ico/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img5").currentSrc`),
-      /wide.png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img5").currentSrc`)
+        ).toMatch(/wide.png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img6").currentSrc`),
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img6").currentSrc`)
+        ).toBe(
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
+        )
+      },
+      30000,
+      1000
     )
   })
 
@@ -644,41 +843,76 @@ function runTests(mode: 'dev' | 'server') {
     await browser.eval(
       `document.getElementById("img1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'no error occurred for img1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('no error occurred for img1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img1").style.color`),
-      'transparent'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").style.color`)
+        ).toBe('transparent')
+      },
+      30000,
+      1000
     )
     await browser.eval(
       `document.getElementById("img2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'no error occurred for img2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('no error occurred for img2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      'transparent'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").style.color`)
+        ).toBe('transparent')
+      },
+      30000,
+      1000
     )
     await browser.eval(`document.getElementById("toggle").click()`)
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'error occurred while loading img2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('error occurred while loading img2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      ''
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").style.color`)
+        ).toBe('')
+      },
+      30000,
+      1000
     )
   })
 
   it('should callback native onError even when error before hydration', async () => {
     let browser = await webdriver(appPort, '/on-error-before-hydration')
-    await check(
-      () => browser.eval(`document.getElementById("msg").textContent`),
-      'error state'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg").textContent`)
+        ).toBe('error state')
+      },
+      30000,
+      1000
     )
   })
 
@@ -687,13 +921,23 @@ function runTests(mode: 'dev' | 'server') {
     try {
       browser = await webdriver(appPort, '/blob')
 
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").src`),
-        /^blob:/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("blob-image").src`)
+          ).toMatch(/^blob:/)
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").srcset`),
-        ''
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("blob-image").srcset`)
+          ).toBe('')
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -706,16 +950,19 @@ function runTests(mode: 'dev' | 'server') {
     let browser
     try {
       browser = await webdriver(appPort, '/flex')
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').width`
-        )
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').width`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -725,24 +972,39 @@ function runTests(mode: 'dev' | 'server') {
 
   it('should work when using overrideSrc prop', async () => {
     const browser = await webdriver(appPort, '/override-src')
-    await check(async () => {
-      const result = await browser.eval(
-        `document.getElementById('override-src').width`
-      )
-      if (result === 0) {
-        throw new Error('Incorrectly loaded image')
-      }
-
-      return 'result-correct'
-    }, /result-correct/)
-
-    await check(
-      () => browser.eval(`document.getElementById('override-src').currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        const result = await browser.eval(
+          `document.getElementById('override-src').width`
+        )
+        if (result === 0) {
+          throw new Error('Incorrectly loaded image')
+        }
+        expect('result-correct').toMatch(/result-correct/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById('override-src').src`),
-      /myoverride/
+
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById('override-src').currentSrc`
+          )
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById('override-src').src`)
+        ).toMatch(/myoverride/)
+      },
+      30000,
+      1000
     )
   })
 
@@ -855,9 +1117,14 @@ function runTests(mode: 'dev' | 'server') {
     await browser.eval(
       `document.getElementById("blur1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur1").currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("blur1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
     )
     expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
@@ -900,9 +1167,14 @@ function runTests(mode: 'dev' | 'server') {
     await browser.eval(
       `document.getElementById("blur2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur2").currentSrc`),
-      /test(.*)png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("blur2").currentSrc`)
+        ).toMatch(/test(.*)png/)
+      },
+      30000,
+      1000
     )
     expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
@@ -1000,17 +1272,19 @@ function runTests(mode: 'dev' | 'server') {
   it('should render picture via getImageProps', async () => {
     const browser = await webdriver(appPort, '/picture')
     // Wait for image to load:
-    await check(async () => {
-      const naturalWidth = await browser.eval(
-        `document.querySelector('img').naturalWidth`
-      )
-
-      if (naturalWidth === 0) {
-        throw new Error('Image did not load')
-      }
-
-      return 'ready'
-    }, 'ready')
+    await retry(
+      async () => {
+        const naturalWidth = await browser.eval(
+          `document.querySelector('img').naturalWidth`
+        )
+        if (naturalWidth === 0) {
+          throw new Error('Image did not load')
+        }
+        expect('ready').toBe('ready')
+      },
+      30000,
+      1000
+    )
     const img = await browser.elementByCss('img')
     expect(img).toBeDefined()
     expect(await img.getAttribute('alt')).toBe('Hero')
@@ -1039,9 +1313,15 @@ function runTests(mode: 'dev' | 'server') {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "src" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show empty string src error', async () => {
@@ -1049,9 +1329,15 @@ function runTests(mode: 'dev' | 'server') {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "src" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show null src error', async () => {
@@ -1141,9 +1427,15 @@ function runTests(mode: 'dev' | 'server') {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "alt" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "alt" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show error when missing width prop', async () => {
@@ -1235,15 +1527,19 @@ function runTests(mode: 'dev' | 'server') {
       let browser = await webdriver(appPort, '/preload-missing-warning')
       try {
         // Wait for image to load:
-        await check(async () => {
-          const result = await browser.eval(
-            `document.getElementById('responsive').naturalWidth`
-          )
-          if (result < 1) {
-            throw new Error('Image not ready')
-          }
-          return 'done'
-        }, 'done')
+        await retry(
+          async () => {
+            const result = await browser.eval(
+              `document.getElementById('responsive').naturalWidth`
+            )
+            if (result < 1) {
+              throw new Error('Image not ready')
+            }
+            expect('done').toBe('done')
+          },
+          30000,
+          1000
+        )
         await waitFor(1000)
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1325,15 +1621,19 @@ function runTests(mode: 'dev' | 'server') {
         `document.querySelector("button").textContent`
       )
       expect(count).toBe('Count: 2')
-      await check(async () => {
-        const result = await browser.eval(
-          'document.getElementById("w").naturalWidth'
-        )
-        if (result < 1) {
-          throw new Error('Image not loaded')
-        }
-        return 'done'
-      }, 'done')
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            'document.getElementById("w").naturalWidth'
+          )
+          if (result < 1) {
+            throw new Error('Image not loaded')
+          }
+          expect('done').toBe('done')
+        },
+        30000,
+        1000
+      )
       await waitFor(1000)
       const warnings = (await browser.log())
         .map((log) => log.message)
@@ -1390,17 +1690,19 @@ function runTests(mode: 'dev' | 'server') {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-        )
-
-        if (result < 1) {
-          throw new Error('Image not ready')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+          )
+          if (result < 1) {
+            throw new Error('Image not ready')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       await waitFor(1000)
 
@@ -1456,8 +1758,24 @@ function runTests(mode: 'dev' | 'server') {
 
   it('should apply filter style after image loads', async () => {
     const browser = await webdriver(appPort, '/style-filter')
-    await check(() => getSrc(browser, 'img-plain'), /^\/_next\/image/)
-    await check(() => getSrc(browser, 'img-blur'), /^\/_next\/image/)
+    await retry(
+      async () => {
+        await expect(getSrc(browser, 'img-plain')).resolves.toMatch(
+          /^\/_next\/image/
+        )
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        await expect(getSrc(browser, 'img-blur')).resolves.toMatch(
+          /^\/_next\/image/
+        )
+      },
+      30000,
+      1000
+    )
     await waitFor(1000)
 
     expect(await getComputedStyle(browser, 'img-plain', 'filter')).toBe(
@@ -1581,17 +1899,19 @@ function runTests(mode: 'dev' | 'server') {
       const id = 'exif-rotation-image'
 
       // Wait for image to load:
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Image not ready')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Image not ready')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       await waitFor(500)
 
@@ -1618,14 +1938,18 @@ function runTests(mode: 'dev' | 'server') {
 
   it('should remove data url placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/data-url-placeholder')
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'data-url-placeholder-raw',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'data-url-placeholder-raw',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
     expect(
       await getComputedStyle(
@@ -1639,14 +1963,18 @@ function runTests(mode: 'dev' | 'server') {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'data-url-placeholder-with-lazy',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'data-url-placeholder-with-lazy',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
   })
 
@@ -1684,14 +2012,18 @@ function runTests(mode: 'dev' | 'server') {
 
   it('should remove blurry placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/blurry-placeholder')
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'blurry-placeholder-raw',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'blurry-placeholder-raw',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
     expect(
       await getComputedStyle(
@@ -1705,14 +2037,18 @@ function runTests(mode: 'dev' | 'server') {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'blurry-placeholder-with-lazy',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'blurry-placeholder-with-lazy',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
   })
 

--- a/test/integration/next-image-new/base-path/test/index.test.ts
+++ b/test/integration/next-image-new/base-path/test/index.test.ts
@@ -3,7 +3,6 @@
 import {
   waitForRedbox,
   waitForNoRedbox,
-  check,
   findPort,
   getRedboxHeader,
   killApp,
@@ -11,6 +10,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -58,17 +58,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/docs')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       expect(
         await hasImageMatchingUrl(
@@ -88,16 +90,26 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/docs/update')
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.jpg/)
+        },
+        30000,
+        1000
       )
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.png/)
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -110,16 +122,19 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/docs/flex')
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').width`
-        )
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').width`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -133,9 +148,15 @@ function runTests(mode) {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "src" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show invalid src error', async () => {
@@ -168,17 +189,19 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-        )
-
-        if (result < 1) {
-          throw new Error('Image not ready')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+          )
+          if (result < 1) {
+            throw new Error('Image not ready')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       await waitFor(1000)
 

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -5,7 +5,6 @@ import validateHTML from 'html-validator'
 import {
   waitForRedbox,
   waitForNoRedbox,
-  check,
   fetchViaHTTP,
   findPort,
   getRedboxHeader,
@@ -81,17 +80,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       expect(
         await hasImageMatchingUrl(
@@ -111,17 +112,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/priority')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -262,17 +265,19 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/preload')
 
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       const links = await browser.elementsByCss('link[rel=preload][as=image]')
       const entries = []
@@ -431,16 +436,26 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/update')
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.jpg/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.jpg/)
+        },
+        30000,
+        1000
       )
 
       await browser.eval(`document.getElementById("toggle").click()`)
 
-      await check(
-        () => browser.eval(`document.getElementById("update-image").src`),
-        /test\.png/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("update-image").src`)
+          ).toMatch(/test\.png/)
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -456,84 +471,172 @@ function runTests(mode) {
       `document.getElementById("footer").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").currentSrc`)
+        ).toMatch(/test(.*).png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img3").currentSrc`)
+        ).toMatch(/test\.svg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img4").currentSrc`)
+        ).toMatch(/test(.*)ico/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded 1 img1 with dimensions 128x128'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('loaded 1 img1 with dimensions 128x128')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded 1 img2 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('loaded 1 img2 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded 1 img3 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toBe('loaded 1 img3 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded 1 img4 with dimensions 32x32'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toBe('loaded 1 img4 with dimensions 32x32')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded 1 img5 with dimensions 3x5'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg5").textContent`)
+        ).toBe('loaded 1 img5 with dimensions 3x5')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded 1 img6 with dimensions 3x5'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg6").textContent`)
+        ).toBe('loaded 1 img6 with dimensions 3x5')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg7").textContent`),
-      'loaded 1 img7 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg7").textContent`)
+        ).toBe('loaded 1 img7 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 1 img8 with dimensions 640x373'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toBe('loaded 1 img8 with dimensions 640x373')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          )
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /wide.png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/wide.png/)
+      },
+      30000,
+      1000
     )
     await browser.eval('document.getElementById("toggle").click()')
-    await check(
-      () => browser.eval(`document.getElementById("msg8").textContent`),
-      'loaded 2 img8 with dimensions 400x300'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg8").textContent`)
+        ).toBe('loaded 2 img8 with dimensions 400x300')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img8").getAttribute("data-nimg")`
-        ),
-      '1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img8").getAttribute("data-nimg")`
+          )
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img8").currentSrc`),
-      /test-rect.jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img8").currentSrc`)
+        ).toMatch(/test-rect.jpg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg9").textContent`),
-      'loaded 1 img9 with dimensions 400x400'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg9").textContent`)
+        ).toBe('loaded 1 img9 with dimensions 400x400')
+      },
+      30000,
+      1000
     )
 
     if (mode === 'dev') {
@@ -553,88 +656,184 @@ function runTests(mode) {
       `document.getElementById("msg1").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('loaded img1 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('loaded img2 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toBe('loaded img3 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toBe('loaded img4 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg5").textContent`)
+        ).toBe('loaded img5 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg6").textContent`)
+        ).toBe('loaded img6 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () =>
-        browser.eval(
-          `document.getElementById("img5").getAttribute("data-nimg")`
-        ),
-      '1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("img5").getAttribute("data-nimg")`
+          )
+        ).toBe('1')
+      },
+      30000,
+      1000
     )
 
     await browser.eval('document.getElementById("toggle").click()')
 
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'loaded img1 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('loaded img1 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'loaded img2 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('loaded img2 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg3").textContent`),
-      'loaded img3 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg3").textContent`)
+        ).toBe('loaded img3 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg4").textContent`),
-      'loaded img4 with native onLoad, count 2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg4").textContent`)
+        ).toBe('loaded img4 with native onLoad, count 2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg5").textContent`),
-      'loaded img5 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg5").textContent`)
+        ).toBe('loaded img5 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg6").textContent`),
-      'loaded img6 with native onLoad, count 1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg6").textContent`)
+        ).toBe('loaded img6 with native onLoad, count 1')
+      },
+      30000,
+      1000
     )
 
-    await check(
-      () => browser.eval(`document.getElementById("img1").currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").currentSrc`),
-      /test(.*).png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").currentSrc`)
+        ).toMatch(/test(.*).png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img3").currentSrc`),
-      /test\.svg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img3").currentSrc`)
+        ).toMatch(/test\.svg/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img4").currentSrc`),
-      /test(.*)ico/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img4").currentSrc`)
+        ).toMatch(/test(.*)ico/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img5").currentSrc`),
-      /wide.png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img5").currentSrc`)
+        ).toMatch(/wide.png/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img6").currentSrc`),
-      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img6").currentSrc`)
+        ).toBe(
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mO8ysv7HwAEngHwC+JqOgAAAABJRU5ErkJggg=='
+        )
+      },
+      30000,
+      1000
     )
   })
 
@@ -643,41 +842,76 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("img1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg1").textContent`),
-      'no error occurred for img1'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg1").textContent`)
+        ).toBe('no error occurred for img1')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img1").style.color`),
-      'transparent'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img1").style.color`)
+        ).toBe('transparent')
+      },
+      30000,
+      1000
     )
     await browser.eval(
       `document.getElementById("img2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'no error occurred for img2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('no error occurred for img2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      'transparent'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").style.color`)
+        ).toBe('transparent')
+      },
+      30000,
+      1000
     )
     await browser.eval(`document.getElementById("toggle").click()`)
-    await check(
-      () => browser.eval(`document.getElementById("msg2").textContent`),
-      'error occurred while loading img2'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg2").textContent`)
+        ).toBe('error occurred while loading img2')
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById("img2").style.color`),
-      ''
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("img2").style.color`)
+        ).toBe('')
+      },
+      30000,
+      1000
     )
   })
 
   it('should callback native onError even when error before hydration', async () => {
     let browser = await webdriver(appPort, '/on-error-before-hydration')
-    await check(
-      () => browser.eval(`document.getElementById("msg").textContent`),
-      'error state'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("msg").textContent`)
+        ).toBe('error state')
+      },
+      30000,
+      1000
     )
   })
 
@@ -686,13 +920,23 @@ function runTests(mode) {
     try {
       browser = await webdriver(appPort, '/blob')
 
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").src`),
-        /^blob:/
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("blob-image").src`)
+          ).toMatch(/^blob:/)
+        },
+        30000,
+        1000
       )
-      await check(
-        () => browser.eval(`document.getElementById("blob-image").srcset`),
-        ''
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(`document.getElementById("blob-image").srcset`)
+          ).toBe('')
+        },
+        30000,
+        1000
       )
     } finally {
       if (browser) {
@@ -705,16 +949,19 @@ function runTests(mode) {
     let browser
     try {
       browser = await webdriver(appPort, '/flex')
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById('basic-image').width`
-        )
-        if (result === 0) {
-          throw new Error('Incorrectly loaded image')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById('basic-image').width`
+          )
+          if (result === 0) {
+            throw new Error('Incorrectly loaded image')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -724,24 +971,39 @@ function runTests(mode) {
 
   it('should work when using overrideSrc prop', async () => {
     const browser = await webdriver(appPort, '/override-src')
-    await check(async () => {
-      const result = await browser.eval(
-        `document.getElementById('override-src').width`
-      )
-      if (result === 0) {
-        throw new Error('Incorrectly loaded image')
-      }
-
-      return 'result-correct'
-    }, /result-correct/)
-
-    await check(
-      () => browser.eval(`document.getElementById('override-src').currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        const result = await browser.eval(
+          `document.getElementById('override-src').width`
+        )
+        if (result === 0) {
+          throw new Error('Incorrectly loaded image')
+        }
+        expect('result-correct').toMatch(/result-correct/)
+      },
+      30000,
+      1000
     )
-    await check(
-      () => browser.eval(`document.getElementById('override-src').src`),
-      /myoverride/
+
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById('override-src').currentSrc`
+          )
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById('override-src').src`)
+        ).toMatch(/myoverride/)
+      },
+      30000,
+      1000
     )
   })
 
@@ -854,9 +1116,14 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("blur1").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur1").currentSrc`),
-      /test(.*)jpg/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("blur1").currentSrc`)
+        ).toMatch(/test(.*)jpg/)
+      },
+      30000,
+      1000
     )
     expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
@@ -899,9 +1166,14 @@ function runTests(mode) {
     await browser.eval(
       `document.getElementById("blur2").scrollIntoView({behavior: "smooth"})`
     )
-    await check(
-      () => browser.eval(`document.getElementById("blur2").currentSrc`),
-      /test(.*)png/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(`document.getElementById("blur2").currentSrc`)
+        ).toMatch(/test(.*)png/)
+      },
+      30000,
+      1000
     )
     expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
       /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
@@ -999,17 +1271,19 @@ function runTests(mode) {
   it('should render picture via getImageProps', async () => {
     const browser = await webdriver(appPort, '/picture')
     // Wait for image to load:
-    await check(async () => {
-      const naturalWidth = await browser.eval(
-        `document.querySelector('img').naturalWidth`
-      )
-
-      if (naturalWidth === 0) {
-        throw new Error('Image did not load')
-      }
-
-      return 'ready'
-    }, 'ready')
+    await retry(
+      async () => {
+        const naturalWidth = await browser.eval(
+          `document.querySelector('img').naturalWidth`
+        )
+        if (naturalWidth === 0) {
+          throw new Error('Image did not load')
+        }
+        expect('ready').toBe('ready')
+      },
+      30000,
+      1000
+    )
     const img = await browser.elementByCss('img')
     expect(img).toBeDefined()
     expect(await img.getAttribute('alt')).toBe('Hero')
@@ -1038,9 +1312,15 @@ function runTests(mode) {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "src" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show empty string src error', async () => {
@@ -1048,9 +1328,15 @@ function runTests(mode) {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "src" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "src" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show null src error', async () => {
@@ -1140,9 +1426,15 @@ function runTests(mode) {
 
       await waitForNoRedbox(browser)
 
-      await check(async () => {
-        return (await browser.log()).map((log) => log.message).join('\n')
-      }, /Image is missing required "alt" property/gm)
+      await retry(
+        async () => {
+          expect(
+            (await browser.log()).map((log) => log.message).join('\n')
+          ).toMatch(/Image is missing required "alt" property/gm)
+        },
+        30000,
+        1000
+      )
     })
 
     it('should show error when missing width prop', async () => {
@@ -1234,15 +1526,19 @@ function runTests(mode) {
       let browser = await webdriver(appPort, '/preload-missing-warning')
       try {
         // Wait for image to load:
-        await check(async () => {
-          const result = await browser.eval(
-            `document.getElementById('responsive').naturalWidth`
-          )
-          if (result < 1) {
-            throw new Error('Image not ready')
-          }
-          return 'done'
-        }, 'done')
+        await retry(
+          async () => {
+            const result = await browser.eval(
+              `document.getElementById('responsive').naturalWidth`
+            )
+            if (result < 1) {
+              throw new Error('Image not ready')
+            }
+            expect('done').toBe('done')
+          },
+          30000,
+          1000
+        )
         await waitFor(1000)
         const warnings = (await browser.log())
           .map((log) => log.message)
@@ -1324,15 +1620,19 @@ function runTests(mode) {
         `document.querySelector("button").textContent`
       )
       expect(count).toBe('Count: 2')
-      await check(async () => {
-        const result = await browser.eval(
-          'document.getElementById("w").naturalWidth'
-        )
-        if (result < 1) {
-          throw new Error('Image not loaded')
-        }
-        return 'done'
-      }, 'done')
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            'document.getElementById("w").naturalWidth'
+          )
+          if (result < 1) {
+            throw new Error('Image not loaded')
+          }
+          expect('done').toBe('done')
+        },
+        30000,
+        1000
+      )
       await waitFor(1000)
       const warnings = (await browser.log())
         .map((log) => log.message)
@@ -1394,17 +1694,19 @@ function runTests(mode) {
       const id = 'prose-image'
 
       // Wait for image to load:
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-        )
-
-        if (result < 1) {
-          throw new Error('Image not ready')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+          )
+          if (result < 1) {
+            throw new Error('Image not ready')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       await waitFor(1000)
 
@@ -1460,8 +1762,24 @@ function runTests(mode) {
 
   it('should apply filter style after image loads', async () => {
     const browser = await webdriver(appPort, '/style-filter')
-    await check(() => getSrc(browser, 'img-plain'), /^\/_next\/image/)
-    await check(() => getSrc(browser, 'img-blur'), /^\/_next\/image/)
+    await retry(
+      async () => {
+        await expect(getSrc(browser, 'img-plain')).resolves.toMatch(
+          /^\/_next\/image/
+        )
+      },
+      30000,
+      1000
+    )
+    await retry(
+      async () => {
+        await expect(getSrc(browser, 'img-blur')).resolves.toMatch(
+          /^\/_next\/image/
+        )
+      },
+      30000,
+      1000
+    )
     await waitFor(1000)
 
     expect(await getComputedStyle(browser, 'img-plain', 'filter')).toBe(
@@ -1585,17 +1903,19 @@ function runTests(mode) {
       const id = 'exif-rotation-image'
 
       // Wait for image to load:
-      await check(async () => {
-        const result = await browser.eval(
-          `document.getElementById(${JSON.stringify(id)}).naturalWidth`
-        )
-
-        if (result === 0) {
-          throw new Error('Image not ready')
-        }
-
-        return 'result-correct'
-      }, /result-correct/)
+      await retry(
+        async () => {
+          const result = await browser.eval(
+            `document.getElementById(${JSON.stringify(id)}).naturalWidth`
+          )
+          if (result === 0) {
+            throw new Error('Image not ready')
+          }
+          expect('result-correct').toMatch(/result-correct/)
+        },
+        30000,
+        1000
+      )
 
       await waitFor(500)
 
@@ -1629,14 +1949,18 @@ function runTests(mode) {
 
   it('should remove data url placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/data-url-placeholder')
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'data-url-placeholder-raw',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'data-url-placeholder-raw',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
     expect(
       await getComputedStyle(
@@ -1650,14 +1974,18 @@ function runTests(mode) {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'data-url-placeholder-with-lazy',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'data-url-placeholder-with-lazy',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
   })
 
@@ -1695,14 +2023,18 @@ function runTests(mode) {
 
   it('should remove blurry placeholder after image loads', async () => {
     const browser = await webdriver(appPort, '/blurry-placeholder')
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'blurry-placeholder-raw',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'blurry-placeholder-raw',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
     expect(
       await getComputedStyle(
@@ -1716,14 +2048,18 @@ function runTests(mode) {
 
     await browser.eval('document.getElementById("spacer").remove()')
 
-    await check(
-      async () =>
-        await getComputedStyle(
-          browser,
-          'blurry-placeholder-with-lazy',
-          'background-image'
-        ),
-      'none'
+    await retry(
+      async () => {
+        expect(
+          await getComputedStyle(
+            browser,
+            'blurry-placeholder-with-lazy',
+            'background-image'
+          )
+        ).toBe('none')
+      },
+      30000,
+      1000
     )
   })
 

--- a/test/integration/next-image-new/trailing-slash/test/index.test.ts
+++ b/test/integration/next-image-new/trailing-slash/test/index.test.ts
@@ -1,12 +1,12 @@
 /* eslint-env jest */
 
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -62,15 +62,18 @@ describe('Image Component Trailing Slash Tests', () => {
         try {
           browser = await webdriver(appPort, '/')
           const id = 'test1'
-          await check(async () => {
-            const srcImage = await browser.eval(
-              `document.getElementById('${id}').src`
-            )
-            expect(srcImage).toMatch(
-              /\/_next\/image\/\?url=%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=828&q=75/
-            )
-            return 'success'
-          }, 'success')
+          await retry(
+            async () => {
+              const srcImage = await browser.eval(
+                `document.getElementById('${id}').src`
+              )
+              expect(srcImage).toMatch(
+                /\/_next\/image\/\?url=%2F_next%2Fstatic%2Fmedia%2Ftest(.+).jpg&w=828&q=75/
+              )
+            },
+            30000,
+            1000
+          )
         } finally {
           if (browser) {
             await browser.close()

--- a/test/integration/next-image-new/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-new/unoptimized/test/index.test.ts
@@ -2,13 +2,13 @@
 
 import { join } from 'path'
 import {
-  check,
   findPort,
   getImagesManifest,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -58,10 +58,16 @@ function runTests(url: string, mode: 'dev' | 'server') {
       `document.getElementById("eager-image").scrollIntoView({behavior: "smooth"})`
     )
 
-    await check(
-      () =>
-        browser.eval(`document.getElementById("external-image").currentSrc`),
-      'https://image-optimization-test.vercel.app/test.jpg'
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(
+            `document.getElementById("external-image").currentSrc`
+          )
+        ).toBe('https://image-optimization-test.vercel.app/test.jpg')
+      },
+      30000,
+      1000
     )
 
     expect(

--- a/test/integration/not-found-revalidate/test/index.test.ts
+++ b/test/integration/not-found-revalidate/test/index.test.ts
@@ -10,7 +10,7 @@ import {
   killApp,
   fetchViaHTTP,
   waitFor,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -46,32 +46,44 @@ const runTests = () => {
 
     // wait for revalidation to occur in background
     try {
-      await check(async () => {
-        res = await fetchViaHTTP(appPort, '/initial-not-found/first')
-        $ = cheerio.load(await res.text())
+      await retry(
+        async () => {
+          res = await fetchViaHTTP(appPort, '/initial-not-found/first')
+          $ = cheerio.load(await res.text())
 
-        return res.status === 200 && $('#data').text() === '200'
-          ? 'success'
-          : `${res.status} - ${$('#data').text()}`
-      }, 'success')
+          return res.status === 200 && $('#data').text() === '200'
+            ? 'success'
+            : `${res.status} - ${$('#data').text()}`
+        },
+        30000,
+        1000
+      )
 
-      await check(async () => {
-        res = await fetchViaHTTP(appPort, '/initial-not-found/second')
-        $ = cheerio.load(await res.text())
+      await retry(
+        async () => {
+          res = await fetchViaHTTP(appPort, '/initial-not-found/second')
+          $ = cheerio.load(await res.text())
 
-        return res.status === 200 && $('#data').text() === '200'
-          ? 'success'
-          : `${res.status} - ${$('#data').text()}`
-      }, 'success')
+          return res.status === 200 && $('#data').text() === '200'
+            ? 'success'
+            : `${res.status} - ${$('#data').text()}`
+        },
+        30000,
+        1000
+      )
 
-      await check(async () => {
-        res = await fetchViaHTTP(appPort, '/initial-not-found')
-        $ = cheerio.load(await res.text())
+      await retry(
+        async () => {
+          res = await fetchViaHTTP(appPort, '/initial-not-found')
+          $ = cheerio.load(await res.text())
 
-        return res.status === 200 && $('#data').text() === '200'
-          ? 'success'
-          : `${res.status} - ${$('#data').text()}`
-      }, 'success')
+          return res.status === 200 && $('#data').text() === '200'
+            ? 'success'
+            : `${res.status} - ${$('#data').text()}`
+        },
+        30000,
+        1000
+      )
     } finally {
       await fs.writeFile(dataFile, '404')
     }

--- a/test/integration/ondemand/test/index.test.ts
+++ b/test/integration/ondemand/test/index.test.ts
@@ -6,11 +6,11 @@ import {
   renderViaHTTP,
   killApp,
   waitFor,
-  check,
   getBrowserBodyText,
   getPageFileFromBuildManifest,
   getBuildManifest,
   initNextServerScript,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -88,10 +88,14 @@ const startServer = async (optEnv = {}, opts?: any) => {
 
         await browser.eval('document.getElementById("to-dynamic").click()')
 
-        await check(async () => {
-          const text = await getBrowserBodyText(browser)
-          return text
-        }, /Hello/)
+        await retry(
+          async () => {
+            const text = await getBrowserBodyText(browser)
+            expect(text).toMatch(/Hello/)
+          },
+          30000,
+          1000
+        )
       } finally {
         if (browser) {
           await browser.close()

--- a/test/integration/preload-viewport/test/index.test.ts
+++ b/test/integration/preload-viewport/test/index.test.ts
@@ -1,7 +1,6 @@
 /* eslint-env jest */
 
 import {
-  check,
   retry,
   findPort,
   killApp,
@@ -519,9 +518,14 @@ describe('Prefetching Links in viewport', () => {
       }
       window.next.router.push('/de-duped')
     })()`)
-        await check(
-          () => browser.eval('document.documentElement.innerHTML'),
-          /to \/first/
+        await retry(
+          async () => {
+            expect(
+              await browser.eval('document.documentElement.innerHTML')
+            ).toMatch(/to \/first/)
+          },
+          30000,
+          1000
         )
         const calledPrefetch = await browser.eval(`window.calledPrefetch`)
         expect(calledPrefetch).toBe(false)

--- a/test/integration/prerender-fallback-encoding/test/index.test.ts
+++ b/test/integration/prerender-fallback-encoding/test/index.test.ts
@@ -11,7 +11,7 @@ import {
   launchApp,
   nextStart,
   fetchViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -107,13 +107,23 @@ function runTests(isDev: boolean) {
             if (!isDev) {
               // we don't block on writing incremental data to the
               // disk so use check
-              await check(
-                () => fs.existsSync(join(pagesDir, mode, path + '.html')),
-                true
+              await retry(
+                () => {
+                  expect(
+                    fs.existsSync(join(pagesDir, mode, path + '.html'))
+                  ).toBe(true)
+                },
+                30000,
+                1000
               )
-              await check(
-                () => fs.existsSync(join(pagesDir, mode, path + '.json')),
-                true
+              await retry(
+                () => {
+                  expect(
+                    fs.existsSync(join(pagesDir, mode, path + '.json'))
+                  ).toBe(true)
+                },
+                30000,
+                1000
               )
             }
 
@@ -255,14 +265,18 @@ function runTests(isDev: boolean) {
           })
         })()`)
 
-        await check(async () => {
-          const browserRouter = JSON.parse(
-            await browser.elementByCss('#router').text()
-          )
-          return browserRouter.asPath === `/${mode}/${nextSlug}`
-            ? 'success'
-            : 'fail'
-        }, 'success')
+        await retry(
+          async () => {
+            const browserRouter = JSON.parse(
+              await browser.elementByCss('#router').text()
+            )
+            return browserRouter.asPath === `/${mode}/${nextSlug}`
+              ? 'success'
+              : 'fail'
+          },
+          30000,
+          1000
+        )
 
         expect(await browser.eval('window.beforeNav')).toBe(1)
       }
@@ -299,14 +313,18 @@ function runTests(isDev: boolean) {
           window.next.router.push('/${mode}/${nextSlug}')
         })()`)
 
-        await check(async () => {
-          const browserRouter = JSON.parse(
-            await browser.elementByCss('#router').text()
-          )
-          return browserRouter.asPath === `/${mode}/${nextSlug}`
-            ? 'success'
-            : 'fail'
-        }, 'success')
+        await retry(
+          async () => {
+            const browserRouter = JSON.parse(
+              await browser.elementByCss('#router').text()
+            )
+            return browserRouter.asPath === `/${mode}/${nextSlug}`
+              ? 'success'
+              : 'fail'
+          },
+          30000,
+          1000
+        )
 
         expect(await browser.eval('window.beforeNav')).toBe(1)
       }

--- a/test/integration/prerender/test/index.test.ts
+++ b/test/integration/prerender/test/index.test.ts
@@ -2,11 +2,11 @@
 import fs from 'fs-extra'
 import { join } from 'path'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -48,7 +48,15 @@ describe('SSG Prerender', () => {
 
     it('should not cache getStaticPaths errors', async () => {
       const errMsg = /The `fallback` key must be returned from getStaticPaths/
-      await check(() => renderViaHTTP(appPort, '/blog/post-1'), /post-1/)
+      await retry(
+        async () => {
+          await expect(renderViaHTTP(appPort, '/blog/post-1')).resolves.toMatch(
+            /post-1/
+          )
+        },
+        30000,
+        1000
+      )
 
       const blogPage = join(appDir, 'pages/blog/[post]/index.js')
       const origContent = await fs.readFile(blogPage, 'utf8')
@@ -58,10 +66,26 @@ describe('SSG Prerender', () => {
       )
 
       try {
-        await check(() => renderViaHTTP(appPort, '/blog/post-1'), errMsg)
+        await retry(
+          async () => {
+            await expect(
+              renderViaHTTP(appPort, '/blog/post-1')
+            ).resolves.toMatch(errMsg)
+          },
+          30000,
+          1000
+        )
 
         await fs.writeFile(blogPage, origContent)
-        await check(() => renderViaHTTP(appPort, '/blog/post-1'), /post-1/)
+        await retry(
+          async () => {
+            await expect(
+              renderViaHTTP(appPort, '/blog/post-1')
+            ).resolves.toMatch(/post-1/)
+          },
+          30000,
+          1000
+        )
       } finally {
         await fs.writeFile(blogPage, origContent)
       }

--- a/test/integration/preview-fallback/test/index.test.ts
+++ b/test/integration/preview-fallback/test/index.test.ts
@@ -13,7 +13,7 @@ import {
   nextBuild,
   nextStart,
   renderViaHTTP,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '..')
@@ -209,10 +209,14 @@ function runTests(isDev: boolean) {
   it('should not write preview dynamic non-prerendered SSG page to cache with fallback', async () => {
     let browser = await webdriver(appPort, '/fallback/second')
 
-    await check(async () => {
-      const props = JSON.parse(await browser.elementByCss('#props').text())
-      return props.params ? 'pass' : 'fail'
-    }, 'pass')
+    await retry(
+      async () => {
+        const props = JSON.parse(await browser.elementByCss('#props').text())
+        expect(props.params).toBeTruthy()
+      },
+      30000,
+      1000
+    )
 
     const props = JSON.parse(await browser.elementByCss('#props').text())
 
@@ -249,10 +253,14 @@ function runTests(isDev: boolean) {
 
     browser = await webdriver(appPort, '/fallback/second')
 
-    await check(async () => {
-      const props = JSON.parse(await browser.elementByCss('#props').text())
-      return props.params ? 'pass' : 'fail'
-    }, 'pass')
+    await retry(
+      async () => {
+        const props = JSON.parse(await browser.elementByCss('#props').text())
+        expect(props.params).toBeTruthy()
+      },
+      30000,
+      1000
+    )
 
     const props2 = JSON.parse(await browser.elementByCss('#props').text())
 

--- a/test/integration/react-current-version/test/index.test.ts
+++ b/test/integration/react-current-version/test/index.test.ts
@@ -4,11 +4,11 @@ import { join } from 'path'
 
 import cheerio from 'cheerio'
 import {
-  check,
   File,
   renderViaHTTP,
   runDevSuite,
   runProdSuite,
+  retry,
 } from 'next-test-utils'
 import webdriver, { type Playwright } from 'next-webdriver'
 
@@ -102,23 +102,31 @@ function runTestsAgainstRuntime(runtime) {
         expect(stylesOccurrence.length).toBe(1)
 
         await withBrowser('/use-flush-effect/styled-jsx', async (browser) => {
-          await check(
-            () =>
-              browser
-                .waitForElementByCss('style#__jsx-900f996af369fc74', {
-                  state: 'attached',
-                })
-                .text(),
-            /(?:blue|#00f)/
+          await retry(
+            async () => {
+              await expect(
+                browser
+                  .waitForElementByCss('style#__jsx-900f996af369fc74', {
+                    state: 'attached',
+                  })
+                  .text()
+              ).resolves.toMatch(/(?:blue|#00f)/)
+            },
+            30000,
+            1000
           )
-          await check(
-            () =>
-              browser
-                .waitForElementByCss('style#__jsx-8b0811664c4e575e', {
-                  state: 'attached',
-                })
-                .text(),
-            /red/
+          await retry(
+            async () => {
+              await expect(
+                browser
+                  .waitForElementByCss('style#__jsx-8b0811664c4e575e', {
+                    state: 'attached',
+                  })
+                  .text()
+              ).resolves.toMatch(/red/)
+            },
+            30000,
+            1000
           )
         })
       })

--- a/test/integration/read-only-source-hmr/test/index.test.ts
+++ b/test/integration/read-only-source-hmr/test/index.test.ts
@@ -2,11 +2,11 @@
 
 import fs from 'fs-extra'
 import {
-  check,
   findPort,
   getBrowserBodyText,
   killApp,
   launchApp,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -60,7 +60,15 @@ describe('Read-only source HMR', () => {
 
     try {
       browser = await webdriver(appPort, '/hello')
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(
+        async () => {
+          await expect(getBrowserBodyText(browser)).resolves.toMatch(
+            /Hello World/
+          )
+        },
+        30000,
+        1000
+      )
 
       const originalContent = await fs.readFile(pagePath, 'utf8')
       const editedContent = originalContent.replace('Hello World', 'COOL page')
@@ -71,10 +79,26 @@ describe('Read-only source HMR', () => {
       }
 
       await writeReadOnlyFile(pagePath, editedContent)
-      await check(() => getBrowserBodyText(browser), /COOL page/)
+      await retry(
+        async () => {
+          await expect(getBrowserBodyText(browser)).resolves.toMatch(
+            /COOL page/
+          )
+        },
+        30000,
+        1000
+      )
 
       await writeReadOnlyFile(pagePath, originalContent)
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(
+        async () => {
+          await expect(getBrowserBodyText(browser)).resolves.toMatch(
+            /Hello World/
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -87,7 +111,15 @@ describe('Read-only source HMR', () => {
 
     try {
       browser = await webdriver(appPort, '/hello')
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(
+        async () => {
+          await expect(getBrowserBodyText(browser)).resolves.toMatch(
+            /Hello World/
+          )
+        },
+        30000,
+        1000
+      )
 
       const originalContent = await fs.readFile(pagePath, 'utf8')
 
@@ -98,7 +130,15 @@ describe('Read-only source HMR', () => {
 
       await fs.remove(pagePath)
       await writeReadOnlyFile(pagePath, originalContent)
-      await check(() => getBrowserBodyText(browser), /Hello World/)
+      await retry(
+        async () => {
+          await expect(getBrowserBodyText(browser)).resolves.toMatch(
+            /Hello World/
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -121,7 +161,13 @@ describe('Read-only source HMR', () => {
       )
 
       browser = await webdriver(appPort, '/new')
-      await check(() => getBrowserBodyText(browser), /New page/)
+      await retry(
+        async () => {
+          await expect(getBrowserBodyText(browser)).resolves.toMatch(/New page/)
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/repeated-slashes/test/index.test.ts
+++ b/test/integration/repeated-slashes/test/index.test.ts
@@ -14,8 +14,8 @@ import {
   startStaticServer,
   launchApp,
   fetchViaHTTP,
-  check,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../app')
@@ -300,12 +300,16 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
     ]
 
     for (const href of invalidHrefs) {
-      await check(
-        () =>
-          browser.eval(
-            'window.caughtErrors.map(err => typeof err !== "string" ? err.message : err).join(", ")'
-          ),
-        new RegExp(escapeRegex(`Invalid href '${href}'`))
+      await retry(
+        async () => {
+          expect(
+            await browser.eval(
+              'window.caughtErrors.map(err => typeof err !== "string" ? err.message : err).join(", ")'
+            )
+          ).toMatch(new RegExp(escapeRegex(`Invalid href '${href}'`)))
+        },
+        30000,
+        1000
       )
     }
   })
@@ -342,9 +346,14 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
           item.as ? `, "${item.as}"` : ''
         })`
       )
-      await check(
-        () => browser.eval('document.readyState'),
-        /interactive|complete/
+      await retry(
+        async () => {
+          expect(await browser.eval('document.readyState')).toMatch(
+            /interactive|complete/
+          )
+        },
+        30000,
+        1000
       )
       expect(await browser.eval('window.location.pathname')).toBe(item.pathname)
       expect(await browser.eval('window.location.search')).toBe(
@@ -388,9 +397,14 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
         })
       })()`)
 
-      await check(
-        () => browser.eval('window.location.pathname'),
-        item.pathname || item.as || item.href
+      await retry(
+        async () => {
+          expect(await browser.eval('window.location.pathname')).toBe(
+            item.pathname || item.as || item.href
+          )
+        },
+        30000,
+        1000
       )
 
       expect(await browser.eval('window.location.search')).toBe(

--- a/test/integration/revalidate-as-path/test/index.test.ts
+++ b/test/integration/revalidate-as-path/test/index.test.ts
@@ -10,7 +10,7 @@ import {
   renderViaHTTP,
   nextStart,
   waitFor,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -39,7 +39,13 @@ const runTests = () => {
       hello: 'world',
     })
 
-    await check(() => stdout, /asPath/)
+    await retry(
+      () => {
+        expect(stdout).toMatch(/asPath/)
+      },
+      30000,
+      1000
+    )
     const asPath = stdout.split('asPath: ').pop().split('\n').shift()
     expect(asPath).toBe('/')
   })
@@ -63,7 +69,13 @@ const runTests = () => {
       hello: 'world',
     })
 
-    await check(() => stdout, /asPath/)
+    await retry(
+      () => {
+        expect(stdout).toMatch(/asPath/)
+      },
+      30000,
+      1000
+    )
     const asPath = stdout.split('asPath: ').pop().split('\n').shift()
     expect(asPath).toBe('/another/index')
   })

--- a/test/integration/rewrites-manual-href-as/test/index.test.ts
+++ b/test/integration/rewrites-manual-href-as/test/index.test.ts
@@ -2,12 +2,12 @@
 
 import { join } from 'path'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -108,12 +108,16 @@ const runTests = () => {
 
     expect(await browser.elementByCss('#preview').text()).toBe('preview page')
     expect(await browser.eval('window.beforeNav')).toBe(1)
-    await check(
-      async () =>
-        JSON.parse(
-          await browser.eval('document.querySelector("#query").innerHTML')
-        ).slug,
-      '321'
+    await retry(
+      async () => {
+        expect(
+          JSON.parse(
+            await browser.eval('document.querySelector("#query").innerHTML')
+          ).slug
+        ).toBe('321')
+      },
+      30000,
+      1000
     )
 
     await browser

--- a/test/integration/router-is-ready-app-gip/test/index.test.ts
+++ b/test/integration/router-is-ready-app-gip/test/index.test.ts
@@ -9,7 +9,7 @@ import {
   nextStart,
   nextBuild,
   File,
-  check,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -18,12 +18,14 @@ const appDir = join(__dirname, '../')
 const invalidPage = new File(join(appDir, 'pages/invalid.js'))
 
 const checkIsReadyValues = (browser, expected = []) => {
-  return check(async () => {
-    const values = JSON.stringify(
-      (await browser.eval('window.isReadyValues')).sort()
-    )
-    return JSON.stringify(expected.sort()) === values ? 'success' : values
-  }, 'success')
+  return retry(
+    async () => {
+      const values = await browser.eval('window.isReadyValues')
+      expect(values.sort()).toEqual(expected.sort())
+    },
+    30000,
+    1000
+  )
 }
 
 function runTests() {

--- a/test/integration/router-is-ready/test/index.test.ts
+++ b/test/integration/router-is-ready/test/index.test.ts
@@ -9,7 +9,7 @@ import {
   nextStart,
   nextBuild,
   File,
-  check,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -18,12 +18,14 @@ const appDir = join(__dirname, '../')
 const invalidPage = new File(join(appDir, 'pages/invalid.js'))
 
 const checkIsReadyValues = (browser, expected = []) => {
-  return check(async () => {
-    const values = JSON.stringify(
-      (await browser.eval('window.isReadyValues')).sort()
-    )
-    return JSON.stringify(expected.sort()) === values ? 'success' : values
-  }, 'success')
+  return retry(
+    async () => {
+      const values = await browser.eval('window.isReadyValues')
+      expect(values.sort()).toEqual(expected.sort())
+    },
+    30000,
+    1000
+  )
 }
 
 function runTests() {

--- a/test/integration/scroll-forward-restoration/test/index.test.ts
+++ b/test/integration/scroll-forward-restoration/test/index.test.ts
@@ -8,7 +8,7 @@ import {
   launchApp,
   nextStart,
   nextBuild,
-  check,
+  retry,
 } from 'next-test-utils'
 
 const appDir = join(__dirname, '../')
@@ -20,9 +20,14 @@ const runTests = () => {
     const browser = await webdriver(appPort, '/another')
     await browser.elementByCss('#to-index').click()
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /the end/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => document.documentElement.innerHTML)
+        ).toMatch(/the end/)
+      },
+      30000,
+      1000
     )
 
     await browser.eval(() =>
@@ -42,15 +47,26 @@ const runTests = () => {
 
     await browser.eval(() => window.history.back())
 
-    await check(
-      () => browser.eval(() => document.documentElement.innerHTML),
-      /hi from another/
+    await retry(
+      async () => {
+        expect(
+          await browser.eval(() => document.documentElement.innerHTML)
+        ).toMatch(/hi from another/)
+      },
+      30000,
+      1000
     )
 
     await browser.eval(() => ((window as any).didHydrate = false))
     await browser.eval(() => window.history.forward())
 
-    await check(() => browser.eval(() => (window as any).didHydrate), true)
+    await retry(
+      async () => {
+        expect(await browser.eval(() => (window as any).didHydrate)).toBe(true)
+      },
+      30000,
+      1000
+    )
 
     const newScrollX = Math.floor(await browser.eval(() => window.scrollX))
     const newScrollY = Math.floor(await browser.eval(() => window.scrollY))

--- a/test/integration/telemetry/test/config.test.ts
+++ b/test/integration/telemetry/test/config.test.ts
@@ -1,11 +1,11 @@
 import {
-  check,
   findAllTelemetryEvents,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   waitFor,
+  retry,
 } from 'next-test-utils'
 import fs from 'fs-extra'
 import path from 'path'
@@ -104,7 +104,13 @@ describe('config telemetry', () => {
             NEXT_TELEMETRY_DEBUG: '1',
           },
         })
-        await check(() => stderr2, /NEXT_CLI_SESSION_STARTED/)
+        await retry(
+          () => {
+            expect(stderr2).toMatch(/NEXT_CLI_SESSION_STARTED/)
+          },
+          30000,
+          1000
+        )
         await killApp(app)
 
         await fs.rename(

--- a/test/integration/telemetry/test/page-features.test.ts
+++ b/test/integration/telemetry/test/page-features.test.ts
@@ -1,12 +1,12 @@
 import path from 'path'
 import fs from 'fs-extra'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 
 const appDir = path.join(__dirname, '..')
@@ -27,7 +27,13 @@ describe('page features telemetry', () => {
         },
         turbo: true,
       })
-      await check(() => stderr, /NEXT_CLI_SESSION_STARTED/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/NEXT_CLI_SESSION_STARTED/)
+        },
+        30000,
+        1000
+      )
       await renderViaHTTP(port, '/hello')
 
       if (app) {
@@ -63,13 +69,25 @@ describe('page features telemetry', () => {
         turbo: true,
       })
 
-      await check(() => stderr, /NEXT_CLI_SESSION_STARTED/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/NEXT_CLI_SESSION_STARTED/)
+        },
+        30000,
+        1000
+      )
       await renderViaHTTP(port, '/hello')
 
       if (app) {
         await killApp(app, 'SIGTERM')
       }
-      await check(() => stderr, /NEXT_CLI_SESSION_STOPPED/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/NEXT_CLI_SESSION_STOPPED/)
+        },
+        30000,
+        1000
+      )
 
       expect(stderr).toContain('NEXT_CLI_SESSION_STOPPED')
       const event1 = /NEXT_CLI_SESSION_STOPPED[\s\S]+?{([\s\S]+?)}/
@@ -98,14 +116,26 @@ describe('page features telemetry', () => {
         },
       })
 
-      await check(() => stderr, /NEXT_CLI_SESSION_STARTED/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/NEXT_CLI_SESSION_STARTED/)
+        },
+        30000,
+        1000
+      )
       await renderViaHTTP(port, '/hello')
 
       if (app) {
         await killApp(app, 'SIGTERM')
       }
 
-      await check(() => stderr, /NEXT_CLI_SESSION_STOPPED/)
+      await retry(
+        () => {
+          expect(stderr).toMatch(/NEXT_CLI_SESSION_STOPPED/)
+        },
+        30000,
+        1000
+      )
 
       expect(stderr).toContain('NEXT_CLI_SESSION_STOPPED')
       const event1 = /NEXT_CLI_SESSION_STOPPED[\s\S]+?{([\s\S]+?)}/

--- a/test/integration/trailing-slashes-href-resolving/test/index.test.ts
+++ b/test/integration/trailing-slashes-href-resolving/test/index.test.ts
@@ -3,12 +3,12 @@ import assert from 'assert'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 
 let app
@@ -76,18 +76,23 @@ const runTests = (dev: boolean) => {
     it('should preload SSG routes correctly', async () => {
       const browser = await webdriver(appPort, '/')
 
-      await check(async () => {
-        const hrefs = await browser.eval(`Object.keys(window.next.router.sdc)`)
-        hrefs.sort()
-
-        assert.deepEqual(
-          hrefs.map((href) =>
-            new URL(href).pathname.replace(/^\/_next\/data\/[^/]+/, '')
-          ),
-          ['/top-level-slug.json', '/world.json']
-        )
-        return 'yes'
-      }, 'yes')
+      await retry(
+        async () => {
+          const hrefs = await browser.eval(
+            `Object.keys(window.next.router.sdc)`
+          )
+          hrefs.sort()
+          assert.deepEqual(
+            hrefs.map((href) =>
+              new URL(href).pathname.replace(/^\/_next\/data\/[^/]+/, '')
+            ),
+            ['/top-level-slug.json', '/world.json']
+          )
+          expect('yes').toBe('yes')
+        },
+        30000,
+        1000
+      )
     })
   }
 }

--- a/test/integration/turbopack-unsupported-log/index.test.ts
+++ b/test/integration/turbopack-unsupported-log/index.test.ts
@@ -1,9 +1,9 @@
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   renderViaHTTP,
+  retry,
 } from 'next-test-utils'
 import fs from 'fs-extra'
 import { join } from 'path'
@@ -83,13 +83,17 @@ describe('turbopack unsupported features log', () => {
       })
 
       try {
-        await check(() => {
-          expect(output).toContain('(Turbopack)')
-          expect(output).toContain(
-            'You are using configuration and/or tools that are not yet'
-          )
-          return 'success'
-        }, /success/)
+        await retry(
+          () => {
+            expect(output).toContain('(Turbopack)')
+            expect(output).toContain(
+              'You are using configuration and/or tools that are not yet'
+            )
+            expect('success').toMatch(/success/)
+          },
+          30000,
+          1000
+        )
       } finally {
         await killApp(app).catch(() => {})
         await fs.remove(nextConfigPath)

--- a/test/integration/typescript-hmr/test/index.test.ts
+++ b/test/integration/typescript-hmr/test/index.test.ts
@@ -2,12 +2,12 @@
 
 import fs from 'fs-extra'
 import {
-  check,
   findPort,
   getBrowserBodyText,
   getRedboxHeader,
   killApp,
   launchApp,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -35,7 +35,15 @@ describe('TypeScript HMR', () => {
       let browser
       try {
         browser = await webdriver(appPort, '/hello')
-        await check(() => getBrowserBodyText(browser), /Hello World/)
+        await retry(
+          async () => {
+            await expect(getBrowserBodyText(browser)).resolves.toMatch(
+              /Hello World/
+            )
+          },
+          30000,
+          1000
+        )
 
         const pagePath = join(appDir, 'pages/hello.tsx')
         const originalContent = await fs.readFile(pagePath, 'utf8')
@@ -48,11 +56,27 @@ describe('TypeScript HMR', () => {
 
         // change the content
         await fs.writeFile(pagePath, editedContent, 'utf8')
-        await check(() => getBrowserBodyText(browser), /COOL page/)
+        await retry(
+          async () => {
+            await expect(getBrowserBodyText(browser)).resolves.toMatch(
+              /COOL page/
+            )
+          },
+          30000,
+          1000
+        )
 
         // add the original content
         await fs.writeFile(pagePath, originalContent, 'utf8')
-        await check(() => getBrowserBodyText(browser), /Hello World/)
+        await retry(
+          async () => {
+            await expect(getBrowserBodyText(browser)).resolves.toMatch(
+              /Hello World/
+            )
+          },
+          30000,
+          1000
+        )
       } finally {
         if (browser) {
           await browser.close()
@@ -71,16 +95,25 @@ describe('TypeScript HMR', () => {
       const errContent = origContent.replace('() =>', '(): boolean =>')
 
       await fs.writeFile(pagePath, errContent)
-      await check(
-        () => getRedboxHeader(browser),
-        /Type 'Element' is not assignable to type 'boolean'/
+      await retry(
+        () => {
+          expect(getRedboxHeader(browser)).toMatch(
+            /Type 'Element' is not assignable to type 'boolean'/
+          )
+        },
+        30000,
+        1000
       )
 
       await fs.writeFile(pagePath, origContent)
-      await check(async () => {
-        const html = await browser.eval('document.documentElement.innerHTML')
-        return html.match(/iframe/) ? 'fail' : 'success'
-      }, /success/)
+      await retry(
+        async () => {
+          const html = await browser.eval('document.documentElement.innerHTML')
+          expect(html.match(/iframe/) ? 'fail' : 'success').toMatch(/success/)
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) browser.close()
       await fs.writeFile(pagePath, origContent)
@@ -102,10 +135,18 @@ describe('TypeScript HMR', () => {
         await new Promise((resolve) => setTimeout(resolve, 500))
       }
       await fs.writeFile(pagePath, errContent)
-      await check(async () => {
-        const html = await browser.eval('document.querySelector("p").innerText')
-        return html.match(/hello with error/) ? 'success' : 'fail'
-      }, /success/)
+      await retry(
+        async () => {
+          const html = await browser.eval(
+            'document.querySelector("p").innerText'
+          )
+          expect(html.match(/hello with error/) ? 'success' : 'fail').toMatch(
+            /success/
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) browser.close()
       await fs.writeFile(pagePath, origContent)

--- a/test/integration/worker-webpack5/test/index.test.ts
+++ b/test/integration/worker-webpack5/test/index.test.ts
@@ -1,11 +1,11 @@
 /* eslint-env jest */
 import {
-  check,
   findPort,
   killApp,
   launchApp,
   nextStart,
   nextBuild,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -21,9 +21,25 @@ const runTests = () => {
     try {
       browser = await webdriver(appPort, '/')
       await browser.waitForElementByCss('#web-status')
-      await check(() => browser.elementByCss('#web-status').text(), /PASS/i)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#web-status').text()).toMatch(
+            /PASS/i
+          )
+        },
+        30000,
+        1000
+      )
       await browser.waitForElementByCss('#worker-status')
-      await check(() => browser.elementByCss('#worker-status').text(), /PASS/i)
+      await retry(
+        async () => {
+          expect(await browser.elementByCss('#worker-status').text()).toMatch(
+            /PASS/i
+          )
+        },
+        30000,
+        1000
+      )
     } finally {
       if (browser) {
         await browser.close()


### PR DESCRIPTION
### What?

Replace deprecated `check()` calls with `retry()` in integration test files.

### Why?

The `check()` function is deprecated and will be removed. `retry()` provides:
- Better error messages (shows actual Jest/expect assertion failures)
- Configurable timeout and interval
- More idiomatic test patterns using `expect()` assertions

### How?

Migrated 73 integration test files, converting `check()` patterns to use `retry()` with `expect()` assertions.

NAR-699