### PR TITLE
Turbopack: add support for matching loaders on resource queries

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -703,6 +703,8 @@ pub enum ConfigConditionItem {
         path: Option<ConfigConditionPath>,
         #[serde(default)]
         content: Option<RegexComponents>,
+        #[serde(default)]
+        query: Option<RcStr>,
     },
 }
 
@@ -723,12 +725,17 @@ impl TryFrom<ConfigConditionItem> for ConditionItem {
             ConfigConditionItem::Builtin(cond) => {
                 ConditionItem::Builtin(RcStr::from(cond.as_str()))
             }
-            ConfigConditionItem::Base { path, content } => ConditionItem::Base {
+            ConfigConditionItem::Base {
+                path,
+                content,
+                query,
+            } => ConditionItem::Base {
                 path: path.map(ConditionPath::try_from).transpose()?,
                 content: content
                     .map(EsRegex::try_from)
                     .transpose()?
                     .map(EsRegex::resolved_cell),
+                query,
             },
         })
     }
@@ -2080,6 +2087,7 @@ mod tests {
                                         source: rcstr!("@someTag"),
                                         flags: rcstr!(""),
                                     }),
+                                    query: None,
                                 },
                             ]
                             .into(),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -14,7 +14,7 @@ use turbo_tasks_env::EnvMap;
 use turbo_tasks_fetch::FetchClientConfig;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
-    ConditionItem, ConditionPath, LoaderRuleItem, WebpackRules,
+    ConditionItem, ConditionPath, ConditionQuery, LoaderRuleItem, WebpackRules,
     module_options_context::MdxTransformOptions,
 };
 use turbopack_core::{
@@ -674,6 +674,42 @@ impl TryFrom<RegexComponents> for EsRegex {
 }
 
 #[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(
+    tag = "type",
+    content = "value",
+    rename_all = "camelCase",
+    deny_unknown_fields
+)]
+pub enum ConfigConditionQuery {
+    Constant(RcStr),
+    Regex(RegexComponents),
+}
+
+impl TryFrom<ConfigConditionQuery> for ConditionQuery {
+    type Error = anyhow::Error;
+
+    fn try_from(config: ConfigConditionQuery) -> Result<ConditionQuery> {
+        Ok(match config {
+            ConfigConditionQuery::Constant(value) => ConditionQuery::Constant(value),
+            ConfigConditionQuery::Regex(regex) => {
+                ConditionQuery::Regex(EsRegex::try_from(regex)?.resolved_cell())
+            }
+        })
+    }
+}
+
+#[derive(
     Deserialize,
     Clone,
     PartialEq,
@@ -704,7 +740,7 @@ pub enum ConfigConditionItem {
         #[serde(default)]
         content: Option<RegexComponents>,
         #[serde(default)]
-        query: Option<RcStr>,
+        query: Option<ConfigConditionQuery>,
     },
 }
 
@@ -735,7 +771,7 @@ impl TryFrom<ConfigConditionItem> for ConditionItem {
                     .map(EsRegex::try_from)
                     .transpose()?
                     .map(EsRegex::resolved_cell),
-                query,
+                query: query.map(ConditionQuery::try_from).transpose()?,
             },
         })
     }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -198,6 +198,7 @@ pub async fn get_babel_loader_rules(
                                 .expect("valid const regex")
                                 .resolved_cell(),
                         ),
+                        query: None,
                     });
                 }
                 ReactCompilerCompilationMode::Infer => {
@@ -210,6 +211,7 @@ pub async fn get_babel_loader_rules(
                                 .expect("valid const regex")
                                 .resolved_cell(),
                         ),
+                        query: None,
                     });
                 }
                 ReactCompilerCompilationMode::All => {}

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -213,7 +213,10 @@ module.exports = {
 ```
 
 - Supported boolean operators are `{all: [...]}`, `{any: [...]}` and `{not: ...}`.
-- Supported customizable operators are `{path: string | RegExp}` and `{content: RegExp}`. If `path` and `content` are specified in the same object, it acts as an implicit `and`.
+- Supported customizable operators are `{path: string | RegExp}`, `{content: RegExp}`, and `{query: string | RegExp}`. If multiple operators are specified in the same object, it acts as an implicit `and`.
+  - `path` matches against the project-relative file path. A string is treated as a glob pattern, while a RegExp matches anywhere in the path.
+  - `content` matches anywhere in the file content.
+  - `query` matches the import's query string (e.g., `?foo` in `import './file?foo'`). A string must match exactly, while a RegExp can match partially.
 
 In addition, a number of built-in conditions are supported:
 
@@ -308,6 +311,7 @@ The option automatically adds a polyfill for debug IDs to the JavaScript bundle 
 
 | Version  | Changes                                         |
 | -------- | ----------------------------------------------- |
+| `16.1.1` | `turbopack.rules.*.condition.query` was added.  |
 | `16.0.0` | `turbopack.debugIds` was added.                 |
 | `16.0.0` | `turbopack.rules.*.condition` was added.        |
 | `15.3.0` | `experimental.turbo` is changed to `turbopack`. |

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -950,6 +950,9 @@ function bindingToApi(
           | { type: 'regex'; value: { source: string; flags: string } }
           | { type: 'glob'; value: string }
         content?: { source: string; flags: string }
+        query?:
+          | { type: 'regex'; value: { source: string; flags: string } }
+          | { type: 'constant'; value: string }
       }
 
   // converts regexes to a `RegexComponents` object so that it can be JSON-serialized when passed to
@@ -985,6 +988,15 @@ function bindingToApi(
                 }
               : { type: 'glob', value: cond.path },
         content: cond.content && regexComponents(cond.content),
+        query:
+          cond.query == null
+            ? undefined
+            : cond.query instanceof RegExp
+              ? {
+                  type: 'regex',
+                  value: regexComponents(cond.query),
+                }
+              : { type: 'constant', value: cond.query },
       }
     }
   }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -129,7 +129,7 @@ const zTurbopackCondition: zod.ZodType<TurbopackRuleCondition> = z.union([
   z.strictObject({
     path: z.union([z.string(), z.instanceof(RegExp)]).optional(),
     content: z.instanceof(RegExp).optional(),
-    query: z.string().optional(),
+    query: z.union([z.string(), z.instanceof(RegExp)]).optional(),
   }),
 ])
 

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -129,6 +129,7 @@ const zTurbopackCondition: zod.ZodType<TurbopackRuleCondition> = z.union([
   z.strictObject({
     path: z.union([z.string(), z.instanceof(RegExp)]).optional(),
     content: z.instanceof(RegExp).optional(),
+    query: z.string().optional(),
   }),
 ])
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -118,6 +118,7 @@ export type TurbopackRuleCondition =
   | {
       path?: string | RegExp
       content?: RegExp
+      query?: string
     }
 
 export type TurbopackRuleConfigItem = {

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -118,7 +118,7 @@ export type TurbopackRuleCondition =
   | {
       path?: string | RegExp
       content?: RegExp
-      query?: string
+      query?: string | RegExp
     }
 
 export type TurbopackRuleConfigItem = {

--- a/test/e2e/app-dir/webpack-loader-resource-query/app/data.txt
+++ b/test/e2e/app-dir/webpack-loader-resource-query/app/data.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/test/e2e/app-dir/webpack-loader-resource-query/app/page.tsx
+++ b/test/e2e/app-dir/webpack-loader-resource-query/app/page.tsx
@@ -2,6 +2,8 @@
 import { v } from './test.mdx?test=hi'
 // @ts-expect-error -- ignore
 import reversed from './data.txt?reverse'
+// @ts-expect-error -- ignore
+import upper from './data.txt?upper'
 
 export default function Page() {
   console.log(v)
@@ -9,6 +11,7 @@ export default function Page() {
     <div>
       <p>hello world</p>
       <p id="reversed">{reversed}</p>
+      <p id="upper">{upper}</p>
     </div>
   )
 }

--- a/test/e2e/app-dir/webpack-loader-resource-query/app/page.tsx
+++ b/test/e2e/app-dir/webpack-loader-resource-query/app/page.tsx
@@ -1,7 +1,14 @@
 // @ts-expect-error -- ignore
 import { v } from './test.mdx?test=hi'
+// @ts-expect-error -- ignore
+import reversed from './data.txt?reverse'
 
 export default function Page() {
   console.log(v)
-  return <p>hello world</p>
+  return (
+    <div>
+      <p>hello world</p>
+      <p id="reversed">{reversed}</p>
+    </div>
+  )
 }

--- a/test/e2e/app-dir/webpack-loader-resource-query/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/next.config.js
@@ -12,6 +12,11 @@ const nextConfig = {
           loaders: [require.resolve('./reverse-loader.js')],
           as: '*.js',
         },
+        {
+          condition: { query: /\?upper/ },
+          loaders: [require.resolve('./upper-loader.js')],
+          as: '*.js',
+        },
       ],
     },
   },
@@ -23,6 +28,10 @@ const nextConfig = {
     config.module.rules.push({
       resourceQuery: '?reverse',
       use: require.resolve('./reverse-loader.js'),
+    })
+    config.module.rules.push({
+      resourceQuery: /\?upper/,
+      use: require.resolve('./upper-loader.js'),
     })
     return config
   },

--- a/test/e2e/app-dir/webpack-loader-resource-query/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/next.config.js
@@ -6,12 +6,23 @@ const nextConfig = {
         loaders: [require.resolve('./test-file-loader.js')],
         as: '*.js',
       },
+      '*.txt': [
+        {
+          condition: { query: '?reverse' },
+          loaders: [require.resolve('./reverse-loader.js')],
+          as: '*.js',
+        },
+      ],
     },
   },
   webpack(config) {
     config.module.rules.push({
       test: /\.mdx/,
       use: require.resolve('./test-file-loader.js'),
+    })
+    config.module.rules.push({
+      resourceQuery: '?reverse',
+      use: require.resolve('./reverse-loader.js'),
     })
     return config
   },

--- a/test/e2e/app-dir/webpack-loader-resource-query/reverse-loader.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/reverse-loader.js
@@ -1,0 +1,4 @@
+module.exports = function reverseLoader(source) {
+  const reversed = source.split('').reverse().join('')
+  return `export default ${JSON.stringify(reversed)}`
+}

--- a/test/e2e/app-dir/webpack-loader-resource-query/upper-loader.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/upper-loader.js
@@ -1,0 +1,4 @@
+module.exports = function upperLoader(source) {
+  const upper = source.toUpperCase()
+  return `export default ${JSON.stringify(upper)}`
+}

--- a/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
@@ -19,4 +19,10 @@ describe('webpack-loader-resource-query', () => {
     const text = $('#reversed').text()
     expect(text).toBe('dlroW olleH')
   })
+
+  it('should apply loader based on resourceQuery regex', async () => {
+    const $ = await next.render$('/')
+    const text = $('#upper').text()
+    expect(text).toBe('HELLO WORLD')
+  })
 })

--- a/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
@@ -14,11 +14,7 @@ describe('webpack-loader-resource-query', () => {
     expect(next.cliOutput).toContain('resource query:  ?test=hi')
   })
 
-  // Skip for Turbopack since condition.query not implemented yet
   it('should apply loader based on resourceQuery', async () => {
-    if (process.env.IS_TURBOPACK_TEST) {
-      return
-    }
     const $ = await next.render$('/')
     const text = $('#reversed').text()
     expect(text).toBe('dlroW olleH')

--- a/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
+++ b/test/e2e/app-dir/webpack-loader-resource-query/webpack-loader-resource-query.test.js
@@ -13,4 +13,14 @@ describe('webpack-loader-resource-query', () => {
 
     expect(next.cliOutput).toContain('resource query:  ?test=hi')
   })
+
+  // Skip for Turbopack since condition.query not implemented yet
+  it('should apply loader based on resourceQuery', async () => {
+    if (process.env.IS_TURBOPACK_TEST) {
+      return
+    }
+    const $ = await next.render$('/')
+    const text = $('#reversed').text()
+    expect(text).toBe('dlroW olleH')
+  })
 })

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -117,7 +117,11 @@ async fn rule_condition_from_webpack_condition(
                 anyhow::bail!("{name:?} is not a valid built-in condition")
             }
         },
-        ConditionItem::Base { path, content } => {
+        ConditionItem::Base {
+            path,
+            content,
+            query,
+        } => {
             let mut rule_conditions = Vec::new();
             match &path {
                 Some(ConditionPath::Glob(glob)) => rule_conditions.push(
@@ -130,6 +134,9 @@ async fn rule_condition_from_webpack_condition(
             }
             if let Some(content) = content {
                 rule_conditions.push(RuleCondition::ResourceContentEsRegex(content.await?));
+            }
+            if let Some(query) = query {
+                rule_conditions.push(RuleCondition::ResourceQueryContains(query.clone().into()));
             }
             RuleCondition::All(rule_conditions)
         }

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -135,8 +135,16 @@ async fn rule_condition_from_webpack_condition(
             if let Some(content) = content {
                 rule_conditions.push(RuleCondition::ResourceContentEsRegex(content.await?));
             }
-            if let Some(query) = query {
-                rule_conditions.push(RuleCondition::ResourceQueryContains(query.clone().into()));
+            match &query {
+                Some(ConditionQuery::Constant(value)) => {
+                    rule_conditions.push(RuleCondition::ResourceQueryContainsEquals(
+                        value.clone().into(),
+                    ));
+                }
+                Some(ConditionQuery::Regex(regex)) => {
+                    rule_conditions.push(RuleCondition::ResourceQueryContainsEsRegex(regex.await?));
+                }
+                None => {}
             }
             RuleCondition::All(rule_conditions)
         }

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -137,12 +137,10 @@ async fn rule_condition_from_webpack_condition(
             }
             match &query {
                 Some(ConditionQuery::Constant(value)) => {
-                    rule_conditions.push(RuleCondition::ResourceQueryContainsEquals(
-                        value.clone().into(),
-                    ));
+                    rule_conditions.push(RuleCondition::ResourceQueryEquals(value.clone().into()));
                 }
                 Some(ConditionQuery::Regex(regex)) => {
-                    rule_conditions.push(RuleCondition::ResourceQueryContainsEsRegex(regex.await?));
+                    rule_conditions.push(RuleCondition::ResourceQueryEsRegex(regex.await?));
                 }
                 None => {}
             }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -47,6 +47,12 @@ pub enum ConditionPath {
     Regex(ResolvedVc<EsRegex>),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum ConditionQuery {
+    Constant(RcStr),
+    Regex(ResolvedVc<EsRegex>),
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub enum ConditionItem {
@@ -57,7 +63,7 @@ pub enum ConditionItem {
     Base {
         path: Option<ConditionPath>,
         content: Option<ResolvedVc<EsRegex>>,
-        query: Option<RcStr>,
+        query: Option<ConditionQuery>,
     },
 }
 

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -57,6 +57,7 @@ pub enum ConditionItem {
     Base {
         path: Option<ConditionPath>,
         content: Option<ResolvedVc<EsRegex>>,
+        query: Option<RcStr>,
     },
 }
 

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -45,6 +45,8 @@ pub enum RuleCondition {
     },
     ResourceBasePathGlob(#[turbo_tasks(trace_ignore)] ReadRef<Glob>),
     ResourceQueryContains(String),
+    ResourceQueryContainsEquals(String),
+    ResourceQueryContainsEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
 }
 
 impl RuleCondition {
@@ -282,6 +284,14 @@ impl RuleCondition {
                     RuleCondition::ResourceQueryContains(query) => {
                         let ident = source.ident().await?;
                         return Ok(ident.query.contains(query));
+                    }
+                    RuleCondition::ResourceQueryContainsEquals(query) => {
+                        let ident = source.ident().await?;
+                        return Ok(ident.query == *query);
+                    }
+                    RuleCondition::ResourceQueryContainsEsRegex(regex) => {
+                        let ident = source.ident().await?;
+                        return Ok(regex.is_match(&ident.query));
                     }
                 }
             }

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -45,8 +45,8 @@ pub enum RuleCondition {
     },
     ResourceBasePathGlob(#[turbo_tasks(trace_ignore)] ReadRef<Glob>),
     ResourceQueryContains(String),
-    ResourceQueryContainsEquals(String),
-    ResourceQueryContainsEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
+    ResourceQueryEquals(String),
+    ResourceQueryEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
 }
 
 impl RuleCondition {
@@ -285,11 +285,11 @@ impl RuleCondition {
                         let ident = source.ident().await?;
                         return Ok(ident.query.contains(query));
                     }
-                    RuleCondition::ResourceQueryContainsEquals(query) => {
+                    RuleCondition::ResourceQueryEquals(query) => {
                         let ident = source.ident().await?;
                         return Ok(ident.query == *query);
                     }
-                    RuleCondition::ResourceQueryContainsEsRegex(regex) => {
+                    RuleCondition::ResourceQueryEsRegex(regex) => {
                         let ident = source.ident().await?;
                         return Ok(regex.is_match(&ident.query));
                     }


### PR DESCRIPTION
### What?

Part of  PACK-1007
Closes PACK-4958
Closes #79311

Adds `condition.query` support to Turbopack's loader rules, enabling loaders to match based on import query strings (e.g., `import './file?raw'`). This mirrors webpack's `resourceQuery` functionality.

The `query` condition accepts either a string (exact match) or RegExp (pattern match).

Adds tests and documentation for the new `condition.query` option.

### How to use

```js
// next.config.js
module.exports = {
  turbopack: {
    rules: {
      '*.txt': [
        // String: exact match
        { condition: { query: '?raw' }, loaders: ['raw-loader'], as: '*.js' },
        // RegExp: pattern match  
        { condition: { query: /\?transform/ }, loaders: ['transform-loader'], as: '*.js' },
      ],
    },
  },
}
```