### PR TITLE
Fix optional parent_task_id compile failure w/`tokio_tracing` enabled

### DIFF
--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -846,8 +846,8 @@ impl<B: Backend + 'static> TurboTasks<B> {
 
         #[cfg(feature = "tokio_tracing")]
         let description = format!(
-            "[local] (parent: {}) {}",
-            self.backend.get_task_description(parent_task_id),
+            "[local] (parent: {:?}) {}",
+            parent_task_id.map(|id| self.backend.get_task_description(id)),
             ty.task_type,
         );
         #[cfg(not(feature = "tokio_tracing"))]


### PR DESCRIPTION
# What

This was causing an error when the `tokio_tracing` feature was enabled because `parent_task_id` is an option:

```
        #[cfg(feature = "tokio_tracing")]
        let description = format!(
            "[local] (parent: {}) {}",
            self.backend.get_task_description(parent_task_id),
            ty.task_type,
        );
```

# How

Reworks this to be valid code using map + debug output.

