### PR TITLE
Turbopack: prefetch children too

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -1003,6 +1003,7 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         let map = iter_many!(self, OutputDependency { target } => (target, TaskDataCategory::Meta))
             .chain(iter_many!(self, CellDependency { target } => (target.task, TaskDataCategory::All)))
             .chain(iter_many!(self, CollectiblesDependency { target } => (target.task, TaskDataCategory::All)))
+            .chain(iter_many!(self, Child { task } => (task, TaskDataCategory::All)))
             .collect::<FxIndexMap<_, _>>();
         (map.len() > 1).then_some(map)
     }


### PR DESCRIPTION
### What?

children need to be prefetched too, since connect_child accesses the child to check for scheduling