### PR TITLE
fix(examples): return 404 rather than 500 when post is not found

### DIFF
--- a/examples/blog-starter/src/lib/api.ts
+++ b/examples/blog-starter/src/lib/api.ts
@@ -9,19 +9,30 @@ export function getPostSlugs() {
   return fs.readdirSync(postsDirectory);
 }
 
-export function getPostBySlug(slug: string) {
+export function getPostBySlug(slug: string): Post | null {
   const realSlug = slug.replace(/\.md$/, "");
   const fullPath = join(postsDirectory, `${realSlug}.md`);
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
   const fileContents = fs.readFileSync(fullPath, "utf8");
   const { data, content } = matter(fileContents);
 
   return { ...data, slug: realSlug, content } as Post;
 }
 
+export function getPostBySlugNonNull(slug: string): Post {
+  const post = getPostBySlug(slug);
+  if (post === null) {
+    throw new Error(`Post with slug "${slug}" not found`);
+  }
+  return post;
+}
+
 export function getAllPosts(): Post[] {
   const slugs = getPostSlugs();
   const posts = slugs
-    .map((slug) => getPostBySlug(slug))
+    .map((slug) => getPostBySlugNonNull(slug))
     // sort posts by date in descending order
     .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
   return posts;

--- a/examples/blog-with-comment/lib/getPost.ts
+++ b/examples/blog-with-comment/lib/getPost.ts
@@ -9,9 +9,15 @@ export function getPostSlugs() {
   return fs.readdirSync(postsDirectory);
 }
 
-export function getPostBySlug(slug: string, fields: string[] = []) {
+export function getPostBySlug(
+  slug: string,
+  fields: string[] = [],
+): Post | null {
   const realSlug = slug.replace(/\.md$/, "");
   const fullPath = join(postsDirectory, `${realSlug}.md`);
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
   const fileContents = fs.readFileSync(fullPath, "utf8");
   const { data, content } = matter(fileContents);
 
@@ -34,10 +40,18 @@ export function getPostBySlug(slug: string, fields: string[] = []) {
   return items;
 }
 
+export function getPostBySlugNonNull(slug: string, fields: string[]): Post {
+  const post = getPostBySlug(slug, fields);
+  if (post === null) {
+    throw new Error(`Post with slug "${slug}" not found`);
+  }
+  return post;
+}
+
 export function getAllPosts(fields: string[] = []) {
   const slugs = getPostSlugs();
   const posts = slugs
-    .map((slug) => getPostBySlug(slug, fields))
+    .map((slug) => getPostBySlugNonNull(slug, fields))
     // sort posts by date in descending order
     .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
   return posts;

--- a/examples/blog-with-comment/pages/posts/[slug].tsx
+++ b/examples/blog-with-comment/pages/posts/[slug].tsx
@@ -4,7 +4,7 @@ import ErrorPage from "next/error";
 import Comment from "../../components/comment";
 import Container from "../../components/container";
 import distanceToNow from "../../lib/dateRelative";
-import { getAllPosts, getPostBySlug } from "../../lib/getPost";
+import { getAllPosts, getPostBySlugNonNull } from "../../lib/getPost";
 import markdownToHtml from "../../lib/markdownToHtml";
 import Head from "next/head";
 
@@ -58,7 +58,7 @@ type Params = {
 };
 
 export async function getStaticProps({ params }: Params) {
-  const post = getPostBySlug(params.slug, [
+  const post = getPostBySlugNonNull(params.slug, [
     "slug",
     "title",
     "excerpt",

--- a/examples/cms-tina/lib/api.js
+++ b/examples/cms-tina/lib/api.js
@@ -11,6 +11,9 @@ export function getPostSlugs() {
 export function getPostBySlug(slug, fields = []) {
   const realSlug = slug.replace(/\.md$/, "");
   const fullPath = join(postsDirectory, `${realSlug}.md`);
+  if (!fs.existsSync(fullPath)) {
+    return null;
+  }
   const fileContents = fs.readFileSync(fullPath, "utf8");
   const { data, content } = matter(fileContents);
 
@@ -33,10 +36,18 @@ export function getPostBySlug(slug, fields = []) {
   return items;
 }
 
+export function getPostBySlugNonNull(slug, fields) {
+  const post = getPostBySlug(slug, fields);
+  if (post === null) {
+    throw new Error(`Post with slug "${slug}" not found`);
+  }
+  return post;
+}
+
 export function getAllPosts(fields = []) {
   const slugs = getPostSlugs();
   const posts = slugs
-    .map((slug) => getPostBySlug(slug, fields))
+    .map((slug) => getPostBySlugNonNull(slug, fields))
     // sort posts by date in descending order
     .sort((post1, post2) => (post1.date > post2.date ? -1 : 1));
   return posts;

--- a/examples/cms-tina/pages/posts/[slug].js
+++ b/examples/cms-tina/pages/posts/[slug].js
@@ -5,7 +5,7 @@ import PostBody from "../../components/post-body";
 import Header from "../../components/header";
 import PostHeader from "../../components/post-header";
 import Layout from "../../components/layout";
-import { getPostBySlug, getAllPosts } from "../../lib/api";
+import { getPostBySlugNonNull, getAllPosts } from "../../lib/api";
 import PostTitle from "../../components/post-title";
 import Head from "next/head";
 import { CMS_NAME } from "../../lib/constants";
@@ -47,7 +47,7 @@ export default function Post({ post, morePosts, preview }) {
 }
 
 export async function getStaticProps({ params }) {
-  const post = getPostBySlug(params.slug, [
+  const post = getPostBySlugNonNull(params.slug, [
     "title",
     "date",
     "slug",


### PR DESCRIPTION
http://localhost:3000/posts/nonexistent crashed with:

```
ENOENT: no such file or directory, open '/src/blog-starter/_posts/nonexistent.md'
    at getPostBySlug (src/lib/api.ts:15:27)
    at Post (src/app/posts/[slug]/page.tsx:14:29)
```
