### PR TITLE
fix(examples): fix test in examples/with-cypress/

### DIFF
--- a/examples/with-cypress/cypress/support/component.ts
+++ b/examples/with-cypress/cypress/support/component.ts
@@ -20,7 +20,7 @@ import "./commands";
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 
-import { mount } from "cypress/react18";
+import { mount } from "cypress/react";
 
 // Augment the Cypress namespace to include type definitions for
 // your custom command.

--- a/examples/with-cypress/package.json
+++ b/examples/with-cypress/package.json
@@ -18,7 +18,7 @@
     "@types/node": "18.0.6",
     "@types/react": "18.2.8",
     "@types/react-dom": "18.0.6",
-    "cypress": "12.3.0",
+    "cypress": "15.8.2",
     "start-server-and-test": "1.15.2",
     "typescript": "4.7.4"
   }


### PR DESCRIPTION
Fix the following error by bumping cypress to the latest.

```console
$ pnpm component:headless

> @ component:headless /src/with-cypress
> cypress run --component

Your configFile threw an error from: cypress.config.js

We stopped running your tests because your config file crashed.

TypeError: webpackModule.init is not a function
    at sourceNextWebpack (/home/wsh/.cache/Cypress/12.3.0/Cypress/resources/app/node_modules/@packages/server/node_modules/@cypress/webpack-dev-server/dist/helpers/nextHandler.js:252:19)
    at sourceNextWebpackDeps (/home/wsh/.cache/Cypress/12.3.0/Cypress/resources/app/node_modules/@packages/server/node_modules/@cypress/webpack-dev-server/dist/helpers/nextHandler.js:212:21)
    at nextHandler (/home/wsh/.cache/Cypress/12.3.0/Cypress/resources/app/node_modules/@packages/server/node_modules/@cypress/webpack-dev-server/dist/helpers/nextHandler.js:18:74)
    at async getPreset (/home/wsh/.cache/Cypress/12.3.0/Cypress/resources/app/node_modules/@packages/server/node_modules/@cypress/webpack-dev-server/dist/devServer.js:74:20)
    at async devServer.create (/home/wsh/.cache/Cypress/12.3.0/Cypress/resources/app/node_modules/@packages/server/node_modules/@cypress/webpack-dev-server/dist/devServer.js:93:61)
    at async /home/wsh/.cache/Cypress/12.3.0/Cypress/resources/app/node_modules/@packages/server/node_modules/@cypress/webpack-dev-server/dist/devServer.js:25:24
 ELIFECYCLE  Command failed with exit code 1.
```
