### PR TITLE
Fix console.trace including unexpected lines

### DIFF
--- a/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
@@ -356,5 +356,73 @@ describe('console-exit patches', () => {
         { method: 'log', input: '[BRIGHT]: with null signal' },
       ])
     })
+
+    it('should output console.trace with a clean stack trace without internal wrapper frames', async () => {
+      async function testForWorker() {
+        let capturedOutput = ''
+
+        // Replace console.log to capture the trace output (console.trace uses console.log internally after our patch)
+        console.log = function (...args) {
+          capturedOutput = args.join(' ')
+          reportResult({
+            type: 'console-call',
+            method: 'log',
+            input: capturedOutput,
+          })
+        }
+
+        // Install patches - this wraps console.trace
+        require('next/dist/server/node-environment-extensions/console-dim.external')
+
+        // Call console.trace - this should output a clean stack trace
+        console.trace('Test message')
+
+        // Report whether the stack trace contains internal wrapper frames
+        const hasInternalFrames = capturedOutput.includes(
+          '/node-environment-extensions/'
+        )
+        reportResult({
+          type: 'serialized',
+          key: 'hasInternalFrames',
+          data: JSON.stringify(hasInternalFrames),
+        })
+
+        // Report whether the stack trace contains the expected "Trace:" prefix
+        const hasTracePrefix = capturedOutput.startsWith('Trace:')
+        reportResult({
+          type: 'serialized',
+          key: 'hasTracePrefix',
+          data: JSON.stringify(hasTracePrefix),
+        })
+
+        // Report whether the stack trace contains the test message
+        const hasTestMessage = capturedOutput.includes('Test message')
+        reportResult({
+          type: 'serialized',
+          key: 'hasTestMessage',
+          data: JSON.stringify(hasTestMessage),
+        })
+
+        // Report whether the stack trace contains "at" lines (actual stack frames)
+        const hasStackFrames = capturedOutput.includes('    at ')
+        reportResult({
+          type: 'serialized',
+          key: 'hasStackFrames',
+          data: JSON.stringify(hasStackFrames),
+        })
+      }
+
+      const { data, exitCode } = await runWorkerCode(testForWorker)
+
+      expect(exitCode).toBe(0)
+      // The stack trace should NOT contain internal wrapper frames
+      expect(data.hasInternalFrames).toBe(false)
+      // The output should have the "Trace:" prefix
+      expect(data.hasTracePrefix).toBe(true)
+      // The output should contain the test message
+      expect(data.hasTestMessage).toBe(true)
+      // The output should contain actual stack frames
+      expect(data.hasStackFrames).toBe(true)
+    })
   })
 })

--- a/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.test.ts
@@ -361,12 +361,12 @@ describe('console-exit patches', () => {
       async function testForWorker() {
         let capturedOutput = ''
 
-        // Replace console.log to capture the trace output (console.trace uses console.log internally after our patch)
-        console.log = function (...args) {
+        // Replace console.error to capture the trace output (console.trace uses console.error internally after our patch)
+        console.error = function (...args) {
           capturedOutput = args.join(' ')
           reportResult({
             type: 'console-call',
-            method: 'log',
+            method: 'error',
             input: capturedOutput,
           })
         }

--- a/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
@@ -204,7 +204,7 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
       const consoleStore = consoleAsyncStorage.getStore()
 
       // Special handling for console.trace: capture the stack trace early
-      // before the wrapper chain pollutes it, then use console.log to output
+      // before the wrapper chain pollutes it, then use console.error to output
       let traceStack: string | undefined
       if (methodName === 'trace') {
         traceStack = getCleanStackTrace()
@@ -329,10 +329,9 @@ function applyMethod<F extends (this: Console, ...args: any[]) => any>(
   traceStack?: string
 ): ReturnType<F> {
   if (methodName === 'trace' && traceStack !== undefined) {
-    // For console.trace, output the label + clean stack using console.log
-    // This goes through the wrapper chain for proper file logging
+    // For console.trace, output the label + clean stack using console.error (stderr)
     const label = args.length > 0 ? `Trace: ${args.join(' ')}` : 'Trace'
-    return console.log(`${label}\n${traceStack}`) as ReturnType<F>
+    return console.error(`${label}\n${traceStack}`) as ReturnType<F>
   }
   return method.apply(this, args)
 }
@@ -349,13 +348,13 @@ function applyWithDimming<F extends (this: Console, ...args: any[]) => any>(
   if (methodName === 'trace' && traceStack !== undefined) {
     const label = args.length > 0 ? `Trace: ${args.join(' ')}` : 'Trace'
     const traceOutput = `${label}\n${traceStack}`
-    // Use console.log with the dimmed trace output
-    const dimmedArgs = convertToDimmedArgs('log', [traceOutput])
+    // Use console.error with the dimmed trace output (outputs to stderr like native trace)
+    const dimmedArgs = convertToDimmedArgs('error', [traceOutput])
     if (consoleStore?.dim === true) {
-      return console.log(...dimmedArgs) as ReturnType<F>
+      return console.error(...dimmedArgs) as ReturnType<F>
     } else {
       return consoleAsyncStorage.run(DIMMED_STORE, () =>
-        console.log(...dimmedArgs)
+        console.error(...dimmedArgs)
       ) as ReturnType<F>
     }
   }

--- a/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
@@ -168,6 +168,28 @@ function convertToDimmedArgs(
   }
 }
 
+/**
+ * For console.trace, we need special handling because it captures the stack trace
+ * at the point where it's called. When wrapped by multiple patching functions,
+ * the stack trace includes all the wrapper frames which pollutes the output.
+ *
+ * This function captures a clean stack trace, filters out internal Next.js frames,
+ * and formats it like console.trace would.
+ */
+function getCleanStackTrace(): string {
+  const err = new Error()
+  const stack = err.stack || ''
+  const lines = stack.split('\n')
+
+  // Filter out internal wrapper frames from node-environment-extensions
+  const filteredLines = lines.filter((line) => {
+    return !line.includes('/node-environment-extensions/')
+  })
+
+  // Remove the "Error" header line and join
+  return filteredLines.slice(1).join('\n')
+}
+
 // Based on https://github.com/facebook/react/blob/28dc0776be2e1370fe217549d32aee2519f0cf05/packages/react-server/src/ReactFlightServer.js#L248
 function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
   const descriptor = Object.getOwnPropertyDescriptor(console, methodName)
@@ -180,6 +202,13 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
     const originalName = Object.getOwnPropertyDescriptor(originalMethod, 'name')
     const wrapperMethod = function (this: typeof console, ...args: any[]) {
       const consoleStore = consoleAsyncStorage.getStore()
+
+      // Special handling for console.trace: capture the stack trace early
+      // before the wrapper chain pollutes it, then use console.log to output
+      let traceStack: string | undefined
+      if (methodName === 'trace') {
+        traceStack = getCleanStackTrace()
+      }
 
       // First we see if there is a cache signal for our current scope. If we're in a client render it'll
       // come from the client React cacheSignal implementation. If we are in a server render it'll come from
@@ -200,7 +229,8 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
             consoleStore,
             originalMethod,
             methodName,
-            args
+            args,
+            traceStack
           )
         } else if (consoleStore?.dim === true) {
           return applyWithDimming.call(
@@ -208,10 +238,17 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
             consoleStore,
             originalMethod,
             methodName,
-            args
+            args,
+            traceStack
           )
         } else {
-          return originalMethod.apply(this, args)
+          return applyMethod.call(
+            this,
+            originalMethod,
+            methodName,
+            args,
+            traceStack
+          )
         }
       }
 
@@ -239,7 +276,8 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
               consoleStore,
               originalMethod,
               methodName,
-              args
+              args,
+              traceStack
             )
           }
         // intentional fallthrough
@@ -255,10 +293,17 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
               consoleStore,
               originalMethod,
               methodName,
-              args
+              args,
+              traceStack
             )
           } else {
-            return originalMethod.apply(this, args)
+            return applyMethod.call(
+              this,
+              originalMethod,
+              methodName,
+              args,
+              traceStack
+            )
           }
         default:
           workUnitStore satisfies never
@@ -273,13 +318,48 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
   }
 }
 
+/**
+ * Helper to apply the console method, with special handling for console.trace
+ */
+function applyMethod<F extends (this: Console, ...args: any[]) => any>(
+  this: Console,
+  method: F,
+  methodName: InterceptableConsoleMethod,
+  args: Parameters<F>,
+  traceStack?: string
+): ReturnType<F> {
+  if (methodName === 'trace' && traceStack !== undefined) {
+    // For console.trace, output the label + clean stack using console.log
+    // This goes through the wrapper chain for proper file logging
+    const label = args.length > 0 ? `Trace: ${args.join(' ')}` : 'Trace'
+    return console.log(`${label}\n${traceStack}`) as ReturnType<F>
+  }
+  return method.apply(this, args)
+}
+
 function applyWithDimming<F extends (this: Console, ...args: any[]) => any>(
   this: Console,
   consoleStore: undefined | ConsoleStore,
   method: F,
   methodName: InterceptableConsoleMethod,
-  args: Parameters<F>
+  args: Parameters<F>,
+  traceStack?: string
 ): ReturnType<F> {
+  // Special handling for console.trace with clean stack
+  if (methodName === 'trace' && traceStack !== undefined) {
+    const label = args.length > 0 ? `Trace: ${args.join(' ')}` : 'Trace'
+    const traceOutput = `${label}\n${traceStack}`
+    // Use console.log with the dimmed trace output
+    const dimmedArgs = convertToDimmedArgs('log', [traceOutput])
+    if (consoleStore?.dim === true) {
+      return console.log(...dimmedArgs) as ReturnType<F>
+    } else {
+      return consoleAsyncStorage.run(DIMMED_STORE, () =>
+        console.log(...dimmedArgs)
+      ) as ReturnType<F>
+    }
+  }
+
   if (consoleStore?.dim === true) {
     return method.apply(this, convertToDimmedArgs(methodName, args))
   } else {


### PR DESCRIPTION
### What?

Fixed `console.trace` to output a clean stack trace that shows the actual call site and parent frames, instead of polluting the output with internal Next.js console patching frames.

### Why?

Before this fix, calling `console.trace('Test')` in a Next.js project would output:

```
Trace: Test
    at console.trace (/node-environment-extensions/console-file.js:21:44)
    at /node-environment-extensions/console-exit.js:22:95
    at AsyncLocalStorage.exit (node:async_hooks:354:14)
    at console.trace (/node-environment-extensions/console-exit.js:22:71)
    at console.trace (/node-environment-extensions/console-dim.external.js:208:47)
    at Object.<anonymous> (/path/to/next.config.js:1:9)  <-- actual call site buried
```

The internal wrapper frames from `console-file`, `console-exit`, and `console-dim.external` were polluting the stack trace, making it difficult to debug.

### How?

In `console-dim.external.tsx` (the outermost wrapper):

1. Added `getCleanStackTrace()` function that captures the stack trace early and filters out any frames containing `/node-environment-extensions/`
2. Modified the console patching to capture the clean stack for `console.trace` before entering the wrapper chain
3. Output the formatted trace via `console.log` (which still goes through the wrapper chain for proper file logging) instead of delegating to the original `console.trace`

After this fix:

```
Trace: Test
    at Object.<anonymous> (/path/to/next.config.js:1:9)
    at Module._compile (node:internal/modules/cjs/loader:1529:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1613:10)
    ...
```

### Test Plan

Added unit test `should output console.trace with a clean stack trace without internal wrapper frames` to `console-dim.external.test.ts` that verifies:
- Stack trace does NOT contain `/node-environment-extensions/` frames
- Output has the correct "Trace:" prefix
- Output contains the provided message
- Output contains actual stack frames