### PR TITLE
Remove `lerna bootstrap` from the `clean` script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "new-error": "turbo gen error",
     "new-test": "turbo gen test",
-    "clean": "lerna clean -y && lerna bootstrap && lerna run clean && lerna exec 'node ../../scripts/rm.mjs dist'",
+    "clean": "lerna clean -y && lerna run clean && lerna exec 'node ../../scripts/rm.mjs dist'",
     "build": "turbo run build --remote-cache-timeout 60 --summarize true",
     "lerna": "lerna",
     "dev": "turbo run dev --parallel --filter=\"!@next/bundle-analyzer-ui\"",


### PR DESCRIPTION
In #87188 we upgraded lerna to v9 which no longer supports/requires the `lerna bootstrap` command. This commit removes it from the `clean` script in the root package.json to avoid errors when running `pnpm clean`.

[More info](https://lerna.js.org/docs/legacy-package-management#replacing-your-usage-of-lerna-bootstraplerna-link)