### PR TITLE
feat(next/image)!: add `images.maximumResponseBody` config

### DIFF
--- a/crates/next-build-test/nextConfig.json
+++ b/crates/next-build-test/nextConfig.json
@@ -31,6 +31,7 @@
     "minimumCacheTTL": 60,
     "formats": ["image/avif", "image/webp"],
     "maximumRedirects": 3,
+    "maximumResponseBody": 300000000,
     "dangerouslyAllowLocalIP": false,
     "dangerouslyAllowSVG": false,
     "contentSecurityPolicy": "script-src 'none'; frame-src 'none'; sandbox;",

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -837,6 +837,28 @@ module.exports = {
 }
 ```
 
+#### `maximumResponseBody`
+
+The default image optimization loader will fetch source images up to 300 MB in size.
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    maximumResponseBody: 300_000_000,
+  },
+}
+```
+
+If you know all your source images are small, you can protect memory constrained servers by reducing this to a smaller value such as 50 MB.
+
+```js filename="next.config.js"
+module.exports = {
+  images: {
+    maximumResponseBody: 50_000_000,
+  },
+}
+```
+
 #### `dangerouslyAllowLocalIP`
 
 In rare cases when self-hosting Next.js on a private network, you may want to allow optimizing images from local IP addresses on the same network. This is not recommended for most users because it could allow malicious users to access content on your internal network.
@@ -1341,6 +1363,7 @@ export default function Home() {
 
 | Version    | Changes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `v16.1.2`  | `maximumResponseBody` configuration added.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `v16.0.0`  | `qualities` default configuration changed to `[75]`, `preload` prop added, `priority` prop deprecated, `dangerouslyAllowLocalIP` config added, `maximumRedirects` config added.                                                                                                                                                                                                                                                                                                            |
 | `v15.3.0`  | `remotePatterns` added support for array of `URL` objects.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | `v15.0.0`  | `contentDispositionType` configuration default changed to `attachment`.                                                                                                                                                                                                                                                                                                                                                                                                                    |

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -585,6 +585,12 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
         loader: z.enum(VALID_LOADERS).optional(),
         loaderFile: z.string().optional(),
         maximumRedirects: z.number().int().min(0).max(20).optional(),
+        maximumResponseBody: z
+          .number()
+          .int()
+          .min(1)
+          .max(Number.MAX_SAFE_INTEGER)
+          .optional(),
         minimumCacheTTL: z.number().int().gte(0).optional(),
         path: z.string().optional(),
         qualities: z

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -777,7 +777,34 @@ export async function fetchExternalImage(
     )
   }
 
-  const buffer = Buffer.from(await res.arrayBuffer())
+  if (!res.body) {
+    throw new ImageError(
+      400,
+      '"url" parameter is valid but upstream response is invalid'
+    )
+  }
+
+  const chunks: Buffer[] = []
+  let totalSize = 0
+
+  for await (const c of res.body) {
+    const chunk = Buffer.from(c)
+    totalSize += chunk.byteLength
+    if (totalSize > 300_000_000) {
+      Log.error(
+        'upstream image response exceeded maximum size for',
+        href,
+        totalSize
+      )
+      throw new ImageError(
+        413,
+        '"url" parameter is valid but upstream response is invalid'
+      )
+    }
+    chunks.push(chunk)
+  }
+
+  const buffer = Buffer.concat(chunks)
   const contentType = res.headers.get('Content-Type')
   const cacheControl = res.headers.get('Cache-Control')
   const etag = extractEtag(res.headers.get('ETag'), buffer)

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -711,6 +711,7 @@ function isRedirect(statusCode: number) {
 export async function fetchExternalImage(
   href: string,
   dangerouslyAllowLocalIP: boolean,
+  maximumResponseBody: number,
   count = 3
 ): Promise<ImageUpstream> {
   if (!dangerouslyAllowLocalIP) {
@@ -766,7 +767,12 @@ export async function fetchExternalImage(
       )
     }
     const redirect = new URL(locationHeader, href).href
-    return fetchExternalImage(redirect, dangerouslyAllowLocalIP, count - 1)
+    return fetchExternalImage(
+      redirect,
+      dangerouslyAllowLocalIP,
+      maximumResponseBody,
+      count - 1
+    )
   }
 
   if (!res.ok) {
@@ -791,7 +797,7 @@ export async function fetchExternalImage(
   for await (const c of res.body) {
     const chunk = Buffer.from(c)
     totalSize += chunk.byteLength
-    if (totalSize > 300_000_000) {
+    if (totalSize > maximumResponseBody) {
       Log.error(
         'upstream image response exceeded maximum size for',
         href,

--- a/packages/next/src/server/image-optimizer.ts
+++ b/packages/next/src/server/image-optimizer.ts
@@ -778,6 +778,7 @@ export async function fetchExternalImage(
   }
 
   if (!res.body) {
+    Log.error('upstream image response is empty for', href)
     throw new ImageError(
       400,
       '"url" parameter is valid but upstream response is invalid'

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -784,7 +784,8 @@ export default class NextNodeServer extends BaseServer<
         ? await fetchExternalImage(
             href,
             this.nextConfig.images.dangerouslyAllowLocalIP,
-            this.nextConfig.images.maximumRedirects
+            this.nextConfig.images.maximumRedirects,
+            this.nextConfig.images.maximumResponseBody
           )
         : await fetchInternalImage(
             href,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -784,8 +784,8 @@ export default class NextNodeServer extends BaseServer<
         ? await fetchExternalImage(
             href,
             this.nextConfig.images.dangerouslyAllowLocalIP,
-            this.nextConfig.images.maximumRedirects,
-            this.nextConfig.images.maximumResponseBody
+            this.nextConfig.images.maximumResponseBody,
+            this.nextConfig.images.maximumRedirects
           )
         : await fetchInternalImage(
             href,

--- a/packages/next/src/shared/lib/image-config.ts
+++ b/packages/next/src/shared/lib/image-config.ts
@@ -106,6 +106,9 @@ export type ImageConfigComplete = {
   /** @see [Maximum Redirects](https://nextjs.org/docs/api-reference/next/image#maximumredirects) */
   maximumRedirects: number
 
+  /** @see [Maximum Response Body](https://nextjs.org/docs/api-reference/next/image#maximumresponsebody) */
+  maximumResponseBody: number
+
   /** @see [Dangerously Allow Local IP](https://nextjs.org/docs/api-reference/next/image#dangerously-allow-local-ip) */
   dangerouslyAllowLocalIP: boolean
 
@@ -147,6 +150,7 @@ export const imageConfigDefault: ImageConfigComplete = {
   minimumCacheTTL: 14400, // 4 hours
   formats: ['image/webp'],
   maximumRedirects: 3,
+  maximumResponseBody: 300_000_000, // 300MB
   dangerouslyAllowLocalIP: false,
   dangerouslyAllowSVG: false,
   contentSecurityPolicy: `script-src 'none'; frame-src 'none'; sandbox;`,

--- a/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-localpatterns/test/index.test.ts
@@ -98,6 +98,7 @@ function runTests(mode: 'dev' | 'server') {
             },
           ],
           maximumRedirects: 3,
+          maximumResponseBody: 300000000,
           minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],

--- a/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir-qualities/test/index.test.ts
@@ -110,6 +110,7 @@ function runTests(mode: 'dev' | 'server') {
             },
           ],
           maximumRedirects: 3,
+          maximumResponseBody: 300000000,
           minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [42, 69, 88],

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -1796,6 +1796,7 @@ function runTests(mode: 'dev' | 'server') {
             },
           ],
           maximumRedirects: 3,
+          maximumResponseBody: 300000000,
           minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],

--- a/test/integration/next-image-new/unicode/test/index.test.ts
+++ b/test/integration/next-image-new/unicode/test/index.test.ts
@@ -103,6 +103,7 @@ function runTests(mode: 'server' | 'dev') {
             },
           ],
           maximumRedirects: 3,
+          maximumResponseBody: 300000000,
           minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],

--- a/test/integration/next-image-new/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-new/unoptimized/test/index.test.ts
@@ -118,6 +118,7 @@ function runTests(url: string, mode: 'dev' | 'server') {
             },
           ],
           maximumRedirects: 3,
+          maximumResponseBody: 300000000,
           minimumCacheTTL: 14400,
           path: '/_next/image',
           qualities: [75],

--- a/test/unit/image-optimizer/fetch-external-image.test.ts
+++ b/test/unit/image-optimizer/fetch-external-image.test.ts
@@ -1,0 +1,173 @@
+/* eslint-env jest */
+import {
+  fetchExternalImage,
+  ImageError,
+} from 'next/dist/server/image-optimizer'
+
+describe('fetchExternalImage', () => {
+  describe('response size limit', () => {
+    it('should successfully fetch an image under 300MB', async () => {
+      const mockImageData = Buffer.alloc(1024 * 1024) // 1MB
+      const mockReadableStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(mockImageData))
+          controller.close()
+        },
+      })
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockReadableStream,
+        headers: {
+          get: jest.fn((header: string) => {
+            if (header === 'Content-Type') return 'image/jpeg'
+            if (header === 'Cache-Control') return 'public, max-age=3600'
+            if (header === 'ETag') return '"test-etag"'
+            return null
+          }),
+        },
+      })
+
+      const result = await fetchExternalImage(
+        'http://example.com/image.jpg',
+        false
+      )
+
+      expect(result.buffer).toBeInstanceOf(Buffer)
+      expect(result.contentType).toBe('image/jpeg')
+      expect(result.cacheControl).toBe('public, max-age=3600')
+    })
+
+    it('should abort and throw error when response exceeds 300MB', async () => {
+      const chunkSize = 50_000_000 // 50MB chunks
+      // We create 8 chunks (400MB) to ensure stream has more data available
+      const numChunks = 8
+
+      global.fetch = jest.fn().mockImplementation(() => {
+        let chunksRead = 0
+        const mockReadableStream = new ReadableStream({
+          async pull(controller) {
+            if (chunksRead < numChunks) {
+              controller.enqueue(new Uint8Array(chunkSize))
+              chunksRead++
+            } else {
+              controller.close()
+            }
+          },
+        })
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: mockReadableStream,
+          headers: {
+            get: jest.fn((header: string) => {
+              if (header === 'Content-Type') return 'image/jpeg'
+              if (header === 'Cache-Control') return 'public, max-age=3600'
+              if (header === 'ETag') return null
+              return null
+            }),
+          },
+        })
+      })
+
+      const error = await fetchExternalImage(
+        'http://example.com/large-image.jpg',
+        false
+      ).catch((e) => e)
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(413)
+      expect((error as ImageError).message).toBe(
+        '"url" parameter is valid but upstream response is invalid'
+      )
+    })
+
+    it('should throw 413 status code for oversized response', async () => {
+      const chunkSize = 100_000_000 // 100MB chunks
+      const numChunks = 4 // 400MB total
+
+      const mockReadableStream = new ReadableStream({
+        async start(controller) {
+          for (let i = 0; i < numChunks; i++) {
+            controller.enqueue(new Uint8Array(chunkSize))
+          }
+          controller.close()
+        },
+      })
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockReadableStream,
+        headers: {
+          get: jest.fn(() => null),
+        },
+      })
+
+      const error = await fetchExternalImage(
+        'http://example.com/huge-image.jpg',
+        false
+      ).catch((e) => e)
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(413)
+      expect((error as ImageError).message).toBe(
+        '"url" parameter is valid but upstream response is invalid'
+      )
+    })
+
+    it('should handle response exactly at 300MB limit', async () => {
+      const exactSize = 300_000_000 // Exactly 300MB
+      const mockImageData = Buffer.alloc(exactSize)
+
+      const mockReadableStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(mockImageData))
+          controller.close()
+        },
+      })
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: mockReadableStream,
+        headers: {
+          get: jest.fn((header: string) => {
+            if (header === 'Content-Type') return 'image/jpeg'
+            return null
+          }),
+        },
+      })
+
+      const result = await fetchExternalImage(
+        'http://example.com/exact-size.jpg',
+        false
+      )
+
+      expect(result.buffer).toBeInstanceOf(Buffer)
+      expect(result.buffer.length).toBe(exactSize)
+    })
+
+    it('should throw error when response has no body', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        body: null,
+        headers: {
+          get: jest.fn(() => null),
+        },
+      })
+
+      const error = await fetchExternalImage(
+        'http://example.com/no-body.jpg',
+        false
+      ).catch((e) => e)
+
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(400)
+      expect((error as ImageError).message).toBe(
+        '"url" parameter is valid but upstream response is invalid'
+      )
+    })
+  })
+})

--- a/test/unit/image-optimizer/fetch-external-image.test.ts
+++ b/test/unit/image-optimizer/fetch-external-image.test.ts
@@ -6,43 +6,33 @@ import {
 
 describe('fetchExternalImage', () => {
   describe('response size limit', () => {
-    it('should successfully fetch an image under 300MB', async () => {
-      const mockImageData = Buffer.alloc(1024 * 1024) // 1MB
-      const mockReadableStream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(new Uint8Array(mockImageData))
-          controller.close()
-        },
-      })
-
+    it('should throw error when response has no body', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         ok: true,
         status: 200,
-        body: mockReadableStream,
+        body: null,
         headers: {
-          get: jest.fn((header: string) => {
-            if (header === 'Content-Type') return 'image/jpeg'
-            if (header === 'Cache-Control') return 'public, max-age=3600'
-            if (header === 'ETag') return '"test-etag"'
-            return null
-          }),
+          get: jest.fn(() => null),
         },
       })
 
-      const result = await fetchExternalImage(
-        'http://example.com/image.jpg',
-        false
-      )
+      const error = await fetchExternalImage(
+        'http://example.com/no-body.jpg',
+        false,
+        300_000_000
+      ).catch((e) => e)
 
-      expect(result.buffer).toBeInstanceOf(Buffer)
-      expect(result.contentType).toBe('image/jpeg')
-      expect(result.cacheControl).toBe('public, max-age=3600')
+      expect(error).toBeInstanceOf(ImageError)
+      expect((error as ImageError).statusCode).toBe(400)
+      expect((error as ImageError).message).toBe(
+        '"url" parameter is valid but upstream response is invalid'
+      )
     })
 
-    it('should abort and throw error when response exceeds 300MB', async () => {
-      const chunkSize = 50_000_000 // 50MB chunks
-      // We create 8 chunks (400MB) to ensure stream has more data available
-      const numChunks = 8
+    it('should throw error when exceeding maximumResponseBody config on later chunk', async () => {
+      const maximumResponseBody = 2_000 // 2KB custom limit
+      const chunkSize = 1_000 // 1KB chunks
+      const numChunks = 3 // 3KB total, exceeds custom 2KB limit
 
       global.fetch = jest.fn().mockImplementation(() => {
         let chunksRead = 0
@@ -64,8 +54,6 @@ describe('fetchExternalImage', () => {
           headers: {
             get: jest.fn((header: string) => {
               if (header === 'Content-Type') return 'image/jpeg'
-              if (header === 'Cache-Control') return 'public, max-age=3600'
-              if (header === 'ETag') return null
               return null
             }),
           },
@@ -73,9 +61,11 @@ describe('fetchExternalImage', () => {
       })
 
       const error = await fetchExternalImage(
-        'http://example.com/large-image.jpg',
-        false
+        'http://example.com/custom-limit.jpg',
+        false,
+        maximumResponseBody
       ).catch((e) => e)
+
       expect(error).toBeInstanceOf(ImageError)
       expect((error as ImageError).statusCode).toBe(413)
       expect((error as ImageError).message).toBe(
@@ -83,32 +73,36 @@ describe('fetchExternalImage', () => {
       )
     })
 
-    it('should throw 413 status code for oversized response', async () => {
-      const chunkSize = 100_000_000 // 100MB chunks
-      const numChunks = 4 // 400MB total
+    it('should throw error when exceeding maximumResponseBody config on first chunk', async () => {
+      const maximumResponseBody = 2_000 // 2KB custom limit
 
-      const mockReadableStream = new ReadableStream({
-        async start(controller) {
-          for (let i = 0; i < numChunks; i++) {
-            controller.enqueue(new Uint8Array(chunkSize))
-          }
-          controller.close()
-        },
-      })
+      global.fetch = jest.fn().mockImplementation(() => {
+        const mockReadableStream = new ReadableStream({
+          async pull(controller) {
+            controller.enqueue(new Uint8Array(maximumResponseBody + 1))
+            controller.close()
+          },
+        })
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        body: mockReadableStream,
-        headers: {
-          get: jest.fn(() => null),
-        },
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: mockReadableStream,
+          headers: {
+            get: jest.fn((header: string) => {
+              if (header === 'Content-Type') return 'image/jpeg'
+              return null
+            }),
+          },
+        })
       })
 
       const error = await fetchExternalImage(
-        'http://example.com/huge-image.jpg',
-        false
+        'http://example.com/custom-limit.jpg',
+        false,
+        maximumResponseBody
       ).catch((e) => e)
+
       expect(error).toBeInstanceOf(ImageError)
       expect((error as ImageError).statusCode).toBe(413)
       expect((error as ImageError).message).toBe(
@@ -116,58 +110,79 @@ describe('fetchExternalImage', () => {
       )
     })
 
-    it('should handle response exactly at 300MB limit', async () => {
-      const exactSize = 300_000_000 // Exactly 300MB
-      const mockImageData = Buffer.alloc(exactSize)
+    it('should succeed when exactly matching maximumResponseBody config on first chunk', async () => {
+      const maximumResponseBody = 3_000 // 3KB custom limit
 
-      const mockReadableStream = new ReadableStream({
-        start(controller) {
-          controller.enqueue(new Uint8Array(mockImageData))
-          controller.close()
-        },
-      })
+      global.fetch = jest.fn().mockImplementation(() => {
+        const mockReadableStream = new ReadableStream({
+          async pull(controller) {
+            controller.enqueue(new Uint8Array(maximumResponseBody))
+            controller.close()
+          },
+        })
 
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        body: mockReadableStream,
-        headers: {
-          get: jest.fn((header: string) => {
-            if (header === 'Content-Type') return 'image/jpeg'
-            return null
-          }),
-        },
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: mockReadableStream,
+          headers: {
+            get: jest.fn((header: string) => {
+              if (header === 'Content-Type') return 'image/jpeg'
+              return null
+            }),
+          },
+        })
       })
 
       const result = await fetchExternalImage(
-        'http://example.com/exact-size.jpg',
-        false
+        'http://example.com/custom-limit.jpg',
+        false,
+        maximumResponseBody
       )
 
       expect(result.buffer).toBeInstanceOf(Buffer)
-      expect(result.buffer.length).toBe(exactSize)
+      expect(result.buffer.length).toBe(maximumResponseBody)
     })
 
-    it('should throw error when response has no body', async () => {
-      global.fetch = jest.fn().mockResolvedValue({
-        ok: true,
-        status: 200,
-        body: null,
-        headers: {
-          get: jest.fn(() => null),
-        },
+    it('should succeed when exactly matching maximumResponseBody config on later chunk', async () => {
+      const maximumResponseBody = 3_000 // 3KB custom limit
+      const chunkSize = 1_000 // 1KB chunks
+      const numChunks = 3 // 3KB total
+
+      global.fetch = jest.fn().mockImplementation(() => {
+        let chunksRead = 0
+        const mockReadableStream = new ReadableStream({
+          async pull(controller) {
+            if (chunksRead < numChunks) {
+              controller.enqueue(new Uint8Array(chunkSize))
+              chunksRead++
+            } else {
+              controller.close()
+            }
+          },
+        })
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          body: mockReadableStream,
+          headers: {
+            get: jest.fn((header: string) => {
+              if (header === 'Content-Type') return 'image/jpeg'
+              return null
+            }),
+          },
+        })
       })
 
-      const error = await fetchExternalImage(
-        'http://example.com/no-body.jpg',
-        false
-      ).catch((e) => e)
-
-      expect(error).toBeInstanceOf(ImageError)
-      expect((error as ImageError).statusCode).toBe(400)
-      expect((error as ImageError).message).toBe(
-        '"url" parameter is valid but upstream response is invalid'
+      const result = await fetchExternalImage(
+        'http://example.com/custom-limit.jpg',
+        false,
+        maximumResponseBody
       )
+
+      expect(result.buffer).toBeInstanceOf(Buffer)
+      expect(result.buffer.length).toBe(maximumResponseBody)
     })
   })
 })


### PR DESCRIPTION
Add `images.maximumResponseBody` configuration to exit early when attempting to optimize large source images.