### PR TITLE
[turbopack] Move some of the logic for issue filtering into the rust layer

### DIFF
--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -87,6 +87,10 @@ static SOURCE_MAP_PREFIX: Lazy<String> = Lazy::new(|| format!("{SOURCE_URL_PROTO
 static SOURCE_MAP_PREFIX_PROJECT: Lazy<String> =
     Lazy::new(|| format!("{SOURCE_URL_PROTOCOL}///[{PROJECT_FILESYSTEM_NAME}]/"));
 
+/// Next doesn't display warnings from node_modules, so configure turbopack to not report them
+/// either. This matches logic in `packages/next/src/server/dev/turbopack-utils.ts`
+pub const NEXT_ISSUE_FILTER: IssueFilter = IssueFilter::warnings_and_foreign_errors();
+
 #[napi(object)]
 #[derive(Clone, Debug)]
 pub struct NapiEnvVar {
@@ -1300,8 +1304,6 @@ pub fn project_hmr_events(
 struct HmrIdentifiers {
     pub identifiers: Vec<RcStr>,
 }
-
-pub const NEXT_ISSUE_FILTER: IssueFilter = IssueFilter::warnings_and_foreign_errors();
 
 #[turbo_tasks::value(serialization = "none")]
 struct HmrIdentifiersWithIssues {

--- a/crates/napi/src/next_api/project.rs
+++ b/crates/napi/src/next_api/project.rs
@@ -50,7 +50,7 @@ use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
     diagnostics::PlainDiagnostic,
     error::PrettyPrintError,
-    issue::PlainIssue,
+    issue::{IssueFilter, PlainIssue},
     output::{OutputAsset, OutputAssets},
     source_map::{SourceMap, Token},
     version::{PartialUpdate, TotalUpdate, Update, VersionState},
@@ -1190,7 +1190,7 @@ async fn hmr_update_with_issues_operation(
 ) -> Result<Vc<HmrUpdateWithIssues>> {
     let update_op = project_hmr_update_operation(project, identifier, state);
     let update = update_op.read_strongly_consistent().await?;
-    let issues = get_issues(update_op).await?;
+    let issues = get_issues(update_op, NEXT_ISSUE_FILTER).await?;
     let diagnostics = get_diagnostics(update_op).await?;
     let effects = Arc::new(get_effects(update_op).await?);
     Ok(HmrUpdateWithIssues {
@@ -1301,6 +1301,8 @@ struct HmrIdentifiers {
     pub identifiers: Vec<RcStr>,
 }
 
+pub const NEXT_ISSUE_FILTER: IssueFilter = IssueFilter::warnings_and_foreign_errors();
+
 #[turbo_tasks::value(serialization = "none")]
 struct HmrIdentifiersWithIssues {
     identifiers: ReadRef<Vec<RcStr>>,
@@ -1315,7 +1317,7 @@ async fn get_hmr_identifiers_with_issues_operation(
 ) -> Result<Vc<HmrIdentifiersWithIssues>> {
     let hmr_identifiers_op = project_container_hmr_identifiers_operation(container);
     let hmr_identifiers = hmr_identifiers_op.read_strongly_consistent().await?;
-    let issues = get_issues(hmr_identifiers_op).await?;
+    let issues = get_issues(hmr_identifiers_op, NEXT_ISSUE_FILTER).await?;
     let diagnostics = get_diagnostics(hmr_identifiers_op).await?;
     let effects = Arc::new(get_effects(hmr_identifiers_op).await?);
     Ok(HmrIdentifiersWithIssues {

--- a/crates/napi/src/next_api/utils.rs
+++ b/crates/napi/src/next_api/utils.rs
@@ -17,13 +17,13 @@ use turbo_tasks_fs::FileContent;
 use turbopack_core::{
     diagnostics::{Diagnostic, DiagnosticContextExt, PlainDiagnostic},
     issue::{
-        CollectibleIssuesExt, IssueSeverity, PlainIssue, PlainIssueSource, PlainSource,
-        StyledString,
+        CollectibleIssuesExt, IssueFilter, IssueSeverity, PlainIssue, PlainIssueSource,
+        PlainSource, StyledString,
     },
     source_pos::SourcePos,
 };
 
-use crate::next_api::turbopack_ctx::NextTurbopackContext;
+use crate::next_api::{project::NEXT_ISSUE_FILTER, turbopack_ctx::NextTurbopackContext};
 
 /// An [`OperationVc`] that can be passed back and forth to JS across the [`napi`][mod@napi]
 /// boundary via [`External`].
@@ -102,8 +102,13 @@ pub fn root_task_dispose(
     Ok(())
 }
 
-pub async fn get_issues<T: Send>(source: OperationVc<T>) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
-    Ok(Arc::new(source.peek_issues().get_plain_issues().await?))
+pub async fn get_issues<T: Send>(
+    source: OperationVc<T>,
+    filter: IssueFilter,
+) -> Result<Arc<Vec<ReadRef<PlainIssue>>>> {
+    Ok(Arc::new(
+        source.peek_issues().get_plain_issues(filter).await?,
+    ))
 }
 
 /// Reads the [turbopack_core::diagnostics::Diagnostic] held
@@ -369,7 +374,7 @@ pub async fn strongly_consistent_catch_collectables<R: VcValueType + Send>(
     Arc<Effects>,
 )> {
     let result = source_op.read_strongly_consistent().await;
-    let issues = get_issues(source_op).await?;
+    let issues = get_issues(source_op, NEXT_ISSUE_FILTER).await?;
     let diagnostics = get_diagnostics(source_op).await?;
     let effects = Arc::new(get_effects(source_op).await?);
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -146,7 +146,7 @@ pub async fn foreign_code_context_condition(
     ));
 
     let result = ContextCondition::all(vec![
-        ContextCondition::InDirectory("node_modules".to_string()),
+        ContextCondition::InNodeModules,
         not_next_template_dir,
         ContextCondition::not(ContextCondition::any(
             transpiled_packages

--- a/turbopack/crates/turbopack-cli-utils/src/issue.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/issue.rs
@@ -15,7 +15,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{RawVc, TransientInstance, TransientValue, Vc};
 use turbo_tasks_fs::{FileLinesContent, source_context::get_source_context};
 use turbopack_core::issue::{
-    CollectibleIssuesExt, IssueReporter, IssueSeverity, PlainIssue, PlainIssueSource,
+    CollectibleIssuesExt, IssueFilter, IssueReporter, IssueSeverity, PlainIssue, PlainIssueSource,
     PlainTraceItem, StyledString,
 };
 
@@ -371,7 +371,7 @@ impl IssueReporter for ConsoleUi {
         } = self.options;
         let mut grouped_issues: GroupedIssues = FxHashMap::default();
 
-        let plain_issues = issues.get_plain_issues().await?;
+        let plain_issues = issues.get_plain_issues(IssueFilter::everything()).await?;
         let issues = plain_issues
             .iter()
             .map(|plain_issue| {

--- a/turbopack/crates/turbopack-cli/src/contexts.rs
+++ b/turbopack/crates/turbopack-cli/src/contexts.rs
@@ -45,7 +45,7 @@ impl fmt::Display for NodeEnv {
 }
 
 fn foreign_code_context_condition() -> ContextCondition {
-    ContextCondition::InDirectory("node_modules".to_string())
+    ContextCondition::InNodeModules
 }
 
 #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/condition.rs
+++ b/turbopack/crates/turbopack-core/src/condition.rs
@@ -8,6 +8,9 @@ pub enum ContextCondition {
     Any(Vec<ContextCondition>),
     Not(Box<ContextCondition>),
     InDirectory(String),
+    /// The same as `InDirectory("node_modules"), but as this is the most common case, we handle it
+    /// directly.`
+    InNodeModules,
     InPath(FileSystemPath),
 }
 
@@ -35,16 +38,21 @@ impl ContextCondition {
             ContextCondition::Any(conditions) => conditions.iter().any(|c| c.matches(path)),
             ContextCondition::Not(condition) => !condition.matches(path),
             ContextCondition::InPath(other_path) => path.is_inside_or_equal_ref(other_path),
+            ContextCondition::InNodeModules => is_in_directory(path, "node_modules"),
             ContextCondition::InDirectory(dir) => {
                 // `dir` must be a substring and bracketd by either `'/'` or the end of the path.
-                if let Some(pos) = path.path.find(dir) {
-                    let end = pos + dir.len();
-                    (pos == 0 || path.path.as_bytes()[pos - 1] == b'/')
-                        && (end == path.path.len() || path.path.as_bytes()[end] == b'/')
-                } else {
-                    false
-                }
+                is_in_directory(path, dir)
             }
         }
+    }
+}
+
+fn is_in_directory(path: &FileSystemPath, dir: &str) -> bool {
+    if let Some(pos) = path.path.find(dir) {
+        let end = pos + dir.len();
+        (pos == 0 || path.path.as_bytes()[pos - 1] == b'/')
+            && (end == path.path.len() || path.path.as_bytes()[end] == b'/')
+    } else {
+        false
     }
 }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -15,14 +15,15 @@ use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     CollectiblesSource, IntoTraitRef, NonLocalValue, OperationVc, RawVc, ReadRef, ResolvedVc,
-    TaskInput, TransientValue, TryJoinIterExt, Upcast, ValueDefault, ValueToString, Vc, emit,
-    trace::TraceRawVcs,
+    TaskInput, TransientValue, TryFlatJoinIterExt, TryJoinIterExt, Upcast, ValueDefault,
+    ValueToString, Vc, emit, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileContent, FileLine, FileLinesContent, FileSystem, FileSystemPath};
 use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher};
 
 use crate::{
     asset::{Asset, AssetContent},
+    condition::ContextCondition,
     ident::{AssetIdent, Layer},
     source::Source,
     source_map::{GenerateSourceMap, SourceMap, TokenWithSource},
@@ -234,6 +235,59 @@ where
 #[turbo_tasks::value(transparent)]
 pub struct Issues(Vec<ResolvedVc<Box<dyn Issue>>>);
 
+#[derive(TaskInput, Hash, Eq, PartialEq, Copy, Clone, Encode, Decode, TraceRawVcs, Debug)]
+pub struct IssueFilter {
+    /// The minimum severity for issues
+    severity: IssueSeverity,
+    /// The minimum severity for issues in node_modules
+    foreign_severity: IssueSeverity,
+}
+
+impl IssueFilter {
+    pub const fn everything() -> Self {
+        Self {
+            severity: IssueSeverity::Info,
+            foreign_severity: IssueSeverity::Info,
+        }
+    }
+
+    pub const fn warnings_and_foreign_errors() -> Self {
+        Self {
+            severity: IssueSeverity::Warning,
+            foreign_severity: IssueSeverity::Error,
+        }
+    }
+
+    /// Returns true if the issue is allowed by this filter. issue
+    async fn matches(&self, issue: ResolvedVc<Box<dyn Issue>>) -> Result<bool> {
+        if *self == IssueFilter::everything() {
+            return Ok(true);
+        }
+        let severity = issue.into_trait_ref().await?.severity();
+        // NOTE: Lower severities are _more_ severe
+        Ok(
+            if severity <= self.severity || severity <= self.foreign_severity {
+                // we need to check the path to see if it is foreign or not.  Only await the path if
+                // it might possibly matter
+                if severity <= self.severity && severity <= self.foreign_severity {
+                    // it matches no matter where the path is
+                    true
+                } else {
+                    let path = issue.file_path().await?;
+                    if ContextCondition::InNodeModules.matches(&path) {
+                        severity <= self.foreign_severity
+                    } else {
+                        severity <= self.severity
+                    }
+                }
+            } else {
+                // it is too low severity to match either way
+                false
+            },
+        )
+    }
+}
+
 /// A list of issues captured with [`Issue::peek_issues_with_path`] and
 /// [`Issue::take_issues`].
 #[turbo_tasks::value(shared)]
@@ -269,12 +323,20 @@ impl CapturedIssues {
     }
 
     // Returns all the issues as formatted `PlainIssues`.
-    pub async fn get_plain_issues(&self) -> Result<Vec<ReadRef<PlainIssue>>> {
+    pub async fn get_plain_issues(&self, filter: IssueFilter) -> Result<Vec<ReadRef<PlainIssue>>> {
         let mut list = self
             .issues
             .iter()
-            .map(|issue| async move { PlainIssue::from_issue(**issue, Some(*self.tracer)).await })
-            .try_join()
+            .map(async |issue| {
+                if filter.matches(*issue).await? {
+                    Ok(Some(
+                        PlainIssue::from_issue(**issue, Some(*self.tracer)).await?,
+                    ))
+                } else {
+                    Ok(None)
+                }
+            })
+            .try_flat_join()
             .await?;
         list.sort();
         Ok(list)

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -14,8 +14,8 @@ use turbo_tasks_fs::{FileSystem, FileSystemPath};
 use turbopack_core::{
     error::PrettyPrintError,
     issue::{
-        CollectibleIssuesExt, Issue, IssueSeverity, IssueStage, OptionStyledString, PlainIssue,
-        StyledString,
+        CollectibleIssuesExt, Issue, IssueFilter, IssueSeverity, IssueStage, OptionStyledString,
+        PlainIssue, StyledString,
     },
     server_fs::ServerFileSystem,
     version::{
@@ -90,7 +90,7 @@ impl GetContentFn {
 async fn peek_issues<T: Send>(source: OperationVc<T>) -> Result<Vec<ReadRef<PlainIssue>>> {
     let captured = source.peek_issues();
 
-    captured.get_plain_issues().await
+    captured.get_plain_issues(IssueFilter::everything()).await
 }
 
 fn extend_issues(issues: &mut Vec<ReadRef<PlainIssue>>, new_issues: Vec<ReadRef<PlainIssue>>) {

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -37,7 +37,7 @@ use turbopack_core::{
     environment::{Environment, ExecutionEnvironment, NodeJsEnvironment},
     file_source::FileSource,
     ident::Layer,
-    issue::CollectibleIssuesExt,
+    issue::{CollectibleIssuesExt, IssueFilter},
     module_graph::{ModuleGraph, binding_usage_info::compute_binding_usage_info},
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
@@ -422,7 +422,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
             environment: Some(env),
             tree_shaking_mode: options.tree_shaking_mode,
             rules: vec![(
-                ContextCondition::InDirectory("node_modules".into()),
+                ContextCondition::InNodeModules,
                 ModuleOptionsContext {
                     tree_shaking_mode: options.tree_shaking_mode,
                     ..Default::default()
@@ -437,7 +437,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
             enable_node_modules: Some(project_root.clone()),
             custom_conditions: vec![rcstr!("development")],
             rules: vec![(
-                ContextCondition::InDirectory("node_modules".into()),
+                ContextCondition::InNodeModules,
                 ResolveOptionsContext {
                     enable_node_modules: Some(project_root.clone()),
                     custom_conditions: vec![rcstr!("development")],
@@ -597,7 +597,10 @@ async fn snapshot_issues(
     let PreparedTest { path, .. } = &*prepared_test.await?;
     let _ = run_result_op.resolve_strongly_consistent().await;
 
-    let plain_issues = run_result_op.peek_issues().get_plain_issues().await?;
+    let plain_issues = run_result_op
+        .peek_issues()
+        .get_plain_issues(IssueFilter::everything())
+        .await?;
 
     turbopack_test_utils::snapshot::snapshot_issues(plain_issues, path.join("issues")?, &REPO_ROOT)
         .await

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -40,7 +40,7 @@ use turbopack_core::{
     file_source::FileSource,
     free_var_references,
     ident::Layer,
-    issue::CollectibleIssuesExt,
+    issue::{CollectibleIssuesExt, IssueFilter},
     module::Module,
     module_graph::{
         ModuleGraph,
@@ -229,7 +229,10 @@ async fn run_inner_operation(resource: RcStr) -> Result<()> {
     let out_op = run_test_operation(resource);
     let out_vc = out_op.resolve_strongly_consistent().await?.owned().await?;
 
-    let plain_issues = out_op.peek_issues().get_plain_issues().await?;
+    let plain_issues = out_op
+        .peek_issues()
+        .get_plain_issues(IssueFilter::everything())
+        .await?;
 
     snapshot_issues(plain_issues, out_vc.join("issues")?, &REPO_ROOT)
         .await
@@ -364,7 +367,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             },
             environment: Some(env),
             rules: vec![(
-                ContextCondition::InDirectory("node_modules".into()),
+                ContextCondition::InNodeModules,
                 ModuleOptionsContext {
                     environment: Some(env),
                     tree_shaking_mode: options.tree_shaking_mode,
@@ -385,7 +388,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             enable_node_modules: Some(project_root.clone()),
             custom_conditions: vec![rcstr!("development")],
             rules: vec![(
-                ContextCondition::InDirectory("node_modules".into()),
+                ContextCondition::InNodeModules,
                 ResolveOptionsContext {
                     enable_node_modules: Some(project_root.clone()),
                     custom_conditions: vec![rcstr!("development")],

--- a/turbopack/crates/turbopack/src/evaluate_context.rs
+++ b/turbopack/crates/turbopack/src/evaluate_context.rs
@@ -82,7 +82,7 @@ pub async fn node_evaluate_asset_context(
         enable_typescript: true,
         import_map: Some(import_map),
         rules: vec![(
-            ContextCondition::InDirectory("node_modules".to_string()),
+            ContextCondition::InNodeModules,
             resolve_options_context.clone().resolved_cell(),
         )],
         ..resolve_options_context


### PR DESCRIPTION
# Optimize issue filtering in Next.js and Turbopack

## What?
This PR introduces an `IssueFilter` system to control which issues are reported based on severity and location

## Why?
To improve performance, we shouldn't spend time formatting issues that will never be displayed to a user.

## How?
- Added `IssueFilter` to control which issues are displayed based on severity and location
- Created a specialized `InNodeModules` context condition for better readability
- Implemented `warnings_and_foreign_errors()` filter that shows:
  - Warnings and errors from application code
  - Only errors from node_modules
- Applied the filter throughout Next.js and Turbopack's issue reporting system
- Refactored issue collection to filter early rather than collecting everything first
