### PR TITLE
ci: Fix retry comments in workflow files

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   retry-on-failure:
     name: retry failed jobs
-    # Retry the test-e2e-deploy-release workflow up to 2 times
+    # Retry the test-e2e-deploy-release workflow once
     if: >-
       ${{
         startsWith(github.event.workflow_run.display_title, 'test-e2e-deploy') &&

--- a/.github/workflows/retry_test.yml
+++ b/.github/workflows/retry_test.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   retry-on-failure:
     name: retry failed jobs
-    # Retry the build-and-test workflow up to 3 times
+    # Retry the build-and-test workflow up to 2 times
     if: >-
       ${{ 
         github.event.workflow_run.conclusion == 'failure' &&


### PR DESCRIPTION
The retry comments for e2e tests and deploy tests were off by one.