### PR TITLE
fix: skip stats-aggregate job for docs-only changes

### DIFF
--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -95,9 +95,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 25
+
+      - name: Check non-docs only change
+        run: echo "DOCS_CHANGE<<EOF" >> $GITHUB_OUTPUT; echo "$(node scripts/run-for-change.mjs --not --type docs --exec echo 'nope')" >> $GITHUB_OUTPUT; echo 'EOF' >> $GITHUB_OUTPUT
+        id: docs-change
 
       - name: Download all stats artifacts
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         uses: actions/download-artifact@v4
         with:
           pattern: pr-stats-*
@@ -105,15 +110,18 @@ jobs:
           merge-multiple: true
 
       - name: Setup Node.js
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_LTS_VERSION }}
 
       - name: Install dependencies
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         working-directory: .github/actions/next-stats-action
         run: npm install
 
       - name: Aggregate and post results
+        if: ${{ steps.docs-change.outputs.DOCS_CHANGE == 'nope' }}
         working-directory: .github/actions/next-stats-action
         run: node src/aggregate-results.js ${{ github.workspace }}/stats-results
         env:


### PR DESCRIPTION
## What?

Adds the docs-only change check to the `stats-aggregate` job.

## Why?

The `stats` job already skips work for docs-only changes using `scripts/run-for-change.mjs`, but the `stats-aggregate` job was missing this check. This caused unnecessary job runs when PRs only contain documentation changes.

## How?

- Added the "Check non-docs only change" step (same pattern as the `stats` job)
- Added conditional `if` checks to all subsequent steps
- Changed `fetch-depth` from 1 to 25 (required for the change detection script to check commit history)