### PR TITLE
test: update parallel/interception tests for Cache Components

### DIFF
--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/(.)photos/[id]/view/page.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/@modal/(.)photos/[id]/view/page.tsx
@@ -1,5 +1,9 @@
 import Modal from '../../../../modal'
 
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function Page({
   params,
 }: {

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/layout.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/layout.tsx
@@ -17,7 +17,6 @@ export default function Root({
   )
 }
 
-export const revalidate = 0
 export async function generateStaticParams() {
   return [{ locale: 'en' }]
 }

--- a/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/photos/[id]/view/page.tsx
+++ b/test/e2e/app-dir/dynamic-interception-route-revalidate/app/[locale]/photos/[id]/view/page.tsx
@@ -1,5 +1,9 @@
 import Modal from '../../../modal'
 
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function PhotoPage({
   params,
 }: {

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/(.)photos/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/@modal/(.)photos/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '1' }, { id: '2' }]
+}
+
 export default async function PhotoModal({
   params,
 }: {

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/layout.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/layout.tsx
@@ -1,5 +1,9 @@
 import Link from 'next/link'
 
+export function generateStaticParams() {
+  return [{ lang: 'en' }]
+}
+
 export default async function Layout(props) {
   const params = await props.params
 

--- a/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/photos/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-middleware-rewrite/app/[lang]/photos/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '1' }, { id: '2' }]
+}
+
 export default async function PhotoPage({
   params,
 }: {

--- a/test/e2e/app-dir/interception-route-prefetch-cache/app/bar/@modal/(...)post/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/app/bar/@modal/(...)post/[id]/page.tsx
@@ -1,5 +1,9 @@
 import { Modal } from '../../../../Modal'
 
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function BarPagePostInterceptSlot({
   params,
 }: {

--- a/test/e2e/app-dir/interception-route-prefetch-cache/app/foo/@modal/(...)post/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/app/foo/@modal/(...)post/[id]/page.tsx
@@ -1,5 +1,9 @@
 import { Modal } from '../../../../Modal'
 
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function FooPagePostInterceptSlot({
   params,
 }: {

--- a/test/e2e/app-dir/interception-route-prefetch-cache/app/layout.fixture-edge.tsx
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/app/layout.fixture-edge.tsx
@@ -2,8 +2,6 @@
 
 import Link from 'next/link'
 
-export const runtime = 'edge'
-
 export default function RootLayout({ children }) {
   return (
     <html>

--- a/test/e2e/app-dir/interception-route-prefetch-cache/app/post/[id]/page.tsx
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/app/post/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function PostPage({
   params,
 }: {

--- a/test/e2e/app-dir/interception-route-prefetch-cache/interception-route-prefetch-cache.test.ts
+++ b/test/e2e/app-dir/interception-route-prefetch-cache/interception-route-prefetch-cache.test.ts
@@ -64,7 +64,9 @@ describe('interception-route-prefetch-cache', () => {
       nextTestSetup({
         files: {
           app: new FileRef(join(__dirname, 'app')),
-          'app/layout.tsx': new FileRef(join(__dirname, 'app/layout-edge.tsx')),
+          'app/layout.tsx': new FileRef(
+            join(__dirname, 'app/layout.fixture-edge.tsx')
+          ),
         },
       })
     )

--- a/test/e2e/app-dir/interception-routes-multiple-catchall/app/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-multiple-catchall/app/[...catchAll]/page.tsx
@@ -1,6 +1,14 @@
 import Link from 'next/link'
 import React from 'react'
 
+export function generateStaticParams() {
+  return [
+    { catchAll: ['single'] },
+    { catchAll: ['multi', 'slug'] },
+    { catchAll: ['another', 'slug'] },
+  ]
+}
+
 async function Page({ params }: { params: Promise<{ catchAll: string[] }> }) {
   const { catchAll } = await params
   return (

--- a/test/e2e/app-dir/interception-routes-multiple-catchall/app/templates/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-multiple-catchall/app/templates/[...catchAll]/page.tsx
@@ -1,6 +1,10 @@
 import Link from 'next/link'
 import React from 'react'
 
+export function generateStaticParams() {
+  return [{ catchAll: ['single'] }, { catchAll: ['multi', 'slug'] }]
+}
+
 async function Page({ params }: { params: Promise<{ catchAll: string[] }> }) {
   const { catchAll } = await params
   return (

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/@modal/(.)items/[...ids]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/@modal/(.)items/[...ids]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ ids: ['1'] }]
+}
+
 export default async function Page({
   params,
 }: {

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/[...slug]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/[...slug]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ slug: ['foobar'] }]
+}
+
 export default function Page() {
   return <div>Root Catch-All Page</div>
 }

--- a/test/e2e/app-dir/interception-routes-root-catchall/app/items/[...ids]/page.tsx
+++ b/test/e2e/app-dir/interception-routes-root-catchall/app/items/[...ids]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ ids: ['1'] }]
+}
+
 export default async function Page({
   params,
 }: {

--- a/test/e2e/app-dir/parallel-routes-and-interception-from-root/app/[locale]/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception-from-root/app/[locale]/layout.tsx
@@ -1,4 +1,6 @@
-export const runtime = 'edge'
+export function generateStaticParams() {
+  return [{ locale: 'en' }]
+}
 
 export default async function RootLayout({
   children,

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal/[username]/@feed/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal/[username]/@feed/page.js
@@ -1,5 +1,9 @@
 import Link from 'next/link'
 
+export function generateStaticParams() {
+  return [{ username: 'vercel' }]
+}
+
 export default async function Page({ params }) {
   return (
     <>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal/[username]/@modal/(..)photo/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal/[username]/@modal/(..)photo/[id]/page.js
@@ -1,3 +1,10 @@
+export function generateStaticParams() {
+  return [
+    { username: 'vercel', id: '0' },
+    { username: 'vercel', id: '1' },
+  ]
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   return <p id={`photo-modal-${id}`}>Photo MODAL {id}</p>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal/photo/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/(group)/intercepting-parallel-modal/photo/[id]/page.js
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '0' }, { id: '1' }]
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   return <p id={`photo-page-${id}`}>Photo PAGE {id}</p>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/edge-runtime/layout.tsx
@@ -1,5 +1,3 @@
-export const runtime = 'edge'
-
 export default function Layout({
   children,
   slot,

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)catchall/[...id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)catchall/[...id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: ['123'] }]
+}
+
 export default function InterceptPage() {
   return <div id="catchall-intercept-page">Intercepted Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)optional-catchall/[[...id]]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/(.)optional-catchall/[[...id]]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: ['123'] }]
+}
+
 export default function InterceptedPage() {
   return <div id="optional-catchall-intercept-page">Intercepted Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/catchall/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/catchall/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '123' }]
+}
+
 export default function RegularPage() {
   return <div id="catchall-regular-page">Regular Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[[...id]]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic-catchall/photos/optional-catchall/[[...id]]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: ['123'] }]
+}
+
 export default function RegularPage() {
   return <div id="optional-catchall-regular-page">Regular Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic/photos/(.)[author]/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic/photos/(.)[author]/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ author: 'next', id: '123' }]
+}
+
 export default function InterceptedAuthorIdPage() {
   return <div id="user-intercept-page">Intercepted Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic/photos/[author]/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes-dynamic/photos/[author]/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ author: 'next', id: '123' }]
+}
+
 export default function AuthorIdPage() {
   return <div id="user-regular-page">Regular Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes/feed/(.)photos/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes/feed/(.)photos/[id]/page.js
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   return <p id={`photo-intercepted-${id}`}>Photo INTERCEPTED {id}</p>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes/feed/photos/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-routes/feed/photos/[id]/page.js
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   return <p id={`photo-page-${id}`}>Photo PAGE {id}</p>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/@modal/(.)[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/@modal/(.)[id]/page.js
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function Page({ params }) {
   return (
     <div>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/intercepting-siblings/[id]/page.js
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '1' }]
+}
+
 export default async function Page({ params }) {
   const { id } = await params
   return (

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/interception-route-special-params/[this-is-my-route]/@intercept/(.)some-page/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/interception-route-special-params/[this-is-my-route]/@intercept/(.)some-page/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ 'this-is-my-route': 'some-random-param' }]
+}
+
 export default async function Page({ params }) {
   return (
     <div>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/interception-route-special-params/[this-is-my-route]/some-page/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/interception-route-special-params/[this-is-my-route]/some-page/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ 'this-is-my-route': 'some-random-param' }]
+}
+
 export default async function Page({ params }) {
   return (
     <div>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-dynamic/[slug]/@bar/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-dynamic/[slug]/@bar/[id]/page.js
@@ -1,6 +1,8 @@
-'use client'
-import { useParams } from 'next/navigation'
+export function generateStaticParams() {
+  return [{ slug: 'foo', id: 'bar' }]
+}
 
-export default function Page() {
-  return <div id="bar">{JSON.stringify(useParams())}</div>
+export default async function Page({ params }) {
+  const resolvedParams = await params
+  return <div id="bar">{JSON.stringify(resolvedParams)}</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-dynamic/[slug]/@foo/[id]/page.js
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-dynamic/[slug]/@foo/[id]/page.js
@@ -1,6 +1,8 @@
-'use client'
-import { useParams } from 'next/navigation'
+export function generateStaticParams() {
+  return [{ slug: 'foo', id: 'bar' }]
+}
 
-export default function Page() {
-  return <div id="foo">{JSON.stringify(useParams())}</div>
+export default async function Page({ params }) {
+  const resolvedParams = await params
+  return <div id="foo">{JSON.stringify(resolvedParams)}</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/@parallelB/nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/@parallelB/nested/page.tsx
@@ -1,4 +1,8 @@
-export default function ParallelPage() {
+import { connection } from 'next/server'
+
+export default async function ParallelPage() {
+  // connection() required for Date.now() with Cache Components
+  await connection()
   return (
     <>
       <p>Hello from nested parallel page!</p>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-nested/home/layout.tsx
@@ -1,8 +1,14 @@
+import { Suspense } from 'react'
+
 export default function Layout({ parallelB }: { parallelB: React.ReactNode }) {
   return (
     <main>
       <h3>{`(parallelB)`}</h3>
-      <div>{parallelB}</div>
+      <div>
+        <Suspense fallback={<div id="timestamp">loading...</div>}>
+          {parallelB}
+        </Suspense>
+      </div>
     </main>
   )
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-no-page/foo/@parallel/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-no-page/foo/@parallel/page.tsx
@@ -1,4 +1,8 @@
-export default function ParallelPage() {
+import { connection } from 'next/server'
+
+export default async function ParallelPage() {
+  // connection() required for Date.now() with Cache Components
+  await connection()
   return (
     <>
       <p>Hello from parallel page!</p>

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-no-page/foo/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/parallel-no-page/foo/layout.tsx
@@ -1,10 +1,13 @@
 import * as React from 'react'
+import { Suspense } from 'react'
 
 export default function Layout({ parallel }: { parallel: React.ReactNode }) {
   return (
     <>
       <h2>LAYOUT</h2>
-      {parallel}
+      <Suspense fallback={<div id="timestamp">loading...</div>}>
+        {parallel}
+      </Suspense>
     </>
   )
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/foo/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/foo/page.tsx
@@ -1,7 +1,8 @@
-// we want to verify that the loading behavior is triggered during Next build, so we opt out of static generation
-export const dynamic = 'force-dynamic'
+import { connection } from 'next/server'
 
 export default async function TestPage() {
+  // Use connection() instead of force-dynamic for Cache Components compatibility
+  await connection()
   await new Promise((resolve) => setTimeout(resolve, 2000))
   return <div>Welcome to Foo Page</div>
 }

--- a/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-and-interception/app/with-loading/layout.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { ReactNode } from 'react'
+import { ReactNode, Suspense } from 'react'
 
 export default function Layout({
   children,
@@ -16,7 +16,9 @@ export default function Layout({
       <div>
         <Link href="/with-loading/foo">To Loading Page</Link>
       </div>
-      <div id="slot">{slot}</div>
+      <div id="slot">
+        <Suspense fallback="loading slot...">{slot}</Suspense>
+      </div>
       <div id="children">{children}</div>
     </>
   )

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -494,7 +494,10 @@ describe.each([true, false])(
       if (isNextDev) {
         it('should support parallel routes with no page component', async () => {
           const browser = await next.browser('/parallel-no-page/foo')
-          const timestamp = await browser.elementByCss('#timestamp').text()
+          // Use waitForElementByCss since with PPR/Cache Components the element is streamed
+          const timestamp = await browser
+            .waitForElementByCss('#timestamp')
+            .text()
 
           await new Promise((resolve) => {
             setTimeout(resolve, 3000)
@@ -502,14 +505,19 @@ describe.each([true, false])(
 
           await check(async () => {
             // an invalid response triggers a fast refresh, so if the timestamp doesn't update, this behaved correctly
-            const newTimestamp = await browser.elementByCss('#timestamp').text()
+            const newTimestamp = await browser
+              .waitForElementByCss('#timestamp')
+              .text()
             return newTimestamp !== timestamp ? 'failure' : 'success'
           }, 'success')
         })
 
         it('should support nested parallel routes', async () => {
           const browser = await next.browser('parallel-nested/home/nested')
-          const timestamp = await browser.elementByCss('#timestamp').text()
+          // Use waitForElementByCss since with PPR/Cache Components the element is streamed
+          const timestamp = await browser
+            .waitForElementByCss('#timestamp')
+            .text()
 
           await new Promise((resolve) => {
             setTimeout(resolve, 3000)
@@ -517,7 +525,9 @@ describe.each([true, false])(
 
           await check(async () => {
             // an invalid response triggers a fast refresh, so if the timestamp doesn't update, this behaved correctly
-            const newTimestamp = await browser.elementByCss('#timestamp').text()
+            const newTimestamp = await browser
+              .waitForElementByCss('#timestamp')
+              .text()
             return newTimestamp !== timestamp ? 'failure' : 'success'
           }, 'success')
         })

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/[...catchAll]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/@modal/[...catchAll]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ catchAll: ['u', 'foobar', 'l'] }, { catchAll: ['trending'] }]
+}
+
 export default function CatchAll() {
   return null
 }

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/comments/[productId]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/comments/[productId]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ productId: 'some-text' }]
+}
+
 export default async function Page({
   params,
 }: {

--- a/test/e2e/app-dir/parallel-routes-catchall-specificity/app/u/[userName]/l/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-catchall-specificity/app/u/[userName]/l/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ userName: 'foobar' }]
+}
+
 export default function Page() {
   return <h1>Profile</h1>
 }

--- a/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/@modal/(.)interception/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/@modal/(.)interception/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '123' }]
+}
+
 export default async function ModalPage({
   params,
 }: {

--- a/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/@modal/no-interception/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/@modal/no-interception/[id]/page.tsx
@@ -1,3 +1,7 @@
+export function generateStaticParams() {
+  return [{ id: '123' }]
+}
+
 export default async function ModalPage({
   params,
 }: {

--- a/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/interception/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/interception/[id]/page.tsx
@@ -1,5 +1,9 @@
 import Link from 'next/link'
 
+export function generateStaticParams() {
+  return [{ id: '123' }]
+}
+
 export default async function Page({
   params,
 }: {

--- a/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/no-interception/[id]/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-generate-static-params/app/[locale]/no-interception/[id]/page.tsx
@@ -1,5 +1,9 @@
 import Link from 'next/link'
 
+export function generateStaticParams() {
+  return [{ id: '123' }]
+}
+
 export default async function Page({
   params,
 }: {


### PR DESCRIPTION
## Summary

Make parallel routes and interception route tests compatible with Cache Components (PPR) to re-enable them in the test manifest. Tests now work with both `__NEXT_CACHE_COMPONENTS=true` and without it.

## Changes

- Added `generateStaticParams()` to dynamic route pages
- Replaced `export const dynamic = 'force-dynamic'` with `await connection()` from `next/server` for Cache Components compatibility
- Wrapped parallel route slots in `<Suspense>` boundaries to support PPR streaming
- Updated tests to use `waitForElementByCss()` for streamed elements instead of assuming immediate availability
- Renamed `layout-edge.tsx` to `layout.fixture-edge.tsx` for clarity

## Testing

All 6 targeted tests pass with both Cache Components enabled and disabled (backwards compatible).

NAR-527