### PR TITLE
ci: fix javascript-urls test to account for React 18

### DIFF
--- a/test/e2e/app-dir/javascript-urls/pages/pages/link-as.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/link-as.tsx
@@ -4,21 +4,19 @@ import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
 
 export default function Page() {
   return (
-    <html>
-      <body>
-        <main>
-          <p>
-            Clicking this link should result in an error where React blocks a
-            javascript URL
-          </p>
-          <Link href="/" as={DANGEROUS_JAVASCRIPT_URL}>
-            Link with javascript URL `as`
-          </Link>
-        </main>
-        <footer>
-          <Link href="/pages/safe">Safe Page</Link>
-        </footer>
-      </body>
-    </html>
+    <div>
+      <main>
+        <p>
+          Clicking this link should result in an error where React blocks a
+          javascript URL
+        </p>
+        <Link href="/" as={DANGEROUS_JAVASCRIPT_URL}>
+          Link with javascript URL `as`
+        </Link>
+      </main>
+      <footer>
+        <Link href="/pages/safe">Safe Page</Link>
+      </footer>
+    </div>
   )
 }

--- a/test/e2e/app-dir/javascript-urls/pages/pages/link-href.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/link-href.tsx
@@ -4,21 +4,19 @@ import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
 
 export default function Page() {
   return (
-    <html>
-      <body>
-        <main>
-          <p>
-            Clicking this link should result in an error where React blocks a
-            javascript URL
-          </p>
-          <Link href={DANGEROUS_JAVASCRIPT_URL}>
-            Link with javascript URL `href`
-          </Link>
-        </main>
-        <footer>
-          <Link href="/pages/safe">Safe Page</Link>
-        </footer>
-      </body>
-    </html>
+    <div>
+      <main>
+        <p>
+          Clicking this link should result in an error where React blocks a
+          javascript URL
+        </p>
+        <Link href={DANGEROUS_JAVASCRIPT_URL}>
+          Link with javascript URL `href`
+        </Link>
+      </main>
+      <footer>
+        <Link href="/pages/safe">Safe Page</Link>
+      </footer>
+    </div>
   )
 }

--- a/test/e2e/app-dir/javascript-urls/pages/pages/router-push.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/router-push.tsx
@@ -6,21 +6,19 @@ import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
 export default function Page() {
   const router = useRouter()
   return (
-    <html>
-      <body>
-        <main>
-          <p>
-            Clicking this button should result in an error where Next.js blocks
-            a javascript URL
-          </p>
-          <button onClick={() => router.push(DANGEROUS_JAVASCRIPT_URL)}>
-            push javascript URL
-          </button>
-        </main>
-        <footer>
-          <Link href="/pages/safe">Safe Page</Link>
-        </footer>
-      </body>
-    </html>
+    <div>
+      <main>
+        <p>
+          Clicking this button should result in an error where Next.js blocks a
+          javascript URL
+        </p>
+        <button onClick={() => router.push(DANGEROUS_JAVASCRIPT_URL)}>
+          push javascript URL
+        </button>
+      </main>
+      <footer>
+        <Link href="/pages/safe">Safe Page</Link>
+      </footer>
+    </div>
   )
 }

--- a/test/e2e/app-dir/javascript-urls/pages/pages/router-replace.tsx
+++ b/test/e2e/app-dir/javascript-urls/pages/pages/router-replace.tsx
@@ -6,21 +6,19 @@ import { DANGEROUS_JAVASCRIPT_URL } from '../../bad-url'
 export default function Page() {
   const router = useRouter()
   return (
-    <html>
-      <body>
-        <main>
-          <p>
-            Clicking this button should result in an error where Next.js blocks
-            a javascript URL
-          </p>
-          <button onClick={() => router.replace(DANGEROUS_JAVASCRIPT_URL)}>
-            replace javascript URL
-          </button>
-        </main>
-        <footer>
-          <Link href="/pages/safe">Safe Page</Link>
-        </footer>
-      </body>
-    </html>
+    <div>
+      <main>
+        <p>
+          Clicking this button should result in an error where Next.js blocks a
+          javascript URL
+        </p>
+        <button onClick={() => router.replace(DANGEROUS_JAVASCRIPT_URL)}>
+          replace javascript URL
+        </button>
+      </main>
+      <footer>
+        <Link href="/pages/safe">Safe Page</Link>
+      </footer>
+    </div>
   )
 }


### PR DESCRIPTION
This was caught by our React 18 tests which only run on `canary`. There was a console error about breaking `javascript:` urls in an upcoming React release but it didn't actually block them. 