### PR TITLE
Fix incorrect 'Ready in' time for next start

### DIFF
--- a/packages/next/src/cli/next-start.ts
+++ b/packages/next/src/cli/next-start.ts
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+// Ensure NEXT_PRIVATE_START_TIME is set for accurate "Ready in" timing.
+// This should already be set by bin/next.ts, but we set it here as a fallback
+// in case the module is loaded through a different code path.
+if (!process.env.NEXT_PRIVATE_START_TIME) {
+  process.env.NEXT_PRIVATE_START_TIME = Date.now().toString()
+}
+
 import '../server/lib/cpu-profile'
 import { saveCpuProfile } from '../server/lib/cpu-profile'
 import { startServer } from '../server/lib/start-server'

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -2,9 +2,6 @@
 import './cpu-profile'
 import { getNetworkHost } from '../../lib/get-network-host'
 
-if (performance.getEntriesByName('next-start').length === 0) {
-  performance.mark('next-start')
-}
 import '../next'
 import '../require-hook'
 
@@ -370,10 +367,11 @@ export async function startServer(
       })
 
       // Calculate and log "Ready in X" before loading config
-      // so it reflects actual framework startup time
+      // so it reflects actual framework startup time.
+      // NEXT_PRIVATE_START_TIME is set by bin/next.ts or cli/next-start.ts.
       const startTime = parseInt(process.env.NEXT_PRIVATE_START_TIME || '0', 10)
       const endTime = Date.now()
-      const startServerProcessDurationMs = endTime - startTime
+      const startServerProcessDurationMs = startTime ? endTime - startTime : 0
 
       const formattedStartDuration = durationToString(
         startServerProcessDurationMs / 1000


### PR DESCRIPTION
## What

Fix the incorrect "Ready in" time displayed when running `next start`. The bug caused the time to show impossibly large values like "Ready in 29474457.7min" instead of the actual startup duration.

## Why

The `NEXT_PRIVATE_START_TIME` environment variable was not being properly set/propagated when `startServer()` read it. When the variable was missing, the code defaulted to `0`, causing the calculation `Date.now() - 0` to equal the entire Unix timestamp (~1.77 trillion milliseconds ≈ 29 million minutes).

## How

1. Added a fallback in `cli/next-start.ts` to set `NEXT_PRIVATE_START_TIME` if it's not already set by `bin/next.ts`
2. Updated the calculation in `start-server.ts` to use `0` as the duration if `startTime` is falsy, preventing the bug
3. Removed unused performance mark code that was leftover

## Test Plan

Run `next start` on a production build and verify the "Ready in" time shows a reasonable value (e.g., "Ready in 523ms" instead of millions of minutes).