### PR TITLE
Deobfuscate function names in stack traces using V8 enclosing position APIs

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -374,9 +374,7 @@ function getSourcemappedFrameIfPossible(
     }
     let maybeSourceMapPayload: ModernSourceMapPayload | undefined
     try {
-      console.error('looking up source map for ', sourceURL)
       const sourceMap = nativeFindSourceMap(sourceURL)
-      console.error('\tfound source map')
       maybeSourceMapPayload = sourceMap?.payload
     } catch (cause) {
       // We should not log an actual error instance here because that will re-enter
@@ -395,12 +393,10 @@ function getSourcemappedFrameIfPossible(
       // source map.
       return createUnsourcemappedFrame(frame)
     }
-    console.error('1: maybeSourceMapPayload=', maybeSourceMapPayload)
     if (maybeSourceMapPayload === undefined) {
       maybeSourceMapPayload = bundlerFindSourceMapPayload(sourceURL)
     }
 
-    console.error('2: maybeSourceMapPayload=', maybeSourceMapPayload)
     if (maybeSourceMapPayload === undefined) {
       return createUnsourcemappedFrame(frame)
     }
@@ -412,13 +408,11 @@ function getSourcemappedFrameIfPossible(
       // relative paths but is actually wrong (the chunk and sourcemap have different content hashes).
       // We are using the node API to read the sourcemap and it doesn't give us access to the URI.
       const sourceMapURL = sourceURL + '.map'
-      console.error('about to parse sourcemap for ', sourceURL)
       sourceMapConsumer = new SyncSourceMapConsumer(
         sourceMapPayload,
         // @ts-expect-error: our typings don't include this parameter but it is here.
         sourceMapURL
       )
-      console.error('\tparsed source map')
     } catch (cause) {
       // We should not log an actual error instance here because that will re-enter
       // this codepath during error inspection and could lead to infinite recursion.

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs'
 import { findSourceMap as nativeFindSourceMap } from 'module'
 import * as path from 'path'
 import * as url from 'url'
@@ -13,6 +14,38 @@ import { parseStack, type StackFrame } from './lib/parse-stack'
 import { getOriginalCodeFrame } from '../next-devtools/server/shared'
 import { workUnitAsyncStorage } from './app-render/work-unit-async-storage.external'
 import { dim, italic } from '../lib/picocolors'
+
+/**
+ * V8 CallSite interface - we only need toString() and enclosing position methods.
+ * @see https://v8.dev/docs/stack-trace-api
+ */
+interface CallSite {
+  toString(): string
+  // V8-specific methods for getting enclosing function location.
+  // These may not be available in all runtimes (e.g., Bun).
+  getEnclosingLineNumber?(): number | null
+  getEnclosingColumnNumber?(): number | null
+}
+
+/**
+ * Enclosing function position for a stack frame.
+ * Used for looking up original function names in source maps.
+ */
+interface EnclosingPosition {
+  /** 1-indexed line number where the enclosing function is defined */
+  line: number
+  /** 1-indexed column number where the enclosing function is defined */
+  column: number
+}
+
+/**
+ * Captured enclosing positions from V8 CallSite objects, keyed by Error.
+ * Positions are stored by frame index to correlate with parsed stack frames.
+ */
+const capturedEnclosingPositions = new WeakMap<
+  Error,
+  Array<EnclosingPosition | null>
+>()
 
 type FindSourceMapPayload = (
   sourceURL: string
@@ -33,10 +66,161 @@ interface IgnorableStackFrame extends StackFrame {
   ignored: boolean
 }
 
-type SourceMapCache = Map<
-  string,
-  null | { map: SyncSourceMapConsumer; payload: ModernSourceMapPayload }
->
+/**
+ * Name mappings indexed by generated line number.
+ * Each entry is an array of {column, name} sorted by column.
+ */
+type NameMappingsByLine = Map<number, Array<{ column: number; name: string }>>
+
+/**
+ * Source map cache entry with optional name mappings and generated source.
+ */
+interface SourceMapCacheEntry {
+  map: SyncSourceMapConsumer
+  payload: ModernSourceMapPayload
+  /** Cached name mappings for efficient lookup */
+  nameMappings?: NameMappingsByLine
+  /** Cached generated source file content for name validation */
+  generatedSource?: string | null
+  /** File name (URL) for reading generated source */
+  fileName: string
+}
+
+type SourceMapCache = Map<string, null | SourceMapCacheEntry>
+
+/**
+ * Lazily get the generated source content from a cache entry.
+ */
+function getGeneratedSource(entry: SourceMapCacheEntry): string | null {
+  if (entry.generatedSource === undefined) {
+    try {
+      let filePath = entry.fileName
+      if (filePath.startsWith('file://')) {
+        filePath = url.fileURLToPath(filePath)
+      } else if (!path.isAbsolute(filePath)) {
+        // Can't read non-file URLs (webpack-internal://, etc.)
+        entry.generatedSource = null
+        return null
+      }
+      entry.generatedSource = fs.readFileSync(filePath, 'utf-8')
+    } catch {
+      entry.generatedSource = null
+    }
+  }
+  return entry.generatedSource
+}
+
+/**
+ * Get the offset of a specific line in the source without creating a substring.
+ */
+function getLineOffset(source: string, line: number): number {
+  if (line < 1) return -1
+  let currentLine = 1
+  let lineStart = 0
+  while (currentLine < line) {
+    const nextNewline = source.indexOf('\n', lineStart)
+    if (nextNewline === -1) return -1
+    lineStart = nextNewline + 1
+    currentLine++
+  }
+  return lineStart
+}
+
+/**
+ * Check if a function name exists at a given position in source code.
+ * Function names must be followed by '(', '=', ':', or whitespace.
+ */
+function isFunctionNameAtPosition(
+  source: string,
+  line: number,
+  column: number,
+  name: string
+): boolean {
+  const lineOffset = getLineOffset(source, line)
+  if (lineOffset === -1) return false
+  const pos = lineOffset + column
+  if (!source.startsWith(name, pos)) return false
+  const endPos = pos + name.length
+  return endPos < source.length && /[(=:\s]/.test(source[endPos])
+}
+
+/**
+ * Lazily build and cache name mappings from a source map.
+ */
+function getNameMappings(entry: SourceMapCacheEntry): NameMappingsByLine {
+  if (!entry.nameMappings) {
+    const nameMappings: NameMappingsByLine = new Map()
+    try {
+      entry.map.eachMapping((mapping) => {
+        if (!mapping.name) return
+        let lineEntries = nameMappings.get(mapping.generatedLine)
+        if (!lineEntries) {
+          lineEntries = []
+          nameMappings.set(mapping.generatedLine, lineEntries)
+        }
+        lineEntries.push({
+          column: mapping.generatedColumn,
+          name: mapping.name,
+        })
+      })
+      for (const entries of nameMappings.values()) {
+        entries.sort((a, b) => a.column - b.column)
+      }
+    } catch {
+      // Some source maps may have invalid internal state - return empty mappings
+      nameMappings.clear()
+    }
+    entry.nameMappings = nameMappings
+  }
+  return entry.nameMappings
+}
+
+/**
+ * Find a valid original function name near the given enclosing position.
+ * Only searches forward since V8's enclosing position points to the start
+ * of the function definition (async/function keyword).
+ */
+function findNameAtPosition(
+  nameMappings: NameMappingsByLine,
+  line: number,
+  column: number,
+  generatedSource: string | null,
+  mangledName: string | undefined
+): string | undefined {
+  const lineEntries = nameMappings.get(line) ?? []
+
+  // Without generated source, we can't validate - don't use source map names
+  if (!generatedSource || !mangledName) return undefined
+
+  // Only search forward, typical distance: "async function " = 15 chars
+  const maxForwardDistance = 16
+
+  // Binary search for first entry at or after column
+  let startIdx = 0
+  let endIdx = lineEntries.length
+  while (startIdx < endIdx) {
+    const mid = (startIdx + endIdx) >> 1
+    if (lineEntries[mid].column < column) {
+      startIdx = mid + 1
+    } else {
+      endIdx = mid
+    }
+  }
+
+  // Check the first entry at or after the enclosing position
+  if (startIdx < lineEntries.length) {
+    const entry = lineEntries[startIdx]
+    if (
+      entry.column >= column &&
+      entry.column - column < maxForwardDistance &&
+      isFunctionNameAtPosition(generatedSource, line, entry.column, mangledName)
+    ) {
+      return entry.name
+    }
+  }
+
+  return undefined
+}
 
 function frameToString(
   methodName: string | null,
@@ -80,10 +264,25 @@ function computeErrorName(error: Error): string {
 
 function prepareUnsourcemappedStackTrace(
   error: Error,
-  structuredStackTrace: any[]
+  structuredStackTrace: CallSite[]
 ): string {
   const name = computeErrorName(error)
   const message = error.message || ''
+
+  // Capture enclosing positions for later use in name deobfuscation.
+  // These V8-specific APIs give us the position where the enclosing function
+  // is defined, which we can use to look up original function names in source maps.
+  const positions = structuredStackTrace.map((callSite) => {
+    const line = callSite.getEnclosingLineNumber?.()
+    const column = callSite.getEnclosingColumnNumber?.()
+    if (line != null && column != null) {
+      return { line, column }
+    }
+    return null
+  })
+  capturedEnclosingPositions.set(error, positions)
+
+  // Use V8's native formatting (unchanged behavior)
   let stack = name + ': ' + message
   for (let i = 0; i < structuredStackTrace.length; i++) {
     stack += '\n    at ' + structuredStackTrace[i].toString()
@@ -145,17 +344,20 @@ function ignoreListAnonymousStackFramesIfSandwiched(
 /**
  * @param frame
  * @param sourceMapCache
+ * @param inspectOptions
+ * @param enclosingPosition - Optional enclosing function position for name deobfuscation
  * @returns The original frame if not sourcemapped.
  */
 function getSourcemappedFrameIfPossible(
   frame: SourcemappableStackFrame,
   sourceMapCache: SourceMapCache,
-  inspectOptions: util.InspectOptions
+  inspectOptions: util.InspectOptions,
+  enclosingPosition: EnclosingPosition | null
 ): {
   stack: IgnorableStackFrame
   code: string | null
 } {
-  const sourceMapCacheEntry = sourceMapCache.get(frame.file)
+  let sourceMapCacheEntry = sourceMapCache.get(frame.file)
   let sourceMapConsumer: SyncSourceMapConsumer
   let sourceMapPayload: ModernSourceMapPayload
   if (sourceMapCacheEntry === undefined) {
@@ -222,10 +424,12 @@ function getSourcemappedFrameIfPossible(
       sourceMapCache.set(frame.file, null)
       return createUnsourcemappedFrame(frame)
     }
-    sourceMapCache.set(frame.file, {
+    sourceMapCacheEntry = {
       map: sourceMapConsumer,
       payload: sourceMapPayload,
-    })
+      fileName: sourceURL,
+    }
+    sourceMapCache.set(frame.file, sourceMapCacheEntry)
   } else if (sourceMapCacheEntry === null) {
     // We failed earlier getting the payload or consumer.
     // Just return an unsourcemapped frame.
@@ -282,14 +486,66 @@ function getSourcemappedFrameIfPossible(
     ignored = applicableSourceMap.ignoreList?.includes(sourceIndex) ?? false
   }
 
+  // Try to deobfuscate the method name using the enclosing function position
+  let methodName = frame.methodName
+    ?.replace('__WEBPACK_DEFAULT_EXPORT__', 'default')
+    ?.replace('__webpack_exports__.', '')
+
+  if (enclosingPosition && sourceMapCacheEntry && methodName) {
+    // Parse the methodName to extract components for reconstruction
+    // Format: [async] [new] [TypeName.]functionName[ [as methodName]]
+    let prefix = ''
+    let remaining = methodName
+
+    // Extract "async " prefix
+    if (remaining.startsWith('async ')) {
+      prefix += 'async '
+      remaining = remaining.slice(6)
+    }
+    // Extract "new " prefix
+    if (remaining.startsWith('new ')) {
+      prefix += 'new '
+      remaining = remaining.slice(4)
+    }
+
+    // Extract " [as methodName]" suffix
+    // Note: We keep the [as methodName] suffix unchanged since we can't
+    // deobfuscate property names - the enclosing position only tells us
+    // where the function is defined, not where it's accessed
+    let asSuffix = ''
+    const asIndex = remaining.indexOf(' [as ')
+    if (asIndex !== -1) {
+      asSuffix = remaining.slice(asIndex)
+      remaining = remaining.slice(0, asIndex)
+    }
+
+    // Extract TypeName. prefix (e.g., "Object.foo" -> typeName="Object.", functionName="foo")
+    let typePrefix = ''
+    const dotIndex = remaining.lastIndexOf('.') // Use lastIndexOf for nested namespaces
+    if (dotIndex !== -1) {
+      typePrefix = remaining.slice(0, dotIndex + 1)
+      remaining = remaining.slice(dotIndex + 1)
+    }
+
+    // `remaining` is now the raw function name
+    const rawFunctionName = remaining
+
+    const deobfuscatedName = findNameAtPosition(
+      getNameMappings(sourceMapCacheEntry),
+      enclosingPosition.line,
+      enclosingPosition.column - 1, // Convert to 0-indexed
+      getGeneratedSource(sourceMapCacheEntry),
+      rawFunctionName
+    )
+
+    if (deobfuscatedName) {
+      // Reconstruct the method name with the deobfuscated function name
+      methodName = prefix + typePrefix + deobfuscatedName + asSuffix
+    }
+  }
+
   const originalFrame: IgnorableStackFrame = {
-    // We ignore the sourcemapped name since it won't be the correct name.
-    // The callsite will point to the column of the variable name instead of the
-    // name of the enclosing function.
-    // TODO(NDX-531): Spy on prepareStackTrace to get the enclosing line number for method name mapping.
-    methodName: frame.methodName
-      ?.replace('__WEBPACK_DEFAULT_EXPORT__', 'default')
-      ?.replace('__webpack_exports__.', ''),
+    methodName,
     file: sourcePosition.source,
     line1: sourcePosition.line,
     column1: sourcePosition.column + 1,
@@ -356,12 +612,17 @@ function parseAndSourceMap(
   const unsourcemappedStack = parseStack(unparsedStack)
   const sourceMapCache: SourceMapCache = new Map()
 
+  // Get captured enclosing positions for name deobfuscation
+  const enclosingPositions = capturedEnclosingPositions.get(error)
+
   const sourceMappedFrames: Array<{
     stack: IgnorableStackFrame
     code: string | null
   }> = []
   let sourceFrame: null | string = null
-  for (const frame of unsourcemappedStack) {
+  for (let i = 0; i < unsourcemappedStack.length; i++) {
+    const frame = unsourcemappedStack[i]
+
     if (frame.file === null) {
       sourceMappedFrames.push({
         code: null,
@@ -379,7 +640,8 @@ function parseAndSourceMap(
         // We narrowed this earlier by bailing if `frame.file` is null.
         frame as SourcemappableStackFrame,
         sourceMapCache,
-        inspectOptions
+        inspectOptions,
+        enclosingPositions?.[i] ?? null
       )
       sourceMappedFrames.push(sourcemappedFrame)
 

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -146,6 +146,11 @@ function isFunctionNameAtPosition(
 
 /**
  * Lazily build and cache name mappings from a source map.
+ *
+ * Ideally we would use `getOriginalPositionFor`/`getGeneratedPositionFor` instead
+ * of maintaining our own map and iterating all mappings, but there is a bug in the
+ * source-map library that prevents us from using these APIs on IndexedSourceMaps, so
+ * we need ot build our own datastructure.
  */
 function getNameMappings(entry: SourceMapCacheEntry): NameMappingsByLine {
   if (!entry.nameMappings) {
@@ -206,7 +211,6 @@ function findNameAtPosition(
       endIdx = mid
     }
   }
-
   // Check the first entry at or after the enclosing position
   if (startIdx < lineEntries.length) {
     const entry = lineEntries[startIdx]
@@ -218,7 +222,6 @@ function findNameAtPosition(
       return entry.name
     }
   }
-
   return undefined
 }
 

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -78,9 +78,9 @@ type NameMappingsByLine = Map<number, Array<{ column: number; name: string }>>
 interface SourceMapCacheEntry {
   map: SyncSourceMapConsumer
   payload: ModernSourceMapPayload
-  /** Cached name mappings for efficient lookup */
+  /** Cached name mappings for efficient lookup, the SourceMapConsumer doesn't allow random access */
   nameMappings?: NameMappingsByLine
-  /** Cached generated source file content for name validation */
+  /** Cached generated source file content for name validation, if `null` then we failed to read the file. */
   generatedSource?: string | null
   /** File name (URL) for reading generated source */
   fileName: string
@@ -374,7 +374,9 @@ function getSourcemappedFrameIfPossible(
     }
     let maybeSourceMapPayload: ModernSourceMapPayload | undefined
     try {
+      console.error('looking up source map for ', sourceURL)
       const sourceMap = nativeFindSourceMap(sourceURL)
+      console.error('\tfound source map')
       maybeSourceMapPayload = sourceMap?.payload
     } catch (cause) {
       // We should not log an actual error instance here because that will re-enter
@@ -393,10 +395,12 @@ function getSourcemappedFrameIfPossible(
       // source map.
       return createUnsourcemappedFrame(frame)
     }
+    console.error('1: maybeSourceMapPayload=', maybeSourceMapPayload)
     if (maybeSourceMapPayload === undefined) {
       maybeSourceMapPayload = bundlerFindSourceMapPayload(sourceURL)
     }
 
+    console.error('2: maybeSourceMapPayload=', maybeSourceMapPayload)
     if (maybeSourceMapPayload === undefined) {
       return createUnsourcemappedFrame(frame)
     }
@@ -408,11 +412,13 @@ function getSourcemappedFrameIfPossible(
       // relative paths but is actually wrong (the chunk and sourcemap have different content hashes).
       // We are using the node API to read the sourcemap and it doesn't give us access to the URI.
       const sourceMapURL = sourceURL + '.map'
+      console.error('about to parse sourcemap for ', sourceURL)
       sourceMapConsumer = new SyncSourceMapConsumer(
         sourceMapPayload,
         // @ts-expect-error: our typings don't include this parameter but it is here.
         sourceMapURL
       )
+      console.error('\tparsed source map')
     } catch (cause) {
       // We should not log an actual error instance here because that will re-enter
       // this codepath during error inspection and could lead to infinite recursion.
@@ -492,43 +498,33 @@ function getSourcemappedFrameIfPossible(
     ?.replace('__webpack_exports__.', '')
 
   if (enclosingPosition && sourceMapCacheEntry && methodName) {
-    // Parse the methodName to extract components for reconstruction
-    // Format: [async] [new] [TypeName.]functionName[ [as methodName]]
-    let prefix = ''
-    let remaining = methodName
+    // Parse methodName format: [async] [new] [TypeName.]functionName[ [as methodName]]
+    // We need to extract just the functionName part for deobfuscation
+    let funcStart = 0
+    let funcEnd = methodName.length
 
-    // Extract "async " prefix
-    if (remaining.startsWith('async ')) {
-      prefix += 'async '
-      remaining = remaining.slice(6)
+    // Skip "async " prefix
+    if (methodName.startsWith('async ')) {
+      funcStart = 6
     }
-    // Extract "new " prefix
-    if (remaining.startsWith('new ')) {
-      prefix += 'new '
-      remaining = remaining.slice(4)
+    // Skip "new " prefix
+    if (methodName.startsWith('new ', funcStart)) {
+      funcStart += 4
     }
 
-    // Extract " [as methodName]" suffix
-    // Note: We keep the [as methodName] suffix unchanged since we can't
-    // deobfuscate property names - the enclosing position only tells us
-    // where the function is defined, not where it's accessed
-    let asSuffix = ''
-    const asIndex = remaining.indexOf(' [as ')
+    // Find " [as methodName]" suffix
+    const asIndex = methodName.indexOf(' [as ', funcStart)
     if (asIndex !== -1) {
-      asSuffix = remaining.slice(asIndex)
-      remaining = remaining.slice(0, asIndex)
+      funcEnd = asIndex
     }
 
-    // Extract TypeName. prefix (e.g., "Object.foo" -> typeName="Object.", functionName="foo")
-    let typePrefix = ''
-    const dotIndex = remaining.lastIndexOf('.') // Use lastIndexOf for nested namespaces
-    if (dotIndex !== -1) {
-      typePrefix = remaining.slice(0, dotIndex + 1)
-      remaining = remaining.slice(dotIndex + 1)
+    // Find TypeName. prefix (after async/new, before [as])
+    const dotIndex = methodName.lastIndexOf('.', funcEnd)
+    if (dotIndex !== -1 && dotIndex >= funcStart) {
+      funcStart = dotIndex + 1
     }
 
-    // `remaining` is now the raw function name
-    const rawFunctionName = remaining
+    const rawFunctionName = methodName.slice(funcStart, funcEnd)
 
     const deobfuscatedName = findNameAtPosition(
       getNameMappings(sourceMapCacheEntry),
@@ -539,8 +535,11 @@ function getSourcemappedFrameIfPossible(
     )
 
     if (deobfuscatedName) {
-      // Reconstruct the method name with the deobfuscated function name
-      methodName = prefix + typePrefix + deobfuscatedName + asSuffix
+      // Replace the function name portion, keeping prefix and suffix
+      methodName =
+        methodName.slice(0, funcStart) +
+        deobfuscatedName +
+        methodName.slice(funcEnd)
     }
   }
 

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -829,7 +829,7 @@ describe('Cache Components Errors', () => {
               if (isTurbopack) {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route "/sync-random-with-fallback" used \`Math.random()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                     at a (app/sync-random-with-fallback/page.tsx:37:23)
+                     at RandomReadingComponent (app/sync-random-with-fallback/page.tsx:37:23)
                    35 |     use(new Promise((r) => process.nextTick(r)))
                    36 |   }
                  > 37 |   const random = Math.random()
@@ -941,7 +941,7 @@ describe('Cache Components Errors', () => {
               if (isTurbopack) {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: Route "/sync-random-without-fallback" used \`Math.random()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                     at a (app/sync-random-without-fallback/page.tsx:32:15)
+                     at RandomReadingComponent (app/sync-random-without-fallback/page.tsx:32:15)
                    30 |
                    31 | function getRandomNumber() {
                  > 32 |   return Math.random()
@@ -1202,8 +1202,8 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error occurred prerendering page "/sync-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
                  TypeError: <module-function>().get is not a function
-                     at a (app/sync-cookies/page.tsx:18:36)
-                     at b (<anonymous>)
+                     at CookiesReadingComponent (app/sync-cookies/page.tsx:18:36)
+                     at a (<anonymous>)
                    16 | async function CookiesReadingComponent() {
                    17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const token = (cookies() as any).get('token')
@@ -1538,8 +1538,8 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error occurred prerendering page "/sync-headers". Read more: https://nextjs.org/docs/messages/prerender-error
                  TypeError: <module-function>().get is not a function
-                     at a (app/sync-headers/page.tsx:18:40)
-                     at b (<anonymous>)
+                     at HeadersReadingComponent (app/sync-headers/page.tsx:18:40)
+                     at a (<anonymous>)
                    16 | async function HeadersReadingComponent() {
                    17 |   // Cast to any as we removed UnsafeUnwrapped types, but still need to test with the sync access
                  > 18 |   const userAgent = (headers() as any).get('user-agent')
@@ -3336,7 +3336,7 @@ describe('Cache Components Errors', () => {
                 expect(output).toMatchInlineSnapshot(`
                  "Error: "use cache: private" must not be used within \`unstable_cache()\`.
                      at <unknown> (app/use-cache-private-in-unstable-cache/page.tsx:21:38)
-                     at async g (app/use-cache-private-in-unstable-cache/page.tsx:16:16)
+                     at async ComponentWithCachedData (app/use-cache-private-in-unstable-cache/page.tsx:16:16)
                    19 | }
                    20 |
                  > 21 | const getCachedData = unstable_cache(async () => {
@@ -3772,7 +3772,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-current-time/date" used \`Date()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time
-                   at a (app/sync-io-current-time/date/page.tsx:19:16)
+                   at DateReadingComponent (app/sync-io-current-time/date/page.tsx:19:16)
                  17 | async function DateReadingComponent() {
                  18 |   await new Promise((r) => process.nextTick(r))
                > 19 |   return <div>{Date()}</div>
@@ -3874,7 +3874,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-current-time/date-now" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time
-                   at a (app/sync-io-current-time/date-now/page.tsx:19:21)
+                   at DateReadingComponent (app/sync-io-current-time/date-now/page.tsx:19:21)
                  17 | async function DateReadingComponent() {
                  18 |   await new Promise((r) => process.nextTick(r))
                > 19 |   return <div>{Date.now()}</div>
@@ -3976,7 +3976,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-current-time/new-date" used \`new Date()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time
-                   at a (app/sync-io-current-time/new-date/page.tsx:19:16)
+                   at DateReadingComponent (app/sync-io-current-time/new-date/page.tsx:19:16)
                  17 | async function DateReadingComponent() {
                  18 |   await new Promise((r) => process.nextTick(r))
                > 19 |   return <div>{new Date().toString()}</div>
@@ -4078,7 +4078,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-random/math-random" used \`Math.random()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-random/math-random/page.tsx:19:21)
+                   at SyncIOComponent (app/sync-io-random/math-random/page.tsx:19:21)
                  17 | async function SyncIOComponent() {
                  18 |   await new Promise((r) => process.nextTick(r))
                > 19 |   return <div>{Math.random()}</div>
@@ -4182,7 +4182,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-web-crypto/get-random-value" used \`crypto.getRandomValues()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random cryptographic values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto
-                   at a (app/sync-io-web-crypto/get-random-value/page.tsx:20:10)
+                   at SyncIOComponent (app/sync-io-web-crypto/get-random-value/page.tsx:20:10)
                  18 |   await new Promise((r) => process.nextTick(r))
                  19 |   const buffer = new Uint8Array(8)
                > 20 |   crypto.getRandomValues(buffer)
@@ -4285,7 +4285,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-web-crypto/random-uuid" used \`crypto.randomUUID()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random cryptographic values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto
-                   at a (app/sync-io-web-crypto/random-uuid/page.tsx:19:23)
+                   at SyncIOComponent (app/sync-io-web-crypto/random-uuid/page.tsx:19:23)
                  17 | async function SyncIOComponent() {
                  18 |   await new Promise((r) => process.nextTick(r))
                > 19 |   return <div>{crypto.randomUUID()}</div>
@@ -4387,7 +4387,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/generate-key-pair-sync" used \`require('node:crypto').generateKeyPairSync(...)\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/generate-key-pair-sync/page.tsx:20:24)
+                   at SyncIOComponent (app/sync-io-node-crypto/generate-key-pair-sync/page.tsx:20:24)
                  18 | async function SyncIOComponent() {
                  19 |   await new Promise((r) => process.nextTick(r))
                > 20 |   const first = crypto.generateKeyPairSync('rsa', keyGenOptions)
@@ -4509,7 +4509,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/generate-key-sync" used \`require('node:crypto').generateKeySync(...)\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/generate-key-sync/page.tsx:21:6)
+                   at SyncIOComponent (app/sync-io-node-crypto/generate-key-sync/page.tsx:21:6)
                  19 |   await new Promise((r) => process.nextTick(r))
                  20 |   const first = crypto
                > 21 |     .generateKeySync('hmac', {
@@ -4631,7 +4631,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/generate-prime-sync" used \`require('node:crypto').generatePrimeSync(...)\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/generate-prime-sync/page.tsx:20:39)
+                   at SyncIOComponent (app/sync-io-node-crypto/generate-prime-sync/page.tsx:20:39)
                  18 | async function SyncIOComponent() {
                  19 |   await new Promise((r) => process.nextTick(r))
                > 20 |   const first = new Uint8Array(crypto.generatePrimeSync(128))
@@ -4753,7 +4753,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/get-random-values" used \`crypto.getRandomValues()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random cryptographic values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-crypto
-                   at a (app/sync-io-node-crypto/get-random-values/page.tsx:21:10)
+                   at SyncIOComponent (app/sync-io-node-crypto/get-random-values/page.tsx:21:10)
                  19 |   await new Promise((r) => process.nextTick(r))
                  20 |   const first = new Uint8Array(8)
                > 21 |   crypto.getRandomValues(first)
@@ -4875,7 +4875,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/random-bytes" used \`require('node:crypto').randomBytes(size)\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/random-bytes/page.tsx:20:24)
+                   at SyncIOComponent (app/sync-io-node-crypto/random-bytes/page.tsx:20:24)
                  18 | async function SyncIOComponent() {
                  19 |   await new Promise((r) => process.nextTick(r))
                > 20 |   const first = crypto.randomBytes(8)
@@ -4997,7 +4997,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/random-fill-sync" used \`require('node:crypto').randomFillSync(...)\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/random-fill-sync/page.tsx:21:10)
+                   at SyncIOComponent (app/sync-io-node-crypto/random-fill-sync/page.tsx:21:10)
                  19 |   await new Promise((r) => process.nextTick(r))
                  20 |   const first = new Uint8Array(16)
                > 21 |   crypto.randomFillSync(first, 4, 8)
@@ -5119,7 +5119,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/random-int-between" used \`require('node:crypto').randomInt(min, max)\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/random-int-between/page.tsx:20:24)
+                   at SyncIOComponent (app/sync-io-node-crypto/random-int-between/page.tsx:20:24)
                  18 | async function SyncIOComponent() {
                  19 |   await new Promise((r) => process.nextTick(r))
                > 20 |   const first = crypto.randomInt(128, 256)
@@ -5241,7 +5241,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/random-int-up-to" used \`require('node:crypto').randomInt(min, max)\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/random-int-up-to/page.tsx:20:24)
+                   at SyncIOComponent (app/sync-io-node-crypto/random-int-up-to/page.tsx:20:24)
                  18 | async function SyncIOComponent() {
                  19 |   await new Promise((r) => process.nextTick(r))
                > 20 |   const first = crypto.randomInt(128)
@@ -5363,7 +5363,7 @@ describe('Cache Components Errors', () => {
             } else {
               expect(output).toMatchInlineSnapshot(`
                "Error: Route "/sync-io-node-crypto/random-uuid" used \`require('node:crypto').randomUUID()\` before accessing either uncached data (e.g. \`fetch()\`) or Request data (e.g. \`cookies()\`, \`headers()\`, \`connection()\`, and \`searchParams\`). Accessing random values synchronously in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-random
-                   at a (app/sync-io-node-crypto/random-uuid/page.tsx:20:24)
+                   at SyncIOComponent (app/sync-io-node-crypto/random-uuid/page.tsx:20:24)
                  18 | async function SyncIOComponent() {
                  19 |   await new Promise((r) => process.nextTick(r))
                > 20 |   const first = crypto.randomUUID()

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -397,25 +397,15 @@ describe('app-dir - server source maps', () => {
             '\n'
         )
       } else {
-        expect(normalizeCliOutput(next.cliOutput.slice(outputIndex))).toContain(
-          // Node.js is not fine with invalid URLs in vanilla source maps.
-          // Feel free to adjust these locations. They're just here to showcase
-          // sourcemapping is broken on invalid sources.
-          '' +
-            `\nwebpack-internal:///(rsc)/./app/bad-sourcemap/page.js: Invalid source map. Only conformant source maps can be used to find the original code. Cause: TypeError [ERR_INVALID_ARG_TYPE]: The "payload" argument must be of type object. Received null` +
-            '\nError: bad-sourcemap' +
-            '\n    at logError (webpack-internal:///(rsc)/./app/bad-sourcemap/page.js:12:19)' +
-            '\n    at Page (webpack-internal:///(rsc)/./app/bad-sourcemap/page.js:15:5)'
-        )
-        // Expect the invalid sourcemap warning only once per render.
-        // Dynamic I/O renders three times.
-        // One from filterStackFrameDEV.
-        // One from findSourceMapURLDEV.
-        expect(
-          normalizeCliOutput(next.cliOutput.slice(outputIndex)).split(
-            'Invalid source map.'
-          ).length - 1
-        ).toEqual(3)
+        // Node.js is not fine with invalid URLs in vanilla source maps.
+        // The specific paths in the output vary based on how the source map consumer
+        // resolves the invalid source URL. Just check for the key elements.
+        // Note: The "Invalid source map" warning may or may not appear depending on
+        // whether Node's findSourceMap throws or returns a successful-but-invalid result.
+        const cliOutput = normalizeCliOutput(next.cliOutput.slice(outputIndex))
+        expect(cliOutput).toContain('Error: bad-sourcemap')
+        expect(cliOutput).toContain('at logError')
+        expect(cliOutput).toContain('at Page')
       }
     } else {
       // Bundlers silently drop invalid sourcemaps.

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -397,15 +397,25 @@ describe('app-dir - server source maps', () => {
             '\n'
         )
       } else {
-        // Node.js is not fine with invalid URLs in vanilla source maps.
-        // The specific paths in the output vary based on how the source map consumer
-        // resolves the invalid source URL. Just check for the key elements.
-        // Note: The "Invalid source map" warning may or may not appear depending on
-        // whether Node's findSourceMap throws or returns a successful-but-invalid result.
-        const cliOutput = normalizeCliOutput(next.cliOutput.slice(outputIndex))
-        expect(cliOutput).toContain('Error: bad-sourcemap')
-        expect(cliOutput).toContain('at logError')
-        expect(cliOutput).toContain('at Page')
+        expect(normalizeCliOutput(next.cliOutput.slice(outputIndex))).toContain(
+          // Node.js is not fine with invalid URLs in vanilla source maps.
+          // Feel free to adjust these locations. They're just here to showcase
+          // sourcemapping is broken on invalid sources.
+          '' +
+            `\nwebpack-internal:///(rsc)/./app/bad-sourcemap/page.js: Invalid source map. Only conformant source maps can be used to find the original code. Cause: TypeError [ERR_INVALID_ARG_TYPE]: The "payload" argument must be of type object. Received null` +
+            '\nError: bad-sourcemap' +
+            '\n    at logError (webpack-internal:///(rsc)/./app/bad-sourcemap/page.js:12:19)' +
+            '\n    at Page (webpack-internal:///(rsc)/./app/bad-sourcemap/page.js:15:5)'
+        )
+        // Expect the invalid sourcemap warning only once per render.
+        // Dynamic I/O renders three times.
+        // One from filterStackFrameDEV.
+        // One from findSourceMapURLDEV.
+        expect(
+          normalizeCliOutput(next.cliOutput.slice(outputIndex)).split(
+            'Invalid source map.'
+          ).length - 1
+        ).toEqual(3)
       }
     } else {
       // Bundlers silently drop invalid sourcemaps.


### PR DESCRIPTION
## What?

Deobfuscate function names in stack traces using V8's enclosing position APIs. When a function name in a stack trace is minified (e.g., `a`, `b`), this PR uses the V8 CallSite's `getEnclosingLineNumber()` and `getEnclosingColumnNumber()` methods to find the original function name from source map name mappings.

## Why?

In production builds, function names are often minified, making stack traces difficult to read. Source maps include name mappings that can restore the original function names, but we need to know where to look in the source map. V8's enclosing position APIs tell us where the function definition starts, which we can use to find the corresponding name mapping.

## How?

**Capture enclosing positions**: In `prepareUnsourcemappedStackTrace`, we capture the enclosing line/column for each CallSite using V8's internal APIs.

 **Deobfuscate names**: When processing a frame, if we have an enclosing position, we:
   - Look up name mappings at/following that position in the generated source
   - Validate that the mangled name actually appears at that position in the generated source
   - Replace the mangled name with the original name from the source map

N.B. bun does not support these apis so we gracefully fallback to not deobfuscating function names in this case.