### PR TITLE
Fix relative same host redirects in node middleware

### DIFF
--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -455,7 +455,10 @@ export async function adapter(
     if (!process.env.__NEXT_NO_MIDDLEWARE_URL_NORMALIZE) {
       if (redirectURL.host === requestURL.host) {
         redirectURL.buildId = buildId || redirectURL.buildId
-        response.headers.set('Location', redirectURL.toString())
+        response.headers.set(
+          'Location',
+          getRelativeURL(redirectURL, requestURL)
+        )
       }
     }
 

--- a/test/e2e/middleware-redirects/app/middleware.js
+++ b/test/e2e/middleware-redirects/app/middleware.js
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 
-export async function middleware(request) {
+export default async function middleware(request) {
   const url = request.nextUrl
 
   // this is needed for tests to get the BUILD_ID

--- a/test/e2e/middleware-redirects/test/node-runtime.test.ts
+++ b/test/e2e/middleware-redirects/test/node-runtime.test.ts
@@ -1,0 +1,3 @@
+process.env.TEST_NODE_MIDDLEWARE = 'true'
+
+require('./index.test')


### PR DESCRIPTION
This ensures we properly relativize URLs in node middleware when deployed and local. Tests weren't catching this previously as none were asserting the raw Location header value due to node-fetch auto-resolving the value. 

Fixes: https://github.com/vercel/next.js/issues/87950
Closes: NEXT-4826