### PR TITLE
Browser debug info env variable

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1941,6 +1941,25 @@ function enforceExperimentalFeatures(
     config.reactCompiler = true
     // TODO: Report if we enable non-experimental features via env
   }
+
+  // Allow disabling browserDebugInfoInTerminal via env variable
+  if (
+    process.env.__NEXT_DISABLE_BROWSER_DEBUG_INFO_IN_TERMINAL === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.browserDebugInfoInTerminal === undefined ||
+      (isDefaultConfig && config.experimental.browserDebugInfoInTerminal))
+  ) {
+    config.experimental.browserDebugInfoInTerminal = false
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'browserDebugInfoInTerminal',
+        false,
+        'disabled by `__NEXT_DISABLE_BROWSER_DEBUG_INFO_IN_TERMINAL`'
+      )
+    }
+  }
 }
 
 function addConfiguredExperimentalFeature<


### PR DESCRIPTION
### What?
Adds an environment variable `__NEXT_DISABLE_BROWSER_DEBUG_INFO_IN_TERMINAL` to disable the `experimental.browserDebugInfoInTerminal` feature.

### Why?
To provide a mechanism for users and CI/CD environments to disable the `browserDebugInfoInTerminal` feature via an environment variable, consistent with how other experimental flags can be controlled.

### How?
The `enforceExperimentalFeatures` function in `packages/next/src/server/config.ts` is updated to check for `process.env.__NEXT_DISABLE_BROWSER_DEBUG_INFO_IN_TERMINAL`. If set to `'true'`, it sets `config.experimental.browserDebugInfoInTerminal` to `false`, while respecting explicit user configurations.

Closes NEXT-
Fixes #

---
[Slack Thread](https://vercel.slack.com/archives/D0A6SL1TGVA/p1768583442959759?thread_ts=1768583442.959759&cid=D0A6SL1TGVA)

<a href="https://cursor.com/background-agent?bcId=bc-b854ddda-0f9f-4560-9804-b9a0e8296dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b854ddda-0f9f-4560-9804-b9a0e8296dd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

