### PR TITLE
Disallow javascript urls in router methods and redirects

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -975,5 +975,6 @@
   "974": "Failed to find Server Action%s. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "975": "Failed to find Server Action. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "976": "Decompressed resume data cache exceeded %s byte limit",
-  "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")"
+  "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")",
+  "978": "Next.js has blocked a javascript: URL as a security precaution."
 }

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -30,6 +30,7 @@ import type {
 import { setLinkForCurrentNavigation, type LinkInstance } from './links'
 import type { ClientInstrumentationHooks } from '../app-index'
 import type { GlobalErrorComponent } from './builtin/global-error'
+import { isJavaScriptURLString } from '../lib/javascript-url'
 
 export type DispatchStatePromise = React.Dispatch<ReducerState>
 
@@ -325,6 +326,11 @@ export const publicAppRouterInstance: AppRouterInstance = {
     // data in the router reducer state; it writes into a global mutable
     // cache. So we don't need to dispatch an action.
     (href: string, options?: PrefetchOptions) => {
+      if (isJavaScriptURLString(href)) {
+        throw new Error(
+          'Next.js has blocked a javascript: URL as a security precaution.'
+        )
+      }
       const actionQueue = getAppRouterActionQueue()
       const prefetchKind = options?.kind ?? PrefetchKind.AUTO
 
@@ -360,11 +366,21 @@ export const publicAppRouterInstance: AppRouterInstance = {
       )
     },
   replace: (href: string, options?: NavigateOptions) => {
+    if (isJavaScriptURLString(href)) {
+      throw new Error(
+        'Next.js has blocked a javascript: URL as a security precaution.'
+      )
+    }
     startTransition(() => {
       dispatchNavigateAction(href, 'replace', options?.scroll ?? true, null)
     })
   },
   push: (href: string, options?: NavigateOptions) => {
+    if (isJavaScriptURLString(href)) {
+      throw new Error(
+        'Next.js has blocked a javascript: URL as a security precaution.'
+      )
+    }
     startTransition(() => {
       dispatchNavigateAction(href, 'push', options?.scroll ?? true, null)
     })

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -18,6 +18,7 @@ import {
 import { NavigationResultTag } from '../../segment-cache/types'
 import { getStaleTimeMs } from '../../segment-cache/cache'
 import { FreshnessPolicy } from '../ppr-navigations'
+import { isJavaScriptURLString } from '../../../lib/javascript-url'
 
 // These values are set by `define-env-plugin` (based on `nextConfig.experimental.staleTimes`)
 // and default to 5 minutes (static) / 0 seconds (dynamic)
@@ -34,6 +35,13 @@ export function handleExternalUrl(
   url: string,
   pendingPush: boolean
 ) {
+  if (isJavaScriptURLString(url)) {
+    console.error(
+      'Next.js has blocked a javascript: URL as a security precaution.'
+    )
+    return handleMutable(state, mutable)
+  }
+
   mutable.mpaNavigation = true
   mutable.canonicalUrl = url
   mutable.pendingPush = pendingPush

--- a/packages/next/src/client/lib/javascript-url.ts
+++ b/packages/next/src/client/lib/javascript-url.ts
@@ -1,0 +1,18 @@
+// Adapted from React's sanitizeURL function found here: https://github.com/facebook/react/blob/b565373afd0cc1988497e1107106e851e8cfb261/packages/react-dom-bindings/src/shared/sanitizeURL.js
+
+// A javascript: URL can contain leading C0 control or \u0020 SPACE,
+// and any newline or tab are filtered out as if they're not part of the URL.
+// https://url.spec.whatwg.org/#url-parsing
+// Tab or newline are defined as \r\n\t:
+// https://infra.spec.whatwg.org/#ascii-tab-or-newline
+// A C0 control is a code point in the range \u0000 NULL to \u001F
+// INFORMATION SEPARATOR ONE, inclusive:
+// https://infra.spec.whatwg.org/#c0-control-or-space
+
+const isJavaScriptProtocol =
+  // eslint-disable-next-line no-control-regex
+  /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i
+
+export function isJavaScriptURLString(url: string): boolean {
+  return isJavaScriptProtocol.test('' + (url as unknown as string))
+}

--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -44,6 +44,7 @@ import { disableSmoothScrollDuringRouteTransition } from './utils/disable-smooth
 import type { Params } from '../../../server/request/params'
 import { MATCHED_PATH_HEADER } from '../../../lib/constants'
 import { getDeploymentId } from '../deployment-id'
+import { isJavaScriptURLString } from '../../../client/lib/javascript-url'
 
 let resolveRewrites: typeof import('./utils/resolve-rewrites').default
 if (process.env.__NEXT_HAS_REWRITES) {
@@ -995,6 +996,14 @@ export default class Router implements BaseRouter {
    * @param options object you can define `shallow` and other options
    */
   push(url: Url, as?: Url, options: TransitionOptions = {}) {
+    if (
+      isJavaScriptURLString(url.toString()) ||
+      (as && isJavaScriptURLString(as.toString()))
+    ) {
+      throw new Error(
+        'Next.js has blocked a javascript: URL as a security precaution.'
+      )
+    }
     if (process.env.__NEXT_SCROLL_RESTORATION) {
       // TODO: remove in the future when we update history before route change
       // is complete, as the popstate event should handle this capture.
@@ -1019,6 +1028,14 @@ export default class Router implements BaseRouter {
    * @param options object you can define `shallow` and other options
    */
   replace(url: Url, as?: Url, options: TransitionOptions = {}) {
+    if (
+      isJavaScriptURLString(url.toString()) ||
+      (as && isJavaScriptURLString(as.toString()))
+    ) {
+      throw new Error(
+        'Next.js has blocked a javascript: URL as a security precaution.'
+      )
+    }
     ;({ url, as } = prepareUrlAs(this, url, as))
     return this.change('replaceState', url, as, options)
   }

--- a/test/e2e/app-dir/javascript-urls/app/app/action-redirect-form/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/action-redirect-form/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from 'next/navigation'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../../bad-url'
+
+async function handleRedirect() {
+  'use server'
+  redirect(DANGEROUS_JAVASCRIPT_URL)
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        Clicking this button should result in an error where Next.js blocks a
+        javascript URL through a server action redirect initiated by an onClick
+        handler
+      </p>
+      <form action={handleRedirect}>
+        <button type="submit">redirect via form action</button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/app/action-redirect-onclick/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/action-redirect-onclick/page.tsx
@@ -1,0 +1,21 @@
+import { redirect } from 'next/navigation'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../../bad-url'
+
+async function handleRedirect() {
+  'use server'
+  redirect(DANGEROUS_JAVASCRIPT_URL)
+}
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        Clicking this button should result in an error where Next.js blocks a
+        javascript URL through a server action redirect initiated by an onClick
+        handler
+      </p>
+      <button onClick={handleRedirect}>redirect via onclick action</button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/app/link-as/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/link-as/page.tsx
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../../bad-url'
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        Clicking this link should result in an error where React blocks a
+        javascript URL
+      </p>
+      {/* In App Router as supercedes href but functionally it acts just like an href */}
+      <Link href="/" as={DANGEROUS_JAVASCRIPT_URL}>
+        Link with javascript URL `as`
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/app/link-href/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/link-href/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../../bad-url'
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        Clicking this link should result in an error where React blocks a
+        javascript URL
+      </p>
+      <Link href={DANGEROUS_JAVASCRIPT_URL}>
+        Link with javascript URL `href`
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/app/router-prefetch/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/router-prefetch/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../../bad-url'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <>
+      <p>
+        Clicking this button should result in an error where Next.js blocks a
+        javascript URL
+      </p>
+      <button onClick={() => router.prefetch(DANGEROUS_JAVASCRIPT_URL)}>
+        prefetch javascript URL
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/app/router-push/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/router-push/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../../bad-url'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <>
+      <p>
+        Clicking this button should result in an error where Next.js blocks a
+        javascript URL
+      </p>
+      <button onClick={() => router.push(DANGEROUS_JAVASCRIPT_URL)}>
+        push javascript URL
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/app/router-replace/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/router-replace/page.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../../bad-url'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <>
+      <p>
+        Clicking this button should result in an error where Next.js blocks a
+        javascript URL
+      </p>
+      <button onClick={() => router.replace(DANGEROUS_JAVASCRIPT_URL)}>
+        replace javascript URL
+      </button>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/app/safe/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/app/safe/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return (
+    <>
+      <p id="canarv">
+        This page is used as a navigation target to ensure SPA navigation
+        continues to work after pushing/redirecting/linking to a javascript URL.
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/boom/page.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/boom/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  return (
+    <>
+      <p id="pwned">
+        If you were redirected here then the dangerous javascript URL was
+        followed.
+      </p>
+    </>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/app/layout.tsx
+++ b/test/e2e/app-dir/javascript-urls/app/layout.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link'
+
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>
+        <main>{children}</main>
+        <Link href="/app/safe">Safe Page</Link>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/bad-url.ts
+++ b/test/e2e/app-dir/javascript-urls/bad-url.ts
@@ -1,0 +1,3 @@
+export const DANGEROUS_JAVASCRIPT_URL =
+  // eslint-disable-next-line no-script-url
+  "javascript:window.location.assign('/boom');"

--- a/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+++ b/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
@@ -1,35 +1,83 @@
 import { nextTestSetup } from 'e2e-utils'
-import { waitForNoRedbox } from 'next-test-utils'
+import {
+  getRedboxDescription,
+  retry,
+  waitForNoRedbox,
+  waitForRedbox,
+} from 'next-test-utils'
+import type { Page, Request } from 'playwright'
 
-describe('hello-world', () => {
-  const { next } = nextTestSetup({
+describe('javascript-urls', () => {
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
   })
 
+  /**
+   * Creates a beforePageLoad handler that intercepts navigation requests
+   * and tracks them for later assertion.
+   */
+  function createNavigationInterceptor() {
+    const navigationRequests: Request[] = []
+
+    const beforePageLoad = (page: Page) => {
+      page.on('request', (request) => {
+        if (request.resourceType() === 'document') {
+          navigationRequests.push(request)
+        }
+      })
+    }
+
+    const getNavigationRequests = () => navigationRequests
+
+    return { beforePageLoad, getNavigationRequests }
+  }
+
+  /**
+   * Helper to test that a javascript: URL is blocked.
+   * Waits for the security error to appear in logs (confirming the click was processed),
+   * then asserts no navigation requests were made.
+   */
+  async function expectJavascriptUrlBlocked(
+    browser: Awaited<ReturnType<typeof next.browser>>,
+    initialUrl: string,
+    getNavigationRequests: () => Request[]
+  ) {
+    const errorMessage =
+      'has blocked a javascript: URL as a security precaution.'
+    // Wait for the security error to appear in logs, confirming the click was processed
+    await retry(async () => {
+      const logs = await browser.log()
+      const errors = logs.filter(
+        (log) => log.source === 'error' && log.message.includes(errorMessage)
+      )
+      expect(errors.length).toBeGreaterThan(0)
+    })
+
+    // Verify no navigation requests were made after the initial page load
+    const navRequests = getNavigationRequests()
+    const postLoadNavigations = navRequests.filter(
+      (req) => !req.url().includes(new URL(initialUrl).pathname)
+    )
+    expect(postLoadNavigations).toHaveLength(0)
+
+    // Verify URL hasn't changed
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl)
+  }
+
   it('should prevent javascript URLs in link `href`', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/app/link-href', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('a').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
-
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'React has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
     // Click the safe page link
     await browser.elementByCss('a[href="/app/safe"]').click()
@@ -44,29 +92,18 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in link `as`', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/app/link-as', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('a').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
-
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'React has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
     // Click the safe page link
     await browser.elementByCss('a[href="/app/safe"]').click()
@@ -81,29 +118,18 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in route.push', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/app/router-push', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('button').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
-
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
     // Click the safe page link
     await browser.elementByCss('a[href="/app/safe"]').click()
@@ -118,30 +144,18 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in route.replace', async () => {
-    jest.useRealTimers()
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/app/router-replace', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('button').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
-
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
     // Click the safe page link
     await browser.elementByCss('a[href="/app/safe"]').click()
@@ -156,29 +170,18 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in route.prefetch', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/app/router-prefetch', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('button').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
-
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
     // Click the safe page link
     await browser.elementByCss('a[href="/app/safe"]').click()
@@ -193,29 +196,18 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in server action redirect through onClick', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/app/action-redirect-onclick', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('button').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
-
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
     // Click the safe page link
     await browser.elementByCss('a[href="/app/safe"]').click()
@@ -230,29 +222,18 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in server action redirect through form action', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/app/action-redirect-form', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('button').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
-
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
     // Click the safe page link
     await browser.elementByCss('a[href="/app/safe"]').click()
@@ -267,29 +248,27 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in pages router Link component', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/pages/link-href', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
-    await Promise.race([
-      browser.elementByCss('a').click(),
-      new Promise((r) => setTimeout(r, 4000)),
-    ])
+    await browser.elementByCss('a').click()
 
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'React has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    if (isNextDev) {
+      await waitForRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"React has blocked a javascript: URL as a security precaution."`
+      )
+      browser.keydown('Escape')
+      await waitForNoRedbox(browser)
+    }
 
     // Click the safe page link
     await browser.elementByCss('a[href="/pages/safe"]').click()
@@ -304,29 +283,27 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in pages router Link as prop', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/pages/link-as', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('a').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    if (isNextDev) {
+      await waitForRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"Next.js has blocked a javascript: URL as a security precaution."`
+      )
+      browser.keydown('Escape')
+      await waitForNoRedbox(browser)
+    }
 
     // Click the safe page link
     await browser.elementByCss('a[href="/pages/safe"]').click()
@@ -341,29 +318,27 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in pages router router.push', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/pages/router-push', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('button').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
+    if (isNextDev) {
+      await waitForRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"Next.js has blocked a javascript: URL as a security precaution."`
+      )
+      browser.keydown('Escape')
+      await waitForNoRedbox(browser)
+    }
 
     // Click the safe page link
     await browser.elementByCss('a[href="/pages/safe"]').click()
@@ -378,31 +353,27 @@ describe('hello-world', () => {
   })
 
   it('should prevent javascript URLs in pages router router.replace', async () => {
+    const { beforePageLoad, getNavigationRequests } =
+      createNavigationInterceptor()
+
     const browser = await next.browser('/pages/router-replace', {
       pushErrorAsConsoleLog: true,
+      beforePageLoad,
     })
     const initialUrl = await browser.url()
 
     await browser.elementByCss('button').click()
 
-    // Wait a bit to ensure no navigation occurs
-    await new Promise((r) => setTimeout(r, 1000))
+    await expectJavascriptUrlBlocked(browser, initialUrl, getNavigationRequests)
 
-    const finalUrl = await browser.url()
-    expect(finalUrl).toBe(initialUrl) // URL should not have changed
-
-    // Check that the browser logged the React security error
-    const logs = await browser.log()
-    const errors = logs.filter(
-      (log) =>
-        log.source === 'error' &&
-        log.message.includes(
-          'Next.js has blocked a javascript: URL as a security precaution'
-        )
-    )
-    expect(errors.length).toBeGreaterThan(0)
-
-    await waitForNoRedbox(browser)
+    if (isNextDev) {
+      await waitForRedbox(browser)
+      expect(await getRedboxDescription(browser)).toMatchInlineSnapshot(
+        `"Next.js has blocked a javascript: URL as a security precaution."`
+      )
+      browser.keydown('Escape')
+      await waitForNoRedbox(browser)
+    }
 
     // Click the safe page link
     await browser.elementByCss('a[href="/pages/safe"]').click()

--- a/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
+++ b/test/e2e/app-dir/javascript-urls/javascript-urls.test.ts
@@ -1,0 +1,418 @@
+import { nextTestSetup } from 'e2e-utils'
+import { waitForNoRedbox } from 'next-test-utils'
+
+describe('hello-world', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should prevent javascript URLs in link `href`', async () => {
+    const browser = await next.browser('/app/link-href', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('a').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'React has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/app/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/app/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/app/safe')
+  })
+
+  it('should prevent javascript URLs in link `as`', async () => {
+    const browser = await next.browser('/app/link-as', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('a').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'React has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/app/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/app/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/app/safe')
+  })
+
+  it('should prevent javascript URLs in route.push', async () => {
+    const browser = await next.browser('/app/router-push', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('button').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/app/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/app/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/app/safe')
+  })
+
+  it('should prevent javascript URLs in route.replace', async () => {
+    jest.useRealTimers()
+    const browser = await next.browser('/app/router-replace', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('button').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/app/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/app/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/app/safe')
+  })
+
+  it('should prevent javascript URLs in route.prefetch', async () => {
+    const browser = await next.browser('/app/router-prefetch', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('button').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/app/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/app/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/app/safe')
+  })
+
+  it('should prevent javascript URLs in server action redirect through onClick', async () => {
+    const browser = await next.browser('/app/action-redirect-onclick', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('button').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/app/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/app/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/app/safe')
+  })
+
+  it('should prevent javascript URLs in server action redirect through form action', async () => {
+    const browser = await next.browser('/app/action-redirect-form', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('button').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/app/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/app/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/app/safe')
+  })
+
+  it('should prevent javascript URLs in pages router Link component', async () => {
+    const browser = await next.browser('/pages/link-href', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await Promise.race([
+      browser.elementByCss('a').click(),
+      new Promise((r) => setTimeout(r, 4000)),
+    ])
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'React has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/pages/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/pages/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/pages/safe')
+  })
+
+  it('should prevent javascript URLs in pages router Link as prop', async () => {
+    const browser = await next.browser('/pages/link-as', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('a').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/pages/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/pages/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/pages/safe')
+  })
+
+  it('should prevent javascript URLs in pages router router.push', async () => {
+    const browser = await next.browser('/pages/router-push', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('button').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/pages/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/pages/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/pages/safe')
+  })
+
+  it('should prevent javascript URLs in pages router router.replace', async () => {
+    const browser = await next.browser('/pages/router-replace', {
+      pushErrorAsConsoleLog: true,
+    })
+    const initialUrl = await browser.url()
+
+    await browser.elementByCss('button').click()
+
+    // Wait a bit to ensure no navigation occurs
+    await new Promise((r) => setTimeout(r, 1000))
+
+    const finalUrl = await browser.url()
+    expect(finalUrl).toBe(initialUrl) // URL should not have changed
+
+    // Check that the browser logged the React security error
+    const logs = await browser.log()
+    const errors = logs.filter(
+      (log) =>
+        log.source === 'error' &&
+        log.message.includes(
+          'Next.js has blocked a javascript: URL as a security precaution'
+        )
+    )
+    expect(errors.length).toBeGreaterThan(0)
+
+    await waitForNoRedbox(browser)
+
+    // Click the safe page link
+    await browser.elementByCss('a[href="/pages/safe"]').click()
+
+    // Wait for navigation to complete
+    await browser.waitForCondition(
+      'window.location.pathname.includes("/pages/safe")'
+    )
+
+    const safePageUrl = await browser.url()
+    expect(safePageUrl).toContain('/pages/safe')
+  })
+})

--- a/test/e2e/app-dir/javascript-urls/next.config.js
+++ b/test/e2e/app-dir/javascript-urls/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/javascript-urls/pages/pages/link-as.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/link-as.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
+
+export default function Page() {
+  return (
+    <html>
+      <body>
+        <main>
+          <p>
+            Clicking this link should result in an error where React blocks a
+            javascript URL
+          </p>
+          <Link href="/" as={DANGEROUS_JAVASCRIPT_URL}>
+            Link with javascript URL `as`
+          </Link>
+        </main>
+        <footer>
+          <Link href="/pages/safe">Safe Page</Link>
+        </footer>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/pages/pages/link-href.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/link-href.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
+
+export default function Page() {
+  return (
+    <html>
+      <body>
+        <main>
+          <p>
+            Clicking this link should result in an error where React blocks a
+            javascript URL
+          </p>
+          <Link href={DANGEROUS_JAVASCRIPT_URL}>
+            Link with javascript URL `href`
+          </Link>
+        </main>
+        <footer>
+          <Link href="/pages/safe">Safe Page</Link>
+        </footer>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/pages/pages/router-push.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/router-push.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <html>
+      <body>
+        <main>
+          <p>
+            Clicking this button should result in an error where Next.js blocks
+            a javascript URL
+          </p>
+          <button onClick={() => router.push(DANGEROUS_JAVASCRIPT_URL)}>
+            push javascript URL
+          </button>
+        </main>
+        <footer>
+          <Link href="/pages/safe">Safe Page</Link>
+        </footer>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/pages/pages/router-replace.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/router-replace.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
+
+export default function Page() {
+  const router = useRouter()
+  return (
+    <html>
+      <body>
+        <main>
+          <p>
+            Clicking this button should result in an error where Next.js blocks
+            a javascript URL
+          </p>
+          <button onClick={() => router.replace(DANGEROUS_JAVASCRIPT_URL)}>
+            replace javascript URL
+          </button>
+        </main>
+        <footer>
+          <Link href="/pages/safe">Safe Page</Link>
+        </footer>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/javascript-urls/pages/pages/safe.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/safe.tsx
@@ -1,0 +1,8 @@
+export default function Page() {
+  return (
+    <p id="canarv">
+      This page is used as a navigation target to ensure SPA navigation
+      continues to work after pushing/redirecting/linking to a javascript URL.
+    </p>
+  )
+}


### PR DESCRIPTION
React already disallows javascript URLs. This change extends this prohibition to Next.js specific APIs that don't serialize to an href on an anchor tag. There are workarounds if need be but this is considered a bugfix because these URLs are non-routable and the affected APIs were never intended to work with these URLs.

This replaces prior efforts here: https://github.com/vercel/next.js/pull/64779/ which attempted to make this capability optional. We decided it was just not supportable and since workarounds exist the burden of upgrading through this bugfix is acceptable.

Closes https://linear.app/vercel/issue/NEXT-3140/