### PR TITLE
Type-check `run-tests.js` and remove unused `related` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "@types/shell-quote": "1.7.1",
     "@types/string-hash": "1.1.1",
     "@types/trusted-types": "2.0.3",
+    "@types/yargs": "16.0.11",
     "@vercel/devlow-bench": "workspace:*",
     "@vercel/kv": "3.0.0",
     "@vercel/og": "0.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       '@types/trusted-types':
         specifier: 2.0.3
         version: 2.0.3
+      '@types/yargs':
+        specifier: 16.0.11
+        version: 16.0.11
       '@vercel/devlow-bench':
         specifier: workspace:*
         version: link:turbopack/packages/devlow-bench
@@ -6904,6 +6907,9 @@ packages:
 
   '@types/yargs-parser@21.0.0':
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
+
+  '@types/yargs@16.0.11':
+    resolution: {integrity: sha512-sbtvk8wDN+JvEdabmZExoW/HNr1cB7D/j4LT08rMiuikfA7m/JNJg7ATQcgzs34zHnoScDkY0ZRSl29Fkmk36g==}
 
   '@types/yargs@17.0.10':
     resolution: {integrity: sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==}
@@ -24369,6 +24375,10 @@ snapshots:
       '@types/node': 20.17.6(patch_hash=rvl3vkomen3tospgr67bzubfyu)
 
   '@types/yargs-parser@21.0.0': {}
+
+  '@types/yargs@16.0.11':
+    dependencies:
+      '@types/yargs-parser': 21.0.0
 
   '@types/yargs@17.0.10':
     dependencies:

--- a/run-tests.js
+++ b/run-tests.js
@@ -29,12 +29,10 @@ let argv = require('yargs/yargs')(process.argv.slice(2))
   .string('g')
   .alias('g', 'group')
   .number('c')
-  .boolean('related')
   .boolean('dry')
   .boolean('print-tests')
   .describe('print-tests', 'Prints the test files that will be run')
   .boolean('local')
-  .alias('r', 'related')
   .alias('c', 'concurrency').argv
 
 function escapeRegexp(str) {
@@ -236,7 +234,6 @@ async function main() {
     group: argv.group ?? false,
     testPattern: argv.testPattern ?? false,
     type: argv.type ?? false,
-    related: argv.related ?? false,
     retries: argv.retries ?? DEFAULT_NUM_RETRIES,
     dry: argv.dry ?? false,
     local: argv.local ?? false,
@@ -286,20 +283,6 @@ async function main() {
 
     if (options.testPattern && typeof options.testPattern === 'string') {
       testPatternRegex = new RegExp(options.testPattern)
-    }
-
-    if (options.related) {
-      const { getRelatedTests } = await import('./scripts/run-related-test.mjs')
-      const tests = await getRelatedTests()
-      if (tests.length)
-        testPatternRegex = new RegExp(tests.map(escapeRegexp).join('|'))
-
-      if (testPatternRegex) {
-        console.log('Running related tests:', testPatternRegex.toString())
-      } else {
-        console.log('No matching related tests, exiting.')
-        process.exit(0)
-      }
     }
 
     tests = (
@@ -555,7 +538,6 @@ ${ENDGROUP}`)
               // Format the output of junit report to include the test name
               // For the debugging purpose to compare actual run list to the generated reports
               // [NOTE]: This won't affect if junit reporter is not enabled
-              // @ts-expect-error .replaceAll() does exist. Follow-up why TS is not recognizing it
               JEST_JUNIT_OUTPUT_NAME: test.file.replaceAll('/', '_'),
               // Specify suite name for the test to avoid unexpected merging across different env / grouped tests
               // This is not individual suites name (corresponding 'describe'), top level suite name which have redundant names by default

--- a/scripts/pack-next.ts
+++ b/scripts/pack-next.ts
@@ -34,7 +34,7 @@ interface CliOptions {
 
 const cliOptions = yargs(hideBin(process.argv))
   .scriptName('pack-next')
-  .command('$0')
+  .command('$0', 'Pack Next.js for testing in external projects')
   .option('js-build', {
     type: 'boolean',
     default: true,
@@ -60,17 +60,18 @@ const cliOptions = yargs(hideBin(process.argv))
       'none',
       'strip',
       ...(process.platform === 'linux' ? ['objcopy-zlib', 'objcopy-zstd'] : []),
-    ],
+    ] as const,
   })
-  .check((opts: CliOptions) => {
-    if (!opts.tar && (opts.compress ?? 'none') !== 'none') {
+  .check((opts) => {
+    const compress = opts.compress as CompressOpt | undefined
+    if (!opts.tar && (compress ?? 'none') !== 'none') {
       throw new Error('--compress is only valid in combination with --tar')
     }
     return true
   })
-  .middleware((opts: CliOptions) => {
+  .middleware((opts) => {
     if (opts.tar && process.platform === 'linux' && opts.compress == null) {
-      opts.compress = 'strip'
+      ;(opts as CliOptions).compress = 'strip'
     }
   })
   .strict().argv as unknown as CliOptions

--- a/scripts/patch-next.ts
+++ b/scripts/patch-next.ts
@@ -11,9 +11,7 @@ import buildNative from './build-native.js'
 interface Options {
   project: string
   build: boolean
-  noBuild: boolean
-  buildNative: boolean
-  noNativeBuild: boolean
+  'build-native': boolean
   verbose: number
   _: string[]
 }
@@ -21,15 +19,15 @@ interface Options {
 // --- Parse command line arguments ---
 const argv = yargs(hideBin(process.argv))
   .scriptName('patch-next')
-  .usage(
-    '$0 <project> [..options]',
-    'Patch Local Next.js packages to the target project directory',
-    (yargs: any) => {
-      yargs
+  .command(
+    '$0 <project> [options]',
+    'Patch local Next.js packages to the target project directory',
+    (yargs) => {
+      return yargs
         .positional('project', {
           type: 'string',
-          describe: ': Target directory of the Next.js Project to patch',
-          nargs: 1,
+          describe: 'Target directory of the Next.js project to patch',
+          demandOption: true,
         })
         .example(
           '$0 ../my-app --no-build --no-build-native',
@@ -69,7 +67,7 @@ const argv = yargs(hideBin(process.argv))
 const {
   project: projectDir,
   build,
-  buildNative: buildNativeEnabled,
+  'build-native': buildNativeEnabled,
   verbose: verboseLevel,
   _: buildNativeArgs,
 } = argv as Options

--- a/test/lib/create-next-install.js
+++ b/test/lib/create-next-install.js
@@ -41,7 +41,7 @@ async function installDependencies(cwd, tmpDir) {
  * @param {object} [param0.packageJson]
  * @param {string} [param0.subDir]
  * @param {boolean} [param0.keepRepoDir]
- * @param {(span: import('@next/telemetry').Span, installDir: string) => Promise<void>} param0.beforeInstall
+ * @param {(span: import('@next/telemetry').Span, installDir: string) => Promise<void>} [param0.beforeInstall]
  * @returns {Promise<{installDir: string, pkgPaths: Map<string, string>, tmpRepoDir: string | undefined}>}
  */
 async function createNextInstall({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     }
   },
   "include": [
+    "run-tests.js",
     "test/**/*.test.ts",
     "test/**/*.test.tsx",
     "test/**/*.util.ts",


### PR DESCRIPTION
The file already had the `@ts-check` directive, so the IDE did show errors in that file. But since it was not included in the root `tsconfig.json`, those errors were not reported during CI runs.

One issue found this way was that the `related` flag was defined but never used. The referenced script was removed in #67644.