### PR TITLE
Turbopack: remove sourcemapping comments

### DIFF
--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
 use anyhow::{Result, bail};
-use either::Either;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use tracing::Instrument;
@@ -31,7 +30,7 @@ use turbopack_ecmascript::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkItemOptions,
         EcmascriptChunkPlaceable, EcmascriptChunkType, EcmascriptExports,
     },
-    source_map::parse_source_map_comment,
+    source_map::{extract_source_mapping_url_from_content, parse_source_map_comment},
     utils::StringifyJs,
 };
 
@@ -263,9 +262,10 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
             }
 
             code += "(function(){\n";
+            let source_mapping_url = extract_source_mapping_url_from_content(&content_str);
             let source_map = if let Some((source_map, _)) = parse_source_map_comment(
                 source,
-                Either::Right(&content_str),
+                source_mapping_url,
                 &*self.module.ident().path().await?,
             )
             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -2043,6 +2043,7 @@ async fn with_consumed_parse_result<T>(
                     globals,
                     eval_context,
                     comments,
+                    ..
                 }) => (
                     program.take(),
                     &*source_map,
@@ -2068,6 +2069,7 @@ async fn with_consumed_parse_result<T>(
                         globals,
                         eval_context,
                         comments,
+                        ..
                     } = &**parsed
                     else {
                         unreachable!();

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -626,7 +626,7 @@ async fn analyze_ecmascript_module_internal(
         eval_context,
         comments,
         source_map,
-        ..
+        source_mapping_url,
     } = &*parsed
     else {
         return analysis.build(Default::default(), false).await;
@@ -727,7 +727,7 @@ async fn analyze_ecmascript_module_internal(
         async {
             if let Some((source_map, reference)) = parse_source_map_comment(
                 source,
-                Either::Left(comments),
+                source_mapping_url.as_deref(),
                 &*origin.origin_path().await?,
             )
             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/source_map.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/source_map.rs
@@ -1,8 +1,8 @@
 use std::sync::LazyLock;
 
 use anyhow::Result;
-use either::Either;
 use regex::Regex;
+use swc_core::common::comments::{Comment, CommentKind};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath, rope::Rope};
@@ -11,8 +11,6 @@ use turbopack_core::{
     source::Source,
     source_map::{GenerateSourceMap, utils::resolve_source_map_sources},
 };
-
-use crate::swc_comments::ImmutableComments;
 
 #[turbo_tasks::value(shared)]
 #[derive(Debug, Clone)]
@@ -38,6 +36,20 @@ impl GenerateSourceMap for InlineSourceMap {
     }
 }
 
+const SOURCE_MAPPING_URL_PREFIX: &str = "# sourceMappingURL=";
+const SOURCE_MAPPING_URL_PREFIX_LEGACY: &str = "@ sourceMappingURL=";
+
+/// Checks if a line comment is a sourceMappingURL directive and extracts the URL.
+pub fn extract_source_mapping_url(comment: &Comment) -> Option<&str> {
+    if comment.kind != CommentKind::Line {
+        return None;
+    }
+    let text = comment.text.trim();
+    text.strip_prefix(SOURCE_MAPPING_URL_PREFIX)
+        .or_else(|| text.strip_prefix(SOURCE_MAPPING_URL_PREFIX_LEGACY))
+        .map(|url| url.trim())
+}
+
 fn maybe_decode_data_url(url: &str) -> Option<Rope> {
     const DATA_PREAMBLE: &str = "data:application/json;base64,";
     const DATA_PREAMBLE_CHARSET: &str = "data:application/json;charset=utf-8;base64,";
@@ -56,9 +68,24 @@ fn maybe_decode_data_url(url: &str) -> Option<Rope> {
         .map(Rope::from)
 }
 
+/// Extracts the sourceMappingURL from raw file content.
+/// This searches for a comment at the end of the file (only followed by whitespace).
+pub fn extract_source_mapping_url_from_content(file_content: &str) -> Option<&str> {
+    // Find a matching comment at the end of the file (only followed by whitespace)
+    static SOURCE_MAP_FILE_REFERENCE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"\n//[@#]\s*sourceMappingURL=(\S*)[\n\s]*$").unwrap());
+
+    file_content.rfind("\n//").and_then(|start| {
+        let line = &file_content[start..];
+        SOURCE_MAP_FILE_REFERENCE
+            .captures(line)
+            .map(|m| m.get(1).unwrap().as_str())
+    })
+}
+
 pub async fn parse_source_map_comment(
     source: ResolvedVc<Box<dyn Source>>,
-    comments: Either<&ImmutableComments, &str>,
+    source_mapping_url: Option<&str>,
     origin_path: &FileSystemPath,
 ) -> Result<
     Option<(
@@ -66,42 +93,7 @@ pub async fn parse_source_map_comment(
         Option<ResolvedVc<Box<dyn ModuleReference>>>,
     )>,
 > {
-    // See https://tc39.es/ecma426/#sec-MatchSourceMapURL for the official regex.
-    let source_map_comment = match comments {
-        Either::Left(comments) => {
-            // Only use the last sourceMappingURL comment by spec
-            static SOURCE_MAP_FILE_REFERENCE: LazyLock<Regex> =
-                LazyLock::new(|| Regex::new(r"[@#]\s*sourceMappingURL=(\S*)$").unwrap());
-            let mut paths_by_pos = Vec::new();
-            for (pos, comments) in comments.trailing.iter() {
-                for comment in comments.iter().rev() {
-                    if let Some(m) = SOURCE_MAP_FILE_REFERENCE.captures(&comment.text) {
-                        let path = m.get(1).unwrap().as_str();
-                        paths_by_pos.push((pos, path));
-                        break;
-                    }
-                }
-            }
-            paths_by_pos
-                .into_iter()
-                .max_by_key(|&(pos, _)| pos)
-                .map(|(_, path)| path)
-        }
-        Either::Right(file_content) => {
-            // Find a matching comment at the end of the file (only followed by whitespace)
-            static SOURCE_MAP_FILE_REFERENCE: LazyLock<Regex> =
-                LazyLock::new(|| Regex::new(r"\n//[@#]\s*sourceMappingURL=(\S*)[\n\s]*$").unwrap());
-
-            file_content.rfind("\n//").and_then(|start| {
-                let line = &file_content[start..];
-                SOURCE_MAP_FILE_REFERENCE
-                    .captures(line)
-                    .map(|m| m.get(1).unwrap().as_str())
-            })
-        }
-    };
-
-    if let Some(path) = source_map_comment {
+    if let Some(path) = source_mapping_url {
         static JSON_DATA_URL_BASE64: LazyLock<Regex> = LazyLock::new(|| {
             Regex::new(r"^data:application\/json;(?:charset=utf-8;)?base64").unwrap()
         });

--- a/turbopack/crates/turbopack-ecmascript/src/source_map.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/source_map.rs
@@ -71,6 +71,8 @@ fn maybe_decode_data_url(url: &str) -> Option<Rope> {
 /// Extracts the sourceMappingURL from raw file content.
 /// This searches for a comment at the end of the file (only followed by whitespace).
 pub fn extract_source_mapping_url_from_content(file_content: &str) -> Option<&str> {
+    // TODO this should use https://tc39.es/ecma426/#sec-JavaScriptExtractSourceMapURL instead
+
     // Find a matching comment at the end of the file (only followed by whitespace)
     static SOURCE_MAP_FILE_REFERENCE: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r"\n//[@#]\s*sourceMappingURL=(\S*)[\n\s]*$").unwrap());

--- a/turbopack/crates/turbopack-ecmascript/src/swc_comments.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/swc_comments.rs
@@ -9,6 +9,8 @@ use swc_core::{
     },
 };
 
+use crate::source_map::extract_source_mapping_url;
+
 /// Immutable version of [SwcComments] which doesn't allow mutation. The `take`
 /// variants are still implemented, but do not mutate the content. They are used
 /// by the SWC Emitter.
@@ -38,6 +40,50 @@ impl ImmutableComments {
                 })
                 .collect(),
         }
+    }
+
+    /// Creates a new ImmutableComments from SwcComments, extracting and removing
+    /// any sourceMappingURL comment. Returns the comments and the extracted URL if found.
+    pub fn new_with_source_mapping_url(comments: SwcComments) -> (Self, Option<String>) {
+        let mut source_mapping_url = None;
+
+        let leading: FxHashMap<BytePos, Vec<Comment>> = comments
+            .leading
+            .iter_mut()
+            .filter_map(|mut r| {
+                let mut c = take(r.value_mut());
+                // Extract and remove sourceMappingURL comments
+                c.retain(|comment| {
+                    if let Some(url) = extract_source_mapping_url(comment) {
+                        source_mapping_url = Some(url.to_string());
+                        false
+                    } else {
+                        true
+                    }
+                });
+                (!c.is_empty()).then_some((*r.key(), c))
+            })
+            .collect();
+
+        let trailing: FxHashMap<BytePos, Vec<Comment>> = comments
+            .trailing
+            .iter_mut()
+            .filter_map(|mut r| {
+                let mut c = take(r.value_mut());
+                // Extract and remove sourceMappingURL comments
+                c.retain(|comment| {
+                    if let Some(url) = extract_source_mapping_url(comment) {
+                        source_mapping_url = Some(url.to_string());
+                        false
+                    } else {
+                        true
+                    }
+                });
+                (!c.is_empty()).then_some((*r.key(), c))
+            })
+            .collect();
+
+        (Self { leading, trailing }, source_mapping_url)
     }
 
     pub fn into_consumable(self) -> CowComments<'static> {

--- a/turbopack/crates/turbopack-ecmascript/src/swc_comments.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/swc_comments.rs
@@ -44,24 +44,27 @@ impl ImmutableComments {
 
     /// Creates a new ImmutableComments from SwcComments, extracting and removing
     /// any sourceMappingURL comment. Returns the comments and the extracted URL if found.
+    /// If multiple sourceMappingURL comments exist, the one with the highest position
+    /// (last in the file) is selected per the ECMAScript spec.
     pub fn new_with_source_mapping_url(comments: SwcComments) -> (Self, Option<String>) {
-        let mut source_mapping_url = None;
+        let mut source_mapping_url_by_pos: Vec<(BytePos, String)> = Vec::new();
 
         let leading: FxHashMap<BytePos, Vec<Comment>> = comments
             .leading
             .iter_mut()
             .filter_map(|mut r| {
+                let pos = *r.key();
                 let mut c = take(r.value_mut());
                 // Extract and remove sourceMappingURL comments
                 c.retain(|comment| {
                     if let Some(url) = extract_source_mapping_url(comment) {
-                        source_mapping_url = Some(url.to_string());
+                        source_mapping_url_by_pos.push((pos, url.to_string()));
                         false
                     } else {
                         true
                     }
                 });
-                (!c.is_empty()).then_some((*r.key(), c))
+                (!c.is_empty()).then_some((pos, c))
             })
             .collect();
 
@@ -69,19 +72,26 @@ impl ImmutableComments {
             .trailing
             .iter_mut()
             .filter_map(|mut r| {
+                let pos = *r.key();
                 let mut c = take(r.value_mut());
                 // Extract and remove sourceMappingURL comments
                 c.retain(|comment| {
                     if let Some(url) = extract_source_mapping_url(comment) {
-                        source_mapping_url = Some(url.to_string());
+                        source_mapping_url_by_pos.push((pos, url.to_string()));
                         false
                     } else {
                         true
                     }
                 });
-                (!c.is_empty()).then_some((*r.key(), c))
+                (!c.is_empty()).then_some((pos, c))
             })
             .collect();
+
+        // Select the sourceMappingURL with the highest position (last one in the file)
+        let source_mapping_url = source_mapping_url_by_pos
+            .into_iter()
+            .max_by_key(|&(pos, _)| pos)
+            .map(|(_, url)| url);
 
         (Self { leading, trailing }, source_mapping_url)
     }

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -580,6 +580,7 @@ pub(super) async fn split_module(asset: Vc<EcmascriptModuleAsset>) -> Result<Vc<
                         comments: comments.clone(),
                         source_map: source_map.clone(),
                         eval_context,
+                        source_mapping_url: None,
                     })
                 })
                 .collect();
@@ -705,6 +706,7 @@ pub(crate) async fn part_of_module(
                         eval_context,
                         globals: globals.clone(),
                         source_map: source_map.clone(),
+                        source_mapping_url: None,
                     }
                     .cell());
                 } else {

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/bf321_tests_snapshot_source_maps_input-source-map-merged_input_index_8a5a4de9.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map-merged/output/bf321_tests_snapshot_source_maps_input-source-map-merged_input_index_8a5a4de9.js
@@ -9,7 +9,7 @@ __turbopack_context__.s([], "[project]/turbopack/crates/turbopack-tests/tests/sn
 ;
 function runExternalSourceMapped(fn) {
     return fn();
-} //# sourceMappingURL=sourcemapped.js.map
+}
 ;
 runExternalSourceMapped();
 }),

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/output/780ce_turbopack-tests_tests_snapshot_source_maps_input-source-map_input_4f68fe02._.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/output/780ce_turbopack-tests_tests_snapshot_source_maps_input-source-map_input_4f68fe02._.js
@@ -8,7 +8,7 @@ __turbopack_context__.s([
 ]);
 function runExternalSourceMapped(fn) {
     return fn();
-} //# sourceMappingURL=sourcemapped.js.map
+}
 }),
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/input-source-map/input/index.js [test] (ecmascript)", ((__turbopack_context__) => {
 "use strict";

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/aaf3a_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_0a0a9887.js
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/aaf3a_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_0a0a9887.js
@@ -1,7 +1,7 @@
 (globalThis.TURBOPACK || (globalThis.TURBOPACK = [])).push(["output/aaf3a_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_0a0a9887.js",
 "[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js [test] (ecmascript)", ((__turbopack_context__, module, exports) => {
 
-console.log('test'); //# sourceMappingURL=index.js.map
+console.log('test');
 }),
 ]);
 

--- a/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/aaf3a_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_0a0a9887.js.map
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/output/aaf3a_crates_turbopack-tests_tests_snapshot_source_maps_invalid_input_index_0a0a9887.js.map
@@ -2,5 +2,5 @@
   "version": 3,
   "sources": [],
   "sections": [
-    {"offset": {"line": 3, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js"],"sourcesContent":["console.log('test')\n//# sourceMappingURL=index.js.map\n"],"names":["console","log"],"mappings":"AAAAA,QAAQC,GAAG,CAAC,SACZ,iCAAiC"}}]
+    {"offset": {"line": 3, "column": 0}, "map": {"version":3,"sources":["turbopack:///[project]/turbopack/crates/turbopack-tests/tests/snapshot/source_maps/invalid/input/index.js"],"sourcesContent":["console.log('test')\n//# sourceMappingURL=index.js.map\n"],"names":["console","log"],"mappings":"AAAAA,QAAQC,GAAG,CAAC"}}]
 }


### PR DESCRIPTION
Otherwise there are stray sourceMappingURL comments in the middle of the chunks.