### PR TITLE
Turbopack: Reduce usage of parse_quote in turbo-tasks-macros

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -4,14 +4,14 @@ use proc_macro2::{Group, Ident, Span, TokenStream, TokenTree};
 use quote::{ToTokens, quote, quote_spanned};
 use rustc_hash::FxHashSet;
 use syn::{
-    AngleBracketedGenericArguments, Attribute, Block, Expr, ExprBlock, ExprPath, FnArg,
-    GenericArgument, Local, LocalInit, Meta, Pat, PatIdent, PatType, Path, PathArguments,
-    PathSegment, Receiver, ReturnType, Signature, Stmt, Token, Type, TypeGroup, TypePath,
-    TypeTuple,
+    AngleBracketedGenericArguments, Attribute, Block, Expr, ExprBlock, FnArg, GenericArgument,
+    Local, LocalInit, Meta, Pat, PatIdent, PatType, Path, PathArguments, PathSegment, Receiver,
+    ReturnType, Signature, Stmt, Token, Type, TypeGroup, TypePath, TypeTuple,
     parse::{Parse, ParseStream},
     parse_quote, parse_quote_spanned,
     punctuated::{Pair, Punctuated},
     spanned::Spanned,
+    token,
     visit_mut::VisitMut,
 };
 
@@ -213,33 +213,23 @@ impl TurboFn<'_> {
 
     /// The signature of the exposed function. This is the original signature
     /// converted to a standard turbo_tasks function signature.
-    pub fn signature(&self) -> Signature {
-        let exposed_inputs: Punctuated<_, Token![,]> = self
+    pub fn signature(&self) -> TokenStream {
+        let exposed_inputs = self
             .this
             .as_ref()
             .into_iter()
             .chain(self.exposed_inputs.iter())
             .map(|input| {
-                FnArg::Typed(PatType {
-                    attrs: Vec::new(),
-                    pat: Box::new(Pat::Ident(PatIdent {
-                        attrs: Default::default(),
-                        by_ref: None,
-                        mutability: None,
-                        ident: input.ident.clone(),
-                        subpat: None,
-                    })),
-                    colon_token: Default::default(),
-                    ty: if self.operation {
-                        // operations shouldn't have their arguments rewritten, they require all
-                        // arguments are explicitly `NonLocalValue`s
-                        Box::new(input.ty.clone())
-                    } else {
-                        Box::new(expand_task_input_type(&input.ty).into_owned())
-                    },
-                })
-            })
-            .collect();
+                let ident = &input.ident;
+                let ty = if self.operation {
+                    // operations shouldn't have their arguments rewritten, they require all
+                    // arguments are explicitly `NonLocalValue`s
+                    input.ty.to_token_stream()
+                } else {
+                    expand_task_input_type(&input.ty).to_token_stream()
+                };
+                quote! { #ident: #ty }
+            });
 
         let ident = &self.ident;
         let orig_output = &self.output;
@@ -249,15 +239,15 @@ impl TurboFn<'_> {
                 .then(|| parse_quote!(turbo_tasks::OperationVc)),
         );
 
-        parse_quote! {
-            fn #ident(#exposed_inputs) -> #new_output
+        quote! {
+            fn #ident(#(#exposed_inputs),*) -> #new_output
         }
     }
 
-    pub fn trait_signature(&self) -> Signature {
+    pub fn trait_signature(&self) -> TokenStream {
         let signature = self.signature();
 
-        parse_quote! {
+        quote! {
             #signature where Self: Sized
         }
     }
@@ -504,9 +494,9 @@ impl TurboFn<'_> {
         }
     }
 
-    fn converted_this(&self) -> Option<Expr> {
+    fn converted_this(&self) -> Option<TokenStream> {
         self.this.as_ref().map(|Input { ty: _, ident }| {
-            parse_quote! {
+            quote! {
                 turbo_tasks::Vc::into_raw(#ident)
             }
         })
@@ -546,9 +536,9 @@ impl TurboFn<'_> {
     }
 
     /// The block of the exposed function for a dynamic dispatch call to the given trait.
-    pub fn dynamic_block(&self, trait_type_ident: &Ident) -> Block {
+    pub fn dynamic_block(&self, trait_type_ident: &Ident) -> TokenStream {
         let Some(converted_this) = self.converted_this() else {
-            return parse_quote! {
+            return quote! {
                 {
                     unimplemented!("trait methods without self are not yet supported")
                 }
@@ -560,7 +550,7 @@ impl TurboFn<'_> {
         let assertions = self.get_assertions();
         let inputs = self.exposed_input_idents();
         let persistence = self.persistence_with_this();
-        parse_quote! {
+        quote! {
             {
                 #assertions
                 let inputs = std::boxed::Box::new((#(#inputs,)*));
@@ -581,7 +571,7 @@ impl TurboFn<'_> {
     }
 
     /// The block of the exposed function for a static dispatch call to the given native function.
-    pub fn static_block(&self, native_function_ident: &Ident) -> Block {
+    pub fn static_block(&self, native_function_ident: &Ident) -> TokenStream {
         let output = &self.output;
         let inputs = self.inline_input_idents();
         let assertions = self.get_assertions();
@@ -589,7 +579,7 @@ impl TurboFn<'_> {
             && let Some(converted_this) = self.converted_this()
         {
             let persistence = self.persistence_with_this();
-            parse_quote! {
+            quote! {
                 {
                     #assertions
                     let inputs = std::boxed::Box::new((#(#inputs,)*));
@@ -607,7 +597,7 @@ impl TurboFn<'_> {
             }
         } else {
             let persistence = self.persistence();
-            parse_quote! {
+            quote! {
                 {
                     #assertions
                     let inputs = std::boxed::Box::new((#(#inputs,)*));
@@ -624,7 +614,7 @@ impl TurboFn<'_> {
             }
         };
         if self.operation {
-            block = parse_quote! {
+            block = quote! {
                 {
                     let vc_output = #block;
                     // Assumption: The turbo-tasks manager will not create a local task for a
@@ -774,7 +764,10 @@ impl Parse for FunctionArguments {
 
 fn return_type_to_type(return_type: &ReturnType) -> Type {
     match return_type {
-        ReturnType::Default => parse_quote! { () },
+        ReturnType::Default => Type::Tuple(TypeTuple {
+            paren_token: token::Paren::default(),
+            elems: Punctuated::new(),
+        }),
         ReturnType::Type(_, return_type) => (**return_type).clone(),
     }
 }
@@ -1080,7 +1073,7 @@ pub struct FilterTraitCallArgsTokens {
 pub struct NativeFn {
     pub function_global_name: TokenStream,
     pub function_path_string: String,
-    pub function_path: ExprPath,
+    pub function_path: TokenStream,
     pub is_method: bool,
     /// Used only if `is_method` is true.
     pub is_self_used: bool,
@@ -1088,8 +1081,8 @@ pub struct NativeFn {
 }
 
 impl NativeFn {
-    pub fn ty(&self) -> Type {
-        parse_quote! { turbo_tasks::macro_helpers::NativeFunction }
+    pub fn ty(&self) -> TokenStream {
+        quote! { turbo_tasks::macro_helpers::NativeFunction }
     }
 
     pub fn definition(&self) -> TokenStream {

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -1,6 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{ItemFn, parse_macro_input, parse_quote};
+use syn::{ItemFn, parse_macro_input};
 
 use crate::{
     func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn, filter_inline_attributes},
@@ -60,7 +60,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let native_fn = NativeFn {
         function_global_name: global_name(&function_path_string),
         function_path_string,
-        function_path: parse_quote! { #inline_function_ident },
+        function_path: quote! { #inline_function_ident },
         is_method: turbo_fn.is_method(),
         is_self_used,
         filter_trait_call_args: None, // not a trait method

--- a/turbopack/crates/turbo-tasks-macros/src/generic_type_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/generic_type_macro.rs
@@ -1,7 +1,10 @@
 use proc_macro::TokenStream;
 use quote::quote;
 use rustc_hash::FxHashSet;
-use syn::{GenericParam, Lifetime, Type, parse_macro_input, spanned::Spanned, visit_mut::VisitMut};
+use syn::{
+    GenericParam, Lifetime, Type, TypeTuple, parse_macro_input, punctuated::Punctuated,
+    spanned::Spanned, token, visit_mut::VisitMut,
+};
 
 use crate::{
     generic_type_input::GenericTypeInput, global_name::global_name, ident::get_type_ident,
@@ -124,7 +127,10 @@ impl VisitMut for ReplaceGenericsVisitor<'_> {
                 .contains(&type_path.path.segments[0].ident.to_string())
         {
             // Replace the whole path with ()
-            *node = syn::parse_quote! { () };
+            *node = Type::Tuple(TypeTuple {
+                paren_token: token::Paren::default(),
+                elems: Punctuated::new(),
+            });
             return;
         }
 

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -5,7 +5,7 @@ use syn::{
     Error, Expr, ExprLit, Generics, ImplItem, ImplItemFn, ItemImpl, Lit, LitStr, Meta,
     MetaNameValue, Path, Token, Type,
     parse::{Parse, ParseStream},
-    parse_macro_input, parse_quote,
+    parse_macro_input,
     spanned::Spanned,
 };
 
@@ -120,7 +120,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             let native_fn = NativeFn {
                 function_global_name: global_name(&function_path_string),
                 function_path_string,
-                function_path: parse_quote! { <#ty>::#inline_function_ident },
+                function_path: quote! { <#ty>::#inline_function_ident },
                 is_method: turbo_fn.is_method(),
                 is_self_used,
                 filter_trait_call_args: None, // not a trait method
@@ -244,7 +244,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                         ty = ty.to_token_stream(),
                         trait_path = trait_path.to_token_stream()
                     ),
-                    function_path: parse_quote! {
+                    function_path: quote! {
                         <#ty as #inline_extension_trait_ident>::#inline_function_ident
                     },
                     is_method: turbo_fn.is_method(),

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -8,7 +8,7 @@ use syn::{
     Error, Expr, ExprLit, Fields, FieldsUnnamed, Generics, Item, ItemEnum, ItemStruct, Lit, LitStr,
     Meta, MetaNameValue, Token,
     parse::{Parse, ParseStream},
-    parse_macro_input, parse_quote,
+    parse_macro_input,
     spanned::Spanned,
 };
 
@@ -216,7 +216,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
                  [`{inner_type_string}`].",
             );
 
-            struct_attributes.push(parse_quote! {
+            struct_attributes.push(quote! {
                 #[doc = #doc_str]
             });
         }

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -1,9 +1,8 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, TokenStream as TokenStream2};
-use quote::{quote, quote_spanned};
+use quote::{ToTokens, quote, quote_spanned};
 use syn::{
-    FnArg, ItemTrait, Pat, Receiver, TraitItem, TraitItemFn, parse_macro_input, parse_quote,
-    spanned::Spanned,
+    FnArg, ItemTrait, Pat, Receiver, TraitItem, TraitItemFn, parse_macro_input, spanned::Spanned,
 };
 
 use crate::{
@@ -71,7 +70,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut dynamic_trait_fns = Vec::new();
     let mut trait_methods: Vec<TokenStream2> = Vec::new();
     let mut native_functions = Vec::new();
-    let mut items = Vec::with_capacity(raw_items.len());
+    let mut items: Vec<TokenStream2> = Vec::with_capacity(raw_items.len());
     let mut errors = Vec::new();
 
     for item in raw_items.iter() {
@@ -97,7 +96,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             Ok(None) => {
                 // There is no turbo_tasks::function annotation, preserve this item as is in the
                 // trait
-                items.push(item.clone());
+                items.push(item.to_token_stream());
                 // But we still need to add a forwarding implementation to the
                 // impl for `turbo_tasks::Dynamic<Box<dyn T>>`
                 // This will have the same signature, but simply forward the call
@@ -195,7 +194,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             #turbo_signature #dynamic_block
         });
 
-        let default = if let Some(default) = default {
+        let default_block = if let Some(default) = default {
             let inline_function_ident = turbo_fn.inline_ident();
             let inline_extension_trait_ident =
                 Ident::new(&format!("{trait_ident}_{ident}_inline"), ident.span());
@@ -206,7 +205,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
             let native_function = NativeFn {
                 function_global_name: global_name(&function_path_string),
                 function_path_string,
-                function_path: parse_quote! {
+                function_path: quote! {
                     <Box<dyn #trait_ident> as #inline_extension_trait_ident>::#inline_function_ident
                 },
                 is_method: turbo_fn.is_method(),
@@ -249,20 +248,19 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             });
 
-            Some(turbo_fn.static_block(&native_function_ident))
+            turbo_fn.static_block(&native_function_ident)
         } else {
             trait_methods.push(quote! {
                 (stringify!(#ident), None),
             });
-            None
+            quote! { ; }
         };
 
-        items.push(TraitItem::Fn(TraitItemFn {
-            sig: turbo_fn.trait_signature(),
-            default,
-            attrs: attrs.iter().map(|a| (*a).clone()).collect(),
-            semi_token: Default::default(),
-        }));
+        let trait_sig = turbo_fn.trait_signature();
+        items.push(quote! {
+            #(#attrs)*
+            #trait_sig #default_block
+        });
     }
 
     let value_debug_impl = if debug {


### PR DESCRIPTION
In theory, `parse_quote` is really nice because it lets you use type safety to assert more things about proc macro code.

However, it does invoke the syn parser, so there's probably some cost.

I had Claude find and remove trivial uses of `parse_quote`. There are still more uses, but they're not as easy to remove (e.g. because we need the real type, not just a `TokenStream`, and the type is annoying to construct by hand).