### PR TITLE
Turbopack: Add #[automatically_derived] to proc macros

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/derive/deterministic_hash_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/deterministic_hash_macro.rs
@@ -24,6 +24,7 @@ pub fn derive_deterministic_hash(input: TokenStream) -> TokenStream {
     };
 
     quote! {
+        #[automatically_derived]
         impl turbo_tasks_hash::DeterministicHash for #ident {
             fn deterministic_hash<H: turbo_tasks_hash::DeterministicHasher>(&self, __state__: &mut H) {
                 #discriminant

--- a/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/key_value_pair_macro.rs
@@ -163,6 +163,7 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
         .collect::<Vec<_>>();
 
     quote! {
+        #[automatically_derived]
         impl turbo_tasks::KeyValuePair for #ident {
             type Type = #type_name;
             type Key = #key_name;
@@ -282,6 +283,7 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
             )*
         }
 
+        #[automatically_derived]
         impl #key_name {
             pub fn ty(&self) -> #type_name {
                 match self {
@@ -292,6 +294,7 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         impl #value_name {
             pub fn as_ref(&self) -> #value_ref_name<'_> {
                 match self {
@@ -321,6 +324,7 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
             )*
         }
 
+        #[automatically_derived]
         impl #storage_name {
             pub fn new(ty: #type_name) -> Self {
                 match ty {
@@ -501,6 +505,7 @@ pub fn derive_key_value_pair(input: TokenStream) -> TokenStream {
             )*
         }
 
+        #[automatically_derived]
         impl<'l> Iterator for #iter_name<'l> {
             type Item = (#key_name, #value_ref_name<'l>);
 

--- a/turbopack/crates/turbo-tasks-macros/src/derive/non_local_value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/non_local_value_macro.rs
@@ -17,6 +17,7 @@ pub fn derive_non_local_value(input: TokenStream) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = derive_input.generics.split_for_impl();
     quote! {
+        #[automatically_derived]
         unsafe impl #impl_generics turbo_tasks::NonLocalValue
             for #ident #ty_generics #where_clause {}
         #assertions

--- a/turbopack/crates/turbo-tasks-macros/src/derive/operation_value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/operation_value_macro.rs
@@ -17,6 +17,7 @@ pub fn derive_operation_value(input: TokenStream) -> TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = derive_input.generics.split_for_impl();
     quote! {
+        #[automatically_derived]
         unsafe impl #impl_generics turbo_tasks::OperationValue
             for #ident #ty_generics #where_clause {}
         #assertions

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_input_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_input_macro.rs
@@ -150,6 +150,7 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
         .collect();
 
     quote! {
+        #[automatically_derived]
         #[turbo_tasks::macro_helpers::async_trait]
         impl #generics turbo_tasks::TaskInput for #ident #generics
         where

--- a/turbopack/crates/turbo-tasks-macros/src/derive/trace_raw_vcs_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/trace_raw_vcs_macro.rs
@@ -23,6 +23,7 @@ pub fn derive_trace_raw_vcs(input: TokenStream) -> TokenStream {
 
     let trace_items = match_expansion(&derive_input, &trace_named, &trace_unnamed, &trace_unit);
     quote! {
+        #[automatically_derived]
         impl #impl_generics turbo_tasks::trace::TraceRawVcs for #ident #ty_generics #where_clause {
             fn trace_raw_vcs(&self, __context__: &mut turbo_tasks::trace::TraceRawVcsContext) {
                 #trace_items

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_debug_format_macro.rs
@@ -34,6 +34,7 @@ pub fn derive_value_debug_format(input: TokenStream) -> TokenStream {
         match_expansion(&derive_input, &format_named, &format_unnamed, &format_unit);
 
     quote! {
+        #[automatically_derived]
         impl #impl_generics turbo_tasks::debug::ValueDebugFormat for #ident #ty_generics #where_clause {
             fn value_debug_format<'a>(&'a self, depth: usize) -> turbo_tasks::debug::ValueDebugFormatString<'a> {
                 turbo_tasks::debug::ValueDebugFormatString::Async(

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -332,7 +332,9 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             // NOTE(alexkirsz) We can't have a general `turbo_tasks::Upcast<Box<dyn Trait>> for T where T: Trait` because
             // rustc complains: error[E0210]: type parameter `T` must be covered by another type when it appears before
             // the first local type (`dyn Trait`).
+            #[automatically_derived]
             unsafe impl #impl_generics turbo_tasks::Upcast<::std::boxed::Box<dyn #trait_path>> for #ty #where_clause {}
+            #[automatically_derived]
             unsafe impl #impl_generics turbo_tasks::UpcastStrict<::std::boxed::Box<dyn #trait_path>> for #ty #where_clause {}
 
             impl #impl_generics #trait_path for #ty #where_clause {

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -427,6 +427,7 @@ pub fn value_type_and_register(
 
         turbo_tasks::macro_helpers::inventory_submit!{turbo_tasks::macro_helpers::CollectableValueType(&#value_type_ident)}
 
+        #[automatically_derived]
         unsafe impl #impl_generics turbo_tasks::VcValueType for #ty #where_clause {
             type Read = #read;
             type CellMode = #cell_mode;

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -267,8 +267,11 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let value_debug_impl = if debug {
         quote! {
+            #[automatically_derived]
             unsafe impl turbo_tasks::Dynamic<Box<dyn turbo_tasks::debug::ValueDebug>> for Box<dyn #trait_ident> {}
+            #[automatically_derived]
             unsafe impl turbo_tasks::Upcast<Box<dyn turbo_tasks::debug::ValueDebug>> for Box<dyn #trait_ident> {}
+            #[automatically_derived]
             unsafe impl turbo_tasks::UpcastStrict<Box<dyn turbo_tasks::debug::ValueDebug>> for Box<dyn #trait_ident> {}
         }
     } else {
@@ -313,6 +316,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             turbo_tasks::macro_helpers::CollectableTrait(&#trait_type_ident)
         }
 
+        #[automatically_derived]
         impl turbo_tasks::VcValueTrait for Box<dyn #trait_ident> {
             type ValueTrait = dyn #trait_ident;
 
@@ -333,9 +337,12 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
 
+        #[automatically_derived]
         unsafe impl turbo_tasks::Dynamic<Box<dyn #trait_ident>> for Box<dyn #trait_ident> {}
+        #[automatically_derived]
         unsafe impl turbo_tasks::Upcast<Box<dyn #trait_ident>> for Box<dyn #trait_ident> {}
 
+        #[automatically_derived]
         impl<T> #trait_ident for T
         where
             T: turbo_tasks::Dynamic<Box<dyn #trait_ident>> + #(#supertraits +)* #(#extended_supertraits +)*,
@@ -344,8 +351,11 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         #(
+            #[automatically_derived]
             unsafe impl turbo_tasks::Dynamic<Box<dyn #supertraits>> for Box<dyn #trait_ident> {}
+            #[automatically_derived]
             unsafe impl turbo_tasks::Upcast<Box<dyn #supertraits>> for Box<dyn #trait_ident> {}
+            #[automatically_derived]
             unsafe impl turbo_tasks::UpcastStrict<Box<dyn #supertraits>> for Box<dyn #trait_ident> {
             }
         )*


### PR DESCRIPTION
https://doc.rust-lang.org/reference/attributes/derive.html#r-attributes.derive.automatically_derived

We discussed this during our morning team meeting. I had an LLM write this.  
  
This does not identify any new dead code.