### PR TITLE
Only log `pending revalidates...` debug log if applicable

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2108,22 +2108,19 @@ async function renderToHTMLOrFlightImpl(
       metadata,
       contentType: HTML_CONTENT_TYPE_HEADER,
     }
+
     // If we have pending revalidates, wait until they are all resolved.
-    if (
-      workStore.pendingRevalidates ||
-      workStore.pendingRevalidateWrites ||
-      workStore.pendingRevalidatedTags
-    ) {
-      const pendingPromise = executeRevalidates(workStore).finally(() => {
+    const maybeRevalidatesPromise = executeRevalidates(workStore)
+    if (maybeRevalidatesPromise !== false) {
+      const revalidatesPromise = maybeRevalidatesPromise.finally(() => {
         if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
-          console.log('pending revalidates promise finished for:', url)
+          console.log('pending revalidates promise finished for:', url.href)
         }
       })
-
       if (renderOpts.waitUntil) {
-        renderOpts.waitUntil(pendingPromise)
+        renderOpts.waitUntil(revalidatesPromise)
       } else {
-        options.waitUntil = pendingPromise
+        options.waitUntil = revalidatesPromise
       }
     }
 
@@ -2290,21 +2287,17 @@ async function renderToHTMLOrFlightImpl(
     }
 
     // If we have pending revalidates, wait until they are all resolved.
-    if (
-      workStore.pendingRevalidates ||
-      workStore.pendingRevalidateWrites ||
-      workStore.pendingRevalidatedTags
-    ) {
-      const pendingPromise = executeRevalidates(workStore).finally(() => {
+    const maybeRevalidatesPromise = executeRevalidates(workStore)
+    if (maybeRevalidatesPromise !== false) {
+      const revalidatesPromise = maybeRevalidatesPromise.finally(() => {
         if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
-          console.log('pending revalidates promise finished for:', url)
+          console.log('pending revalidates promise finished for:', url.href)
         }
       })
-
       if (renderOpts.waitUntil) {
-        renderOpts.waitUntil(pendingPromise)
+        renderOpts.waitUntil(revalidatesPromise)
       } else {
-        options.waitUntil = pendingPromise
+        options.waitUntil = revalidatesPromise
       }
     }
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -331,16 +331,20 @@ export class AppRouteRouteModule extends RouteModule<
     }
 
     const resolvePendingRevalidations = () => {
-      context.renderOpts.pendingWaitUntil = executeRevalidates(
-        workStore
-      ).finally(() => {
-        if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
-          console.log(
-            'pending revalidates promise finished for:',
-            requestStore.url
-          )
-        }
-      })
+      const maybeRevalidatesPromise = executeRevalidates(workStore)
+
+      if (maybeRevalidatesPromise !== false) {
+        context.renderOpts.pendingWaitUntil = maybeRevalidatesPromise.finally(
+          () => {
+            if (process.env.NEXT_PRIVATE_DEBUG_CACHE) {
+              console.log(
+                'pending revalidates promise finished for:',
+                requestStore.url.pathname + requestStore.url.search
+              )
+            }
+          }
+        )
+      }
     }
 
     let prerenderStore: null | PrerenderStore = null


### PR DESCRIPTION
When [verbose cache logging](https://nextjs.org/docs/app/guides/incremental-static-regeneration#verifying-correct-production-behavior) is enabled, we were always adding a debug log as follows after rendering a page (during prerendering or at request time):

```
pending revalidates promise finished for: {
  auth: null,
  host: null,
  hostname: null,
  pathname: '/',
  port: null,
  protocol: null,
  query: undefined,
  search: '',
  hash: '',
  href: '/',
  slashes: null
}
```

However, if there were no pending revalidates to process, this log is misleading as it suggests that there were pending revalidates that have now been processed, while in reality there were none. So with this PR, we now only log this message if there are actually any pending revalidates, i.e. some tags were revalidated, a `fetch` cache entry was revalidated, an `unstable_cache` entry was revalidated, or a `'use cache'` entry was saved to a cache handler.

In addition, the log is now shortened to only log the URL string instead of the full URL object for better readability, e.g.:

```
pending revalidates promise finished for: /
```