### PR TITLE
Revert "refactor: consolidate PPR into cacheComponents architecture (#88243)"

### DIFF
--- a/packages/next/src/build/analyze/index.ts
+++ b/packages/next/src/build/analyze/index.ts
@@ -19,6 +19,7 @@ import { findPagesDir } from '../../lib/find-pages-dir'
 import { PAGE_TYPES } from '../../lib/page-types'
 import loadCustomRoutes from '../../lib/load-custom-routes'
 import { generateRoutesManifest } from '../generate-routes-manifest'
+import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr'
 import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
 import http from 'node:http'
 
@@ -187,7 +188,7 @@ async function collectRoutesForAnalyze(
     config.basePath ? `${config.basePath}${pathPrefix}` : pathPrefix
   )
 
-  const isAppPPREnabled = !!config.cacheComponents
+  const isAppPPREnabled = checkIsAppPPREnabled(config.experimental.ppr)
 
   // Generate routes manifest
   const { routesManifest } = generateRoutesManifest({

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -7,6 +7,7 @@ import type { ProxyMatcher } from './analysis/get-page-static-info'
 import type { Rewrite } from '../lib/load-custom-routes'
 import path from 'node:path'
 import { needsExperimentalReact } from '../lib/needs-experimental-react'
+import { checkIsAppPPREnabled } from '../server/lib/experimental/ppr'
 import {
   getNextConfigEnv,
   getNextPublicEnvironmentVariables,
@@ -114,6 +115,7 @@ export function getDefineEnv({
   const nextPublicEnv = getNextPublicEnvironmentVariables()
   const nextConfigEnv = getNextConfigEnv(config)
 
+  const isPPREnabled = checkIsAppPPREnabled(config.experimental.ppr)
   const isCacheComponentsEnabled = !!config.cacheComponents
   const isUseCacheEnabled = !!config.experimental.useCache
 
@@ -159,6 +161,7 @@ export function getDefineEnv({
     'process.env.__NEXT_APP_NAV_FAIL_HANDLING': Boolean(
       config.experimental.appNavFailHandling
     ),
+    'process.env.__NEXT_PPR': isPPREnabled,
     'process.env.__NEXT_CACHE_COMPONENTS': isCacheComponentsEnabled,
     'process.env.__NEXT_USE_CACHE': isUseCacheEnabled,
 

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -20,6 +20,7 @@ import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { interopDefault } from '../../server/app-render/interop-default'
 import { stripFlightHeaders } from '../../server/app-render/strip-flight-headers'
 import { NodeNextRequest, NodeNextResponse } from '../../server/base-http/node'
+import { checkIsAppPPREnabled } from '../../server/lib/experimental/ppr'
 import {
   getFallbackRouteParams,
   createOpaqueFallbackRouteParams,
@@ -221,10 +222,12 @@ export async function handler(
   const isPossibleServerAction = getIsPossibleServerAction(req)
 
   /**
-   * If the route being rendered is an app page, and the cacheComponents feature
-   * has been enabled, then the given route _could_ support PPR.
+   * If the route being rendered is an app page, and the ppr feature has been
+   * enabled, then the given route _could_ support PPR.
    */
-  const couldSupportPPR: boolean = !!nextConfig.cacheComponents
+  const couldSupportPPR: boolean = checkIsAppPPREnabled(
+    nextConfig.experimental.ppr
+  )
 
   if (
     !getRequestMeta(req, 'postponed') &&

--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -20,6 +20,7 @@ function hasFallbackRouteParams(): boolean {
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-ppr':
         const fallbackParams = workUnitStore.fallbackRouteParams
         return fallbackParams ? fallbackParams.size > 0 : false
       case 'prerender-legacy':

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -164,11 +164,15 @@ export async function fetchServerResponse(
 
     // Typically, during a navigation, we decode the response using Flight's
     // `createFromFetch` API, which accepts a `fetch` promise.
+    // TODO: Remove this check once the old PPR flag is removed
+    const isLegacyPPR =
+      process.env.__NEXT_PPR && !process.env.__NEXT_CACHE_COMPONENTS
+    const shouldImmediatelyDecode = !isLegacyPPR
     const res = await createFetch<NavigationFlightResponse>(
       url,
       headers,
       'auto',
-      true
+      shouldImmediatelyDecode
     )
 
     const responseUrl = urlToUrlWithoutFlightMarker(new URL(res.url))

--- a/packages/next/src/client/components/unstable-rethrow.server.ts
+++ b/packages/next/src/client/components/unstable-rethrow.server.ts
@@ -2,7 +2,10 @@ import { isHangingPromiseRejectionError } from '../../server/dynamic-rendering-u
 import { isPostpone } from '../../server/lib/router-utils/is-postpone'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { isNextRouterError } from './is-next-router-error'
-import { isPrerenderInterruptedError } from '../../server/app-render/dynamic-rendering'
+import {
+  isDynamicPostpone,
+  isPrerenderInterruptedError,
+} from '../../server/app-render/dynamic-rendering'
 import { isDynamicServerError } from './hooks-server-context'
 
 export function unstable_rethrow(error: unknown): void {
@@ -10,6 +13,7 @@ export function unstable_rethrow(error: unknown): void {
     isNextRouterError(error) ||
     isBailoutToCSRError(error) ||
     isDynamicServerError(error) ||
+    isDynamicPostpone(error) ||
     isPostpone(error) ||
     isHangingPromiseRejectionError(error) ||
     isPrerenderInterruptedError(error)

--- a/packages/next/src/export/helpers/is-dynamic-usage-error.ts
+++ b/packages/next/src/export/helpers/is-dynamic-usage-error.ts
@@ -1,8 +1,10 @@
 import { isDynamicServerError } from '../../client/components/hooks-server-context'
 import { isBailoutToCSRError } from '../../shared/lib/lazy-dynamic/bailout-to-csr'
 import { isNextRouterError } from '../../client/components/is-next-router-error'
+import { isDynamicPostpone } from '../../server/app-render/dynamic-rendering'
 
 export const isDynamicUsageError = (err: unknown) =>
   isDynamicServerError(err) ||
   isBailoutToCSRError(err) ||
-  isNextRouterError(err)
+  isNextRouterError(err) ||
+  isDynamicPostpone(err)

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1862,6 +1862,7 @@ async function renderToHTMLOrFlightImpl(
         case 'cache':
         case 'private-cache':
           return true
+        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'request':
         case 'unstable-cache':
@@ -4960,6 +4961,254 @@ async function prerenderToStream(
           collectedStale: selectStaleTime(finalServerPrerenderStore.stale),
           collectedTags: finalServerPrerenderStore.tags,
           renderResumeDataCache: createRenderResumeDataCache(resumeDataCache),
+        }
+      }
+    } else if (experimental.isRoutePPREnabled) {
+      // We're statically generating with PPR and need to do dynamic tracking
+      let dynamicTracking = createDynamicTrackingState(isDebugDynamicAccesses)
+
+      const prerenderResumeDataCache = createPrerenderResumeDataCache()
+      const reactServerPrerenderStore: PrerenderStore = (prerenderStore = {
+        type: 'prerender-ppr',
+        phase: 'render',
+        rootParams,
+        fallbackRouteParams,
+        implicitTags,
+        dynamicTracking,
+        revalidate: INFINITE_CACHE,
+        expire: INFINITE_CACHE,
+        stale: INFINITE_CACHE,
+        tags: [...implicitTags.tags],
+        prerenderResumeDataCache,
+      })
+      const RSCPayload = await workUnitAsyncStorage.run(
+        reactServerPrerenderStore,
+        getRSCPayload,
+        tree,
+        ctx,
+        res.statusCode === 404
+      )
+      const reactServerResult = (reactServerPrerenderResult =
+        await createReactServerPrerenderResultFromRender(
+          workUnitAsyncStorage.run(
+            reactServerPrerenderStore,
+            ComponentMod.renderToReadableStream,
+            // ... the arguments for the function to run
+            RSCPayload,
+            clientModules,
+            {
+              filterStackFrame,
+              onError: serverComponentsErrorHandler,
+            }
+          )
+        ))
+
+      const ssrPrerenderStore: PrerenderStore = {
+        type: 'prerender-ppr',
+        phase: 'render',
+        rootParams,
+        fallbackRouteParams,
+        implicitTags,
+        dynamicTracking,
+        revalidate: INFINITE_CACHE,
+        expire: INFINITE_CACHE,
+        stale: INFINITE_CACHE,
+        tags: [...implicitTags.tags],
+        prerenderResumeDataCache,
+      }
+      const prerender = (
+        require('react-dom/static') as typeof import('react-dom/static')
+      ).prerender
+      const { prelude: unprocessedPrelude, postponed } =
+        await workUnitAsyncStorage.run(
+          ssrPrerenderStore,
+          prerender,
+          // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+          <App
+            reactServerStream={reactServerResult.asUnclosingStream()}
+            reactDebugStream={undefined}
+            debugEndTime={undefined}
+            preinitScripts={preinitScripts}
+            ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+            nonce={nonce}
+            images={ctx.renderOpts.images}
+          />,
+          {
+            onError: htmlRendererErrorHandler,
+            onHeaders: (headers: Headers) => {
+              headers.forEach((value, key) => {
+                appendHeader(key, value)
+              })
+            },
+            maxHeadersLength: reactMaxHeadersLength,
+            bootstrapScripts: [bootstrapScript],
+          }
+        )
+      const getServerInsertedHTML = makeGetServerInsertedHTML({
+        polyfills,
+        renderServerInsertedHTML,
+        serverCapturedErrors: allCapturedErrors,
+        basePath,
+        tracingMetadata: tracingMetadata,
+      })
+
+      // After awaiting here we've waited for the entire RSC render to complete. Crucially this means
+      // that when we detect whether we've used dynamic APIs below we know we'll have picked up even
+      // parts of the React Server render that might not be used in the SSR render.
+      const flightData = await streamToBuffer(reactServerResult.asStream())
+
+      if (shouldGenerateStaticFlightData(workStore)) {
+        metadata.flightData = flightData
+        metadata.segmentData = await collectSegmentData(
+          flightData,
+          ssrPrerenderStore,
+          ComponentMod,
+          renderOpts
+        )
+      }
+
+      const { prelude, preludeIsEmpty } =
+        await processPrelude(unprocessedPrelude)
+
+      /**
+       * When prerendering there are three outcomes to consider
+       *
+       *   Dynamic HTML:      The prerender has dynamic holes (caused by using Next.js Dynamic Rendering APIs)
+       *                      We will need to resume this result when requests are handled and we don't include
+       *                      any server inserted HTML or inlined flight data in the static HTML
+       *
+       *   Dynamic Data:      The prerender has no dynamic holes but dynamic APIs were used. We will not
+       *                      resume this render when requests are handled but we will generate new inlined
+       *                      flight data since it is dynamic and differences may end up reconciling on the client
+       *
+       *   Static:            The prerender has no dynamic holes and no dynamic APIs were used. We statically encode
+       *                      all server inserted HTML and flight data
+       */
+      // First we check if we have any dynamic holes in our HTML prerender
+      if (accessedDynamicData(dynamicTracking.dynamicAccesses)) {
+        if (postponed != null) {
+          // Dynamic HTML case.
+          metadata.postponed = await getDynamicHTMLPostponedState(
+            postponed,
+            preludeIsEmpty
+              ? DynamicHTMLPreludeState.Empty
+              : DynamicHTMLPreludeState.Full,
+            fallbackRouteParams,
+            prerenderResumeDataCache,
+            cacheComponents
+          )
+        } else {
+          // Dynamic Data case.
+          metadata.postponed = await getDynamicDataPostponedState(
+            prerenderResumeDataCache,
+            cacheComponents
+          )
+        }
+        // Regardless of whether this is the Dynamic HTML or Dynamic Data case we need to ensure we include
+        // server inserted html in the static response because the html that is part of the prerender may depend on it
+        // It is possible in the set of stream transforms for Dynamic HTML vs Dynamic Data may differ but currently both states
+        // require the same set so we unify the code path here
+        reactServerResult.consume()
+        return {
+          digestErrorsMap: reactServerErrorsByDigest,
+          ssrErrors: allCapturedErrors,
+          stream: await continueDynamicPrerender(prelude, {
+            getServerInsertedHTML,
+            getServerInsertedMetadata,
+          }),
+          dynamicAccess: dynamicTracking.dynamicAccesses,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: reactServerPrerenderStore.revalidate,
+          collectedExpire: reactServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(reactServerPrerenderStore.stale),
+          collectedTags: reactServerPrerenderStore.tags,
+        }
+      } else if (fallbackRouteParams && fallbackRouteParams.size > 0) {
+        // Rendering the fallback case.
+        metadata.postponed = await getDynamicDataPostponedState(
+          prerenderResumeDataCache,
+          cacheComponents
+        )
+
+        return {
+          digestErrorsMap: reactServerErrorsByDigest,
+          ssrErrors: allCapturedErrors,
+          stream: await continueDynamicPrerender(prelude, {
+            getServerInsertedHTML,
+            getServerInsertedMetadata,
+          }),
+          dynamicAccess: dynamicTracking.dynamicAccesses,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: reactServerPrerenderStore.revalidate,
+          collectedExpire: reactServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(reactServerPrerenderStore.stale),
+          collectedTags: reactServerPrerenderStore.tags,
+        }
+      } else {
+        // Static case
+        // We still have not used any dynamic APIs. At this point we can produce an entirely static prerender response
+        if (workStore.forceDynamic) {
+          throw new StaticGenBailoutError(
+            'Invariant: a Page with `dynamic = "force-dynamic"` did not trigger the dynamic pathway. This is a bug in Next.js'
+          )
+        }
+
+        let htmlStream = prelude
+        if (postponed != null) {
+          // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
+          // so we can set all the postponed boundaries to client render mode before we store the HTML response
+          const resume = (
+            require('react-dom/server') as typeof import('react-dom/server')
+          ).resume
+
+          // We don't actually want to render anything so we just pass a stream
+          // that never resolves. The resume call is going to abort immediately anyway
+          const foreverStream = new ReadableStream<Uint8Array>()
+
+          const resumeStream = await resume(
+            // eslint-disable-next-line @next/internal/no-ambiguous-jsx
+            <App
+              reactServerStream={foreverStream}
+              reactDebugStream={undefined}
+              debugEndTime={undefined}
+              preinitScripts={() => {}}
+              ServerInsertedHTMLProvider={ServerInsertedHTMLProvider}
+              nonce={nonce}
+              images={ctx.renderOpts.images}
+            />,
+            JSON.parse(JSON.stringify(postponed)),
+            {
+              signal: createRenderInBrowserAbortSignal(),
+              onError: htmlRendererErrorHandler,
+              nonce,
+            }
+          )
+
+          // First we write everything from the prerender, then we write everything from the aborted resume render
+          htmlStream = chainStreams(prelude, resumeStream)
+        }
+
+        return {
+          digestErrorsMap: reactServerErrorsByDigest,
+          ssrErrors: allCapturedErrors,
+          stream: await continueStaticPrerender(htmlStream, {
+            inlinedDataStream: createInlinedDataReadableStream(
+              reactServerResult.consumeAsStream(),
+              nonce,
+              formState
+            ),
+            getServerInsertedHTML,
+            getServerInsertedMetadata,
+            isBuildTimePrerendering:
+              ctx.workStore.isBuildTimePrerendering === true,
+            buildId: ctx.workStore.buildId,
+          }),
+          dynamicAccess: dynamicTracking.dynamicAccesses,
+          // TODO: Should this include the SSR pass?
+          collectedRevalidate: reactServerPrerenderStore.revalidate,
+          collectedExpire: reactServerPrerenderStore.expire,
+          collectedStale: selectStaleTime(reactServerPrerenderStore.stale),
+          collectedTags: reactServerPrerenderStore.tags,
         }
       }
     } else {

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -119,6 +119,7 @@ async function createComponentTreeInternal(
       createServerParamsForServerSegment,
       createPrerenderParamsForClientSegment,
       serverHooks: { DynamicServerError },
+      Postpone,
     },
     pagePath,
     getDynamicParamFromSegment,
@@ -303,6 +304,7 @@ async function createComponentTreeInternal(
         case 'prerender':
         case 'prerender-runtime':
         case 'prerender-legacy':
+        case 'prerender-ppr':
           if (workUnitStore.revalidate > defaultRevalidate) {
             workUnitStore.revalidate = defaultRevalidate
           }
@@ -688,6 +690,42 @@ async function createComponentTreeInternal(
   }
 
   const Component = MaybeComponent
+  // If force-dynamic is used and the current render supports postponing, we
+  // replace it with a node that will postpone the render. This ensures that the
+  // postpone is invoked during the react render phase and not during the next
+  // render phase.
+  // @TODO this does not actually do what it seems like it would or should do. The idea is that
+  // if we are rendering in a force-dynamic mode and we can postpone we should only make the segments
+  // that ask for force-dynamic to be dynamic, allowing other segments to still prerender. However
+  // because this comes after the children traversal and the static generation store is mutated every segment
+  // along the parent path of a force-dynamic segment will hit this condition effectively making the entire
+  // render force-dynamic. We should refactor this function so that we can correctly track which segments
+  // need to be dynamic
+  if (
+    workStore.isStaticGeneration &&
+    workStore.forceDynamic &&
+    experimental.isRoutePPREnabled
+  ) {
+    return createSeedData(
+      ctx,
+      createElement(
+        Fragment,
+        {
+          key: cacheNodeKey,
+        },
+        createElement(Postpone, {
+          reason: 'dynamic = "force-dynamic" was used',
+          route: workStore.route,
+        }),
+        layerAssets
+      ),
+      parallelRouteCacheNodeSeedData,
+      loadingData,
+      true,
+      hasRuntimePrefetch
+    )
+  }
+
   const isClientComponent = isClientReference(layoutOrPageMod)
 
   if (

--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -276,6 +276,7 @@ export async function decryptActionBoundArgs(
             }
             break
           case 'prerender-client':
+          case 'prerender-ppr':
           case 'prerender-legacy':
           case 'request':
           case 'cache':

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -38,6 +38,7 @@ export { createMetadataComponents } from '../../lib/metadata/metadata'
 export { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 
 export { preloadStyle, preloadFont, preconnect } from './rsc/preloads'
+export { Postpone } from './rsc/postpone'
 export { taintObjectReference } from './rsc/taint'
 export { collectSegmentData } from './collect-segment-data'
 

--- a/packages/next/src/server/app-render/rsc/postpone.ts
+++ b/packages/next/src/server/app-render/rsc/postpone.ts
@@ -1,0 +1,8 @@
+/*
+
+Files in the rsc directory are meant to be packaged as part of the RSC graph using next-app-loader.
+
+*/
+
+// When postpone is available in canary React we can switch to importing it directly
+export { Postpone } from '../dynamic-rendering'

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -123,6 +123,7 @@ export function getFlightStream<T>(
         return responseOnNextTick
       case 'prerender':
       case 'prerender-runtime':
+      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -134,6 +134,7 @@ import { toRoute } from './lib/to-route'
 import type { DeepReadonly } from '../shared/lib/deep-readonly'
 import { isNodeNextRequest, isNodeNextResponse } from './base-http/helpers'
 import { patchSetHeaderWithCookieSupport } from './lib/patch-set-header'
+import { checkIsAppPPREnabled } from './lib/experimental/ppr'
 import {
   getBuiltinRequestContext,
   type WaitUntil,
@@ -422,7 +423,7 @@ export default abstract class Server<
     readonly data: NextDataPathnameNormalizer | undefined
   }
 
-  private readonly isCacheComponentsEnabled: boolean
+  private readonly isAppPPREnabled: boolean
 
   /**
    * This is used to persist cache scopes across
@@ -504,8 +505,9 @@ export default abstract class Server<
 
     this.enabledDirectories = this.getEnabledDirectories(dev)
 
-    this.isCacheComponentsEnabled =
-      this.enabledDirectories.app && !!this.nextConfig.cacheComponents
+    this.isAppPPREnabled =
+      this.enabledDirectories.app &&
+      checkIsAppPPREnabled(this.nextConfig.experimental.ppr)
 
     this.normalizers = {
       // We should normalize the pathname from the RSC prefix only in minimal
@@ -1054,7 +1056,7 @@ export default abstract class Server<
           // It's important to execute the following block even it the request
           // matches a pages data route from above.
           if (
-            this.isCacheComponentsEnabled &&
+            this.isAppPPREnabled &&
             this.minimalMode &&
             req.headers[NEXT_RESUME_HEADER] === '1' &&
             req.method === 'POST'
@@ -2175,7 +2177,7 @@ export default abstract class Server<
      * enabled, then the given route _could_ support PPR.
      */
     const couldSupportPPR: boolean =
-      this.isCacheComponentsEnabled &&
+      this.isAppPPREnabled &&
       typeof routeModule !== 'undefined' &&
       isAppPageRouteModule(routeModule)
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -11,10 +11,7 @@ import type { WEB_VITALS } from '../shared/lib/utils'
 import type { NextParsedUrlQuery } from './request-meta'
 import type { SizeLimit } from '../types'
 import type { SupportedTestRunners } from '../cli/next-test'
-/**
- * @deprecated This type is only kept for backwards compatibility with the deprecated `experimental.ppr` config option.
- */
-export type ExperimentalPPRConfig = boolean | 'incremental'
+import type { ExperimentalPPRConfig } from './lib/experimental/ppr'
 import { INFINITE_CACHE } from '../lib/constants'
 import { isStableBuild } from '../shared/lib/errors/canary-only-config-error'
 import type { FallbackRouteParam } from '../build/static-paths/types'

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1350,6 +1350,9 @@ function assignDefaultsAndValidate(
   }
 
   if (result.cacheComponents) {
+    // TODO: remove once we've finished migrating internally to cacheComponents.
+    result.experimental.ppr = true
+
     // Prerender sourcemaps are enabled by default when using cacheComponents, unless explicitly disabled.
     if (result.enablePrerenderSourceMaps === undefined) {
       result.enablePrerenderSourceMaps = true

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -778,6 +778,7 @@ export default class DevServer extends Server {
           distDir: this.distDir,
           pathname,
           config: {
+            pprConfig: this.nextConfig.experimental.ppr,
             configFileName,
             cacheComponents: Boolean(this.nextConfig.cacheComponents),
           },

--- a/packages/next/src/server/dev/static-paths-worker.ts
+++ b/packages/next/src/server/dev/static-paths-worker.ts
@@ -17,6 +17,10 @@ import { loadComponents } from '../load-components'
 import { setHttpClientAndAgentOptions } from '../setup-http-agent-env'
 import type { IncrementalCache } from '../lib/incremental-cache'
 import { isAppPageRouteModule } from '../route-modules/checks'
+import {
+  checkIsRoutePPREnabled,
+  type ExperimentalPPRConfig,
+} from '../lib/experimental/ppr'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { collectRootParamKeys } from '../../build/segment-config/app/collect-root-param-keys'
 import { buildAppStaticPaths } from '../../build/static-paths/app'
@@ -25,6 +29,7 @@ import { createIncrementalCache } from '../../export/helpers/create-incremental-
 import { parseAppRoute } from '../../shared/lib/router/routes/app'
 
 type RuntimeConfig = {
+  pprConfig: ExperimentalPPRConfig | undefined
   configFileName: string
   cacheComponents: boolean
 }
@@ -121,7 +126,8 @@ export async function loadStaticPaths({
     }
 
     const isRoutePPREnabled =
-      isAppPageRouteModule(routeModule) && config.cacheComponents
+      isAppPageRouteModule(routeModule) &&
+      checkIsRoutePPREnabled(config.pprConfig)
 
     const rootParamKeys = collectRootParamKeys(routeModule)
 

--- a/packages/next/src/server/lib/experimental/ppr.ts
+++ b/packages/next/src/server/lib/experimental/ppr.ts
@@ -1,0 +1,52 @@
+/**
+ * If set to `incremental`, only those leaf pages that export
+ * `experimental_ppr = true` will have partial prerendering enabled. If any
+ * page exports this value as `false` or does not export it at all will not
+ * have partial prerendering enabled. If set to a boolean, the options for
+ * `experimental_ppr` will be ignored.
+ */
+
+export type ExperimentalPPRConfig = boolean | 'incremental'
+
+/**
+ * Returns true if partial prerendering is enabled for the application. It does
+ * not tell you if a given route has PPR enabled, as that requires analysis of
+ * the route's configuration.
+ *
+ * @see {@link checkIsRoutePPREnabled} - for checking if a specific route has PPR enabled.
+ */
+export function checkIsAppPPREnabled(
+  config: ExperimentalPPRConfig | undefined
+): boolean {
+  // If the config is undefined, partial prerendering is disabled.
+  if (typeof config === 'undefined') return false
+
+  // If the config is a boolean, use it directly.
+  if (typeof config === 'boolean') return config
+
+  // If the config is a string, it must be 'incremental' to enable partial
+  // prerendering.
+  if (config === 'incremental') return true
+
+  return false
+}
+
+/**
+ * Returns true if partial prerendering is supported for the current page with
+ * the provided app configuration. If the application doesn't have partial
+ * prerendering enabled, this function will always return false. If you want to
+ * check if the application has partial prerendering enabled
+ *
+ * @see {@link checkIsAppPPREnabled} for checking if the application has PPR enabled.
+ */
+export function checkIsRoutePPREnabled(
+  config: ExperimentalPPRConfig | undefined
+): boolean {
+  // If the config is undefined, partial prerendering is disabled.
+  if (typeof config === 'undefined') return false
+
+  // If the config is a boolean, use it directly.
+  if (typeof config === 'boolean') return config
+
+  return false
+}

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -358,6 +358,7 @@ export function createPatchedFetcher(
             case 'prerender-runtime':
             // TODO: Stop accumulating tags in client prerender. (fallthrough)
             case 'prerender-client':
+            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'cache':
             case 'private-cache':
@@ -398,6 +399,7 @@ export function createPatchedFetcher(
             case 'prerender':
             case 'prerender-client':
             case 'prerender-runtime':
+            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'request':
             case 'cache':
@@ -566,6 +568,7 @@ export function createPatchedFetcher(
                 )
               }
               break
+            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'cache':
             case 'private-cache':
@@ -691,6 +694,7 @@ export function createPatchedFetcher(
                     )
                   }
                   break
+                case 'prerender-ppr':
                 case 'prerender-legacy':
                 case 'cache':
                 case 'private-cache':
@@ -735,6 +739,7 @@ export function createPatchedFetcher(
             case 'prerender':
             case 'prerender-client':
             case 'prerender-runtime':
+            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'unstable-cache':
               break
@@ -880,6 +885,7 @@ export function createPatchedFetcher(
                       )
                     }
                   // fallthrough
+                  case 'prerender-ppr':
                   case 'prerender-legacy':
                   case 'cache':
                   case 'private-cache':
@@ -960,6 +966,7 @@ export function createPatchedFetcher(
                     )
                   }
                   break
+                case 'prerender-ppr':
                 case 'prerender-legacy':
                 case 'cache':
                 case 'private-cache':
@@ -1087,6 +1094,7 @@ export function createPatchedFetcher(
                     )
                   }
                   break
+                case 'prerender-ppr':
                 case 'prerender-legacy':
                 case 'cache':
                 case 'private-cache':
@@ -1136,6 +1144,7 @@ export function createPatchedFetcher(
                   case 'private-cache':
                   case 'unstable-cache':
                   case 'prerender-legacy':
+                  case 'prerender-ppr':
                     break
                   default:
                     workUnitStore satisfies never

--- a/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
@@ -244,6 +244,7 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
           }
         // intentional fallthrough
         case 'prerender-legacy':
+        case 'prerender-ppr':
         case 'cache':
         case 'unstable-cache':
         case 'private-cache':

--- a/packages/next/src/server/node-environment-extensions/unhandled-rejection.tsx
+++ b/packages/next/src/server/node-environment-extensions/unhandled-rejection.tsx
@@ -599,6 +599,7 @@ function filteringUnhandledRejectionHandler(
         }
         break
       }
+      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':

--- a/packages/next/src/server/node-environment-extensions/utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/utils.tsx
@@ -142,6 +142,7 @@ export function io(expression: string, type: ApiType) {
         }
       }
       break
+    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -4,6 +4,7 @@ import {
   workUnitAsyncStorage,
 } from '../app-render/work-unit-async-storage.external'
 import {
+  postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -82,6 +83,14 @@ export function connection(): Promise<void> {
             workUnitStore.renderSignal,
             workStore.route,
             '`connection()`'
+          )
+        case 'prerender-ppr':
+          // We use React's postpone API to interrupt rendering here to create a
+          // dynamic hole
+          return postponeWithTracking(
+            workStore.route,
+            'connection',
+            workUnitStore.dynamicTracking
           )
         case 'prerender-legacy':
           // We throw an error here to interrupt prerendering to mark the route

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -16,6 +16,7 @@ import {
 } from '../app-render/work-unit-async-storage.external'
 import {
   delayUntilRuntimeStage,
+  postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -78,6 +79,14 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
           const exportName = '`cookies`'
           throw new InvariantError(
             `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
+          )
+        case 'prerender-ppr':
+          // We need track dynamic access here eagerly to keep continuity with
+          // how cookies has worked in PPR without cacheComponents.
+          return postponeWithTracking(
+            workStore.route,
+            callingExpression,
+            workUnitStore.dynamicTracking
           )
         case 'prerender-legacy':
           // We track dynamic access here so we don't need to wrap the cookies

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -13,6 +13,7 @@ import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.exte
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
   delayUntilRuntimeStage,
+  postponeWithTracking,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -59,6 +60,7 @@ export function draftMode(): Promise<DraftMode> {
     // eslint-disable-next-line no-fallthrough
     case 'prerender':
     case 'prerender-client':
+    case 'prerender-ppr':
     case 'prerender-legacy':
       // Return empty draft mode
       return createOrGetCachedDraftMode(null, workStore)
@@ -218,6 +220,12 @@ function trackDynamicDraftMode(expression: string, constructorOpt: Function) {
           const exportName = '`draftMode`'
           throw new InvariantError(
             `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
+          )
+        case 'prerender-ppr':
+          return postponeWithTracking(
+            workStore.route,
+            expression,
+            workUnitStore.dynamicTracking
           )
         case 'prerender-legacy':
           workUnitStore.revalidate = 0

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -5,10 +5,16 @@ import {
 import type { OpaqueFallbackRouteParams } from './fallback-params'
 
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
-import { delayUntilRuntimeStage } from '../app-render/dynamic-rendering'
+import {
+  throwToInterruptStaticGeneration,
+  postponeWithTracking,
+  delayUntilRuntimeStage,
+} from '../app-render/dynamic-rendering'
 
 import {
   workUnitAsyncStorage,
+  type PrerenderStorePPR,
+  type PrerenderStoreLegacy,
   type StaticPrerenderStoreModern,
   type StaticPrerenderStore,
   throwInvariantForMissingStore,
@@ -40,6 +46,7 @@ export function createParamsFromClient(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderParams(
           underlyingParams,
@@ -92,6 +99,7 @@ export function createServerParamsForRoute(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderParams(
           underlyingParams,
@@ -137,6 +145,7 @@ export function createServerParamsForServerSegment(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderParams(
           underlyingParams,
@@ -211,6 +220,7 @@ export function createPrerenderParamsForClientSegment(
         throw new InvariantError(
           'createPrerenderParamsForClientSegment should not be called in cache contexts.'
         )
+      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'prerender-runtime':
       case 'request':
@@ -243,6 +253,22 @@ function createStaticPrerenderParams(
             // resolves.
             return makeHangingParams(
               underlyingParams,
+              workStore,
+              prerenderStore
+            )
+          }
+        }
+      }
+      break
+    }
+    case 'prerender-ppr': {
+      const fallbackParams = prerenderStore.fallbackRouteParams
+      if (fallbackParams) {
+        for (const key in underlyingParams) {
+          if (fallbackParams.has(key)) {
+            return makeErroringParams(
+              underlyingParams,
+              fallbackParams,
               workStore,
               prerenderStore
             )
@@ -348,6 +374,65 @@ function makeHangingParams(
   )
 
   CachedParams.set(underlyingParams, promise)
+
+  return promise
+}
+
+function makeErroringParams(
+  underlyingParams: Params,
+  fallbackParams: OpaqueFallbackRouteParams,
+  workStore: WorkStore,
+  prerenderStore: PrerenderStorePPR | PrerenderStoreLegacy
+): Promise<Params> {
+  const cachedParams = CachedParams.get(underlyingParams)
+  if (cachedParams) {
+    return cachedParams
+  }
+
+  const augmentedUnderlying = { ...underlyingParams }
+
+  // We don't use makeResolvedReactPromise here because params
+  // supports copying with spread and we don't want to unnecessarily
+  // instrument the promise with spreadable properties of ReactPromise.
+  const promise = Promise.resolve(augmentedUnderlying)
+  CachedParams.set(underlyingParams, promise)
+
+  Object.keys(underlyingParams).forEach((prop) => {
+    if (wellKnownProperties.has(prop)) {
+      // These properties cannot be shadowed because they need to be the
+      // true underlying value for Promises to work correctly at runtime
+    } else {
+      if (fallbackParams.has(prop)) {
+        Object.defineProperty(augmentedUnderlying, prop, {
+          get() {
+            const expression = describeStringPropertyAccess('params', prop)
+            // In most dynamic APIs we also throw if `dynamic = "error"` however
+            // for params is only dynamic when we're generating a fallback shell
+            // and even when `dynamic = "error"` we still support generating dynamic
+            // fallback shells
+            // TODO remove this comment when cacheComponents is the default since there
+            // will be no `dynamic = "error"`
+            if (prerenderStore.type === 'prerender-ppr') {
+              // PPR Prerender (no cacheComponents)
+              postponeWithTracking(
+                workStore.route,
+                expression,
+                prerenderStore.dynamicTracking
+              )
+            } else {
+              // Legacy Prerender
+              throwToInterruptStaticGeneration(
+                expression,
+                workStore,
+                prerenderStore
+              )
+            }
+          },
+          enumerable: true,
+        })
+      }
+    }
+  })
 
   return promise
 }

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -1,6 +1,10 @@
 import type { WorkStore } from '../app-render/work-async-storage.external'
 
-import { delayUntilRuntimeStage } from '../app-render/dynamic-rendering'
+import {
+  delayUntilRuntimeStage,
+  postponeWithTracking,
+  type DynamicTrackingState,
+} from '../app-render/dynamic-rendering'
 
 import {
   throwInvariantForMissingStore,
@@ -19,6 +23,7 @@ export function createServerPathnameForMetadata(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
+      case 'prerender-ppr':
       case 'prerender-legacy': {
         return createPrerenderPathname(
           underlyingPathname,
@@ -68,6 +73,13 @@ function createPrerenderPathname(
       }
       break
     }
+    case 'prerender-ppr': {
+      const fallbackParams = prerenderStore.fallbackRouteParams
+      if (fallbackParams && fallbackParams.size > 0) {
+        return makeErroringPathname(workStore, prerenderStore.dynamicTracking)
+      }
+      break
+    }
     case 'prerender-legacy':
       break
     default:
@@ -76,6 +88,41 @@ function createPrerenderPathname(
 
   // We don't have any fallback params so we have an entirely static safe params object
   return Promise.resolve(underlyingPathname)
+}
+
+function makeErroringPathname<T>(
+  workStore: WorkStore,
+  dynamicTracking: null | DynamicTrackingState
+): Promise<T> {
+  let reject: null | ((reason: unknown) => void) = null
+  const promise = new Promise<T>((_, re) => {
+    reject = re
+  })
+
+  const originalThen = promise.then.bind(promise)
+
+  // We instrument .then so that we can generate a tracking event only if you actually
+  // await this promise, not just that it is created.
+  promise.then = (onfulfilled, onrejected) => {
+    if (reject) {
+      try {
+        postponeWithTracking(
+          workStore.route,
+          'metadata relative url resolving',
+          dynamicTracking
+        )
+      } catch (error) {
+        reject(error)
+        reject = null
+      }
+    }
+    return originalThen(onfulfilled, onrejected)
+  }
+
+  // We wrap in a noop proxy to trick the runtime into thinking it
+  // isn't a native promise (it's not really). This is so that awaiting
+  // the promise will call the `then` property triggering the lazy postpone
+  return new Proxy(promise, {})
 }
 
 function createRenderPathname(underlyingPathname: string): Promise<string> {

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -60,6 +60,7 @@ import { StaticGenBailoutError } from '../../../client/components/static-generat
 import { isStaticGenEnabled } from './helpers/is-static-gen-enabled'
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
+  postponeWithTracking,
   createDynamicTrackingState,
   getFirstDynamicReason,
 } from '../../app-render/dynamic-rendering'
@@ -1207,6 +1208,12 @@ function trackDynamic(
       case 'prerender-runtime':
         throw new InvariantError(
           'A runtime prerender store should not be used for a route handler.'
+        )
+      case 'prerender-ppr':
+        return postponeWithTracking(
+          store.route,
+          expression,
+          workUnitStore.dynamicTracking
         )
       case 'prerender-legacy':
         workUnitStore.revalidate = 0

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -87,6 +87,7 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
     case 'prerender':
     case 'prerender-client':
     case 'prerender-runtime':
+    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':
     case 'unstable-cache':

--- a/packages/next/src/server/use-cache/cache-tag.ts
+++ b/packages/next/src/server/use-cache/cache-tag.ts
@@ -14,6 +14,7 @@ export function cacheTag(...tags: string[]): void {
     case 'prerender':
     case 'prerender-client':
     case 'prerender-runtime':
+    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':
     case 'unstable-cache':

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -1,4 +1,7 @@
-import { abortAndThrowOnSynchronousRequestDataAccess } from '../../app-render/dynamic-rendering'
+import {
+  abortAndThrowOnSynchronousRequestDataAccess,
+  postponeWithTracking,
+} from '../../app-render/dynamic-rendering'
 import { isDynamicRoute } from '../../../shared/lib/router/utils'
 import {
   NEXT_CACHE_IMPLICIT_TAG_ID,
@@ -158,6 +161,12 @@ function revalidate(
       case 'prerender-client':
         throw new InvariantError(
           `${expression} must not be used within a client component. Next.js should be preventing ${expression} from being included in client components statically, but did not in this case.`
+        )
+      case 'prerender-ppr':
+        return postponeWithTracking(
+          store.route,
+          expression,
+          workUnitStore.dynamicTracking
         )
       case 'prerender-legacy':
         workUnitStore.revalidate = 0

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -164,6 +164,7 @@ export function unstable_cache<T extends Callback>(
             case 'private-cache':
             case 'prerender':
             case 'prerender-runtime':
+            case 'prerender-ppr':
             case 'prerender-legacy':
               // We update the store's revalidate property if the option.revalidate is a higher precedence
               // options.revalidate === undefined doesn't affect timing.
@@ -408,6 +409,7 @@ function getFetchUrlPrefix(
     case 'prerender':
     case 'prerender-client':
     case 'prerender-runtime':
+    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -37,6 +37,7 @@ export function unstable_noStore() {
         case 'prerender-runtime':
           // unstable_noStore() is a noop in Dynamic I/O.
           return
+        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'request':
         case 'cache':

--- a/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
+++ b/test/e2e/app-dir/static-shell-debugging/static-shell-debugging.test.ts
@@ -1,25 +1,61 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('static-shell-debugging', () => {
-  // TODO: The static shell debugging feature (__nextppronly) needs to be
-  // reimplemented for the cacheComponents architecture. The feature was
-  // previously tied to the PPR render path which has been consolidated.
-  // For now, this test verifies the basic page rendering works correctly.
-  // When the feature is reimplemented, re-enable the static shell assertions.
+// TODO(NAR-423): Migrate to Cache Components.
+describe.skip('static-shell-debugging', () => {
+  const ppr = Boolean(process.env.__NEXT_CACHE_COMPONENTS)
+  const context = {
+    ppr,
+    debugging: ppr,
+  }
 
-  const { next, skipped } = nextTestSetup({
+  const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
+    // This test skips deployment because env vars that are doubled underscore prefixed
+    // are not supported. This is also intended to be used in development.
     skipDeployment: true,
+    env: {
+      __NEXT_EXPERIMENTAL_STATIC_SHELL_DEBUGGING: context.debugging
+        ? '1'
+        : undefined,
+    },
+    nextConfig: {
+      experimental: { ppr: context.ppr },
+    },
   })
 
   if (skipped) return
 
-  it('should render the full page', async () => {
-    const res = await next.fetch('/')
-    expect(res.status).toBe(200)
+  if (context.debugging && context.ppr) {
+    it('should only render the static shell', async () => {
+      const res = await next.fetch('/?__nextppronly=1')
+      expect(res.status).toBe(200)
 
-    const html = await res.text()
-    expect(html).toContain('Fallback')
-    expect(html).toContain('Dynamic')
-  })
+      const html = await res.text()
+      expect(html).toContain('Fallback')
+      expect(html).not.toContain('Dynamic')
+    })
+
+    // The __nextppronly query param is currently only supported in dev mode.
+    if (isNextDev) {
+      it('should skip hydration to avoid blanking out the page', async () => {
+        const browser = await next.browser('/?__nextppronly=1', {
+          waitHydration: false,
+        })
+
+        expect(await browser.elementByCss('div').text()).toBe('Fallback')
+
+        // Must not log the page error "Error: Connection closed."
+        expect(await browser.log()).toEqual([])
+      })
+    }
+  } else {
+    it('should render the full page', async () => {
+      const res = await next.fetch('/?__nextppronly=1')
+      expect(res.status).toBe(200)
+
+      const html = await res.text()
+      expect(html).toContain('Fallback')
+      expect(html).toContain('Dynamic')
+    })
+  }
 })

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -4,6 +4,8 @@ const { version: nextVersion } = require('next/package.json')
 
 const cacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
+const pprEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
+
 describe('build-output-prerender', () => {
   describe('with a next config file', () => {
     describe('without --debug-prerender', () => {
@@ -28,6 +30,20 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+            `)
+          }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack, Cache Components)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (webpack, Cache Components)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           }
         } else {
@@ -114,6 +130,28 @@ describe('build-output-prerender', () => {
              - Experiments (use with caution):
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
+               ⨯ serverMinification (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+             ▲ Next.js x.y.z (Turbopack, Cache Components)
+             - Experiments (use with caution):
+               ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+             ▲ Next.js x.y.z (webpack, Cache Components)
+             - Experiments (use with caution):
+               ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -240,6 +278,20 @@ describe('build-output-prerender', () => {
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (Turbopack)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "▲ Next.js x.y.z (webpack)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
+            `)
+          }
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
@@ -293,6 +345,28 @@ describe('build-output-prerender', () => {
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
+            `)
+          }
+        } else if (pprEnabled) {
+          if (isTurbopack) {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+              ▲ Next.js x.y.z (Turbopack)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
+                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
+            `)
+          } else {
+            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
+             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
+              ▲ Next.js x.y.z (webpack)
+              - Experiments (use with caution):
+                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
+                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
+                ⨯ serverMinification (disabled by \`--debug-prerender\`)
+                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         } else {

--- a/test/production/app-dir/metadata-streaming-config/app/dynamic/page.tsx
+++ b/test/production/app-dir/metadata-streaming-config/app/dynamic/page.tsx
@@ -1,15 +1,6 @@
-import { Suspense } from 'react'
 import { connection } from 'next/server'
 
-async function DynamicContent() {
+export default async function Page() {
   await connection()
   return <p>dynamic</p>
-}
-
-export default function Page() {
-  return (
-    <Suspense fallback={<p>Loading...</p>}>
-      <DynamicContent />
-    </Suspense>
-  )
 }

--- a/test/production/app-dir/metadata-streaming-config/app/ppr/page.tsx
+++ b/test/production/app-dir/metadata-streaming-config/app/ppr/page.tsx
@@ -1,15 +1,8 @@
-import { Suspense } from 'react'
 import { connection } from 'next/server'
 
-async function DynamicContent() {
+export default async function Page() {
   await connection()
   return <p>ppr</p>
 }
 
-export default function Page() {
-  return (
-    <Suspense fallback={<p>Loading...</p>}>
-      <DynamicContent />
-    </Suspense>
-  )
-}
+export const experimental_ppr = true

--- a/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
+++ b/test/production/app-dir/metadata-streaming-config/metadata-streaming-config-customized.test.ts
@@ -1,6 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('app-dir - metadata-streaming-config-customized', () => {
+// TODO: the incremental option has been removed, update to use cacheComponents
+describe.skip('app-dir - metadata-streaming-config-customized', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -8,7 +9,9 @@ describe('app-dir - metadata-streaming-config-customized', () => {
       'next.config.js': `
         module.exports = {
           htmlLimitedBots: /MyBot/i,
-          cacheComponents: true,
+            experimental: {
+            ppr: 'incremental',
+          }
         }
       `,
     },
@@ -30,26 +33,6 @@ describe('app-dir - metadata-streaming-config-customized', () => {
 
     expect(bypassConfigs).toMatchInlineSnapshot(`
      {
-       "/": {
-         "key": "user-agent",
-         "type": "header",
-         "value": "MyBot",
-       },
-       "/_global-error": {
-         "key": "user-agent",
-         "type": "header",
-         "value": "MyBot",
-       },
-       "/_not-found": {
-         "key": "user-agent",
-         "type": "header",
-         "value": "MyBot",
-       },
-       "/dynamic": {
-         "key": "user-agent",
-         "type": "header",
-         "value": "MyBot",
-       },
        "/ppr": {
          "key": "user-agent",
          "type": "header",

--- a/test/production/app-dir/metadata-streaming-config/next.config.js
+++ b/test/production/app-dir/metadata-streaming-config/next.config.js
@@ -2,7 +2,9 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  cacheComponents: true,
+  experimental: {
+    ppr: 'incremental',
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
This reverts commit a85d888a77707e60c55f1880b7307e4ba285e7a7.

PR #88243 introduced deploy test regressions in the following test suites:

- `test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts`
- `test/e2e/app-dir/segment-cache/client-params/client-params.test.ts`