### PR TITLE
Turbopack: experimental.immutableAssetToken

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1172,12 +1172,6 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn emit_client_hashes(&self) -> Vc<bool> {
-        // TODO
-        Vc::cell(false)
-    }
-
-    #[turbo_tasks::function]
     pub(super) fn next_mode(&self) -> Vc<NextMode> {
         *self.mode
     }

--- a/crates/next-api/src/project_asset_hashes_manifest.rs
+++ b/crates/next-api/src/project_asset_hashes_manifest.rs
@@ -183,7 +183,7 @@ impl Asset for AssetHashesManifestAsset {
 pub async fn immutable_hashes_manifest_asset_if_enabled(
     project: ResolvedVc<Project>,
 ) -> Result<Vc<OutputAssets>> {
-    if *project.emit_client_hashes().await? {
+    if *project.next_config().enable_immutable_assets().await? {
         let path = project
             .node_root()
             .await?

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1090,6 +1090,7 @@ pub struct ExperimentalConfig {
     use_cache: Option<bool>,
     root_params: Option<bool>,
     runtime_server_deployment_id: Option<bool>,
+    immutable_asset_token: Option<RcStr>,
 
     // ---
     // UNSUPPORTED
@@ -1116,7 +1117,7 @@ pub struct ExperimentalConfig {
     fully_specified: Option<bool>,
     gzip_size: Option<bool>,
 
-    pub inline_css: Option<bool>,
+    inline_css: Option<bool>,
     instrumentation_hook: Option<bool>,
     client_trace_metadata: Option<Vec<String>>,
     large_page_data_bytes: Option<f64>,
@@ -1889,13 +1890,21 @@ impl NextConfig {
 
     /// Returns the suffix to use for chunk loading.
     #[turbo_tasks::function]
-    pub async fn asset_suffix_path(self: Vc<Self>) -> Result<Vc<Option<RcStr>>> {
-        let this = self.await?;
+    pub fn asset_suffix_path(&self) -> Vc<Option<RcStr>> {
+        let id = self
+            .experimental
+            .immutable_asset_token
+            .as_ref()
+            .or(self.deployment_id.as_ref());
 
-        match &this.deployment_id {
-            Some(deployment_id) => Ok(Vc::cell(Some(format!("?dpl={deployment_id}").into()))),
-            None => Ok(Vc::cell(None)),
-        }
+        Vc::cell(id.as_ref().map(|id| format!("?dpl={id}").into()))
+    }
+
+    /// Whether to enable immutable assets, which uses a different asset suffix, and writes a
+    /// .next/immutable-static-hashes.json manifest.
+    #[turbo_tasks::function]
+    pub fn enable_immutable_assets(&self) -> Vc<bool> {
+        Vc::cell(self.experimental.immutable_asset_token.is_some())
     }
 
     #[turbo_tasks::function]

--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -176,6 +176,9 @@ export function getDefineEnv({
       !!config.experimental.instantNavigationDevToolsToggle,
     'process.env.__NEXT_USE_CACHE': isUseCacheEnabled,
 
+    'process.env.NEXT_IMMUTABLE_ASSET_TOKEN':
+      config.experimental.immutableAssetToken || '',
+
     ...(config.experimental?.useSkewCookie || !config.deploymentId
       ? {
           'process.env.NEXT_DEPLOYMENT_ID': false,

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2061,8 +2061,8 @@ export default async function build(
               pprConfig: config.experimental.ppr,
               cacheLifeProfiles: config.cacheLife,
               buildId,
-              deploymentId: config.deploymentId,
-              immutableAssetToken: config.experimental.immutableAssetToken,
+              clientAssetToken:
+                config.experimental.immutableAssetToken || config.deploymentId,
               sriEnabled,
               cacheMaxMemorySize: config.cacheMaxMemorySize,
             })
@@ -2288,9 +2288,9 @@ export default async function build(
                             pprConfig: config.experimental.ppr,
                             cacheLifeProfiles: config.cacheLife,
                             buildId,
-                            deploymentId: config.deploymentId,
-                            immutableAssetToken:
-                              config.experimental.immutableAssetToken,
+                            clientAssetToken:
+                              config.experimental.immutableAssetToken ||
+                              config.deploymentId,
                             sriEnabled,
                           })
                         }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -854,9 +854,10 @@ export function createStaticWorker(
             }
           : undefined),
         // worker.ts copies this value into globalThis.NEXT_CLIENT_ASSET_SUFFIX
-        __NEXT_PRERENDER_CLIENT_ASSET_SUFFIX: config.deploymentId
-          ? `?dpl=${config.deploymentId}`
-          : '',
+        __NEXT_PRERENDER_CLIENT_ASSET_SUFFIX:
+          config.experimental.immutableAssetToken || config.deploymentId
+            ? `?dpl=${config.experimental.immutableAssetToken || config.deploymentId}`
+            : '',
       },
     },
   }) as StaticWorker
@@ -2061,6 +2062,7 @@ export default async function build(
               cacheLifeProfiles: config.cacheLife,
               buildId,
               deploymentId: config.deploymentId,
+              immutableAssetToken: config.experimental.immutableAssetToken,
               sriEnabled,
               cacheMaxMemorySize: config.cacheMaxMemorySize,
             })
@@ -2287,6 +2289,8 @@ export default async function build(
                             cacheLifeProfiles: config.cacheLife,
                             buildId,
                             deploymentId: config.deploymentId,
+                            immutableAssetToken:
+                              config.experimental.immutableAssetToken,
                             sriEnabled,
                           })
                         }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -184,6 +184,7 @@ export async function handler(
     parsedUrl,
     interceptionRoutePatterns,
     deploymentId,
+    immutableAssetToken,
   } = prepareResult
 
   const normalizedSrcPage = normalizeAppPath(srcPage)
@@ -643,6 +644,7 @@ export async function handler(
         sharedContext: {
           buildId,
           deploymentId,
+          immutableAssetToken,
         },
         serverComponentsHmrCache: getRequestMeta(
           req,

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -184,7 +184,7 @@ export async function handler(
     parsedUrl,
     interceptionRoutePatterns,
     deploymentId,
-    immutableAssetToken,
+    clientAssetToken,
   } = prepareResult
 
   const normalizedSrcPage = normalizeAppPath(srcPage)
@@ -644,7 +644,7 @@ export async function handler(
         sharedContext: {
           buildId,
           deploymentId,
-          immutableAssetToken,
+          clientAssetToken,
         },
         serverComponentsHmrCache: getRequestMeta(
           req,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -85,7 +85,7 @@ async function requestHandler(
     interceptionRoutePatterns,
     routerServerContext,
     deploymentId,
-    immutableAssetToken,
+    clientAssetToken,
   } = prepareResult
 
   // Initialize the cache handlers interface.
@@ -108,7 +108,7 @@ async function requestHandler(
     sharedContext: {
       buildId,
       deploymentId,
-      immutableAssetToken,
+      clientAssetToken,
     },
     fallbackRouteParams: null,
 

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -85,6 +85,7 @@ async function requestHandler(
     interceptionRoutePatterns,
     routerServerContext,
     deploymentId,
+    immutableAssetToken,
   } = prepareResult
 
   // Initialize the cache handlers interface.
@@ -107,6 +108,7 @@ async function requestHandler(
     sharedContext: {
       buildId,
       deploymentId,
+      immutableAssetToken,
     },
     fallbackRouteParams: null,
 

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -117,7 +117,7 @@ async function requestHandler(
     reactLoadableManifest,
     subresourceIntegrityManifest,
     dynamicCssManifest,
-    immutableAssetToken,
+    clientAssetToken,
   } = prepareResult
 
   initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
@@ -130,7 +130,7 @@ async function requestHandler(
     sharedContext: {
       buildId,
       deploymentId,
-      immutableAssetToken: immutableAssetToken,
+      clientAssetToken,
       customServer: undefined,
     },
 

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -117,6 +117,7 @@ async function requestHandler(
     reactLoadableManifest,
     subresourceIntegrityManifest,
     dynamicCssManifest,
+    immutableAssetToken,
   } = prepareResult
 
   initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
@@ -129,6 +130,7 @@ async function requestHandler(
     sharedContext: {
       buildId,
       deploymentId,
+      immutableAssetToken: immutableAssetToken,
       customServer: undefined,
     },
 

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -758,6 +758,7 @@ export async function isPageStatic({
   pprConfig,
   buildId,
   deploymentId,
+  immutableAssetToken,
   sriEnabled,
 }: {
   dir: string
@@ -785,6 +786,7 @@ export async function isPageStatic({
   pprConfig: ExperimentalPPRConfig | undefined
   buildId: string
   deploymentId: string
+  immutableAssetToken: string | undefined
   sriEnabled: boolean
 }): Promise<PageIsStaticResult> {
   // Skip page data collection for synthetic _global-error routes
@@ -838,7 +840,7 @@ export async function isPageStatic({
           name: edgeInfo.name,
           useCache: true,
           distDir,
-          deploymentId,
+          clientAssetToken: immutableAssetToken || deploymentId,
         })
         const mod = (
           await runtime.context._ENTRIES[`middleware_${edgeInfo.name}`]

--- a/packages/next/src/build/utils.ts
+++ b/packages/next/src/build/utils.ts
@@ -757,8 +757,7 @@ export async function isPageStatic({
   cacheLifeProfiles,
   pprConfig,
   buildId,
-  deploymentId,
-  immutableAssetToken,
+  clientAssetToken,
   sriEnabled,
 }: {
   dir: string
@@ -785,8 +784,7 @@ export async function isPageStatic({
   nextConfigOutput: 'standalone' | 'export' | undefined
   pprConfig: ExperimentalPPRConfig | undefined
   buildId: string
-  deploymentId: string
-  immutableAssetToken: string | undefined
+  clientAssetToken: string
   sriEnabled: boolean
 }): Promise<PageIsStaticResult> {
   // Skip page data collection for synthetic _global-error routes
@@ -840,7 +838,7 @@ export async function isPageStatic({
           name: edgeInfo.name,
           useCache: true,
           distDir,
-          clientAssetToken: immutableAssetToken || deploymentId,
+          clientAssetToken,
         })
         const mod = (
           await runtime.context._ENTRIES[`middleware_${edgeInfo.name}`]

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -19,7 +19,7 @@ import { getProxiedPluginState } from '../../build-context'
 import { WEBPACK_LAYERS } from '../../../lib/constants'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
 import { CLIENT_STATIC_FILES_RUNTIME_MAIN_APP } from '../../../shared/lib/constants'
-import { getDeploymentIdQueryOrEmptyString } from '../../../shared/lib/deployment-id'
+import { getAssetTokenQuery } from '../../../shared/lib/deployment-id'
 import {
   formatBarrelOptimizedResource,
   getModuleReferencesInOrder,
@@ -119,7 +119,7 @@ function getAppPathRequiredChunks(
   chunkGroup: webpack.ChunkGroup,
   excludedFiles: Set<string>
 ) {
-  const deploymentIdChunkQuery = getDeploymentIdQueryOrEmptyString()
+  const assetTokenQuery = getAssetTokenQuery()
 
   const chunks: Array<string> = []
   chunkGroup.chunks.forEach((chunk) => {
@@ -142,10 +142,7 @@ function getAppPathRequiredChunks(
         // previously done for dynamic chunks by patching the webpack runtime but we want
         // these filenames to be managed by React's Flight runtime instead and so we need
         // to implement any special handling of the file name here.
-        return chunks.push(
-          chunkId,
-          encodeURIPath(file) + deploymentIdChunkQuery
-        )
+        return chunks.push(chunkId, encodeURIPath(file) + assetTokenQuery)
       })
     }
   })

--- a/packages/next/src/client/app-webpack.ts
+++ b/packages/next/src/client/app-webpack.ts
@@ -2,18 +2,15 @@
 // https://github.com/webpack/webpack/blob/2738eebc7880835d88c727d364ad37f3ec557593/lib/RuntimeGlobals.js#L204
 
 import './register-deployment-id-global'
-import {
-  getDeploymentId,
-  getDeploymentIdQueryOrEmptyString,
-} from '../shared/lib/deployment-id'
+import { getAssetToken, getAssetTokenQuery } from '../shared/lib/deployment-id'
 import { encodeURIPath } from '../shared/lib/encode-uri-path'
 
 declare const __webpack_require__: any
 
 // If we have a deployment ID, we need to append it to the webpack chunk names
 // I am keeping the process check explicit so this can be statically optimized
-if (getDeploymentId()) {
-  const suffix = getDeploymentIdQueryOrEmptyString()
+if (getAssetToken()) {
+  const suffix = getAssetTokenQuery()
   const getChunkScriptFilename = __webpack_require__.u
   __webpack_require__.u = (...args: any[]) =>
     // We encode the chunk filename because our static server matches against and encoded

--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -50,7 +50,7 @@ import RootErrorBoundary from './errors/root-error-boundary'
 import DefaultGlobalError from './builtin/global-error'
 import { RootLayoutBoundary } from '../../lib/framework/boundary-components'
 import type { StaticIndicatorState } from '../dev/hot-reloader/app/hot-reloader-app'
-import { getDeploymentIdQueryOrEmptyString } from '../../shared/lib/deployment-id'
+import { getAssetTokenQuery } from '../../shared/lib/deployment-id'
 
 const globalMutable: {
   pendingMpaPath?: string
@@ -633,12 +633,12 @@ function RuntimeStylesForWebpack() {
     }
   }, [renderedStylesSize, forceUpdate])
 
-  const dplId = getDeploymentIdQueryOrEmptyString()
+  const query = getAssetTokenQuery()
   return [...(runtimeStyles || [])].map((href, i) => (
     <link
       key={i}
       rel="stylesheet"
-      href={`${href}${dplId}`}
+      href={`${href}${query}`}
       // @ts-ignore
       precedence="next"
       // TODO figure out crossOrigin and nonce

--- a/packages/next/src/client/route-loader.ts
+++ b/packages/next/src/client/route-loader.ts
@@ -4,7 +4,7 @@ import type { RequiredServerFilesManifest } from '../build'
 import getAssetPathFromRoute from '../shared/lib/router/utils/get-asset-path-from-route'
 import { __unsafeCreateTrustedScriptURL } from './trusted-types'
 import { requestIdleCallback } from './request-idle-callback'
-import { getDeploymentIdQueryOrEmptyString } from '../shared/lib/deployment-id'
+import { getAssetTokenQuery } from '../shared/lib/deployment-id'
 import { encodeURIPath } from '../shared/lib/encode-uri-path'
 import { resolvePromiseWithTimeout } from './lib/promise'
 
@@ -114,10 +114,6 @@ function hasPrefetch(link?: HTMLLinkElement): boolean {
 
 const canPrefetch: boolean = hasPrefetch()
 
-const getAssetQueryString = () => {
-  return getDeploymentIdQueryOrEmptyString()
-}
-
 function prefetchViaDom(
   href: string,
   as: string,
@@ -218,7 +214,7 @@ function getFilesForRoute(
       assetPrefix +
       '/_next/static/chunks/pages' +
       encodeURIPath(getAssetPathFromRoute(route, '.js')) +
-      getAssetQueryString()
+      getAssetTokenQuery()
     return Promise.resolve({
       scripts: [__unsafeCreateTrustedScriptURL(scriptUrl)],
       // Styles are handled by `style-loader` in development:
@@ -235,10 +231,10 @@ function getFilesForRoute(
     return {
       scripts: allFiles
         .filter((v) => v.endsWith('.js'))
-        .map((v) => __unsafeCreateTrustedScriptURL(v) + getAssetQueryString()),
+        .map((v) => __unsafeCreateTrustedScriptURL(v) + getAssetTokenQuery()),
       css: allFiles
         .filter((v) => v.endsWith('.css'))
-        .map((v) => v + getAssetQueryString()),
+        .map((v) => v + getAssetTokenQuery()),
     }
   })
 }

--- a/packages/next/src/client/webpack.ts
+++ b/packages/next/src/client/webpack.ts
@@ -1,15 +1,12 @@
 declare const __webpack_require__: any
 declare let __webpack_public_path__: string
 
-import {
-  getDeploymentId,
-  getDeploymentIdQueryOrEmptyString,
-} from '../shared/lib/deployment-id'
+import { getAssetToken, getAssetTokenQuery } from '../shared/lib/deployment-id'
 
-// If we have a deployment ID, we need to append it to the webpack chunk names
+// If we have a deployment ID query string, we need to append it to the webpack chunk names
 // I am keeping the process check explicit so this can be statically optimized
-if (getDeploymentId()) {
-  const suffix = getDeploymentIdQueryOrEmptyString()
+if (getAssetToken()) {
+  const suffix = getAssetTokenQuery()
   const getChunkScriptFilename = __webpack_require__.u
   __webpack_require__.u = (...args: any[]) =>
     // We enode the chunk filename because our static server matches against and encoded

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -704,6 +704,9 @@ async function exportAppImpl(
           worker.exportPages({
             buildId,
             deploymentId: nextConfig.deploymentId,
+            immutableAssetToken:
+              nextConfig.experimental.immutableAssetToken ??
+              nextConfig.deploymentId,
             exportPaths: batch,
             parentSpanId: span.getId(),
             pagesDataDir,

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -704,8 +704,8 @@ async function exportAppImpl(
           worker.exportPages({
             buildId,
             deploymentId: nextConfig.deploymentId,
-            immutableAssetToken:
-              nextConfig.experimental.immutableAssetToken ??
+            clientAssetToken:
+              nextConfig.experimental.immutableAssetToken ||
               nextConfig.deploymentId,
             exportPaths: batch,
             parentSpanId: span.getId(),

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -24,6 +24,7 @@ export type ExportPathEntry = ExportPathMap[keyof ExportPathMap] & {
 export interface ExportPagesInput {
   buildId: string
   deploymentId: string
+  immutableAssetToken: string
   exportPaths: ExportPathEntry[]
   parentSpanId: number
   dir: string
@@ -43,6 +44,7 @@ export interface ExportPagesInput {
 export interface ExportPageInput {
   buildId: string
   deploymentId: string
+  immutableAssetToken: string
   exportPath: ExportPathEntry
   distDir: string
   outDir: string

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -24,7 +24,7 @@ export type ExportPathEntry = ExportPathMap[keyof ExportPathMap] & {
 export interface ExportPagesInput {
   buildId: string
   deploymentId: string
-  immutableAssetToken: string
+  clientAssetToken: string
   exportPaths: ExportPathEntry[]
   parentSpanId: number
   dir: string
@@ -44,7 +44,7 @@ export interface ExportPagesInput {
 export interface ExportPageInput {
   buildId: string
   deploymentId: string
-  immutableAssetToken: string
+  clientAssetToken: string
   exportPath: ExportPathEntry
   distDir: string
   outDir: string

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -86,7 +86,7 @@ async function exportPageImpl(
     outDir: commonOutDir,
     buildId,
     deploymentId,
-    immutableAssetToken,
+    clientAssetToken,
     renderResumeDataCache,
   } = input
 
@@ -279,7 +279,7 @@ async function exportPageImpl(
     const sharedContext: AppSharedContext = {
       buildId,
       deploymentId,
-      immutableAssetToken,
+      clientAssetToken,
     }
 
     return exportAppPage(
@@ -301,7 +301,7 @@ async function exportPageImpl(
     const sharedContext: PagesSharedContext = {
       buildId,
       deploymentId,
-      immutableAssetToken,
+      clientAssetToken,
       customServer: undefined,
     }
 
@@ -424,7 +424,7 @@ export async function exportPages(
             sriEnabled: Boolean(nextConfig.experimental.sri?.algorithm),
             buildId: input.buildId,
             deploymentId: input.deploymentId,
-            immutableAssetToken: input.immutableAssetToken,
+            clientAssetToken: input.clientAssetToken,
             renderResumeDataCache,
           }),
           hasDebuggerAttached

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -86,6 +86,7 @@ async function exportPageImpl(
     outDir: commonOutDir,
     buildId,
     deploymentId,
+    immutableAssetToken,
     renderResumeDataCache,
   } = input
 
@@ -275,7 +276,11 @@ async function exportPageImpl(
 
   // Handle App Pages
   if (isAppDir) {
-    const sharedContext: AppSharedContext = { buildId, deploymentId }
+    const sharedContext: AppSharedContext = {
+      buildId,
+      deploymentId,
+      immutableAssetToken,
+    }
 
     return exportAppPage(
       req,
@@ -296,6 +301,7 @@ async function exportPageImpl(
     const sharedContext: PagesSharedContext = {
       buildId,
       deploymentId,
+      immutableAssetToken,
       customServer: undefined,
     }
 
@@ -418,6 +424,7 @@ export async function exportPages(
             sriEnabled: Boolean(nextConfig.experimental.sri?.algorithm),
             buildId: input.buildId,
             deploymentId: input.deploymentId,
+            immutableAssetToken: input.immutableAssetToken,
             renderResumeDataCache,
           }),
           hasDebuggerAttached

--- a/packages/next/src/pages/_document.tsx
+++ b/packages/next/src/pages/_document.tsx
@@ -138,6 +138,7 @@ function getScripts(
     buildManifest,
     isDevelopment,
     assetQueryString,
+    mutableAssetQueryString,
     disableOptimizedLoading,
     crossOrigin,
   } = context
@@ -148,10 +149,15 @@ function getScripts(
   )
 
   return [...normalScripts, ...lowPriorityScripts].map((file) => {
+    // static/chunks/51e975e7b637a580.js should use the immutable id, while
+    // static/Yj152X97rfGgF7NPcJEZs/_ssgManifest.js should use the deployment id
+    const query = file.startsWith('static/chunks')
+      ? assetQueryString
+      : mutableAssetQueryString
     return (
       <script
         key={file}
-        src={`${assetPrefix}/_next/${encodeURIPath(file)}${assetQueryString}`}
+        src={`${assetPrefix}/_next/${encodeURIPath(file)}${query}`}
         nonce={props.nonce}
         async={!isDevelopment && disableOptimizedLoading}
         defer={!disableOptimizedLoading}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -267,7 +267,7 @@ export type GenerateFlight = typeof generateDynamicFlightRenderResult
 export type AppSharedContext = {
   buildId: string
   deploymentId: string
-  immutableAssetToken: string
+  clientAssetToken: string
 }
 
 export type AppRenderContext = {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -267,6 +267,7 @@ export type GenerateFlight = typeof generateDynamicFlightRenderResult
 export type AppSharedContext = {
   buildId: string
   deploymentId: string
+  immutableAssetToken: string
 }
 
 export type AppRenderContext = {

--- a/packages/next/src/server/app-render/get-asset-query-string.ts
+++ b/packages/next/src/server/app-render/get-asset-query-string.ts
@@ -18,8 +18,8 @@ export function getAssetQueryString(
     qs += `?v=${ctx.requestTimestamp}`
   }
 
-  if (ctx.sharedContext.deploymentId) {
-    qs += `${shouldAddVersion ? '&' : '?'}dpl=${ctx.sharedContext.deploymentId}`
+  if (ctx.sharedContext.immutableAssetToken) {
+    qs += `${shouldAddVersion ? '&' : '?'}dpl=${ctx.sharedContext.immutableAssetToken}`
   }
   return qs
 }

--- a/packages/next/src/server/app-render/get-asset-query-string.ts
+++ b/packages/next/src/server/app-render/get-asset-query-string.ts
@@ -18,8 +18,8 @@ export function getAssetQueryString(
     qs += `?v=${ctx.requestTimestamp}`
   }
 
-  if (ctx.sharedContext.immutableAssetToken) {
-    qs += `${shouldAddVersion ? '&' : '?'}dpl=${ctx.sharedContext.immutableAssetToken}`
+  if (ctx.sharedContext.clientAssetToken) {
+    qs += `${shouldAddVersion ? '&' : '?'}dpl=${ctx.sharedContext.clientAssetToken}`
   }
   return qs
 }

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -467,9 +467,6 @@ export default abstract class Server<
         )
       }
       this.deploymentId = process.env.NEXT_DEPLOYMENT_ID
-      ;(globalThis as any).NEXT_CLIENT_ASSET_SUFFIX = this.deploymentId
-        ? `?dpl=${this.deploymentId}`
-        : ''
     } else {
       let id = this.nextConfig.experimental.useSkewCookie
         ? ''
@@ -477,8 +474,11 @@ export default abstract class Server<
 
       this.deploymentId = id
       process.env.NEXT_DEPLOYMENT_ID = id
-      ;(globalThis as any).NEXT_CLIENT_ASSET_SUFFIX = id ? `?dpl=${id}` : ''
     }
+    ;(globalThis as any).NEXT_CLIENT_ASSET_SUFFIX =
+      this.nextConfig.experimental.immutableAssetToken || this.deploymentId
+        ? `?dpl=${this.nextConfig.experimental.immutableAssetToken || this.deploymentId}`
+        : ''
 
     this.hostname = hostname
     if (this.hostname) {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -980,16 +980,16 @@ function assignDefaultsAndValidate(
     result.deploymentId = process.env.NEXT_DEPLOYMENT_ID
   }
 
-  // Only read process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID to make our testing setup easier. This is
+  // Only read process.env.__NEXT_IMMUTABLE_ASSET_TOKEN to make our testing setup easier. This is
   // actually done by the adapter's modifyConfig
   if (
     process.env.__NEXT_TEST_MODE &&
     process.env.IS_TURBOPACK_TEST &&
     result.deploymentId &&
-    process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID
+    process.env.__NEXT_IMMUTABLE_ASSET_TOKEN
   ) {
     result.experimental.immutableAssetToken =
-      process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID
+      process.env.__NEXT_IMMUTABLE_ASSET_TOKEN
   }
 
   const tracingRoot = result?.outputFileTracingRoot

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -980,6 +980,18 @@ function assignDefaultsAndValidate(
     result.deploymentId = process.env.NEXT_DEPLOYMENT_ID
   }
 
+  // Only read process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID to make our testing setup easier. This is
+  // actually done by the adapter's modifyConfig
+  if (
+    process.env.__NEXT_TEST_MODE &&
+    process.env.IS_TURBOPACK_TEST &&
+    result.deploymentId &&
+    process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID
+  ) {
+    result.experimental.immutableAssetToken =
+      process.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID
+  }
+
   const tracingRoot = result?.outputFileTracingRoot
   const turbopackRoot = result?.turbopack?.root
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1742,6 +1742,7 @@ export default async function loadConfig(
     }
 
     if (
+      phase === PHASE_PRODUCTION_BUILD &&
       bundler !== Bundler.Turbopack &&
       userConfig.experimental?.immutableAssetToken
     ) {

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1742,8 +1742,7 @@ export default async function loadConfig(
     }
 
     if (
-      // TODO enable once everything is merged
-      (true || bundler !== Bundler.Turbopack) &&
+      bundler !== Bundler.Turbopack &&
       userConfig.experimental?.immutableAssetToken
     ) {
       // Silently ignore that flag for Webpack/Rspack since the server code assumes that all files

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -57,6 +57,18 @@ export function getResolveRoutes(
   renderServerOpts: Parameters<RenderServer['initialize']>[0],
   ensureMiddleware?: (url?: string) => Promise<void>
 ) {
+  let clientHashes: Record<string, string> | undefined = undefined
+  if (process.env.__NEXT_TEST_MODE && process.env.IS_TURBOPACK_TEST) {
+    try {
+      clientHashes = JSON.parse(
+        (require('fs') as typeof import('fs')).readFileSync(
+          path.join(opts.dir, config.distDir, 'immutable-static-hashes.json'),
+          'utf8'
+        )
+      )
+    } catch {}
+  }
+
   type Route = {
     /**
      * The path matcher to check if this route applies to this request.
@@ -481,7 +493,13 @@ export function getResolveRoutes(
                 output.type === 'nextStaticFolder' &&
                 config.deploymentId
               ) {
-                const expectedToken = config.deploymentId
+                let useImmutableToken =
+                  config.experimental.immutableAssetToken &&
+                  clientHashes![`static${decodeURI(output.itemPath)}`]
+
+                const expectedToken = useImmutableToken
+                  ? config.experimental.immutableAssetToken
+                  : config.deploymentId
                 if (parsedUrl.query.dpl !== expectedToken) {
                   console.error(
                     `Invalid dpl query param: ${req.url}, expected: ${expectedToken}`

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -274,6 +274,8 @@ export default class NextNodeServer extends BaseServer<
     // when using compile mode static env isn't inlined so we
     // need to populate in normal runtime env
     if (this.renderOpts.isExperimentalCompile) {
+      // immutableAssetToken only works with Turbopack, and `isExperimentalCompile` isn't supported
+      // with that anyway, so we can assign immutableAssetToken to deploymentId here
       populateStaticEnv(this.nextConfig, this.deploymentId || '')
     }
 
@@ -634,6 +636,9 @@ export default class NextNodeServer extends BaseServer<
           {
             buildId: this.buildId,
             deploymentId: this.deploymentId,
+            immutableAssetToken:
+              this.nextConfig.experimental.immutableAssetToken ??
+              this.deploymentId,
           }
         )
       } else {
@@ -649,6 +654,9 @@ export default class NextNodeServer extends BaseServer<
           {
             buildId: this.buildId,
             deploymentId: this.deploymentId,
+            immutableAssetToken:
+              this.nextConfig.experimental.immutableAssetToken ??
+              this.deploymentId,
             customServer: this.serverOptions.customServer || undefined,
           },
           {

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -636,7 +636,7 @@ export default class NextNodeServer extends BaseServer<
           {
             buildId: this.buildId,
             deploymentId: this.deploymentId,
-            immutableAssetToken:
+            clientAssetToken:
               this.nextConfig.experimental.immutableAssetToken ??
               this.deploymentId,
           }
@@ -654,7 +654,7 @@ export default class NextNodeServer extends BaseServer<
           {
             buildId: this.buildId,
             deploymentId: this.deploymentId,
-            immutableAssetToken:
+            clientAssetToken:
               this.nextConfig.experimental.immutableAssetToken ??
               this.deploymentId,
             customServer: this.serverOptions.customServer || undefined,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1742,7 +1742,8 @@ export default class NextNodeServer extends BaseServer<
         request: requestData,
         useCache: true,
         onWarning: params.onWarning,
-        deploymentId: this.deploymentId,
+        clientAssetToken:
+          this.nextConfig.experimental.immutableAssetToken || this.deploymentId,
       })
     }
 
@@ -2040,7 +2041,8 @@ export default class NextNodeServer extends BaseServer<
         params.req,
         'serverComponentsHmrCache'
       ),
-      deploymentId: this.deploymentId,
+      clientAssetToken:
+        this.nextConfig.experimental.immutableAssetToken || this.deploymentId,
     })
 
     if (result.fetchMetrics) {

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -60,6 +60,7 @@ export type PagesRenderResultMetadata = {
   pageData?: any
   cacheControl?: CacheControl
   assetQueryString?: string
+  mutableAssetQueryString?: string
   isNotFound?: boolean
   isRedirect?: boolean
 }

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -308,9 +308,9 @@ export type PagesSharedContext = {
   deploymentId: string | undefined
 
   /**
-   * See NextConfig.experimental.immutableAssetToken
+   * Either NextConfig.experimental.immutableAssetToken or NextConfig.deploymentId
    */
-  immutableAssetToken: string | undefined
+  clientAssetToken: string | undefined
 
   /**
    * True if the user is using a custom server.
@@ -480,8 +480,8 @@ export async function renderToHTMLImpl(
       : '')
   const assetQueryString =
     baseAssetQueryString +
-    (sharedContext.immutableAssetToken
-      ? `${baseAssetQueryString ? '&' : '?'}dpl=${sharedContext.immutableAssetToken}`
+    (sharedContext.clientAssetToken
+      ? `${baseAssetQueryString ? '&' : '?'}dpl=${sharedContext.clientAssetToken}`
       : '')
   const metadata: PagesRenderResultMetadata = {
     assetQueryString,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -458,12 +458,10 @@ export async function renderToHTMLImpl(
   // Adds support for reading `cookies` in `getServerSideProps` when SSR.
   setLazyProp({ req: req as any }, 'cookies', getCookieParser(req.headers))
 
-  const metadata: PagesRenderResultMetadata = {}
-
-  metadata.assetQueryString =
+  let baseAssetQueryString =
     (process.env.__NEXT_DEV_SERVER && renderOpts.assetQueryString) || ''
 
-  if (process.env.__NEXT_DEV_SERVER && !metadata.assetQueryString) {
+  if (process.env.__NEXT_DEV_SERVER && !baseAssetQueryString) {
     const userAgent = (req.headers['user-agent'] || '').toLowerCase()
     if (userAgent.includes('safari') && !userAgent.includes('chrome')) {
       // In dev we invalidate the cache by appending a timestamp to the resource URL.
@@ -471,15 +469,23 @@ export async function renderToHTMLImpl(
       // TODO: remove this workaround when https://bugs.webkit.org/show_bug.cgi?id=187726 is fixed.
       // Note: The workaround breaks breakpoints on reload since the script url always changes,
       // so we only apply it to Safari.
-      metadata.assetQueryString = `?ts=${Date.now()}`
+      baseAssetQueryString = `?ts=${Date.now()}`
     }
   }
 
-  // if deploymentId is provided we append it to all asset requests
-  if (sharedContext.immutableAssetToken) {
-    metadata.assetQueryString += `${metadata.assetQueryString ? '&' : '?'}dpl=${
-      sharedContext.immutableAssetToken
-    }`
+  const mutableAssetQueryString =
+    baseAssetQueryString +
+    (sharedContext.deploymentId
+      ? `${baseAssetQueryString ? '&' : '?'}dpl=${sharedContext.deploymentId}`
+      : '')
+  const assetQueryString =
+    baseAssetQueryString +
+    (sharedContext.immutableAssetToken
+      ? `${baseAssetQueryString ? '&' : '?'}dpl=${sharedContext.immutableAssetToken}`
+      : '')
+  const metadata: PagesRenderResultMetadata = {
+    assetQueryString,
+    mutableAssetQueryString,
   }
 
   // don't modify original query object
@@ -504,8 +510,6 @@ export async function renderToHTMLImpl(
     expireTime,
   } = renderOpts
   const { App } = extra
-
-  const assetQueryString = metadata.assetQueryString
 
   let Document = extra.Document
 
@@ -1522,7 +1526,8 @@ export async function renderToHTMLImpl(
         ? pageConfig.unstable_runtimeJS
         : undefined,
     unstable_JsPreload: pageConfig.unstable_JsPreload,
-    assetQueryString,
+    assetQueryString: assetQueryString || '',
+    mutableAssetQueryString: mutableAssetQueryString || '',
     scriptLoader,
     locale,
     disableOptimizedLoading,

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -303,9 +303,14 @@ export type PagesSharedContext = {
   buildId: string
 
   /**
-   * The deployment ID if the user is deploying to a platform that provides one.
+   * See NextConfig.deploymentId
    */
-  deploymentId: string
+  deploymentId: string | undefined
+
+  /**
+   * See NextConfig.experimental.immutableAssetToken
+   */
+  immutableAssetToken: string | undefined
 
   /**
    * True if the user is using a custom server.
@@ -471,9 +476,9 @@ export async function renderToHTMLImpl(
   }
 
   // if deploymentId is provided we append it to all asset requests
-  if (sharedContext.deploymentId) {
+  if (sharedContext.immutableAssetToken) {
     metadata.assetQueryString += `${metadata.assetQueryString ? '&' : '?'}dpl=${
-      sharedContext.deploymentId
+      sharedContext.immutableAssetToken
     }`
   }
 

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -48,7 +48,6 @@ import type {
   GetStaticPaths,
   GetStaticProps,
 } from '../../../types'
-import { getDeploymentId } from '../../../shared/lib/deployment-id'
 
 export const getHandler = ({
   srcPage: originalSrcPage,
@@ -146,6 +145,8 @@ export const getHandler = ({
       nextConfig,
       resolvedPathname,
       encodedResolvedPathname,
+      deploymentId,
+      immutableAssetToken,
     } = prepareResult
 
     const isExperimentalCompile =
@@ -266,7 +267,8 @@ export const getHandler = ({
                     buildId,
                     customServer:
                       Boolean(routerServerContext?.isCustomServer) || undefined,
-                    deploymentId: getDeploymentId() || '',
+                    deploymentId,
+                    immutableAssetToken,
                   },
                   renderOpts: {
                     params,
@@ -634,7 +636,6 @@ export const getHandler = ({
           res.statusCode = 404
 
           if (isNextDataRequest) {
-            const deploymentId = getDeploymentId()
             if (deploymentId) {
               res.setHeader(NEXT_NAV_DEPLOYMENT_ID_HEADER, deploymentId)
             }
@@ -646,7 +647,6 @@ export const getHandler = ({
 
         if (result.value.kind === CachedRouteKind.REDIRECT) {
           if (isNextDataRequest) {
-            const deploymentId = getDeploymentId()
             if (deploymentId) {
               res.setHeader(NEXT_NAV_DEPLOYMENT_ID_HEADER, deploymentId)
             }
@@ -724,7 +724,6 @@ export const getHandler = ({
 
         // Add deployment ID header for data requests
         if (isNextDataRequest && !isErrorPage && !is500Page) {
-          const deploymentId = getDeploymentId()
           if (deploymentId) {
             res.setHeader(NEXT_NAV_DEPLOYMENT_ID_HEADER, deploymentId)
           }

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -146,7 +146,7 @@ export const getHandler = ({
       resolvedPathname,
       encodedResolvedPathname,
       deploymentId,
-      immutableAssetToken,
+      clientAssetToken,
     } = prepareResult
 
     const isExperimentalCompile =
@@ -268,7 +268,7 @@ export const getHandler = ({
                     customServer:
                       Boolean(routerServerContext?.isCustomServer) || undefined,
                     deploymentId,
-                    immutableAssetToken,
+                    clientAssetToken,
                   },
                   renderOpts: {
                     params,

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -569,7 +569,7 @@ export abstract class RouteModule<
     | {
         buildId: string
         deploymentId: string
-        immutableAssetToken: string
+        clientAssetToken: string
         locale?: string
         locales?: readonly string[]
         defaultLocale?: string
@@ -1027,7 +1027,7 @@ export abstract class RouteModule<
         nextConfig satisfies DeepReadonly<NextConfigRuntime> as NextConfigRuntime,
       routerServerContext,
       deploymentId,
-      immutableAssetToken:
+      clientAssetToken:
         nextConfig.experimental.immutableAssetToken || deploymentId,
     }
   }

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -569,6 +569,7 @@ export abstract class RouteModule<
     | {
         buildId: string
         deploymentId: string
+        immutableAssetToken: string
         locale?: string
         locales?: readonly string[]
         defaultLocale?: string
@@ -1026,6 +1027,8 @@ export abstract class RouteModule<
         nextConfig satisfies DeepReadonly<NextConfigRuntime> as NextConfigRuntime,
       routerServerContext,
       deploymentId,
+      immutableAssetToken:
+        nextConfig.experimental.immutableAssetToken || deploymentId,
     }
   }
 

--- a/packages/next/src/server/web/sandbox/sandbox.ts
+++ b/packages/next/src/server/web/sandbox/sandbox.ts
@@ -37,7 +37,7 @@ interface RunnerFnParams {
   distDir: string
   incrementalCache?: any
   serverComponentsHmrCache?: ServerComponentsHmrCache
-  deploymentId: string
+  clientAssetToken: string
 }
 
 type RunnerFn = (params: RunnerFnParams) => Promise<FetchEventResult>
@@ -97,10 +97,9 @@ export async function getRuntimeContext(
       params.serverComponentsHmrCache
   }
 
-  if (params.deploymentId) {
-    runtime.context.globalThis.NEXT_CLIENT_ASSET_SUFFIX = params.deploymentId
-      ? `?dpl=${params.deploymentId}`
-      : ''
+  if (params.clientAssetToken) {
+    runtime.context.globalThis.NEXT_CLIENT_ASSET_SUFFIX =
+      params.clientAssetToken ? `?dpl=${params.clientAssetToken}` : ''
   }
 
   for (const paramPath of params.paths) {

--- a/packages/next/src/shared/lib/deployment-id.ts
+++ b/packages/next/src/shared/lib/deployment-id.ts
@@ -15,9 +15,24 @@ export function getDeploymentId(): string | undefined {
   return deploymentId
 }
 
-export function getDeploymentIdQueryOrEmptyString(): string {
-  if (deploymentId) {
-    return `?dpl=${deploymentId}`
+export function getDeploymentIdQuery(ampersand = false): string {
+  let id = getDeploymentId()
+  if (id) {
+    return `${ampersand ? '&' : '?'}dpl=${id}`
+  }
+  return ''
+}
+
+export function getAssetToken(): string | undefined {
+  return (
+    process.env.NEXT_IMMUTABLE_ASSET_TOKEN || process.env.NEXT_DEPLOYMENT_ID
+  )
+}
+
+export function getAssetTokenQuery(ampersand = false): string {
+  let id = getAssetToken()
+  if (id) {
+    return `${ampersand ? '&' : '?'}dpl=${id}`
   }
   return ''
 }

--- a/packages/next/src/shared/lib/html-context.shared-runtime.ts
+++ b/packages/next/src/shared/lib/html-context.shared-runtime.ts
@@ -30,6 +30,7 @@ export type HtmlProps = {
   unstable_runtimeJS?: false
   unstable_JsPreload?: false
   assetQueryString: string
+  mutableAssetQueryString: string
   scriptLoader: {
     afterInteractive?: string[]
     beforeInteractive?: any[]

--- a/packages/next/src/shared/lib/image-loader.ts
+++ b/packages/next/src/shared/lib/image-loader.ts
@@ -26,7 +26,9 @@ function defaultLoader({
     }
   }
 
-  // Extract dpl parameter early so validation uses the clean URL
+  // Extract dpl parameter early so validation uses the clean URL.
+  // If a immutable asset token should be used, it was already added as a query parameter and will
+  // be extracted and reused here.
   let deploymentId = getDeploymentId()
   if (src.startsWith('/') && !src.startsWith('//')) {
     // We unfortunately can't easily use `new URL()` here, because it normalizes the URL which causes

--- a/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
+++ b/packages/next/src/shared/lib/lazy-dynamic/preload-chunks.tsx
@@ -4,7 +4,7 @@ import { preload } from 'react-dom'
 
 import { workAsyncStorage } from '../../../server/app-render/work-async-storage.external'
 import { encodeURIPath } from '../encode-uri-path'
-import { getDeploymentIdQueryOrEmptyString } from '../deployment-id'
+import { getAssetTokenQuery } from '../deployment-id'
 
 export function PreloadChunks({
   moduleIds,
@@ -38,12 +38,12 @@ export function PreloadChunks({
     return null
   }
 
-  const dplId = getDeploymentIdQueryOrEmptyString()
+  const query = getAssetTokenQuery()
 
   return (
     <>
       {allFiles.map((chunk) => {
-        const href = `${workStore.assetPrefix}/_next/${encodeURIPath(chunk)}${dplId}`
+        const href = `${workStore.assetPrefix}/_next/${encodeURIPath(chunk)}${query}`
         const isCss = chunk.endsWith('.css')
         // If it's stylesheet we use `precedence` o help hoist with React Float.
         // For stylesheets we actually need to render the CSS because nothing else is going to do it so it needs to be part of the component tree.

--- a/test/e2e/url/url.test.ts
+++ b/test/e2e/url/url.test.ts
@@ -16,7 +16,7 @@ describe(`Handle new URL asset references`, () => {
     env: {
       // rely on skew protection when deployed
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
-      VERCEL_IMMUTABLE_DEPLOYMENT_ID: isNextStart
+      __NEXT_IMMUTABLE_ASSET_TOKEN: isNextStart
         ? 'test-immutable-tkn-7890'
         : undefined,
     },

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -285,7 +285,7 @@ export class NextInstance {
                     ? // since we can't get the build id as a build artifact,
                       // add it in build logs
                       {
-                        'post-build': `node -e 'console.log("BUILD" + "_ID: " + fs.readFileSync("${this.distDir}/BUILD_ID") + "\\nDEPLOYMENT" + "_ID: " + process.env.NEXT_DEPLOYMENT_ID)'`,
+                        'post-build': `node -e 'console.log("BUILD" + "_ID: " + fs.readFileSync("${this.distDir}/BUILD_ID") + "\\nDEPLOYMENT" + "_ID: " + process.env.NEXT_DEPLOYMENT_ID + "\\nIMMUTABLE_ASSET" + "_TOKEN: " + process.env.VERCEL_IMMUTABLE_ASSET_TOKEN)'`,
                       }
                     : {}),
                   ...pkgScripts,
@@ -647,8 +647,12 @@ export class NextInstance {
     return this.deploymentId ? `${prefix}dpl=${this.deploymentId}` : ''
   }
 
+  public get immutableAssetToken(): string | undefined {
+    return undefined
+  }
+
   public get assetToken(): string | undefined {
-    return this.deploymentId
+    return this.immutableAssetToken || this.deploymentId
   }
 
   public getAssetQuery(ampersand: boolean = false): string | undefined {

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -10,6 +10,7 @@ export class NextDeployInstance extends NextInstance {
   private _cliOutput: string
   private _buildId: string
   private _deploymentId: string | undefined
+  private _immutableAssetToken: string | undefined
   private _writtenHostsLine: string | null = null
 
   protected throwIfUnavailable(): void | never {
@@ -36,6 +37,10 @@ export class NextDeployInstance extends NextInstance {
 
   public get deploymentId() {
     return this._deploymentId
+  }
+
+  public get immutableAssetToken() {
+    return process.env.IS_TURBOPACK_TEST ? this._immutableAssetToken : undefined
   }
 
   private async deployUsingCustomScript(): Promise<{ url: string }> {
@@ -131,9 +136,18 @@ export class NextDeployInstance extends NextInstance {
       throw new Error(`Failed to get deploymentId from logs ${this._cliOutput}`)
     }
     this._deploymentId = deploymentId
+    const immutableAssetToken = this._cliOutput
+      .match(/IMMUTABLE_ASSET_TOKEN: (.+)/)?.[1]
+      ?.trim()
+    if (!immutableAssetToken) {
+      throw new Error(
+        `Failed to get immutableAssetToken from logs ${this._cliOutput}`
+      )
+    }
+    this._immutableAssetToken = immutableAssetToken
 
     require('console').log(
-      `Got buildId: ${this._buildId}, deploymentId: ${this._deploymentId}`
+      `Got buildId: ${this._buildId}, deploymentId: ${this._deploymentId}, immutableAssetToken: ${this._immutableAssetToken}`
     )
   }
 

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -20,7 +20,7 @@ export class NextStartInstance extends NextInstance {
 
     if (!opts.disableAutoSkewProtection && shouldUseTurbopack()) {
       this.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
-      this.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID = 'test-immutable-tkn-7890'
+      this.env.__NEXT_IMMUTABLE_ASSET_TOKEN = 'test-immutable-tkn-7890'
     }
   }
 

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -19,6 +19,7 @@ export class NextStartInstance extends NextInstance {
 
     if (!opts.disableAutoSkewProtection && shouldUseTurbopack()) {
       this.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
+      this.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID = 'test-immutable-tkn-7890'
     }
   }
 

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -10,6 +10,7 @@ import { shouldUseTurbopack } from 'next-test-utils'
 export class NextStartInstance extends NextInstance {
   private _buildId: string
   private _deploymentId: string | undefined
+  private _immutableAssetToken: string | undefined
   private _cliOutput: string = ''
 
   private _prerenderFinishedTimeMS: number | null = null
@@ -29,6 +30,10 @@ export class NextStartInstance extends NextInstance {
 
   public get deploymentId() {
     return this._deploymentId
+  }
+
+  public get immutableAssetToken() {
+    return process.env.IS_TURBOPACK_TEST ? this._immutableAssetToken : undefined
   }
 
   public get cliOutput() {
@@ -142,6 +147,9 @@ export class NextStartInstance extends NextInstance {
         )
         this._deploymentId =
           requiredServerFiles.config?.deploymentId || undefined
+        this._immutableAssetToken =
+          requiredServerFiles.config?.experimental.immutableAssetToken ||
+          undefined
       } catch {}
     }
 
@@ -294,6 +302,9 @@ export class NextStartInstance extends NextInstance {
         )
       )
       this._deploymentId = requiredServerFiles.config?.deploymentId || undefined
+      this._immutableAssetToken =
+        requiredServerFiles.config?.experimental.immutableAssetToken ||
+        undefined
     } catch {}
 
     return result

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -522,7 +522,7 @@ export function nextBuild(
   if (!opts.disableAutoSkewProtection && shouldUseTurbopack() && !opts.env) {
     opts.env ??= {}
     opts.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
-    opts.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID = 'test-immutable-tkn-7890'
+    opts.env.__NEXT_IMMUTABLE_ASSET_TOKEN = 'test-immutable-tkn-7890'
   }
 
   return runNextCommand(['build', dir, ...args], opts)
@@ -550,7 +550,7 @@ export function nextStart(
   if (!opts.disableAutoSkewProtection && shouldUseTurbopack() && !opts.env) {
     opts.env ??= {}
     opts.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
-    opts.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID = 'test-immutable-tkn-7890'
+    opts.env.__NEXT_IMMUTABLE_ASSET_TOKEN = 'test-immutable-tkn-7890'
   }
 
   return runNextCommandDev(

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -522,6 +522,7 @@ export function nextBuild(
   if (!opts.disableAutoSkewProtection && shouldUseTurbopack() && !opts.env) {
     opts.env ??= {}
     opts.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
+    opts.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID = 'test-immutable-tkn-7890'
   }
 
   return runNextCommand(['build', dir, ...args], opts)
@@ -549,6 +550,7 @@ export function nextStart(
   if (!opts.disableAutoSkewProtection && shouldUseTurbopack() && !opts.env) {
     opts.env ??= {}
     opts.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
+    opts.env.VERCEL_IMMUTABLE_DEPLOYMENT_ID = 'test-immutable-tkn-7890'
   }
 
   return runNextCommandDev(

--- a/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
+++ b/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
@@ -7,7 +7,7 @@ describe('css-url-deployment-id', () => {
     dependencies: { sass: '1.54.0' },
     env: {
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
-      VERCEL_IMMUTABLE_DEPLOYMENT_ID: isNextStart
+      __NEXT_IMMUTABLE_ASSET_TOKEN: isNextStart
         ? 'imm-deployment-id'
         : undefined,
     },

--- a/test/production/deployment-id-handling/app/next.config.js
+++ b/test/production/deployment-id-handling/app/next.config.js
@@ -1,8 +1,12 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
-  deploymentId: process.env.CUSTOM_DEPLOYMENT_ID,
+  deploymentId:
+    process.env.IMMUTABLE_ASSET_TOKEN ?? process.env.CUSTOM_DEPLOYMENT_ID,
   experimental: {
     useSkewCookie: Boolean(process.env.COOKIE_SKEW),
     runtimeServerDeploymentId: !!process.env.RUNTIME_SERVER_DEPLOYMENT_ID,
+    immutableAssetToken: process.env.IMMUTABLE_ASSET_TOKEN
+      ? `imm-${process.env.IMMUTABLE_ASSET_TOKEN}`
+      : undefined,
   },
 }

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -6,10 +6,19 @@ describe.each([
   ['NEXT_DEPLOYMENT_ID', ''],
   ['CUSTOM_DEPLOYMENT_ID', ''],
   ['NEXT_DEPLOYMENT_ID', ' and runtimeServerDeploymentId'],
+  ['IMMUTABLE_ASSET_TOKEN', ''],
 ])(
   'deployment-id-handling enabled with %s%s',
   (envKey, runtimeServerDeploymentId) => {
+    if (envKey === 'IMMUTABLE_ASSET_TOKEN' && !process.env.IS_TURBOPACK_TEST) {
+      it.skip('skip for webpack', () => {})
+      return
+    }
+
     const deploymentId = Date.now() + ''
+    const immutableAssetToken =
+      envKey === 'IMMUTABLE_ASSET_TOKEN' ? `imm-${deploymentId}` : deploymentId
+
     const { next } = nextTestSetup({
       files: join(__dirname, 'app'),
       env: {
@@ -20,6 +29,18 @@ describe.each([
       },
       disableAutoSkewProtection: true,
     })
+
+    const tokenForRequest = (url) => {
+      return url.includes('_next/static/chunks') ||
+        url.includes('_next/static/media')
+        ? // Turbopack-emitted chunks
+          immutableAssetToken
+        : // e.g. _next/static/build-id/_ssgManifest.js
+          deploymentId
+    }
+    const validateTokenForRequest = (url) => {
+      expect(url).toContain('dpl=' + tokenForRequest(url))
+    }
 
     it.each([
       { urlPath: '/' },
@@ -39,7 +60,7 @@ describe.each([
 
         for (const script of scripts) {
           if (script.attribs.src) {
-            expect(script.attribs.src).toContain('dpl=' + deploymentId)
+            validateTokenForRequest(script.attribs.src)
           }
         }
 
@@ -48,7 +69,7 @@ describe.each([
 
         for (const link of links) {
           if (link.attribs.href && link.attribs.rel !== 'expect') {
-            expect(link.attribs.href).toContain('dpl=' + deploymentId)
+            validateTokenForRequest(link.attribs.href)
           }
         }
 
@@ -59,6 +80,7 @@ describe.each([
         const browser = await next.browser(urlPath, {
           beforePageLoad(page) {
             page.on('request', async (req) => {
+              // TODO this currently exclude _next/image
               if (req.url().includes('/_next/static')) {
                 clientRequests.push(req.url())
               }
@@ -76,11 +98,9 @@ describe.each([
         await retry(() => expect(dynamicImportRequests).not.toBeEmpty())
 
         try {
-          expect(
-            dynamicImportRequests.every((item) =>
-              item.includes('dpl=' + deploymentId)
-            )
-          ).toBe(true)
+          expect(dynamicImportRequests).toSatisfyAll((item) =>
+            item.includes('dpl=' + tokenForRequest(item))
+          )
         } finally {
           require('console').error(
             'dynamicImportRequests',
@@ -89,9 +109,9 @@ describe.each([
         }
 
         try {
-          expect(
-            clientRequests.every((item) => item.includes('dpl=' + deploymentId))
-          ).toBe(true)
+          expect(clientRequests).toSatisfyAll((item) =>
+            item.includes('dpl=' + tokenForRequest(item))
+          )
         } finally {
           require('console').error('clientRequests', clientRequests)
         }
@@ -114,7 +134,7 @@ describe.each([
       const browser = await next.browser('/', {
         beforePageLoad(page) {
           page.on('request', async (req) => {
-            const headers = await req.allHeaders()
+            const headers = req.headers()
             if (headers['x-nextjs-data']) {
               dataHeaders.push(headers)
             }
@@ -142,7 +162,7 @@ describe.each([
       const browser = await next.browser('/from-app', {
         beforePageLoad(page) {
           page.on('request', async (req) => {
-            const headers = await req.allHeaders()
+            const headers = req.headers()
             if (headers['rsc']) {
               rscHeaders.push(headers)
             }
@@ -158,11 +178,9 @@ describe.each([
         expect(rscHeaders.length).toBeGreaterThan(0)
       })
 
-      expect(
-        rscHeaders.every(
-          (headers) => headers['x-deployment-id'] === deploymentId
-        )
-      ).toBe(true)
+      expect(rscHeaders).toSatisfyAll(
+        (headers) => headers['x-deployment-id'] === deploymentId
+      )
     })
   }
 )
@@ -215,9 +233,9 @@ describe('deployment-id-handling disabled', () => {
       await retry(() => expect(requests).not.toBeEmpty())
 
       try {
-        expect(
-          requests.every((item) => !item.includes('dpl=' + deploymentId))
-        ).toBe(true)
+        expect(requests).toSatisfyAll(
+          (item) => !item.includes('dpl=' + deploymentId)
+        )
       } finally {
         require('console').error('requests', requests)
       }

--- a/test/unit/next-image-get-img-props.test.ts
+++ b/test/unit/next-image-get-img-props.test.ts
@@ -8,6 +8,19 @@ jest.mock('next/dist/shared/lib/deployment-id.js', () => {
     getDeploymentId() {
       return deploymentId
     },
+    getDeploymentIdQuery(ampersand = false): string {
+      let id = deploymentId
+      if (id) {
+        return `${ampersand ? '&' : '?'}dpl=${id}`
+      }
+      return ''
+    },
+    getAssetToken() {
+      throw new Error("getAssetToken shouldn't be called ")
+    },
+    getAssetTokenQuery(ampersand = false) {
+      throw new Error("getAssetTokenQuery shouldn't be called ")
+    },
   }
 })
 

--- a/test/unit/next-image-legacy.test.ts
+++ b/test/unit/next-image-legacy.test.ts
@@ -11,6 +11,19 @@ jest.mock('next/dist/shared/lib/deployment-id.js', () => {
     getDeploymentId() {
       return deploymentId
     },
+    getDeploymentIdQuery(ampersand = false): string {
+      let id = deploymentId
+      if (id) {
+        return `${ampersand ? '&' : '?'}dpl=${id}`
+      }
+      return ''
+    },
+    getAssetToken() {
+      throw new Error("getAssetToken shouldn't be called ")
+    },
+    getAssetTokenQuery(ampersand = false) {
+      throw new Error("getAssetTokenQuery shouldn't be called ")
+    },
   }
 })
 


### PR DESCRIPTION
This allows specifying a different deployment id for static immutable assets

- [x] rename `getImmutableAssetToken` to `getAssetToken` (because it can be non-immutable as well)
- [x] disable for webpack

Closes PACK-6534

For https://github.com/nextjs/adapter-vercel/pull/25

Part of PACK-6802