### PR TITLE
[test] Remove rogue debug log

### DIFF
--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../../shared'
-import { workUnitAsyncStorage } from 'next/dist/server/app-render/work-unit-async-storage.external'
 
 type Params = { id: string }
 
@@ -25,11 +24,6 @@ export default async function Page({ params }: { params: Promise<Params> }) {
 }
 
 async function RuntimePrefetchable({ params }: { params: Promise<Params> }) {
-  const res = await params
-  console.log(
-    'RuntimePrefetchable :: awaited params',
-    res,
-    workUnitAsyncStorage.getStore()
-  )
+  await params
   return <div id="timestamp">Timestamp: {Date.now()}</div>
 }


### PR DESCRIPTION
Logging the work unit store caused the following runtime error under some circumstances:

```
TypeError: Cannot read private member #headersList from an object whose class did not declare it
```