### PR TITLE
Warn when overriding Cache-Control header on `/_next/` routes

### DIFF
--- a/packages/next/src/lib/load-custom-routes.ts
+++ b/packages/next/src/lib/load-custom-routes.ts
@@ -725,6 +725,27 @@ export default async function loadCustomRoutes(
     )
   }
 
+  const cacheControlSources: string[] = []
+  for (const headerRoute of headers) {
+    if (!headerRoute.source.startsWith('/_next/')) {
+      continue
+    }
+    for (const header of headerRoute.headers) {
+      if (header.key.toLowerCase() === 'cache-control') {
+        cacheControlSources.push(headerRoute.source)
+        break
+      }
+    }
+  }
+  if (cacheControlSources.length > 0) {
+    console.warn(
+      bold(yellow(`Warning: `)) +
+        `Custom Cache-Control headers detected for the following routes:\n` +
+        cacheControlSources.map((source) => `  - ${source}`).join('\n') +
+        `\n\nSetting a custom Cache-Control header can break Next.js development behavior.`
+    )
+  }
+
   if (config.experimental?.useSkewCookie && config.deploymentId) {
     headers.unshift({
       source: '/:path*',


### PR DESCRIPTION
Custom `Cache-Control` headers on `/_next/` routes can cause hard-to-debug development behaviors. Normally the dev server sends no-cache values to ensure that assets are always fresh. If a developer sets the max-age or immutable flag,, the browser can cache resources between requests, even if the source changes.

Adding a warning will at least make this problem easier to debug.