### PR TITLE
fix(app-router): handle back/forward navigation after native anchor link clicks

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -356,6 +356,33 @@ function Router({
     }
 
     /**
+     * Handle hashchange event to mark native anchor link navigation with Next.js state.
+     * When a user clicks an anchor link (e.g., <a href="#section">), the browser creates
+     * a history entry with null state. We dispatch a restore action to update the router
+     * state, which will then trigger HistoryUpdater to save the correct tree to history.
+     * This ensures that pressing back/forward after clicking anchor links works correctly.
+     */
+    const onHashChange = () => {
+      // Only dispatch if the history state doesn't already have __NA.
+      // If __NA is present, this hashchange was triggered by a popstate (back/forward)
+      // which already dispatched a restore action - we don't want to dispatch twice.
+      if (window.history.state?.__NA) {
+        return
+      }
+
+      // Dispatch a restore action to update the router's canonical URL.
+      // This will trigger HistoryUpdater to save the tree to the history state,
+      // marking this entry with __NA so future back/forward navigation works.
+      startTransition(() => {
+        dispatchAppRouterAction({
+          type: ACTION_RESTORE,
+          url: new URL(window.location.href),
+          historyState: window.history.state?.__PRIVATE_NEXTJS_INTERNALS_TREE,
+        })
+      })
+    }
+
+    /**
      * Handle popstate event, this is used to handle back/forward in the browser.
      * By default dispatches ACTION_RESTORE, however if the history entry was not pushed/replaced by app-router it will reload the page.
      * That case can happen when the old router injected the history entry.
@@ -382,12 +409,14 @@ function Router({
       })
     }
 
-    // Register popstate event to call onPopstate.
+    // Register event listeners
     window.addEventListener('popstate', onPopState)
+    window.addEventListener('hashchange', onHashChange)
     return () => {
       window.history.pushState = originalPushState
       window.history.replaceState = originalReplaceState
       window.removeEventListener('popstate', onPopState)
+      window.removeEventListener('hashchange', onHashChange)
     }
   }, [])
 

--- a/test/e2e/app-dir/navigation/app/native-anchor-link-navigation/other/page.js
+++ b/test/e2e/app-dir/navigation/app/native-anchor-link-navigation/other/page.js
@@ -1,0 +1,18 @@
+import Link from 'next/link'
+
+export default function OtherPage() {
+  return (
+    <div style={{ fontFamily: 'sans-serif', fontSize: '16px' }}>
+      <p id="other-page-title">Other Page</p>
+      <Link href="/native-anchor-link-navigation" id="link-back">
+        Back to anchor test
+      </Link>
+      <Link
+        href="/native-anchor-link-navigation#section-2"
+        id="link-back-with-hash"
+      >
+        Back to anchor test with hash
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/app/native-anchor-link-navigation/page.js
+++ b/test/e2e/app-dir/navigation/app/native-anchor-link-navigation/page.js
@@ -1,0 +1,89 @@
+import Link from 'next/link'
+
+export default function NativeAnchorLinkPage() {
+  return (
+    <div style={{ fontFamily: 'sans-serif', fontSize: '16px' }}>
+      <p id="page-title">Native Anchor Link Navigation Test</p>
+
+      {/* Navigation using native anchor tags (not Next.js Link) */}
+      <nav
+        style={{
+          position: 'fixed',
+          top: 0,
+          left: 0,
+          background: 'white',
+          padding: '10px',
+          zIndex: 100,
+        }}
+      >
+        <a
+          href="#section-1"
+          id="link-to-section-1"
+          style={{ marginRight: '10px' }}
+        >
+          Section 1
+        </a>
+        <a
+          href="#section-2"
+          id="link-to-section-2"
+          style={{ marginRight: '10px' }}
+        >
+          Section 2
+        </a>
+        <a
+          href="#section-3"
+          id="link-to-section-3"
+          style={{ marginRight: '10px' }}
+        >
+          Section 3
+        </a>
+        <Link href="/native-anchor-link-navigation/other" id="link-to-other">
+          Other Page
+        </Link>
+      </nav>
+
+      <div style={{ marginTop: '60px' }}>
+        {/* Spacer to make scrolling observable */}
+        <div style={{ height: '500px', background: '#f0f0f0' }}>
+          Scroll spacer
+        </div>
+
+        <section
+          id="section-1"
+          style={{ height: '500px', background: '#e0f0e0', padding: '20px' }}
+        >
+          <h2>Section 1</h2>
+          <p id="section-1-content">This is section 1 content</p>
+        </section>
+
+        <div style={{ height: '500px', background: '#f0f0f0' }}>
+          Scroll spacer
+        </div>
+
+        <section
+          id="section-2"
+          style={{ height: '500px', background: '#e0e0f0', padding: '20px' }}
+        >
+          <h2>Section 2</h2>
+          <p id="section-2-content">This is section 2 content</p>
+        </section>
+
+        <div style={{ height: '500px', background: '#f0f0f0' }}>
+          Scroll spacer
+        </div>
+
+        <section
+          id="section-3"
+          style={{ height: '500px', background: '#f0e0e0', padding: '20px' }}
+        >
+          <h2>Section 3</h2>
+          <p id="section-3-content">This is section 3 content</p>
+        </section>
+
+        <div style={{ height: '500px', background: '#f0f0f0' }}>
+          Bottom spacer
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation/navigation.test.ts
+++ b/test/e2e/app-dir/navigation/navigation.test.ts
@@ -278,6 +278,63 @@ describe('app dir - navigation', () => {
     })
   })
 
+  describe('native-anchor-link-navigation', () => {
+    it('should handle back/forward navigation after clicking native anchor links', async () => {
+      const browser = await next.browser('/native-anchor-link-navigation')
+
+      // Click on section 1
+      await browser.elementByCss('#link-to-section-1').click()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-1'))
+
+      // Click on section 2
+      await browser.elementByCss('#link-to-section-2').click()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-2'))
+
+      // Click on section 3
+      await browser.elementByCss('#link-to-section-3').click()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-3'))
+
+      // Press back button - should go to section 2
+      await browser.back()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-2'))
+
+      // Press back button - should go to section 1
+      await browser.back()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-1'))
+
+      // Press forward button - should go to section 2
+      await browser.forward()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-2'))
+
+      // Press forward button - should go to section 3
+      await browser.forward()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-3'))
+    })
+
+    it('should handle back navigation from another page to a page with hash', async () => {
+      const browser = await next.browser('/native-anchor-link-navigation')
+
+      // Click on section 2 anchor link
+      await browser.elementByCss('#link-to-section-2').click()
+      await retry(() => expect(browser.url()).resolves.toContain('#section-2'))
+
+      // Navigate to other page using Next.js Link
+      await browser.elementByCss('#link-to-other').click()
+      await browser.waitForElementByCss('#other-page-title')
+
+      // Press back button - should go back to page with #section-2
+      await browser.back()
+      await retry(async () => {
+        const url = await browser.url()
+        expect(url).toContain('/native-anchor-link-navigation')
+        expect(url).toContain('#section-2')
+      })
+
+      // Verify we're on the correct page
+      await browser.waitForElementByCss('#page-title')
+    })
+  })
+
   describe('relative hashes and queries', () => {
     const pathname = '/nested-relative-query-and-hash'
 


### PR DESCRIPTION
### What
Fixes browser back/forward navigation failing after clicking native anchor links (`<a href="#section">`).

### Problem
When a user clicks a native HTML anchor link (not Next.js `<Link>`), the browser creates a history entry with `null` state. The existing `popstate` handler checks for `__NA` in history state to determine if it's a Next.js-managed entry - entries without `__NA` are ignored or trigger a page reload. This breaks back/forward navigation after clicking anchor links.

### Solution
Added a `hashchange` event listener that:
1. Detects when a native anchor link is clicked (history state lacks `__NA`)
2. Dispatches a `RESTORE` action to update the router's canonical URL
3. This triggers `HistoryUpdater` to save `__NA` and `__PRIVATE_NEXTJS_INTERNALS_TREE` to the history entry
4. Future back/forward navigation works correctly because `popstate` now recognizes these entries

The listener also checks if `__NA` is already present to avoid double-dispatching when `hashchange` fires after `popstate` (which happens during back/forward to hash URLs).

### Test
Added e2e tests for:
- Back/forward navigation between multiple hash anchors on the same page
- Back navigation from another page to a page with hash fragment

Fixes #88345