### PR TITLE
fix(build): prevent route handler manifests from inheriting unrelated client components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,7 @@ See [Codebase structure](#codebase-structure) above for detailed explanations.
 - Do NOT add "Generated with Claude Code" or co-author footers to commits or PRs
 - Keep commit messages concise and descriptive
 - PR descriptions should focus on what changed and why
+- Do NOT mark PRs as "ready for review" (`gh pr ready`) - leave PRs in draft mode and let the user decide when to mark them ready
 
 ## Development Anti-Patterns
 

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -578,13 +578,27 @@ export class ClientReferenceManifestPlugin {
         edgeRscModuleMapping: {},
       }
 
-      const segments = [...entryNameToGroupName(pageName).split('/'), 'page']
-      let group = ''
-      for (const segment of segments) {
-        for (const manifest of manifestsPerGroup.get(group) || []) {
+      // Route handlers don't render React components and don't need
+      // client component references from parent layouts/pages.
+      // They only need their own entry's manifest (for 'use cache' support).
+      const isRouteHandler = /\/route$/.test(pageName)
+
+      if (isRouteHandler) {
+        // Route handlers only get their own manifest, not parent manifests
+        const groupName = entryNameToGroupName(pageName)
+        for (const manifest of manifestsPerGroup.get(groupName) || []) {
           mergeManifest(mergedManifest, manifest)
         }
-        group += (group ? '/' : '') + segment
+      } else {
+        // Pages need manifests merged from parent layouts
+        const segments = [...entryNameToGroupName(pageName).split('/'), 'page']
+        let group = ''
+        for (const segment of segments) {
+          for (const manifest of manifestsPerGroup.get(group) || []) {
+            mergeManifest(mergedManifest, manifest)
+          }
+          group += (group ? '/' : '') + segment
+        }
       }
 
       const json = JSON.stringify(mergedManifest)

--- a/test/production/app-dir/route-handler-manifest-size/app/api-with-client/client-utils.ts
+++ b/test/production/app-dir/route-handler-manifest-size/app/api-with-client/client-utils.ts
@@ -1,0 +1,6 @@
+'use client'
+
+// A client utility module directly imported by a route handler
+export function formatData(data: { value: number }) {
+  return `Formatted: ${data.value}`
+}

--- a/test/production/app-dir/route-handler-manifest-size/app/api-with-client/route.ts
+++ b/test/production/app-dir/route-handler-manifest-size/app/api-with-client/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+// Direct import from a 'use client' module
+// The import creates a client reference in the manifest
+import { formatData } from './client-utils'
+
+export async function GET() {
+  // Note: formatData is a client reference here, not the actual function
+  // This tests that direct client imports appear in the route's manifest
+  return NextResponse.json({
+    message: 'Hello from route handler with client import',
+    // We can't actually call formatData here since it's a client reference
+    hasClientImport: typeof formatData !== 'undefined',
+  })
+}

--- a/test/production/app-dir/route-handler-manifest-size/app/api/hello/route.ts
+++ b/test/production/app-dir/route-handler-manifest-size/app/api/hello/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server'
+
+// Pure route handler with no client component imports
+export async function GET() {
+  return NextResponse.json({ message: 'Hello from pure route handler' })
+}

--- a/test/production/app-dir/route-handler-manifest-size/app/components/Button.tsx
+++ b/test/production/app-dir/route-handler-manifest-size/app/components/Button.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+export function Button({ children }: { children: React.ReactNode }) {
+  return (
+    <button
+      onClick={() => console.log('Button clicked')}
+      className="px-4 py-2 bg-blue-500 text-white rounded"
+    >
+      {children}
+    </button>
+  )
+}

--- a/test/production/app-dir/route-handler-manifest-size/app/components/Dropdown.tsx
+++ b/test/production/app-dir/route-handler-manifest-size/app/components/Dropdown.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useState } from 'react'
+
+export function Dropdown({
+  items,
+}: {
+  items: { label: string; value: string }[]
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [selected, setSelected] = useState<string | null>(null)
+
+  return (
+    <div className="relative">
+      <button onClick={() => setIsOpen(!isOpen)}>
+        {selected || 'Select an option'}
+      </button>
+      {isOpen && (
+        <ul className="absolute mt-1 bg-white border rounded shadow">
+          {items.map((item) => (
+            <li
+              key={item.value}
+              onClick={() => {
+                setSelected(item.label)
+                setIsOpen(false)
+              }}
+              className="px-4 py-2 hover:bg-gray-100 cursor-pointer"
+            >
+              {item.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/test/production/app-dir/route-handler-manifest-size/app/components/Modal.tsx
+++ b/test/production/app-dir/route-handler-manifest-size/app/components/Modal.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { useState } from 'react'
+
+export function Modal({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setIsOpen(true)}>Open Modal</button>
+      {isOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+          <div className="bg-white p-4 rounded">
+            {children}
+            <button onClick={() => setIsOpen(false)}>Close</button>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/test/production/app-dir/route-handler-manifest-size/app/layout.tsx
+++ b/test/production/app-dir/route-handler-manifest-size/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/route-handler-manifest-size/app/page.tsx
+++ b/test/production/app-dir/route-handler-manifest-size/app/page.tsx
@@ -1,0 +1,19 @@
+import { Button } from './components/Button'
+import { Modal } from './components/Modal'
+import { Dropdown } from './components/Dropdown'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Page with Client Components</h1>
+      <Button>Click me</Button>
+      <Modal>Modal content</Modal>
+      <Dropdown
+        items={[
+          { label: 'Option 1', value: '1' },
+          { label: 'Option 2', value: '2' },
+        ]}
+      />
+    </main>
+  )
+}

--- a/test/production/app-dir/route-handler-manifest-size/route-handler-manifest-size.test.ts
+++ b/test/production/app-dir/route-handler-manifest-size/route-handler-manifest-size.test.ts
@@ -1,0 +1,123 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import type { ClientReferenceManifest } from 'next/dist/build/webpack/plugins/flight-manifest-plugin'
+
+describe('route-handler-manifest-size', () => {
+  const { next, isNextStart, skipped } = nextTestSetup({
+    files: __dirname,
+    // This test is specifically for webpack behavior
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  /**
+   * Loads and returns the client reference manifest for a given route
+   */
+  function getClientReferenceManifest(route: string): ClientReferenceManifest {
+    const appDir = next.testDir
+    const manifestPath = join(
+      appDir,
+      `.next/server/app${route}_client-reference-manifest.js`
+    )
+    const modulePath = require.resolve(manifestPath)
+
+    // Clear any cached version
+    delete require.cache[modulePath]
+
+    // Initialize global if needed
+    if (!(globalThis as any).__RSC_MANIFEST) {
+      ;(globalThis as any).__RSC_MANIFEST = {}
+    }
+
+    // Load the manifest (it sets globalThis.__RSC_MANIFEST)
+    require(modulePath)
+
+    const manifest = (globalThis as any).__RSC_MANIFEST[
+      route
+    ] as ClientReferenceManifest
+
+    // Clean up require cache but keep manifest for potential re-reads
+    delete require.cache[modulePath]
+
+    return manifest
+  }
+
+  /**
+   * Gets the module paths from clientModules
+   */
+  function getClientModulePaths(manifest: ClientReferenceManifest): string[] {
+    return Object.keys(manifest.clientModules)
+  }
+
+  if (isNextStart) {
+    it('should not include page client components in pure route handler manifest', () => {
+      const manifest = getClientReferenceManifest('/api/hello/route')
+      const modulePaths = getClientModulePaths(manifest)
+
+      // The pure route handler should NOT contain client components from the page
+      const hasButton = modulePaths.some((p) => p.includes('Button'))
+      const hasModal = modulePaths.some((p) => p.includes('Modal'))
+      const hasDropdown = modulePaths.some((p) => p.includes('Dropdown'))
+
+      expect(hasButton).toBe(false)
+      expect(hasModal).toBe(false)
+      expect(hasDropdown).toBe(false)
+    })
+
+    it('should include page client components in page manifest', () => {
+      const manifest = getClientReferenceManifest('/page')
+      const modulePaths = getClientModulePaths(manifest)
+
+      // The page should contain its client components
+      const hasButton = modulePaths.some((p) => p.includes('Button'))
+      const hasModal = modulePaths.some((p) => p.includes('Modal'))
+      const hasDropdown = modulePaths.some((p) => p.includes('Dropdown'))
+
+      expect(hasButton).toBe(true)
+      expect(hasModal).toBe(true)
+      expect(hasDropdown).toBe(true)
+    })
+
+    it('should have significantly smaller manifest for pure route handler compared to page', () => {
+      const routeManifest = getClientReferenceManifest('/api/hello/route')
+      const pageManifest = getClientReferenceManifest('/page')
+
+      const routeModuleCount = Object.keys(routeManifest.clientModules).length
+      const pageModuleCount = Object.keys(pageManifest.clientModules).length
+
+      // Route handler should have fewer client modules than the page
+      // (ideally 0 for a pure route handler, but allowing some for internal modules)
+      expect(routeModuleCount).toBeLessThan(pageModuleCount)
+    })
+
+    it('should not include page components in route handler that imports client module', () => {
+      const manifest = getClientReferenceManifest('/api-with-client/route')
+      const modulePaths = getClientModulePaths(manifest)
+
+      // Route handler should NOT have unrelated client components from the page
+      // (even if it imports its own client module)
+      const hasButton = modulePaths.some((p) => p.includes('Button'))
+      const hasModal = modulePaths.some((p) => p.includes('Modal'))
+      const hasDropdown = modulePaths.some((p) => p.includes('Dropdown'))
+
+      expect(hasButton).toBe(false)
+      expect(hasModal).toBe(false)
+      expect(hasDropdown).toBe(false)
+    })
+  }
+
+  // Functional tests that work in both dev and production
+  it('should respond correctly from pure route handler', async () => {
+    const res = await next.fetch('/api/hello')
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json.message).toBe('Hello from pure route handler')
+  })
+
+  it('should render page with client components', async () => {
+    const browser = await next.browser('/')
+    const heading = await browser.elementByCss('h1').text()
+    expect(heading).toBe('Page with Client Components')
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #88316

Route handlers (API routes) were generating bloated `client-reference-manifest.js` files containing unrelated client components from pages when using Webpack. This was caused by the manifest merging logic in `flight-manifest-plugin.ts` which inherited manifests from all parent path segments.

### Changes

- Modified `flight-manifest-plugin.ts` to detect route handlers (`/route$` pattern)
- Route handlers now only get their own group's manifest, skipping parent manifest inheritance
- Pages continue to inherit manifests from parent layouts as before

### Why this works

Route handlers:
- Don't render React components
- Return `Response` objects, not JSX
- Don't need client component references from parent layouts/pages

Turbopack already handles this correctly by doing targeted module graph traversal per entry. This fix aligns Webpack's behavior.

## Test Plan

Added test suite `test/production/app-dir/route-handler-manifest-size/`:
- Verifies pure route handlers don't include unrelated page client components
- Verifies pages still include their client components
- Verifies route handlers with direct client imports don't get page components
- Tests pass for both Webpack and Turbopack