### PR TITLE
Turbopack: use mimalloc on Linux musl

### DIFF
--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -12,13 +12,13 @@ bench = false
 [dependencies]
 
 
-[target.'cfg(not(any(target_os = "linux", target_family = "wasm", target_env = "musl")))'.dependencies]
+[target.'cfg(not(any(target_os = "linux", target_family = "wasm")))'.dependencies]
 mimalloc = { version = "0.1.48", features = [
   "v3",
   "extended",
 ], optional = true }
 
-[target.'cfg(all(target_os = "linux", not(any(target_family = "wasm", target_env = "musl"))))'.dependencies]
+[target.'cfg(all(target_os = "linux", not(target_family = "wasm")))'.dependencies]
 mimalloc = { version = "0.1.48", features = [
   "v3",
   "extended",

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -114,29 +114,17 @@ impl TurboMalloc {
 /// Get the allocator for this platform that we should wrap with TurboMalloc.
 #[inline]
 fn base_alloc() -> &'static impl GlobalAlloc {
-    #[cfg(all(
-        feature = "custom_allocator",
-        not(any(target_family = "wasm", target_env = "musl"))
-    ))]
+    #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
     return &mimalloc::MiMalloc;
-    #[cfg(any(
-        not(feature = "custom_allocator"),
-        any(target_family = "wasm", target_env = "musl")
-    ))]
+    #[cfg(not(all(feature = "custom_allocator", not(target_family = "wasm"))))]
     return &std::alloc::System;
 }
 
 #[allow(unused_variables)]
 unsafe fn base_alloc_size(ptr: *const u8, layout: Layout) -> usize {
-    #[cfg(all(
-        feature = "custom_allocator",
-        not(any(target_family = "wasm", target_env = "musl"))
-    ))]
+    #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
     return unsafe { mimalloc::MiMalloc.usable_size(ptr) };
-    #[cfg(any(
-        not(feature = "custom_allocator"),
-        any(target_family = "wasm", target_env = "musl")
-    ))]
+    #[cfg(not(all(feature = "custom_allocator", not(target_family = "wasm"))))]
     return layout.size();
 }
 


### PR DESCRIPTION
Closes #88174

With musl (i.e. Alpine), the system memory allocator can cause catastrophic slowdowns
- https://medium.com/p/stop-using-alpine-images-b51d12b0fde2
- https://nickb.dev/blog/default-musl-allocator-considered-harmful-to-performance/

We were seeing it cause a 10x slowdown, simply using mimalloc fixes this.

<img width="612" height="1091" alt="Bildschirmfoto 2026-01-12 um 15 00 29" src="https://github.com/user-attachments/assets/8de6dea3-012b-4c73-94e3-284d478bd7ef" />

<img width="1888" height="687" alt="Bildschirmfoto 2026-01-12 um 15 35 15" src="https://github.com/user-attachments/assets/d594d3ef-ae9b-468a-b022-032f1cf967e1" />
