### PR TITLE
fix: improve warning message for _error page during static export

### DIFF
--- a/docs/02-pages/03-building-your-application/01-routing/08-custom-error.mdx
+++ b/docs/02-pages/03-building-your-application/01-routing/08-custom-error.mdx
@@ -95,4 +95,6 @@ If you have a custom `Error` component be sure to import that one instead. `next
 ### Caveats
 
 - `Error` does not currently support Next.js [Data Fetching methods](/docs/pages/building-your-application/data-fetching) like [`getStaticProps`](/docs/pages/building-your-application/data-fetching/get-static-props) or [`getServerSideProps`](/docs/pages/building-your-application/data-fetching/get-server-side-props).
+  - **Note**: While `getStaticProps` might technically compile in `_error`, it is not part of the standard static generation flow and will not receive dynamic error context (like `statusCode`).
+  - **Recommendation**: If you need to fetch data for error pages during static export, use [`pages/404.js`](#customizing-the-404-page) or [`pages/500.js`](#customizing-the-500-page) instead.
 - `_error`, like `_app`, is a reserved pathname. `_error` is used to define the customized layouts and behaviors of the error pages. `/_error` will render 404 when accessed directly via [routing](/docs/pages/building-your-application/routing) or rendering in a [custom server](/docs/pages/guides/custom-server).

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -537,12 +537,23 @@ export async function renderToHTMLImpl(
     hasPageGetInitialProps &&
     !defaultErrorGetInitialProps
   ) {
-    warn(
-      `Detected getInitialProps on page '${pathname}'` +
-        ` while running export. It's recommended to use getStaticProps` +
-        ` which has a more correct behavior for static exporting.` +
-        `\nRead more: https://nextjs.org/docs/messages/get-initial-props-export`
-    )
+    // Custom _error page (not the default Next.js error page)
+    if (pathname === '/_error') {
+      warn(
+        `Detected getInitialProps on 'pages/_error' while running export. ` +
+          `Note that 'pages/_error' does not support getStaticProps. ` +
+          `To fetch data for static error pages, it is recommended to create 'pages/404.js' or 'pages/500.js' and use getStaticProps there instead.` +
+          `\nRead more: https://nextjs.org/docs/advanced-features/static-html-export`
+      )
+    } else {
+      // Regular page with getInitialProps
+      warn(
+        `Detected getInitialProps on page '${pathname}'` +
+          ` while running export. It's recommended to use getStaticProps` +
+          ` which has a more correct behavior for static exporting.` +
+          `\nRead more: https://nextjs.org/docs/messages/get-initial-props-export`
+      )
+    }
   }
 
   let isAutoExport =


### PR DESCRIPTION
### What?

This PR improves the confusing warning message that appears when using a custom `_error` page during static export (`next export`).

**Changes:**
1. `packages/next/src/server/render.tsx`: Add a specific warning message for `_error` pages
   - **Before**: Generic message recommending `getStaticProps` for all pages
   - **After**: For `_error` pages, references the documentation that states `getStaticProps` is not supported and recommends using `404.js` or `500.js` instead

2. `docs/02-pages/03-building-your-application/01-routing/08-custom-error.mdx`: Enhance documentation
   - Clarify that while `getStaticProps` may technically compile in `_error`, it has limitations
   - Add guidance on the correct data fetching pattern for static export

### Why?

Currently, when running `next export` with a custom `_error` page that uses `getInitialProps`, Next.js displays a warning recommending the use of `getStaticProps`. However, according to the documentation, `_error` pages do not support `getStaticProps`, which causes confusion for developers.

**Problem:**
- Custom `_error` page with `getInitialProps` → warning appears
- Warning message recommends using `getStaticProps`
- The documentation states that `getStaticProps` is not supported in `_error` pages
- Developers experience frustration trying to follow the recommendation that contradicts the documentation

### How?

1. **Warning message branching:**
   - Display a specific warning message when `pathname === '/_error'`
   - Reference the documentation that states `_error` pages do not support `getStaticProps`
   - Recommend using `404.js` or `500.js` as alternatives

2. **Documentation enhancement:**
   - Add explanation of technical limitations of `getStaticProps` in the Caveats section
   - Provide guidance on the correct pattern for static export
