### PR TITLE
[ci] Don't retry/notify for failed deploy tests with custom tarball URLs

### DIFF
--- a/.github/workflows/retry_deploy_test.yml
+++ b/.github/workflows/retry_deploy_test.yml
@@ -18,7 +18,10 @@ jobs:
     # Retry the test-e2e-deploy-release workflow once
     if: >-
       ${{
-        startsWith(github.event.workflow_run.display_title, 'test-e2e-deploy') &&
+        (
+          github.event.workflow_run.event == 'release' ||
+          github.event.workflow_run.display_title == 'test-e2e-deploy canary'
+        ) &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.repository == 'vercel/next.js' &&
         github.event.workflow_run.run_attempt < 2
@@ -40,7 +43,10 @@ jobs:
     # Report the failure to Slack if the test-e2e-deploy-release workflow has failed 2 times
     if: >-
       ${{
-        startsWith(github.event.workflow_run.display_title, 'test-e2e-deploy') &&
+        (
+          github.event.workflow_run.event == 'release' ||
+          github.event.workflow_run.display_title == 'test-e2e-deploy canary'
+        ) &&
         github.event.workflow_run.conclusion == 'failure' &&
         github.event.workflow_run.run_attempt >= 2 &&
         !github.event.workflow_run.head_repository.fork


### PR DESCRIPTION
Fixes a regression from #85981 where manual deploy tests with custom tarball URLs incorrectly trigger retries and Slack notifications. Now only release-triggered runs and manually-triggered canary tests are retried/reported.