### PR TITLE
docs: add guidance for code block highlight line numbers to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,3 +309,10 @@ See [Codebase structure](#codebase-structure) above for detailed explanations.
 - `findSourceMap()` needs `--enable-source-maps` flag or returns undefined
 - Source map paths vary (webpack: `./src/`, tsc: `src/`) - try multiple formats
 - `process.cwd()` in stack trace formatting produces different paths in tests vs production
+
+### Documentation Code Blocks
+
+- When adding `highlight={...}` attributes to code blocks, carefully count the actual line numbers within the code block
+- Account for empty lines, import statements, and type imports that shift line numbers
+- Highlights should point to the actual relevant code, not unrelated lines like `return (` or framework boilerplate
+- Double-check highlights by counting lines from 1 within each code block


### PR DESCRIPTION
## Summary

Adds a note to AGENTS.md reminding AI agents to carefully count line numbers when adding `highlight={...}` attributes to documentation code blocks.

### Changes

- Added "Documentation Code Blocks" subsection under Development Anti-Patterns in AGENTS.md
- Documents the importance of accounting for empty lines, imports, and type imports when specifying highlight line numbers