### PR TITLE
Remove loadConfig from main development process, pass value from child process

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -63,7 +63,7 @@ let dir: string
 let child: undefined | ChildProcess
 // distDir is received from the child process via IPC, used for telemetry and trace.
 let distDir: string | undefined
-let bundler: Bundler
+let isTurbopack: boolean
 let traceUploadUrl: string
 let sessionStopHandled = false
 const sessionStarted = Date.now()
@@ -128,7 +128,7 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
     telemetry.record(
       eventCliSessionStopped({
         cliCommand: 'dev',
-        turboFlag: bundler === Bundler.Turbopack,
+        turboFlag: isTurbopack,
         durationMilliseconds: Date.now() - sessionStarted,
         pagesDir,
         appDir,
@@ -172,8 +172,9 @@ const nextDev = async (
   portSource: PortSource,
   directory?: string
 ) => {
-  // Note: This variable is only Turbopack or webpack. Rspack can be configured via next.config.js but next.config.js is not loaded in the main process, only in the child process.
-  bundler = parseBundlerArgs(options)
+  // Note: parseBundlerArgs can only decide on Turbopack or webpack.
+  // Rspack can be configured via next.config.js but next.config.js is not loaded in the main process, only in the child process.
+  isTurbopack = parseBundlerArgs(options) === Bundler.Turbopack
 
   dir = getProjectDir(process.env.NEXT_PRIVATE_DEV_DIR || directory)
 
@@ -303,9 +304,7 @@ const nextDev = async (
         stdio: 'inherit',
         env: {
           ...defaultEnv,
-          ...(bundler === Bundler.Turbopack
-            ? { TURBOPACK: process.env.TURBOPACK }
-            : undefined),
+          ...(isTurbopack ? { TURBOPACK: process.env.TURBOPACK } : undefined),
           NEXT_PRIVATE_WORKER: '1',
           NEXT_PRIVATE_TRACE_ID: traceId,
           NODE_EXTRA_CA_CERTS: startServerOptions.selfSignedCertificate
@@ -363,7 +362,7 @@ const nextDev = async (
               mode: 'dev',
               projectDir: dir,
               distDir,
-              isTurboSession: bundler === Bundler.Turbopack,
+              isTurboSession: isTurbopack,
               sync: true,
             })
           }

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -16,12 +16,9 @@ import {
 } from '../server/lib/utils'
 import * as Log from '../build/output/log'
 import { getProjectDir } from '../lib/get-project-dir'
-import { PHASE_DEVELOPMENT_SERVER } from '../shared/lib/constants'
 import path from 'path'
-import type { NextConfigComplete } from '../server/config-shared'
 import { traceGlobals } from '../trace/shared'
 import { Telemetry } from '../telemetry/storage'
-import loadConfig from '../server/config'
 import { findPagesDir } from '../lib/find-pages-dir'
 import { fileExists, FileType } from '../lib/file-exists'
 import { getNpxCommand } from '../lib/helpers/get-npx-command'
@@ -40,11 +37,7 @@ import { once } from 'node:events'
 import { clearTimeout } from 'timers'
 import { flushAllTraces, trace } from '../trace'
 import { traceId } from '../trace/shared'
-import {
-  Bundler,
-  finalizeBundlerFromConfig,
-  parseBundlerArgs,
-} from '../lib/bundler'
+import { Bundler, parseBundlerArgs } from '../lib/bundler'
 
 export type NextDevOptions = {
   disableSourceMaps: boolean
@@ -68,8 +61,8 @@ type PortSource = 'cli' | 'default' | 'env'
 
 let dir: string
 let child: undefined | ChildProcess
-// The config in next-dev is only used to access config.distDir for telemetry and trace.
-let config: NextConfigComplete
+// distDir is received from the child process via IPC, used for telemetry and trace.
+let distDir: string | undefined
 let bundler: Bundler
 let traceUploadUrl: string
 let sessionStopHandled = false
@@ -124,19 +117,13 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
       pagesDir = !!pagesResult.pagesDir
     }
 
-    config =
-      config ||
-      (await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, { silent: true }))
-
     let telemetry =
       (traceGlobals.get('telemetry') as InstanceType<
         typeof import('../telemetry/storage').Telemetry
       >) ||
       new Telemetry({
-        distDir: path.join(dir, config.distDir),
+        distDir: path.join(dir, distDir || '.next'),
       })
-    // Reading the config can modify environment variables that influence the bundler selection.
-    bundler = finalizeBundlerFromConfig(bundler)
 
     telemetry.record(
       eventCliSessionStopped({
@@ -154,12 +141,12 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
     // noise to the output
   }
 
-  if (traceUploadUrl) {
+  if (traceUploadUrl && distDir) {
     uploadTrace({
       traceUploadUrl,
       mode: 'dev',
       projectDir: dir,
-      distDir: config.distDir,
+      distDir,
       isTurboSession: bundler === Bundler.Turbopack,
     })
   }
@@ -350,6 +337,10 @@ const nextDev = async (
               // it can be re-used on automatic dev server restarts.
               port = parseInt(msg.port, 10)
             }
+            if (msg.distDir) {
+              // Store the distDir from the child process for telemetry and trace uploads.
+              distDir = msg.distDir
+            }
 
             resolved = true
             resolve()
@@ -365,20 +356,12 @@ const nextDev = async (
           // Starting the dev server will overwrite the `.next/trace` file, so we
           // must upload the existing contents before restarting the server to
           // preserve the metrics.
-          if (traceUploadUrl) {
-            // Postpone loading next config when we need to get
-            //  config.distDir for upload trace.
-            config =
-              config ||
-              (await loadConfig(PHASE_DEVELOPMENT_SERVER, dir, {
-                silent: true,
-              }))
-            bundler = finalizeBundlerFromConfig(bundler)
+          if (traceUploadUrl && distDir) {
             uploadTrace({
               traceUploadUrl,
               mode: 'dev',
               projectDir: dir,
-              distDir: config.distDir,
+              distDir,
               isTurboSession: bundler === Bundler.Turbopack,
               sync: true,
             })

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -147,7 +147,7 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
       mode: 'dev',
       projectDir: dir,
       distDir,
-      isTurboSession: bundler === Bundler.Turbopack,
+      isTurboSession: isTurbopack,
     })
   }
 

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -172,6 +172,7 @@ const nextDev = async (
   portSource: PortSource,
   directory?: string
 ) => {
+  // Note: This variable is only Turbopack or webpack. Rspack can be configured via next.config.js but next.config.js is not loaded in the main process, only in the child process.
   bundler = parseBundlerArgs(options)
 
   dir = getProjectDir(process.env.NEXT_PRIVATE_DEV_DIR || directory)

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -15,6 +15,8 @@ export type ServerInitResult = {
   server: NextServer
   // Make an effort to close upgraded HTTP requests (e.g. Turbopack HMR websockets)
   closeUpgraded: () => void
+  // The distDir from config, used by the parent process for telemetry/trace
+  distDir: string
 }
 
 let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}
@@ -91,6 +93,7 @@ async function initializeImpl(opts: {
   startServerSpan: Span | undefined
   quiet?: boolean
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
+  distDir: string
 }): Promise<ServerInitResult> {
   const type = process.env.__NEXT_PRIVATE_RENDER_WORKER
   if (type) {
@@ -166,6 +169,7 @@ async function initializeImpl(opts: {
     closeUpgraded() {
       opts.bundlerService?.close()
     },
+    distDir: opts.distDir,
   }
 }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -727,6 +727,7 @@ export async function initialize(opts: {
     startServerSpan: opts.startServerSpan,
     quiet: opts.quiet,
     onDevServerCleanup: opts.onDevServerCleanup,
+    distDir: config.distDir,
   }
   renderServerOpts.serverFields.routerServerHandler = requestHandlerImpl
 
@@ -898,5 +899,6 @@ export async function initialize(opts: {
     closeUpgraded() {
       development?.bundler?.hotReloader?.close()
     },
+    distDir: config.distDir,
   }
 }


### PR DESCRIPTION
## Eliminate duplicate `loadConfig` calls during development server startup

### What?

Remove duplicate `loadConfig` calls from the parent process (`next-dev.ts`) by passing `distDir` via IPC from the child process where config is already loaded.

### Why?

Previously, when booting the development server:

1. The **child process** (`start-server.ts` → `router-server.ts`) would call `loadConfig` to get the full configuration for the actual server
2. The **parent process** (`next-dev.ts`) would also call `loadConfig` separately just to access `config.distDir` for telemetry and trace uploads

Since these are separate processes, the in-memory config cache couldn't be shared, resulting in redundant config loading work.

### How?

Extended the existing IPC messaging to include `distDir` when the child process sends `nextServerReady`:

```
Parent (next-dev.ts)         Child (start-server.ts → router-server.ts)
        |                                    |
        |-------- fork() ------------------>|
        |<------- nextWorkerReady ----------|
        |-------- nextWorkerOptions ------->|
        |                                   | loadConfig() ← only called here now
        |<-- nextServerReady + distDir -----|
        |                                    |
   Store distDir for                         
   telemetry/trace uploads                   
```

**Changes:**

- **`render-server.ts`**: Added `distDir` to `ServerInitResult` type
- **`router-server.ts`**: Return `config.distDir` in `initialize()` result and pass to render server opts
- **`start-server.ts`**: Return `distDir` from `startServer()` and include it in IPC message
- **`next-dev.ts`**: Receive `distDir` from IPC, remove both `loadConfig` calls, use `distDir` directly for telemetry/trace