### PR TITLE
Better typesafety for `interopDefault`

### DIFF
--- a/packages/next/src/lib/interop-default.ts
+++ b/packages/next/src/lib/interop-default.ts
@@ -1,3 +1,4 @@
-export function interopDefault(mod: any) {
+export function interopDefault<T>(mod: { default: T } | T): T {
+  // @ts-ignore
   return mod.default || mod
 }

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -177,8 +177,8 @@ async function loadComponentsImpl<
   sriEnabled: boolean
   needsManifestsForLegacyReasons: boolean
 }): Promise<LoadComponentsReturnType<N>> {
-  let DocumentMod: any = {}
-  let AppMod: any = {}
+  let DocumentMod = {}
+  let AppMod = {}
   if (!isAppPath) {
     ;[DocumentMod, AppMod] = await Promise.all([
       requirePage('/_document', distDir, false),
@@ -308,7 +308,9 @@ async function loadComponentsImpl<
       ComponentMod
 
     return {
+      // @ts-expect-error this is indeed `{} || AppType` and not always `AppType`
       App,
+      // @ts-expect-error this is indeed `{} || DocumentType` and not always `DocumentType`
       Document,
       Component,
       buildManifest,

--- a/packages/next/src/server/load-components.ts
+++ b/packages/next/src/server/load-components.ts
@@ -177,8 +177,8 @@ async function loadComponentsImpl<
   sriEnabled: boolean
   needsManifestsForLegacyReasons: boolean
 }): Promise<LoadComponentsReturnType<N>> {
-  let DocumentMod = {}
-  let AppMod = {}
+  let DocumentMod: any = {}
+  let AppMod: any = {}
   if (!isAppPath) {
     ;[DocumentMod, AppMod] = await Promise.all([
       requirePage('/_document', distDir, false),


### PR DESCRIPTION
Make it actually typed instead of `any -> any`