### PR TITLE
fix(turbo-tasks-backend): use correct TaskDataCategory for is_immutable check

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2129,11 +2129,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(task);
 
         // Check if the task can be marked as immutable
+        // Note: We use TaskDataCategory::Meta because the Immutable flag is stored in Meta category
         let mut is_now_immutable = false;
         if let Some(dependencies) = task_dependencies_for_immutable
             && dependencies
                 .iter()
-                .all(|&task_id| ctx.task(task_id, TaskDataCategory::Data).is_immutable())
+                .all(|&task_id| ctx.task(task_id, TaskDataCategory::Meta).is_immutable())
         {
             is_now_immutable = true;
         }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -2129,7 +2129,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         drop(task);
 
         // Check if the task can be marked as immutable
-        // Note: We use TaskDataCategory::Meta because the Immutable flag is stored in Meta category
         let mut is_now_immutable = false;
         if let Some(dependencies) = task_dependencies_for_immutable
             && dependencies

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -662,7 +662,9 @@ pub trait TaskGuard: Debug {
     /// Only returns Some once per task.
     /// It returns a set of tasks and which info is needed.
     fn prefetch(&mut self) -> Option<FxIndexMap<TaskId, TaskDataCategory>>;
-    fn is_immutable(&self) -> bool;
+    fn is_immutable(&self) -> bool {
+        self.has_key(&CachedDataItemKey::Immutable {})
+    }
     fn is_dirty(&self) -> bool {
         get!(self, Dirty).is_some_and(|dirtyness| match dirtyness {
             Dirtyness::Dirty => true,
@@ -1006,10 +1008,6 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
             .chain(iter_many!(self, Child { task } => (task, TaskDataCategory::All)))
             .collect::<FxIndexMap<_, _>>();
         (map.len() > 1).then_some(map)
-    }
-
-    fn is_immutable(&self) -> bool {
-        self.task.contains_key(&CachedDataItemKey::Immutable {})
     }
 }
 


### PR DESCRIPTION
## Fix task immutability check by using correct TaskDataCategory

### What?
This PR fixes a bug in the task immutability check by ensuring we use `TaskDataCategory::Meta` instead of `TaskDataCategory::Data` when checking if dependent tasks are immutable.

### Why?
The immutable flag is stored in the Meta category, but we were incorrectly checking the Data category. This could prevent us from reading the immutable flag if Meta hadn't been restored for the task.

### How?
- Changed the category from `TaskDataCategory::Data` to `TaskDataCategory::Meta` when reading tasks where we needed `immutability`
- Added a clarifying comment explaining why we use the Meta category
- Moved the `is_immutable()` implementation from `TaskGuardImpl` to the `TaskGuard` trait with a default implementation that uses `has_key(&CachedDataItemKey::Immutable {})` which enforces correct access modes
