### PR TITLE
Turbopack: use correct flags in tests

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -521,7 +521,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
     )
     .unused_references(
         options
-            .remove_unused_exports
+            .remove_unused_imports
             .then(|| binding_usage.unwrap()),
     );
     if options.production_chunking {

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -480,7 +480,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             )
             .unused_references(
                 options
-                    .remove_unused_exports
+                    .remove_unused_imports
                     .then(|| binding_usage.unwrap()),
             )
             .debug_ids(options.enable_debug_ids)
@@ -521,7 +521,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             )
             .unused_references(
                 options
-                    .remove_unused_exports
+                    .remove_unused_imports
                     .then(|| binding_usage.unwrap()),
             )
             .debug_ids(options.enable_debug_ids)


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
