### PR TITLE
Turbopack: improve cell order lint rule

### DIFF
--- a/.config/ast-grep/rules/no-map-async-cell.yml
+++ b/.config/ast-grep/rules/no-map-async-cell.yml
@@ -8,13 +8,16 @@ language: Rust
 rule:
   all:
     - any:
-        - pattern: $X.cell()
-        - pattern: $X.resolved_cell()
+        - pattern: $_X.cell()
+        - pattern: $_X.resolved_cell()
+        - pattern: ResolvedVc::cell($_X)
+        - pattern: Vc::cell($_X)
     - inside:
         stopBy: end
         all:
           - any:
               - pattern: 'async |$$$ARGS| $BODY'
+              - pattern: 'async move |$$$ARGS| $BODY'
               - pattern: '|$$$ARGS| async { $$$BODY }'
               - pattern: '|$$$ARGS| async move { $$$BODY }'
           - inside:

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/content.rs
@@ -116,14 +116,11 @@ impl EcmascriptDevChunkListContent {
 
         let by_merger = by_merger
             .into_iter()
-            .map(|(merger, contents)| async move {
+            .map(|(merger, contents)| (merger, Vc::cell(contents)))
+            .map(async |(merger, contents)| {
                 Ok((
                     merger.to_resolved().await?,
-                    merger
-                        .merge(Vc::cell(contents))
-                        .version()
-                        .into_trait_ref()
-                        .await?,
+                    merger.merge(contents).version().into_trait_ref().await?,
                 ))
             })
             .try_join()


### PR DESCRIPTION
Addresses the comments on this PR: https://github.com/vercel/next.js/pull/88474#discussion_r2687626329

"Merge when ready" had striked again

This did actually find another violation