### PR TITLE
[Backport] mimalloc upgrade and enabling it on musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,6 +3643,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "cty",
+ "libc",
+]
+
+[[package]]
 name = "libunwind"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3997,12 +4008,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "mimalloc-rspack"
-version = "0.2.4"
+name = "mimalloc"
+version = "0.1.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de20bb33bf95d9c060030d53bcb5d5dc03cbbedfbd1dcda5f6f285b946dae2c0"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
 dependencies = [
- "rspack-libmimalloc-sys",
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6040,17 +6051,6 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "serde",
-]
-
-[[package]]
-name = "rspack-libmimalloc-sys"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c741844b1fbe0cfbae8dfeb73b5e5fdc95daf7be58bdd72afb3fd85c86bccdb"
-dependencies = [
- "cc",
- "cty",
- "libc",
 ]
 
 [[package]]
@@ -9437,8 +9437,7 @@ dependencies = [
 name = "turbo-tasks-malloc"
 version = "0.1.0"
 dependencies = [
- "mimalloc-rspack",
- "rspack-libmimalloc-sys",
+ "mimalloc",
 ]
 
 [[package]]

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -10,21 +10,21 @@ autobenches = false
 bench = false
 
 [dependencies]
-rspack-libmimalloc-sys = { version = "0.2.4", default-features = false, features = [], optional = true }
+
 
 [target.'cfg(not(any(target_os = "linux", target_family = "wasm", target_env = "musl")))'.dependencies]
-mimalloc-rspack = { version = "0.2.4", features = [
+mimalloc = { version = "0.1.48", features = [
   "v3",
-  "extended"
+  "extended",
 ], optional = true }
 
 [target.'cfg(all(target_os = "linux", not(any(target_family = "wasm", target_env = "musl"))))'.dependencies]
-mimalloc-rspack = { version = "0.2.4", features = [
+mimalloc = { version = "0.1.48", features = [
   "v3",
   "extended",
   "local_dynamic_tls",
 ], optional = true }
 
 [features]
-custom_allocator = ["dep:mimalloc-rspack", "dep:rspack-libmimalloc-sys"]
+custom_allocator = ["dep:mimalloc"]
 default = ["custom_allocator"]

--- a/turbopack/crates/turbo-tasks-malloc/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-malloc/Cargo.toml
@@ -12,13 +12,13 @@ bench = false
 [dependencies]
 
 
-[target.'cfg(not(any(target_os = "linux", target_family = "wasm", target_env = "musl")))'.dependencies]
+[target.'cfg(not(any(target_os = "linux", target_family = "wasm")))'.dependencies]
 mimalloc = { version = "0.1.48", features = [
   "v3",
   "extended",
 ], optional = true }
 
-[target.'cfg(all(target_os = "linux", not(any(target_family = "wasm", target_env = "musl"))))'.dependencies]
+[target.'cfg(all(target_os = "linux", not(target_family = "wasm")))'.dependencies]
 mimalloc = { version = "0.1.48", features = [
   "v3",
   "extended",

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -114,29 +114,17 @@ impl TurboMalloc {
 /// Get the allocator for this platform that we should wrap with TurboMalloc.
 #[inline]
 fn base_alloc() -> &'static impl GlobalAlloc {
-    #[cfg(all(
-        feature = "custom_allocator",
-        not(any(target_family = "wasm", target_env = "musl"))
-    ))]
+    #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
     return &mimalloc::MiMalloc;
-    #[cfg(any(
-        not(feature = "custom_allocator"),
-        any(target_family = "wasm", target_env = "musl")
-    ))]
+    #[cfg(not(all(feature = "custom_allocator", not(target_family = "wasm"))))]
     return &std::alloc::System;
 }
 
 #[allow(unused_variables)]
 unsafe fn base_alloc_size(ptr: *const u8, layout: Layout) -> usize {
-    #[cfg(all(
-        feature = "custom_allocator",
-        not(any(target_family = "wasm", target_env = "musl"))
-    ))]
+    #[cfg(all(feature = "custom_allocator", not(target_family = "wasm")))]
     return unsafe { mimalloc::MiMalloc.usable_size(ptr) };
-    #[cfg(any(
-        not(feature = "custom_allocator"),
-        any(target_family = "wasm", target_env = "musl")
-    ))]
+    #[cfg(not(all(feature = "custom_allocator", not(target_family = "wasm"))))]
     return layout.size();
 }
 

--- a/turbopack/crates/turbo-tasks-malloc/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-malloc/src/lib.rs
@@ -118,7 +118,7 @@ fn base_alloc() -> &'static impl GlobalAlloc {
         feature = "custom_allocator",
         not(any(target_family = "wasm", target_env = "musl"))
     ))]
-    return &mimalloc_rspack::MiMalloc;
+    return &mimalloc::MiMalloc;
     #[cfg(any(
         not(feature = "custom_allocator"),
         any(target_family = "wasm", target_env = "musl")
@@ -132,7 +132,7 @@ unsafe fn base_alloc_size(ptr: *const u8, layout: Layout) -> usize {
         feature = "custom_allocator",
         not(any(target_family = "wasm", target_env = "musl"))
     ))]
-    return unsafe { mimalloc_rspack::MiMalloc.usable_size(ptr) };
+    return unsafe { mimalloc::MiMalloc.usable_size(ptr) };
     #[cfg(any(
         not(feature = "custom_allocator"),
         any(target_family = "wasm", target_env = "musl")


### PR DESCRIPTION
Backports
- chore(turbo-tasks-malloc): replace mimalloc-rspack to mimalloc ([#87815](https://github.com/vercel/next.js/issues/87815))
- Turbopack: use mimalloc on Linux musl ([#88426](https://github.com/vercel/next.js/issues/88426))