### PR TITLE
fix: move conductor.json to repo root for proper detection

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -2,8 +2,8 @@
   "name": "next.js",
   "description": "Next.js framework development workspace",
   "scripts": {
-    "setup": "./scripts/setup.sh",
-    "run": "./scripts/run.sh"
+    "setup": "./.conductor/scripts/setup.sh",
+    "run": "./.conductor/scripts/run.sh"
   },
   "worktree": {
     "default_branch": "canary"


### PR DESCRIPTION
## What?

Moves `conductor.json` from `.conductor/conductor.json` to the repository root and updates script paths accordingly.

## Why?

Conductor searches for configuration files in a specific priority order:
1. Workspace root
2. Remote default branch
3. Repository root

The previous location at `.conductor/conductor.json` wasn't in the standard search path, which could cause Conductor to not detect the configuration properly. Moving to the repo root follows the [recommended pattern from Conductor's documentation](https://docs.conductor.build/core/conductor-json).

## How?

- Moved `conductor.json` to repository root
- Updated script paths from `./scripts/` to `./.conductor/scripts/`
- Scripts remain in `.conductor/scripts/` for organization