### PR TITLE
docs(localFont): enhance details about using the `localFont` function

### DIFF
--- a/docs/01-app/01-getting-started/13-fonts.mdx
+++ b/docs/01-app/01-getting-started/13-fonts.mdx
@@ -132,13 +132,13 @@ export default function RootLayout({ children }) {
 
 ## Local fonts
 
-To use a local font, import your font from `next/font/local` and specify the [`src`](/docs/app/api-reference/components/font#src) of your local font file. Fonts can be stored in the [`public`](/docs/app/api-reference/file-conventions/public-folder) folder or co-located inside the `app` folder. For example:
+To use a local font, import your font from `next/font/local` and specify the [`src`](/docs/app/api-reference/components/font#src) of your local font file. Fonts can be stored in the [`public`](/docs/app/api-reference/file-conventions/public-folder) folder or co-located inside the `app` folder and can be referenced by the `src` property using relative paths. For example:
 
 ```tsx filename="app/layout.tsx" switcher
 import localFont from 'next/font/local'
 
 const myFont = localFont({
-  src: './my-font.woff2',
+  src: './my-font.woff2', // relative path to the font file
 })
 
 export default function RootLayout({

--- a/docs/01-app/01-getting-started/13-fonts.mdx
+++ b/docs/01-app/01-getting-started/13-fonts.mdx
@@ -132,13 +132,13 @@ export default function RootLayout({ children }) {
 
 ## Local fonts
 
-To use a local font, import your font from `next/font/local` and specify the [`src`](/docs/app/api-reference/components/font#src) of your local font file. Fonts can be stored in the [`public`](/docs/app/api-reference/file-conventions/public-folder) folder or co-located inside the `app` folder and can be referenced by the `src` property using relative paths. For example:
+To use a local font, import the `localFont` function from `next/font/local` and specify the [`src`](/docs/app/api-reference/components/font#src) of your local font file using a relative path. Fonts can be stored anywhere in the project, including the [`public`](/docs/app/api-reference/file-conventions/public-folder) folder or the `app` folder. For example:
 
 ```tsx filename="app/layout.tsx" switcher
 import localFont from 'next/font/local'
 
 const myFont = localFont({
-  src: './my-font.woff2', // relative path to the font file
+  src: './my-font.woff2',
 })
 
 export default function RootLayout({


### PR DESCRIPTION
### What?
Enhance the documentation about how to use the `localFont` function.

### Why?
The Next.js documentation about [local fonts](https://nextjs.org/docs/app/getting-started/fonts#local-fonts) has insufficient information about where to store the font files and how to reference them with the `localFont` function. The lack of detail causes confusion like this issue: https://github.com/vercel/next.js/issues/76573.

### How?
I created a demo (https://nextjs-localfont-demo.vercel.app/) to investigate the behavior of the `localFont` function. I confirmed that the font files can be located anywhere inside the project, including at root, the `src` directory, the `app` directory, and the `public` directory, and that they must all be referenced using relative paths.

Fixes #76573
