### PR TITLE
Fix typo in Linking and Navigating documentation

### DIFF
--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -156,7 +156,7 @@ Next.js avoids this with client-side transitions using the `<Link>` component. I
 - Keeping any shared layouts and UI.
 - Replacing the current page with the prefetched loading state or a new page if available.
 
-Client-side transitions are what makes a server-rendered apps _feel_ like client-rendered apps. And when paired with [prefetching](#prefetching) and [streaming](#streaming), it enables fast transitions, even for dynamic routes.
+Client-side transitions are what makes server-rendered apps _feel_ like client-rendered apps. And when paired with [prefetching](#prefetching) and [streaming](#streaming), it enables fast transitions, even for dynamic routes.
 
 ## What can make transitions slow?
 


### PR DESCRIPTION
### What?

Corrects a grammatical typo in the "Linking and Navigating" documentation.

### Why?

The original text used the singular article "a" before the plural noun "apps." Removing the article ensures the sentence is grammatically correct and improves the overall readability of the section.

### How?

Updated the phrase `a server-rendered apps` to `server-rendered apps`.
