### PR TITLE
docs(AGENTS.md): add rule to not mark PRs as ready for review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,6 +292,7 @@ See [Codebase structure](#codebase-structure) above for detailed explanations.
 - Do NOT add "Generated with Claude Code" or co-author footers to commits or PRs
 - Keep commit messages concise and descriptive
 - PR descriptions should focus on what changed and why
+- Do NOT mark PRs as "ready for review" (`gh pr ready`) - leave PRs in draft mode and let the user decide when to mark them ready
 
 ## Development Anti-Patterns
 


### PR DESCRIPTION
### What?

Added a rule to AGENTS.md instructing AI agents to not mark PRs as "ready for review" using `gh pr ready`.

### Why?

AI agents should leave PRs in draft mode and let users decide when to mark them ready. This ensures users maintain control over when their PRs are published for review.

### How?

Added a single line to the "Commit and PR Style" section in AGENTS.md.