### PR TITLE
fix(examples): fix tests in examples/with-mocha/

### DIFF
--- a/examples/with-mocha/mocha.setup.js
+++ b/examples/with-mocha/mocha.setup.js
@@ -1,4 +1,1 @@
-import Enzyme from "enzyme";
-import Adapter from "enzyme-adapter-react-16";
-
-Enzyme.configure({ adapter: new Adapter() });
+import "jsdom-global/register";

--- a/examples/with-mocha/package.json
+++ b/examples/with-mocha/package.json
@@ -14,10 +14,11 @@
   "devDependencies": {
     "@babel/core": "7.22.5",
     "@babel/register": "7.22.5",
+    "@testing-library/react": "^16.3.1",
     "cross-env": "7.0.2",
-    "enzyme": "^3.11.0",
-    "enzyme-adapter-react-16": "^1.15.2",
     "expect.js": "^0.3.1",
+    "jsdom": "^27.4.0",
+    "jsdom-global": "^3.0.2",
     "mocha": "^7.1.1"
   }
 }

--- a/examples/with-mocha/test/index.test.js
+++ b/examples/with-mocha/test/index.test.js
@@ -1,14 +1,15 @@
 /* global describe, it */
-import { shallow } from "enzyme";
-import React from "react";
+import { render } from "@testing-library/react";
 import expect from "expect.js";
 
 import App from "../pages/index.js";
 
-describe("With Enzyme", () => {
+describe("With React Testing Library", () => {
   it('App shows "Hello world!"', () => {
-    const app = shallow(<App />);
+    const app = render(<App />);
 
-    expect(app.find("p").text()).to.equal("Hello World!");
+    expect(app.container.querySelector("p")?.textContent).to.equal(
+      "Hello World!",
+    );
   });
 });


### PR DESCRIPTION
The tests were failing:

```console
$ pnpm test  # Error: Cannot find module '@babel/runtime/helpers/interopRequireDefault'
$ pnpm i -D @babel/runtime
$ pnpm test  # Error: Package subpath './lib/utils' is not defined by "exports" in /src/with-mocha/node_modules/.pnpm/enzyme@3.11.0/node_modules/cheerio/package.json
```

Since Enzyme doesn't support React 18, migrate to React Testing Library.
