### PR TITLE
feat(mdx): allow custom `parse` options

### DIFF
--- a/packages/next-mdx/mdx-rs-loader.js
+++ b/packages/next-mdx/mdx-rs-loader.js
@@ -47,8 +47,8 @@ function coereceMdxTransformOptions(options = {}) {
   }
 
   return {
-    ...restOptions,
     parse,
+    ...restOptions,
   }
 }
 


### PR DESCRIPTION
The MDX parser used by `@next/mdx` (mdxjs-rs) supports a wide and highly configurable [set of parsing options](https://github.com/wooorm/markdown-rs/blob/main/src/configuration.rs#L480), allowing for extensive fine-tuning of MD/X behavior.

At present, Next.js exposes only two predefined parsing presets to users: `gfm` and `commonMark`. While these presets cover common use cases, they represent only a small subset of the parser’s full capabilities. It would therefore be advantageous to allow users to pass additional low-level `parse` options directly to the MDX parser.

> [!NOTE]
> Many of the options that can already be passed to `mdxRs` via `next.config.mjs` remain undocumented (for example, `mdExtensions`, `format`, and others). As such, I did not make any documentation changes related to this PR.
