### PR TITLE
Turbopack: properly remove unused TS enums with scope hoisting

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -2568,6 +2568,17 @@ impl SourceMapper for CodeGenResultSourceMap {
             }
         }
     }
+    fn map_raw_pos(&self, pos: BytePos) -> BytePos {
+        match self {
+            CodeGenResultSourceMap::None => BytePos::DUMMY,
+            CodeGenResultSourceMap::Single { .. } => pos,
+            CodeGenResultSourceMap::ScopeHoisting {
+                modules_header_width,
+                lookup_table,
+                ..
+            } => CodeGenResultComments::decode_bytepos(*modules_header_width, pos, lookup_table).1,
+        }
+    }
 }
 impl SourceMapperExt for CodeGenResultSourceMap {
     fn get_code_map(&self) -> &dyn SourceMapper {

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/a.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/a.ts
@@ -1,3 +1,7 @@
 export enum Unused {
   THIS_SHOULD_BE_REMOVED,
 }
+
+export enum Used {
+  THIS_IS_USED,
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/a.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/a.ts
@@ -1,0 +1,3 @@
+export enum Unused {
+  THIS_SHOULD_BE_REMOVED,
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/index.js
@@ -1,13 +1,15 @@
-import './a.ts'
+import { Used } from './a.ts'
 
 it('should retain PURE comments with scope hoisting', () => {
+  expect(Used.THIS_IS_USED).toBe(0)
+
   let factory = __turbopack_modules__.get(
     [...__turbopack_modules__.keys()].find((m) =>
-      m.endsWith(
-        'scope-hoisting/pure-comments/input/index.js [test] (ecmascript)'
-      )
+      m.endsWith('scope-hoisting/pure-comments/input/a.ts [test] (ecmascript)')
     )
   )
 
-  expect(factory.toString()).not.toContain('THIS_SHOULD_BE_REMOVED')
+  const source = factory.toString()
+  expect(source).not.toContain('THIS_SHOULD_BE_REMOVED')
+  expect(source).toContain('THIS_IS_USED')
 })

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/input/index.js
@@ -1,0 +1,13 @@
+import './a.ts'
+
+it('should retain PURE comments with scope hoisting', () => {
+  let factory = __turbopack_modules__.get(
+    [...__turbopack_modules__.keys()].find((m) =>
+      m.endsWith(
+        'scope-hoisting/pure-comments/input/index.js [test] (ecmascript)'
+      )
+    )
+  )
+
+  expect(factory.toString()).not.toContain('THIS_SHOULD_BE_REMOVED')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/options.json
@@ -1,0 +1,3 @@
+{
+  "minify": true
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/scope-hoisting/pure-comments/options.json
@@ -1,3 +1,4 @@
 {
-  "minify": true
+  "minify": true,
+  "scopeHoisting": false
 }


### PR DESCRIPTION
Needs https://github.com/swc-project/swc/pull/11777

https://github.com/swc-project/swc/pull/10560 added `Files.map_raw_pos` which can be used to translate BytePos before generating the sourcemap.

The same is also needed in `SourceMapper`, so that the `pos.is_pure()` in `emit_leading_comments` uses the decoded BytePos.

This came up in https://github.com/vercel/next.js/pull/88205 where my BytePos re-encoding mechanism caused `BytePos::PURE` to not codegen the pure comment anymore.

Closes https://github.com/vercel/next.js/issues/88009
Closes https://github.com/vercel/next.js/pull/90004
Closes PACK-6424