### PR TITLE
Fix/88343 server action race condition

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -119,6 +119,19 @@ async function runAction({
       return
     }
 
+    // Prevent stale (the router navigated before the server action was resolved)
+    // state coming from an async server-action from overwriting newer state
+    if (
+      action.payload.type === ACTION_SERVER_ACTION &&
+      actionQueue.state !== prevState
+    ) {
+      // State changed (e.g. navigation committed) while this action was in flight.
+      // Do not commit the stale result.
+      runRemainingActions(actionQueue, setState)
+      action.resolve(actionQueue.state)
+      return
+    }
+
     actionQueue.state = nextState
 
     runRemainingActions(actionQueue, setState)

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -119,13 +119,11 @@ async function runAction({
       return
     }
 
-    // Prevent stale (the router navigated before the server action was resolved)
-    // state coming from an async server-action from overwriting newer state
-    if (
-      action.payload.type === ACTION_SERVER_ACTION &&
-      actionQueue.state !== prevState
-    ) {
-      // State changed (e.g. navigation committed) while this action was in flight.
+    // Prevent stale state from an async action from overwriting newer state that was
+    // applied while this action was in flight (e.g., another action that took priority
+    // like a navigation, or an action that completed earlier in the queue).
+    if (actionQueue.state !== prevState) {
+      // State changed while this action was in flight.
       // Do not commit the stale result.
       runRemainingActions(actionQueue, setState)
       action.resolve(actionQueue.state)

--- a/test/e2e/app-dir/server-actions-navigation/app/actions.ts
+++ b/test/e2e/app-dir/server-actions-navigation/app/actions.ts
@@ -1,8 +1,8 @@
 'use server'
 
-export async function delayedAction(): Promise<string> {
-  // Artificial delay to force race with navigation
-  await new Promise((resolve) => setTimeout(resolve, 500))
+export async function runServerAction() {
+  // Simulate a slow async server action
+  await new Promise((resolve) => setTimeout(resolve, 3000))
 
   return 'STALE_RESULT'
 }

--- a/test/e2e/app-dir/server-actions-navigation/app/actions.ts
+++ b/test/e2e/app-dir/server-actions-navigation/app/actions.ts
@@ -1,0 +1,8 @@
+'use server'
+
+export async function delayedAction(): Promise<string> {
+  // Artificial delay to force race with navigation
+  await new Promise((resolve) => setTimeout(resolve, 500))
+
+  return 'STALE_RESULT'
+}

--- a/test/e2e/app-dir/server-actions-navigation/app/layout.tsx
+++ b/test/e2e/app-dir/server-actions-navigation/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/server-actions-navigation/app/next/page.tsx
+++ b/test/e2e/app-dir/server-actions-navigation/app/next/page.tsx
@@ -1,3 +1,30 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
 export default function NextPage() {
-  return <div id="next-page">Next page</div>
+  const router = useRouter()
+  const didRefreshRef = useRef(false)
+  const [refreshed, setRefreshed] = useState(false)
+
+  useEffect(() => {
+    // Prevent refresh loop after router.refresh()
+    if (didRefreshRef.current) return
+
+    const timer = setTimeout(() => {
+      didRefreshRef.current = true
+      router.refresh()
+      setRefreshed(true)
+    }, 4000)
+
+    return () => clearTimeout(timer)
+  }, [router])
+
+  return (
+    <div>
+      <div id="next-page">Next page</div>
+      <div id="result">{refreshed ? 'REFRESHED_OK' : 'NOT_REFRESHED'}</div>
+    </div>
+  )
 }

--- a/test/e2e/app-dir/server-actions-navigation/app/next/page.tsx
+++ b/test/e2e/app-dir/server-actions-navigation/app/next/page.tsx
@@ -1,0 +1,3 @@
+export default function NextPage() {
+  return <div id="next-page">Next page</div>
+}

--- a/test/e2e/app-dir/server-actions-navigation/app/page.tsx
+++ b/test/e2e/app-dir/server-actions-navigation/app/page.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { useTransition, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { delayedAction } from './actions'
+
+export default function Page() {
+  const router = useRouter()
+  const [result, setResult] = useState<string | null>(null)
+  const [_, startTransition] = useTransition()
+
+  async function onClick() {
+    startTransition(async () => {
+      const value = await delayedAction()
+
+      // This is the state update that must NOT be committed
+      // if navigation has already occurred
+      setResult(value)
+    })
+
+    // Navigate immediately after starting the action
+    router.push('/next')
+  }
+
+  return (
+    <main>
+      <button onClick={onClick}>Run server action</button>
+
+      {result && <div id="result">{result}</div>}
+    </main>
+  )
+}

--- a/test/e2e/app-dir/server-actions-navigation/app/page.tsx
+++ b/test/e2e/app-dir/server-actions-navigation/app/page.tsx
@@ -1,32 +1,23 @@
 'use client'
 
-import { useTransition, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { delayedAction } from './actions'
+import { runServerAction } from './actions'
 
 export default function Page() {
   const router = useRouter()
-  const [result, setResult] = useState<string | null>(null)
-  const [_, startTransition] = useTransition()
-
-  async function onClick() {
-    startTransition(async () => {
-      const value = await delayedAction()
-
-      // This is the state update that must NOT be committed
-      // if navigation has already occurred
-      setResult(value)
-    })
-
-    // Navigate immediately after starting the action
-    router.push('/next')
-  }
 
   return (
-    <main>
-      <button onClick={onClick}>Run server action</button>
+    <button
+      onClick={() => {
+        // Start server action WITHOUT awaiting
+        runServerAction()
 
-      {result && <div id="result">{result}</div>}
-    </main>
+        // Immediately navigate away
+        router.push('/next')
+      }}
+      id="run-action"
+    >
+      Run server action
+    </button>
   )
 }

--- a/test/e2e/app-dir/server-actions-navigation/server-actions-navigation.test.ts
+++ b/test/e2e/app-dir/server-actions-navigation/server-actions-navigation.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('server action resolving after navigation', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('does not commit stale server action state after navigation', async () => {
+    const browser = await next.browser('/')
+
+    // Trigger server action + immediate navigation
+    await browser.getByRole('button', { name: 'Run server action' }).click()
+
+    // Ensure navigation completed
+    await browser.waitForElementByCss('#next-page')
+
+    // Ensure stale server action result was NOT applied
+    const result = await browser.eval(() => {
+      const el = document.querySelector('#result')
+      return el?.textContent ?? null
+    })
+
+    expect(result).not.toBe('STALE_RESULT')
+  })
+})

--- a/test/e2e/app-dir/server-actions-navigation/server-actions-navigation.test.ts
+++ b/test/e2e/app-dir/server-actions-navigation/server-actions-navigation.test.ts
@@ -5,21 +5,28 @@ describe('server action resolving after navigation', () => {
     files: __dirname,
   })
 
-  it('does not commit stale server action state after navigation', async () => {
+  it('does not apply stale server action result after navigation and refresh', async () => {
     const browser = await next.browser('/')
 
-    // Trigger server action + immediate navigation
-    await browser.getByRole('button', { name: 'Run server action' }).click()
+    // Trigger async server action and immediately navigate to /next
+    await browser.elementByCss('#run-action').click()
 
     // Ensure navigation completed
     await browser.waitForElementByCss('#next-page')
 
-    // Ensure stale server action result was NOT applied
-    const result = await browser.eval(() => {
-      const el = document.querySelector('#result')
-      return el?.textContent ?? null
-    })
+    // Wait long enough for:
+    // - server action to resolve
+    // - delayed router.refresh() on /next to make sure that
+    //   the server action has been completed
+    await browser.eval(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(resolve, 5500)
+        })
+    )
 
-    expect(result).not.toBe('STALE_RESULT')
+    // Assert we are still on /next after refresh
+    const url = await browser.url()
+    expect(url.endsWith('/next')).toBe(true)
   })
 })


### PR DESCRIPTION
### What?

Prevents stale router state from being committed when an async server action resolves **after a navigation has already committed a newer App Router state**.

### Why?

A race condition exists where an in-flight async server action can resolve after a client navigation (or restore) has already updated the router state. When this happens, the resolved server action result may overwrite the newer state, leading to incorrect navigation state and inconsistent UI behavior.

This is particularly visible when a `router.refresh()` occurs after navigation, as the refresh may replay a stale router tree produced by the late-resolving server action.

This scenario is described in #88343.

### How?

- Capture the router `prevState` before executing a server action in `runAction`
- When handling the resolved result of an async server action:
  - Compare the current `actionQueue.state` against the captured `prevState`
  - If the state has changed (e.g. due to a navigation committing), skip applying the stale result
  - Continue processing the remaining action queue without mutating router state

This ensures navigations and refreshes always take precedence over outdated async server action results while preserving existing queue behavior.

### Tests

Adds an App Router e2e test that reproduces the race condition:

- Triggers an async server action **without awaiting**
- Immediately navigates to a different route
- Delays a `router.refresh()` on the destination route until after the server action resolves
- Asserts that the refresh does **not** replay stale router state and the app remains on the correct route

The test fails without this change and passes with the fix applied.

Fixes #88343
