### PR TITLE
Fix/88512 cache LRU infinite loop

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache-map.ts
+++ b/packages/next/src/client/components/segment-cache/cache-map.ts
@@ -349,7 +349,6 @@ export function setInCacheMap<V extends MapValue>(
 
   // This is an LRU access. Move the entry to the front of the list.
   lruPut(entry)
-  updateLruSize(entry, value.size)
 }
 
 function setMapEntryValue(entry: UnknownMapEntry, value: MapValue): void {

--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -110,6 +110,7 @@ function cleanup() {
   // infinite loop because even if `maxLruSize` were 0, eventually
   // `deleteFromLru` sets `head` to `null` when we run out entries.
   const ninetyPercentMax = maxLruSize * 0.9
+  const prevSize = lruSize
   while (lruSize > ninetyPercentMax && head !== null) {
     const tail = head.prev
     // In practice, this is never null, but that isn't encoded in the type
@@ -117,6 +118,12 @@ function cleanup() {
       // Delete the entry from the map. In turn, this will remove it from
       // the LRU.
       deleteMapEntry(tail)
+
+      // If the size is not being reduced by deleting the entry,
+      // break to avoid infinite loop
+      if (lruSize === prevSize) {
+        break
+      }
     }
   }
 }


### PR DESCRIPTION
## Fixing a bug

## What?

This PR fixes incorrect LRU size accounting when inserting cache entries.  
- `setInCacheMap` was updating the LRU size redundantly, causing entries to be double-counted. This could lead to `cleanup()` looping indefinitely because the LRU size would not decrease as entries were evicted.
- The while loop, as mentioned in #88512 was running infinitely leading to page freeze as LRU size was not being reduced after deleting the map entities. Added a condition to break out of it to avoid the infinite loop.
---

## Why?

The LRU implementation relies on the invariant that each entry contributes its size exactly once when it enters the LRU.  
However, `setInCacheMap` was calling `updateLruSize` in addition to the size update performed during value assignment and LRU insertion. This broke the invariant and caused the total LRU size to become inflated.

As a result, the cleanup loop could fail to make progress and run indefinitely.

---

## How?

The fix removes the redundant `updateLruSize` call from `setInCacheMap`.

- `setMapEntryValue` remains the single source of truth for assigning an entry’s size
- `lruPut` remains responsible for adding a new entry’s size to the global LRU total
- This restores correct size accounting and ensures cleanup terminates as expected
- Adds a protective condition to avoid the infinite loop and page freeze
---

Closes NEXT-
Fixes #88512
