### PR TITLE
feat(turbopack): optimize resolve plugin conditions with Option

### DIFF
--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -15,7 +15,9 @@ use turbopack_core::{
     resolve::{
         ResolveResult, ResolveResultItem, ResolveResultOption,
         parse::Request,
-        plugin::{BeforeResolvePlugin, BeforeResolvePluginCondition},
+        plugin::{
+            BeforeResolvePlugin, BeforeResolvePluginCondition, OptionBeforeResolvePluginCondition,
+        },
     },
     virtual_source::VirtualSource,
 };
@@ -64,11 +66,14 @@ impl NextFontLocalResolvePlugin {
 #[turbo_tasks::value_impl]
 impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
-    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_request_glob(Glob::new(
-            rcstr!("{next,@vercel/turbopack-next/internal}/font/local/*"),
-            GlobOptions::default(),
-        ))
+    fn before_resolve_condition(&self) -> Vc<OptionBeforeResolvePluginCondition> {
+        OptionBeforeResolvePluginCondition::some(
+            BeforeResolvePluginCondition::from_request_glob(Glob::new(
+                rcstr!("{next,@vercel/turbopack-next/internal}/font/local/*"),
+                GlobOptions::default(),
+            ))
+            .to_resolved(),
+        )
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -17,7 +17,9 @@ use turbopack_core::{
         package_json,
         parse::Request,
         pattern::Pattern,
-        plugin::{AfterResolvePlugin, AfterResolvePluginCondition},
+        plugin::{
+            AfterResolvePlugin, AfterResolvePluginCondition, OptionAfterResolvePluginCondition,
+        },
         resolve,
     },
     source::Source,
@@ -64,17 +66,20 @@ impl ExternalCjsModulesResolvePlugin {
 }
 
 #[turbo_tasks::function]
-fn condition(root: FileSystemPath) -> Vc<AfterResolvePluginCondition> {
-    AfterResolvePluginCondition::new(
-        root,
-        Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
+fn condition(root: FileSystemPath) -> Vc<OptionAfterResolvePluginCondition> {
+    OptionAfterResolvePluginCondition::some(
+        AfterResolvePluginCondition::new(
+            root,
+            Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
+        )
+        .to_resolved(),
     )
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
-    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+    fn after_resolve_condition(&self) -> Vc<OptionAfterResolvePluginCondition> {
         condition(self.root.clone())
     }
 

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -19,7 +19,8 @@ use turbopack_core::{
         pattern::Pattern,
         plugin::{
             AfterResolvePlugin, AfterResolvePluginCondition, BeforeResolvePlugin,
-            BeforeResolvePluginCondition,
+            BeforeResolvePluginCondition, OptionAfterResolvePluginCondition,
+            OptionBeforeResolvePluginCondition,
         },
     },
 };
@@ -128,8 +129,11 @@ impl InvalidImportResolvePlugin {
 #[turbo_tasks::value_impl]
 impl BeforeResolvePlugin for InvalidImportResolvePlugin {
     #[turbo_tasks::function]
-    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_modules(Vc::cell(vec![self.invalid_import.clone()]))
+    fn before_resolve_condition(&self) -> Vc<OptionBeforeResolvePluginCondition> {
+        OptionBeforeResolvePluginCondition::some(
+            BeforeResolvePluginCondition::from_modules(Vc::cell(vec![self.invalid_import.clone()]))
+                .to_resolved(),
+        )
     }
 
     #[turbo_tasks::function]
@@ -223,13 +227,16 @@ impl NextExternalResolvePlugin {
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextExternalResolvePlugin {
     #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new(
-            self.project_path.root().owned().await?,
-            Glob::new(
-                rcstr!("**/next/dist/**/*.{external,runtime.dev,runtime.prod}.js"),
-                GlobOptions::default(),
-            ),
+    async fn after_resolve_condition(&self) -> Result<Vc<OptionAfterResolvePluginCondition>> {
+        Ok(OptionAfterResolvePluginCondition::some(
+            AfterResolvePluginCondition::new(
+                self.project_path.root().owned().await?,
+                Glob::new(
+                    rcstr!("**/next/dist/**/*.{external,runtime.dev,runtime.prod}.js"),
+                    GlobOptions::default(),
+                ),
+            )
+            .to_resolved(),
         ))
     }
 
@@ -281,13 +288,16 @@ impl NextNodeSharedRuntimeResolvePlugin {
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new(
-            self.root.root().owned().await?,
-            Glob::new(
-                rcstr!("**/next/dist/**/*.shared-runtime.js"),
-                GlobOptions::default(),
-            ),
+    async fn after_resolve_condition(&self) -> Result<Vc<OptionAfterResolvePluginCondition>> {
+        Ok(OptionAfterResolvePluginCondition::some(
+            AfterResolvePluginCondition::new(
+                self.root.root().owned().await?,
+                Glob::new(
+                    rcstr!("**/next/dist/**/*.shared-runtime.js"),
+                    GlobOptions::default(),
+                ),
+            )
+            .to_resolved(),
         ))
     }
 
@@ -352,13 +362,16 @@ impl ModuleFeatureReportResolvePlugin {
 #[turbo_tasks::value_impl]
 impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
     #[turbo_tasks::function]
-    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_modules(Vc::cell(
-            FEATURE_MODULES
-                .keys()
-                .map(|k| (*k).into())
-                .collect::<Vec<RcStr>>(),
-        ))
+    fn before_resolve_condition(&self) -> Vc<OptionBeforeResolvePluginCondition> {
+        OptionBeforeResolvePluginCondition::some(
+            BeforeResolvePluginCondition::from_modules(Vc::cell(
+                FEATURE_MODULES
+                    .keys()
+                    .map(|k| (*k).into())
+                    .collect::<Vec<RcStr>>(),
+            ))
+            .to_resolved(),
+        )
     }
 
     #[turbo_tasks::function]
@@ -409,13 +422,16 @@ impl NextSharedRuntimeResolvePlugin {
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new(
-            self.root.root().owned().await?,
-            Glob::new(
-                rcstr!("**/next/dist/esm/**/*.shared-runtime.js"),
-                GlobOptions::default(),
-            ),
+    async fn after_resolve_condition(&self) -> Result<Vc<OptionAfterResolvePluginCondition>> {
+        Ok(OptionAfterResolvePluginCondition::some(
+            AfterResolvePluginCondition::new(
+                self.root.root().owned().await?,
+                Glob::new(
+                    rcstr!("**/next/dist/esm/**/*.shared-runtime.js"),
+                    GlobOptions::default(),
+                ),
+            )
+            .to_resolved(),
         ))
     }
 

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1683,9 +1683,12 @@ async fn handle_before_resolve_plugins(
     options: Vc<ResolveOptions>,
 ) -> Result<Option<Vc<ResolveResult>>> {
     for plugin in &options.await?.before_resolve_plugins {
-        let condition = plugin.before_resolve_condition().resolve().await?;
-        if !*condition.matches(request).await? {
-            continue;
+        let condition_option = plugin.before_resolve_condition().await?;
+        if let Some(condition) = *condition_option {
+            let condition = condition.resolve().await?;
+            if !*condition.matches(request).await? {
+                continue;
+            }
         }
 
         if let Some(result) = *plugin
@@ -1714,17 +1717,31 @@ async fn handle_after_resolve_plugins(
         options: Vc<ResolveOptions>,
     ) -> Result<Option<Vc<ResolveResult>>> {
         for plugin in &options.await?.after_resolve_plugins {
-            let after_resolve_condition = plugin.after_resolve_condition().resolve().await?;
-            if *after_resolve_condition.matches(path.clone()).await?
-                && let Some(result) = *plugin
-                    .after_resolve(
-                        path.clone(),
-                        lookup_path.clone(),
-                        reference_type.clone(),
-                        request,
-                    )
-                    .await?
+            let after_resolve_condition_option = plugin.after_resolve_condition().await?;
+            if let Some(after_resolve_condition) = *after_resolve_condition_option {
+                let after_resolve_condition = after_resolve_condition.resolve().await?;
+                if *after_resolve_condition.matches(path.clone()).await?
+                    && let Some(result) = *plugin
+                        .after_resolve(
+                            path.clone(),
+                            lookup_path.clone(),
+                            reference_type.clone(),
+                            request,
+                        )
+                        .await?
+                {
+                    return Ok(Some(*result));
+                }
+            } else if let Some(result) = *plugin
+                .after_resolve(
+                    path.clone(),
+                    lookup_path.clone(),
+                    reference_type.clone(),
+                    request,
+                )
+                .await?
             {
+                // If there is no condition, the plugin applies to all paths.
                 return Ok(Some(*result));
             }
         }

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -40,6 +40,22 @@ impl AfterResolvePluginCondition {
     }
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionAfterResolvePluginCondition(Option<ResolvedVc<AfterResolvePluginCondition>>);
+
+#[turbo_tasks::value_impl]
+impl OptionAfterResolvePluginCondition {
+    #[turbo_tasks::function]
+    pub fn none() -> Vc<Self> {
+        Vc::cell(None)
+    }
+
+    #[turbo_tasks::function]
+    pub fn some(condition: ResolvedVc<AfterResolvePluginCondition>) -> Vc<Self> {
+        Vc::cell(Some(condition))
+    }
+}
+
 /// A condition which determines if the hooks of a resolve plugin gets called.
 #[turbo_tasks::value]
 pub enum BeforeResolvePluginCondition {
@@ -80,10 +96,26 @@ impl BeforeResolvePluginCondition {
     }
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct OptionBeforeResolvePluginCondition(Option<ResolvedVc<BeforeResolvePluginCondition>>);
+
+#[turbo_tasks::value_impl]
+impl OptionBeforeResolvePluginCondition {
+    #[turbo_tasks::function]
+    pub fn none() -> Vc<Self> {
+        Vc::cell(None)
+    }
+
+    #[turbo_tasks::function]
+    pub fn some(condition: ResolvedVc<BeforeResolvePluginCondition>) -> Vc<Self> {
+        Vc::cell(Some(condition))
+    }
+}
+
 #[turbo_tasks::value_trait]
 pub trait BeforeResolvePlugin {
     #[turbo_tasks::function]
-    fn before_resolve_condition(self: Vc<Self>) -> Vc<BeforeResolvePluginCondition>;
+    fn before_resolve_condition(self: Vc<Self>) -> Vc<OptionBeforeResolvePluginCondition>;
 
     #[turbo_tasks::function]
     fn before_resolve(
@@ -98,7 +130,7 @@ pub trait BeforeResolvePlugin {
 pub trait AfterResolvePlugin {
     /// A condition which determines if the hooks gets called.
     #[turbo_tasks::function]
-    fn after_resolve_condition(self: Vc<Self>) -> Vc<AfterResolvePluginCondition>;
+    fn after_resolve_condition(self: Vc<Self>) -> Vc<OptionAfterResolvePluginCondition>;
 
     /// This hook gets called when a full filepath has been resolved and the
     /// condition matches. If a value is returned it replaces the resolve


### PR DESCRIPTION
This PR refactors the Resolution Plugin traits to use Option for their conditions. This allow plugins (like [ExternalsPlugin](https://github.com/utooland/utoo/pull/2494) when no externals are configured) to return None, skipping the expensive matches() task calls entirely. Testing on a medium project showed a reduction of ~1.4k resolve_call tasks.