### PR TITLE
docs(contributing): replace deprecated check() with retry() in testing guide

### DIFF
--- a/contributing/core/testing.md
+++ b/contributing/core/testing.md
@@ -73,7 +73,16 @@ the new checks can be added to the existing test suite.
 ### Best Practices
 
 - When checking for a condition that might take time,
-  ensure it is waited for either using the browser `waitForElement` or using the `check` util in `next-test-utils`.
+  ensure it is waited for either using the browser `waitForElement` or using `retry()` with `expect()` from `next-test-utils`.
+  Note: `check()` is deprecated; use `retry()` instead.
+
+  ```typescript
+  await retry(async () => {
+    const text = await browser.elementByCss('p').text()
+    expect(text).toMatch(/expected/)
+  })
+  ```
+
 - When applying a fix, ensure the test fails without the fix.
   This makes sure the test will properly catch regressions.
 


### PR DESCRIPTION
## What

Updates the testing documentation to recommend `retry()` + `expect()` instead of the deprecated `check()` utility.

## Why

The current guidance in `contributing/core/testing.md` recommends using the `check` util, but this is deprecated. The authoritative contributor guide (`AGENTS.md`) states:

> Do NOT use `check()` - it is deprecated. Use `retry()` + `expect()` instead

This PR aligns the testing documentation with current best practices.

## How

- Replaced the `check` util recommendation with `retry()` + `expect()` pattern
- Added a deprecation note for `check()`
- Added a code example showing the correct usage pattern

