### PR TITLE
docs: clarify Sass variables feature is only supported with Webpack

### DIFF
--- a/docs/01-app/02-guides/sass.mdx
+++ b/docs/01-app/02-guides/sass.mdx
@@ -81,7 +81,9 @@ module.exports = nextConfig
 
 ### Sass Variables
 
-Next.js supports Sass variables exported from CSS Module files.
+Next.js supports Sass variables exported from CSS Module files. However, this feature **only works with Webpack** and is not supported by Turbopack (the default bundler in Next.js 15+).
+
+If you need to use Sass variables exported from CSS Modules, you'll need to configure your project to use Webpack instead of Turbopack. See the [Turbopack documentation](/docs/app/api-reference/turbopack) for details on how to switch to Webpack.
 
 For example, using the exported `primaryColor` Sass variable:
 


### PR DESCRIPTION
Clarifies that Sass variables exported from CSS Module files only work with Webpack and are not supported by Turbopack (the default bundler in Next.js 15+).

This addresses the documentation gap mentioned in issue #88544, where users may follow the docs and implement Sass variables only to discover their code breaks when using Turbopack.

The update:
- Clearly states the Webpack-only limitation
- Suggests switching to Webpack as a workaround
- References the Turbopack configuration documentation

Fixes #88544