### PR TITLE
docs: fix Pages Router fonts documentation showing App Router examples

### DIFF
--- a/docs/01-app/01-getting-started/13-fonts.mdx
+++ b/docs/01-app/01-getting-started/13-fonts.mdx
@@ -12,6 +12,8 @@ The [`next/font`](/docs/app/api-reference/components/font) module automatically 
 
 It includes **built-in self-hosting** for any font file. This means you can optimally load web fonts with no layout shift.
 
+<AppOnly>
+
 To start using `next/font`, import it from [`next/font/local`](#local-fonts) or [`next/font/google`](#google-fonts), call it as a function with the appropriate options, and set the `className` of the element you want to apply the font to. For example:
 
 ```tsx filename="app/layout.tsx" highlight={1,3-5,9} switcher
@@ -48,11 +50,98 @@ export default function Layout({ children }) {
 
 Fonts are scoped to the component they're used in. To apply a font to your entire application, add it to the [Root Layout](/docs/app/api-reference/file-conventions/layout#root-layout).
 
+</AppOnly>
+
+<PagesOnly>
+
+To start using `next/font`, import it from [`next/font/local`](#local-fonts) or [`next/font/google`](#google-fonts), call it as a function with the appropriate options, and set the `className` of the element you want to apply the font to. For example, you can apply fonts globally in your [Custom App](/docs/pages/building-your-application/routing/custom-app) (`pages/_app`):
+
+```tsx filename="pages/_app.tsx" highlight={1,3-5,10} switcher
+import { Geist } from 'next/font/google'
+import type { AppProps } from 'next/app'
+
+const geist = Geist({
+  subsets: ['latin'],
+})
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <main className={geist.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+```jsx filename="pages/_app.js" highlight={1,3-5,9} switcher
+import { Geist } from 'next/font/google'
+
+const geist = Geist({
+  subsets: ['latin'],
+})
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <main className={geist.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+If you want to apply the font to the `<html>` element, you can use a [Custom Document](/docs/pages/building-your-application/routing/custom-document) (`pages/_document`):
+
+```tsx filename="pages/_document.tsx" highlight={2,9,14} switcher
+import { Html, Head, Main, NextScript } from 'next/document'
+import { Geist } from 'next/font/google'
+
+const geist = Geist({
+  subsets: ['latin'],
+})
+
+export default function Document() {
+  return (
+    <Html lang="en" className={geist.className}>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}
+```
+
+```jsx filename="pages/_document.js" highlight={2,9,14} switcher
+import { Html, Head, Main, NextScript } from 'next/document'
+import { Geist } from 'next/font/google'
+
+const geist = Geist({
+  subsets: ['latin'],
+})
+
+export default function Document() {
+  return (
+    <Html lang="en" className={geist.className}>
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}
+```
+
+</PagesOnly>
+
 ## Google fonts
 
 You can automatically self-host any Google Font. Fonts are included stored as static assets and served from the same domain as your deployment, meaning no requests are sent to Google by the browser when the user visits your site.
 
 To start using a Google Font, import your chosen font from `next/font/google`:
+
+<AppOnly>
 
 ```tsx filename="app/layout.tsx" switcher
 import { Geist } from 'next/font/google'
@@ -90,7 +179,48 @@ export default function RootLayout({ children }) {
 }
 ```
 
+</AppOnly>
+
+<PagesOnly>
+
+```tsx filename="pages/_app.tsx" switcher
+import { Geist } from 'next/font/google'
+import type { AppProps } from 'next/app'
+
+const geist = Geist({
+  subsets: ['latin'],
+})
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <main className={geist.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+```jsx filename="pages/_app.js" switcher
+import { Geist } from 'next/font/google'
+
+const geist = Geist({
+  subsets: ['latin'],
+})
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <main className={geist.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+</PagesOnly>
+
 We recommend using [variable fonts](https://fonts.google.com/variablefonts) for the best performance and flexibility. But if you can't use a variable font, you will need to specify a weight:
+
+<AppOnly>
 
 ```tsx filename="app/layout.tsx" highlight={4} switcher
 import { Roboto } from 'next/font/google'
@@ -130,7 +260,50 @@ export default function RootLayout({ children }) {
 }
 ```
 
+</AppOnly>
+
+<PagesOnly>
+
+```tsx filename="pages/_app.tsx" highlight={5} switcher
+import { Roboto } from 'next/font/google'
+import type { AppProps } from 'next/app'
+
+const roboto = Roboto({
+  weight: '400',
+  subsets: ['latin'],
+})
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <main className={roboto.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+```jsx filename="pages/_app.js" highlight={4} switcher
+import { Roboto } from 'next/font/google'
+
+const roboto = Roboto({
+  weight: '400',
+  subsets: ['latin'],
+})
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <main className={roboto.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+</PagesOnly>
+
 ## Local fonts
+
+<AppOnly>
 
 To use a local font, import your font from `next/font/local` and specify the [`src`](/docs/app/api-reference/components/font#src) of your local font file. Fonts can be stored in the [`public`](/docs/app/api-reference/file-conventions/public-folder) folder or co-located inside the `app` folder. For example:
 
@@ -169,6 +342,47 @@ export default function RootLayout({ children }) {
   )
 }
 ```
+
+</AppOnly>
+
+<PagesOnly>
+
+To use a local font, import your font from `next/font/local` and specify the [`src`](/docs/pages/api-reference/components/font#src) of your local font file. Fonts can be stored in the [`public`](/docs/pages/api-reference/file-conventions/public-folder) folder or inside the `pages` folder. For example:
+
+```tsx filename="pages/_app.tsx" switcher
+import localFont from 'next/font/local'
+import type { AppProps } from 'next/app'
+
+const myFont = localFont({
+  src: './my-font.woff2',
+})
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <main className={myFont.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+```jsx filename="pages/_app.js" switcher
+import localFont from 'next/font/local'
+
+const myFont = localFont({
+  src: './my-font.woff2',
+})
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <main className={myFont.className}>
+      <Component {...pageProps} />
+    </main>
+  )
+}
+```
+
+</PagesOnly>
 
 If you want to use multiple files for a single font family, `src` can be an array:
 

--- a/docs/01-app/01-getting-started/13-fonts.mdx
+++ b/docs/01-app/01-getting-started/13-fonts.mdx
@@ -56,7 +56,7 @@ Fonts are scoped to the component they're used in. To apply a font to your entir
 
 To start using `next/font`, import it from [`next/font/local`](#local-fonts) or [`next/font/google`](#google-fonts), call it as a function with the appropriate options, and set the `className` of the element you want to apply the font to. For example, you can apply fonts globally in your [Custom App](/docs/pages/building-your-application/routing/custom-app) (`pages/_app`):
 
-```tsx filename="pages/_app.tsx" highlight={1,3-5,10} switcher
+```tsx filename="pages/_app.tsx" highlight={1,4-6,10} switcher
 import { Geist } from 'next/font/google'
 import type { AppProps } from 'next/app'
 
@@ -91,7 +91,7 @@ export default function MyApp({ Component, pageProps }) {
 
 If you want to apply the font to the `<html>` element, you can use a [Custom Document](/docs/pages/building-your-application/routing/custom-document) (`pages/_document`):
 
-```tsx filename="pages/_document.tsx" highlight={2,9,14} switcher
+```tsx filename="pages/_document.tsx" highlight={2,4-6,10} switcher
 import { Html, Head, Main, NextScript } from 'next/document'
 import { Geist } from 'next/font/google'
 
@@ -112,7 +112,7 @@ export default function Document() {
 }
 ```
 
-```jsx filename="pages/_document.js" highlight={2,9,14} switcher
+```jsx filename="pages/_document.js" highlight={2,4-6,10} switcher
 import { Html, Head, Main, NextScript } from 'next/document'
 import { Geist } from 'next/font/google'
 


### PR DESCRIPTION
## Summary

Fixes #88291

The Pages Router fonts documentation was incorrectly showing App Router examples (`app/layout.tsx`) which don't exist in Pages Router. This confused users trying to use fonts with the Pages Router.

## Changes

Updated `docs/01-app/01-getting-started/13-fonts.mdx` to include proper `<AppOnly>` and `<PagesOnly>` sections:

**For Pages Router users:**
- Added examples using `pages/_app.tsx` (Custom App) to wrap components with font className
- Added examples using `pages/_document.tsx` (Custom Document) to apply fonts to the `<html>` element

**For App Router users:**
- Wrapped existing `app/layout.tsx` examples in `<AppOnly>` sections

This follows the same pattern used in other shared documentation like `docs/01-app/01-getting-started/11-css.mdx` which properly separates App Router and Pages Router content.