### PR TITLE
docs: fix CSP example to only include unsafe-eval in development

### DIFF
--- a/docs/01-app/02-guides/content-security-policy.mdx
+++ b/docs/01-app/02-guides/content-security-policy.mdx
@@ -415,9 +415,11 @@ Consider nonces when:
 For applications that do not require nonces, you can set the CSP header directly in your [`next.config.js`](/docs/app/api-reference/config/next-config-js) file:
 
 ```js filename="next.config.js"
+const isDev = process.env.NODE_ENV === 'development'
+
 const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline';
+    script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''};
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;
     font-src 'self';


### PR DESCRIPTION
## What

Fixes the CSP documentation "Without Nonces" example to only include `'unsafe-eval'` in development mode.

## Why

The example was showing `'unsafe-eval'` without a development check, which would cause it to be shipped to production. This is inconsistent with the guidance in the "Development vs Production Considerations" section which correctly shows how to conditionally add `'unsafe-eval'` only in development.

## How

Added a `isDev` check using `process.env.NODE_ENV === 'development'` and conditionally includes `'unsafe-eval'` in the `script-src` directive only when in development mode.