### PR TITLE
fix: use getProperError to avoid [object Object] in error messages

### DIFF
--- a/packages/next/src/next-devtools/userspace/app/errors/stitched-error.ts
+++ b/packages/next/src/next-devtools/userspace/app/errors/stitched-error.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import isError from '../../../../lib/is-error'
+import { getProperError } from '../../../../lib/is-error'
 
 const ownerStacks = new WeakMap<Error, string | null>()
 
@@ -10,10 +10,6 @@ export function setOwnerStack(error: Error, stack: string | null) {
   ownerStacks.set(error, stack)
 }
 
-export function coerceError(value: unknown): Error {
-  return isError(value) ? value : new Error('' + value)
-}
-
 export function setOwnerStackIfAvailable(error: Error): void {
   // React 18 and prod does not have `captureOwnerStack`
   if ('captureOwnerStack' in React) {
@@ -22,7 +18,7 @@ export function setOwnerStackIfAvailable(error: Error): void {
 }
 
 export function decorateDevError(thrownValue: unknown) {
-  const error = coerceError(thrownValue)
+  const error = getProperError(thrownValue)
   setOwnerStackIfAvailable(error)
   return error
 }

--- a/packages/next/src/next-devtools/userspace/app/errors/use-error-handler.ts
+++ b/packages/next/src/next-devtools/userspace/app/errors/use-error-handler.ts
@@ -4,9 +4,9 @@ import {
   formatConsoleArgs,
   parseConsoleArgs,
 } from '../../../../client/lib/console'
-import isError from '../../../../lib/is-error'
+import isError, { getProperError } from '../../../../lib/is-error'
 import { createConsoleError } from '../../../shared/console-error'
-import { coerceError, setOwnerStackIfAvailable } from './stitched-error'
+import { setOwnerStackIfAvailable } from './stitched-error'
 import { forwardUnhandledError, logUnhandledRejection } from '../forward-logs'
 
 const queueMicroTask =
@@ -93,7 +93,7 @@ function onUnhandledError(event: WindowEventMap['error']): void | boolean {
   // When there's an error property present, we log the error to error overlay.
   // Otherwise we don't do anything as it's not logging in the console either.
   if (thrownValue) {
-    const error = coerceError(thrownValue)
+    const error = getProperError(thrownValue)
     setOwnerStackIfAvailable(error)
     handleClientError(error)
     forwardUnhandledError(error)
@@ -107,7 +107,7 @@ function onUnhandledRejection(ev: WindowEventMap['unhandledrejection']): void {
     return
   }
 
-  const error = coerceError(reason)
+  const error = getProperError(reason)
   setOwnerStackIfAvailable(error)
 
   rejectionQueue.push(error)


### PR DESCRIPTION
<img width="979" height="486" alt="CleanShot 2026-01-15 at 16 20 46" src="https://github.com/user-attachments/assets/43a9fafb-545a-4dff-8889-73981f977f63" />
