### PR TITLE
fix(examples): copy .yarnrc files in Docker examples

### DIFF
--- a/examples/with-docker-multi-env/docker/development/Dockerfile
+++ b/examples/with-docker-multi-env/docker/development/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* .yarnrc* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \

--- a/examples/with-docker-multi-env/docker/production/Dockerfile
+++ b/examples/with-docker-multi-env/docker/production/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* .yarnrc* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \

--- a/examples/with-docker-multi-env/docker/staging/Dockerfile
+++ b/examples/with-docker-multi-env/docker/staging/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* .yarnrc* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \

--- a/examples/with-docker/Dockerfile
+++ b/examples/with-docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* ./
+COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* .npmrc* .yarnrc* ./
 RUN \
   if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
   elif [ -f package-lock.json ]; then npm ci; \


### PR DESCRIPTION
## Summary

Added `.yarnrc*` to COPY commands in Docker examples to support Yarn configuration files (e.g., for private registries).

## Problem

The example Dockerfiles copy `.npmrc*` but not `.yarnrc*` files, which can cause issues when installing packages from private registries configured in `.yarnrc` or `.yarnrc.yml`.

## Solution

Added `.yarnrc*` pattern to the COPY commands alongside the existing `.npmrc*` pattern.

## Updated Files

- `examples/with-docker/Dockerfile`
- `examples/with-docker-multi-env/docker/development/Dockerfile`
- `examples/with-docker-multi-env/docker/production/Dockerfile`
- `examples/with-docker-multi-env/docker/staging/Dockerfile`

## Related Issues

Fixes #71827