### PR TITLE
Turbopack: add support for selective reads of keyed cell values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9620,6 +9620,7 @@ dependencies = [
  "anyhow",
  "futures",
  "rustc-hash 2.1.1",
+ "smallvec",
  "tokio",
  "turbo-tasks",
 ]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -24,8 +24,8 @@ use smallvec::{SmallVec, smallvec};
 use tokio::time::{Duration, Instant};
 use tracing::{Span, trace_span};
 use turbo_tasks::{
-    CellId, FxDashMap, KeyValuePair, RawVc, ReadCellOptions, ReadConsistency, ReadOutputOptions,
-    ReadTracking, TRANSIENT_TASK_BIT, TaskExecutionReason, TaskId, TraitTypeId,
+    CellId, FxDashMap, KeyValuePair, RawVc, ReadCellOptions, ReadCellTracking, ReadConsistency,
+    ReadOutputOptions, ReadTracking, TRANSIENT_TASK_BIT, TaskExecutionReason, TaskId, TraitTypeId,
     TurboTasksBackendApi, ValueTypeId,
     backend::{
         Backend, CachedTaskType, CellContent, TaskExecutionSpec, TransientTaskRoot,
@@ -791,12 +791,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             reader: Option<TaskId>,
             reader_task: Option<impl TaskGuard>,
             cell: CellId,
+            key: Option<u64>,
         ) {
             if let Some(mut reader_task) = reader_task
                 && (!task.is_immutable() || cfg!(feature = "verify_immutable"))
             {
                 let _ = task.add(CachedDataItem::CellDependent {
                     cell,
+                    key,
                     task: reader.unwrap(),
                     value: (),
                 });
@@ -812,10 +814,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                     cell,
                 };
                 if reader_task
-                    .remove(&CachedDataItemKey::OutdatedCellDependency { target })
+                    .remove(&CachedDataItemKey::OutdatedCellDependency { target, key })
                     .is_none()
                 {
-                    let _ = reader_task.add(CachedDataItem::CellDependency { target, value: () });
+                    let _ = reader_task.add(CachedDataItem::CellDependency {
+                        target,
+                        key,
+                        value: (),
+                    });
                 }
             }
         }
@@ -828,7 +834,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
 
         let mut ctx = self.execute_context(turbo_tasks);
         let (mut task, reader_task) = if self.should_track_dependencies()
-            && !matches!(tracking, ReadTracking::Untracked)
+            && !matches!(tracking, ReadCellTracking::Untracked)
             && let Some(reader_id) = reader
             && reader_id != task_id
         {
@@ -848,7 +854,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         if let Some(content) = content {
             if tracking.should_track(false) {
-                add_cell_dependency(task_id, task, reader, reader_task, cell);
+                add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             return Ok(Ok(TypedCellContent(
                 cell.type_id,
@@ -875,7 +881,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         .copied();
         let Some(max_id) = max_id else {
             if tracking.should_track(true) {
-                add_cell_dependency(task_id, task, reader, reader_task, cell);
+                add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             bail!(
                 "Cell {cell:?} no longer exists in task {} (no cell of this type exists)",
@@ -884,7 +890,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         };
         if cell.index >= max_id {
             if tracking.should_track(true) {
-                add_cell_dependency(task_id, task, reader, reader_task, cell);
+                add_cell_dependency(task_id, task, reader, reader_task, cell, tracking.key());
             }
             bail!(
                 "Cell {cell:?} no longer exists in task {} (index out of bounds)",
@@ -1684,22 +1690,26 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             if self.should_track_dependencies() {
                 // Make all dependencies outdated
                 let outdated_cell_dependencies_to_add =
-                    iter_many!(task, CellDependency { target } => target)
+                    iter_many!(task, CellDependency { target, key } => (target, key))
                         .collect::<SmallVec<[_; 8]>>();
                 let outdated_cell_dependencies_to_remove =
-                    iter_many!(task, OutdatedCellDependency { target } => target)
-                        .filter(|&target| {
-                            !task.has_key(&CachedDataItemKey::CellDependency { target })
+                    iter_many!(task, OutdatedCellDependency { target, key } => (target, key))
+                        .filter(|&(target, key)| {
+                            !task.has_key(&CachedDataItemKey::CellDependency { target, key })
                         })
                         .collect::<SmallVec<[_; 8]>>();
                 task.extend(
                     CachedDataItemType::OutdatedCellDependency,
                     outdated_cell_dependencies_to_add
                         .into_iter()
-                        .map(|target| CachedDataItem::OutdatedCellDependency { target, value: () }),
+                        .map(|(target, key)| CachedDataItem::OutdatedCellDependency {
+                            target,
+                            key,
+                            value: (),
+                        }),
                 );
-                for target in outdated_cell_dependencies_to_remove {
-                    task.remove(&CachedDataItemKey::OutdatedCellDependency { target });
+                for (target, key) in outdated_cell_dependencies_to_remove {
+                    task.remove(&CachedDataItemKey::OutdatedCellDependency { target, key });
                 }
 
                 let outdated_output_dependencies_to_add =
@@ -2000,7 +2010,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             Some(
                 // Collect all dependencies on tasks to check if all dependencies are immutable
                 iter_many!(task, OutputDependency { target } => target)
-                    .chain(iter_many!(task, CellDependency { target } => target.task))
+                    .chain(iter_many!(task, CellDependency { target, key: _ } => target.task))
                     .collect::<FxHashSet<_>>(),
             )
         } else {
@@ -2054,7 +2064,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         );
 
         if self.should_track_dependencies() {
-            old_edges.extend(iter_many!(task, OutdatedCellDependency { target } => OutdatedEdge::CellDependency(target)));
+            old_edges.extend(iter_many!(task, OutdatedCellDependency { target, key } => OutdatedEdge::CellDependency(target, key)));
             old_edges.extend(iter_many!(task, OutdatedOutputDependency { target } => OutdatedEdge::OutputDependency(target)));
             old_edges.extend(
                 iter_many!(task, CellDependent { cell, task } => (cell, task)).filter_map(
@@ -2742,6 +2752,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         cell: CellId,
         is_serializable_cell_content: bool,
         content: CellContent,
+        updated_key_hashes: Option<SmallVec<[u64; 2]>>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) {
@@ -2750,6 +2761,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             cell,
             content,
             is_serializable_cell_content,
+            updated_key_hashes,
             verification_mode,
             self.execute_context(turbo_tasks),
         );
@@ -3337,6 +3349,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         cell: CellId,
         is_serializable_cell_content: bool,
         content: CellContent,
+        updated_key_hashes: Option<SmallVec<[u64; 2]>>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) {
@@ -3345,6 +3358,7 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
             cell,
             is_serializable_cell_content,
             content,
+            updated_key_hashes,
             verification_mode,
             turbo_tasks,
         );

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2067,7 +2067,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             old_edges.extend(iter_many!(task, OutdatedCellDependency { target, key } => OutdatedEdge::CellDependency(target, key)));
             old_edges.extend(iter_many!(task, OutdatedOutputDependency { target } => OutdatedEdge::OutputDependency(target)));
             old_edges.extend(
-                iter_many!(task, CellDependent { cell, task } => (cell, task)).filter_map(
+                iter_many!(task, CellDependent { cell, task, key: _ } => (cell, task)).filter_map(
                     |(cell, task)| {
                         if cell_counters
                             .get(&cell.type_id)

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/cleanup_old_edges.rs
@@ -42,7 +42,7 @@ pub enum CleanupOldEdgesOperation {
 pub enum OutdatedEdge {
     Child(TaskId),
     Collectible(CollectibleRef, i32),
-    CellDependency(CellRef),
+    CellDependency(CellRef, Option<u64>),
     OutputDependency(TaskId),
     CollectiblesDependency(CollectiblesRef),
     RemovedCellDependent {
@@ -160,14 +160,18 @@ impl Operation for CleanupOldEdgesOperation {
                                     AggregatedDataUpdate::new().collectibles_update(collectibles),
                                 ));
                             }
-                            OutdatedEdge::CellDependency(CellRef {
-                                task: cell_task_id,
-                                cell,
-                            }) => {
+                            OutdatedEdge::CellDependency(
+                                CellRef {
+                                    task: cell_task_id,
+                                    cell,
+                                },
+                                key,
+                            ) => {
                                 {
                                     let mut task = ctx.task(cell_task_id, TaskDataCategory::Data);
                                     task.remove(&CachedDataItemKey::CellDependent {
                                         cell,
+                                        key,
                                         task: task_id,
                                     });
                                 }
@@ -178,6 +182,7 @@ impl Operation for CleanupOldEdgesOperation {
                                             task: cell_task_id,
                                             cell,
                                         },
+                                        key,
                                     });
                                 }
                             }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/invalidate.rs
@@ -64,7 +64,7 @@ impl Operation for InvalidateOperation {
                         make_task_dirty(
                             task_id,
                             #[cfg(feature = "trace_task_dirty")]
-                            cause,
+                            cause.clone(),
                             &mut queue,
                             ctx,
                         );
@@ -90,11 +90,12 @@ impl Operation for InvalidateOperation {
 }
 
 #[cfg(feature = "trace_task_dirty")]
-#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[derive(Encode, Decode, Clone, Debug)]
 pub enum TaskDirtyCause {
     InitialDirty,
     CellChange {
         value_type: turbo_tasks::ValueTypeId,
+        keys: SmallVec<[Option<u64>; 2]>,
     },
     CellRemoved {
         value_type: turbo_tasks::ValueTypeId,
@@ -132,12 +133,27 @@ impl<'e, E: ExecuteContext<'e>> std::fmt::Display for TaskDirtyCauseInContext<'_
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self.cause {
             TaskDirtyCause::InitialDirty => write!(f, "initial dirty"),
-            TaskDirtyCause::CellChange { value_type } => {
-                write!(
-                    f,
-                    "{} cell changed",
-                    turbo_tasks::registry::get_value_type(*value_type).name
-                )
+            TaskDirtyCause::CellChange { value_type, keys } => {
+                if keys.is_empty() {
+                    write!(
+                        f,
+                        "{} cell changed",
+                        turbo_tasks::registry::get_value_type(*value_type).name
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{} cell changed (keys: {})",
+                        turbo_tasks::registry::get_value_type(*value_type).name,
+                        keys.iter()
+                            .map(|key| match key {
+                                Some(k) => k.to_string(),
+                                None => "*".to_string(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                }
             }
             TaskDirtyCause::CellRemoved { value_type } => {
                 write!(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -243,6 +243,8 @@ where
                 if id.is_transient() {
                     if call_prepared_task_callback_for_transient_tasks {
                         let mut task = self.backend.storage.access_mut(id);
+                        // TODO add is_restoring and avoid concurrent restores and duplicates tasks
+                        // ids in `task_ids`
                         if !task.state().is_restored(category) {
                             task.state_mut().set_restored(TaskDataCategory::All);
                         }
@@ -1003,7 +1005,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         }
         self.task.state_mut().set_prefetched(true);
         let map = iter_many!(self, OutputDependency { target } => (target, TaskDataCategory::Meta))
-            .chain(iter_many!(self, CellDependency { target } => (target.task, TaskDataCategory::All)))
+            .chain(iter_many!(self, CellDependency { target, key: _ } => (target.task, TaskDataCategory::All)))
             .chain(iter_many!(self, CollectiblesDependency { target } => (target.task, TaskDataCategory::All)))
             .chain(iter_many!(self, Child { task } => (task, TaskDataCategory::All)))
             .collect::<FxIndexMap<_, _>>();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -30,6 +30,7 @@ pub enum UpdateCellOperation {
         cell_ref: CellRef,
         #[bincode(with = "turbo_bincode::indexmap")]
         dependent_tasks: FxIndexMap<TaskId, SmallVec<[Option<u64>; 2]>>,
+        #[cfg(feature = "trace_task_dirty")]
         has_updated_key_hashes: bool,
         content: Option<TypedSharedReference>,
         queue: AggregationUpdateQueue,
@@ -101,6 +102,7 @@ impl UpdateCellOperation {
             // When not recomputing, we need to notify dependent tasks if the content actually
             // changes.
 
+            #[cfg(feature = "trace_task_dirty")]
             let has_updated_key_hashes = updated_key_hashes.is_some();
             let updated_key_hashes_set = updated_key_hashes.map(|updated_key_hashes| {
                 Lazy::new(|| updated_key_hashes.into_iter().collect::<FxHashSet<u64>>())
@@ -161,6 +163,7 @@ impl UpdateCellOperation {
                         cell,
                     },
                     dependent_tasks,
+                    #[cfg(feature = "trace_task_dirty")]
                     has_updated_key_hashes,
                     content,
                     queue: AggregationUpdateQueue::new(),
@@ -223,6 +226,7 @@ impl Operation for UpdateCellOperation {
                     is_serializable_cell_content,
                     cell_ref,
                     ref mut dependent_tasks,
+                    #[cfg(feature = "trace_task_dirty")]
                     has_updated_key_hashes,
                     ref mut content,
                     ref mut queue,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -1,10 +1,12 @@
 use std::mem::take;
 
 use bincode::{Decode, Encode};
+use once_cell::unsync::Lazy;
+use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 #[cfg(not(feature = "verify_determinism"))]
 use turbo_tasks::backend::VerificationMode;
-use turbo_tasks::{CellId, TaskId, TypedSharedReference, backend::CellContent};
+use turbo_tasks::{CellId, FxIndexMap, TaskId, TypedSharedReference, backend::CellContent};
 
 #[cfg(feature = "trace_task_dirty")]
 use crate::backend::operation::invalidate::TaskDirtyCause;
@@ -26,7 +28,8 @@ pub enum UpdateCellOperation {
     InvalidateWhenCellDependency {
         is_serializable_cell_content: bool,
         cell_ref: CellRef,
-        dependent_tasks: SmallVec<[TaskId; 4]>,
+        #[bincode(with = "turbo_bincode::indexmap")]
+        dependent_tasks: FxIndexMap<TaskId, SmallVec<[Option<u64>; 2]>>,
         content: Option<TypedSharedReference>,
         queue: AggregationUpdateQueue,
     },
@@ -49,6 +52,7 @@ impl UpdateCellOperation {
         cell: CellId,
         content: CellContent,
         is_serializable_cell_content: bool,
+        updated_key_hashes: Option<SmallVec<[u64; 2]>>,
         #[cfg(feature = "verify_determinism")] verification_mode: VerificationMode,
         #[cfg(not(feature = "verify_determinism"))] _verification_mode: VerificationMode,
         mut ctx: impl ExecuteContext,
@@ -96,17 +100,29 @@ impl UpdateCellOperation {
             // When not recomputing, we need to notify dependent tasks if the content actually
             // changes.
 
-            let dependent_tasks: SmallVec<[TaskId; 4]> = iter_many!(
+            let updated_key_hashes_set = updated_key_hashes.map(|updated_key_hashes| {
+                Lazy::new(|| updated_key_hashes.into_iter().collect::<FxHashSet<u64>>())
+            });
+
+            let tasks_with_keys = iter_many!(
                 task,
-                CellDependent { cell: dependent_cell, task }
-                if dependent_cell == cell
-                => task
+                CellDependent { cell: dependent_cell, key, task }
+                if dependent_cell == cell && key.is_none_or(|key_hash| {
+                    updated_key_hashes_set.as_ref().is_none_or(|set| {
+                        set.contains(&key_hash)
+                    })
+                })
+                => (task, key)
             )
-            .filter(|&dependent_task_id| {
+            .filter(|&(dependent_task_id, _)| {
                 // once tasks are never invalidated
                 !ctx.is_once_task(dependent_task_id)
-            })
-            .collect();
+            });
+            let mut dependent_tasks: FxIndexMap<TaskId, SmallVec<[Option<u64>; 2]>> =
+                FxIndexMap::default();
+            for (task, key) in tasks_with_keys {
+                dependent_tasks.entry(task).or_default().push(key);
+            }
 
             if !dependent_tasks.is_empty() {
                 // Slow path: We need to invalidate tasks depending on this cell.
@@ -132,7 +148,7 @@ impl UpdateCellOperation {
 
                 ctx.prepare_tasks(
                     dependent_tasks
-                        .iter()
+                        .keys()
                         .map(|&id| (id, TaskDataCategory::All)),
                 );
 
@@ -207,24 +223,31 @@ impl Operation for UpdateCellOperation {
                     ref mut content,
                     ref mut queue,
                 } => {
-                    if let Some(dependent_task_id) = dependent_tasks.pop() {
-                        let mut make_stale = true;
+                    if let Some((dependent_task_id, keys)) = dependent_tasks.pop() {
+                        let mut make_stale = false;
                         let dependent = ctx.task(dependent_task_id, TaskDataCategory::All);
-                        if dependent.has_key(&CachedDataItemKey::OutdatedCellDependency {
-                            target: cell_ref,
-                        }) {
-                            // cell dependency is outdated, so it hasn't read the cell yet
-                            // and doesn't need to be invalidated.
-                            // But importantly we still need to make the task dirty as it should no
-                            // longer be considered as "recomputation".
-                            make_stale = false;
-                        } else if !dependent
-                            .has_key(&CachedDataItemKey::CellDependency { target: cell_ref })
-                        {
-                            // cell dependency has been removed, so the task doesn't depend on the
-                            // cell anymore and doesn't need to be
-                            // invalidated
-                            continue;
+                        for key in keys {
+                            if dependent.has_key(&CachedDataItemKey::OutdatedCellDependency {
+                                target: cell_ref,
+                                key,
+                            }) {
+                                // cell dependency is outdated, so it hasn't read the cell yet
+                                // and doesn't need to be invalidated.
+                                // We do not need to make the task stale in this case.
+                                // But importantly we still need to make the task dirty as it should
+                                // no longer be considered as
+                                // "recomputation".
+                            } else if !dependent.has_key(&CachedDataItemKey::CellDependency {
+                                target: cell_ref,
+                                key,
+                            }) {
+                                // cell dependency has been removed, so the task doesn't depend on
+                                // the cell anymore and doesn't need
+                                // to be invalidated
+                                continue;
+                            } else {
+                                make_stale = true;
+                            }
                         }
                         make_task_dirty_internal(
                             dependent,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -30,6 +30,7 @@ pub enum UpdateCellOperation {
         cell_ref: CellRef,
         #[bincode(with = "turbo_bincode::indexmap")]
         dependent_tasks: FxIndexMap<TaskId, SmallVec<[Option<u64>; 2]>>,
+        has_updated_key_hashes: bool,
         content: Option<TypedSharedReference>,
         queue: AggregationUpdateQueue,
     },
@@ -100,6 +101,7 @@ impl UpdateCellOperation {
             // When not recomputing, we need to notify dependent tasks if the content actually
             // changes.
 
+            let has_updated_key_hashes = updated_key_hashes.is_some();
             let updated_key_hashes_set = updated_key_hashes.map(|updated_key_hashes| {
                 Lazy::new(|| updated_key_hashes.into_iter().collect::<FxHashSet<u64>>())
             });
@@ -159,6 +161,7 @@ impl UpdateCellOperation {
                         cell,
                     },
                     dependent_tasks,
+                    has_updated_key_hashes,
                     content,
                     queue: AggregationUpdateQueue::new(),
                 }
@@ -220,6 +223,7 @@ impl Operation for UpdateCellOperation {
                     is_serializable_cell_content,
                     cell_ref,
                     ref mut dependent_tasks,
+                    has_updated_key_hashes,
                     ref mut content,
                     ref mut queue,
                 } => {
@@ -256,7 +260,7 @@ impl Operation for UpdateCellOperation {
                             #[cfg(feature = "trace_task_dirty")]
                             TaskDirtyCause::CellChange {
                                 value_type: cell_ref.cell.type_id,
-                                keys,
+                                keys: has_updated_key_hashes.then_some(keys).unwrap_or_default(),
                             },
                             queue,
                             ctx,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/update_cell.rs
@@ -226,7 +226,7 @@ impl Operation for UpdateCellOperation {
                     if let Some((dependent_task_id, keys)) = dependent_tasks.pop() {
                         let mut make_stale = false;
                         let dependent = ctx.task(dependent_task_id, TaskDataCategory::All);
-                        for key in keys {
+                        for key in keys.iter().copied() {
                             if dependent.has_key(&CachedDataItemKey::OutdatedCellDependency {
                                 target: cell_ref,
                                 key,
@@ -256,6 +256,7 @@ impl Operation for UpdateCellOperation {
                             #[cfg(feature = "trace_task_dirty")]
                             TaskDirtyCause::CellChange {
                                 value_type: cell_ref.cell.type_id,
+                                keys,
                             },
                             queue,
                             ctx,

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -263,6 +263,7 @@ pub enum CachedDataItem {
     },
     CellDependency {
         target: CellRef,
+        key: Option<u64>,
         value: (),
     },
     CollectiblesDependency {
@@ -277,6 +278,7 @@ pub enum CachedDataItem {
     },
     CellDependent {
         cell: CellId,
+        key: Option<u64>,
         task: TaskId,
         value: (),
     },
@@ -362,6 +364,8 @@ pub enum CachedDataItem {
     OutdatedCellDependency {
         #[bincode(skip, default = "unreachable_decode")]
         target: CellRef,
+        #[bincode(skip, default = "unreachable_decode")]
+        key: Option<u64>,
         #[bincode(skip, default = "unreachable_decode")]
         value: (),
     },
@@ -669,8 +673,8 @@ mod tests {
     #[test]
     fn test_sizes() {
         assert_eq!(std::mem::size_of::<super::CachedDataItem>(), 40);
-        assert_eq!(std::mem::size_of::<super::CachedDataItemKey>(), 20);
+        assert_eq!(std::mem::size_of::<super::CachedDataItemKey>(), 32);
         assert_eq!(std::mem::size_of::<super::CachedDataItemValue>(), 32);
-        assert_eq!(std::mem::size_of::<super::CachedDataItemStorage>(), 48);
+        assert_eq!(std::mem::size_of::<super::CachedDataItemStorage>(), 56);
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
@@ -3,14 +3,22 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use anyhow::Result;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_tasks::{OperationVc, ResolvedVc, State, Vc};
 use turbo_tasks_testing::{Registration, register, run};
 
 static REGISTRATION: Registration = register!();
 
+#[turbo_tasks::value(transparent)]
+struct Step(State<u32>);
+
+#[turbo_tasks::function]
+fn create_state() -> Vc<Step> {
+    Step(State::new(0)).cell()
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn invalidation() {
+async fn invalidation_map() {
     run(&REGISTRATION, || async {
         let state = create_state().to_resolved().await?;
         state.await?.set(1);
@@ -57,14 +65,6 @@ async fn invalidation() {
     .unwrap()
 }
 
-#[turbo_tasks::value(transparent)]
-struct Step(State<u32>);
-
-#[turbo_tasks::function]
-fn create_state() -> Vc<Step> {
-    Step(State::new(0)).cell()
-}
-
 #[turbo_tasks::value(transparent, cell = "keyed")]
 struct Map(FxHashMap<String, u32>);
 
@@ -93,4 +93,83 @@ async fn get_value(map: OperationVc<Map>, key: String) -> Result<Vc<GetValueResu
     let value = map.get(&key).await?.as_deref().copied();
     let random = rand::random::<u32>();
     Ok(GetValueResult { value, random }.cell())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalidation_set() {
+    run(&REGISTRATION, || async {
+        let state = create_state().to_resolved().await?;
+        state.await?.set(1);
+
+        let set = create_set(state);
+        let a = has_value(set, "a".to_string());
+        let b = has_value(set, "b".to_string());
+        let c = has_value(set, "c".to_string());
+
+        let a_ref = a.read_strongly_consistent().await?;
+        let b_ref = b.read_strongly_consistent().await?;
+        let c_ref = c.read_strongly_consistent().await?;
+
+        assert_eq!(a_ref.value, true);
+        assert_eq!(b_ref.value, true);
+        assert_eq!(c_ref.value, false);
+
+        state.await?.set(2);
+
+        let a_ref2 = a.read_strongly_consistent().await?;
+        let b_ref2 = b.read_strongly_consistent().await?;
+        let c_ref2 = c.read_strongly_consistent().await?;
+
+        assert_eq!(a_ref2.value, true);
+        assert_eq!(b_ref2.value, true);
+        assert_eq!(c_ref2.value, false);
+        assert_eq!(a_ref.random, a_ref2.random);
+        assert_eq!(b_ref.random, b_ref2.random);
+        assert_eq!(c_ref.random, c_ref2.random);
+
+        state.await?.set(3);
+
+        let a_ref3 = a.read_strongly_consistent().await?;
+        let b_ref3 = b.read_strongly_consistent().await?;
+        let c_ref3 = c.read_strongly_consistent().await?;
+
+        assert_eq!(a_ref3.value, false);
+        assert_eq!(b_ref3.value, true);
+        assert_eq!(c_ref3.value, true);
+        assert_eq!(b_ref2.random, b_ref3.random);
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+#[turbo_tasks::value(transparent, cell = "keyed")]
+struct Set(FxHashSet<String>);
+
+#[turbo_tasks::function(operation)]
+async fn create_set(step: ResolvedVc<Step>) -> Result<Vc<Set>> {
+    let step = step.await?;
+    let step_value = step.get();
+
+    Ok(Vc::cell(match *step_value {
+        1 => FxHashSet::from_iter(["a".to_string(), "b".to_string()]),
+        2 => FxHashSet::from_iter(["e".to_string(), "a".to_string(), "b".to_string()]),
+        3 => FxHashSet::from_iter(["c".to_string(), "b".to_string()]),
+        _ => FxHashSet::default(),
+    }))
+}
+
+#[turbo_tasks::value]
+struct HasValueResult {
+    value: bool,
+    random: u32,
+}
+
+#[turbo_tasks::function(operation)]
+async fn has_value(set: OperationVc<Set>, key: String) -> Result<Vc<HasValueResult>> {
+    let set = set.connect();
+    let value = set.contains_key(&key).await?;
+    let random = rand::random::<u32>();
+    Ok(HasValueResult { value, random }.cell())
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
@@ -110,9 +110,9 @@ async fn invalidation_set() {
         let b_ref = b.read_strongly_consistent().await?;
         let c_ref = c.read_strongly_consistent().await?;
 
-        assert_eq!(a_ref.value, true);
-        assert_eq!(b_ref.value, true);
-        assert_eq!(c_ref.value, false);
+        assert!(a_ref.value);
+        assert!(b_ref.value);
+        assert!(!c_ref.value);
 
         state.await?.set(2);
 
@@ -120,9 +120,9 @@ async fn invalidation_set() {
         let b_ref2 = b.read_strongly_consistent().await?;
         let c_ref2 = c.read_strongly_consistent().await?;
 
-        assert_eq!(a_ref2.value, true);
-        assert_eq!(b_ref2.value, true);
-        assert_eq!(c_ref2.value, false);
+        assert!(a_ref2.value);
+        assert!(b_ref2.value);
+        assert!(!c_ref2.value);
         assert_eq!(a_ref.random, a_ref2.random);
         assert_eq!(b_ref.random, b_ref2.random);
         assert_eq!(c_ref.random, c_ref2.random);
@@ -133,9 +133,9 @@ async fn invalidation_set() {
         let b_ref3 = b.read_strongly_consistent().await?;
         let c_ref3 = c.read_strongly_consistent().await?;
 
-        assert_eq!(a_ref3.value, false);
-        assert_eq!(b_ref3.value, true);
-        assert_eq!(c_ref3.value, true);
+        assert!(!a_ref3.value);
+        assert!(b_ref3.value);
+        assert!(c_ref3.value);
         assert_eq!(b_ref2.random, b_ref3.random);
 
         anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/invalidation.rs
@@ -1,0 +1,96 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use anyhow::Result;
+use rustc_hash::FxHashMap;
+use turbo_tasks::{OperationVc, ResolvedVc, State, Vc};
+use turbo_tasks_testing::{Registration, register, run};
+
+static REGISTRATION: Registration = register!();
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn invalidation() {
+    run(&REGISTRATION, || async {
+        let state = create_state().to_resolved().await?;
+        state.await?.set(1);
+
+        let map = create_map(state);
+        let a = get_value(map, "a".to_string());
+        let b = get_value(map, "b".to_string());
+        let c = get_value(map, "c".to_string());
+
+        let a_ref = a.read_strongly_consistent().await?;
+        let b_ref = b.read_strongly_consistent().await?;
+        let c_ref = c.read_strongly_consistent().await?;
+
+        assert_eq!(a_ref.value, Some(1));
+        assert_eq!(b_ref.value, Some(2));
+        assert_eq!(c_ref.value, None);
+
+        state.await?.set(2);
+
+        let a_ref2 = a.read_strongly_consistent().await?;
+        let b_ref2 = b.read_strongly_consistent().await?;
+        let c_ref2 = c.read_strongly_consistent().await?;
+
+        assert_eq!(a_ref2.value, Some(1));
+        assert_eq!(b_ref2.value, Some(22));
+        assert_eq!(c_ref2.value, None);
+        assert_eq!(a_ref.random, a_ref2.random);
+        assert_eq!(c_ref.random, c_ref2.random);
+
+        state.await?.set(3);
+
+        let a_ref3 = a.read_strongly_consistent().await?;
+        let b_ref3 = b.read_strongly_consistent().await?;
+        let c_ref3 = c.read_strongly_consistent().await?;
+
+        assert_eq!(a_ref3.value, None);
+        assert_eq!(b_ref3.value, Some(22));
+        assert_eq!(c_ref3.value, Some(3));
+        assert_eq!(b_ref2.random, b_ref3.random);
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+#[turbo_tasks::value(transparent)]
+struct Step(State<u32>);
+
+#[turbo_tasks::function]
+fn create_state() -> Vc<Step> {
+    Step(State::new(0)).cell()
+}
+
+#[turbo_tasks::value(transparent, cell = "keyed")]
+struct Map(FxHashMap<String, u32>);
+
+#[turbo_tasks::function(operation)]
+async fn create_map(step: ResolvedVc<Step>) -> Result<Vc<Map>> {
+    let step = step.await?;
+    let step_value = step.get();
+
+    Ok(Vc::cell(match *step_value {
+        1 => FxHashMap::from_iter([("a".to_string(), 1), ("b".to_string(), 2)]),
+        2 => FxHashMap::from_iter([("a".to_string(), 1), ("b".to_string(), 22)]),
+        3 => FxHashMap::from_iter([("c".to_string(), 3), ("b".to_string(), 22)]),
+        _ => FxHashMap::default(),
+    }))
+}
+
+#[turbo_tasks::value]
+struct GetValueResult {
+    value: Option<u32>,
+    random: u32,
+}
+
+#[turbo_tasks::function(operation)]
+async fn get_value(map: OperationVc<Map>, key: String) -> Result<Vc<GetValueResult>> {
+    let map = map.connect();
+    let value = map.get(&key).await?.as_deref().copied();
+    let random = rand::random::<u32>();
+    Ok(GetValueResult { value, random }.cell())
+}

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -15,6 +15,7 @@ use syn::{
 use crate::{global_name::global_name, ident::get_value_type_ident};
 
 enum CellMode {
+    KeyedCompare,
     Compare,
     New,
 }
@@ -31,9 +32,13 @@ impl TryFrom<LitStr> for CellMode {
 
     fn try_from(lit: LitStr) -> Result<Self, Self::Error> {
         match lit.value().as_str() {
+            "keyed" => Ok(CellMode::KeyedCompare),
             "compare" => Ok(CellMode::Compare),
             "new" => Ok(CellMode::New),
-            _ => Err(Error::new_spanned(&lit, "expected \"new\" or \"compare\"")),
+            _ => Err(Error::new_spanned(
+                &lit,
+                "expected \"new\", \"keyed\", or \"compare\"",
+            )),
         }
     }
 }
@@ -274,6 +279,9 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         },
         CellMode::Compare => quote! {
             turbo_tasks::VcCellCompareMode<#ident>
+        },
+        CellMode::KeyedCompare => quote! {
+            turbo_tasks::VcCellKeyedCompareMode<#ident>
         },
     };
 

--- a/turbopack/crates/turbo-tasks-testing/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-testing/Cargo.toml
@@ -17,5 +17,6 @@ workspace = true
 anyhow = { workspace = true }
 futures = { workspace = true }
 rustc-hash = { workspace = true }
+smallvec = { workspace = true }
 tokio = { workspace = true }
 turbo-tasks = { workspace = true, features = ["non_operation_vc_strongly_consistent"] }

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -14,6 +14,7 @@ use std::{
 use anyhow::{Result, anyhow};
 use futures::FutureExt;
 use rustc_hash::FxHashMap;
+use smallvec::SmallVec;
 use tokio::sync::mpsc::Receiver;
 use turbo_tasks::{
     CellId, ExecutionId, InvalidationReason, LocalTaskId, MagicAny, RawVc, ReadCellOptions,
@@ -267,6 +268,7 @@ impl TurboTasksApi for VcStorage {
         index: CellId,
         _is_serializable_cell_content: bool,
         content: CellContent,
+        _updated_key_hashes: Option<SmallVec<[u64; 2]>>,
         _verification_mode: VerificationMode,
     ) {
         let mut map = self.cells.lock().unwrap();

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -16,6 +16,7 @@ use bincode::{
     impl_borrow_decode,
 };
 use rustc_hash::FxHasher;
+use smallvec::SmallVec;
 use tracing::Span;
 use turbo_bincode::{
     TurboBincodeDecode, TurboBincodeDecoder, TurboBincodeEncode, TurboBincodeEncoder,
@@ -508,6 +509,7 @@ pub trait Backend: Sync + Send {
         index: CellId,
         is_serializable_cell_content: bool,
         content: CellContent,
+        updated_key_hashes: Option<SmallVec<[u64; 2]>>,
         verification_mode: VerificationMode,
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     );

--- a/turbopack/crates/turbo-tasks/src/keyed.rs
+++ b/turbopack/crates/turbo-tasks/src/keyed.rs
@@ -1,0 +1,250 @@
+use std::{
+    collections::{HashMap, HashSet},
+    hash::{BuildHasher, Hash},
+};
+
+use indexmap::{IndexMap, IndexSet};
+use smallvec::SmallVec;
+
+pub trait Keyed {
+    type Key;
+    type Value;
+
+    fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]>;
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value>;
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        self.get(key).is_some()
+    }
+}
+
+impl<K: Eq + Hash, V: PartialEq, H: BuildHasher> Keyed for HashMap<K, V, H> {
+    type Key = K;
+    type Value = V;
+
+    fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
+        let mut different_keys = SmallVec::new();
+
+        for (key, value) in self.iter() {
+            if let Some(other_value) = other.get(key) {
+                if value != other_value {
+                    different_keys.push(key);
+                }
+            } else {
+                different_keys.push(key);
+            }
+        }
+
+        if other.len() != self.len() || !different_keys.is_empty() {
+            for key in other.keys() {
+                if !self.contains_key(key) {
+                    different_keys.push(key);
+                }
+            }
+        }
+
+        different_keys
+    }
+
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+        self.get(key)
+    }
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        self.contains_key(key)
+    }
+}
+
+impl<K: Eq + Hash, V: PartialEq, H: BuildHasher> Keyed for IndexMap<K, V, H> {
+    type Key = K;
+    type Value = V;
+
+    fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
+        let mut different_keys = SmallVec::new();
+
+        for (key, value) in self.iter() {
+            if let Some(other_value) = other.get(key) {
+                if value != other_value {
+                    different_keys.push(key);
+                }
+            } else {
+                different_keys.push(key);
+            }
+        }
+
+        if other.len() != self.len() || !different_keys.is_empty() {
+            for key in other.keys() {
+                if !self.contains_key(key) {
+                    different_keys.push(key);
+                }
+            }
+        }
+
+        different_keys
+    }
+
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+        self.get(key)
+    }
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        self.contains_key(key)
+    }
+}
+
+impl<K: Eq + Hash, H: BuildHasher> Keyed for HashSet<K, H> {
+    type Key = K;
+    type Value = ();
+
+    fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
+        let mut different_keys = SmallVec::new();
+
+        for key in self.iter() {
+            if !other.contains(key) {
+                different_keys.push(key);
+            }
+        }
+
+        if other.len() != self.len() || !different_keys.is_empty() {
+            for key in other.iter() {
+                if !self.contains(key) {
+                    different_keys.push(key);
+                }
+            }
+        }
+
+        different_keys
+    }
+
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+        if self.contains(key) { Some(&()) } else { None }
+    }
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        self.contains(key)
+    }
+}
+
+impl<K: Eq + Hash, H: BuildHasher> Keyed for IndexSet<K, H> {
+    type Key = K;
+    type Value = ();
+
+    fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
+        let mut different_keys = SmallVec::new();
+
+        for key in self.iter() {
+            if !other.contains(key) {
+                different_keys.push(key);
+            }
+        }
+
+        if other.len() != self.len() || !different_keys.is_empty() {
+            for key in other.iter() {
+                if !self.contains(key) {
+                    different_keys.push(key);
+                }
+            }
+        }
+
+        different_keys
+    }
+
+    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+        if self.contains(key) { Some(&()) } else { None }
+    }
+
+    fn contains_key(&self, key: &Self::Key) -> bool {
+        self.contains(key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn abc() -> [(&'static str, i32); 3] {
+        [("a", 1), ("b", 2), ("c", 3)]
+    }
+
+    fn abd() -> [(&'static str, i32); 3] {
+        [("a", 1), ("b", 22), ("d", 4)]
+    }
+
+    fn ab() -> [(&'static str, i32); 2] {
+        [("a", 1), ("b", 2)]
+    }
+
+    fn abcde() -> [(&'static str, i32); 5] {
+        [("a", 1), ("b", 2), ("c", 3), ("d", 4), ("e", 5)]
+    }
+
+    fn edcba() -> [(&'static str, i32); 5] {
+        [("e", 5), ("d", 4), ("c", 3), ("b", 2), ("a", 1)]
+    }
+
+    fn assert_diff<T: Keyed>(a: &T, b: &T, expected: &[&T::Key])
+    where
+        T::Key: std::fmt::Debug + PartialEq,
+    {
+        let diffs = a.different_keys(&b);
+        assert_eq!(diffs.len(), expected.len());
+        for key in expected {
+            assert!(diffs.contains(key));
+        }
+    }
+
+    #[test]
+    fn test_hash_map_diff() {
+        let map1 = HashMap::from(abc());
+        let map2 = HashMap::from(abd());
+        assert_diff(&map1, &map2, &[&"b", &"c", &"d"]);
+    }
+
+    #[test]
+    fn test_index_map_diff() {
+        let map1 = IndexMap::from(abc());
+        let map2 = IndexMap::from(abd());
+        assert_diff(&map1, &map2, &[&"b", &"c", &"d"]);
+    }
+
+    #[test]
+    fn test_hash_map_equal() {
+        let map1 = HashMap::from(abcde());
+        let map2 = HashMap::from(edcba());
+        assert_diff(&map1, &map2, &[]);
+    }
+
+    #[test]
+    fn test_index_map_equal() {
+        let map1 = IndexMap::from(abcde());
+        let map2 = IndexMap::from(edcba());
+        assert_diff(&map1, &map2, &[]);
+    }
+
+    #[test]
+    fn test_hash_map_add_key() {
+        let map1 = HashMap::from(ab());
+        let map2 = HashMap::from(abc());
+        assert_diff(&map1, &map2, &[&"c"]);
+    }
+
+    #[test]
+    fn test_index_map_add_key() {
+        let map1 = IndexMap::from(ab());
+        let map2 = IndexMap::from(abc());
+        assert_diff(&map1, &map2, &[&"c"]);
+    }
+
+    #[test]
+    fn test_hash_map_remove_key() {
+        let map1 = HashMap::from(abc());
+        let map2 = HashMap::from(ab());
+        assert_diff(&map1, &map2, &[&"c"]);
+    }
+
+    #[test]
+    fn test_index_map_remove_key() {
+        let map1 = IndexMap::from(abc());
+        let map2 = IndexMap::from(ab());
+        assert_diff(&map1, &map2, &[&"c"]);
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/keyed.rs
+++ b/turbopack/crates/turbo-tasks/src/keyed.rs
@@ -185,7 +185,7 @@ mod tests {
     where
         T::Key: std::fmt::Debug + PartialEq,
     {
-        let diffs = a.different_keys(&b);
+        let diffs = a.different_keys(b);
         assert_eq!(diffs.len(), expected.len());
         for key in expected {
             assert!(diffs.contains(key));

--- a/turbopack/crates/turbo-tasks/src/keyed_read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/keyed_read_ref.rs
@@ -53,7 +53,7 @@ where
     T: Debug,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        (&**self).fmt(f)
+        (**self).fmt(f)
     }
 }
 
@@ -123,7 +123,7 @@ where
     }
 }
 
-impl<'a, A, T, I, J: Iterator<Item = I>> IntoIterator for &'a MappedReadRef<A, T>
+impl<A, T, I, J: Iterator<Item = I>> IntoIterator for &MappedReadRef<A, T>
 where
     T: Keyed,
     for<'b> &'b T: IntoIterator<Item = I, IntoIter = J>,
@@ -145,6 +145,6 @@ where
     where
         S: serde::Serializer,
     {
-        (&**self).serialize(serializer)
+        (**self).serialize(serializer)
     }
 }

--- a/turbopack/crates/turbo-tasks/src/keyed_read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/keyed_read_ref.rs
@@ -1,0 +1,150 @@
+use std::fmt::{Debug, Display};
+
+use serde::Serialize;
+
+use crate::{
+    debug::{ValueDebugFormat, ValueDebugFormatString},
+    keyed::Keyed,
+    trace::{TraceRawVcs, TraceRawVcsContext},
+};
+
+pub struct MappedReadRef<A, T> {
+    value: *const T,
+    arc: triomphe::Arc<A>,
+}
+
+impl<A, T> MappedReadRef<A, T> {
+    /// # Safety
+    /// The caller must ensure that the `arc` keeps the value pointed to by `value` alive.
+    pub unsafe fn new(arc: triomphe::Arc<A>, value: *const T) -> Self {
+        Self { value, arc }
+    }
+}
+
+impl<A, T> MappedReadRef<A, T> {
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        std::ptr::eq(self.value, other.value)
+    }
+
+    pub fn ptr(&self) -> *const T {
+        self.value
+    }
+}
+
+impl<A, T> Clone for MappedReadRef<A, T> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value,
+            arc: self.arc.clone(),
+        }
+    }
+}
+
+impl<A, T> std::ops::Deref for MappedReadRef<A, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.value }
+    }
+}
+
+impl<A, T> Debug for MappedReadRef<A, T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        (&**self).fmt(f)
+    }
+}
+
+impl<A, T> Display for MappedReadRef<A, T>
+where
+    T: Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+
+impl<A, T> PartialEq for MappedReadRef<A, T>
+where
+    T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl<A, T> Eq for MappedReadRef<A, T> where T: Eq {}
+
+impl<A, T> PartialOrd for MappedReadRef<A, T>
+where
+    T: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        (**self).partial_cmp(&**other)
+    }
+}
+
+impl<A, T> Ord for MappedReadRef<A, T>
+where
+    T: Ord,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (**self).cmp(&**other)
+    }
+}
+
+impl<A, T> std::hash::Hash for MappedReadRef<A, T>
+where
+    T: std::hash::Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        (**self).hash(state);
+    }
+}
+
+impl<A, T> ValueDebugFormat for MappedReadRef<A, T>
+where
+    T: ValueDebugFormat,
+{
+    fn value_debug_format(&self, depth: usize) -> ValueDebugFormatString<'_> {
+        let value = &**self;
+        value.value_debug_format(depth)
+    }
+}
+
+impl<A, T> TraceRawVcs for MappedReadRef<A, T>
+where
+    T: TraceRawVcs,
+{
+    fn trace_raw_vcs(&self, trace_context: &mut TraceRawVcsContext) {
+        (**self).trace_raw_vcs(trace_context);
+    }
+}
+
+impl<'a, A, T, I, J: Iterator<Item = I>> IntoIterator for &'a MappedReadRef<A, T>
+where
+    T: Keyed,
+    for<'b> &'b T: IntoIterator<Item = I, IntoIter = J>,
+{
+    type Item = I;
+
+    type IntoIter = J;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&**self).into_iter()
+    }
+}
+
+impl<A, T> Serialize for MappedReadRef<A, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        (&**self).serialize(serializer)
+    }
+}

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -54,6 +54,8 @@ mod id_factory;
 mod invalidation;
 mod join_iter_ext;
 mod key_value_pair;
+pub mod keyed;
+pub mod keyed_read_ref;
 #[doc(hidden)]
 pub mod macro_helpers;
 mod magic_any;
@@ -109,11 +111,11 @@ pub use crate::{
     key_value_pair::KeyValuePair,
     magic_any::MagicAny,
     manager::{
-        CurrentCellRef, ReadConsistency, ReadTracking, TaskPersistence, TurboTasks, TurboTasksApi,
-        TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo, dynamic_call, emit,
-        get_serialization_invalidator, mark_finished, mark_root, mark_session_dependent,
-        prevent_gc, run, run_once, run_once_with_reason, trait_call, turbo_tasks,
-        turbo_tasks_scope, turbo_tasks_weak, with_turbo_tasks,
+        CurrentCellRef, ReadCellTracking, ReadConsistency, ReadTracking, TaskPersistence,
+        TurboTasks, TurboTasksApi, TurboTasksBackendApi, TurboTasksCallApi, Unused, UpdateInfo,
+        dynamic_call, emit, get_serialization_invalidator, mark_finished, mark_root,
+        mark_session_dependent, prevent_gc, run, run_once, run_once_with_reason, trait_call,
+        turbo_tasks, turbo_tasks_scope, turbo_tasks_weak, with_turbo_tasks,
     },
     output::OutputContent,
     raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError},
@@ -132,9 +134,9 @@ pub use crate::{
     value_type::{TraitMethod, TraitType, ValueType},
     vc::{
         Dynamic, NonLocalValue, OperationValue, OperationVc, OptionVcExt, ReadVcFuture, ResolvedVc,
-        Upcast, UpcastStrict, ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellNewMode,
-        VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast, VcValueType,
-        VcValueTypeCast,
+        Upcast, UpcastStrict, ValueDefault, Vc, VcCast, VcCellCompareMode, VcCellKeyedCompareMode,
+        VcCellNewMode, VcDefaultRead, VcRead, VcTransparentRead, VcValueTrait, VcValueTraitCast,
+        VcValueType, VcValueTypeCast,
     },
 };
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Display,
     future::Future,
-    hash::BuildHasherDefault,
+    hash::{BuildHasher, BuildHasherDefault},
     mem::take,
     pin::Pin,
     sync::{
@@ -14,8 +14,9 @@ use std::{
 use anyhow::{Result, anyhow};
 use auto_hash_map::AutoMap;
 use bincode::{Decode, Encode};
-use rustc_hash::FxHasher;
+use rustc_hash::{FxBuildHasher, FxHasher};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use tokio::{select, sync::mpsc::Receiver, task_local};
 use tokio_util::task::TaskTracker;
 use tracing::{Instrument, instrument};
@@ -32,6 +33,7 @@ use crate::{
     event::{Event, EventListener},
     id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TraitTypeId},
     id_factory::IdFactoryWithReuse,
+    keyed::Keyed,
     macro_helpers::NativeFunction,
     magic_any::MagicAny,
     message_queue::{CompilationEvent, CompilationEventQueue},
@@ -162,6 +164,7 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         index: CellId,
         is_serializable_cell_content: bool,
         content: CellContent,
+        updated_key_hashes: Option<SmallVec<[u64; 2]>>,
         verification_mode: VerificationMode,
     );
     fn mark_own_task_as_finished(&self, task: TaskId);
@@ -303,6 +306,60 @@ pub enum ReadConsistency {
     ///
     /// Top-level code that returns data to the user should use strongly consistent reads.
     Strong,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReadCellTracking {
+    /// Reads are tracked as dependencies of the current task.
+    Tracked {
+        /// The key used for the dependency
+        key: Option<u64>,
+    },
+    /// The read is only tracked when there is an error, otherwise it is untracked.
+    ///
+    /// INVALIDATION: Be careful with this, it will not track dependencies, so
+    /// using it could break cache invalidation.
+    TrackOnlyError,
+    /// The read is not tracked as a dependency of the current task.
+    ///
+    /// INVALIDATION: Be careful with this, it will not track dependencies, so
+    /// using it could break cache invalidation.
+    Untracked,
+}
+
+impl ReadCellTracking {
+    pub fn should_track(&self, is_err: bool) -> bool {
+        match self {
+            ReadCellTracking::Tracked { .. } => true,
+            ReadCellTracking::TrackOnlyError => is_err,
+            ReadCellTracking::Untracked => false,
+        }
+    }
+
+    pub fn key(&self) -> Option<u64> {
+        match self {
+            ReadCellTracking::Tracked { key } => *key,
+            ReadCellTracking::TrackOnlyError => None,
+            ReadCellTracking::Untracked => None,
+        }
+    }
+}
+
+impl Default for ReadCellTracking {
+    fn default() -> Self {
+        ReadCellTracking::Tracked { key: None }
+    }
+}
+
+impl Display for ReadCellTracking {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadCellTracking::Tracked { key: None } => write!(f, "tracked"),
+            ReadCellTracking::Tracked { key: Some(key) } => write!(f, "tracked with key {key}"),
+            ReadCellTracking::TrackOnlyError => write!(f, "track only error"),
+            ReadCellTracking::Untracked => write!(f, "untracked"),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Default)]
@@ -1343,6 +1400,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         index: CellId,
         is_serializable_cell_content: bool,
         content: CellContent,
+        updated_key_hashes: Option<SmallVec<[u64; 2]>>,
         verification_mode: VerificationMode,
     ) {
         self.backend.update_task_cell(
@@ -1350,6 +1408,7 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
             index,
             is_serializable_cell_content,
             content,
+            updated_key_hashes,
             verification_mode,
             self,
         );
@@ -1728,28 +1787,36 @@ pub struct CurrentCellRef {
 }
 
 type VcReadRepr<T> = <<T as VcValueType>::Read as VcRead<T>>::Repr;
+type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
 
 impl CurrentCellRef {
     /// Updates the cell if the given `functor` returns a value.
-    pub fn conditional_update<T>(&self, functor: impl FnOnce(Option<&T>) -> Option<T>)
-    where
+    fn conditional_update<T>(
+        &self,
+        functor: impl FnOnce(Option<&T>) -> Option<(T, Option<SmallVec<[u64; 2]>>)>,
+    ) where
         T: VcValueType,
     {
         self.conditional_update_with_shared_reference(|old_shared_reference| {
             let old_ref = old_shared_reference
                 .and_then(|sr| sr.0.downcast_ref::<VcReadRepr<T>>())
                 .map(|content| <T::Read as VcRead<T>>::repr_to_value_ref(content));
-            let new_value = functor(old_ref)?;
-            Some(SharedReference::new(triomphe::Arc::new(
-                <T::Read as VcRead<T>>::value_to_repr(new_value),
-            )))
+            let (new_value, updated_key_hashes) = functor(old_ref)?;
+            Some((
+                SharedReference::new(triomphe::Arc::new(<T::Read as VcRead<T>>::value_to_repr(
+                    new_value,
+                ))),
+                updated_key_hashes,
+            ))
         })
     }
 
     /// Updates the cell if the given `functor` returns a `SharedReference`.
-    pub fn conditional_update_with_shared_reference(
+    fn conditional_update_with_shared_reference(
         &self,
-        functor: impl FnOnce(Option<&SharedReference>) -> Option<SharedReference>,
+        functor: impl FnOnce(
+            Option<&SharedReference>,
+        ) -> Option<(SharedReference, Option<SmallVec<[u64; 2]>>)>,
     ) {
         let tt = turbo_tasks();
         let cell_content = tt
@@ -1758,19 +1825,20 @@ impl CurrentCellRef {
                 self.index,
                 ReadCellOptions {
                     // INVALIDATION: Reading our own cell must be untracked
-                    tracking: ReadTracking::Untracked,
+                    tracking: ReadCellTracking::Untracked,
                     is_serializable_cell_content: self.is_serializable_cell_content,
                     final_read_hint: false,
                 },
             )
             .ok();
         let update = functor(cell_content.as_ref().and_then(|cc| cc.1.0.as_ref()));
-        if let Some(update) = update {
+        if let Some((update, updated_key_hashes)) = update {
             tt.update_own_task_cell(
                 self.current_task,
                 self.index,
                 self.is_serializable_cell_content,
                 CellContent(Some(update)),
+                updated_key_hashes,
                 VerificationMode::EqualityCheck,
             )
         }
@@ -1819,7 +1887,7 @@ impl CurrentCellRef {
             {
                 return None;
             }
-            Some(new_value)
+            Some((new_value, None))
         });
     }
 
@@ -1835,21 +1903,72 @@ impl CurrentCellRef {
     where
         T: VcValueType + PartialEq,
     {
-        fn extract_sr_value<T: VcValueType>(sr: &SharedReference) -> &T {
-            <T::Read as VcRead<T>>::repr_to_value_ref(
-                sr.0.downcast_ref::<VcReadRepr<T>>()
-                    .expect("cannot update SharedReference of different type"),
-            )
-        }
         self.conditional_update_with_shared_reference(|old_sr| {
             if let Some(old_sr) = old_sr {
-                let old_value: &T = extract_sr_value(old_sr);
-                let new_value = extract_sr_value(&new_shared_reference);
+                let old_value = extract_sr_value::<T>(old_sr)?;
+                let new_value = extract_sr_value::<T>(&new_shared_reference)?;
                 if old_value == new_value {
                     return None;
                 }
             }
-            Some(new_shared_reference)
+            Some((new_shared_reference, None))
+        });
+    }
+
+    /// See [`Self::compare_and_update`], but selectively update individual keys.
+    pub fn keyed_compare_and_update<T>(&self, new_value: T)
+    where
+        T: PartialEq + VcValueType,
+        VcReadTarget<T>: Keyed,
+        <VcReadTarget<T> as Keyed>::Key: std::hash::Hash,
+    {
+        self.conditional_update(|old_value| {
+            let Some(old_value) = old_value else {
+                return Some((new_value, None));
+            };
+            let old_value = <T as VcValueType>::Read::value_to_target_ref(old_value);
+            let new_value_ref = <T as VcValueType>::Read::value_to_target_ref(&new_value);
+            let updated_keys = old_value.different_keys(new_value_ref);
+            if updated_keys.is_empty() {
+                return None;
+            }
+            // Duplicates are very unlikely, but ok since the backend is deduplicating them
+            let updated_key_hashes = updated_keys
+                .into_iter()
+                .map(|key| FxBuildHasher.hash_one(key))
+                .collect();
+            Some((new_value, Some(updated_key_hashes)))
+        });
+    }
+
+    /// See [`Self::compare_and_update_with_shared_reference`], but selectively update individual
+    /// keys.
+    pub fn keyed_compare_and_update_with_shared_reference<T>(
+        &self,
+        new_shared_reference: SharedReference,
+    ) where
+        T: VcValueType + PartialEq,
+        VcReadTarget<T>: Keyed,
+        <VcReadTarget<T> as Keyed>::Key: std::hash::Hash,
+    {
+        self.conditional_update_with_shared_reference(|old_sr| {
+            let Some(old_sr) = old_sr else {
+                return Some((new_shared_reference, None));
+            };
+            let old_value = extract_sr_value::<T>(old_sr)?;
+            let old_value = <T as VcValueType>::Read::value_to_target_ref(old_value);
+            let new_value = extract_sr_value::<T>(&new_shared_reference)?;
+            let new_value = <T as VcValueType>::Read::value_to_target_ref(&new_value);
+            let updated_keys = old_value.different_keys(new_value);
+            if updated_keys.is_empty() {
+                return None;
+            }
+            // Duplicates are very unlikely, but ok since the backend is deduplicating them
+            let updated_key_hashes = updated_keys
+                .into_iter()
+                .map(|key| FxBuildHasher.hash_one(key))
+                .collect();
+            Some((new_shared_reference, Some(updated_key_hashes)))
         });
     }
 
@@ -1866,6 +1985,7 @@ impl CurrentCellRef {
             CellContent(Some(SharedReference::new(triomphe::Arc::new(
                 <T::Read as VcRead<T>>::value_to_repr(new_value),
             )))),
+            None,
             verification_mode,
         )
     }
@@ -1891,7 +2011,7 @@ impl CurrentCellRef {
                     self.index,
                     ReadCellOptions {
                         // INVALIDATION: Reading our own cell must be untracked
-                        tracking: ReadTracking::Untracked,
+                        tracking: ReadCellTracking::Untracked,
                         is_serializable_cell_content: self.is_serializable_cell_content,
                         final_read_hint: false,
                     },
@@ -1912,6 +2032,7 @@ impl CurrentCellRef {
                 self.index,
                 self.is_serializable_cell_content,
                 CellContent(Some(shared_ref)),
+                None,
                 verification_mode,
             )
         }
@@ -1922,6 +2043,11 @@ impl From<CurrentCellRef> for RawVc {
     fn from(cell: CurrentCellRef) -> Self {
         RawVc::TaskCell(cell.current_task, cell.index)
     }
+}
+
+fn extract_sr_value<T: VcValueType>(sr: &SharedReference) -> Option<&T> {
+    sr.0.downcast_ref::<VcReadRepr<T>>()
+        .map(<T::Read as VcRead<T>>::repr_to_value_ref)
 }
 
 pub fn find_cell_by_type<T: VcValueType>() -> CurrentCellRef {

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1958,7 +1958,7 @@ impl CurrentCellRef {
             let old_value = extract_sr_value::<T>(old_sr)?;
             let old_value = <T as VcValueType>::Read::value_to_target_ref(old_value);
             let new_value = extract_sr_value::<T>(&new_shared_reference)?;
-            let new_value = <T as VcValueType>::Read::value_to_target_ref(&new_value);
+            let new_value = <T as VcValueType>::Read::value_to_target_ref(new_value);
             let updated_keys = old_value.different_keys(new_value);
             if updated_keys.is_empty() {
                 return None;

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -18,7 +18,8 @@ use crate::{
     event::EventListener,
     id::{ExecutionId, LocalTaskId},
     manager::{
-        ReadTracking, read_local_output, read_task_cell, read_task_output, with_turbo_tasks,
+        ReadCellTracking, ReadTracking, read_local_output, read_task_cell, read_task_output,
+        with_turbo_tasks,
     },
     registry::{self, get_value_type},
     turbo_tasks,
@@ -212,8 +213,7 @@ impl RawVc {
                         index,
                         ReadCellOptions {
                             is_serializable_cell_content: value_type.bincode.is_some(),
-                            final_read_hint: false,
-                            tracking: ReadTracking::default(),
+                            ..Default::default()
                         },
                     )
                     .await
@@ -236,8 +236,8 @@ impl RawVc {
     /// See [`crate::Vc::resolve`].
     pub(crate) async fn resolve(self) -> Result<RawVc> {
         self.resolve_inner(ReadOutputOptions {
-            tracking: ReadTracking::default(),
             consistency: ReadConsistency::Eventual,
+            ..Default::default()
         })
         .await
     }
@@ -245,8 +245,8 @@ impl RawVc {
     /// See [`crate::Vc::resolve_strongly_consistent`].
     pub(crate) async fn resolve_strongly_consistent(self) -> Result<RawVc> {
         self.resolve_inner(ReadOutputOptions {
-            tracking: ReadTracking::default(),
             consistency: ReadConsistency::Strong,
+            ..Default::default()
         })
         .await
     }
@@ -398,8 +398,16 @@ impl ReadRawVcFuture {
         }
     }
 
+    /// Make reads strongly consistent.
     pub fn strongly_consistent(mut self) -> Self {
         self.read_output_options.consistency = ReadConsistency::Strong;
+        self
+    }
+
+    /// Track the value as a dependency with an key.
+    pub fn track_with_key(mut self, key: u64) -> Self {
+        self.read_output_options.tracking = ReadTracking::Tracked;
+        self.read_cell_options.tracking = ReadCellTracking::Tracked { key: Some(key) };
         self
     }
 
@@ -410,7 +418,7 @@ impl ReadRawVcFuture {
     /// using it could break cache invalidation.
     pub fn untracked(mut self) -> Self {
         self.read_output_options.tracking = ReadTracking::TrackOnlyError;
-        self.read_cell_options.tracking = ReadTracking::TrackOnlyError;
+        self.read_cell_options.tracking = ReadCellTracking::TrackOnlyError;
         self
     }
 
@@ -421,10 +429,11 @@ impl ReadRawVcFuture {
     /// using it could break cache invalidation.
     pub fn untracked_including_errors(mut self) -> Self {
         self.read_output_options.tracking = ReadTracking::Untracked;
-        self.read_cell_options.tracking = ReadTracking::Untracked;
+        self.read_cell_options.tracking = ReadCellTracking::Untracked;
         self
     }
 
+    /// Hint that this is the final read of the cell content.
     pub fn final_read_hint(mut self) -> Self {
         self.read_cell_options.final_read_hint = true;
         self

--- a/turbopack/crates/turbo-tasks/src/read_options.rs
+++ b/turbopack/crates/turbo-tasks/src/read_options.rs
@@ -1,8 +1,8 @@
-use crate::{ReadConsistency, ReadTracking};
+use crate::{ReadConsistency, ReadTracking, manager::ReadCellTracking};
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct ReadCellOptions {
-    pub tracking: ReadTracking,
+    pub tracking: ReadCellTracking,
     pub is_serializable_cell_content: bool,
     pub final_read_hint: bool,
 }

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -32,7 +32,7 @@ type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
 /// certain point in time.
 ///
 /// Internally it stores a reference counted reference to a value on the heap.
-pub struct ReadRef<T>(triomphe::Arc<T>);
+pub struct ReadRef<T>(pub(crate) triomphe::Arc<T>);
 
 impl<T> Clone for ReadRef<T> {
     fn clone(&self) -> Self {
@@ -253,6 +253,11 @@ impl<T> ReadRef<T> {
     /// (the behavior of [`Deref`]).
     pub fn as_raw_ref(this: &ReadRef<T>) -> &T {
         &this.0
+    }
+
+    /// Returns the inner `Arc<T>`.
+    pub fn into_raw_arc(self) -> triomphe::Arc<T> {
+        self.0
     }
 
     pub fn ptr_eq(&self, other: &ReadRef<T>) -> bool {

--- a/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
@@ -2,7 +2,7 @@ use std::{any::type_name, marker::PhantomData};
 
 use super::{read::VcRead, traits::VcValueType};
 use crate::{
-    RawVc, Vc, backend::VerificationMode, manager::find_cell_by_type,
+    RawVc, Vc, backend::VerificationMode, keyed::Keyed, manager::find_cell_by_type,
     task::shared_reference::TypedSharedReference,
 };
 
@@ -81,6 +81,35 @@ where
         debug_assert_repr::<T>(&content);
         let cell = find_cell_by_type::<T>();
         cell.compare_and_update_with_shared_reference::<T>(content.reference);
+        cell.into()
+    }
+}
+
+/// Mode that compares the cell's content with the new value key by key and only updates
+/// individual keys if the new value is different.
+pub struct VcCellKeyedCompareMode<T> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T> VcCellMode<T> for VcCellKeyedCompareMode<T>
+where
+    T: VcValueType + PartialEq,
+    VcReadTarget<T>: Keyed,
+    <VcReadTarget<T> as Keyed>::Key: std::hash::Hash,
+{
+    fn cell(inner: VcReadTarget<T>) -> Vc<T> {
+        let cell = find_cell_by_type::<T>();
+        cell.keyed_compare_and_update(<T::Read as VcRead<T>>::target_to_value(inner));
+        Vc {
+            node: cell.into(),
+            _t: PhantomData,
+        }
+    }
+
+    fn raw_cell(content: TypedSharedReference) -> RawVc {
+        debug_assert_repr::<T>(&content);
+        let cell = find_cell_by_type::<T>();
+        cell.keyed_compare_and_update_with_shared_reference::<T>(content.reference);
         cell.into()
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -23,7 +23,7 @@ use shrink_to_fit::ShrinkToFit;
 
 pub use self::{
     cast::{VcCast, VcValueTraitCast, VcValueTypeCast},
-    cell_mode::{VcCellCompareMode, VcCellMode, VcCellNewMode},
+    cell_mode::{VcCellCompareMode, VcCellKeyedCompareMode, VcCellMode, VcCellNewMode},
     default::ValueDefault,
     local::NonLocalValue,
     operation::{OperationValue, OperationVc},
@@ -34,8 +34,10 @@ pub use self::{
 use crate::{
     CellId, RawVc, ResolveTypeError,
     debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
+    keyed::Keyed,
     registry,
     trace::{TraceRawVcs, TraceRawVcsContext},
+    vc::read::ReadKeyedVcFuture,
 };
 
 type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
@@ -667,6 +669,20 @@ where
     pub fn owned(self) -> ReadOwnedVcFuture<T> {
         let future: ReadVcFuture<T> = self.node.into_read(T::has_serialization()).into();
         future.owned()
+    }
+}
+
+impl<T> Vc<T>
+where
+    T: VcValueType,
+    VcReadTarget<T>: Keyed,
+    <VcReadTarget<T> as Keyed>::Key: Hash,
+{
+    /// Read the value and selects a keyed value from it. Only depends on the used key instead of
+    /// the full value.
+    pub fn get<'l>(self, key: &'l <VcReadTarget<T> as Keyed>::Key) -> ReadKeyedVcFuture<'l, T> {
+        let future: ReadVcFuture<T> = self.node.into_read(T::has_serialization()).into();
+        future.get(key)
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -37,7 +37,7 @@ use crate::{
     keyed::Keyed,
     registry,
     trace::{TraceRawVcs, TraceRawVcsContext},
-    vc::read::ReadKeyedVcFuture,
+    vc::read::{ReadContainsKeyedVcFuture, ReadKeyedVcFuture},
 };
 
 type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
@@ -683,6 +683,16 @@ where
     pub fn get<'l>(self, key: &'l <VcReadTarget<T> as Keyed>::Key) -> ReadKeyedVcFuture<'l, T> {
         let future: ReadVcFuture<T> = self.node.into_read(T::has_serialization()).into();
         future.get(key)
+    }
+
+    /// Read the value and checks if it contains the given key. Only depends on the used key instead
+    /// of the full value.
+    pub fn contains_key<'l>(
+        self,
+        key: &'l <VcReadTarget<T> as Keyed>::Key,
+    ) -> ReadContainsKeyedVcFuture<'l, T> {
+        let future: ReadVcFuture<T> = self.node.into_read(T::has_serialization()).into();
+        future.contains_key(key)
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -1,10 +1,22 @@
-use std::{any::Any, marker::PhantomData, mem::ManuallyDrop, pin::Pin, task::Poll};
+use std::{
+    any::Any,
+    hash::{BuildHasher, Hash},
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    pin::Pin,
+    task::Poll,
+};
 
 use anyhow::Result;
 use futures::Future;
+use pin_project_lite::pin_project;
+use rustc_hash::FxBuildHasher;
 
 use super::traits::VcValueType;
-use crate::{ReadRawVcFuture, ReadRef, VcCast, VcValueTrait, VcValueTraitCast, VcValueTypeCast};
+use crate::{
+    ReadRawVcFuture, ReadRef, VcCast, VcValueTrait, VcValueTraitCast, VcValueTypeCast,
+    keyed::Keyed, keyed_read_ref::MappedReadRef,
+};
 
 type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
 
@@ -204,16 +216,21 @@ where
     T: ?Sized,
     Cast: VcCast,
 {
+    /// Do not use this: Use [`OperationVc::read_strongly_consistent`] instead.
     pub fn strongly_consistent(mut self) -> Self {
         self.raw = self.raw.strongly_consistent();
         self
     }
 
+    /// Returns a untracked read of the value. This will not invalidate the current function when
+    /// the read value changed.
     pub fn untracked(mut self) -> Self {
         self.raw = self.raw.untracked();
         self
     }
 
+    /// Read the value with the hint that this is the final read of the value. This might drop the
+    /// cell content. Future reads might need to recompute the value.
     pub fn final_read_hint(mut self) -> Self {
         self.raw = self.raw.final_read_hint();
         self
@@ -225,8 +242,23 @@ where
     T: VcValueType,
     VcReadTarget<T>: Clone,
 {
+    /// Read the value and returns a owned version of it. It might clone the value.
     pub fn owned(self) -> ReadOwnedVcFuture<T> {
         ReadOwnedVcFuture { future: self }
+    }
+}
+
+impl<T> ReadVcFuture<T, VcValueTypeCast<T>>
+where
+    T: VcValueType,
+    VcReadTarget<T>: Keyed,
+    <VcReadTarget<T> as Keyed>::Key: Hash,
+{
+    /// Read the value and selects a keyed value from it. Only depends on the used key instead of
+    /// the full value.
+    pub fn get<'l>(mut self, key: &'l <VcReadTarget<T> as Keyed>::Key) -> ReadKeyedVcFuture<'l, T> {
+        self.raw = self.raw.track_with_key(FxBuildHasher.hash_one(key));
+        ReadKeyedVcFuture { future: self, key }
     }
 }
 
@@ -290,6 +322,44 @@ where
         let future = unsafe { self.map_unchecked_mut(|this| &mut this.future) };
         match future.poll(cx) {
             Poll::Ready(Ok(result)) => Poll::Ready(Ok(ReadRef::into_owned(result))),
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pin_project! {
+    pub struct ReadKeyedVcFuture<'l, T>
+    where
+        T: VcValueType,
+        VcReadTarget<T>: Keyed,
+    {
+        #[pin]
+        future: ReadVcFuture<T, VcValueTypeCast<T>>,
+        key: &'l <VcReadTarget<T> as Keyed>::Key,
+    }
+}
+
+impl<'l, T> Future for ReadKeyedVcFuture<'l, T>
+where
+    T: VcValueType,
+    VcReadTarget<T>: Keyed,
+{
+    type Output = Result<Option<MappedReadRef<T, <VcReadTarget<T> as Keyed>::Value>>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        // Safety: We never move the contents of `self`
+        let this = self.project();
+        match this.future.poll(cx) {
+            Poll::Ready(Ok(result)) => {
+                let mapped_read_ref = if let Some(value) = (&*result).get(this.key) {
+                    let ptr = value as *const _;
+                    Some(unsafe { MappedReadRef::new(result.into_raw_arc(), ptr) })
+                } else {
+                    None
+                };
+                Poll::Ready(Ok(mapped_read_ref))
+            }
             Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
             Poll::Pending => Poll::Pending,
         }

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -362,7 +362,7 @@ where
         let this = self.project();
         match this.future.poll(cx) {
             Poll::Ready(Ok(result)) => {
-                let mapped_read_ref = if let Some(value) = (&*result).get(this.key) {
+                let mapped_read_ref = if let Some(value) = (*result).get(this.key) {
                     let ptr = value as *const _;
                     Some(unsafe { MappedReadRef::new(result.into_raw_arc(), ptr) })
                 } else {
@@ -400,7 +400,7 @@ where
         let this = self.project();
         match this.future.poll(cx) {
             Poll::Ready(Ok(result)) => {
-                let result = (&*result).contains_key(this.key);
+                let result = (*result).contains_key(this.key);
                 Poll::Ready(Ok(result))
             }
             Poll::Ready(Err(err)) => Poll::Ready(Err(err)),

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -263,6 +263,9 @@ where
 
     /// Read the value and checks if it contains the given key. Only depends on the used key instead
     /// of the full value.
+    ///
+    /// Note: This is also invalidated when the value of the key changes, not only when the presence
+    /// of the key changes.
     pub fn contains_key<'l>(
         mut self,
         key: &'l <VcReadTarget<T> as Keyed>::Key,

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -260,6 +260,16 @@ where
         self.raw = self.raw.track_with_key(FxBuildHasher.hash_one(key));
         ReadKeyedVcFuture { future: self, key }
     }
+
+    /// Read the value and checks if it contains the given key. Only depends on the used key instead
+    /// of the full value.
+    pub fn contains_key<'l>(
+        mut self,
+        key: &'l <VcReadTarget<T> as Keyed>::Key,
+    ) -> ReadContainsKeyedVcFuture<'l, T> {
+        self.raw = self.raw.track_with_key(FxBuildHasher.hash_one(key));
+        ReadContainsKeyedVcFuture { future: self, key }
+    }
 }
 
 impl<T> From<ReadRawVcFuture> for ReadVcFuture<T, VcValueTypeCast<T>>
@@ -359,6 +369,39 @@ where
                     None
                 };
                 Poll::Ready(Ok(mapped_read_ref))
+            }
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+pin_project! {
+    pub struct ReadContainsKeyedVcFuture<'l, T>
+    where
+        T: VcValueType,
+        VcReadTarget<T>: Keyed,
+    {
+        #[pin]
+        future: ReadVcFuture<T, VcValueTypeCast<T>>,
+        key: &'l <VcReadTarget<T> as Keyed>::Key,
+    }
+}
+
+impl<'l, T> Future for ReadContainsKeyedVcFuture<'l, T>
+where
+    T: VcValueType,
+    VcReadTarget<T>: Keyed,
+{
+    type Output = Result<bool>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
+        // Safety: We never move the contents of `self`
+        let this = self.project();
+        match this.future.poll(cx) {
+            Poll::Ready(Ok(result)) => {
+                let result = (&*result).contains_key(this.key);
+                Poll::Ready(Ok(result))
             }
             Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
             Poll::Pending => Poll::Pending,


### PR DESCRIPTION
### What?

Previously cells could either be unchanged or changed. This falls short when updating Maps or Sets.
We can't have a dependency on a single key of a map or set.
The workaround for this was to create an "selector" turbo-tasks which picks the value and copies it into a new cell.
This allows more granular invalidation.

But it also creates a lot of extra tasks. And changing the map/set does invalidate all these selector tasks, which causes a lot of invalidation work.

This change adds support for dependencies on certain keys of cells.

On write side a turbo-tasks value need to opt-in into that behavior via `cell = "keyed"`.
This changes the `cell` method to compare the new value key-by-key and report the changed keys to the backend.

On read side the Vc need to be read via `.get(key).await?` or `.contains_key(key).await?`, which returns only the value resp. existance of the key and adds a dependency only to that key.

With this approach the "selector" tasks can be avoided, while maintaining the same level of invalidation.

### How?

On implementation side we only track the hash of the key for size reasons.
A dependency has an additional field `key: Option<u64>` which represents the key depending on.

When updating a cell we have a new optional argument `updated_key_hashes: Option<SmallVec<[u64; 2]>>` where the updates keys can be provided. The new `CellMode` (cell = "keyed") fills that.