### PR TITLE
Guard against Object/Array shadowing in 'use cache' transform

### DIFF
--- a/crates/next-core/src/next_shared/transforms/server_actions.rs
+++ b/crates/next-core/src/next_shared/transforms/server_actions.rs
@@ -71,6 +71,7 @@ impl CustomTransformer for NextServerActions {
                 cache_kinds: self.cache_kinds.owned().await?,
             },
             ctx.comments.clone(),
+            ctx.unresolved_mark,
             ctx.source_map.clone(),
             Default::default(),
             ServerActionsMode::Turbopack,

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -322,6 +322,7 @@ where
                     None,
                     config.clone(),
                     comments.clone(),
+                    unresolved_mark,
                     cm.clone(),
                     use_cache_telemetry_tracker,
                     ServerActionsMode::Webpack,

--- a/crates/next-custom-transforms/tests/errors.rs
+++ b/crates/next-custom-transforms/tests/errors.rs
@@ -162,10 +162,11 @@ fn react_server_actions_errors(input: PathBuf) {
     test_fixture(
         syntax(),
         &|tr| {
+            let unresolved_mark = Mark::new();
             (
                 // The transforms are intentionally declared in the same order as in
                 // crates/next-custom-transforms/src/chain_transforms.rs
-                resolver(Mark::new(), Mark::new(), false),
+                resolver(unresolved_mark, Mark::new(), false),
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")).into(),
                     Config::WithOptions(Options {
@@ -188,6 +189,7 @@ fn react_server_actions_errors(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
+                    unresolved_mark,
                     tr.cm.clone(),
                     Default::default(),
                     ServerActionsMode::Webpack,
@@ -229,10 +231,11 @@ fn use_cache_not_allowed(input: PathBuf) {
     test_fixture(
         syntax(),
         &|tr| {
+            let unresolved_mark = Mark::new();
             (
                 // The transforms are intentionally declared in the same order as in
                 // crates/next-custom-transforms/src/chain_transforms.rs
-                resolver(Mark::new(), Mark::new(), false),
+                resolver(unresolved_mark, Mark::new(), false),
                 server_components(
                     FileName::Real(PathBuf::from("/app/item.js")).into(),
                     Config::WithOptions(Options {
@@ -255,6 +258,7 @@ fn use_cache_not_allowed(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter([rcstr!("x")]),
                     },
                     tr.comments.as_ref().clone(),
+                    unresolved_mark,
                     tr.cm.clone(),
                     Default::default(),
                     ServerActionsMode::Webpack,

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -477,6 +477,7 @@ fn react_server_components_fixture(input: PathBuf) {
     test_fixture(
         syntax(),
         &|tr| {
+            let unresolved_mark = Mark::new();
             (
                 // The transforms are intentionally declared in the same order as in
                 // crates/next-custom-transforms/src/chain_transforms.rs
@@ -502,6 +503,7 @@ fn react_server_components_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
+                    unresolved_mark,
                     tr.cm.clone(),
                     Default::default(),
                     ServerActionsMode::Webpack,
@@ -561,8 +563,9 @@ fn server_actions_fixture(input: PathBuf) {
     test_fixture(
         input_syntax,
         &|tr| {
+            let unresolved_mark = Mark::new();
             (
-                resolver(Mark::new(), Mark::new(), false),
+                resolver(unresolved_mark, Mark::new(), false),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
                     None,
@@ -574,6 +577,7 @@ fn server_actions_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter(["x".into()]),
                     },
                     tr.comments.as_ref().clone(),
+                    unresolved_mark,
                     tr.cm.clone(),
                     Default::default(),
                     mode,
@@ -595,8 +599,9 @@ fn next_font_with_directive_fixture(input: PathBuf) {
     test_fixture(
         syntax(),
         &|tr| {
+            let unresolved_mark = Mark::new();
             (
-                resolver(Mark::new(), Mark::new(), false),
+                resolver(unresolved_mark, Mark::new(), false),
                 next_font_loaders(FontLoaderConfig {
                     relative_file_path_from_root: "app/test.tsx".into(),
                     font_loaders: vec!["@next/font/google".into()],
@@ -612,6 +617,7 @@ fn next_font_with_directive_fixture(input: PathBuf) {
                         cache_kinds: FxHashSet::default(),
                     },
                     tr.comments.as_ref().clone(),
+                    unresolved_mark,
                     tr.cm.clone(),
                     Default::default(),
                     ServerActionsMode::Webpack,
@@ -912,8 +918,9 @@ fn test_source_maps(input: PathBuf) {
     test_fixture(
         syntax(),
         &|tr| {
+            let unresolved_mark = Mark::new();
             (
-                resolver(Mark::new(), Mark::new(), false),
+                resolver(unresolved_mark, Mark::new(), false),
                 server_actions(
                     &FileName::Real("/app/item.js".into()),
                     None,
@@ -925,6 +932,7 @@ fn test_source_maps(input: PathBuf) {
                         cache_kinds: FxHashSet::from_iter([]),
                     },
                     tr.comments.as_ref().clone(),
+                    unresolved_mark,
                     tr.cm.clone(),
                     Default::default(),
                     mode,

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/70/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/70/input.js
@@ -1,0 +1,7 @@
+// shadow the builtin Array global (used in the transform output)
+const Array = {}
+
+export async function action(x) {
+  'use cache'
+  return x
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/70/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/70/output.js
@@ -1,0 +1,16 @@
+import { registerServerReference } from "private-next-rsc-server-reference";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+import { cache as $$reactCache__ } from "react";
+// shadow the builtin Array global (used in the transform output)
+/* __next_internal_action_entry_do_not_use__ {"c03128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ const Array1 = {};
+const $$RSC_SERVER_CACHE_0_INNER = async function action(x) {
+    return x;
+};
+export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function action() {
+    return $$cache__("default", "c03128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, Array.prototype.slice.call(arguments, 0, 1));
+});
+registerServerReference($$RSC_SERVER_CACHE_0, "c03128060c414d59f8552e4788b846c0d2b7f74743", null);
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
+    value: "action"
+});
+export var action = $$RSC_SERVER_CACHE_0;

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/71/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/71/input.js
@@ -1,0 +1,7 @@
+// shadow the builtin Object global (used in transform output)
+const Object = {}
+
+export async function foo() {
+  'use cache'
+  return 1
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/71/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/71/output.js
@@ -1,0 +1,16 @@
+import { registerServerReference } from "private-next-rsc-server-reference";
+import { cache as $$cache__ } from "private-next-rsc-cache-wrapper";
+import { cache as $$reactCache__ } from "react";
+// shadow the builtin Object global (used in transform output)
+/* __next_internal_action_entry_do_not_use__ {"803128060c414d59f8552e4788b846c0d2b7f74743":"$$RSC_SERVER_CACHE_0"} */ const Object1 = {};
+const $$RSC_SERVER_CACHE_0_INNER = async function foo() {
+    return 1;
+};
+export var $$RSC_SERVER_CACHE_0 = $$reactCache__(function foo() {
+    return $$cache__("default", "803128060c414d59f8552e4788b846c0d2b7f74743", 0, $$RSC_SERVER_CACHE_0_INNER, []);
+});
+registerServerReference($$RSC_SERVER_CACHE_0, "803128060c414d59f8552e4788b846c0d2b7f74743", null);
+Object["defineProperty"]($$RSC_SERVER_CACHE_0, "name", {
+    value: "foo"
+});
+export var foo = $$RSC_SERVER_CACHE_0;


### PR DESCRIPTION
The transform output for 'use cache' uses `Object.defineProperty` and `Array.prototype.slice`. In theory, it's possible for a module to shadow those names and break it:
```ts
// i want to suffer!
const Array = {}
const Object = {}

async function cached() {
  "use cache"
  ...
}
```

We should defensively make sure that our transform's output refers to the actual Object/Array builtins, not whatever's in scope for that name. We can do this by using an unresolved syntax context for the identifiers. This is what we do for `require()` elsewhere: https://github.com/vercel/next.js/blob/6805af48baf1128e6b2a9e8f1752ee5982f02c60/crates/next-custom-transforms/src/transforms/track_dynamic_imports.rs#L119-L122
Using `quote_ident!(unresolved_ctxt, "Array")` will cause SWC to rename any local redefinitions of `Array` to something that doesn't clash (which can be seen in the added snapshots).