### PR TITLE
Add more known folders to is-folder-empty check in create-next-app

### DIFF
--- a/packages/create-next-app/helpers/is-folder-empty.ts
+++ b/packages/create-next-app/helpers/is-folder-empty.ts
@@ -4,7 +4,9 @@ import { join } from 'node:path'
 import { green, blue } from 'picocolors'
 
 export function isFolderEmpty(root: string, name: string): boolean {
-  const validFiles = [
+  const validFilesOrFolders = [
+    '.claude',
+    '.cursor',
     '.DS_Store',
     '.git',
     '.gitattributes',
@@ -16,6 +18,7 @@ export function isFolderEmpty(root: string, name: string): boolean {
     '.idea',
     '.npmignore',
     '.travis.yml',
+    '.vscode',
     'LICENSE',
     'Thumbs.db',
     'docs',
@@ -28,10 +31,10 @@ export function isFolderEmpty(root: string, name: string): boolean {
   ]
 
   const conflicts = readdirSync(root).filter(
-    (file) =>
-      !validFiles.includes(file) &&
+    (fileOrFolder) =>
+      !validFilesOrFolders.includes(fileOrFolder) &&
       // Support IntelliJ IDEA-based editors
-      !/\.iml$/.test(file)
+      !/\.iml$/.test(fileOrFolder)
   )
 
   if (conflicts.length > 0) {

--- a/packages/create-next-app/helpers/is-folder-empty.ts
+++ b/packages/create-next-app/helpers/is-folder-empty.ts
@@ -19,6 +19,7 @@ export function isFolderEmpty(root: string, name: string): boolean {
     '.npmignore',
     '.travis.yml',
     '.vscode',
+    '.zed',
     'LICENSE',
     'Thumbs.db',
     'docs',


### PR DESCRIPTION
## What?

Allows creating a new Next.js app when there's an existing `.claude`, `.vscode`, or `.cursor` folder/file.