### PR TITLE
Turbopack: docs: condition.query will ship in 16.2.0, not 16.1.1

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -311,7 +311,7 @@ The option automatically adds a polyfill for debug IDs to the JavaScript bundle 
 
 | Version  | Changes                                         |
 | -------- | ----------------------------------------------- |
-| `16.1.1` | `turbopack.rules.*.condition.query` was added.  |
+| `16.2.0` | `turbopack.rules.*.condition.query` was added.  |
 | `16.0.0` | `turbopack.debugIds` was added.                 |
 | `16.0.0` | `turbopack.rules.*.condition` was added.        |
 | `15.3.0` | `experimental.turbo` is changed to `turbopack`. |


### PR DESCRIPTION
Follow up to https://github.com/vercel/next.js/pull/88644