### PR TITLE
[cna] Avoid error with out-of-box Netlify config

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -321,7 +321,8 @@ export const installTemplate = async ({
 
   if (packageManager === "pnpm") {
     const pnpmWorkspaceYaml = [
-      // required for v9, v10 doesn't need it anymore
+      // required for v9 to avoid "packages field missing or empty", v10 doesn't need it anymore
+      // TODO: remove when v9 no longer supported
       "packages: []",
       // v10 setting without counterpart in v9
       "ignoredBuiltDependencies:",

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -322,8 +322,7 @@ export const installTemplate = async ({
   if (packageManager === "pnpm") {
     const pnpmWorkspaceYaml = [
       // required for v9, v10 doesn't need it anymore
-      "packages:",
-      "  - .",
+      "packages: []",
       // v10 setting without counterpart in v9
       "ignoredBuiltDependencies:",
       // Sharp has prebuilt binaries for the platforms next-swc has binaries.


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

### What?

Fix error with Netlify not finding `pnpm create-next-app` build output (when users use pnpm)

Also, remove unnecessary configuration, since pnpm v9 and v10 docs mention that the root package is always included:

> The root package is always included, even when custom location wildcards are used.

- v9 docs https://pnpm.io/9.x/pnpm-workspace_yaml#:~:text=The%20root%20package%20is%20always%20included%2C%20even%20when%20custom%20location%20wildcards%20are%20used.
- v10 docs https://pnpm.io/pnpm-workspace_yaml#:~:text=The%20root%20package%20is%20always%20included%2C%20even%20when%20custom%20location%20wildcards%20are%20used.

For pnpm v9 (eg. latest version `9.15.9`), the `packages: []` cannot be entirely removed, because pnpm will error out with the message `packages field missing or empty`:

```
$ pnpm i
 ERROR  packages field missing or empty
For help, run: pnpm help install
```

### Why?

When `packages` is set to a single item with `.`, Netlify infers the build command as `pnpm --filter <package name from root package.json> build`

```bash
$ pnpm --filter repro-pkg-name build
No projects matched the filters in "/Users/k/p/repro"
$ echo $?
0
```

### How?

Change `packages` config from single item with `.` to an empty array, which causes Netlify to infer `pnpm build` as the command

cc @eps1lon 