### PR TITLE
docs: add PR description guidance to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,13 @@ The main Next.js framework lives in `packages/next/`. This is what gets publishe
 
 **Note**: `gt submit` runs in interactive mode by default and won't push in automated contexts. Always use `gt submit --no-edit` or `gt submit -q` when running from Claude.
 
+**Creating PRs with descriptions**: All PRs created require a description. `gt submit --no-edit` creates PRs in draft mode without a description. To add a PR title and description, use `gh pr edit` immediately after submitting:
+
+```bash
+gt submit --no-edit
+gh pr edit <pr-number> --body "Place description here"
+```
+
 **Graphite Stack Safety Rules:**
 
 - Graphite force-pushes everything - old commits only recoverable via reflog


### PR DESCRIPTION
### What?

Adds documentation to AGENTS.md explaining how to create PRs with descriptions when using Graphite.

### Why?

`gt submit --no-edit` creates PRs in draft mode without a description, but all PRs require a description following the mandatory format. This documents the recommended workflow for AI agents.

### How?

Added a new "Creating PRs with descriptions" section to the Git Workflow documentation with example bash commands showing how to use `gh pr edit` immediately after `gt submit --no-edit` to add PR descriptions.