### PR TITLE
Fix `revalidatePath` with params and trailing slash when deployed

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -978,5 +978,6 @@
   "977": "maxPostponedStateSize must be a valid number (bytes) or filesize format string (e.g., \"5mb\")",
   "978": "Next.js has blocked a javascript: URL as a security precaution.",
   "979": "invariant: expected %s bytes of postponed state but only received %s bytes",
-  "980": "Failed to load client middleware manifest"
+  "980": "Failed to load client middleware manifest",
+  "981": "resolvedPathname must be set in request metadata"
 }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -24,6 +24,7 @@ import { trace } from '../trace'
 import { setHttpClientAndAgentOptions } from '../server/setup-http-agent-env'
 import { addRequestMeta } from '../server/request-meta'
 import { normalizeAppPath } from '../shared/lib/router/utils/app-paths'
+import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 
 import { createRequestResponseMocks } from '../server/lib/mock-request'
 import { isAppRouteRoute } from '../lib/is-app-route-route'
@@ -175,6 +176,9 @@ async function exportPageImpl(
   if (trailingSlash && !req.url?.endsWith('/')) {
     req.url += '/'
   }
+
+  // Set the resolved pathname without trailing slash as request metadata.
+  addRequestMeta(req, 'resolvedPathname', removeTrailingSlash(updatedPath))
 
   if (
     locale &&

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2017,18 +2017,16 @@ async function renderToHTMLOrFlightImpl(
 
   const isPossibleActionRequest = getIsPossibleServerAction(req)
 
-  // For implicit tags, we need to use the rewritten pathname (if a rewrite
-  // occurred) rather than the original request pathname. Implicit tags are used
-  // to check cache staleness on read (for 'use cache') and as soft tags for
-  // fetch cache. Using the destination path ensures that
-  // revalidatePath('/dest') invalidates cache entries for pages rewritten to
-  // that destination.
-  const implicitTagsPathname =
-    getRequestMeta(req, 'rewrittenPathname') || url.pathname
+  // For implicit tags, we use the resolved pathname which has dynamic params
+  // interpolated, is decoded, and has trailing slash removed.
+  const resolvedPathname = getRequestMeta(req, 'resolvedPathname')
+  if (!resolvedPathname) {
+    throw new InvariantError('resolvedPathname must be set in request metadata')
+  }
 
   const implicitTags = await getImplicitTags(
     workStore.page,
-    implicitTagsPathname,
+    resolvedPathname,
     fallbackRouteParams
   )
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -87,6 +87,12 @@ export interface RequestMeta {
   rewrittenPathname?: string
 
   /**
+   * The resolved pathname for the request. Dynamic route params are
+   * interpolated, the pathname is decoded, and the trailing slash is removed.
+   */
+  resolvedPathname?: string
+
+  /**
    * The cookies that were added by middleware and were added to the response.
    */
   middlewareCookie?: string[]

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -935,6 +935,7 @@ export abstract class RouteModule<
     } catch (_) {}
 
     resolvedPathname = removeTrailingSlash(resolvedPathname)
+    addRequestMeta(req, 'resolvedPathname', resolvedPathname)
 
     let deploymentId
     if (nextConfig.experimental?.runtimeServerDeploymentId) {

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -15,6 +15,7 @@ import {
   ActionDidRevalidateDynamicOnly,
   ActionDidRevalidateStaticAndDynamic as ActionDidRevalidate,
 } from '../../../shared/lib/action-revalidation-kind'
+import { removeTrailingSlash } from '../../../shared/lib/router/utils/remove-trailing-slash'
 
 type CacheLifeConfig = {
   expire?: number
@@ -96,7 +97,7 @@ export function revalidatePath(originalPath: string, type?: 'layout' | 'page') {
     return
   }
 
-  let normalizedPath = `${NEXT_CACHE_IMPLICIT_TAG_ID}${originalPath || '/'}`
+  let normalizedPath = `${NEXT_CACHE_IMPLICIT_TAG_ID}${removeTrailingSlash(originalPath)}`
 
   if (type) {
     normalizedPath += `${normalizedPath.endsWith('/') ? '' : '/'}${type}`

--- a/test/e2e/app-dir/trailingslash/app/[lang]/cache-components/page.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/cache-components/page.js
@@ -1,0 +1,12 @@
+import SharedPage from '../shared-page'
+
+// This page is compatible with Cache Components. It does not define a
+// `revalidate` route segment config, and uses 'use cache' instead. The path is
+// rewritten to here from /:lang(en|es)/ via rewrites in next.config.js when
+// __NEXT_CACHE_COMPONENTS is set to true.
+
+export default async function Page({ params }) {
+  'use cache'
+
+  return <SharedPage params={params} />
+}

--- a/test/e2e/app-dir/trailingslash/app/[lang]/layout.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/layout.js
@@ -1,0 +1,16 @@
+import Link from 'next/link'
+
+export function generateStaticParams() {
+  return [{ lang: 'en' }, { lang: 'es' }]
+}
+
+export default function LangLayout({ children }) {
+  return (
+    <>
+      <nav>
+        <Link href="/en">English</Link> | <Link href="/es">Spanish</Link>
+      </nav>
+      <main>{children}</main>
+    </>
+  )
+}

--- a/test/e2e/app-dir/trailingslash/app/[lang]/legacy/page.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/legacy/page.js
@@ -1,0 +1,9 @@
+import SharedPage from '../shared-page'
+
+// This page uses the legacy `revalidate` route segment config instead of 'use
+// cache'. The path is rewritten to here from /:lang(en|es)/ via rewrites in
+// next.config.js when __NEXT_CACHE_COMPONENTS is not set.
+
+export const revalidate = 900
+
+export default SharedPage

--- a/test/e2e/app-dir/trailingslash/app/[lang]/page.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/page.js
@@ -1,0 +1,18 @@
+import { RevalidateButton } from './revalidate-button'
+
+export const revalidate = 86400
+
+export default async function Page({ params }) {
+  const { lang } = await params
+  const generatedAt = new Date().toISOString()
+
+  return (
+    <div>
+      <h1>Revalidation Test - {lang}</h1>
+      <pre>
+        Page generated at: <span id="generated-at">{generatedAt}</span>
+      </pre>
+      <RevalidateButton lang={lang} />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
@@ -6,12 +6,12 @@ export function RevalidateButton({ lang }) {
   const [isPending, startTransition] = useTransition()
   const [result, setResult] = useState(null)
 
-  function handleRevalidate() {
+  function handleRevalidate(withSlash) {
     startTransition(async () => {
       try {
-        const data = await fetch(`/api/revalidate/?lang=${lang}`).then((res) =>
-          res.json()
-        )
+        const data = await fetch(
+          `/api/revalidate/?lang=${lang}&withSlash=${withSlash}`
+        ).then((res) => res.json())
         startTransition(() => {
           setResult(`Revalidated at: ${data.timestamp}`)
         })
@@ -26,11 +26,18 @@ export function RevalidateButton({ lang }) {
   return (
     <div>
       <button
-        onClick={handleRevalidate}
+        onClick={handleRevalidate.bind(null, true)}
         disabled={isPending}
-        id="revalidate-button"
+        id="revalidate-button-with-slash"
       >
         {isPending ? 'Revalidating...' : `Revalidate /${lang}/`}
+      </button>
+      <button
+        onClick={handleRevalidate.bind(null, false)}
+        disabled={isPending}
+        id="revalidate-button-no-slash"
+      >
+        {isPending ? 'Revalidating...' : `Revalidate /${lang} (no slash)`}
       </button>
       {result && <pre id="revalidate-result">{result}</pre>}
     </div>

--- a/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
@@ -8,13 +8,17 @@ export function RevalidateButton({ lang }) {
 
   function handleRevalidate() {
     startTransition(async () => {
-      setResult(null)
       try {
-        const res = await fetch(`/api/revalidate/?lang=${lang}`)
-        const data = await res.json()
-        setResult(`Revalidated at: ${data.timestamp}`)
+        const data = await fetch(`/api/revalidate/?lang=${lang}`).then((res) =>
+          res.json()
+        )
+        startTransition(() => {
+          setResult(`Revalidated at: ${data.timestamp}`)
+        })
       } catch (e) {
-        setResult(`Error: ${e}`)
+        startTransition(() => {
+          setResult(`Error: ${e}`)
+        })
       }
     })
   }
@@ -28,7 +32,7 @@ export function RevalidateButton({ lang }) {
       >
         {isPending ? 'Revalidating...' : `Revalidate /${lang}/`}
       </button>
-      <pre id="revalidate-result">{result}</pre>
+      {result && <pre id="revalidate-result">{result}</pre>}
     </div>
   )
 }

--- a/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
@@ -10,7 +10,7 @@ export function RevalidateButton({ lang }) {
     startTransition(async () => {
       setResult(null)
       try {
-        const res = await fetch(`/api/revalidate/?path=/${lang}/`)
+        const res = await fetch(`/api/revalidate/?lang=${lang}`)
         const data = await res.json()
         setResult(`Revalidated at: ${data.timestamp}`)
       } catch (e) {

--- a/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/revalidate-button.js
@@ -1,0 +1,34 @@
+'use client'
+
+import { useState, useTransition } from 'react'
+
+export function RevalidateButton({ lang }) {
+  const [isPending, startTransition] = useTransition()
+  const [result, setResult] = useState(null)
+
+  function handleRevalidate() {
+    startTransition(async () => {
+      setResult(null)
+      try {
+        const res = await fetch(`/api/revalidate/?path=/${lang}/`)
+        const data = await res.json()
+        setResult(`Revalidated at: ${data.timestamp}`)
+      } catch (e) {
+        setResult(`Error: ${e}`)
+      }
+    })
+  }
+
+  return (
+    <div>
+      <button
+        onClick={handleRevalidate}
+        disabled={isPending}
+        id="revalidate-button"
+      >
+        {isPending ? 'Revalidating...' : `Revalidate /${lang}/`}
+      </button>
+      <pre id="revalidate-result">{result}</pre>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/trailingslash/app/[lang]/shared-page.js
+++ b/test/e2e/app-dir/trailingslash/app/[lang]/shared-page.js
@@ -1,7 +1,5 @@
 import { RevalidateButton } from './revalidate-button'
 
-export const revalidate = 86400
-
 export default async function Page({ params }) {
   const { lang } = await params
   const generatedAt = new Date().toISOString()

--- a/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
+++ b/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
@@ -1,7 +1,7 @@
 import { revalidatePath } from 'next/cache'
 import { NextResponse } from 'next/server'
 
-const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+const isCacheComponentsEnabled = !!process.env.__NEXT_CACHE_COMPONENTS
 
 export async function GET(request) {
   const lang = request.nextUrl.searchParams.get('lang') || 'en'

--- a/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
+++ b/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
@@ -5,12 +5,17 @@ const isCacheComponentsEnabled = !!process.env.__NEXT_CACHE_COMPONENTS
 
 export async function GET(request) {
   const lang = request.nextUrl.searchParams.get('lang') || 'en'
+  const withSlash = request.nextUrl.searchParams.get('withSlash') !== 'false'
 
   // With rewrites, we need to revalidate the destination path (the actual
   // page), not the source path that users visit.
-  const path = isCacheComponentsEnabled
-    ? `/${lang}/cache-components/`
-    : `/${lang}/legacy/`
+  let path = isCacheComponentsEnabled
+    ? `/${lang}/cache-components`
+    : `/${lang}/legacy`
+
+  if (withSlash) {
+    path += '/'
+  }
 
   revalidatePath(path)
 

--- a/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
+++ b/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
@@ -1,0 +1,10 @@
+import { revalidatePath } from 'next/cache'
+import { NextResponse } from 'next/server'
+
+export async function GET(request) {
+  const path = request.nextUrl.searchParams.get('path') || '/en/'
+
+  revalidatePath(path)
+
+  return NextResponse.json({ timestamp: new Date().toISOString() })
+}

--- a/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
+++ b/test/e2e/app-dir/trailingslash/app/api/revalidate/route.js
@@ -1,8 +1,16 @@
 import { revalidatePath } from 'next/cache'
 import { NextResponse } from 'next/server'
 
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
 export async function GET(request) {
-  const path = request.nextUrl.searchParams.get('path') || '/en/'
+  const lang = request.nextUrl.searchParams.get('lang') || 'en'
+
+  // With rewrites, we need to revalidate the destination path (the actual
+  // page), not the source path that users visit.
+  const path = isCacheComponentsEnabled
+    ? `/${lang}/cache-components/`
+    : `/${lang}/legacy/`
 
   revalidatePath(path)
 

--- a/test/e2e/app-dir/trailingslash/next.config.js
+++ b/test/e2e/app-dir/trailingslash/next.config.js
@@ -1,16 +1,19 @@
-const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-
 /**
  * @type {import('next').NextConfig}
  */
 module.exports = {
   trailingSlash: true,
-  rewrites: async () => [
-    {
-      source: '/:lang(en|es)/',
-      destination: isCacheComponentsEnabled
-        ? '/:lang/cache-components/'
-        : '/:lang/legacy/',
-    },
-  ],
+  rewrites: async () => {
+    const isCacheComponentsEnabled =
+      process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
+    return [
+      {
+        source: '/:lang(en|es)/',
+        destination: isCacheComponentsEnabled
+          ? '/:lang/cache-components/'
+          : '/:lang/legacy/',
+      },
+    ]
+  },
 }

--- a/test/e2e/app-dir/trailingslash/next.config.js
+++ b/test/e2e/app-dir/trailingslash/next.config.js
@@ -1,3 +1,16 @@
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
+/**
+ * @type {import('next').NextConfig}
+ */
 module.exports = {
   trailingSlash: true,
+  rewrites: async () => [
+    {
+      source: '/:lang(en|es)/',
+      destination: isCacheComponentsEnabled
+        ? '/:lang/cache-components/'
+        : '/:lang/legacy/',
+    },
+  ],
 }

--- a/test/e2e/app-dir/trailingslash/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash/trailingslash.test.ts
@@ -1,14 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
 
 describe('app-dir trailingSlash handling', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
-
-  if (skipped) {
-    return
-  }
 
   it('should redirect route when requesting it directly', async () => {
     const res = await next.fetch('/a', {
@@ -59,4 +55,33 @@ describe('app-dir trailingSlash handling', () => {
       'http://trailingslash-another.com/metadata'
     )
   })
+
+  // TODO: Likely needs an infrastructure fix to pass as a deploy test.
+  const itFailsWhenDeployed = isNextDeploy ? it.failing : it
+  /* eslint-disable jest/no-standalone-expect */
+  itFailsWhenDeployed(
+    'should revalidate a page with generated static params and trailing slash',
+    async () => {
+      const browser = await next.browser('/en/')
+      const initialGeneratedAt = await browser
+        .elementById('generated-at')
+        .text()
+
+      expect(initialGeneratedAt).toBeDateString()
+
+      await browser.elementById('revalidate-button').click()
+
+      expect(await browser.elementById('revalidate-result').text()).toInclude(
+        'Revalidated'
+      )
+
+      await retry(async () => {
+        await browser.refresh()
+        const generatedAt = await browser.elementById('generated-at').text()
+        expect(generatedAt).toBeDateString()
+        expect(generatedAt).not.toBe(initialGeneratedAt)
+      })
+    }
+  )
+  /* eslint-enable jest/no-standalone-expect */
 })

--- a/test/e2e/app-dir/trailingslash/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash/trailingslash.test.ts
@@ -4,7 +4,7 @@ import { retry } from 'next-test-utils'
 const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
 describe('app-dir trailingSlash handling', () => {
-  const { next, isNextDev, isNextDeploy } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     buildArgs: [
       '--debug-build-paths',
@@ -64,12 +64,9 @@ describe('app-dir trailingSlash handling', () => {
     )
   })
 
-  // TODO: Likely needs an infrastructure fix to pass as a deploy test.
-  const itFailsWhenDeployed = isNextDeploy ? it.failing : it
-  /* eslint-disable jest/no-standalone-expect */
-  itFailsWhenDeployed(
-    'should revalidate a page with generated static params and trailing slash',
-    async () => {
+  it.each([{ withSlash: true }, { withSlash: false }])(
+    'should revalidate a page with generated static params (withSlash=$withSlash)',
+    async ({ withSlash }) => {
       const browser = await next.browser('/en')
       const initialGeneratedAt = await browser
         .elementById('generated-at')
@@ -87,7 +84,13 @@ describe('app-dir trailingSlash handling', () => {
         expect(refreshedGeneratedAt).toBe(initialGeneratedAt)
       }
 
-      await browser.elementById('revalidate-button').click()
+      await browser
+        .elementById(
+          withSlash
+            ? 'revalidate-button-with-slash'
+            : 'revalidate-button-no-slash'
+        )
+        .click()
 
       expect(await browser.elementById('revalidate-result').text()).toInclude(
         'Revalidated'
@@ -101,5 +104,4 @@ describe('app-dir trailingSlash handling', () => {
       })
     }
   )
-  /* eslint-enable jest/no-standalone-expect */
 })

--- a/test/e2e/app-dir/trailingslash/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash/trailingslash.test.ts
@@ -1,9 +1,27 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
 describe('app-dir trailingSlash handling', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next, isNextDeploy, isNextDev } = nextTestSetup({
     files: __dirname,
+    skipStart: true,
+  })
+
+  beforeAll(async () => {
+    if (!isNextDev) {
+      await next.build({
+        args: [
+          '--debug-build-paths',
+          isCacheComponentsEnabled
+            ? '!app/[lang]/legacy/page.js'
+            : '!app/[lang]/cache-components/page.js',
+        ],
+      })
+    }
+
+    await next.start({ skipBuild: true })
   })
 
   it('should redirect route when requesting it directly', async () => {
@@ -62,12 +80,20 @@ describe('app-dir trailingSlash handling', () => {
   itFailsWhenDeployed(
     'should revalidate a page with generated static params and trailing slash',
     async () => {
-      const browser = await next.browser('/en/')
+      const browser = await next.browser('/en')
       const initialGeneratedAt = await browser
         .elementById('generated-at')
         .text()
 
       expect(initialGeneratedAt).toBeDateString()
+
+      await browser.refresh()
+
+      const refreshedGeneratedAt = await browser
+        .elementById('generated-at')
+        .text()
+
+      expect(refreshedGeneratedAt).toBe(initialGeneratedAt)
 
       await browser.elementById('revalidate-button').click()
 

--- a/test/e2e/app-dir/trailingslash/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash/trailingslash.test.ts
@@ -87,13 +87,15 @@ describe('app-dir trailingSlash handling', () => {
 
       expect(initialGeneratedAt).toBeDateString()
 
-      await browser.refresh()
+      if (!isNextDev) {
+        await browser.refresh()
 
-      const refreshedGeneratedAt = await browser
-        .elementById('generated-at')
-        .text()
+        const refreshedGeneratedAt = await browser
+          .elementById('generated-at')
+          .text()
 
-      expect(refreshedGeneratedAt).toBe(initialGeneratedAt)
+        expect(refreshedGeneratedAt).toBe(initialGeneratedAt)
+      }
 
       await browser.elementById('revalidate-button').click()
 

--- a/test/e2e/app-dir/trailingslash/trailingslash.test.ts
+++ b/test/e2e/app-dir/trailingslash/trailingslash.test.ts
@@ -4,24 +4,14 @@ import { retry } from 'next-test-utils'
 const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
 describe('app-dir trailingSlash handling', () => {
-  const { next, isNextDeploy, isNextDev } = nextTestSetup({
+  const { next, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
-    skipStart: true,
-  })
-
-  beforeAll(async () => {
-    if (!isNextDev) {
-      await next.build({
-        args: [
-          '--debug-build-paths',
-          isCacheComponentsEnabled
-            ? '!app/[lang]/legacy/page.js'
-            : '!app/[lang]/cache-components/page.js',
-        ],
-      })
-    }
-
-    await next.start({ skipBuild: true })
+    buildArgs: [
+      '--debug-build-paths',
+      isCacheComponentsEnabled
+        ? '!app/[lang]/legacy/page.js'
+        : '!app/[lang]/cache-components/page.js',
+    ],
   })
 
   it('should redirect route when requesting it directly', async () => {


### PR DESCRIPTION
Revalidating a page with generated static params and `trailingSlash: true` using `revalidatePath` works with `next start`, but currently does not work when deployed. This PR fixes that by using `resolvedPathname` (which has dynamic params interpolated, is decoded, and has trailing slash removed) for the implicit/soft tags in the `x-next-cache-tags` header. This ensures the tags generated at build time match the tags used by `revalidatePath` at runtime.

In addition, we now normalize the pathname in `revalidatePath` so that users can pass in a pathname either with or without trailing slash.