### PR TITLE
Turbopack: Add file write invalidation tracking to filesystem watcher fuzzing

### DIFF
--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -16,7 +16,9 @@ use tokio::time::sleep;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, ResolvedVc, TransientInstance, Vc, trace::TraceRawVcs};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
-use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
+use turbo_tasks_fs::{
+    DiskFileSystem, File, FileContent, FileSystem, FileSystemPath, LinkContent, LinkType,
+};
 
 /// A collection of fuzzers for `turbo-tasks`. These are not test cases as they're slow and (in many
 /// cases) non-deterministic.
@@ -66,6 +68,10 @@ struct FsWatcher {
     /// Number of symlink modifications per iteration (only used when --symlinks is set).
     #[arg(long, default_value_t = 20, requires = "symlinks")]
     symlink_modifications: u32,
+    /// Track file writes instead of reads. When enabled, the fuzzer writes files via
+    /// turbo-tasks and verifies that external modifications trigger invalidations.
+    #[arg(long)]
+    track_writes: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -79,6 +85,17 @@ enum SymlinkMode {
     /// Test junction points (Windows-only)
     #[cfg(windows)]
     Junction,
+}
+
+impl SymlinkMode {
+    fn to_link_type(self) -> LinkType {
+        match self {
+            SymlinkMode::File => LinkType::empty(),
+            SymlinkMode::Directory => LinkType::DIRECTORY,
+            #[cfg(windows)]
+            SymlinkMode::Junction => LinkType::DIRECTORY,
+        }
+    }
 }
 
 #[tokio::main]
@@ -129,21 +146,31 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
             project_fs.await?.start_watching(None).await?;
         }
 
-        let read_all_paths_op = read_all_paths_operation(
+        let symlink_count = if args.symlinks.is_some() {
+            args.symlink_count
+        } else {
+            0
+        };
+        let track_writes = args.track_writes;
+        let symlink_mode = args.symlinks;
+        let symlink_is_directory =
+            symlink_mode.map(|m| m.to_link_type().contains(LinkType::DIRECTORY));
+
+        read_or_write_all_paths_operation(
             invalidations.clone(),
             project_root.clone(),
             args.depth,
             args.width,
-            if args.symlinks.is_some() {
-                args.symlink_count
-            } else {
-                0
-            },
-        );
-        read_all_paths_op.read_strongly_consistent().await?;
+            symlink_count,
+            symlink_is_directory,
+            track_writes,
+        )
+        .read_strongly_consistent()
+        .await?;
         {
             let mut invalidations = invalidations.0.lock().unwrap();
-            println!("read all {} files", invalidations.len());
+            let verb = if track_writes { "wrote" } else { "read" };
+            println!("{} all {} files", verb, invalidations.len());
             invalidations.clear();
         }
 
@@ -201,7 +228,17 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
             // there's no way to know when we've received all the pending events from the operating
             // system, so just sleep and pray
             sleep(Duration::from_millis(args.notify_timeout_ms)).await;
-            read_all_paths_op.read_strongly_consistent().await?;
+            read_or_write_all_paths_operation(
+                invalidations.clone(),
+                project_root.clone(),
+                args.depth,
+                args.width,
+                symlink_count,
+                symlink_is_directory,
+                track_writes,
+            )
+            .read_strongly_consistent()
+            .await?;
             {
                 let mut invalidations = invalidations.0.lock().unwrap();
                 let symlink_info = if args.symlinks.is_some() {
@@ -267,43 +304,97 @@ async fn read_link(
     Ok(())
 }
 
+#[turbo_tasks::function]
+async fn write_path(
+    invalidations: TransientInstance<PathInvalidations>,
+    path: FileSystemPath,
+) -> anyhow::Result<()> {
+    let path_str = path.path.clone();
+    invalidations.0.lock().unwrap().insert(path_str);
+    let content = FileContent::Content(File::from(""));
+    let _ = path.write(content.cell()).await?;
+    Ok(())
+}
+
+#[turbo_tasks::function]
+async fn write_link(
+    invalidations: TransientInstance<PathInvalidations>,
+    path: FileSystemPath,
+    target: RcStr,
+    is_directory: bool,
+) -> anyhow::Result<()> {
+    let path_str = path.path.clone();
+    invalidations.0.lock().unwrap().insert(path_str);
+    let link_type = if is_directory {
+        LinkType::DIRECTORY
+    } else {
+        LinkType::empty()
+    };
+    let link_content = LinkContent::Link { target, link_type };
+    let _ = path
+        .fs()
+        .write_link(path.clone(), link_content.cell())
+        .await?;
+    Ok(())
+}
+
 #[turbo_tasks::function(operation)]
-async fn read_all_paths_operation(
+async fn read_or_write_all_paths_operation(
     invalidations: TransientInstance<PathInvalidations>,
     root: FileSystemPath,
     depth: usize,
     width: usize,
     symlink_count: u32,
+    symlink_is_directory: Option<bool>,
+    write: bool,
 ) -> anyhow::Result<()> {
-    async fn read_all_paths_inner(
+    async fn process_paths_inner(
         invalidations: TransientInstance<PathInvalidations>,
         parent: FileSystemPath,
         depth: usize,
         width: usize,
+        write: bool,
     ) -> anyhow::Result<()> {
         for child_id in 0..width {
             let child_name = child_id.to_string();
             let child_path = parent.join(&child_name)?;
             if depth == 1 {
-                read_path(invalidations.clone(), child_path).await?;
+                if write {
+                    write_path(invalidations.clone(), child_path).await?;
+                } else {
+                    read_path(invalidations.clone(), child_path).await?;
+                }
             } else {
-                Box::pin(read_all_paths_inner(
+                Box::pin(process_paths_inner(
                     invalidations.clone(),
                     child_path,
                     depth - 1,
                     width,
+                    write,
                 ))
                 .await?;
             }
         }
         Ok(())
     }
-    read_all_paths_inner(invalidations.clone(), root.clone(), depth, width).await?;
+    process_paths_inner(invalidations.clone(), root.clone(), depth, width, write).await?;
 
-    let symlinks_dir = root.join("_symlinks")?;
-    for i in 0..symlink_count {
-        let symlink_path = symlinks_dir.join(&i.to_string())?;
-        read_link(invalidations.clone(), symlink_path).await?;
+    if symlink_count > 0 {
+        let symlinks_dir = root.join("_symlinks")?;
+        for i in 0..symlink_count {
+            let symlink_path = symlinks_dir.join(&i.to_string())?;
+            if write {
+                write_link(
+                    invalidations.clone(),
+                    symlink_path,
+                    rcstr!("../0"),
+                    symlink_is_directory.unwrap_or(false),
+                )
+                .await?;
+            } else {
+                read_link(invalidations.clone(), symlink_path).await?;
+            }
+        }
     }
 
     Ok(())

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -175,8 +175,13 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
         initial_op.read_strongly_consistent().await?;
         if track_writes {
             apply_effects(initial_op).await?;
-            let (total, mismatched) =
-                verify_written_files(&fs_root, args.depth, args.width, symlink_count);
+            let (total, mismatched) = verify_written_files(
+                &fs_root,
+                args.depth,
+                args.width,
+                symlink_count,
+                symlink_mode,
+            );
             println!("wrote all {} paths, {} mismatches", total, mismatched.len());
             if args.print_missing_invalidations && !mismatched.is_empty() {
                 for path in &mismatched {
@@ -260,8 +265,13 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
             };
             if track_writes {
                 apply_effects(read_or_write_op).await?;
-                let (total, mismatched) =
-                    verify_written_files(&fs_root, args.depth, args.width, symlink_count);
+                let (total, mismatched) = verify_written_files(
+                    &fs_root,
+                    args.depth,
+                    args.width,
+                    symlink_count,
+                    symlink_mode,
+                );
                 println!(
                     "modified {} files{}. verified {} paths, {} mismatches",
                     modified_file_paths.len(),
@@ -443,6 +453,7 @@ fn verify_written_files(
     depth: usize,
     width: usize,
     symlink_count: u32,
+    symlink_mode: Option<SymlinkMode>,
 ) -> (usize, Vec<PathBuf>) {
     fn check_files_inner(
         parent: &Path,
@@ -470,14 +481,30 @@ fn verify_written_files(
 
     check_files_inner(fs_root, depth, width, &mut total, &mut mismatched);
 
-    // Check symlinks
     if symlink_count > 0 {
         let symlinks_dir = fs_root.join("_symlinks");
+
+        #[cfg(windows)]
+        let expected_target = {
+            match symlink_mode {
+                Some(SymlinkMode::Junction) => {
+                    // On Windows, junctions are stored as absolute paths
+                    symlinks_dir.join(SYMLINK_SENTINEL_TARGET)
+                }
+                _ => PathBuf::from(SYMLINK_SENTINEL_TARGET),
+            }
+        };
+        #[cfg(not(windows))]
+        let expected_target = {
+            let _ = symlink_mode;
+            PathBuf::from(SYMLINK_SENTINEL_TARGET)
+        };
+
         for i in 0..symlink_count {
             total += 1;
             let symlink_path = symlinks_dir.join(i.to_string());
             match std::fs::read_link(&symlink_path) {
-                Ok(target) if target == Path::new(SYMLINK_SENTINEL_TARGET) => {}
+                Ok(target) if target == expected_target => {}
                 _ => mismatched.push(symlink_path),
             }
         }

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -14,7 +14,9 @@ use rand::{Rng, RngCore, SeedableRng};
 use rustc_hash::FxHashSet;
 use tokio::time::sleep;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{NonLocalValue, ResolvedVc, TransientInstance, Vc, trace::TraceRawVcs};
+use turbo_tasks::{
+    NonLocalValue, ResolvedVc, TransientInstance, Vc, apply_effects, trace::TraceRawVcs,
+};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_fs::{
     DiskFileSystem, File, FileContent, FileSystem, FileSystemPath, LinkContent, LinkType,
@@ -156,7 +158,7 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
         let symlink_is_directory =
             symlink_mode.map(|m| m.to_link_type().contains(LinkType::DIRECTORY));
 
-        read_or_write_all_paths_operation(
+        let initial_op = read_or_write_all_paths_operation(
             invalidations.clone(),
             project_root.clone(),
             args.depth,
@@ -164,9 +166,11 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
             symlink_count,
             symlink_is_directory,
             track_writes,
-        )
-        .read_strongly_consistent()
-        .await?;
+        );
+        initial_op.read_strongly_consistent().await?;
+        if track_writes {
+            apply_effects(initial_op).await?;
+        }
         {
             let mut invalidations = invalidations.0.lock().unwrap();
             let verb = if track_writes { "wrote" } else { "read" };
@@ -228,7 +232,7 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
             // there's no way to know when we've received all the pending events from the operating
             // system, so just sleep and pray
             sleep(Duration::from_millis(args.notify_timeout_ms)).await;
-            read_or_write_all_paths_operation(
+            let read_or_write_op = read_or_write_all_paths_operation(
                 invalidations.clone(),
                 project_root.clone(),
                 args.depth,
@@ -236,9 +240,11 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
                 symlink_count,
                 symlink_is_directory,
                 track_writes,
-            )
-            .read_strongly_consistent()
-            .await?;
+            );
+            read_or_write_op.read_strongly_consistent().await?;
+            if track_writes {
+                apply_effects(read_or_write_op).await?;
+            }
             {
                 let mut invalidations = invalidations.0.lock().unwrap();
                 let symlink_info = if args.symlinks.is_some() {

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -22,6 +22,11 @@ use turbo_tasks_fs::{
     DiskFileSystem, File, FileContent, FileSystem, FileSystemPath, LinkContent, LinkType,
 };
 
+// `read_or_write_all_paths_operation` always writes the sentinel values to files/symlinks. We can
+// check for these sentinel values to see if `write`/`write_link` was re-run.
+const FILE_SENTINEL_CONTENT: &[u8] = b"sentinel_value";
+const SYMLINK_SENTINEL_TARGET: &str = "../0";
+
 /// A collection of fuzzers for `turbo-tasks`. These are not test cases as they're slow and (in many
 /// cases) non-deterministic.
 ///
@@ -170,13 +175,19 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
         initial_op.read_strongly_consistent().await?;
         if track_writes {
             apply_effects(initial_op).await?;
+            let (total, mismatched) =
+                verify_written_files(&fs_root, args.depth, args.width, symlink_count);
+            println!("wrote all {} paths, {} mismatches", total, mismatched.len());
+            if args.print_missing_invalidations && !mismatched.is_empty() {
+                for path in &mismatched {
+                    println!("  mismatch {path:?}");
+                }
+            }
+        } else {
+            let invalidations = invalidations.0.lock().unwrap();
+            println!("read all {} files", invalidations.len());
         }
-        {
-            let mut invalidations = invalidations.0.lock().unwrap();
-            let verb = if track_writes { "wrote" } else { "read" };
-            println!("{} all {} files", verb, invalidations.len());
-            invalidations.clear();
-        }
+        invalidations.0.lock().unwrap().clear();
 
         if args.start_watching_late {
             project_fs.await?.start_watching(None).await?;
@@ -242,16 +253,31 @@ async fn fuzz_fs_watcher(args: FsWatcher) -> anyhow::Result<()> {
                 track_writes,
             );
             read_or_write_op.read_strongly_consistent().await?;
+            let symlink_info = if args.symlinks.is_some() {
+                " and symlinks"
+            } else {
+                ""
+            };
             if track_writes {
                 apply_effects(read_or_write_op).await?;
-            }
-            {
+                let (total, mismatched) =
+                    verify_written_files(&fs_root, args.depth, args.width, symlink_count);
+                println!(
+                    "modified {} files{}. verified {} paths, {} mismatches",
+                    modified_file_paths.len(),
+                    symlink_info,
+                    total,
+                    mismatched.len()
+                );
+                if args.print_missing_invalidations && !mismatched.is_empty() {
+                    let mut sorted = mismatched;
+                    sorted.sort_unstable();
+                    for path in &sorted {
+                        println!("  mismatch {path:?}");
+                    }
+                }
+            } else {
                 let mut invalidations = invalidations.0.lock().unwrap();
-                let symlink_info = if args.symlinks.is_some() {
-                    " and symlinks"
-                } else {
-                    ""
-                };
                 println!(
                     "modified {} files{}. found {} invalidations",
                     modified_file_paths.len(),
@@ -317,7 +343,7 @@ async fn write_path(
 ) -> anyhow::Result<()> {
     let path_str = path.path.clone();
     invalidations.0.lock().unwrap().insert(path_str);
-    let content = FileContent::Content(File::from(""));
+    let content = FileContent::Content(File::from(FILE_SENTINEL_CONTENT));
     let _ = path.write(content.cell()).await?;
     Ok(())
 }
@@ -393,7 +419,7 @@ async fn read_or_write_all_paths_operation(
                 write_link(
                     invalidations.clone(),
                     symlink_path,
-                    rcstr!("../0"),
+                    RcStr::from(SYMLINK_SENTINEL_TARGET),
                     symlink_is_directory.unwrap_or(false),
                 )
                 .await?;
@@ -404,6 +430,60 @@ async fn read_or_write_all_paths_operation(
     }
 
     Ok(())
+}
+
+/// Verifies that all files and symlinks have the expected sentinel content. Returns (total_checked,
+/// mismatched_paths).
+///
+/// We use this when using `--track-writes`/`track_writes`. We can't use the same trick that reads
+/// do, because `write`/`write_link` will never invalidate their caller (their return value is
+/// `Vc<()>`).
+fn verify_written_files(
+    fs_root: &Path,
+    depth: usize,
+    width: usize,
+    symlink_count: u32,
+) -> (usize, Vec<PathBuf>) {
+    fn check_files_inner(
+        parent: &Path,
+        depth: usize,
+        width: usize,
+        total: &mut usize,
+        mismatched: &mut Vec<PathBuf>,
+    ) {
+        for child_id in 0..width {
+            let child_path = parent.join(child_id.to_string());
+            if depth == 1 {
+                *total += 1;
+                match std::fs::read(&child_path) {
+                    Ok(content) if content == FILE_SENTINEL_CONTENT => {}
+                    _ => mismatched.push(child_path),
+                }
+            } else {
+                check_files_inner(&child_path, depth - 1, width, total, mismatched);
+            }
+        }
+    }
+
+    let mut total = 0;
+    let mut mismatched = Vec::new();
+
+    check_files_inner(fs_root, depth, width, &mut total, &mut mismatched);
+
+    // Check symlinks
+    if symlink_count > 0 {
+        let symlinks_dir = fs_root.join("_symlinks");
+        for i in 0..symlink_count {
+            total += 1;
+            let symlink_path = symlinks_dir.join(i.to_string());
+            match std::fs::read_link(&symlink_path) {
+                Ok(target) if target == Path::new(SYMLINK_SENTINEL_TARGET) => {}
+                _ => mismatched.push(symlink_path),
+            }
+        }
+    }
+
+    (total, mismatched)
 }
 
 fn create_directory_tree(

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -484,28 +484,43 @@ fn verify_written_files(
     if symlink_count > 0 {
         let symlinks_dir = fs_root.join("_symlinks");
 
+        // Compute expected target based on mode. On Windows, junctions are stored with absolute
+        // paths by DiskFileSystem::write_link. We also need to canonicalize because read_link
+        // returns paths with the \\?\ extended-length prefix.
         #[cfg(windows)]
-        let expected_target = {
-            match symlink_mode {
-                Some(SymlinkMode::Junction) => {
-                    // On Windows, junctions are stored as absolute paths
-                    symlinks_dir.join(SYMLINK_SENTINEL_TARGET)
-                }
-                _ => PathBuf::from(SYMLINK_SENTINEL_TARGET),
+        let expected_target_canonicalized: Option<PathBuf> = match symlink_mode {
+            Some(SymlinkMode::Junction) => {
+                // Absolute path: fs_root/_symlinks/../0 resolves to fs_root/0
+                // Canonicalize to get the \\?\ prefixed form that read_link returns
+                std::fs::canonicalize(fs_root.join("0")).ok()
             }
-        };
-        #[cfg(not(windows))]
-        let expected_target = {
-            let _ = symlink_mode;
-            PathBuf::from(SYMLINK_SENTINEL_TARGET)
+            _ => None,
         };
 
         for i in 0..symlink_count {
             total += 1;
             let symlink_path = symlinks_dir.join(i.to_string());
-            match std::fs::read_link(&symlink_path) {
-                Ok(target) if target == expected_target => {}
-                _ => mismatched.push(symlink_path),
+            let matches = match std::fs::read_link(&symlink_path) {
+                Ok(target) => {
+                    #[cfg(windows)]
+                    {
+                        if let Some(ref expected) = expected_target_canonicalized {
+                            // Canonicalize the target we read back for consistent comparison
+                            std::fs::canonicalize(&target).ok().as_ref() == Some(expected)
+                        } else {
+                            target == Path::new(SYMLINK_SENTINEL_TARGET)
+                        }
+                    }
+                    #[cfg(not(windows))]
+                    {
+                        let _ = symlink_mode;
+                        target == Path::new(SYMLINK_SENTINEL_TARGET)
+                    }
+                }
+                Err(_) => false,
+            };
+            if !matches {
+                mismatched.push(symlink_path);
             }
         }
     }


### PR DESCRIPTION
In addition to creating task invalidators for file reads, we also create invalidators for file writes. This extends the fuzzer to cover that.

This is a bit trickier to test. Because the `write` call doesn't return anything, the caller of `write` never gets invalidated and re-executed, even though `write` does. So instead, we must observe that `write` was re-executed by looking at the contents of the file it wrote to. We write a sentinel value to files when we call the turbo-tasks-fs `write` function, and write random values to it to trigger an invalidation.

I tested this on Windows and Linux.

I don't care about the code quality here, so this was LLM-generated with very lightweight review.