### PR TITLE
Log browser error and warnings in terminal

### DIFF
--- a/packages/next/src/next-devtools/userspace/app/errors/intercept-console-error.ts
+++ b/packages/next/src/next-devtools/userspace/app/errors/intercept-console-error.ts
@@ -14,8 +14,11 @@ export function patchConsoleError() {
   }
   window.console.error = function error(...args: any[]) {
     let maybeError: unknown
+    let isReplayedLog = false
     if (process.env.NODE_ENV !== 'production') {
-      const { error: replayedError } = parseConsoleArgs(args)
+      const { error: replayedError, environmentName } = parseConsoleArgs(args)
+      // If environmentName is set, this is a server log replayed by React in the browser
+      isReplayedLog = !!environmentName
       if (replayedError) {
         maybeError = replayedError
       } else if (isError(args[0])) {
@@ -37,7 +40,10 @@ export function patchConsoleError() {
           args
         )
       }
-      forwardErrorLog(args)
+      // Don't forward replayed server logs to terminal - they were already logged on the server
+      if (!isReplayedLog) {
+        forwardErrorLog(args)
+      }
 
       originConsoleError.apply(window.console, args)
     }

--- a/packages/next/src/next-devtools/userspace/app/forward-logs.ts
+++ b/packages/next/src/next-devtools/userspace/app/forward-logs.ts
@@ -369,6 +369,11 @@ const createLogEntry = (level: LogMethod, args: any[]) => {
 }
 
 export const forwardErrorLog = (args: any[]) => {
+  // Skip React server replayed logs - they were already logged on the server
+  if (isReactServerReplayedLog(args)) {
+    return
+  }
+
   // Always log to client file logger with args (formatting done inside log method)
   clientFileLogger.log('error', args)
   // Only forward to terminal if enabled

--- a/packages/next/src/next-devtools/userspace/app/forward-logs.ts
+++ b/packages/next/src/next-devtools/userspace/app/forward-logs.ts
@@ -1,7 +1,3 @@
-import {
-  getOwnerStack,
-  setOwnerStackIfAvailable,
-} from './errors/stitched-error'
 import { getErrorSource } from '../../../shared/lib/error-source'
 import { getIsTerminalLoggingEnabled } from './terminal-logging-config'
 import {
@@ -328,7 +324,7 @@ const stringifyUserArg = (
 }
 
 const createErrorArg = (error: Error) => {
-  const stack = stackWithOwners(error)
+  const stack = getErrorStack(error)
   return {
     kind: 'formatted-error-arg' as const,
     prefix: error.message ? `${error.name}: ${error.message}` : `${error.name}`,
@@ -347,7 +343,7 @@ const createLogEntry = (level: LogMethod, args: any[]) => {
 
   // do not abstract this, it implicitly relies on which functions call it. forcing the inlined implementation makes you think about callers
   // error capture stack trace maybe
-  const stack = stackWithOwners(new Error())
+  const stack = getErrorStack(new Error())
   const stackLines = stack?.split('\n')
   const cleanStack = stackLines?.slice(3).join('\n') // this is probably ignored anyways
   const entry: ConsoleEntry<unknown> = {
@@ -394,7 +390,7 @@ export const forwardErrorLog = (args: any[]) => {
    *
    * do not abstract this, it implicitly relies on which functions call it. forcing the inlined implementation makes you think about callers
    */
-  const stack = stackWithOwners(new Error())
+  const stack = getErrorStack(new Error())
   const stackLines = stack?.split('\n')
   const cleanStack = stackLines?.slice(3).join('\n')
 
@@ -431,12 +427,8 @@ const createUncaughtErrorEntry = (
   logQueue.scheduleLogSend(entry)
 }
 
-const stackWithOwners = (error: Error) => {
-  let ownerStack = ''
-  setOwnerStackIfAvailable(error)
-  ownerStack = getOwnerStack(error) || ''
-  const stack = (error.stack || '') + ownerStack
-  return stack
+const getErrorStack = (error: Error) => {
+  return error.stack || ''
 }
 
 export function logUnhandledRejection(reason: unknown) {
@@ -453,7 +445,7 @@ export function logUnhandledRejection(reason: unknown) {
   }
 
   if (reason instanceof Error) {
-    createUnhandledRejectionErrorEntry(reason, stackWithOwners(reason))
+    createUnhandledRejectionErrorEntry(reason, getErrorStack(reason))
     return
   }
   createUnhandledRejectionNonErrorEntry(reason)
@@ -548,7 +540,7 @@ export function forwardUnhandledError(error: Error) {
     return
   }
 
-  createUncaughtErrorEntry(error.name, error.message, stackWithOwners(error))
+  createUncaughtErrorEntry(error.name, error.message, getErrorStack(error))
 }
 
 // TODO: this router check is brittle, we need to update based on the current router the user is using

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -340,9 +340,9 @@ export const experimentalSchema = {
   browserDebugInfoInTerminal: z
     .union([
       z.boolean(),
-      z.enum(['error', 'warn', 'info', 'log', 'verbose']),
+      z.enum(['error', 'warn', 'verbose']),
       z.object({
-        level: z.enum(['error', 'warn', 'info', 'log', 'verbose']).optional(),
+        level: z.enum(['error', 'warn', 'verbose']).optional(),
         depthLimit: z.number().int().positive().optional(),
         edgeLimit: z.number().int().positive().optional(),
         showSourceLocation: z.boolean().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -340,7 +340,9 @@ export const experimentalSchema = {
   browserDebugInfoInTerminal: z
     .union([
       z.boolean(),
+      z.enum(['error', 'warn', 'info', 'log', 'verbose']),
       z.object({
+        level: z.enum(['error', 'warn', 'info', 'log', 'verbose']).optional(),
         depthLimit: z.number().int().positive().optional(),
         edgeLimit: z.number().int().positive().optional(),
         showSourceLocation: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -761,9 +761,7 @@ export interface ExperimentalConfig {
    *
    * - `'warn'` (default): Forward warnings and errors to terminal
    * - `'error'`: Forward only errors to terminal
-   * - `'info'`: Forward info, warnings, and errors to terminal
-   * - `'log'`: Forward log, info, warnings, and errors to terminal
-   * - `'verbose'`: Forward all browser console output including debug to terminal
+   * - `'verbose'`: Forward all browser console output to terminal
    * - `true`: Same as 'verbose' - forward all browser console output to terminal
    * - `false`: Disable browser log forwarding to terminal
    * - Object: Enable with custom configuration
@@ -772,15 +770,13 @@ export interface ExperimentalConfig {
     | boolean
     | 'error'
     | 'warn'
-    | 'info'
-    | 'log'
     | 'verbose'
     | {
         /**
          * Minimum log level to show in terminal.
-         * @default 'warn'
+         * @default 'verbose' (for object config, to preserve backward compatibility)
          */
-        level?: 'error' | 'warn' | 'info' | 'log' | 'verbose'
+        level?: 'error' | 'warn' | 'verbose'
 
         /**
          * Option to limit stringification at a specific nesting depth when logging circular objects.

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -757,11 +757,31 @@ export interface ExperimentalConfig {
   globalNotFound?: boolean
 
   /**
-   * Enable debug information to be forwarded from browser to dev server stdout/stderr
+   * Enable debug information to be forwarded from browser to dev server stdout/stderr.
+   *
+   * - `'warn'` (default): Forward warnings and errors to terminal
+   * - `'error'`: Forward only errors to terminal
+   * - `'info'`: Forward info, warnings, and errors to terminal
+   * - `'log'`: Forward log, info, warnings, and errors to terminal
+   * - `'verbose'`: Forward all browser console output including debug to terminal
+   * - `true`: Same as 'verbose' - forward all browser console output to terminal
+   * - `false`: Disable browser log forwarding to terminal
+   * - Object: Enable with custom configuration
    */
   browserDebugInfoInTerminal?:
     | boolean
+    | 'error'
+    | 'warn'
+    | 'info'
+    | 'log'
+    | 'verbose'
     | {
+        /**
+         * Minimum log level to show in terminal.
+         * @default 'warn'
+         */
+        level?: 'error' | 'warn' | 'info' | 'log' | 'verbose'
+
         /**
          * Option to limit stringification at a specific nesting depth when logging circular objects.
          * @default 5
@@ -1570,7 +1590,7 @@ export const defaultConfig = Object.freeze({
     useCache: undefined,
     slowModuleDetection: undefined,
     globalNotFound: false,
-    browserDebugInfoInTerminal: false,
+    browserDebugInfoInTerminal: 'warn',
     lockDistDir: true,
     isolatedDevBuild: true,
     proxyClientMaxBodySize: 10_485_760, // 10MB

--- a/packages/next/src/server/dev/browser-logs/receive-logs.ts
+++ b/packages/next/src/server/dev/browser-logs/receive-logs.ts
@@ -445,44 +445,47 @@ async function handleDefaultConsole(
   }
 }
 
-type LogLevel = 'error' | 'warn' | 'info' | 'log' | 'verbose'
+type LogLevel = 'error' | 'warn' | 'verbose'
 
 type BrowserLogConfig =
   | boolean
   | LogLevel
-  | { level?: LogLevel; logDepth?: number; showSourceLocation?: boolean }
+  | { level?: LogLevel; showSourceLocation?: boolean }
 
 // Log levels from most severe to least severe
 // Lower index = more severe
 const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
   error: 0,
   warn: 1,
-  info: 2,
-  log: 3,
-  verbose: 4,
+  verbose: 2,
 }
 
 // Map console methods to log levels
 const METHOD_TO_LEVEL: Record<string, LogLevel> = {
   error: 'error',
   warn: 'warn',
-  info: 'info',
-  log: 'log',
+  info: 'verbose',
+  log: 'verbose',
   debug: 'verbose',
-  table: 'log',
-  trace: 'log',
-  dir: 'log',
-  dirxml: 'log',
+  table: 'verbose',
+  trace: 'verbose',
+  dir: 'verbose',
+  dirxml: 'verbose',
   assert: 'error',
-  group: 'log',
-  groupCollapsed: 'log',
-  groupEnd: 'log',
+  group: 'verbose',
+  groupCollapsed: 'verbose',
+  groupEnd: 'verbose',
 }
 
 function shouldShowEntry(
   entry: ServerLogEntry,
   config: BrowserLogConfig
 ): boolean {
+  // If config is false, don't show any entries
+  if (config === false) {
+    return false
+  }
+
   // Determine the effective minimum log level
   const minLevel: LogLevel =
     typeof config === 'string'
@@ -491,7 +494,7 @@ function shouldShowEntry(
         ? 'verbose' // true means show everything
         : typeof config === 'object'
           ? (config.level ?? 'verbose') // object config defaults to verbose for backward compatibility
-          : 'warn' // this case shouldn't happen, but default to warn
+          : 'warn' // default for new installations
 
   const minPriority = LOG_LEVEL_PRIORITY[minLevel]
 

--- a/packages/next/src/server/dev/browser-logs/receive-logs.ts
+++ b/packages/next/src/server/dev/browser-logs/receive-logs.ts
@@ -416,7 +416,7 @@ async function handleDefaultConsole(
   browserPrefix: string,
   ctx: MappingContext,
   distDir: string,
-  config: boolean | { logDepth?: number; showSourceLocation?: boolean },
+  config: BrowserLogConfig,
   isServerLog: boolean
 ) {
   const consoleArgs = await prepareConsoleArgs(entry, ctx, distDir)
@@ -445,11 +445,74 @@ async function handleDefaultConsole(
   }
 }
 
+type LogLevel = 'error' | 'warn' | 'info' | 'log' | 'verbose'
+
+type BrowserLogConfig =
+  | boolean
+  | LogLevel
+  | { level?: LogLevel; logDepth?: number; showSourceLocation?: boolean }
+
+// Log levels from most severe to least severe
+// Lower index = more severe
+const LOG_LEVEL_PRIORITY: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  log: 3,
+  verbose: 4,
+}
+
+// Map console methods to log levels
+const METHOD_TO_LEVEL: Record<string, LogLevel> = {
+  error: 'error',
+  warn: 'warn',
+  info: 'info',
+  log: 'log',
+  debug: 'verbose',
+  table: 'log',
+  trace: 'log',
+  dir: 'log',
+  dirxml: 'log',
+  assert: 'error',
+  group: 'log',
+  groupCollapsed: 'log',
+  groupEnd: 'log',
+}
+
+function shouldShowEntry(
+  entry: ServerLogEntry,
+  config: BrowserLogConfig
+): boolean {
+  // Determine the effective minimum log level
+  const minLevel: LogLevel =
+    typeof config === 'string'
+      ? config
+      : config === true
+        ? 'verbose' // true means show everything
+        : typeof config === 'object'
+          ? (config.level ?? 'verbose') // object config defaults to verbose for backward compatibility
+          : 'warn' // this case shouldn't happen, but default to warn
+
+  const minPriority = LOG_LEVEL_PRIORITY[minLevel]
+
+  // formatted-error and any-logged-error are always treated as errors
+  if (entry.kind === 'formatted-error' || entry.kind === 'any-logged-error') {
+    return LOG_LEVEL_PRIORITY['error'] <= minPriority
+  }
+
+  if (entry.kind === 'console') {
+    const entryLevel = METHOD_TO_LEVEL[entry.method] || 'log'
+    return LOG_LEVEL_PRIORITY[entryLevel] <= minPriority
+  }
+
+  return false
+}
+
 export async function handleLog(
   entries: ServerLogEntry[],
   ctx: MappingContext,
   distDir: string,
-  config: boolean | { logDepth?: number; showSourceLocation?: boolean }
+  config: BrowserLogConfig
 ): Promise<void> {
   // Determine the source based on the context
   const isServerLog = ctx.isServer || ctx.isEdgeServer
@@ -457,6 +520,10 @@ export async function handleLog(
   const fileLogger = getFileLogger()
 
   for (const entry of entries) {
+    // Filter entries based on config mode
+    if (!shouldShowEntry(entry, config)) {
+      continue
+    }
     try {
       switch (entry.kind) {
         case 'console': {
@@ -596,7 +663,7 @@ export async function receiveBrowserLogsWebpack(opts: {
   edgeServerStats: () => any
   rootDirectory: string
   distDir: string
-  config: boolean | { logDepth?: number; showSourceLocation?: boolean }
+  config: BrowserLogConfig
 }): Promise<void> {
   const {
     entries,
@@ -634,7 +701,7 @@ export async function receiveBrowserLogsTurbopack(opts: {
   project: Project
   projectPath: string
   distDir: string
-  config: boolean | { logDepth?: number; showSourceLocation?: boolean }
+  config: BrowserLogConfig
 }): Promise<void> {
   const { entries, router, sourceType, project, projectPath, distDir } = opts
 

--- a/packages/next/src/server/dev/browser-logs/source-map.ts
+++ b/packages/next/src/server/dev/browser-logs/source-map.ts
@@ -261,7 +261,12 @@ export const withLocation = async (
   },
   ctx: MappingContext,
   distDir: string,
-  config: boolean | string | { logDepth?: number; showSourceLocation?: boolean }
+  config:
+    | boolean
+    | 'error'
+    | 'warn'
+    | 'verbose'
+    | { level?: 'error' | 'warn' | 'verbose'; showSourceLocation?: boolean }
 ) => {
   if (typeof config === 'object' && config.showSourceLocation === false) {
     return original

--- a/packages/next/src/server/dev/browser-logs/source-map.ts
+++ b/packages/next/src/server/dev/browser-logs/source-map.ts
@@ -261,7 +261,7 @@ export const withLocation = async (
   },
   ctx: MappingContext,
   distDir: string,
-  config: boolean | { logDepth?: number; showSourceLocation?: boolean }
+  config: boolean | string | { logDepth?: number; showSourceLocation?: boolean }
 ) => {
   if (typeof config === 'object' && config.showSourceLocation === false) {
     return original

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -347,7 +347,6 @@ describe('ReactRefreshLogBox', () => {
              |                                                   ^",
            "stack": [
              "FunctionDefault FunctionDefault.js (1:51)",
-             "App index.js (24:23)",
            ],
          }
         `)
@@ -645,7 +644,6 @@ describe('ReactRefreshLogBox', () => {
              |           ^",
            "stack": [
              "ClickCount.render Child.js (4:11)",
-             "Home index.js (6:13)",
            ],
          }
         `)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -637,7 +637,7 @@ describe('ReactRefreshLogBox', () => {
            ],
          }
         `)
-      } else {
+      } else if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
            "description": "",
@@ -649,6 +649,21 @@ describe('ReactRefreshLogBox', () => {
            "stack": [
              "ClickCount.render Child.js (4:11)",
              "Home index.js (6:13)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "Child.js (4:11) @ ClickCount.render
+         > 4 |     throw new Error()
+             |           ^",
+           "stack": [
+             "ClickCount.render Child.js (4:11)",
+             "Home index.js (6:7)",
            ],
          }
         `)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -68,6 +68,8 @@ describe('ReactRefreshLogBox', () => {
             |                           ^",
          "stack": [
            "onClick index.js (8:27)",
+           "a <anonymous>",
+           "Page index.js (7:19)",
          ],
        }
       `)
@@ -377,6 +379,7 @@ describe('ReactRefreshLogBox', () => {
              |                                                   ^",
            "stack": [
              "FunctionDefault FunctionDefault.js (1:51)",
+             "App index.js (24:7)",
            ],
          }
         `)
@@ -644,6 +647,7 @@ describe('ReactRefreshLogBox', () => {
              |           ^",
            "stack": [
              "ClickCount.render Child.js (4:11)",
+             "Home index.js (6:7)",
            ],
          }
         `)
@@ -853,6 +857,8 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
+           "button <anonymous>",
+           "Index index.js (9:7)",
          ],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -68,8 +68,6 @@ describe('ReactRefreshLogBox', () => {
             |                           ^",
          "stack": [
            "onClick index.js (8:27)",
-           "a <anonymous>",
-           "Page index.js (7:19)",
          ],
        }
       `)
@@ -380,7 +378,6 @@ describe('ReactRefreshLogBox', () => {
              |                                                   ^",
            "stack": [
              "FunctionDefault FunctionDefault.js (1:51)",
-             "App index.js (24:7)",
            ],
          }
         `)
@@ -663,7 +660,6 @@ describe('ReactRefreshLogBox', () => {
              |           ^",
            "stack": [
              "ClickCount.render Child.js (4:11)",
-             "Home index.js (6:7)",
            ],
          }
         `)
@@ -873,8 +869,6 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
          ],
        }
       `)
@@ -926,8 +920,6 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
          ],
        }
       `)
@@ -979,8 +971,6 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
          ],
        }
       `)
@@ -1032,8 +1022,6 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
          ],
        }
       `)
@@ -1085,8 +1073,6 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
-           "button <anonymous>",
-           "Index index.js (9:7)",
          ],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -910,6 +910,8 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
+           "button <anonymous>",
+           "Index index.js (9:7)",
          ],
        }
       `)
@@ -961,6 +963,8 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
+           "button <anonymous>",
+           "Index index.js (9:7)",
          ],
        }
       `)
@@ -1012,6 +1016,8 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
+           "button <anonymous>",
+           "Index index.js (9:7)",
          ],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -349,6 +349,7 @@ describe('ReactRefreshLogBox', () => {
              |                                                   ^",
            "stack": [
              "FunctionDefault FunctionDefault.js (1:51)",
+             "App index.js (24:23)",
            ],
          }
         `)
@@ -647,7 +648,7 @@ describe('ReactRefreshLogBox', () => {
              |           ^",
            "stack": [
              "ClickCount.render Child.js (4:11)",
-             "Home index.js (6:7)",
+             "Home index.js (6:13)",
            ],
          }
         `)
@@ -1069,6 +1070,8 @@ describe('ReactRefreshLogBox', () => {
            |           ^",
          "stack": [
            "Index.useCallback[boom] index.js (5:11)",
+           "button <anonymous>",
+           "Index index.js (9:7)",
          ],
        }
       `)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -315,7 +315,7 @@ describe('pages/ error recovery', () => {
            ],
          }
         `)
-      } else {
+      } else if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
            "description": "oops",
@@ -327,6 +327,21 @@ describe('pages/ error recovery', () => {
            "stack": [
              "Child child.js (3:9)",
              "Index index.js (6:13)",
+           ],
+         }
+        `)
+      } else {
+        await expect(browser).toDisplayRedbox(`
+         {
+           "description": "oops",
+           "environmentLabel": null,
+           "label": "Runtime Error",
+           "source": "child.js (3:9) @ Child
+         > 3 |   throw new Error('oops')
+             |         ^",
+           "stack": [
+             "Child child.js (3:9)",
+             "Index index.js (6:7)",
            ],
          }
         `)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -324,7 +324,6 @@ describe('pages/ error recovery', () => {
              |         ^",
            "stack": [
              "Child child.js (3:9)",
-             "Index index.js (6:13)",
            ],
          }
         `)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -326,7 +326,7 @@ describe('pages/ error recovery', () => {
              |         ^",
            "stack": [
              "Child child.js (3:9)",
-             "Index index.js (6:7)",
+             "Index index.js (6:13)",
            ],
          }
         `)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -166,6 +166,8 @@ describe('pages/ error recovery', () => {
           |           ^",
        "stack": [
          "Index.useCallback[increment] index.js (7:11)",
+         "button <anonymous>",
+         "Index index.js (12:7)",
        ],
      }
     `)
@@ -324,6 +326,7 @@ describe('pages/ error recovery', () => {
              |         ^",
            "stack": [
              "Child child.js (3:9)",
+             "Index index.js (6:7)",
            ],
          }
         `)
@@ -703,6 +706,7 @@ describe('pages/ error recovery', () => {
              |   ^",
            "stack": [
              "Foo Foo.js (3:3)",
+             "FunctionDefault index.js (4:10)",
            ],
          }
         `)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -166,8 +166,6 @@ describe('pages/ error recovery', () => {
           |           ^",
        "stack": [
          "Index.useCallback[increment] index.js (7:11)",
-         "button <anonymous>",
-         "Index index.js (12:7)",
        ],
      }
     `)
@@ -341,7 +339,6 @@ describe('pages/ error recovery', () => {
              |         ^",
            "stack": [
              "Child child.js (3:9)",
-             "Index index.js (6:7)",
            ],
          }
         `)
@@ -721,7 +718,6 @@ describe('pages/ error recovery', () => {
              |   ^",
            "stack": [
              "Foo Foo.js (3:3)",
-             "FunctionDefault index.js (4:10)",
            ],
          }
         `)

--- a/test/development/app-dir/browser-log-forwarding/fixtures/error-level/app/layout.tsx
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/error-level/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/browser-log-forwarding/fixtures/error-level/app/page.tsx
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/error-level/app/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Page() {
+  useEffect(() => {
+    console.log('browser log: this is a log message')
+    console.info('browser info: this is an info message')
+    console.warn('browser warn: this is a warning message')
+    console.error('browser error: this is an error message')
+    console.debug('browser debug: this is a debug message')
+  }, [])
+
+  return <p>Browser Log Forwarding Test</p>
+}

--- a/test/development/app-dir/browser-log-forwarding/fixtures/error-level/error-level.test.ts
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/error-level/error-level.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('browser-log-forwarding error level', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should only forward error logs to terminal', async () => {
+    const outputIndex = next.cliOutput.length
+    await next.browser('/')
+
+    await retry(() => {
+      const output = next.cliOutput.slice(outputIndex)
+      expect(output).toContain('browser error:')
+    })
+
+    // Get final output after logs are forwarded
+    const output = next.cliOutput.slice(outputIndex)
+
+    // Filter to only browser forwarded logs, excluding hydration noise
+    const browserLogs = output
+      .split('\n')
+      .filter(
+        (line) =>
+          line.includes('[browser]') &&
+          !line.includes('Next.js hydrate callback fire')
+      )
+      .join('\n')
+
+    expect(browserLogs).toMatchInlineSnapshot(
+      `"[browser] browser error: this is an error message "`
+    )
+  })
+})

--- a/test/development/app-dir/browser-log-forwarding/fixtures/error-level/next.config.js
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/error-level/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    browserDebugInfoInTerminal: 'error',
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/app/layout.tsx
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/app/page.tsx
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/app/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Page() {
+  useEffect(() => {
+    console.log('browser log: this is a log message')
+    console.info('browser info: this is an info message')
+    console.warn('browser warn: this is a warning message')
+    console.error('browser error: this is an error message')
+    console.debug('browser debug: this is a debug message')
+  }, [])
+
+  return <p>Browser Log Forwarding Test</p>
+}

--- a/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/next.config.js
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    browserDebugInfoInTerminal: 'verbose',
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
@@ -1,0 +1,41 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('browser-log-forwarding verbose level', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should forward all logs to terminal', async () => {
+    const outputIndex = next.cliOutput.length
+    await next.browser('/')
+
+    await retry(() => {
+      const output = next.cliOutput.slice(outputIndex)
+      expect(output).toContain('browser error:')
+      expect(output).toContain('browser warn:')
+      expect(output).toContain('browser log:')
+    })
+
+    // Get final output after logs are forwarded
+    const output = next.cliOutput.slice(outputIndex)
+
+    // Filter to only browser forwarded logs, excluding hydration noise
+    const browserLogs = output
+      .split('\n')
+      .filter(
+        (line) =>
+          line.includes('[browser]') &&
+          !line.includes('Next.js hydrate callback fire')
+      )
+      .join('\n')
+
+    expect(browserLogs).toMatchInlineSnapshot(`
+     "[browser] browser log: this is a log message (app/page.tsx:7:13)
+     [browser] browser info: this is an info message (app/page.tsx:8:13)
+     [browser] browser warn: this is a warning message (app/page.tsx:9:13)
+     [browser] browser error: this is an error message 
+     [browser] browser debug: this is a debug message (app/page.tsx:11:13)"
+    `)
+  })
+})

--- a/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
@@ -20,13 +20,17 @@ describe('browser-log-forwarding verbose level', () => {
     // Get final output after logs are forwarded
     const output = next.cliOutput.slice(outputIndex)
 
-    // Filter to only browser forwarded logs, excluding hydration noise
+    // Filter to only browser forwarded logs, excluding noise
     const browserLogs = output
       .split('\n')
       .filter(
         (line) =>
           line.includes('[browser]') &&
-          !line.includes('Next.js hydrate callback fire')
+          !line.includes('Next.js hydrate callback fire') &&
+          !line.includes('connected to ws at') &&
+          !line.includes('received ws message') &&
+          !line.includes('Download the React DevTools') &&
+          !line.includes('Next.js page already hydrated')
       )
       .join('\n')
 

--- a/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/app/layout.tsx
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/app/page.tsx
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/app/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function Page() {
+  useEffect(() => {
+    console.log('browser log: this is a log message')
+    console.info('browser info: this is an info message')
+    console.warn('browser warn: this is a warning message')
+    console.error('browser error: this is an error message')
+    console.debug('browser debug: this is a debug message')
+  }, [])
+
+  return <p>Browser Log Forwarding Test</p>
+}

--- a/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/next.config.js
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    browserDebugInfoInTerminal: 'warn',
+  },
+}
+
+module.exports = nextConfig

--- a/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/warn-level.test.ts
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/warn-level/warn-level.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('browser-log-forwarding warn level', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should forward warn and error logs to terminal', async () => {
+    const outputIndex = next.cliOutput.length
+    await next.browser('/')
+
+    await retry(() => {
+      const output = next.cliOutput.slice(outputIndex)
+      expect(output).toContain('browser error:')
+      expect(output).toContain('browser warn:')
+    })
+
+    // Get final output after logs are forwarded
+    const output = next.cliOutput.slice(outputIndex)
+
+    // Filter to only browser forwarded logs, excluding hydration noise
+    const browserLogs = output
+      .split('\n')
+      .filter(
+        (line) =>
+          line.includes('[browser]') &&
+          !line.includes('Next.js hydrate callback fire')
+      )
+      .join('\n')
+
+    expect(browserLogs).toMatchInlineSnapshot(`
+     "[browser] browser warn: this is a warning message (app/page.tsx:9:13)
+     [browser] browser error: this is an error message "
+    `)
+  })
+})

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -7,6 +7,14 @@ import {
   getRedboxDescription,
   getRedboxSource,
 } from 'next-test-utils'
+
+// Filter out browser log lines from CLI output to avoid counting forwarded browser errors
+function filterBrowserLogs(output: string): string {
+  return output
+    .split('\n')
+    .filter((line) => !line.includes('[browser]'))
+    .join('\n')
+}
 ;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
   'cache-components-edge-deduplication',
   () => {
@@ -49,7 +57,9 @@ import {
          Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."
         `)
         // Count occurrences of the layout error at the specific location
-        const layoutErrorMatches = next.cliOutput.match(
+        // Filter out browser logs to avoid counting forwarded browser errors
+        const filteredOutput = filterBrowserLogs(next.cliOutput)
+        const layoutErrorMatches = filteredOutput.match(
           /\.\/app\/edge-with-layout\/layout\.tsx:1:14/g
         )
         // We don't show an error stack, just the individual error messages at each location

--- a/test/e2e/app-dir/log-file/log-file.test.ts
+++ b/test/e2e/app-dir/log-file/log-file.test.ts
@@ -86,6 +86,8 @@ describe('log-file', () => {
          "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
          [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
          [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
+         [xx:xx:xx.xxx] Server  ERROR   [browser] " Server  RSC: This is an error message from server component" "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
+         [xx:xx:xx.xxx] Browser ERROR    Server  RSC: This is an error message from server component "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
          "
         `)
       })
@@ -122,6 +124,10 @@ describe('log-file', () => {
         expect(newLogContent).toMatchInlineSnapshot(`
          "[xx:xx:xx.xxx] Browser LOG     Client: Complex circular object: {"data":{"nested":{"items":[1,2,3],"value":42},"parent":"[Circular]"},"metadata":{"name":"safe stringify","version":"1.0.0"},"name":"test"}
          [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component
+         [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
+         [xx:xx:xx.xxx] Server  ERROR   [browser] "Client: This is an error message from client component" "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
+         [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
+         [xx:xx:xx.xxx] Server  WARN    [browser] "Client: This is a warning message from client component" "(app/client/page.tsx:26:13)"
          [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
          "
         `)

--- a/test/e2e/app-dir/log-file/log-file.test.ts
+++ b/test/e2e/app-dir/log-file/log-file.test.ts
@@ -3,8 +3,6 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-
 describe('log-file', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
@@ -84,21 +82,14 @@ describe('log-file', () => {
     if (isNextDev) {
       await retry(async () => {
         const newLogContent = getNewLogContent()
-        if (isCacheComponentsEnabled) {
-          expect(newLogContent).toMatchInlineSnapshot(`
-           "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
-           [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
-           [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
-           "
-          `)
-        } else {
-          expect(newLogContent).toMatchInlineSnapshot(`
-           "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
-           [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
-           [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
-           "
-          `)
-        }
+        // The server logs will be replayed in the browser, but they'll not be forwarded to terminal,
+        // as terminal already has them in the first place.
+        expect(newLogContent).toMatchInlineSnapshot(`
+         "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
+         [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
+         [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
+         "
+        `)
       })
     } else {
       expect(hasLogFile()).toBe(false)
@@ -130,13 +121,14 @@ describe('log-file', () => {
     if (isNextDev) {
       await retry(async () => {
         const newLogContent = getNewLogContent()
+        // Only browser only logs are being forwarded to terminal
         expect(newLogContent).toMatchInlineSnapshot(`
-         "[xx:xx:xx.xxx] Server  ERROR   [browser] "Client: This is an error message from client component" "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
+         "[xx:xx:xx.xxx] Browser LOG     Client: Complex circular object: {"data":{"nested":{"items":[1,2,3],"value":42},"parent":"[Circular]"},"metadata":{"name":"safe stringify","version":"1.0.0"},"name":"test"}
+         [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component
+         [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
+         [xx:xx:xx.xxx] Server  ERROR   [browser] "Client: This is an error message from client component" "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
          [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
          [xx:xx:xx.xxx] Server  WARN    [browser] "Client: This is a warning message from client component" "(app/client/page.tsx:26:13)"
-         [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
-         [xx:xx:xx.xxx] Browser LOG     Client: Complex circular object: {"data":{"nested":{"items":[1,2,3],"value":42},"parent":"[Circular]"},"metadata":{"name":"safe stringify","version":"1.0.0"},"name":"test"}
-         [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component
          [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
          "
         `)

--- a/test/e2e/app-dir/log-file/log-file.test.ts
+++ b/test/e2e/app-dir/log-file/log-file.test.ts
@@ -3,6 +3,8 @@ import path from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
 describe('log-file', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
@@ -82,14 +84,23 @@ describe('log-file', () => {
     if (isNextDev) {
       await retry(async () => {
         const newLogContent = getNewLogContent()
-        expect(newLogContent).toMatchInlineSnapshot(`
-         "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
-         [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
-         [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
-         [xx:xx:xx.xxx] Server  ERROR   [browser] " Server  RSC: This is an error message from server component" "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
-         [xx:xx:xx.xxx] Browser ERROR    Server  RSC: This is an error message from server component "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
-         "
-        `)
+        if (isCacheComponentsEnabled) {
+          expect(newLogContent).toMatchInlineSnapshot(`
+           "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
+           [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
+           [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
+           [xx:xx:xx.xxx] Server  ERROR   [browser] " Prerender  RSC: This is an error message from server component" "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
+           [xx:xx:xx.xxx] Browser ERROR    Prerender  RSC: This is an error message from server component "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
+           "
+          `)
+        } else {
+          expect(newLogContent).toMatchInlineSnapshot(`
+           "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
+           [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
+           [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
+           "
+          `)
+        }
       })
     } else {
       expect(hasLogFile()).toBe(false)

--- a/test/e2e/app-dir/log-file/log-file.test.ts
+++ b/test/e2e/app-dir/log-file/log-file.test.ts
@@ -89,8 +89,6 @@ describe('log-file', () => {
            "[xx:xx:xx.xxx] Server  LOG     RSC: This is a log message from server component
            [xx:xx:xx.xxx] Server  ERROR   RSC: This is an error message from server component
            [xx:xx:xx.xxx] Server  WARN    RSC: This is a warning message from server component
-           [xx:xx:xx.xxx] Server  ERROR   [browser] " Prerender  RSC: This is an error message from server component" "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
-           [xx:xx:xx.xxx] Browser ERROR    Prerender  RSC: This is an error message from server component "\\n    at Page (app/server/page.tsx:4:11)\\n    at Page (<anonymous>)\\n  2 |   // Logging in RSC render\\n  3 |   console.log('RSC: This is a log message from server component')\\n> 4 |   console.error('RSC: This is an error message from server component')\\n    |           ^\\n  5 |   console.warn('RSC: This is a warning message from server component')\\n  6 |\\n  7 |   return <p>hello world</p>" "(app/server/page.tsx:4:11)"
            "
           `)
         } else {
@@ -133,12 +131,12 @@ describe('log-file', () => {
       await retry(async () => {
         const newLogContent = getNewLogContent()
         expect(newLogContent).toMatchInlineSnapshot(`
-         "[xx:xx:xx.xxx] Browser LOG     Client: Complex circular object: {"data":{"nested":{"items":[1,2,3],"value":42},"parent":"[Circular]"},"metadata":{"name":"safe stringify","version":"1.0.0"},"name":"test"}
-         [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component
-         [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
-         [xx:xx:xx.xxx] Server  ERROR   [browser] "Client: This is an error message from client component" "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
+         "[xx:xx:xx.xxx] Server  ERROR   [browser] "Client: This is an error message from client component" "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
          [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component "\\n    at ClientPage.useEffect (app/client/page.tsx:25:13)\\n  23 |     circularObj.data.parent = circularObj\\n  24 |     console.log('Client: Complex circular object:', circularObj)\\n> 25 |     console.error('Client: This is an error message from client component')\\n     |             ^\\n  26 |     console.warn('Client: This is a warning message from client component')\\n  27 |   }, [])\\n  28 |" "(app/client/page.tsx:25:13)"
          [xx:xx:xx.xxx] Server  WARN    [browser] "Client: This is a warning message from client component" "(app/client/page.tsx:26:13)"
+         [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
+         [xx:xx:xx.xxx] Browser LOG     Client: Complex circular object: {"data":{"nested":{"items":[1,2,3],"value":42},"parent":"[Circular]"},"metadata":{"name":"safe stringify","version":"1.0.0"},"name":"test"}
+         [xx:xx:xx.xxx] Browser ERROR   Client: This is an error message from client component
          [xx:xx:xx.xxx] Browser WARN    Client: This is a warning message from client component
          "
         `)

--- a/test/e2e/app-dir/log-file/next.config.js
+++ b/test/e2e/app-dir/log-file/next.config.js
@@ -1,11 +1,6 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {
-  experimental: {
-    // Disable browser log forwarding to terminal to avoid duplicate logs in the file
-    browserDebugInfoInTerminal: false,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/log-file/next.config.js
+++ b/test/e2e/app-dir/log-file/next.config.js
@@ -1,6 +1,11 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    // Disable browser log forwarding to terminal to avoid duplicate logs in the file
+    browserDebugInfoInTerminal: false,
+  },
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
This PR enables browser log forwarding to terminal by default during development. Previously, developers had to explicitly opt-in to see browser console output in their terminal. Now, browser console.error and console.warn are automatically forwarded with the new default level of 'warn' (both warnings and errors)


### Changes

- Changed `browserDebugInfoInTerminal` default from `false` to `'warn'`
- Only `console.error` and console.warn are forwarded by default
- Users can configure: `'error'` (errors only), `'warn'` (default), or `'verbose'` (all logs)
- Do not forward react replayed logs in browser

