### PR TITLE
docs: add useSearchParams and useParams documentation for Pages Router

### DIFF
--- a/docs/02-pages/04-api-reference/03-functions/use-params.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/use-params.mdx
@@ -1,0 +1,242 @@
+---
+title: useParams
+description: API Reference for the useParams hook in the Pages Router.
+---
+
+`useParams` is a hook that lets you read a route's [dynamic params](/docs/pages/building-your-application/routing/dynamic-routes) filled in by the current URL.
+
+```tsx filename="pages/shop/[slug].tsx" switcher
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const params = useParams<{ slug: string }>()
+
+  if (!params) {
+    // Render fallback UI while params are not yet available
+    return null
+  }
+
+  // Route -> /shop/[slug]
+  // URL -> /shop/shoes
+  // `params` -> { slug: 'shoes' }
+  return <>Shop: {params.slug}</>
+}
+```
+
+```jsx filename="pages/shop/[slug].js" switcher
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const params = useParams()
+
+  if (!params) {
+    // Render fallback UI while params are not yet available
+    return null
+  }
+
+  // Route -> /shop/[slug]
+  // URL -> /shop/shoes
+  // `params` -> { slug: 'shoes' }
+  return <>Shop: {params.slug}</>
+}
+```
+
+## Parameters
+
+```tsx
+const params = useParams()
+```
+
+`useParams` does not take any parameters.
+
+## Returns
+
+`useParams` returns an object containing the current route's filled in [dynamic parameters](/docs/pages/building-your-application/routing/dynamic-routes), or `null` during [pre-rendering](#behavior-during-pre-rendering).
+
+- Each property in the object is an active dynamic segment.
+- The property name is the segment's name, and the property value is what the segment is filled in with.
+- The property value will either be a `string` or array of `string`s depending on the [type of dynamic segment](/docs/pages/building-your-application/routing/dynamic-routes).
+- If the route contains no dynamic parameters, `useParams` returns an empty object.
+
+For example:
+
+| Route                        | URL         | `useParams()`             |
+| ---------------------------- | ----------- | ------------------------- |
+| `pages/shop/page.js`         | `/shop`     | `{}`                      |
+| `pages/shop/[slug].js`       | `/shop/1`   | `{ slug: '1' }`           |
+| `pages/shop/[tag]/[item].js` | `/shop/1/2` | `{ tag: '1', item: '2' }` |
+| `pages/shop/[...slug].js`    | `/shop/1/2` | `{ slug: ['1', '2'] }`    |
+
+> **Good to know**: `useParams` is a [React Hook](https://react.dev/learn#using-hooks) and cannot be used with classes.
+
+## Behavior
+
+### Behavior during pre-rendering
+
+For pages that are [statically optimized](/docs/pages/building-your-application/rendering/automatic-static-optimization), `useParams` will return `null` on the initial render. After hydration, the value will be updated to the actual params once the router is ready.
+
+This is because params cannot be known during static generation for dynamic routes.
+
+```tsx filename="pages/shop/[slug].tsx" switcher
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const params = useParams<{ slug: string }>()
+
+  if (!params) {
+    // Return a fallback UI while params are loading
+    // This prevents hydration mismatches
+    return <ShopPageSkeleton />
+  }
+
+  return <>Shop: {params.slug}</>
+}
+```
+
+```jsx filename="pages/shop/[slug].js" switcher
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const params = useParams()
+
+  if (!params) {
+    // Return a fallback UI while params are loading
+    // This prevents hydration mismatches
+    return <ShopPageSkeleton />
+  }
+
+  return <>Shop: {params.slug}</>
+}
+```
+
+### Using with `getServerSideProps`
+
+When using [`getServerSideProps`](/docs/pages/building-your-application/data-fetching/get-server-side-props), the page is server-rendered on each request and `useParams` will return the actual params immediately:
+
+```tsx filename="pages/shop/[slug].tsx" switcher
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const params = useParams<{ slug: string }>()
+
+  // With getServerSideProps, this fallback is never rendered because
+  // params is always available on the server. However, keeping
+  // the fallback allows this component to be reused on other pages
+  // that may not use getServerSideProps.
+  if (!params) {
+    return null
+  }
+
+  return <>Shop: {params.slug}</>
+}
+
+export async function getServerSideProps() {
+  return { props: {} }
+}
+```
+
+```jsx filename="pages/shop/[slug].js" switcher
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const params = useParams()
+
+  // With getServerSideProps, this fallback is never rendered because
+  // params is always available on the server. However, keeping
+  // the fallback allows this component to be reused on other pages
+  // that may not use getServerSideProps.
+  if (!params) {
+    return null
+  }
+
+  return <>Shop: {params.slug}</>
+}
+
+export async function getServerSideProps() {
+  return { props: {} }
+}
+```
+
+### Comparison with `router.query`
+
+`useParams` only returns the dynamic route parameters, whereas [`router.query`](/docs/pages/api-reference/functions/use-router#router-object) from `useRouter` includes both dynamic parameters and query string parameters.
+
+```tsx filename="pages/shop/[slug].tsx" switcher
+import { useRouter } from 'next/router'
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const router = useRouter()
+  const params = useParams()
+
+  // URL -> /shop/shoes?color=red
+
+  // router.query -> { slug: 'shoes', color: 'red' }
+  // params -> { slug: 'shoes' }
+
+  // ...
+}
+```
+
+```jsx filename="pages/shop/[slug].js" switcher
+import { useRouter } from 'next/router'
+import { useParams } from 'next/navigation'
+
+export default function ShopPage() {
+  const router = useRouter()
+  const params = useParams()
+
+  // URL -> /shop/shoes?color=red
+
+  // router.query -> { slug: 'shoes', color: 'red' }
+  // params -> { slug: 'shoes' }
+
+  // ...
+}
+```
+
+## Examples
+
+### Sharing components with App Router
+
+`useParams` from `next/navigation` works in both the Pages Router and App Router. This allows you to create shared components that work in either context:
+
+```tsx filename="components/breadcrumb.tsx" switcher
+import { useParams } from 'next/navigation'
+
+// This component works in both pages/ and app/
+export function Breadcrumb() {
+  const params = useParams<{ slug: string }>()
+
+  if (!params) {
+    // Fallback for Pages Router during pre-rendering
+    return <nav>Home / ...</nav>
+  }
+
+  return <nav>Home / {params.slug}</nav>
+}
+```
+
+```jsx filename="components/breadcrumb.js" switcher
+import { useParams } from 'next/navigation'
+
+// This component works in both pages/ and app/
+export function Breadcrumb() {
+  const params = useParams()
+
+  if (!params) {
+    // Fallback for Pages Router during pre-rendering
+    return <nav>Home / ...</nav>
+  }
+
+  return <nav>Home / {params.slug}</nav>
+}
+```
+
+> **Good to know**: When using this component in the App Router, `useParams` never returns `null`, so the fallback branch will not be rendered.
+
+## Version History
+
+| Version   | Changes                 |
+| --------- | ----------------------- |
+| `v13.3.0` | `useParams` introduced. |

--- a/docs/02-pages/04-api-reference/03-functions/use-search-params.mdx
+++ b/docs/02-pages/04-api-reference/03-functions/use-search-params.mdx
@@ -1,0 +1,318 @@
+---
+title: useSearchParams
+description: API Reference for the useSearchParams hook in the Pages Router.
+---
+
+`useSearchParams` is a hook that lets you read the current URL's **query string**.
+
+`useSearchParams` returns a **read-only** version of the [`URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams) interface.
+
+```tsx filename="pages/dashboard.tsx" switcher
+import { useSearchParams } from 'next/navigation'
+
+export default function Dashboard() {
+  const searchParams = useSearchParams()
+
+  if (!searchParams) {
+    // Render fallback UI while search params are not yet available
+    return null
+  }
+
+  const search = searchParams.get('search')
+
+  // URL -> `/dashboard?search=my-project`
+  // `search` -> 'my-project'
+  return <>Search: {search}</>
+}
+```
+
+```jsx filename="pages/dashboard.js" switcher
+import { useSearchParams } from 'next/navigation'
+
+export default function Dashboard() {
+  const searchParams = useSearchParams()
+
+  if (!searchParams) {
+    // Render fallback UI while search params are not yet available
+    return null
+  }
+
+  const search = searchParams.get('search')
+
+  // URL -> `/dashboard?search=my-project`
+  // `search` -> 'my-project'
+  return <>Search: {search}</>
+}
+```
+
+## Parameters
+
+```tsx
+const searchParams = useSearchParams()
+```
+
+`useSearchParams` does not take any parameters.
+
+## Returns
+
+`useSearchParams` returns a **read-only** version of the [`URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams) interface, or `null` during [pre-rendering](#behavior-during-pre-rendering).
+
+The interface includes utility methods for reading the URL's query string:
+
+- [`URLSearchParams.get()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/get): Returns the first value associated with the search parameter. For example:
+
+  | URL                  | `searchParams.get("a")`                                                                                         |
+  | -------------------- | --------------------------------------------------------------------------------------------------------------- |
+  | `/dashboard?a=1`     | `'1'`                                                                                                           |
+  | `/dashboard?a=`      | `''`                                                                                                            |
+  | `/dashboard?b=3`     | `null`                                                                                                          |
+  | `/dashboard?a=1&a=2` | `'1'` _- use [`getAll()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll) to get all values_ |
+
+- [`URLSearchParams.has()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/has): Returns a boolean value indicating if the given parameter exists. For example:
+
+  | URL              | `searchParams.has("a")` |
+  | ---------------- | ----------------------- |
+  | `/dashboard?a=1` | `true`                  |
+  | `/dashboard?b=3` | `false`                 |
+
+- Learn more about other **read-only** methods of [`URLSearchParams`](https://developer.mozilla.org/docs/Web/API/URLSearchParams), including the [`getAll()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/getAll), [`keys()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/keys), [`values()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/values), [`entries()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/entries), [`forEach()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/forEach), and [`toString()`](https://developer.mozilla.org/docs/Web/API/URLSearchParams/toString).
+
+> **Good to know**: `useSearchParams` is a [React Hook](https://react.dev/learn#using-hooks) and cannot be used with classes.
+
+## Behavior
+
+### Behavior during pre-rendering
+
+For pages that are [statically optimized](/docs/pages/building-your-application/rendering/automatic-static-optimization) (not using `getServerSideProps`), `useSearchParams` will return `null` during pre-rendering. After hydration, the value will be updated to the actual search params.
+
+This is because search params cannot be known during static generation as they depend on the request.
+
+```tsx filename="pages/dashboard.tsx" switcher
+import { useSearchParams } from 'next/navigation'
+
+export default function Dashboard() {
+  const searchParams = useSearchParams()
+
+  if (!searchParams) {
+    // Return a fallback UI while search params are loading
+    // This prevents hydration mismatches
+    return <DashboardSkeleton />
+  }
+
+  const search = searchParams.get('search')
+
+  return <>Search: {search}</>
+}
+```
+
+```jsx filename="pages/dashboard.js" switcher
+import { useSearchParams } from 'next/navigation'
+
+export default function Dashboard() {
+  const searchParams = useSearchParams()
+
+  if (!searchParams) {
+    // Return a fallback UI while search params are loading
+    // This prevents hydration mismatches
+    return <DashboardSkeleton />
+  }
+
+  const search = searchParams.get('search')
+
+  return <>Search: {search}</>
+}
+```
+
+### Using with `getServerSideProps`
+
+When using [`getServerSideProps`](/docs/pages/building-your-application/data-fetching/get-server-side-props), the page is server-rendered on each request and `useSearchParams` will return the actual search params immediately:
+
+```tsx filename="pages/dashboard.tsx" switcher
+import { useSearchParams } from 'next/navigation'
+
+export default function Dashboard() {
+  const searchParams = useSearchParams()
+
+  // With getServerSideProps, this fallback is never rendered because
+  // searchParams is always available on the server. However, keeping
+  // the fallback allows this component to be reused on other pages
+  // that may not use getServerSideProps.
+  if (!searchParams) {
+    return null
+  }
+
+  const search = searchParams.get('search')
+
+  return <>Search: {search}</>
+}
+
+export async function getServerSideProps() {
+  return { props: {} }
+}
+```
+
+```jsx filename="pages/dashboard.js" switcher
+import { useSearchParams } from 'next/navigation'
+
+export default function Dashboard() {
+  const searchParams = useSearchParams()
+
+  // With getServerSideProps, this fallback is never rendered because
+  // searchParams is always available on the server. However, keeping
+  // the fallback allows this component to be reused on other pages
+  // that may not use getServerSideProps.
+  if (!searchParams) {
+    return null
+  }
+
+  const search = searchParams.get('search')
+
+  return <>Search: {search}</>
+}
+
+export async function getServerSideProps() {
+  return { props: {} }
+}
+```
+
+## Examples
+
+### Updating search params
+
+You can use the [`useRouter`](/docs/pages/api-reference/functions/use-router) hook to update search params:
+
+```tsx filename="pages/dashboard.tsx" switcher
+import { useRouter } from 'next/router'
+import { useSearchParams } from 'next/navigation'
+import { useCallback } from 'react'
+
+export default function Dashboard() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const createQueryString = useCallback(
+    (name: string, value: string) => {
+      const params = new URLSearchParams(searchParams?.toString())
+      params.set(name, value)
+      return params.toString()
+    },
+    [searchParams]
+  )
+
+  if (!searchParams) {
+    return null
+  }
+
+  return (
+    <>
+      <p>Sort By</p>
+      <button
+        onClick={() => {
+          router.push(router.pathname + '?' + createQueryString('sort', 'asc'))
+        }}
+      >
+        ASC
+      </button>
+      <button
+        onClick={() => {
+          router.push(router.pathname + '?' + createQueryString('sort', 'desc'))
+        }}
+      >
+        DESC
+      </button>
+    </>
+  )
+}
+```
+
+```jsx filename="pages/dashboard.js" switcher
+import { useRouter } from 'next/router'
+import { useSearchParams } from 'next/navigation'
+import { useCallback } from 'react'
+
+export default function Dashboard() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const createQueryString = useCallback(
+    (name, value) => {
+      const params = new URLSearchParams(searchParams?.toString())
+      params.set(name, value)
+      return params.toString()
+    },
+    [searchParams]
+  )
+
+  if (!searchParams) {
+    return null
+  }
+
+  return (
+    <>
+      <p>Sort By</p>
+      <button
+        onClick={() => {
+          router.push(router.pathname + '?' + createQueryString('sort', 'asc'))
+        }}
+      >
+        ASC
+      </button>
+      <button
+        onClick={() => {
+          router.push(router.pathname + '?' + createQueryString('sort', 'desc'))
+        }}
+      >
+        DESC
+      </button>
+    </>
+  )
+}
+```
+
+### Sharing components with App Router
+
+`useSearchParams` from `next/navigation` works in both the Pages Router and App Router. This allows you to create shared components that work in either context:
+
+```tsx filename="components/search-bar.tsx" switcher
+import { useSearchParams } from 'next/navigation'
+
+// This component works in both pages/ and app/
+export function SearchBar() {
+  const searchParams = useSearchParams()
+
+  if (!searchParams) {
+    // Fallback for Pages Router during pre-rendering
+    return <input defaultValue="" placeholder="Search..." />
+  }
+
+  const search = searchParams.get('search') ?? ''
+
+  return <input defaultValue={search} placeholder="Search..." />
+}
+```
+
+```jsx filename="components/search-bar.js" switcher
+import { useSearchParams } from 'next/navigation'
+
+// This component works in both pages/ and app/
+export function SearchBar() {
+  const searchParams = useSearchParams()
+
+  if (!searchParams) {
+    // Fallback for Pages Router during pre-rendering
+    return <input defaultValue="" placeholder="Search..." />
+  }
+
+  const search = searchParams.get('search') ?? ''
+
+  return <input defaultValue={search} placeholder="Search..." />
+}
+```
+
+> **Good to know**: When using this component in the App Router, wrap it in a `<Suspense>` boundary for [static rendering](/docs/app/api-reference/functions/use-search-params#static-rendering) support.
+
+## Version History
+
+| Version   | Changes                       |
+| --------- | ----------------------------- |
+| `v13.0.0` | `useSearchParams` introduced. |


### PR DESCRIPTION
## Description

This PR adds dedicated documentation pages for `useSearchParams` and `useParams` hooks in the Pages Router documentation.

### Changes

- Added `docs/02-pages/04-api-reference/03-functions/use-search-params.mdx`
- Added `docs/02-pages/04-api-reference/03-functions/use-params.mdx`

### Why

Both `useSearchParams` and `useParams` from `next/navigation` work in the Pages Router, but this was not well documented. The only mention was a brief note in the App Router docs and a migration section in the Pages Router `useRouter` docs.

### What's Documented

For both hooks:
- Basic usage with the fallback UI pattern for handling `null` during pre-rendering
- Return values and behavior differences from App Router
- Usage with `getServerSideProps` (where params are immediately available)
- Examples for sharing components between App Router and Pages Router

For `useParams` specifically:
- Comparison with `router.query` (which includes both dynamic params and query string params)

### Related Test

The existing test at `test/e2e/app-dir/params-hooks-compat` validates that these hooks work in both routers.