### PR TITLE
[cna] Ensure created app is not considered the workspace root in pnpm

### DIFF
--- a/packages/create-next-app/helpers/get-pkg-manager.ts
+++ b/packages/create-next-app/helpers/get-pkg-manager.ts
@@ -25,7 +25,7 @@ export function getPkgManager(): PackageManager {
  * Returns null if unable to determine the version.
  *
  * First tries to parse from npm_config_user_agent (e.g., "pnpm/9.13.2 npm/? ..."),
- * then falls back to spawning `pnpm --version`.
+ * then falls back to spawning `pnpm --version --silent`.
  */
 export function getPnpmMajorVersion(): number | null {
   // Try to get version from user agent first (e.g., "pnpm/9.13.2 npm/? node/v20.x linux x64")
@@ -37,7 +37,7 @@ export function getPnpmMajorVersion(): number | null {
 
   // Fall back to spawning pnpm --version
   try {
-    const version = execSync('pnpm --version', {
+    const version = execSync('pnpm --version --silent', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
     }).trim()

--- a/packages/create-next-app/helpers/get-pkg-manager.ts
+++ b/packages/create-next-app/helpers/get-pkg-manager.ts
@@ -37,12 +37,12 @@ export function getPnpmMajorVersion(): number | null {
 
   // Fall back to spawning pnpm --version
   try {
-    const version = execSync('pnpm --version --quiet', {
+    const version = execSync('pnpm --version', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
     }).trim()
     const majorVersion = parseInt(version.split('.')[0], 10)
-    if (!isNaN(majorVersion)) {
+    if (!Number.isNaN(majorVersion)) {
       return majorVersion
     }
   } catch {

--- a/packages/create-next-app/helpers/get-pkg-manager.ts
+++ b/packages/create-next-app/helpers/get-pkg-manager.ts
@@ -1,3 +1,5 @@
+import { execSync } from 'child_process'
+
 export type PackageManager = 'npm' | 'pnpm' | 'yarn' | 'bun'
 
 export function getPkgManager(): PackageManager {
@@ -16,4 +18,36 @@ export function getPkgManager(): PackageManager {
   }
 
   return 'npm'
+}
+
+/**
+ * Get the major version of pnpm being used.
+ * Returns null if unable to determine the version.
+ *
+ * First tries to parse from npm_config_user_agent (e.g., "pnpm/9.13.2 npm/? ..."),
+ * then falls back to spawning `pnpm --version`.
+ */
+export function getPnpmMajorVersion(): number | null {
+  // Try to get version from user agent first (e.g., "pnpm/9.13.2 npm/? node/v20.x linux x64")
+  const userAgent = process.env.npm_config_user_agent || ''
+  const pnpmVersionMatch = userAgent.match(/pnpm\/(\d+)/)
+  if (pnpmVersionMatch) {
+    return parseInt(pnpmVersionMatch[1], 10)
+  }
+
+  // Fall back to spawning pnpm --version
+  try {
+    const version = execSync('pnpm --version', {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim()
+    const majorVersion = parseInt(version.split('.')[0], 10)
+    if (!isNaN(majorVersion)) {
+      return majorVersion
+    }
+  } catch {
+    // pnpm not available or failed to run
+  }
+
+  return null
 }

--- a/packages/create-next-app/helpers/get-pkg-manager.ts
+++ b/packages/create-next-app/helpers/get-pkg-manager.ts
@@ -37,7 +37,7 @@ export function getPnpmMajorVersion(): number | null {
 
   // Fall back to spawning pnpm --version
   try {
-    const version = execSync('pnpm --version', {
+    const version = execSync('pnpm --version --quiet', {
       encoding: 'utf8',
       stdio: ['pipe', 'pipe', 'ignore'],
     }).trim()

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -324,9 +324,11 @@ export const installTemplate = async ({
   // In v9, having a pnpm-workspace.yaml (even with packages: []) causes
   // ERR_PNPM_ADDING_TO_ROOT errors when running `pnpm add`.
   // In v10, the packages field can be omitted entirely.
+  // If we can't determine the version, assume latest (v10+) since we already
+  // know pnpm is being used at this point.
   if (packageManager === "pnpm") {
     const pnpmMajorVersion = getPnpmMajorVersion();
-    if (pnpmMajorVersion !== null && pnpmMajorVersion >= 10) {
+    if (pnpmMajorVersion === null || pnpmMajorVersion >= 10) {
       const pnpmWorkspaceYaml = [
         "ignoredBuiltDependencies:",
         // Sharp has prebuilt binaries for the platforms next-swc has binaries.

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -320,13 +320,13 @@ export const installTemplate = async ({
     packageJson.devDependencies = sorted(packageJson.devDependencies);
   }
 
-  // Only create pnpm-workspace.yaml for pnpm v10+.
-  // In v9, having a pnpm-workspace.yaml (even with packages: []) causes
-  // ERR_PNPM_ADDING_TO_ROOT errors when running `pnpm add`.
-  // In v10, the packages field can be omitted entirely.
-  // If we can't determine the version, assume latest (v10+) since we already
-  // know pnpm is being used at this point.
   if (packageManager === "pnpm") {
+    // Only create pnpm-workspace.yaml for pnpm v10+.
+    // In v9, having a pnpm-workspace.yaml (even with packages: []) causes
+    // ERR_PNPM_ADDING_TO_ROOT errors when running `pnpm add`.
+    // In v10, the packages field can be omitted entirely.
+    // If we can't determine the version, assume latest (v10+) since we already
+    // know pnpm is being used at this point.
     const pnpmMajorVersion = getPnpmMajorVersion();
     if (pnpmMajorVersion === null || pnpmMajorVersion >= 10) {
       const pnpmWorkspaceYaml = [

--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -1,6 +1,7 @@
 import { install } from "../helpers/install";
 import { runTypegen } from "../helpers/typegen";
 import { copy } from "../helpers/copy";
+import { getPnpmMajorVersion } from "../helpers/get-pkg-manager";
 
 import { async as glob } from "fast-glob";
 import os from "os";
@@ -319,25 +320,28 @@ export const installTemplate = async ({
     packageJson.devDependencies = sorted(packageJson.devDependencies);
   }
 
+  // Only create pnpm-workspace.yaml for pnpm v10+.
+  // In v9, having a pnpm-workspace.yaml (even with packages: []) causes
+  // ERR_PNPM_ADDING_TO_ROOT errors when running `pnpm add`.
+  // In v10, the packages field can be omitted entirely.
   if (packageManager === "pnpm") {
-    const pnpmWorkspaceYaml = [
-      // required for v9 to avoid "packages field missing or empty", v10 doesn't need it anymore
-      // TODO: remove when v9 no longer supported
-      "packages: []",
-      // v10 setting without counterpart in v9
-      "ignoredBuiltDependencies:",
-      // Sharp has prebuilt binaries for the platforms next-swc has binaries.
-      // If it needs to build binaries from source, next-swc wouldn't work either.
-      // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
-      "  - sharp",
-      // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
-      "  - unrs-resolver",
-      "",
-    ].join(os.EOL);
-    await fs.writeFile(
-      path.join(root, "pnpm-workspace.yaml"),
-      pnpmWorkspaceYaml,
-    );
+    const pnpmMajorVersion = getPnpmMajorVersion();
+    if (pnpmMajorVersion !== null && pnpmMajorVersion >= 10) {
+      const pnpmWorkspaceYaml = [
+        "ignoredBuiltDependencies:",
+        // Sharp has prebuilt binaries for the platforms next-swc has binaries.
+        // If it needs to build binaries from source, next-swc wouldn't work either.
+        // See https://sharp.pixelplumbing.com/install/#:~:text=When%20using%20pnpm%2C%20add%20sharp%20to%20ignoredBuiltDependencies%20to%20silence%20warnings
+        "  - sharp",
+        // Not needed for pnpm: https://github.com/unrs/unrs-resolver/issues/193#issuecomment-3295510146
+        "  - unrs-resolver",
+        "",
+      ].join(os.EOL);
+      await fs.writeFile(
+        path.join(root, "pnpm-workspace.yaml"),
+        pnpmWorkspaceYaml,
+      );
+    }
   }
 
   if (packageManager === "bun") {

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_FILES,
   FULL_EXAMPLE_PATH,
   projectFilesShouldExist,
+  projectFilesShouldNotExist,
   run,
   useTempDir,
 } from '../utils'
@@ -82,6 +83,68 @@ describe('create-next-app with package manager pnpm', () => {
         cwd,
         projectName,
         files,
+      })
+    })
+  })
+
+  it('should create pnpm-workspace.yaml for pnpm v10+', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'pnpm-v10-workspace'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--no-turbopack',
+          '--no-linter',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+          '--no-react-compiler',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+          env: { npm_config_user_agent: 'pnpm/10.0.0 npm/? node/v20.0.0' },
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files: [...files, 'pnpm-workspace.yaml'],
+      })
+    })
+  })
+
+  it('should NOT create pnpm-workspace.yaml for pnpm v9', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'pnpm-v9-no-workspace'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--no-turbopack',
+          '--no-linter',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+          '--no-react-compiler',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+          env: { npm_config_user_agent: 'pnpm/9.13.2 npm/? node/v20.0.0' },
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldNotExist({
+        cwd,
+        projectName,
+        files: ['pnpm-workspace.yaml'],
       })
     })
   })

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -149,6 +149,38 @@ describe('create-next-app with package manager pnpm', () => {
     })
   })
 
+  it('should create pnpm-workspace.yaml when pnpm version is unknown (assumes latest)', async () => {
+    await useTempDir(async (cwd) => {
+      const projectName = 'pnpm-unknown-version-workspace'
+      const res = await run(
+        [
+          projectName,
+          '--ts',
+          '--app',
+          '--no-turbopack',
+          '--no-linter',
+          '--no-src-dir',
+          '--no-tailwind',
+          '--no-import-alias',
+          '--no-react-compiler',
+        ],
+        nextTgzFilename,
+        {
+          cwd,
+          // User agent without version number - assumes latest pnpm
+          env: { npm_config_user_agent: 'pnpm' },
+        }
+      )
+
+      expect(res.exitCode).toBe(0)
+      projectFilesShouldExist({
+        cwd,
+        projectName,
+        files: [...files, 'pnpm-workspace.yaml'],
+      })
+    })
+  })
+
   it('should use pnpm for --use-pnpm flag with example', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'use-pnpm-with-example'

--- a/test/integration/create-next-app/package-manager/pnpm.test.ts
+++ b/test/integration/create-next-app/package-manager/pnpm.test.ts
@@ -87,6 +87,10 @@ describe('create-next-app with package manager pnpm', () => {
     })
   })
 
+  // These tests use --skip-install because:
+  // 1. We only need to verify the workspace file is created/not created
+  // 2. The CI runs pnpm v9, but when testing v10 behavior, the workspace file
+  //    created for v10 (without packages field) would fail with pnpm v9
   it('should create pnpm-workspace.yaml for pnpm v10+', async () => {
     await useTempDir(async (cwd) => {
       const projectName = 'pnpm-v10-workspace'
@@ -101,6 +105,7 @@ describe('create-next-app with package manager pnpm', () => {
           '--no-tailwind',
           '--no-import-alias',
           '--no-react-compiler',
+          '--skip-install',
         ],
         nextTgzFilename,
         {
@@ -113,7 +118,7 @@ describe('create-next-app with package manager pnpm', () => {
       projectFilesShouldExist({
         cwd,
         projectName,
-        files: [...files, 'pnpm-workspace.yaml'],
+        files: ['package.json', 'pnpm-workspace.yaml'],
       })
     })
   })
@@ -132,6 +137,7 @@ describe('create-next-app with package manager pnpm', () => {
           '--no-tailwind',
           '--no-import-alias',
           '--no-react-compiler',
+          '--skip-install',
         ],
         nextTgzFilename,
         {
@@ -145,38 +151,6 @@ describe('create-next-app with package manager pnpm', () => {
         cwd,
         projectName,
         files: ['pnpm-workspace.yaml'],
-      })
-    })
-  })
-
-  it('should create pnpm-workspace.yaml when pnpm version is unknown (assumes latest)', async () => {
-    await useTempDir(async (cwd) => {
-      const projectName = 'pnpm-unknown-version-workspace'
-      const res = await run(
-        [
-          projectName,
-          '--ts',
-          '--app',
-          '--no-turbopack',
-          '--no-linter',
-          '--no-src-dir',
-          '--no-tailwind',
-          '--no-import-alias',
-          '--no-react-compiler',
-        ],
-        nextTgzFilename,
-        {
-          cwd,
-          // User agent without version number - assumes latest pnpm
-          env: { npm_config_user_agent: 'pnpm' },
-        }
-      )
-
-      expect(res.exitCode).toBe(0)
-      projectFilesShouldExist({
-        cwd,
-        projectName,
-        files: [...files, 'pnpm-workspace.yaml'],
       })
     })
   })


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/83168

With `packages`, pnpm will assume the package is the workspace root and demand the `-w` flag (ERR_PNPM_ADDING_TO_ROOT). Even if `packages` is empty.

Since we only need `packages` for v9 (which doesn't even support `ignoreBuiltDependencies`), we just skip generation of pnpm-workspace.yaml entirely which also means we can drop `packages`

I originally skipped the check because I wanted to avoid an expensive `pnpm` invocation. Cursor figured we can use `npm_config_user_agent` (see https://github.com/pnpm/pnpm/issues/3985) to parse the version from which avoids spawning a sub process entirely. We still fallback to `pnpm --quiet --version` if the env variable is not available.

## test plan

- [x] v9 produces no workspace.yml `p create next-app@http://vercel-packages.vercel.app/next/commits/399b272b713abcb1c63c28c93cc082d2b41b031b/create-next-app next-pnpm-built-workspace-yml`
- [x] v10 produces workspace.yml `p create next-app@http://vercel-packages.vercel.app/next/commits/399b272b713abcb1c63c28c93cc082d2b41b031b/create-next-app next-pnpm-built-workspace-yml`