### PR TITLE
docs: add rebuild guidance and ICE troubleshooting to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -307,7 +307,7 @@ See [Codebase structure](#codebase-structure) above for detailed explanations.
 When running Next.js integration tests, you must rebuild if source files have changed:
 
 - **Edited Next.js code?** → `pnpm build`
-- **Edited Turbopack (Rust)?** → `pnpm build-native`
+- **Edited Turbopack (Rust)?** → `pnpm swc-build-native`
 - **Edited both?** → `pnpm turbo build build-native`
 
 ## Development Anti-Patterns

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,20 @@ The main Next.js framework lives in `packages/next/`. This is what gets publishe
 
 ## Git Workflow
 
-**Use Graphite for all git operations** instead of raw git commands:
+**CRITICAL: Use Graphite (`gt`) instead of git for ALL branch and commit operations.**
+
+NEVER use these git commands directly:
+
+- `git push` → use `gt submit --no-edit`
+- `git branch` → use `gt create`
+
+**Graphite commands:**
 
 - `gt create <branch-name> -m "message"` - Create a new branch with commit
 - `gt modify -a --no-edit` - Stage all and amend current branch's commit
-- `gt checkout <branch>` - Switch branches (use instead of `git checkout`)
+- `gt checkout <branch>` - Switch branches
 - `gt sync` - Sync and restack all branches
-- `gt submit --no-edit` - Push and create/update PRs (use `--no-edit` to avoid interactive prompts)
+- `gt submit --no-edit` - Push and create/update PRs
 - `gt log short` - View stack status
 
 **Note**: `gt submit` runs in interactive mode by default and won't push in automated contexts. Always use `gt submit --no-edit` or `gt submit -q` when running from Claude.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -295,6 +295,14 @@ See [Codebase structure](#codebase-structure) above for detailed explanations.
 - Keep commit messages concise and descriptive
 - PR descriptions should focus on what changed and why
 
+## Rebuilding Before Running Tests
+
+When running Next.js integration tests, you must rebuild if source files have changed:
+
+- **Edited Next.js code?** → `pnpm build`
+- **Edited Turbopack (Rust)?** → `pnpm build-native`
+- **Edited both?** → `pnpm turbo build build-native`
+
 ## Development Anti-Patterns
 
 ### Test Gotchas
@@ -305,6 +313,7 @@ See [Codebase structure](#codebase-structure) above for detailed explanations.
 ### Rust/Cargo
 
 - cargo fmt uses ASCII order (uppercase before lowercase) - just run `cargo fmt`
+- **Internal compiler error (ICE)?** Delete incremental compilation artifacts and retry. Remove `*/incremental` directories from your cargo target directory (default `target/`, or check `CARGO_TARGET_DIR` env var)
 
 ### Node.js Source Maps
 


### PR DESCRIPTION
Update AGENTS.md with better instructions abotu rebuilding and handling rustc crashes

Also make the graphite instructions more emphatic
