### PR TITLE
Ensure password doesn't start or end with a empty space before trim.

### DIFF
--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -119,6 +119,7 @@ export const SignupFormSchema = z.object({
     .regex(/[^a-zA-Z0-9]/, {
       error: 'Contain at least one special character.',
     })
+    .regex(/^[^\s].*[^\s]$/, {error: "Not start or end with a space"})
     .trim(),
 })
 

--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -119,7 +119,9 @@ export const SignupFormSchema = z.object({
     .regex(/[^a-zA-Z0-9]/, {
       error: 'Contain at least one special character.',
     })
-    .regex(/^[^\s].*[^\s]$/, { error: "Not start or end with a space" })
+    .regex(/^(?:[^\s]|[^\s].*[^\s])$/, {
+      error: "Not start or end with a space."
+    })
     .trim(),
 })
 
@@ -152,7 +154,9 @@ export const SignupFormSchema = z.object({
     .regex(/[^a-zA-Z0-9]/, {
       error: 'Contain at least one special character.',
     })
-    .regex(/^[^\s].*[^\s]$/, { error: "Not start or end with a space" })
+    .regex(/^(?:[^\s]|[^\s].*[^\s])$/, {
+      error: "Not start or end with a space."
+    })
     .trim(),
 })
 ```

--- a/docs/01-app/02-guides/authentication.mdx
+++ b/docs/01-app/02-guides/authentication.mdx
@@ -119,7 +119,7 @@ export const SignupFormSchema = z.object({
     .regex(/[^a-zA-Z0-9]/, {
       error: 'Contain at least one special character.',
     })
-    .regex(/^[^\s].*[^\s]$/, {error: "Not start or end with a space"})
+    .regex(/^[^\s].*[^\s]$/, { error: "Not start or end with a space" })
     .trim(),
 })
 
@@ -152,6 +152,7 @@ export const SignupFormSchema = z.object({
     .regex(/[^a-zA-Z0-9]/, {
       error: 'Contain at least one special character.',
     })
+    .regex(/^[^\s].*[^\s]$/, { error: "Not start or end with a space" })
     .trim(),
 })
 ```


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Currently, in the documentation authentication guide ([guides/authentication#2-validate-form-fields-on-the-server](https://nextjs.org/docs/app/guides/authentication#2-validate-form-fields-on-the-server)), Zod is being used to validate the password; however, the issue is that the final `.trim` call modifies the user's password and silently removes spaces at the beginning or at the end. This obviously isn't a major issue by any means, but I think that, for completeness, a regex to check for this exact problem could be a neat addition.