### PR TITLE
Turbopack: Clean up `VcRead::Repr` associated type

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
@@ -59,7 +59,7 @@ pub fn primitive(input: TokenStream) -> TokenStream {
         quote! { #ty },
         None,
         quote! {
-            turbo_tasks::VcTransparentRead<#ty, #ty, #ty>
+            turbo_tasks::VcTransparentRead<#ty, #ty>
         },
         quote! {
             turbo_tasks::VcCellCompareMode<#ty>

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -256,7 +256,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
                 content.0
             },
             quote! {
-                turbo_tasks::VcTransparentRead::<#ident, #inner_type, #ident>
+                turbo_tasks::VcTransparentRead::<#ident, #inner_type>
             },
         )
     } else {

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -26,11 +26,10 @@ use turbo_rcstr::RcStr;
 
 use crate::{
     RawVc, ReadCellOptions, ReadOutputOptions, ReadRef, SharedReference, TaskId, TaskIdSet,
-    TraitRef, TraitTypeId, TurboTasksPanic, ValueTypeId, VcRead, VcValueTrait, VcValueType,
+    TraitRef, TraitTypeId, TurboTasksPanic, ValueTypeId, VcValueTrait, VcValueType,
     event::EventListener, macro_helpers::NativeFunction, magic_any::MagicAny,
     manager::TurboTasksBackendApi, raw_vc::CellId, registry,
     task::shared_reference::TypedSharedReference, task_statistics::TaskStatisticsApi,
-    triomphe_utils::unchecked_sidecast_triomphe_arc,
 };
 
 pub type TransientTaskRoot =
@@ -162,11 +161,8 @@ impl TypedCellContent {
     pub fn cast<T: VcValueType>(self) -> Result<ReadRef<T>> {
         let data = self.1.0.ok_or_else(|| anyhow!("Cell is empty"))?;
         let data = data
-            .downcast::<<T::Read as VcRead<T>>::Repr>()
+            .downcast::<T>()
             .map_err(|_err| anyhow!("Unexpected type in cell"))?;
-        // SAFETY: `T` and `T::Read::Repr` must have equivalent memory representations,
-        // guaranteed by the unsafe implementation of `VcValueType`.
-        let data = unsafe { unchecked_sidecast_triomphe_arc(data) };
         Ok(ReadRef::new_arc(data))
     }
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1786,7 +1786,6 @@ pub struct CurrentCellRef {
     is_serializable_cell_content: bool,
 }
 
-type VcReadRepr<T> = <<T as VcValueType>::Read as VcRead<T>>::Repr;
 type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
 
 impl CurrentCellRef {
@@ -1798,14 +1797,10 @@ impl CurrentCellRef {
         T: VcValueType,
     {
         self.conditional_update_with_shared_reference(|old_shared_reference| {
-            let old_ref = old_shared_reference
-                .and_then(|sr| sr.0.downcast_ref::<VcReadRepr<T>>())
-                .map(|content| <T::Read as VcRead<T>>::repr_to_value_ref(content));
+            let old_ref = old_shared_reference.and_then(|sr| sr.0.downcast_ref::<T>());
             let (new_value, updated_key_hashes) = functor(old_ref)?;
             Some((
-                SharedReference::new(triomphe::Arc::new(<T::Read as VcRead<T>>::value_to_repr(
-                    new_value,
-                ))),
+                SharedReference::new(triomphe::Arc::new(new_value)),
                 updated_key_hashes,
             ))
         })
@@ -1891,22 +1886,21 @@ impl CurrentCellRef {
         });
     }
 
-    /// Replace the current cell's content with `new_shared_reference` if the
-    /// current content is not equal by value with the existing content.
+    /// Replace the current cell's content with `new_shared_reference` if the current content is not
+    /// equal by value with the existing content.
     ///
     /// If you already have a `SharedReference`, this is a faster version of
     /// [`CurrentCellRef::compare_and_update`].
     ///
-    /// The [`SharedReference`] is expected to use the `<T::Read as
-    /// VcRead<T>>::Repr` type for its representation of the value.
+    /// The value should be stored in [`SharedReference`] using the type `T`.
     pub fn compare_and_update_with_shared_reference<T>(&self, new_shared_reference: SharedReference)
     where
         T: VcValueType + PartialEq,
     {
         self.conditional_update_with_shared_reference(|old_sr| {
             if let Some(old_sr) = old_sr {
-                let old_value = extract_sr_value::<T>(old_sr)?;
-                let new_value = extract_sr_value::<T>(&new_shared_reference)?;
+                let old_value = extract_sr_value::<T>(old_sr);
+                let new_value = extract_sr_value::<T>(&new_shared_reference);
                 if old_value == new_value {
                     return None;
                 }
@@ -1955,9 +1949,9 @@ impl CurrentCellRef {
             let Some(old_sr) = old_sr else {
                 return Some((new_shared_reference, None));
             };
-            let old_value = extract_sr_value::<T>(old_sr)?;
+            let old_value = extract_sr_value::<T>(old_sr);
             let old_value = <T as VcValueType>::Read::value_to_target_ref(old_value);
-            let new_value = extract_sr_value::<T>(&new_shared_reference)?;
+            let new_value = extract_sr_value::<T>(&new_shared_reference);
             let new_value = <T as VcValueType>::Read::value_to_target_ref(new_value);
             let updated_keys = old_value.different_keys(new_value);
             if updated_keys.is_empty() {
@@ -1982,9 +1976,7 @@ impl CurrentCellRef {
             self.current_task,
             self.index,
             self.is_serializable_cell_content,
-            CellContent(Some(SharedReference::new(triomphe::Arc::new(
-                <T::Read as VcRead<T>>::value_to_repr(new_value),
-            )))),
+            CellContent(Some(SharedReference::new(triomphe::Arc::new(new_value)))),
             None,
             verification_mode,
         )
@@ -1996,8 +1988,7 @@ impl CurrentCellRef {
     /// If the passed-in [`SharedReference`] is the same as the existing cell's
     /// by identity, no update is performed.
     ///
-    /// The [`SharedReference`] is expected to use the `<T::Read as
-    /// VcRead<T>>::Repr` type for its representation of the value.
+    /// The value should be stored in [`SharedReference`] using the type `T`.
     pub fn update_with_shared_reference(
         &self,
         shared_ref: SharedReference,
@@ -2045,9 +2036,9 @@ impl From<CurrentCellRef> for RawVc {
     }
 }
 
-fn extract_sr_value<T: VcValueType>(sr: &SharedReference) -> Option<&T> {
-    sr.0.downcast_ref::<VcReadRepr<T>>()
-        .map(<T::Read as VcRead<T>>::repr_to_value_ref)
+fn extract_sr_value<T: VcValueType>(sr: &SharedReference) -> &T {
+    sr.0.downcast_ref::<T>()
+        .expect("cannot update SharedReference of different type")
 }
 
 pub fn find_cell_by_type<T: VcValueType>() -> CurrentCellRef {

--- a/turbopack/crates/turbo-tasks/src/read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/read_ref.rs
@@ -21,7 +21,6 @@ use crate::{
     SharedReference, Vc, VcRead, VcValueType,
     debug::{ValueDebugFormat, ValueDebugFormatString},
     trace::{TraceRawVcs, TraceRawVcsContext},
-    triomphe_utils::unchecked_sidecast_triomphe_arc,
     vc::VcCellMode,
 };
 
@@ -277,14 +276,9 @@ where
     /// reference.
     pub fn cell(read_ref: ReadRef<T>) -> Vc<T> {
         let type_id = T::get_value_type_id();
-        // SAFETY: `T` and `T::Read::Repr` must have equivalent memory representations,
-        // guaranteed by the unsafe implementation of `VcValueType`.
-        let value = unsafe {
-            unchecked_sidecast_triomphe_arc::<T, <T::Read as VcRead<T>>::Repr>(read_ref.0)
-        };
         Vc {
             node: <T::CellMode as VcCellMode<T>>::raw_cell(
-                SharedReference::new(value).into_typed(type_id),
+                SharedReference::new(read_ref.0).into_typed(type_id),
             ),
             _t: PhantomData,
         }

--- a/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 
 type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
-type VcReadRepr<T> = <<T as VcValueType>::Read as VcRead<T>>::Repr;
 
 /// Trait that controls the behavior of [`Vc::cell`] based on the value type's
 /// [`VcValueType::CellMode`].
@@ -51,7 +50,7 @@ where
     }
 
     fn raw_cell(content: TypedSharedReference) -> RawVc {
-        debug_assert_repr::<T>(&content);
+        debug_assert_type::<T>(&content);
         let cell = find_cell_by_type::<T>();
         cell.update_with_shared_reference(content.reference, VerificationMode::Skip);
         cell.into()
@@ -78,7 +77,7 @@ where
     }
 
     fn raw_cell(content: TypedSharedReference) -> RawVc {
-        debug_assert_repr::<T>(&content);
+        debug_assert_type::<T>(&content);
         let cell = find_cell_by_type::<T>();
         cell.compare_and_update_with_shared_reference::<T>(content.reference);
         cell.into()
@@ -107,18 +106,17 @@ where
     }
 
     fn raw_cell(content: TypedSharedReference) -> RawVc {
-        debug_assert_repr::<T>(&content);
+        debug_assert_type::<T>(&content);
         let cell = find_cell_by_type::<T>();
         cell.keyed_compare_and_update_with_shared_reference::<T>(content.reference);
         cell.into()
     }
 }
 
-fn debug_assert_repr<T: VcValueType>(content: &TypedSharedReference) {
+fn debug_assert_type<T: VcValueType>(content: &TypedSharedReference) {
     debug_assert!(
-        (*content.reference.0).is::<VcReadRepr<T>>(),
-        "SharedReference for type {} must use representation type {}",
+        (*content.reference.0).is::<T>(),
+        "SharedReference for type {} must contain data matching that type",
         type_name::<T>(),
-        type_name::<VcReadRepr<T>>(),
     );
 }

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -378,11 +378,10 @@ where
     }
 }
 
-impl<T, Inner, Repr> Vc<T>
+impl<T, Inner> Vc<T>
 where
-    T: VcValueType<Read = VcTransparentRead<T, Inner, Repr>>,
+    T: VcValueType<Read = VcTransparentRead<T, Inner>>,
     Inner: Any + Send + Sync,
-    Repr: VcValueType,
 {
     pub fn cell(inner: Inner) -> Self {
         Self::cell_private(inner)

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -39,25 +39,11 @@ where
     /// target will be different than the value type.
     type Target;
 
-    /// The representation type. This is what will be used to
-    /// serialize/deserialize the value, and this determines the
-    /// type that the value will be upcasted to for storage.
-    ///
-    /// For instance, when storing generic collection types such as
-    /// `Vec<Vc<ValueType>>`, we first cast them to a shared `Vec<Vc<()>>`
-    /// type instead, which has an equivalent memory representation to any
-    /// `Vec<Vc<T>>` type. This allows sharing implementations of methods and
-    /// traits between all `Vec<Vc<T>>`.
-    type Repr: VcValueType;
-
     /// Convert a reference to a value to a reference to the target type.
     fn value_to_target_ref(value: &T) -> &Self::Target;
 
     /// Convert a value to the target type.
     fn value_to_target(value: T) -> Self::Target;
-
-    /// Convert the value type to the repr.
-    fn value_to_repr(value: T) -> Self::Repr;
 
     /// Convert the target type to the value.
     fn target_to_value(target: Self::Target) -> T;
@@ -67,12 +53,6 @@ where
 
     /// Convert a mutable reference to a target type to a reference to a value.
     fn target_to_value_mut_ref(target: &mut Self::Target) -> &mut T;
-
-    /// Convert the target type to the repr.
-    fn target_to_repr(target: Self::Target) -> Self::Repr;
-
-    /// Convert a reference to a repr type to a reference to a value.
-    fn repr_to_value_ref(repr: &Self::Repr) -> &T;
 }
 
 /// Representation for standard `#[turbo_tasks::value]`, where a read return a
@@ -86,17 +66,12 @@ where
     T: VcValueType,
 {
     type Target = T;
-    type Repr = T;
 
     fn value_to_target_ref(value: &T) -> &Self::Target {
         value
     }
 
     fn value_to_target(value: T) -> Self::Target {
-        value
-    }
-
-    fn value_to_repr(value: T) -> Self::Repr {
         value
     }
 
@@ -111,30 +86,20 @@ where
     fn target_to_value_mut_ref(target: &mut Self::Target) -> &mut T {
         target
     }
-
-    fn target_to_repr(target: Self::Target) -> Self::Repr {
-        target
-    }
-
-    fn repr_to_value_ref(repr: &Self::Repr) -> &T {
-        repr
-    }
 }
 
 /// Representation for `#[turbo_tasks::value(transparent)]` types, where reads
 /// return a reference to the target type.
-pub struct VcTransparentRead<T, Target, Repr> {
-    _phantom: PhantomData<(T, Target, Repr)>,
+pub struct VcTransparentRead<T, Target> {
+    _phantom: PhantomData<(T, Target)>,
 }
 
-impl<T, Target, Repr> VcRead<T> for VcTransparentRead<T, Target, Repr>
+impl<T, Target> VcRead<T> for VcTransparentRead<T, Target>
 where
     T: VcValueType,
     Target: Any + Send + Sync,
-    Repr: VcValueType,
 {
     type Target = Target;
-    type Repr = Repr;
 
     fn value_to_target_ref(value: &T) -> &Self::Target {
         // Safety: the `VcValueType` implementor must guarantee that both `T` and
@@ -151,13 +116,6 @@ where
         // Safety: see `Self::value_to_target_ref` above.
         unsafe {
             std::mem::transmute_copy::<ManuallyDrop<T>, Self::Target>(&ManuallyDrop::new(value))
-        }
-    }
-
-    fn value_to_repr(value: T) -> Self::Repr {
-        // Safety: see `Self::value_to_target_ref` above.
-        unsafe {
-            std::mem::transmute_copy::<ManuallyDrop<T>, Self::Repr>(&ManuallyDrop::new(value))
         }
     }
 
@@ -181,22 +139,6 @@ where
             std::mem::transmute_copy::<ManuallyDrop<&mut Self::Target>, &mut T>(&ManuallyDrop::new(
                 target,
             ))
-        }
-    }
-
-    fn target_to_repr(target: Self::Target) -> Self::Repr {
-        // Safety: see `Self::value_to_target_ref` above.
-        unsafe {
-            std::mem::transmute_copy::<ManuallyDrop<Self::Target>, Self::Repr>(&ManuallyDrop::new(
-                target,
-            ))
-        }
-    }
-
-    fn repr_to_value_ref(repr: &Self::Repr) -> &T {
-        // Safety: see `Self::value_to_target_ref` above.
-        unsafe {
-            std::mem::transmute_copy::<ManuallyDrop<&Self::Repr>, &T>(&ManuallyDrop::new(repr))
         }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -135,11 +135,10 @@ where
     }
 }
 
-impl<T, Inner, Repr> Default for ResolvedVc<T>
+impl<T, Inner> Default for ResolvedVc<T>
 where
-    T: VcValueType<Read = VcTransparentRead<T, Inner, Repr>>,
+    T: VcValueType<Read = VcTransparentRead<T, Inner>>,
     Inner: Any + Send + Sync + Default,
-    Repr: VcValueType,
 {
     fn default() -> Self {
         Self::cell(Default::default())
@@ -178,11 +177,10 @@ where
     }
 }
 
-impl<T, Inner, Repr> ResolvedVc<T>
+impl<T, Inner> ResolvedVc<T>
 where
-    T: VcValueType<Read = VcTransparentRead<T, Inner, Repr>>,
+    T: VcValueType<Read = VcTransparentRead<T, Inner>>,
     Inner: Any + Send + Sync,
-    Repr: VcValueType,
 {
     pub fn cell(inner: Inner) -> Self {
         Self {


### PR DESCRIPTION
It used to be that a cell could contain a transmuted representation. This was a hack for the previous limited generic support that I removed in https://github.com/vercel/next.js/pull/70817.

Clean this up! `Repr` and `T` are always the same type!