### PR TITLE
Add maximum size limit for postponed body parsing

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -973,5 +973,7 @@
   "972": "Failed to resolve pattern \"%s\": %s",
   "973": "Server Actions are not enabled for this application. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "974": "Failed to find Server Action%s. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
-  "975": "Failed to find Server Action. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action"
+  "975": "Failed to find Server Action. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
+  "976": "Decompressed resume data cache exceeded %s byte limit",
+  "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")"
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -56,7 +56,7 @@ import type { CacheControl } from '../../server/lib/cache-control'
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags'
 import { sendRenderResult } from '../../server/send-payload'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
-import { parseMaxPostponedStateSize } from '../../server/config-shared'
+import { parseMaxPostponedStateSize } from '../../shared/lib/size-limit'
 
 // These are injected by the loader afterwards.
 

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -56,6 +56,7 @@ import type { CacheControl } from '../../server/lib/cache-control'
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags'
 import { sendRenderResult } from '../../server/send-payload'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
+import { parseMaxPostponedStateSize } from '../../server/config-shared'
 
 // These are injected by the loader afterwards.
 
@@ -591,6 +592,9 @@ export async function handler(
               nextConfig.experimental.clientTraceMetadata || ([] as any),
             clientParamParsingOrigins:
               nextConfig.experimental.clientParamParsingOrigins,
+            maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
+              nextConfig.experimental.maxPostponedStateSize
+            ),
           },
 
           waitUntil: ctx.waitUntil,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -26,7 +26,7 @@ import { interopDefault } from '../../lib/interop-default'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { checkIsOnDemandRevalidate } from '../../server/api-utils'
 import { CloseController } from '../../server/web/web-on-close'
-import { parseMaxPostponedStateSize } from '../../server/config-shared'
+import { parseMaxPostponedStateSize } from '../../shared/lib/size-limit'
 
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:incrementalCacheHandler

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -26,6 +26,7 @@ import { interopDefault } from '../../lib/interop-default'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import { checkIsOnDemandRevalidate } from '../../server/api-utils'
 import { CloseController } from '../../server/web/web-on-close'
+import { parseMaxPostponedStateSize } from '../../server/config-shared'
 
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:incrementalCacheHandler
@@ -159,6 +160,9 @@ async function requestHandler(
           nextConfig.experimental.clientTraceMetadata || ([] as any),
         clientParamParsingOrigins:
           nextConfig.experimental.clientParamParsingOrigins,
+        maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
+          nextConfig.experimental.maxPostponedStateSize
+        ),
       },
 
       incrementalCache: await pageRouteModule.getIncrementalCache(

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -46,6 +46,7 @@ import {
 } from '../shared/lib/constants'
 import loadConfig from '../server/config'
 import type { ExportPathMap } from '../server/config-shared'
+import { parseMaxPostponedStateSize } from '../server/config-shared'
 import { eventCliSession } from '../telemetry/events'
 import { hasNextSupport } from '../server/ci-info'
 import { Telemetry } from '../telemetry/storage'
@@ -396,6 +397,9 @@ async function exportAppImpl(
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
+      maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
+        nextConfig.experimental.maxPostponedStateSize
+      ),
     },
     reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,
     hasReadableErrorStacks:

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -385,7 +385,10 @@ export async function exportPages(
       process.env.NODE_OPTIONS?.includes('--inspect')
 
     const renderResumeDataCache = renderResumeDataCachesByPage[page]
-      ? createRenderResumeDataCache(renderResumeDataCachesByPage[page])
+      ? createRenderResumeDataCache(
+          renderResumeDataCachesByPage[page],
+          renderOpts.experimental.maxPostponedStateSizeBytes
+        )
       : undefined
 
     while (attempt < maxAttempts) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2371,7 +2371,8 @@ export const renderToHTMLOrFlight: AppPageRender = (
 
     postponedState = parsePostponedState(
       renderOpts.postponed,
-      interpolatedParams
+      interpolatedParams,
+      renderOpts.experimental.maxPostponedStateSizeBytes
     )
   } else {
     interpolatedParams = interpolateParallelRouteParams(

--- a/packages/next/src/server/app-render/postponed-state.test.ts
+++ b/packages/next/src/server/app-render/postponed-state.test.ts
@@ -51,7 +51,7 @@ describe('getDynamicHTMLPostponedState', () => {
       isCacheComponentsEnabled
     )
 
-    const parsed = parsePostponedState(state, { slug: '123' })
+    const parsed = parsePostponedState(state, { slug: '123' }, undefined)
 
     expect(parsed).toMatchInlineSnapshot(`
      {
@@ -109,7 +109,7 @@ describe('getDynamicHTMLPostponedState', () => {
 
     const value = 'hello'
     const params = { slug: value }
-    const parsed = parsePostponedState(state, params)
+    const parsed = parsePostponedState(state, params, undefined)
     expect(parsed).toEqual({
       type: DynamicState.HTML,
       data: [1, { [value]: value }],
@@ -137,7 +137,7 @@ describe('parsePostponedState', () => {
     const params = {
       slug: Math.random().toString(16).slice(3),
     }
-    const parsed = parsePostponedState(state, params)
+    const parsed = parsePostponedState(state, params, undefined)
 
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({
@@ -153,7 +153,7 @@ describe('parsePostponedState', () => {
   it('parses a HTML postponed state without fallback params', () => {
     const state = `2:{}null`
     const params = {}
-    const parsed = parsePostponedState(state, params)
+    const parsed = parsePostponedState(state, params, undefined)
 
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({
@@ -165,7 +165,7 @@ describe('parsePostponedState', () => {
 
   it('parses a data postponed state', () => {
     const state = '4:nullnull'
-    const parsed = parsePostponedState(state, {})
+    const parsed = parsePostponedState(state, {}, undefined)
 
     // Ensure that it parsed it correctly.
     expect(parsed).toEqual({

--- a/packages/next/src/server/app-render/postponed-state.ts
+++ b/packages/next/src/server/app-render/postponed-state.ts
@@ -116,7 +116,8 @@ export async function getDynamicDataPostponedState(
 
 export function parsePostponedState(
   state: string,
-  interpolatedParams: Params
+  interpolatedParams: Params,
+  maxPostponedStateSizeBytes: number | undefined
 ): PostponedState {
   try {
     const postponedStringLengthMatch = state.match(/^([0-9]*):/)?.[1]
@@ -134,7 +135,10 @@ export function parsePostponedState(
     )
 
     const renderResumeDataCache = createRenderResumeDataCache(
-      state.slice(postponedStringLengthMatch.length + postponedStringLength + 1)
+      state.slice(
+        postponedStringLengthMatch.length + postponedStringLength + 1
+      ),
+      maxPostponedStateSizeBytes
     )
 
     try {

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -158,6 +158,12 @@ export interface RenderOptsPartial {
     dynamicOnHover: boolean
     inlineCss: boolean
     authInterrupts: boolean
+
+    /**
+     * The maximum size (in bytes) of the postponed state body for PPR resume
+     * requests. Used to calculate decompression limits (5x this value).
+     */
+    maxPostponedStateSizeBytes: number | undefined
   }
   postponed?: string
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1054,11 +1054,37 @@ export default abstract class Server<
             req.headers[NEXT_RESUME_HEADER] === '1' &&
             req.method === 'POST'
           ) {
+            // Get the configured max postponed state size (default 10 MB).
+            const maxPostponedStateSize =
+              this.nextConfig.experimental.maxPostponedStateSize ?? '10 MB'
+            const maxPostponedStateSizeBytes = (
+              require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
+            ).parse(maxPostponedStateSize)
+            if (
+              maxPostponedStateSizeBytes === null ||
+              isNaN(maxPostponedStateSizeBytes) ||
+              maxPostponedStateSizeBytes < 1
+            ) {
+              throw new Error(
+                'maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., "5mb")'
+              )
+            }
+
             // Decode the postponed state from the request body, it will come as
             // an array of buffers, so collect them and then concat them to form
             // the string.
             const body: Array<Buffer> = []
+            let size = 0
             for await (const chunk of req.body) {
+              size += Buffer.byteLength(chunk)
+              if (size > maxPostponedStateSizeBytes) {
+                res.statusCode = 413
+                const errorMessage =
+                  `Postponed state exceeded ${maxPostponedStateSize} limit. ` +
+                  `To configure the limit, see: https://nextjs.org/docs/app/api-reference/config/next-config-js/max-postponed-state-size`
+                res.body(errorMessage).send()
+                return
+              }
               body.push(chunk)
             }
             const postponed = Buffer.concat(body).toString('utf8')

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -6,6 +6,10 @@ import type {
 import type { MiddlewareRouteMatch } from '../shared/lib/router/utils/middleware-route-matcher'
 import type { Params } from './request/params'
 import type { NextConfig, NextConfigRuntime } from './config-shared'
+import {
+  DEFAULT_MAX_POSTPONED_STATE_SIZE,
+  parseMaxPostponedStateSize,
+} from './config-shared'
 import type {
   NextParsedUrlQuery,
   NextUrlWithParsedQuery,
@@ -563,6 +567,9 @@ export default abstract class Server<
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,
         cdnCacheControlHeader:
           this.nextConfig.experimental.cdnCacheControlHeader,
+        maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
+          this.nextConfig.experimental.maxPostponedStateSize
+        ),
       },
       onInstrumentationRequestError:
         this.instrumentationOnRequestError.bind(this),
@@ -1054,17 +1061,14 @@ export default abstract class Server<
             req.headers[NEXT_RESUME_HEADER] === '1' &&
             req.method === 'POST'
           ) {
-            // Get the configured max postponed state size (default 10 MB).
+            // Get the configured max postponed state size.
             const maxPostponedStateSize =
-              this.nextConfig.experimental.maxPostponedStateSize ?? '10 MB'
-            const maxPostponedStateSizeBytes = (
-              require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
-            ).parse(maxPostponedStateSize)
-            if (
-              maxPostponedStateSizeBytes === null ||
-              isNaN(maxPostponedStateSizeBytes) ||
-              maxPostponedStateSizeBytes < 1
-            ) {
+              this.nextConfig.experimental.maxPostponedStateSize ??
+              DEFAULT_MAX_POSTPONED_STATE_SIZE
+            const maxPostponedStateSizeBytes = parseMaxPostponedStateSize(
+              this.nextConfig.experimental.maxPostponedStateSize
+            )
+            if (maxPostponedStateSizeBytes === undefined) {
               throw new Error(
                 'maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., "5mb")'
               )

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -206,6 +206,7 @@ export const experimentalSchema = {
       allowedOrigins: z.array(z.string()).optional(),
     })
     .optional(),
+  maxPostponedStateSize: zSizeLimit.optional(),
   // The original type was Record<string, any>
   extensionAlias: z.record(z.string(), z.any()).optional(),
   externalDir: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -659,6 +659,14 @@ export interface ExperimentalConfig {
   }
 
   /**
+   * Allows adjusting the maximum size of the postponed state body for PPR
+   * resume requests. This includes the Resume Data Cache (RDC) which may grow
+   * large for some applications.
+   * @default '10 MB'
+   */
+  maxPostponedStateSize?: SizeLimit
+
+  /**
    * enables the minification of server code.
    */
   serverMinification?: boolean
@@ -1686,6 +1694,7 @@ export interface NextConfigRuntime {
     | 'proxyTimeout'
     | 'testProxy'
     | 'runtimeServerDeploymentId'
+    | 'maxPostponedStateSize'
   > & {
     // Pick on @internal fields generates invalid .d.ts files
     /** @internal */
@@ -1742,6 +1751,7 @@ export function getNextConfigRuntime(
         proxyTimeout: ex.proxyTimeout,
         testProxy: ex.testProxy,
         runtimeServerDeploymentId: ex.runtimeServerDeploymentId,
+        maxPostponedStateSize: ex.maxPostponedStateSize,
 
         trustHostHeader: ex.trustHostHeader,
         isExperimentalCompile: ex.isExperimentalCompile,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -662,7 +662,7 @@ export interface ExperimentalConfig {
    * Allows adjusting the maximum size of the postponed state body for PPR
    * resume requests. This includes the Resume Data Cache (RDC) which may grow
    * large for some applications.
-   * @default '10 MB'
+   * @default '100 MB'
    */
   maxPostponedStateSize?: SizeLimit
 
@@ -1798,4 +1798,31 @@ export function getNextConfigRuntime(
   }
 
   return runtimeConfig
+}
+
+/**
+ * The default maximum size for postponed state in PPR resume requests.
+ */
+export const DEFAULT_MAX_POSTPONED_STATE_SIZE: SizeLimit = '100 MB'
+
+/**
+ * Parses a SizeLimit value into bytes. Returns undefined if parsing fails.
+ */
+function parseSizeLimit(size: SizeLimit): number | undefined {
+  const bytes = (
+    require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
+  ).parse(size)
+  if (bytes === null || isNaN(bytes) || bytes < 1) {
+    return undefined
+  }
+  return bytes
+}
+
+/**
+ * Parses the maxPostponedStateSize config value, using the default if not provided.
+ */
+export function parseMaxPostponedStateSize(
+  size: SizeLimit | undefined
+): number | undefined {
+  return parseSizeLimit(size ?? DEFAULT_MAX_POSTPONED_STATE_SIZE)
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1800,29 +1800,8 @@ export function getNextConfigRuntime(
   return runtimeConfig
 }
 
-/**
- * The default maximum size for postponed state in PPR resume requests.
- */
-export const DEFAULT_MAX_POSTPONED_STATE_SIZE: SizeLimit = '100 MB'
-
-/**
- * Parses a SizeLimit value into bytes. Returns undefined if parsing fails.
- */
-function parseSizeLimit(size: SizeLimit): number | undefined {
-  const bytes = (
-    require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
-  ).parse(size)
-  if (bytes === null || isNaN(bytes) || bytes < 1) {
-    return undefined
-  }
-  return bytes
-}
-
-/**
- * Parses the maxPostponedStateSize config value, using the default if not provided.
- */
-export function parseMaxPostponedStateSize(
-  size: SizeLimit | undefined
-): number | undefined {
-  return parseSizeLimit(size ?? DEFAULT_MAX_POSTPONED_STATE_SIZE)
-}
+// Re-export from shared lib for backwards compatibility
+export {
+  DEFAULT_MAX_POSTPONED_STATE_SIZE,
+  parseMaxPostponedStateSize,
+} from '../shared/lib/size-limit'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -753,10 +753,18 @@ function assignDefaultsAndValidate(
   if (
     typeof result.experimental?.serverActions?.bodySizeLimit !== 'undefined'
   ) {
-    const value = parseInt(
-      result.experimental.serverActions?.bodySizeLimit.toString()
-    )
-    if (isNaN(value) || value < 1) {
+    const bytes =
+      require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
+    const bodySizeLimit = result.experimental.serverActions.bodySizeLimit
+    let value: number | null
+
+    if (typeof bodySizeLimit === 'number') {
+      value = bodySizeLimit
+    } else {
+      value = bytes.parse(bodySizeLimit)
+    }
+
+    if (value === null || isNaN(value) || value < 1) {
       throw new Error(
         'Server Actions Size Limit must be a valid number or filesize format larger than 1MB: https://nextjs.org/docs/app/api-reference/next-config-js/serverActions#bodysizelimit'
       )

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.test.ts
@@ -125,7 +125,7 @@ describe('stringifyResumeDataCache', () => {
 
 describe('parseResumeDataCache', () => {
   it('parses an empty cache', () => {
-    expect(createRenderResumeDataCache('null')).toEqual(
+    expect(createRenderResumeDataCache('null', undefined)).toEqual(
       createPrerenderResumeDataCache()
     )
   })
@@ -137,7 +137,7 @@ describe('parseResumeDataCache', () => {
       isCacheComponentsEnabled
     )
 
-    const parsed = createRenderResumeDataCache(serialized)
+    const parsed = createRenderResumeDataCache(serialized, undefined)
 
     expect(parsed.cache.size).toBe(isCacheComponentsEnabled ? 1 : 3)
     expect(parsed.fetch.size).toBe(0)

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.ts
@@ -206,11 +206,29 @@ export function createRenderResumeDataCache(
     // synchronous inflateSync function.
     const { inflateSync } = require('node:zlib') as typeof import('node:zlib')
 
-    const json: ResumeStoreSerialized = JSON.parse(
-      inflateSync(
-        Buffer.from(resumeDataCacheOrPersistedCache, 'base64')
-      ).toString('utf-8')
-    )
+    // Limit decompressed size to prevent zipbomb attacks. This is 5x the
+    // default maxPostponedStateSize (10MB), allowing reasonable compression
+    // ratios while preventing extreme decompression bombs.
+    const maxDecompressedSize = 50 * 1024 * 1024 // 50MB
+
+    let json: ResumeStoreSerialized
+    try {
+      json = JSON.parse(
+        inflateSync(Buffer.from(resumeDataCacheOrPersistedCache, 'base64'), {
+          maxOutputLength: maxDecompressedSize,
+        }).toString('utf-8')
+      )
+    } catch (err: unknown) {
+      if (
+        err instanceof RangeError &&
+        (err as NodeJS.ErrnoException).code === 'ERR_BUFFER_TOO_LARGE'
+      ) {
+        throw new Error(
+          `Decompressed resume data cache exceeded ${maxDecompressedSize} byte limit`
+        )
+      }
+      throw err
+    }
 
     return {
       cache: parseUseCacheCacheStore(Object.entries(json.store.cache)),

--- a/packages/next/src/server/resume-data-cache/resume-data-cache.ts
+++ b/packages/next/src/server/resume-data-cache/resume-data-cache.ts
@@ -164,6 +164,7 @@ export function createPrerenderResumeDataCache(): PrerenderResumeDataCache {
  * @param renderResumeDataCache - A RenderResumeDataCache instance to be used directly
  * @param prerenderResumeDataCache - A PrerenderResumeDataCache instance to convert to immutable
  * @param persistedCache - A serialized cache string to parse
+ * @param maxPostponedStateSizeBytes - The max compressed size limit in bytes (used to calculate 5x decompression limit)
  * @returns An immutable RenderResumeDataCache instance
  */
 export function createRenderResumeDataCache(
@@ -173,13 +174,15 @@ export function createRenderResumeDataCache(
   prerenderResumeDataCache: PrerenderResumeDataCache
 ): RenderResumeDataCache
 export function createRenderResumeDataCache(
-  persistedCache: string
+  persistedCache: string,
+  maxPostponedStateSizeBytes: number | undefined
 ): RenderResumeDataCache
 export function createRenderResumeDataCache(
   resumeDataCacheOrPersistedCache:
     | RenderResumeDataCache
     | PrerenderResumeDataCache
-    | string
+    | string,
+  maxPostponedStateSizeBytes?: number | undefined
 ): RenderResumeDataCache {
   if (process.env.NEXT_RUNTIME === 'edge') {
     throw new InvariantError(
@@ -207,9 +210,12 @@ export function createRenderResumeDataCache(
     const { inflateSync } = require('node:zlib') as typeof import('node:zlib')
 
     // Limit decompressed size to prevent zipbomb attacks. This is 5x the
-    // default maxPostponedStateSize (10MB), allowing reasonable compression
+    // configured maxPostponedStateSize, allowing reasonable compression
     // ratios while preventing extreme decompression bombs.
-    const maxDecompressedSize = 50 * 1024 * 1024 // 50MB
+    // Default is 500MB (5x the default 100MB compressed limit).
+    const maxDecompressedSize = maxPostponedStateSizeBytes
+      ? maxPostponedStateSizeBytes * 5
+      : 500 * 1024 * 1024
 
     let json: ResumeStoreSerialized
     try {

--- a/packages/next/src/shared/lib/size-limit.ts
+++ b/packages/next/src/shared/lib/size-limit.ts
@@ -1,0 +1,22 @@
+import type { SizeLimit } from '../../types'
+
+export const DEFAULT_MAX_POSTPONED_STATE_SIZE: SizeLimit = '100 MB'
+
+function parseSizeLimit(size: SizeLimit): number | undefined {
+  const bytes = (
+    require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
+  ).parse(size)
+  if (bytes === null || isNaN(bytes) || bytes < 1) {
+    return undefined
+  }
+  return bytes
+}
+
+/**
+ * Parses the maxPostponedStateSize config value, using the default if not provided.
+ */
+export function parseMaxPostponedStateSize(
+  size: SizeLimit | undefined
+): number | undefined {
+  return parseSizeLimit(size ?? DEFAULT_MAX_POSTPONED_STATE_SIZE)
+}

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1429,6 +1429,7 @@ function extractResumeDataCacheFromPostponedState(
   const postponedStringLength = parseInt(postponedStringLengthMatch)
 
   return createRenderResumeDataCache(
-    state.slice(postponedStringLengthMatch.length + postponedStringLength + 1)
+    state.slice(postponedStringLengthMatch.length + postponedStringLength + 1),
+    undefined
   )
 }


### PR DESCRIPTION
### What?

Adds a configurable `experimental.maxPostponedStateSize` limit for PPR postponed state body parsing to prevent OOM/DoS attacks.

### Why?

The postponed state body was read entirely without size limits, creating a potential denial-of-service vector through unbounded memory allocation.

### How?

Enforces a 100 MB default limit (configurable via next.config.js) with byte counting during body parsing. Returns HTTP 413 when exceeded with a helpful error message directing users to increase the limit if needed.

<!-- Closes NEXT- -->
<!-- Fixes # -->