### PR TITLE
fix overlay frames cannot be opened sometimes

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.tsx
@@ -21,17 +21,20 @@ export function ErrorOverlayCallStack({
   function onToggleIgnoreList() {
     const dialog = dialogResizerRef?.current
 
-    if (!dialog) {
-      return
-    }
-
-    const { height: currentHeight } = dialog.getBoundingClientRect()
-
-    if (!initialDialogHeight.current) {
-      initialDialogHeight.current = currentHeight
-    }
-
     if (isIgnoreListOpen) {
+      // Closing requires dialog for animation
+      if (!dialog) {
+        // No dialog ref available, just close without animation
+        setIsIgnoreListOpen(false)
+        return
+      }
+
+      const { height: currentHeight } = dialog.getBoundingClientRect()
+
+      if (!initialDialogHeight.current) {
+        initialDialogHeight.current = currentHeight
+      }
+
       function onTransitionEnd() {
         // TS bug. We closed over a non-nullable value here.
         dialog!.removeEventListener('transitionend', onTransitionEnd)
@@ -41,6 +44,14 @@ export function ErrorOverlayCallStack({
       dialog.style.height = `${initialDialogHeight.current}px`
       dialog.addEventListener('transitionend', onTransitionEnd)
     } else {
+      if (dialog) {
+        const { height: currentHeight } = dialog.getBoundingClientRect()
+        // When the ignore list is closed, we need to store the initial height of the dialog,
+        // we need this value to restore the dialog to its original height when the ignore list is opened again.
+        if (!initialDialogHeight.current) {
+          initialDialogHeight.current = currentHeight
+        }
+      }
       setIsIgnoreListOpen(true)
     }
   }


### PR DESCRIPTION
Noticed sometimes when error overlay pops up, the ignored frames cannot be clicked, it's rare to repro.

The problem: `When dialogResizerRef?.current` is null, the function returns early before reaching the `setIsIgnoreListOpen(tr
ue)` call. This prevents opening the toggle even though opening doesn't actually need the dialog reference - only closing does (for the height transition animation).

Possible scenario: During the initial animation phase when animating is still `true`
