### PR TITLE
refactor: consume global-error from loader tree

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -419,15 +419,6 @@ impl AppPageLoaderTreeBuilder {
         let loader_tree = &*loader_tree.await?;
 
         let modules = &loader_tree.modules;
-        // load global-error module
-        if let Some(global_error) = &modules.global_error {
-            let module = self
-                .base
-                .process_source(Vc::upcast(FileSource::new(global_error.clone())))
-                .to_resolved()
-                .await?;
-            self.base.inner_assets.insert(GLOBAL_ERROR.into(), module);
-        };
         // load global-not-found module
         if let Some(global_not_found) = &modules.global_not_found {
             let module = self
@@ -468,5 +459,4 @@ impl AppPageLoaderTreeModule {
     }
 }
 
-pub const GLOBAL_ERROR: &str = "GLOBAL_ERROR_MODULE";
 pub const GLOBAL_NOT_FOUND: &str = "GLOBAL_NOT_FOUND_MODULE";

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1850,7 +1850,8 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         // the build isn't app-only. If the build is app-only (no user pages/api), we should still
         // expose the app global error so runtime errors render, but we shouldn't emit it otherwise.
         if matches!(*next_mode.await?, NextMode::Build) {
-            // Use built-in global-error.js to create a `_global-error/page` route.
+            // Create a `_global-error/page` route using user's global-error.js or built-in
+            // fallback.
             let next_package = get_next_package(app_dir.clone()).await?;
             let global_error_tree = AppPageLoaderTree {
                 page: app_page.clone(),
@@ -1869,11 +1870,10 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                         static_siblings: Vec::new(),
                     }
                 },
-                // global-error is needed for getGlobalErrorStyles to work during rendering
+                // global-error is needed for getGlobalErrorStyles to work during rendering.
+                // Use user's custom global-error if defined, otherwise builtin fallback.
                 modules: AppDirModules {
-                    global_error: Some(
-                        next_package.join("dist/client/components/builtin/global-error.js")?,
-                    ),
+                    global_error: modules.global_error.clone(),
                     ..Default::default()
                 },
                 global_metadata,

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1742,6 +1742,13 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                     .join("dist/client/components/builtin/unauthorized.js")?,
             );
         }
+        if modules.global_error.is_none() {
+            modules.global_error = Some(
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/global-error.js")?,
+            );
+        }
 
         // Next.js has this logic in "collect-app-paths", where the root not-found page
         // is considered as its own entry point.
@@ -1752,14 +1759,6 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             is_global_not_found_enabled || modules.global_not_found.is_some();
 
         let not_found_root_modules = modules.without_leaves();
-        let global_error_path = match &modules.global_error {
-            Some(path) => Some(path.clone()),
-            None => Some(
-                get_next_package(app_dir.clone())
-                    .await?
-                    .join("dist/client/components/builtin/global-error.js")?,
-            ),
-        };
         let not_found_tree = AppPageLoaderTree {
             page: app_page.clone(),
             segment: directory_name.clone(),
@@ -1802,7 +1801,6 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                         }
                     },
                     modules: AppDirModules {
-                        global_error: global_error_path.clone(),
                         ..Default::default()
                     },
                     global_metadata,
@@ -1854,8 +1852,6 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         if matches!(*next_mode.await?, NextMode::Build) {
             // Use built-in global-error.js to create a `_global-error/page` route.
             let next_package = get_next_package(app_dir.clone()).await?;
-            let global_error_path =
-                Some(next_package.join("dist/client/components/builtin/global-error.js")?);
             let global_error_tree = AppPageLoaderTree {
                 page: app_page.clone(),
                 segment: directory_name.clone(),
@@ -1873,8 +1869,11 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                         static_siblings: Vec::new(),
                     }
                 },
+                // global-error is needed for getGlobalErrorStyles to work during rendering
                 modules: AppDirModules {
-                    global_error: global_error_path,
+                    global_error: Some(
+                        next_package.join("dist/client/components/builtin/global-error.js")?,
+                    ),
                     ..Default::default()
                 },
                 global_metadata,

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1752,6 +1752,14 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             is_global_not_found_enabled || modules.global_not_found.is_some();
 
         let not_found_root_modules = modules.without_leaves();
+        let global_error_path = match &modules.global_error {
+            Some(path) => Some(path.clone()),
+            None => Some(
+                get_next_package(app_dir.clone())
+                    .await?
+                    .join("dist/client/components/builtin/global-error.js")?,
+            ),
+        };
         let not_found_tree = AppPageLoaderTree {
             page: app_page.clone(),
             segment: directory_name.clone(),
@@ -1794,6 +1802,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                         }
                     },
                     modules: AppDirModules {
+                        global_error: global_error_path.clone(),
                         ..Default::default()
                     },
                     global_metadata,

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -1844,6 +1844,9 @@ async fn directory_tree_to_entrypoints_internal_untraced(
         // expose the app global error so runtime errors render, but we shouldn't emit it otherwise.
         if matches!(*next_mode.await?, NextMode::Build) {
             // Use built-in global-error.js to create a `_global-error/page` route.
+            let next_package = get_next_package(app_dir.clone()).await?;
+            let global_error_path =
+                Some(next_package.join("dist/client/components/builtin/global-error.js")?);
             let global_error_tree = AppPageLoaderTree {
                 page: app_page.clone(),
                 segment: directory_name.clone(),
@@ -1853,8 +1856,7 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                         segment: rcstr!("__PAGE__"),
                         parallel_routes: FxIndexMap::default(),
                         modules: AppDirModules {
-                            page: Some(get_next_package(app_dir.clone())
-                                .await?
+                            page: Some(next_package
                                 .join("dist/client/components/builtin/app-error.js")?),
                             ..Default::default()
                         },
@@ -1862,7 +1864,10 @@ async fn directory_tree_to_entrypoints_internal_untraced(
                         static_siblings: Vec::new(),
                     }
                 },
-                modules: AppDirModules::default(),
+                modules: AppDirModules {
+                    global_error: global_error_path,
+                    ..Default::default()
+                },
                 global_metadata,
                 static_siblings: Vec::new(),
             }

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -16,7 +16,7 @@ use turbopack_core::{
 use turbopack_ecmascript::runtime_functions::{TURBOPACK_LOAD, TURBOPACK_REQUIRE};
 
 use crate::{
-    app_page_loader_tree::{AppPageLoaderTreeModule, GLOBAL_ERROR},
+    app_page_loader_tree::AppPageLoaderTreeModule,
     app_structure::AppPageLoaderTree,
     next_app::{AppPage, AppPath, app_entry::AppEntry},
     next_config::NextConfig,
@@ -78,14 +78,6 @@ pub async fn get_app_page_entry(
         [
             ("VAR_DEFINITION_PAGE", &*page.to_string()),
             ("VAR_DEFINITION_PATHNAME", &pathname),
-            (
-                "VAR_MODULE_GLOBAL_ERROR",
-                if inner_assets.contains_key(GLOBAL_ERROR) {
-                    GLOBAL_ERROR
-                } else {
-                    "next/dist/client/components/builtin/global-error"
-                },
-            ),
         ],
         [
             ("tree", &*loader_tree_code),

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -982,5 +982,6 @@
   "981": "resolvedPathname must be set in request metadata",
   "982": "`serializeResumeDataCache` should not be called in edge runtime.",
   "983": "globalErrorModule is required but not found in loader tree",
-  "984": "Invariant: globalErrorModule is required but not found in loader tree"
+  "984": "Invariant: globalErrorModule is required but not found in loader tree",
+  "985": "Invariant: global-error module is required but not found in loader tree"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -981,7 +981,5 @@
   "980": "Failed to load client middleware manifest",
   "981": "resolvedPathname must be set in request metadata",
   "982": "`serializeResumeDataCache` should not be called in edge runtime.",
-  "983": "globalErrorModule is required but not found in loader tree",
-  "984": "Invariant: globalErrorModule is required but not found in loader tree",
-  "985": "Invariant: global-error module is required but not found in loader tree"
+  "983": "Invariant: global-error module is required but not found in loader tree"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -980,5 +980,7 @@
   "979": "invariant: expected %s bytes of postponed state but only received %s bytes",
   "980": "Failed to load client middleware manifest",
   "981": "resolvedPathname must be set in request metadata",
-  "982": "`serializeResumeDataCache` should not be called in edge runtime."
+  "982": "`serializeResumeDataCache` should not be called in edge runtime.",
+  "983": "globalErrorModule is required but not found in loader tree",
+  "984": "Invariant: globalErrorModule is required but not found in loader tree"
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -75,10 +75,6 @@ import {
  */
 declare const tree: LoaderTree
 
-// TODO this should ideally be read from the loader tree instead, where it's always inserted already anyway.
-import GlobalError from 'VAR_MODULE_GLOBAL_ERROR' with { 'turbopack-transition': 'next-server-component' }
-export { GlobalError }
-
 // These are injected by the loader afterwards.
 declare const __next_app_require__: (id: string | number) => unknown
 declare const __next_app_load_chunk__: (id: string | number) => Promise<unknown>
@@ -86,7 +82,6 @@ declare const __next_app_load_chunk__: (id: string | number) => Promise<unknown>
 // We inject the tree and pages here so that we can use them in the route
 // module.
 // INJECT:tree
-
 // INJECT:__next_app_require__
 // INJECT:__next_app_load_chunk__
 
@@ -491,7 +486,6 @@ export async function handler(
   const ComponentMod = {
     ...entryBase,
     tree,
-    GlobalError,
     handler,
     routeModule,
     __next_app__,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -443,6 +443,9 @@ async function createTreeCodeFromPath(
               )?.[1] ?? defaultGlobalNotFoundPath)
             : undefined
 
+          const globalErrorVarName = `globalError${nestedCollectedDeclarations.length}`
+          nestedCollectedDeclarations.push([globalErrorVarName, globalError])
+
           // If custom global-not-found.js is defined, use global-not-found.js
           if (matchedGlobalNotFound) {
             const varName = `notFound${nestedCollectedDeclarations.length}`
@@ -461,7 +464,12 @@ async function createTreeCodeFromPath(
                     ${JSON.stringify(defaultEmptyStubPath)}
                   ]
                 }]
-              }, {}]
+              }, {
+                '${GLOBAL_ERROR_FILE_TYPE}': [
+                  ${globalErrorVarName},
+                  ${JSON.stringify(globalError)}
+                ]
+              }]
             }`
           } else {
             // If custom not-found.js is found, use it and layout to compose the page,
@@ -479,7 +487,12 @@ async function createTreeCodeFromPath(
                     ${JSON.stringify(notFoundPath)}
                   ]
                 }]
-              }, {}]
+              }, {
+                '${GLOBAL_ERROR_FILE_TYPE}': [
+                  ${globalErrorVarName},
+                  ${JSON.stringify(globalError)}
+                ]
+              }]
             }`
           }
         }

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -443,9 +443,6 @@ async function createTreeCodeFromPath(
               )?.[1] ?? defaultGlobalNotFoundPath)
             : undefined
 
-          const globalErrorVarName = `globalError${nestedCollectedDeclarations.length}`
-          nestedCollectedDeclarations.push([globalErrorVarName, globalError])
-
           // If custom global-not-found.js is defined, use global-not-found.js
           if (matchedGlobalNotFound) {
             const varName = `notFound${nestedCollectedDeclarations.length}`
@@ -464,12 +461,7 @@ async function createTreeCodeFromPath(
                     ${JSON.stringify(defaultEmptyStubPath)}
                   ]
                 }]
-              }, {
-                '${GLOBAL_ERROR_FILE_TYPE}': [
-                  ${globalErrorVarName},
-                  ${JSON.stringify(globalError)}
-                ]
-              }]
+              }, {}]
             }`
           } else {
             // If custom not-found.js is found, use it and layout to compose the page,
@@ -487,12 +479,7 @@ async function createTreeCodeFromPath(
                     ${JSON.stringify(notFoundPath)}
                   ]
                 }]
-              }, {
-                '${GLOBAL_ERROR_FILE_TYPE}': [
-                  ${globalErrorVarName},
-                  ${JSON.stringify(globalError)}
-                ]
-              }]
+              }, {}]
             }`
           }
         }
@@ -500,24 +487,17 @@ async function createTreeCodeFromPath(
 
       // If it's app-error route, set app-error as children page
       if (isAppErrorRoute) {
-        const pageVarName = `appError${nestedCollectedDeclarations.length}`
-        nestedCollectedDeclarations.push([pageVarName, appErrorPath])
-        const globalErrorVarName = `globalError${nestedCollectedDeclarations.length}`
-        nestedCollectedDeclarations.push([globalErrorVarName, globalError])
+        const varName = `appError${nestedCollectedDeclarations.length}`
+        nestedCollectedDeclarations.push([varName, appErrorPath])
         subtreeCode = `{
           children: [${JSON.stringify(UNDERSCORE_GLOBAL_ERROR_ROUTE.slice(1))}, {
             children: ['${PAGE_SEGMENT_KEY}', {}, {
               page: [
-                ${pageVarName},
+                ${varName},
                 ${JSON.stringify(appErrorPath)}
               ]
             }]
-          }, {
-            '${GLOBAL_ERROR_FILE_TYPE}': [
-              ${globalErrorVarName},
-              ${JSON.stringify(globalError)}
-            ]
-          }]
+          }, {}]
         }`
       }
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -487,17 +487,24 @@ async function createTreeCodeFromPath(
 
       // If it's app-error route, set app-error as children page
       if (isAppErrorRoute) {
-        const varName = `appError${nestedCollectedDeclarations.length}`
-        nestedCollectedDeclarations.push([varName, appErrorPath])
+        const pageVarName = `appError${nestedCollectedDeclarations.length}`
+        nestedCollectedDeclarations.push([pageVarName, appErrorPath])
+        const globalErrorVarName = `globalError${nestedCollectedDeclarations.length}`
+        nestedCollectedDeclarations.push([globalErrorVarName, globalError])
         subtreeCode = `{
           children: [${JSON.stringify(UNDERSCORE_GLOBAL_ERROR_ROUTE.slice(1))}, {
             children: ['${PAGE_SEGMENT_KEY}', {}, {
               page: [
-                ${varName},
+                ${pageVarName},
                 ${JSON.stringify(appErrorPath)}
               ]
             }]
-          }, {}]
+          }, {
+            '${GLOBAL_ERROR_FILE_TYPE}': [
+              ${globalErrorVarName},
+              ${JSON.stringify(globalError)}
+            ]
+          }]
         }`
       }
 

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -1103,7 +1103,6 @@ const nextAppLoader: AppLoader = async function nextAppLoader() {
     {
       VAR_DEFINITION_PAGE: page,
       VAR_DEFINITION_PATHNAME: pathname,
-      VAR_MODULE_GLOBAL_ERROR: treeCodeResult.globalError,
     },
     {
       tree: treeCodeResult.treeCode,

--- a/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/index.ts
@@ -333,7 +333,7 @@ async function createTreeCodeFromPath(
         filePathEntries
       )
 
-      // Only resolve global-* convention files at the root layer
+      // Resolve global-* convention files at the root layer
       if (isRootLayer) {
         const resolvedGlobalErrorPath = await resolver(
           `${appDirPrefix}/${GLOBAL_ERROR_FILE_TYPE}`
@@ -341,9 +341,6 @@ async function createTreeCodeFromPath(
         if (resolvedGlobalErrorPath) {
           globalError = resolvedGlobalErrorPath
         }
-        // Add global-error to root layer's filePaths, so that it's always available,
-        // by default it's the built-in global-error.js
-        filePaths.set(GLOBAL_ERROR_FILE_TYPE, globalError)
 
         // TODO(global-not-found): remove this flag assertion condition
         //  once global-not-found is stable
@@ -359,6 +356,10 @@ async function createTreeCodeFromPath(
           filePaths.set(GLOBAL_NOT_FOUND_FILE_TYPE, globalNotFound)
         }
       }
+
+      // Add global-error to ALL layers' filePaths, so that it's always available.
+      // By default it's the built-in global-error.js, or user's custom one if defined.
+      filePaths.set(GLOBAL_ERROR_FILE_TYPE, globalError)
 
       let definedFilePaths = Array.from(filePaths.entries()).filter(
         ([, filePath]) => filePath !== undefined

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5545,19 +5545,16 @@ const getGlobalErrorStyles = async (
   const {
     componentMod: { createElement },
   } = ctx
-  const GlobalErrorComponent: GlobalErrorComponent =
-    ctx.componentMod.GlobalError
-  let globalErrorStyles
-  if (globalErrorModule) {
-    const [, styles] = await createComponentStylesAndScripts({
-      ctx,
-      filePath: globalErrorModule[1],
-      getComponent: globalErrorModule[0],
-      injectedCSS: new Set(),
-      injectedJS: new Set(),
-    })
-    globalErrorStyles = styles
-  }
+
+  const [GlobalErrorComponent, styles] = await createComponentStylesAndScripts({
+    ctx,
+    filePath: globalErrorModule![1],
+    getComponent: globalErrorModule![0],
+    injectedCSS: new Set(),
+    injectedJS: new Set(),
+  })
+
+  let globalErrorStyles: ReactNode = styles
   if (ctx.renderOpts.dev) {
     const dir =
       (process.env.NEXT_RUNTIME === 'edge'
@@ -5566,7 +5563,7 @@ const getGlobalErrorStyles = async (
 
     const globalErrorModulePath = normalizeConventionFilePath(
       dir,
-      globalErrorModule?.[1]
+      globalErrorModule![1]
     )
     if (globalErrorModulePath) {
       const SegmentViewNode = ctx.componentMod.SegmentViewNode

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -388,9 +388,12 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
     {
       children: [PAGE_SEGMENT_KEY, {}, notFoundTreeComponents, null],
     },
-    // When global-not-found is present, use full components including global-error.
-    // Otherwise, use empty modules - getGlobalErrorStyles will fall back to the default.
-    hasGlobalNotFound ? components : {},
+    // Always include global-error so that getGlobalErrorStyles can access it.
+    // When global-not-found is present, use full components.
+    // Otherwise, only include global-error module.
+    hasGlobalNotFound
+      ? components
+      : { 'global-error': components['global-error'] },
     null, // staticSiblings
   ]
 }
@@ -5547,18 +5550,16 @@ const getGlobalErrorStyles = async (
     componentMod: { createElement },
   } = ctx
 
-  // If globalErrorModule is not available (e.g., during error rendering),
-  // fall back to the default global error component
+  // globalErrorModule should always be available as it's bundled by default
+  // (either user's custom global-error or the builtin one)
   if (!globalErrorModule) {
-    const DefaultGlobalError: GlobalErrorComponent = (
-      await import('../../client/components/builtin/global-error')
-    ).default
-    return {
-      GlobalError: DefaultGlobalError,
-      styles: undefined,
-    }
+    // This shouldn't happen in normal circumstances, but handle gracefully
+    throw new Error(
+      'Invariant: globalErrorModule is required but not found in loader tree'
+    )
   }
 
+  // Get the GlobalError component and styles from the loader tree
   const [GlobalErrorComponent, styles] = await createComponentStylesAndScripts({
     ctx,
     filePath: globalErrorModule[1],
@@ -5568,6 +5569,7 @@ const getGlobalErrorStyles = async (
   })
 
   let globalErrorStyles: ReactNode = styles
+
   if (ctx.renderOpts.dev) {
     const dir =
       (process.env.NEXT_RUNTIME === 'edge'

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5546,10 +5546,22 @@ const getGlobalErrorStyles = async (
     componentMod: { createElement },
   } = ctx
 
+  // If globalErrorModule is not available (e.g., during error rendering),
+  // fall back to the default global error component
+  if (!globalErrorModule) {
+    const DefaultGlobalError: GlobalErrorComponent = (
+      await import('../../client/components/builtin/global-error')
+    ).default
+    return {
+      GlobalError: DefaultGlobalError,
+      styles: undefined,
+    }
+  }
+
   const [GlobalErrorComponent, styles] = await createComponentStylesAndScripts({
     ctx,
-    filePath: globalErrorModule![1],
-    getComponent: globalErrorModule![0],
+    filePath: globalErrorModule[1],
+    getComponent: globalErrorModule[0],
     injectedCSS: new Set(),
     injectedJS: new Set(),
   })
@@ -5563,7 +5575,7 @@ const getGlobalErrorStyles = async (
 
     const globalErrorModulePath = normalizeConventionFilePath(
       dir,
-      globalErrorModule![1]
+      globalErrorModule[1]
     )
     if (globalErrorModulePath) {
       const SegmentViewNode = ctx.componentMod.SegmentViewNode

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5542,22 +5542,17 @@ const getGlobalErrorStyles = async (
   GlobalError: GlobalErrorComponent
   styles: ReactNode | undefined
 }> => {
-  const {
-    modules: { 'global-error': globalErrorModule },
-  } = parseLoaderTree(tree)
+  const globalErrorModule = parseLoaderTree(tree).modules['global-error']
+
+  if (!globalErrorModule) {
+    throw new Error(
+      'Invariant: global-error module is required but not found in loader tree'
+    )
+  }
 
   const {
     componentMod: { createElement },
   } = ctx
-
-  // globalErrorModule should always be available as it's bundled by default
-  // (either user's custom global-error or the builtin one)
-  if (!globalErrorModule) {
-    // This shouldn't happen in normal circumstances, but handle gracefully
-    throw new Error(
-      'Invariant: globalErrorModule is required but not found in loader tree'
-    )
-  }
 
   // Get the GlobalError component and styles from the loader tree
   const [GlobalErrorComponent, styles] = await createComponentStylesAndScripts({

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -388,7 +388,8 @@ function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
     {
       children: [PAGE_SEGMENT_KEY, {}, notFoundTreeComponents, null],
     },
-    // When global-not-found is present, skip layout from components
+    // When global-not-found is present, use full components including global-error.
+    // Otherwise, use empty modules - getGlobalErrorStyles will fall back to the default.
     hasGlobalNotFound ? components : {},
     null, // staticSiblings
   ]

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -170,7 +170,7 @@ describe('opentelemetry', () => {
                       },
                       {
                         attributes: {
-                          'next.clientComponentLoadCount': isNextDev ? 7 : 6,
+                          'next.clientComponentLoadCount': isNextDev ? 8 : 7,
                           'next.span_type':
                             'NextNodeServer.clientComponentLoading',
                         },
@@ -578,7 +578,7 @@ describe('opentelemetry', () => {
                       },
                       {
                         attributes: {
-                          'next.clientComponentLoadCount': isNextDev ? 10 : 8,
+                          'next.clientComponentLoadCount': isNextDev ? 12 : 10,
                           'next.span_type':
                             'NextNodeServer.clientComponentLoading',
                         },
@@ -701,7 +701,7 @@ describe('opentelemetry', () => {
                       },
                       {
                         attributes: {
-                          'next.clientComponentLoadCount': isNextDev ? 8 : 7,
+                          'next.clientComponentLoadCount': isNextDev ? 9 : 8,
                           'next.span_type':
                             'NextNodeServer.clientComponentLoading',
                         },
@@ -1380,7 +1380,7 @@ describe('opentelemetry with custom server', () => {
                   },
                   {
                     attributes: {
-                      'next.clientComponentLoadCount': isNextDev ? 7 : 6,
+                      'next.clientComponentLoadCount': isNextDev ? 8 : 7,
                       'next.span_type': 'NextNodeServer.clientComponentLoading',
                     },
                     kind: 0,


### PR DESCRIPTION
Always consume global-error module from loader tree, instead from the `ComponentMod`.

This removes the `GlobalError` export in the `ComponentMod`


The telemetry tests change is because: Before it was imported in the entry file, where that module is already loaded.

And now after we switched to access it in the loader tree, the getComponent is executed during render, then it will go through the __next_app__ require stuff which is instrumented with client component count
https://github.com/vercel/next.js/blob/363783dbbca73fa77aa6bb6be57d1397b8557e2e/packages/next/src/server/client-component-renderer-logger.ts#L16

x-ref: [slack](https://vercel.slack.com/archives/C04KC8A53T7/p1768231417652559)