### PR TITLE
[test] Always run all tests without aborting on failure

### DIFF
--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -91,7 +91,6 @@ jobs:
       afterBuild: |
         # e2e and ${{ inputs.test_type }} tests with `node run-tests.js`
 
-        export NEXT_TEST_CONTINUE_ON_ERROR=true
         export NEXT_TEST_MODE=${{
           inputs.test_type == 'development' && 'dev' || 'start'
         }}
@@ -122,8 +121,6 @@ jobs:
       nodeVersion: 20.9.0
       afterBuild: |
         # legacy integration tests with `node run-tests.js`
-
-        export NEXT_TEST_CONTINUE_ON_ERROR=true
 
         # HACK: Despite the name, these environment variables are just used to
         # gate tests, so they're applicable to both turbopack and rspack tests

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -19,10 +19,6 @@ on:
         description: Override the proxy address to use for the test
         default: ''
         type: string
-      continueOnError:
-        description: whether the tests should continue on failure
-        default: false
-        type: boolean
 
 env:
   TURBO_TEAM: 'vercel'
@@ -85,7 +81,6 @@ jobs:
         NEXT_E2E_TEST_TIMEOUT=240000 \
         NEXT_TEST_MODE=deploy \
         IS_WEBPACK_TEST=1 \
-        NEXT_TEST_CONTINUE_ON_ERROR="${{ github.event.inputs.continueOnError || false }}" \
         NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" \
         NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || needs.setup.outputs.next-version || 'canary' }}" \
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \

--- a/run-tests.js
+++ b/run-tests.js
@@ -685,7 +685,7 @@ ${ENDGROUP}`)
     }
 
     // Emit test output, parsed by the commenter webhook to notify about failing tests
-    if (isTestJob) {
+    if (!passed && isTestJob) {
       try {
         const testsOutput = await fsp.readFile(
           `${test.file}${RESULTS_EXT}`,

--- a/run-tests.js
+++ b/run-tests.js
@@ -477,6 +477,7 @@ ${ENDGROUP}`)
     '.bin',
     `jest${process.platform === 'win32' ? '.CMD' : ''}`
   )
+  let firstError = true
   let hadFailures = false
 
   const runTestOnce = (/** @type {TestFile} */ test, isFinalRun, isRetry) =>
@@ -590,7 +591,13 @@ ${ENDGROUP}`)
         if (isChildExitWithNonZero) {
           if (hideOutput) {
             await outputSema.acquire()
-            process.stdout.write(`${GROUP}❌ ${test.file} output\n`)
+            const isExpanded = firstError
+            if (isExpanded) {
+              firstError = false
+              process.stdout.write(`❌ ${test.file} output:\n`)
+            } else {
+              process.stdout.write(`${GROUP}❌ ${test.file} output\n`)
+            }
 
             let output = ''
             // limit out to last 64kb so that we don't
@@ -604,7 +611,11 @@ ${ENDGROUP}`)
               errorsPerTests.set(test.file, output)
             }
 
-            process.stdout.write(`end of ${test.file} output\n${ENDGROUP}\n`)
+            if (isExpanded) {
+              process.stdout.write(`end of ${test.file} output\n`)
+            } else {
+              process.stdout.write(`end of ${test.file} output\n${ENDGROUP}\n`)
+            }
             outputSema.release()
           }
           const err = new Error(

--- a/run-tests.js
+++ b/run-tests.js
@@ -53,10 +53,6 @@ const DEFAULT_NUM_RETRIES = 2
 const DEFAULT_CONCURRENCY = 2
 const RESULTS_EXT = `.results.json`
 const isTestJob = !!process.env.NEXT_TEST_JOB
-// Check env to see if test should continue even if some of test fails
-const shouldContinueTestsOnError =
-  process.env.NEXT_TEST_CONTINUE_ON_ERROR === 'true'
-
 const KV_TIMINGS_KEY = 'test-timings'
 
 const kvClient =
@@ -481,9 +477,6 @@ ${ENDGROUP}`)
     '.bin',
     `jest${process.platform === 'win32' ? '.CMD' : ''}`
   )
-  let firstError = true
-  const testController = new AbortController()
-  const testSignal = testController.signal
   let hadFailures = false
 
   const runTestOnce = (/** @type {TestFile} */ test, isFinalRun, isRetry) =>
@@ -597,16 +590,7 @@ ${ENDGROUP}`)
         if (isChildExitWithNonZero) {
           if (hideOutput) {
             await outputSema.acquire()
-            const isExpanded =
-              firstError && !testSignal.aborted && !shouldContinueTestsOnError
-            if (isExpanded) {
-              firstError = false
-              process.stdout.write(`❌ ${test.file} output:\n`)
-            } else if (testSignal.aborted) {
-              process.stdout.write(`${GROUP}${test.file} output (killed)\n`)
-            } else {
-              process.stdout.write(`${GROUP}❌ ${test.file} output\n`)
-            }
+            process.stdout.write(`${GROUP}❌ ${test.file} output\n`)
 
             let output = ''
             // limit out to last 64kb so that we don't
@@ -616,15 +600,11 @@ ${ENDGROUP}`)
               output += chunk.toString()
             }
 
-            if (process.env.CI && !testSignal.aborted) {
+            if (process.env.CI) {
               errorsPerTests.set(test.file, output)
             }
 
-            if (isExpanded) {
-              process.stdout.write(`end of ${test.file} output\n`)
-            } else {
-              process.stdout.write(`end of ${test.file} output\n${ENDGROUP}\n`)
-            }
+            process.stdout.write(`end of ${test.file} output\n${ENDGROUP}\n`)
             outputSema.release()
           }
           const err = new Error(
@@ -700,24 +680,12 @@ ${ENDGROUP}`)
 
     if (!passed) {
       hadFailures = true
-      const error = new Error(
-        // "failed to pass within" is a keyword parsed by next-pr-webhook
-        `${test.file} failed to pass within ${numRetries} retries`
-      )
-      console.error(error.message)
-
-      if (!shouldContinueTestsOnError) {
-        testController.abort(error)
-      } else {
-        console.log(
-          `CONTINUE_ON_ERROR enabled, continuing tests after ${test.file} failed`
-        )
-      }
+      // "failed to pass within" is a keyword parsed by next-pr-webhook
+      console.error(`${test.file} failed to pass within ${numRetries} retries`)
     }
 
-    // Emit test output if test failed or if we're continuing tests on error
-    // This is parsed by the commenter webhook to notify about failing tests
-    if ((!passed || shouldContinueTestsOnError) && isTestJob) {
+    // Emit test output, parsed by the commenter webhook to notify about failing tests
+    if (isTestJob) {
       try {
         const testsOutput = await fsp.readFile(
           `${test.file}${RESULTS_EXT}`,
@@ -761,13 +729,6 @@ ${ENDGROUP}`)
       await sema.acquire()
 
       try {
-        if (testSignal.aborted) {
-          // We already logged the abort reason. No need to include it in cause.
-          const error = new Error(`Skipped due to abort.`)
-          error.name = test.file
-          throw error
-        }
-
         await runTest(test)
       } finally {
         sema.release()
@@ -781,11 +742,6 @@ ${ENDGROUP}`)
       hadFailures = true
       console.error(result.reason)
     }
-  }
-
-  if (hadFailures && !shouldContinueTestsOnError) {
-    // TODO: Does it make sense to update timings if there were failures if without shouldContinueTestsOnError?
-    return hadFailures
   }
 
   if (options.timings) {


### PR DESCRIPTION
It's more useful and efficient to run all tests and report all failures instead of aborting on the first failure. This way, developers get a complete picture of what needs to be fixed in a single run, and don't have to go through multiple iterations of fixing one failure at a time.