### PR TITLE
[Server Functions] Incorrect compilation of default argument value from closed-over scope

### DIFF
--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/input.js
@@ -1,0 +1,14 @@
+import { Client } from 'components'
+
+export function Component() {
+  const value = 3
+
+  // `value` is not referenced in the closure's body, but it's used as
+  // the default value for `x`, so it still needs to be available
+  async function closedOverDefaultArgValue(x = value) {
+    'use server'
+    return x
+  }
+
+  return <Client action={closedOverDefaultArgValue} />
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/72/output.js
@@ -1,0 +1,15 @@
+import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+/* __next_internal_action_entry_do_not_use__ {"606a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { Client } from 'components';
+export const // `value` is not referenced in the closure's body, but it's used as
+// the default value for `x`, so it still needs to be available
+$$RSC_SERVER_ACTION_0 = async function closedOverDefaultArgValue($$ACTION_CLOSURE_BOUND, x = value) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_CLOSURE_BOUND);
+    return x;
+};
+registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
+export function Component() {
+    const value = 3;
+    var closedOverDefaultArgValue = $$RSC_SERVER_ACTION_0.bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", value));
+    return <Client action={closedOverDefaultArgValue}/>;
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/input.js
@@ -1,0 +1,14 @@
+import { Client } from 'components'
+
+export function Component() {
+  const value = 3
+
+  // `value` is not referenced in the closure's body, but it's used as
+  // the default value for `x`, so it still needs to be available
+  const closedOverDefaultArgValue = async (x = value) => {
+    'use server'
+    return x
+  }
+
+  return <Client action={closedOverDefaultArgValue} />
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/73/output.js
@@ -1,0 +1,15 @@
+import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+/* __next_internal_action_entry_do_not_use__ {"606a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { Client } from 'components';
+export const $$RSC_SERVER_ACTION_0 = async function closedOverDefaultArgValue($$ACTION_CLOSURE_BOUND, x = value) {
+    var [$$ACTION_ARG_0] = await decryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_CLOSURE_BOUND);
+    return x;
+};
+registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
+export function Component() {
+    const value = 3;
+    // `value` is not referenced in the closure's body, but it's used as
+    // the default value for `x`, so it still needs to be available
+    const closedOverDefaultArgValue = $$RSC_SERVER_ACTION_0.bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", value));
+    return <Client action={closedOverDefaultArgValue}/>;
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/74/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/74/input.js
@@ -1,0 +1,15 @@
+import { Client } from 'components'
+
+export function Component() {
+  const value = 3
+  const obj = {}
+
+  // `value` is not referenced in the closure's body, but it's used as
+  // the default value for `<param0>.x`, so it still needs to be available
+  async function closedOverDefaultArgValue({ x = value } = obj) {
+    'use server'
+    return x
+  }
+
+  return <Client action={closedOverDefaultArgValue} />
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/74/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/74/output.js
@@ -1,0 +1,16 @@
+import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+/* __next_internal_action_entry_do_not_use__ {"606a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { Client } from 'components';
+export const // `value` is not referenced in the closure's body, but it's used as
+// the default value for `<param0>.x`, so it still needs to be available
+$$RSC_SERVER_ACTION_0 = async function closedOverDefaultArgValue($$ACTION_CLOSURE_BOUND, { x = value } = obj) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_CLOSURE_BOUND);
+    return x;
+};
+registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
+export function Component() {
+    const value = 3;
+    const obj = {};
+    var closedOverDefaultArgValue = $$RSC_SERVER_ACTION_0.bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", value, obj));
+    return <Client action={closedOverDefaultArgValue}/>;
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/75/input.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/75/input.js
@@ -1,0 +1,15 @@
+import { Client } from 'components'
+
+export function Component() {
+  const value = 3
+  const obj = {}
+
+  // `value` is not referenced in the closure's body, but it's used as
+  // the default value for `<param0>.x`, so it still needs to be available
+  const closedOverDefaultArgValue = async ({ x = value } = obj) => {
+    'use server'
+    return x
+  }
+
+  return <Client action={closedOverDefaultArgValue} />
+}

--- a/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/75/output.js
+++ b/crates/next-custom-transforms/tests/fixture/server-actions/server-graph/75/output.js
@@ -1,0 +1,16 @@
+import { registerServerReference } from "private-next-rsc-server-reference";
+import { encryptActionBoundArgs, decryptActionBoundArgs } from "private-next-rsc-action-encryption";
+/* __next_internal_action_entry_do_not_use__ {"606a88810ecce4a4e8b59d53b8327d7e98bbf251d7":"$$RSC_SERVER_ACTION_0"} */ import { Client } from 'components';
+export const $$RSC_SERVER_ACTION_0 = async function closedOverDefaultArgValue($$ACTION_CLOSURE_BOUND, { x = value } = obj) {
+    var [$$ACTION_ARG_0, $$ACTION_ARG_1] = await decryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", $$ACTION_CLOSURE_BOUND);
+    return x;
+};
+registerServerReference($$RSC_SERVER_ACTION_0, "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", null);
+export function Component() {
+    const value = 3;
+    const obj = {};
+    // `value` is not referenced in the closure's body, but it's used as
+    // the default value for `<param0>.x`, so it still needs to be available
+    const closedOverDefaultArgValue = $$RSC_SERVER_ACTION_0.bind(null, encryptActionBoundArgs("606a88810ecce4a4e8b59d53b8327d7e98bbf251d7", value, obj));
+    return <Client action={closedOverDefaultArgValue}/>;
+}


### PR DESCRIPTION
Stuff like this should work, but currently doesn't:
```ts
function Component() {
  const value = 3
  const obj = {}
  
  // `value` and `obj` from the surrounding scope are referenced
  // in the parameter declarations
  async function closure({ x = value } = obj) {
    'use server'
    return x
  }
  
  return <Client action={closedOverDefaultArgValue} />
}
```
We seem to be detecting that `value` and `obj` are referenced inside (because we do pass them in as bound args), but we do not adjust the argument definitions accordingly. See snapshots for current output

To correctly handle this, we'd need to move the initialization down to after `decryptActionBoundArgs`.
```js
export const $$RSC_SERVER_ACTION_0 = async function closedOverDefaultArgValue(
  $$ACTION_CLOSURE_BOUND,
  $$ACTION_DESTRUCTURED_ARG_0
) {
  var [/* value */ $$ACTION_ARG_0, /* obj */ $$ACTION_ARG_1] =
    await decryptActionBoundArgs(
      "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7",
      $$ACTION_CLOSURE_BOUND
    );

  // initialize arg pattern `{ x = value } = obj`
  var { x = $$ACTION_ARG_0 } =
    $$ACTION_DESTRUCTURED_ARG_0 === void 0
      ? $$ACTION_ARG_1
      : $$ACTION_DESTRUCTURED_ARG_0;

  return x;
};

export function Component() {
  const value = 3;
  const obj = {};
  var closedOverDefaultArgValue = $$RSC_SERVER_ACTION_0.bind(
    null,
    encryptActionBoundArgs(
      "606a88810ecce4a4e8b59d53b8327d7e98bbf251d7",
      value,
      obj
    )
  );
  return <Client action={closedOverDefaultArgValue} />;
}
```

also note that default values can reference previous arguments, so we can't just move `x = value` down, we probably need to move all of the argument initializers:
```js
async function closure(x = value, y = x) { ... } 
```