### PR TITLE
feat(types): add NextParams and NextSearchParams interfaces

### DIFF
--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1413,6 +1413,20 @@ export interface NextConfig {
   _originalRewrites?: any
 }
 
+/**
+ * A promise that resolves to an object containing the dynamic route parameters from the root segment down to that page.
+ * 
+ * Read more: [Next.js Docs: `params (optional)`](https://nextjs.org/docs/app/api-reference/file-conventions/page#params-optional)
+ */
+export interface NextParams<T> { params: Promise<T> }
+
+/**
+ * A promise that resolves to an object containing the search parameters of the current URL. For example:
+ * 
+ * Read more [searchParams (optional)](https://nextjs.org/docs/app/api-reference/file-conventions/page#searchparams-optional)
+ */
+export interface NextSearchParams<T> { searchParams: T }
+
 export const defaultConfig = Object.freeze({
   env: {},
   webpack: null,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1421,11 +1421,11 @@ export interface NextConfig {
 export interface NextParams<T> { params: Promise<T> }
 
 /**
- * A promise that resolves to an object containing the search parameters of the current URL. For example:
+ * A promise that resolves to an object containing the search parameters of the current URL.
  * 
- * Read more [searchParams (optional)](https://nextjs.org/docs/app/api-reference/file-conventions/page#searchparams-optional)
+ * Read more: [Next.js Docs: `searchParams (optional)`](https://nextjs.org/docs/app/api-reference/file-conventions/page#searchparams-optional)
  */
-export interface NextSearchParams<T> { searchParams: T }
+export interface NextSearchParams<T> { searchParams: Promise<T> }
 
 export const defaultConfig = Object.freeze({
   env: {},


### PR DESCRIPTION
feat(types): add NextParams and NextSearchParams interfaces

- Added NextParams interface for dynamic route parameters.
- Added NextSearchParams interface for URL search parameters.
- Included official documentation links in JSDoc comments.

### What?
This PR introduces two new helper interfaces, NextParams<T> and NextSearchParams<T>, to provide standard TypeScript definitions for Page and Layout props. These interfaces include JSDoc comments with links to the official Next.js documentation.

### Why?
Currently, developers often have to manually define types for params and searchParams in every page or layout. Providing these built-in interfaces:

Reduces boilerplate code.

Ensures consistency (especially with the Promise wrapper required in Next.js 15+).

Provides instant access to documentation via IDE hover/IntelliSense.

### How?
Added NextParams<T> which wraps params in a Promise.

Added NextSearchParams<T> which wraps searchParams in a Promise.

example:
```tsx
const Page = async ({ 
  params,
  searchParams
}: NextParams<{ locale: string }> &
  NextSearchParams<{ q?: string }>) => {
  const { locale } = await params
  const { q } = await searchParams
  // ...
}
```

Included documentation links in the JSDoc for better developer experience.