### PR TITLE
Turbopack: Add a stress test / fuzzer that tries creating many symlinks in a tight loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9535,6 +9535,7 @@ dependencies = [
  "mime",
  "notify",
  "parking_lot",
+ "rand 0.9.0",
  "regex",
  "rstest",
  "rustc-hash 2.1.1",

--- a/turbopack/crates/turbo-tasks-fs/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-fs/Cargo.toml
@@ -55,6 +55,7 @@ urlencoding = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }
+rand = { workspace = true }
 rstest = { workspace = true }
 sha2 = "0.10.2"
 tempfile = { workspace = true }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -3102,13 +3102,6 @@ mod tests {
             fs.root()
         }
 
-        #[derive(Clone, Copy)]
-        enum SymlinkStressMode {
-            Directory,
-            #[cfg(windows)]
-            Junction,
-        }
-
         #[turbo_tasks::function(operation)]
         async fn write_symlink_stress_batch(
             fs: ResolvedVc<DiskFileSystem>,
@@ -3120,7 +3113,7 @@ mod tests {
             updates
                 .into_iter()
                 .map(|(symlink_idx, target_idx)| {
-                    let target: RcStr = format!("../_targets/{}", target_idx).into();
+                    let target = RcStr::from(format!("../_targets/{target_idx}"));
                     let symlink_path = symlinks_dir.join(&symlink_idx.to_string()).unwrap();
                     async move {
                         fs.write_link(

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2987,8 +2987,9 @@ mod tests {
             io::Write,
         };
 
+        use rand::{Rng, SeedableRng};
         use turbo_rcstr::{RcStr, rcstr};
-        use turbo_tasks::{ResolvedVc, apply_effects};
+        use turbo_tasks::{ResolvedVc, Vc, apply_effects};
         use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 
         use crate::{DiskFileSystem, FileSystem, FileSystemPath, LinkContent, LinkType};
@@ -3084,6 +3085,118 @@ mod tests {
             })
             .await
             .unwrap();
+        }
+
+        const STRESS_ITERATIONS: usize = 100;
+        const STRESS_PARALLELISM: usize = 8;
+        const STRESS_TARGET_COUNT: usize = 20;
+        const STRESS_SYMLINK_COUNT: usize = 16;
+
+        #[turbo_tasks::function(operation)]
+        fn disk_file_system_operation(fs_root: RcStr) -> Vc<DiskFileSystem> {
+            DiskFileSystem::new(rcstr!("test"), fs_root)
+        }
+
+        #[turbo_tasks::function(operation)]
+        fn disk_file_system_root_operation(fs: ResolvedVc<DiskFileSystem>) -> Vc<FileSystemPath> {
+            fs.root()
+        }
+
+        #[derive(Clone, Copy)]
+        enum SymlinkStressMode {
+            Directory,
+            #[cfg(windows)]
+            Junction,
+        }
+
+        #[turbo_tasks::function(operation)]
+        async fn write_symlink_stress_batch(
+            fs: ResolvedVc<DiskFileSystem>,
+            symlinks_dir: FileSystemPath,
+            updates: Vec<(usize, usize)>,
+        ) -> anyhow::Result<()> {
+            use turbo_tasks::TryJoinIterExt;
+
+            updates
+                .into_iter()
+                .map(|(symlink_idx, target_idx)| {
+                    let target: RcStr = format!("../_targets/{}", target_idx).into();
+                    let symlink_path = symlinks_dir.join(&symlink_idx.to_string()).unwrap();
+                    async move {
+                        fs.write_link(
+                            symlink_path,
+                            LinkContent::Link {
+                                target,
+                                link_type: LinkType::DIRECTORY,
+                            }
+                            .cell(),
+                        )
+                        .await
+                    }
+                })
+                .try_join()
+                .await?;
+            Ok(())
+        }
+
+        #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        async fn test_symlink_stress() {
+            let scratch = tempfile::tempdir().unwrap();
+            let path = scratch.path().to_owned();
+
+            let targets_dir = path.join("_targets");
+            create_dir_all(&targets_dir).unwrap();
+            for i in 0..STRESS_TARGET_COUNT {
+                create_dir_all(targets_dir.join(i.to_string())).unwrap();
+            }
+            create_dir_all(path.join("_symlinks")).unwrap();
+
+            let root: RcStr = path.to_str().unwrap().into();
+
+            let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+                BackendOptions::default(),
+                noop_backing_storage(),
+            ));
+
+            tt.run_once(async move {
+                let fs = disk_file_system_operation(root)
+                    .resolve_strongly_consistent()
+                    .await?;
+                let root_path = disk_file_system_root_operation(fs)
+                    .resolve_strongly_consistent()
+                    .await?
+                    .owned()
+                    .await?;
+                let symlinks_dir = root_path.join("_symlinks")?;
+
+                let initial_updates: Vec<(usize, usize)> =
+                    (0..STRESS_SYMLINK_COUNT).map(|i| (i, 0)).collect();
+                let initial_op =
+                    write_symlink_stress_batch(fs, symlinks_dir.clone(), initial_updates);
+                initial_op.read_strongly_consistent().await?;
+                apply_effects(initial_op).await?;
+
+                let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
+                for _ in 0..STRESS_ITERATIONS {
+                    let updates: Vec<(usize, usize)> = (0..STRESS_PARALLELISM)
+                        .map(|_| {
+                            let symlink_idx = rng.random_range(0..STRESS_SYMLINK_COUNT);
+                            let target_idx = rng.random_range(0..STRESS_TARGET_COUNT);
+                            (symlink_idx, target_idx)
+                        })
+                        .collect();
+
+                    let write_op = write_symlink_stress_batch(fs, symlinks_dir.clone(), updates);
+                    write_op.read_strongly_consistent().await?;
+                    apply_effects(write_op).await?;
+                }
+
+                anyhow::Ok(())
+            })
+            .await
+            .unwrap();
+
+            tt.stop_and_wait().await;
         }
     }
 

--- a/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/fs_watcher.rs
@@ -102,8 +102,7 @@ pub async fn run(args: FsWatcher) -> anyhow::Result<()> {
 
     tt.run_once(async move {
         let invalidations = TransientInstance::new(PathInvalidations::default());
-        let fs_root_rcstr = RcStr::from(fs_root.to_str().unwrap());
-        let project_fs = disk_file_system_operation(fs_root_rcstr.clone())
+        let project_fs = disk_file_system_operation(RcStr::from(fs_root.to_str().unwrap()))
             .resolve_strongly_consistent()
             .await?;
         let project_root = disk_file_system_root_operation(project_fs)

--- a/turbopack/crates/turbo-tasks-fuzz/src/main.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(windows, feature(junction_point))]
 
 mod fs_watcher;
+mod symlink_stress;
 
 use clap::{Parser, Subcommand};
 
@@ -22,6 +23,8 @@ struct Cli {
 enum Commands {
     /// Continuously fuzzes the filesystem watcher until ctrl+c'd.
     FsWatcher(fs_watcher::FsWatcher),
+    /// Stress tests symlink/junction writes in a tight loop.
+    SymlinkStress(symlink_stress::SymlinkStress),
 }
 
 #[tokio::main]
@@ -30,5 +33,6 @@ async fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::FsWatcher(args) => fs_watcher::run(args).await,
+        Commands::SymlinkStress(args) => symlink_stress::run(args).await,
     }
 }

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -73,8 +73,7 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
     let mode = args.mode;
 
     tt.run_once(async move {
-        let fs_root_rcstr = RcStr::from(fs_root.to_str().unwrap());
-        let project_fs = disk_file_system_operation(fs_root_rcstr.clone())
+        let project_fs = disk_file_system_operation(RcStr::from(fs_root.to_str().unwrap()))
             .resolve_strongly_consistent()
             .await?;
         let project_root = disk_file_system_root_operation(project_fs)

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -1,0 +1,234 @@
+use std::{
+    path::{Path, PathBuf},
+    time::{Duration, Instant},
+};
+
+const PROGRESS_INTERVAL: Duration = Duration::from_secs(1);
+
+use clap::{Args, ValueEnum};
+use rand::{Rng, SeedableRng};
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, apply_effects};
+use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
+use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath, LinkContent, LinkType};
+
+#[derive(Args)]
+pub struct SymlinkStress {
+    #[arg(long)]
+    fs_root: PathBuf,
+    /// Number of target directories symlinks can point to.
+    #[arg(long, default_value_t = 20)]
+    target_count: usize,
+    /// Number of symlinks to create and update.
+    #[arg(long, default_value_t = 50)]
+    symlink_count: usize,
+    /// Number of symlink writes to perform in parallel.
+    #[arg(long, default_value_t = 16)]
+    parallelism: usize,
+    /// How long to run the stress test for.
+    #[arg(long, default_value_t = 5)]
+    duration_secs: u64,
+    /// Type of symlink to test.
+    #[arg(long, value_enum, default_value_t = SymlinkMode::Directory)]
+    mode: SymlinkMode,
+}
+
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum SymlinkMode {
+    /// Test directory symlinks
+    #[cfg_attr(windows, doc = "(requires developer mode or admin)")]
+    Directory,
+    /// Test junction points (Windows-only)
+    #[cfg(windows)]
+    Junction,
+}
+
+pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
+    std::fs::create_dir(&args.fs_root)?;
+    let fs_root = args.fs_root.canonicalize()?;
+    let _guard = FsCleanup {
+        path: &fs_root.clone(),
+    };
+
+    // Create target directories that symlinks will point to
+    let targets_dir = fs_root.join("_targets");
+    std::fs::create_dir(&targets_dir)?;
+    for i in 0..args.target_count {
+        std::fs::create_dir(targets_dir.join(i.to_string()))?;
+    }
+
+    // Create symlinks directory
+    let symlinks_dir = fs_root.join("_symlinks");
+    std::fs::create_dir(&symlinks_dir)?;
+
+    let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+        BackendOptions::default(),
+        noop_backing_storage(),
+    ));
+
+    let target_count = args.target_count;
+    let symlink_count = args.symlink_count;
+    let parallelism = args.parallelism;
+    let duration = Duration::from_secs(args.duration_secs);
+    let mode = args.mode;
+
+    tt.run_once(async move {
+        let fs_root_rcstr = RcStr::from(fs_root.to_str().unwrap());
+        let project_fs = disk_file_system_operation(fs_root_rcstr.clone())
+            .resolve_strongly_consistent()
+            .await?;
+        let project_root = disk_file_system_root_operation(project_fs)
+            .resolve_strongly_consistent()
+            .await?
+            .owned()
+            .await?;
+
+        // Create initial symlinks via turbo-tasks, all pointing to target 0
+        let symlinks_path = project_root.join("_symlinks")?;
+        let initial_target = RcStr::from("../_targets/0");
+
+        println!(
+            "creating {} initial symlinks (mode: {:?})...",
+            symlink_count, mode
+        );
+
+        let initial_op =
+            create_initial_symlinks_operation(symlinks_path.clone(), symlink_count, initial_target);
+        initial_op.read_strongly_consistent().await?;
+        apply_effects(initial_op).await?;
+
+        println!(
+            "starting stress test with parallelism={} for {}s...",
+            parallelism,
+            duration.as_secs()
+        );
+
+        let mut rng = rand::rngs::SmallRng::from_rng(&mut rand::rng());
+        let mut total_writes: u64 = 0;
+        let mut last_progress_writes: u64 = 0;
+        let start_time = Instant::now();
+        let mut last_progress_time = start_time;
+
+        loop {
+            // Check if we've reached the duration limit
+            if start_time.elapsed() >= duration {
+                break;
+            }
+
+            // Generate random symlink updates for this batch
+            let updates: Vec<(usize, usize)> = (0..parallelism)
+                .map(|_| {
+                    let symlink_idx = rng.random_range(0..symlink_count);
+                    let target_idx = rng.random_range(0..target_count);
+                    (symlink_idx, target_idx)
+                })
+                .collect();
+
+            // Execute writes in parallel via turbo-tasks
+            let write_op = write_symlinks_batch_operation(symlinks_path.clone(), updates);
+            write_op.read_strongly_consistent().await?;
+            apply_effects(write_op).await?;
+
+            total_writes += parallelism as u64;
+
+            // Print progress every PROGRESS_INTERVAL
+            let now = Instant::now();
+            if now.duration_since(last_progress_time) >= PROGRESS_INTERVAL {
+                let interval_writes = total_writes - last_progress_writes;
+                let interval_duration = now.duration_since(last_progress_time);
+                let writes_per_sec = interval_writes as f64 / interval_duration.as_secs_f64();
+                println!(
+                    "{:.1}s: {} writes, {:.0} writes/sec",
+                    start_time.elapsed().as_secs_f64(),
+                    total_writes,
+                    writes_per_sec
+                );
+                last_progress_time = now;
+                last_progress_writes = total_writes;
+            }
+        }
+
+        // Final summary
+        let elapsed = start_time.elapsed();
+        let writes_per_sec = total_writes as f64 / elapsed.as_secs_f64();
+        println!(
+            "completed {} symlink writes in {:.2}s ({:.0} writes/sec)",
+            total_writes,
+            elapsed.as_secs_f64(),
+            writes_per_sec
+        );
+
+        Ok(())
+    })
+    .await?;
+
+    tt.stop_and_wait().await;
+    Ok(())
+}
+
+#[turbo_tasks::function(operation)]
+fn disk_file_system_operation(fs_root: RcStr) -> Vc<DiskFileSystem> {
+    DiskFileSystem::new(rcstr!("project"), fs_root)
+}
+
+#[turbo_tasks::function(operation)]
+fn disk_file_system_root_operation(fs: ResolvedVc<DiskFileSystem>) -> Vc<FileSystemPath> {
+    fs.root()
+}
+
+#[turbo_tasks::function(operation)]
+async fn create_initial_symlinks_operation(
+    symlinks_dir: FileSystemPath,
+    count: usize,
+    target: RcStr,
+) -> anyhow::Result<()> {
+    (0..count)
+        .map(|i| write_symlink(symlinks_dir.clone(), i, target.clone()))
+        .try_join()
+        .await?;
+    Ok(())
+}
+
+#[turbo_tasks::function(operation)]
+async fn write_symlinks_batch_operation(
+    symlinks_dir: FileSystemPath,
+    updates: Vec<(usize, usize)>,
+) -> anyhow::Result<()> {
+    updates
+        .into_iter()
+        .map(|(symlink_idx, target_idx)| {
+            let target = RcStr::from(format!("../_targets/{}", target_idx));
+            write_symlink(symlinks_dir.clone(), symlink_idx, target)
+        })
+        .try_join()
+        .await?;
+    Ok(())
+}
+
+#[turbo_tasks::function]
+async fn write_symlink(
+    symlinks_dir: FileSystemPath,
+    symlink_idx: usize,
+    target: RcStr,
+) -> anyhow::Result<()> {
+    let symlink_path = symlinks_dir.join(&symlink_idx.to_string())?;
+    let link_content = LinkContent::Link {
+        target,
+        link_type: LinkType::DIRECTORY,
+    };
+    symlink_path
+        .fs()
+        .write_link(symlink_path.clone(), link_content.cell())
+        .await?;
+    Ok(())
+}
+
+struct FsCleanup<'a> {
+    path: &'a Path,
+}
+
+impl Drop for FsCleanup<'_> {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(self.path).unwrap();
+    }
+}

--- a/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
+++ b/turbopack/crates/turbo-tasks-fuzz/src/symlink_stress.rs
@@ -5,7 +5,7 @@ use std::{
 
 const PROGRESS_INTERVAL: Duration = Duration::from_secs(1);
 
-use clap::{Args, ValueEnum};
+use clap::Args;
 use rand::{Rng, SeedableRng};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, apply_effects};
@@ -28,19 +28,6 @@ pub struct SymlinkStress {
     /// How long to run the stress test for.
     #[arg(long, default_value_t = 5)]
     duration_secs: u64,
-    /// Type of symlink to test.
-    #[arg(long, value_enum, default_value_t = SymlinkMode::Directory)]
-    mode: SymlinkMode,
-}
-
-#[derive(Clone, Copy, Debug, ValueEnum)]
-pub enum SymlinkMode {
-    /// Test directory symlinks
-    #[cfg_attr(windows, doc = "(requires developer mode or admin)")]
-    Directory,
-    /// Test junction points (Windows-only)
-    #[cfg(windows)]
-    Junction,
 }
 
 pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
@@ -70,7 +57,6 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
     let symlink_count = args.symlink_count;
     let parallelism = args.parallelism;
     let duration = Duration::from_secs(args.duration_secs);
-    let mode = args.mode;
 
     tt.run_once(async move {
         let project_fs = disk_file_system_operation(RcStr::from(fs_root.to_str().unwrap()))
@@ -86,10 +72,7 @@ pub async fn run(args: SymlinkStress) -> anyhow::Result<()> {
         let symlinks_path = project_root.join("_symlinks")?;
         let initial_target = RcStr::from("../_targets/0");
 
-        println!(
-            "creating {} initial symlinks (mode: {:?})...",
-            symlink_count, mode
-        );
+        println!("creating {symlink_count} initial symlinks...");
 
         let initial_op =
             create_initial_symlinks_operation(symlinks_path.clone(), symlink_count, initial_target);


### PR DESCRIPTION
In an attempt to reproduce https://github.com/vercel/next.js/discussions/88382, this tries creating and updating a bunch of symlinks/junction points in a tight loop with some parallelism. However, I've been unable to reproduce the error reported in that discussion.

I don't care about the code quality here, so this was LLM-generated with very lightweight review.

A simplified version of the fuzzer is also included as a unit test in `turbo-tasks-fs`. This version only does a few iterations and runs very quickly.