### PR TITLE
[test] Add a failing test for cycle serialization in segment prefetches

### DIFF
--- a/test/e2e/app-dir/segment-cache/basic/app/cycle/client.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/cycle/client.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export function ClientComponent({ testProp }: { testProp: { self: unknown } }) {
+  return (
+    <div id="cycle-check">
+      {testProp.self === testProp ? 'Cycle resolved' : 'Cycle broken'}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/cycle/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/cycle/page.tsx
@@ -1,0 +1,8 @@
+import { ClientComponent } from './client'
+
+export default async function Page() {
+  const cycle = { self: null as unknown }
+  cycle.self = cycle
+
+  return <ClientComponent testProp={cycle} />
+}

--- a/test/e2e/app-dir/segment-cache/basic/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/basic/app/page.tsx
@@ -1,5 +1,14 @@
 import { LinkAccordion } from '../components/link-accordion'
 
 export default function Page() {
-  return <LinkAccordion href="/test">Go to test page</LinkAccordion>
+  return (
+    <>
+      <p>
+        <LinkAccordion href="/test">Go to test page</LinkAccordion>
+      </p>
+      <p>
+        <LinkAccordion href="/cycle">Go to cycle page</LinkAccordion>
+      </p>
+    </>
+  )
 }


### PR DESCRIPTION
Requires a fix in React to pass (possibly https://github.com/facebook/react/pull/35471).

closes #86401