### PR TITLE
Turbopack: replace is_reference_used with unused_references set

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -47,7 +47,7 @@ use turbopack_core::{
     PROJECT_FILESYSTEM_NAME,
     changed::content_changed,
     chunk::{
-        ChunkingContext, EvaluatableAssets,
+        ChunkingContext, EvaluatableAssets, UnusedReferences,
         module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
     },
     compile_time_info::CompileTimeInfo,
@@ -2067,17 +2067,15 @@ impl Project {
 
     /// Compute the unused references that were removed (inner graph tree shaking).
     #[turbo_tasks::function]
-    pub async fn unused_references(self: Vc<Self>) -> Result<Vc<OptionBindingUsageInfo>> {
+    pub async fn unused_references(self: Vc<Self>) -> Result<Vc<UnusedReferences>> {
         if *self
             .next_config()
             .turbopack_remove_unused_imports(self.next_mode())
             .await?
         {
-            Ok(Vc::cell(Some(
-                self.binding_usage_info().to_resolved().await?,
-            )))
+            Ok(self.binding_usage_info().unused_references())
         } else {
-            Ok(Vc::cell(None))
+            Ok(Vc::cell(Default::default()))
         }
     }
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -17,7 +17,7 @@ use turbopack_browser::{
 use turbopack_core::{
     chunk::{
         ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapSourceType,
-        SourceMapsType, module_id_strategies::ModuleIdStrategy,
+        SourceMapsType, UnusedReferences, module_id_strategies::ModuleIdStrategy,
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
@@ -423,7 +423,7 @@ pub struct ClientChunkingContextOptions {
     pub environment: Vc<Environment>,
     pub module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
     pub export_usage: Vc<OptionBindingUsageInfo>,
-    pub unused_references: Vc<OptionBindingUsageInfo>,
+    pub unused_references: Vc<UnusedReferences>,
     pub minify: Vc<bool>,
     pub source_maps: Vc<SourceMapsType>,
     pub no_mangling: Vc<bool>,
@@ -481,7 +481,7 @@ pub async fn get_client_chunking_context(
     .asset_base_path(Some(asset_prefix))
     .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
     .export_usage(*export_usage.await?)
-    .unused_references(*unused_references.await?)
+    .unused_references(unused_references.to_resolved().await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .debug_ids(*debug_ids.await?)
     .should_use_absolute_url_references(*should_use_absolute_url_references.await?)

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -6,7 +6,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
     chunk::{
-        ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapsType,
+        ChunkingConfig, ChunkingContext, MangleType, MinifyType, SourceMapsType, UnusedReferences,
         module_id_strategies::ModuleIdStrategy,
     },
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReference, FreeVarReferences},
@@ -205,7 +205,7 @@ pub struct EdgeChunkingContextOptions {
     pub environment: Vc<Environment>,
     pub module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
     pub export_usage: Vc<OptionBindingUsageInfo>,
-    pub unused_references: Vc<OptionBindingUsageInfo>,
+    pub unused_references: Vc<UnusedReferences>,
     pub turbo_minify: Vc<bool>,
     pub turbo_source_maps: Vc<SourceMapsType>,
     pub no_mangling: Vc<bool>,
@@ -261,7 +261,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
     .source_maps(*turbo_source_maps.await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .export_usage(*export_usage.await?)
-    .unused_references(*unused_references.await?)
+    .unused_references(unused_references.to_resolved().await?)
     .nested_async_availability(*nested_async_chunking.await?);
 
     if !next_mode.is_development() {
@@ -338,7 +338,7 @@ pub async fn get_edge_chunking_context(
     .source_maps(*turbo_source_maps.await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .export_usage(*export_usage.await?)
-    .unused_references(*unused_references.await?)
+    .unused_references(unused_references.to_resolved().await?)
     .nested_async_availability(*nested_async_chunking.await?);
 
     if !next_mode.is_development() {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -16,7 +16,7 @@ use turbopack::{
 use turbopack_core::{
     chunk::{
         ChunkingConfig, MangleType, MinifyType, SourceMapSourceType, SourceMapsType,
-        module_id_strategies::ModuleIdStrategy,
+        UnusedReferences, module_id_strategies::ModuleIdStrategy,
     },
     compile_time_defines,
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
@@ -995,7 +995,7 @@ pub struct ServerChunkingContextOptions {
     pub environment: Vc<Environment>,
     pub module_id_strategy: Vc<Box<dyn ModuleIdStrategy>>,
     pub export_usage: Vc<OptionBindingUsageInfo>,
-    pub unused_references: Vc<OptionBindingUsageInfo>,
+    pub unused_references: Vc<UnusedReferences>,
     pub minify: Vc<bool>,
     pub source_maps: Vc<SourceMapsType>,
     pub no_mangling: Vc<bool>,
@@ -1056,7 +1056,7 @@ pub async fn get_server_chunking_context_with_client_assets(
     .source_maps(*source_maps.await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .export_usage(*export_usage.await?)
-    .unused_references(*unused_references.await?)
+    .unused_references(unused_references.to_resolved().await?)
     .file_tracing(next_mode.is_production())
     .debug_ids(*debug_ids.await?)
     .nested_async_availability(*nested_async_chunking.await?);
@@ -1140,7 +1140,7 @@ pub async fn get_server_chunking_context(
     .source_maps(*source_maps.await?)
     .module_id_strategy(module_id_strategy.to_resolved().await?)
     .export_usage(*export_usage.await?)
-    .unused_references(*unused_references.await?)
+    .unused_references(unused_references.to_resolved().await?)
     .file_tracing(next_mode.is_production())
     .debug_ids(*debug_ids.await?)
     .nested_async_availability(*nested_async_chunking.await?);

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -14,6 +14,7 @@ use turbopack_core::{
         Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule, ChunkingConfig,
         ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAsset,
         EvaluatableAssets, MinifyType, ModuleId, SourceMapSourceType, SourceMapsType,
+        UnusedReferences,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
         module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
@@ -27,7 +28,6 @@ use turbopack_core::{
         chunk_group_info::ChunkGroup,
     },
     output::{OutputAsset, OutputAssets},
-    reference::ModuleReference,
 };
 use turbopack_ecmascript::{
     async_chunk::module::AsyncLoaderModule,
@@ -174,11 +174,8 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn unused_references(
-        mut self,
-        unused_references: Option<ResolvedVc<BindingUsageInfo>>,
-    ) -> Self {
-        self.chunking_context.unused_references = unused_references;
+    pub fn unused_references(mut self, unused_references: ResolvedVc<UnusedReferences>) -> Self {
+        self.chunking_context.unused_references = Some(unused_references);
         self
     }
 
@@ -305,7 +302,7 @@ pub struct BrowserChunkingContext {
     /// The module export usage info, if available.
     export_usage: Option<ResolvedVc<BindingUsageInfo>>,
     /// Which references are unused and should be skipped (e.g. during codegen).
-    unused_references: Option<ResolvedVc<BindingUsageInfo>>,
+    unused_references: Option<ResolvedVc<UnusedReferences>>,
     /// The chunking configs
     chunking_configs: Vec<(ResolvedVc<Box<dyn ChunkType>>, ChunkingConfig)>,
     /// Whether to use absolute URLs for static assets (e.g. in CSS: `url("/absolute/path")`)
@@ -886,16 +883,11 @@ impl ChunkingContext for BrowserChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn is_reference_unused(
-        &self,
-        reference: ResolvedVc<Box<dyn ModuleReference>>,
-    ) -> Result<Vc<bool>> {
+    fn unused_references(&self) -> Vc<UnusedReferences> {
         if let Some(unused_references) = self.unused_references {
-            Ok(Vc::cell(
-                unused_references.await?.is_reference_unused(&reference),
-            ))
+            *unused_references
         } else {
-            Ok(Vc::cell(false))
+            Vc::cell(Default::default())
         }
     }
 

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -317,6 +317,7 @@ async fn build_internal(
     let binding_usage = compute_binding_usage_info(module_graph.to_resolved().await?, true)
         .resolve_strongly_consistent()
         .await?;
+    let unused_references = binding_usage.unused_references().to_resolved().await?;
     module_graph = module_graph.without_unused_references(*binding_usage);
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match target {
@@ -344,7 +345,7 @@ async fn build_internal(
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
             .export_usage(Some(binding_usage))
-            .unused_references(Some(binding_usage))
+            .unused_references(unused_references)
             .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
             .minify_type(minify_type);
 
@@ -394,7 +395,7 @@ async fn build_internal(
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
             .export_usage(Some(binding_usage))
-            .unused_references(Some(binding_usage))
+            .unused_references(unused_references)
             .minify_type(minify_type);
 
             match *node_env.await? {

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Upcast, Vc, trace::TraceRawVcs};
@@ -262,6 +262,9 @@ pub enum SourceMapSourceType {
     TurbopackUri,
 }
 
+#[turbo_tasks::value(transparent, cell = "keyed")]
+pub struct UnusedReferences(FxHashSet<ResolvedVc<Box<dyn ModuleReference>>>);
+
 /// A context for the chunking that influences the way chunks are created
 #[turbo_tasks::value_trait]
 pub trait ChunkingContext {
@@ -447,10 +450,7 @@ pub trait ChunkingContext {
     ) -> Result<Vc<ModuleExportUsage>>;
 
     #[turbo_tasks::function]
-    async fn is_reference_unused(
-        self: Vc<Self>,
-        reference: Vc<Box<dyn ModuleReference>>,
-    ) -> Result<Vc<bool>>;
+    async fn unused_references(self: Vc<Self>) -> Result<Vc<UnusedReferences>>;
 
     /// Returns whether debug IDs are enabled for this chunking context.
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -29,7 +29,7 @@ pub use crate::chunk::{
     chunking_context::{
         ChunkGroupResult, ChunkGroupType, ChunkingConfig, ChunkingConfigs, ChunkingContext,
         ChunkingContextExt, EntryChunkGroupResult, MangleType, MinifyType, SourceMapSourceType,
-        SourceMapsType,
+        SourceMapsType, UnusedReferences,
     },
     data::{ChunkData, ChunkDataOption, ChunksData},
     evaluate::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},

--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -8,19 +8,19 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{
+    chunk::chunking_context::UnusedReferences,
     module::Module,
     module_graph::{
         GraphEdgeIndex, GraphTraversalAction, ModuleGraph,
         side_effect_module_info::compute_side_effect_free_module_info,
     },
-    reference::ModuleReference,
     resolve::{ExportUsage, ImportUsage},
 };
 
 #[turbo_tasks::value]
 #[derive(Clone, Default, Debug)]
 pub struct BindingUsageInfo {
-    unused_references: FxHashSet<ResolvedVc<Box<dyn ModuleReference>>>,
+    unused_references: ResolvedVc<UnusedReferences>,
     #[turbo_tasks(trace_ignore)]
     unused_references_edges: FxHashSet<GraphEdgeIndex>,
 
@@ -54,10 +54,6 @@ impl BindingUsageInfo {
         self.unused_references_edges.contains(edge)
     }
 
-    pub fn is_reference_unused(&self, reference: &ResolvedVc<Box<dyn ModuleReference>>) -> bool {
-        self.unused_references.contains(reference)
-    }
-
     pub async fn used_exports(
         &self,
         module: ResolvedVc<Box<dyn Module>>,
@@ -81,6 +77,14 @@ impl BindingUsageInfo {
             is_circuit_breaker,
         }
         .cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl BindingUsageInfo {
+    #[turbo_tasks::function]
+    pub fn unused_references(&self) -> Vc<UnusedReferences> {
+        *self.unused_references
     }
 }
 
@@ -284,7 +288,7 @@ pub async fn compute_binding_usage_info(
         }
 
         Ok(BindingUsageInfo {
-            unused_references,
+            unused_references: ResolvedVc::cell(unused_references),
             unused_references_edges,
             used_exports,
             export_circuit_breakers,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -528,14 +528,15 @@ impl ChunkableModuleReference for EsmAssetReference {
 
 impl EsmAssetReference {
     pub async fn code_generation(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
         scope_hoisting_context: ScopeHoistingContext<'_>,
     ) -> Result<CodeGeneration> {
         let this = &*self.await?;
 
-        if *chunking_context
-            .is_reference_unused(Vc::upcast(self))
+        if chunking_context
+            .unused_references()
+            .contains_key(&ResolvedVc::upcast(self))
             .await?
         {
             return Ok(CodeGeneration::empty());

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
     chunk::{
         Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule, ChunkingConfig,
         ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAssets, MinifyType,
-        ModuleId, SourceMapSourceType, SourceMapsType,
+        ModuleId, SourceMapSourceType, SourceMapsType, UnusedReferences,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
         module_id_strategies::{DevModuleIdStrategy, ModuleIdStrategy},
@@ -22,7 +22,6 @@ use turbopack_core::{
         chunk_group_info::ChunkGroup,
     },
     output::{OutputAsset, OutputAssets},
-    reference::ModuleReference,
 };
 use turbopack_ecmascript::{
     async_chunk::module::AsyncLoaderModule,
@@ -123,11 +122,8 @@ impl NodeJsChunkingContextBuilder {
         self
     }
 
-    pub fn unused_references(
-        mut self,
-        unused_references: Option<ResolvedVc<BindingUsageInfo>>,
-    ) -> Self {
-        self.chunking_context.unused_references = unused_references;
+    pub fn unused_references(mut self, unused_references: ResolvedVc<UnusedReferences>) -> Self {
+        self.chunking_context.unused_references = Some(unused_references);
         self
     }
 
@@ -202,7 +198,7 @@ pub struct NodeJsChunkingContext {
     /// The module export usage info, if available.
     export_usage: Option<ResolvedVc<BindingUsageInfo>>,
     /// Which references are unused and should be skipped (e.g. during codegen).
-    unused_references: Option<ResolvedVc<BindingUsageInfo>>,
+    unused_references: Option<ResolvedVc<UnusedReferences>>,
     /// The strategy to use for generating source map source uris
     source_map_source_type: SourceMapSourceType,
     /// The chunking configs
@@ -633,16 +629,11 @@ impl ChunkingContext for NodeJsChunkingContext {
     }
 
     #[turbo_tasks::function]
-    async fn is_reference_unused(
-        &self,
-        reference: ResolvedVc<Box<dyn ModuleReference>>,
-    ) -> Result<Vc<bool>> {
+    fn unused_references(&self) -> Vc<UnusedReferences> {
         if let Some(unused_references) = self.unused_references {
-            Ok(Vc::cell(
-                unused_references.await?.is_reference_unused(&reference),
-            ))
+            *unused_references
         } else {
-            Ok(Vc::cell(false))
+            Vc::cell(Default::default())
         }
     }
 

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -520,12 +520,18 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         options
             .remove_unused_exports
             .then(|| binding_usage.unwrap()),
-    )
-    .unused_references(
-        options
-            .remove_unused_imports
-            .then(|| binding_usage.unwrap()),
     );
+
+    if options.remove_unused_imports {
+        builder = builder.unused_references(
+            binding_usage
+                .unwrap()
+                .unused_references()
+                .to_resolved()
+                .await?,
+        );
+    }
+
     if options.production_chunking {
         builder = builder
             .chunking_config(

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -479,13 +479,18 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                     .remove_unused_exports
                     .then(|| binding_usage.unwrap()),
             )
-            .unused_references(
-                options
-                    .remove_unused_imports
-                    .then(|| binding_usage.unwrap()),
-            )
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type);
+
+            if options.remove_unused_imports {
+                builder = builder.unused_references(
+                    binding_usage
+                        .unwrap()
+                        .unused_references()
+                        .to_resolved()
+                        .await?,
+                );
+            }
 
             if options.production_chunking {
                 builder = builder
@@ -520,13 +525,18 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                     .remove_unused_exports
                     .then(|| binding_usage.unwrap()),
             )
-            .unused_references(
-                options
-                    .remove_unused_imports
-                    .then(|| binding_usage.unwrap()),
-            )
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type);
+
+            if options.remove_unused_imports {
+                builder = builder.unused_references(
+                    binding_usage
+                        .unwrap()
+                        .unused_references()
+                        .to_resolved()
+                        .await?,
+                );
+            }
 
             if options.production_chunking {
                 builder = builder


### PR DESCRIPTION
### What?

Replaces `is_reference_used` with `unused_references` and uses the new keyed invalidation. This avoid having a `is_reference_used` for each reference in the application