### PR TITLE
Reuse bfcache data during Full prefetches

### DIFF
--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -41,7 +41,9 @@ import {
   readFromBFCache,
   readFromBFCacheDuringRegularNavigation,
   writeToBFCache,
+  writeHeadToBFCache,
 } from '../segment-cache/bfcache'
+import { DYNAMIC_STALETIME_MS } from './reducers/navigate-reducer'
 
 // This is yet another tree type that is used to track pending promises that
 // need to be fulfilled once the dynamic data is received. The terminal nodes of
@@ -881,20 +883,28 @@ function createCacheNodeForSegment(
   switch (freshness) {
     case FreshnessPolicy.Default: {
       // When experimental.staleTimes.dynamic config is set, we read from the
-      // BFCache even during regular navigations.
-      const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
-        now,
-        tree.varyPath
-      )
-      if (bfcacheEntry !== null) {
-        return {
-          cacheNode: createCacheNode(
-            bfcacheEntry.rsc,
-            bfcacheEntry.prefetchRsc,
-            bfcacheEntry.head,
-            bfcacheEntry.prefetchHead
-          ),
-          needsDynamicRequest: false,
+      // BFCache even during regular navigations. (This is not a recommended API
+      // with Cache Components, but it's supported for backwards compatibility.
+      // Use cacheLife instead.)
+
+      // This outer check isn't semantically necessary; even if the configured
+      // stale time is 0, the bfcache will return null, because any entry would
+      // have immediately expired. Just an optimization.
+      if (DYNAMIC_STALETIME_MS > 0) {
+        const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
+          now,
+          tree.varyPath
+        )
+        if (bfcacheEntry !== null) {
+          return {
+            cacheNode: createCacheNode(
+              bfcacheEntry.rsc,
+              bfcacheEntry.prefetchRsc,
+              bfcacheEntry.head,
+              bfcacheEntry.prefetchHead
+            ),
+            needsDynamicRequest: false,
+          }
         }
       }
       break
@@ -921,6 +931,9 @@ function createCacheNodeForSegment(
       const head = isPage ? seedHead : null
       const prefetchHead = null
       writeToBFCache(now, tree.varyPath, rsc, prefetchRsc, head, prefetchHead)
+      if (isPage && metadataVaryPath !== null) {
+        writeHeadToBFCache(now, metadataVaryPath, head, prefetchHead)
+      }
       return {
         cacheNode: createCacheNode(rsc, prefetchRsc, head, prefetchHead),
         needsDynamicRequest: false,
@@ -1126,6 +1139,9 @@ function createCacheNodeForSegment(
   // and will be replaced by the canonical navigation.
   if (freshness !== FreshnessPolicy.Gesture) {
     writeToBFCache(now, tree.varyPath, rsc, prefetchRsc, head, prefetchHead)
+    if (isPage && metadataVaryPath !== null) {
+      writeHeadToBFCache(now, metadataVaryPath, head, prefetchHead)
+    }
   }
 
   return {

--- a/packages/next/src/client/components/segment-cache/bfcache.ts
+++ b/packages/next/src/client/components/segment-cache/bfcache.ts
@@ -39,6 +39,9 @@ export function writeToBFCache(
   const entry: BFCacheEntry = {
     rsc,
     prefetchRsc,
+
+    // TODO: These fields will be removed from both BFCacheEntry and
+    // SegmentCacheEntry. The head has its own separate cache entry.
     head,
     prefetchHead,
 
@@ -57,6 +60,16 @@ export function writeToBFCache(
   }
   const isRevalidation = false
   setInCacheMap(bfcacheMap, varyPath, entry, isRevalidation)
+}
+
+export function writeHeadToBFCache(
+  now: number,
+  varyPath: SegmentVaryPath,
+  head: React.ReactNode,
+  prefetchHead: React.ReactNode
+): void {
+  // Read the special "segment" that represents the head data.
+  writeToBFCache(now, varyPath, head, prefetchHead, null, null)
 }
 
 export function readFromBFCache(
@@ -79,13 +92,6 @@ export function readFromBFCacheDuringRegularNavigation(
   now: number,
   varyPath: SegmentVaryPath
 ): BFCacheEntry | null {
-  if (DYNAMIC_STALETIME_MS <= 0) {
-    // Only reuse the dynamic data if experimental.staleTimes.dynamic config
-    // is set, and the data is not stale. (This is not a recommended API with
-    // Cache Components, but it's supported for backwards compatibility. Use
-    // cacheLife instead.)
-    return null
-  }
   const isRevalidation = false
   return getFromCacheMap(
     now,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -86,11 +86,15 @@ import {
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
 } from '../../flight-data-helpers'
-import { STATIC_STALETIME_MS } from '../router-reducer/reducers/navigate-reducer'
+import {
+  DYNAMIC_STALETIME_MS,
+  STATIC_STALETIME_MS,
+} from '../router-reducer/reducers/navigate-reducer'
 import { pingVisibleLinks } from '../links'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
+import { readFromBFCacheDuringRegularNavigation } from './bfcache'
 
 /**
  * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
@@ -862,6 +866,51 @@ export function upgradeToPendingSegment(
   // before the data is read on the server.
   pendingEntry.version = getCurrentCacheVersion()
   return pendingEntry
+}
+
+export function attemptToFulfillDynamicSegmentFromBFCache(
+  now: number,
+  segment: EmptySegmentCacheEntry,
+  tree: RouteTree
+): FulfilledSegmentCacheEntry | null {
+  // Attempts to fulfill an empty segment cache entry using data from the
+  // bfcache. This is only valid during a Full prefetch (i.e. one that includes
+  // dynamic data), because the bfcache stores data from navigations which
+  // always include dynamic data.
+
+  // We always use the canonical vary path when checking the bfcache. This is
+  // the same operation we'd use to access the cache during a
+  // regular navigation.
+  const varyPath = tree.varyPath
+
+  // The stale time for dynamic prefetches (default: 5 mins) is different from
+  // the stale time for regular navigations (default: 0 secs). We adjust the
+  // current timestamp to account for the difference.
+  const adjustedCurrentTime = now - STATIC_STALETIME_MS + DYNAMIC_STALETIME_MS
+  const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
+    adjustedCurrentTime,
+    varyPath
+  )
+  if (bfcacheEntry !== null) {
+    // Fulfill the prefetch using the bfcache entry.
+
+    // As explained above, the stale time of this prefetch entry is different
+    // than the one for the bfcache. Calculate when it was originally requested
+    // by subtracting the stale time used by the bfcache.
+    const requestedAt = bfcacheEntry.staleAt - DYNAMIC_STALETIME_MS
+    // Now add the stale time used by dynamic prefetches.
+    const dynamicPrefetchStaleAt = requestedAt + STATIC_STALETIME_MS
+
+    const pendingSegment = upgradeToPendingSegment(segment, FetchStrategy.Full)
+    const isPartial = false
+    return fulfillSegmentCacheEntry(
+      pendingSegment,
+      bfcacheEntry.rsc,
+      dynamicPrefetchStaleAt,
+      isPartial
+    )
+  }
+  return null
 }
 
 function pingBlockedTasks(entry: {

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -25,6 +25,7 @@ import {
   waitForSegmentCacheEntry,
   overwriteRevalidatingSegmentCacheEntry,
   canNewFetchStrategyProvideMoreContent,
+  attemptToFulfillDynamicSegmentFromBFCache,
 } from './cache'
 import { getSegmentVaryPathForRequest, type SegmentVaryPath } from './vary-path'
 import type { RouteCacheKey } from './cache-key'
@@ -1269,7 +1270,20 @@ function pingRouteTreeAndIncludeDynamicData(
 
   switch (segment.status) {
     case EntryStatus.Empty: {
-      // This segment is not cached. Include it in the request.
+      // This segment is not cached.
+      if (fetchStrategy === FetchStrategy.Full) {
+        // Check if there's a matching entry in the bfcache. If so, fulfill the
+        // segment using the bfcache entry instead of issuing a new request.
+        const fulfilled = attemptToFulfillDynamicSegmentFromBFCache(
+          now,
+          segment,
+          tree
+        )
+        if (fulfilled !== null) {
+          break
+        }
+      }
+      // Include it in the request.
       spawnedSegment = upgradeToPendingSegment(segment, fetchStrategy)
       break
     }

--- a/test/e2e/app-dir/segment-cache/force-stale/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/force-stale/app/page.tsx
@@ -1,9 +1,19 @@
+import Link from 'next/link'
 import { LinkAccordion } from '../components/link-accordion'
 
 export default function Page() {
   return (
-    <LinkAccordion href="/dynamic" prefetch={true}>
-      Dynamic page
-    </LinkAccordion>
+    <ul>
+      <li>
+        <LinkAccordion href="/dynamic" prefetch={true}>
+          Dynamic page
+        </LinkAccordion>
+      </li>
+      <li>
+        <Link href="/dynamic" prefetch={false} id="link-without-prefetch">
+          Dynamic page (no prefetch)
+        </Link>
+      </li>
+    </ul>
   )
 }

--- a/test/e2e/app-dir/segment-cache/force-stale/force-stale.test.ts
+++ b/test/e2e/app-dir/segment-cache/force-stale/force-stale.test.ts
@@ -54,4 +54,46 @@ describe('force stale', () => {
       expect(await content.text()).toBe('Dynamic page content')
     }
   )
+
+  it(
+    'during a "full" prefetch, read from bfcache before issuing new ' +
+      'prefetch request',
+    async () => {
+      let act: ReturnType<typeof createRouterAct>
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          act = createRouterAct(p)
+        },
+      })
+
+      // Navigate to the dynamic page using the link without prefetch.
+      // This will fetch the page data and store it in the bfcache.
+      await act(
+        async () => {
+          const link = await browser.elementById('link-without-prefetch')
+          await link.click()
+        },
+        {
+          includes: 'Dynamic page content',
+        }
+      )
+
+      // Navigate back to the home page
+      await browser.back()
+
+      // Now reveal a link with prefetch={true} to the same page. Because we've
+      // already navigated to this page, the data should be in the bfcache.
+      // The prefetch should reuse the bfcache data instead of making a new
+      // request to the server.
+      await act(
+        async () => {
+          const toggleLinkVisibility = await browser.elementByCss(
+            'input[data-link-accordion="/dynamic"]'
+          )
+          await toggleLinkVisibility.click()
+        },
+        { includes: 'Dynamic page content', block: 'reject' }
+      )
+    }
+  )
 })

--- a/test/e2e/app-dir/segment-cache/force-stale/next.config.js
+++ b/test/e2e/app-dir/segment-cache/force-stale/next.config.js
@@ -3,6 +3,7 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  productionBrowserSourceMaps: true,
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
+++ b/test/e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts
@@ -295,9 +295,17 @@ describe('segment cache (revalidation)', () => {
       // target route has changed.
       //
       // This time, the response does include the content for page A.
-      {
-        includes: 'Page A content',
-      }
+      //
+      // TODO: The request is actually skipped entirely because <Link
+      // prefetch={true} /> now reads from the bfcache before issuing a prefetch
+      // request, which wasn't true before the test was written. I'm leaving
+      // the test here for now, though, since we may want to re-write it in
+      // terms of runtime prefetching at some point. There's other coverage of
+      // this behavior though so it might be fine to just remove the whole test.
+      // {
+      //   includes: 'Page A content',
+      // }
+      'no-requests'
     )
 
     // Navigate to page A


### PR DESCRIPTION
During a Full prefetch (`<Link prefetch={true}>`), check the bfcache for matching segment data before issuing a new request. The bfcache stores data from previous navigations, which always includes dynamic data.

This optimization avoids redundant server requests when the user has already navigated to a route and the data is still fresh according to the staleTimes.dynamic configuration.