### PR TITLE
fix(dev): include basePath in dev server startup URLs

### DIFF
--- a/packages/next/src/server/lib/app-info-log.ts
+++ b/packages/next/src/server/lib/app-info-log.ts
@@ -9,20 +9,10 @@ import { experimentalSchema } from '../config-schema'
 export type { ConfiguredExperimentalFeature }
 
 /**
- * Logs basic startup info that doesn't require config.
- * Called before "Ready in X" to show immediate feedback.
+ * Logs the Next.js banner with version and bundler info.
+ * Called immediately at startup for fast visual feedback.
  */
-export function logStartInfo({
-  networkUrl,
-  appUrl,
-  envInfo,
-  logBundler,
-}: {
-  networkUrl: string | null
-  appUrl: string | null
-  envInfo?: string[]
-  logBundler: boolean
-}) {
+export function logBanner({ logBundler }: { logBundler: boolean }) {
   let versionSuffix = ''
   const parts = []
 
@@ -45,11 +35,26 @@ export function logStartInfo({
       purple(`${Log.prefixes.ready} Next.js ${process.env.__NEXT_VERSION}`)
     )}${versionSuffix}`
   )
+}
+
+/**
+ * Logs URL and environment info.
+ * Called after config is loaded so URLs can include basePath.
+ */
+export function logUrls({
+  networkUrl,
+  appUrl,
+  envInfo,
+}: {
+  networkUrl: string | null
+  appUrl: string | null
+  envInfo?: string[]
+}) {
   if (appUrl) {
-    Log.bootstrap(`- Local:         ${appUrl}`)
+    Log.bootstrap(`- Local:        ${appUrl}`)
   }
   if (networkUrl) {
-    Log.bootstrap(`- Network:       ${networkUrl}`)
+    Log.bootstrap(`- Network:      ${networkUrl}`)
   }
   const inspectorUrl = inspector.url()
   if (inspectorUrl) {
@@ -61,6 +66,26 @@ export function logStartInfo({
     Log.bootstrap(`- Debugger port: ${debugPort}`)
   }
   if (envInfo?.length) Log.bootstrap(`- Environments: ${envInfo.join(', ')}`)
+}
+
+/**
+ * Logs basic startup info that doesn't require config.
+ * Called before "Ready in X" to show immediate feedback.
+ * @deprecated Use logBanner() and logUrls() separately for better control over timing.
+ */
+export function logStartInfo({
+  networkUrl,
+  appUrl,
+  envInfo,
+  logBundler,
+}: {
+  networkUrl: string | null
+  appUrl: string | null
+  envInfo?: string[]
+  logBundler: boolean
+}) {
+  logBanner({ logBundler })
+  logUrls({ networkUrl, appUrl, envInfo })
 }
 
 /**

--- a/packages/next/src/server/lib/render-server.ts
+++ b/packages/next/src/server/lib/render-server.ts
@@ -22,6 +22,8 @@ export type ServerInitResult = {
   experimentalFeatures: ConfiguredExperimentalFeature[]
   // Whether cache components is enabled
   cacheComponents: boolean
+  // The basePath from config, used for displaying URLs with correct path prefix
+  basePath: string
 }
 
 let initializations: Record<string, Promise<ServerInitResult> | undefined> = {}
@@ -101,6 +103,7 @@ async function initializeImpl(opts: {
   distDir: string
   experimentalFeatures: ConfiguredExperimentalFeature[]
   cacheComponents: boolean
+  basePath: string
 }): Promise<ServerInitResult> {
   const type = process.env.__NEXT_PRIVATE_RENDER_WORKER
   if (type) {
@@ -179,6 +182,7 @@ async function initializeImpl(opts: {
     distDir: opts.distDir,
     experimentalFeatures: opts.experimentalFeatures,
     cacheComponents: opts.cacheComponents,
+    basePath: opts.basePath,
   }
 }
 

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -738,6 +738,7 @@ export async function initialize(opts: {
     distDir: config.distDir,
     experimentalFeatures,
     cacheComponents: config.cacheComponents,
+    basePath: config.basePath,
   }
   renderServerOpts.serverFields.routerServerHandler = requestHandlerImpl
 
@@ -912,5 +913,6 @@ export async function initialize(opts: {
     distDir: config.distDir,
     experimentalFeatures,
     cacheComponents: config.cacheComponents,
+    basePath: config.basePath,
   }
 }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -29,7 +29,12 @@ import {
   CONFIG_FILES,
   PHASE_DEVELOPMENT_SERVER,
 } from '../../shared/lib/constants'
-import { getEnvInfo, logExperimentalInfo, logStartInfo } from './app-info-log'
+import {
+  getEnvInfo,
+  logBanner,
+  logExperimentalInfo,
+  logUrls,
+} from './app-info-log'
 import { validateTurboNextConfig } from '../../lib/turbopack-warning'
 import { type Span, trace, flushAllTraces } from '../../trace'
 import { isIPv6 } from './is-ipv6'
@@ -361,13 +366,8 @@ export async function startServer(
       // Get env info first (fast, doesn't require config)
       const envInfo = isDev ? getEnvInfo(dir) : undefined
 
-      // Log basic startup info immediately (before loading config)
-      logStartInfo({
-        networkUrl,
-        appUrl,
-        envInfo,
-        logBundler: isDev,
-      })
+      // Log banner immediately for fast visual feedback
+      logBanner({ logBundler: isDev })
 
       // Calculate and log "Ready in X" before loading config
       // so it reflects actual framework startup time
@@ -466,6 +466,14 @@ export async function startServer(
         upgradeHandler = initResult.upgradeHandler
         nextServer = initResult.server
         closeUpgraded = initResult.closeUpgraded
+
+        // Log URLs after config is loaded so we can include basePath
+        const { basePath } = initResult
+        logUrls({
+          appUrl: appUrl + basePath,
+          networkUrl: networkUrl ? networkUrl + basePath : null,
+          envInfo,
+        })
 
         // Log experimental features after config is loaded
         if (isDev) {


### PR DESCRIPTION
When a basePath is configured in next.config.js, the dev server startup message now displays the full URL including the basePath, making it easier for developers to access their application at the correct path.

Split logStartInfo() into logBanner() and logUrls() to allow displaying the banner immediately for fast feedback, while deferring URL display until after config loads so basePath can be included.

Fixes #82882
