### PR TITLE
fix: performance.measure negative timestamp error when notFound() is called

### DIFF
--- a/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.browser.development.js
@@ -3722,7 +3722,7 @@
                       startTime$jscomp$2 = startTime$jscomp$1,
                       childrenEndTime$jscomp$1 = childrenEndTime$jscomp$0,
                       error = root.reason;
-                    if (supportsUserTiming) {
+                    if (supportsUserTiming && 0 <= childrenEndTime$jscomp$1) {
                       var env = componentInfo$jscomp$2.env,
                         name = componentInfo$jscomp$2.name,
                         entryName$jscomp$0 =
@@ -3985,7 +3985,7 @@
                     trackIdx$jscomp$4 = trackIdx$jscomp$6,
                     startTime$jscomp$5 = time,
                     childrenEndTime$jscomp$3 = childrenEndTime;
-                  if (supportsUserTiming) {
+                  if (supportsUserTiming && 0 <= childrenEndTime$jscomp$3) {
                     var env$jscomp$2 = componentInfo$jscomp$4.env,
                       name$jscomp$1 = componentInfo$jscomp$4.name,
                       entryName$jscomp$2 =

--- a/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.development.js
@@ -3722,7 +3722,7 @@
                       startTime$jscomp$2 = startTime$jscomp$1,
                       childrenEndTime$jscomp$1 = childrenEndTime$jscomp$0,
                       error = root.reason;
-                    if (supportsUserTiming) {
+                    if (supportsUserTiming && 0 <= childrenEndTime$jscomp$1) {
                       var env = componentInfo$jscomp$2.env,
                         name = componentInfo$jscomp$2.name,
                         entryName$jscomp$0 =
@@ -3985,7 +3985,7 @@
                     trackIdx$jscomp$4 = trackIdx$jscomp$6,
                     startTime$jscomp$5 = time,
                     childrenEndTime$jscomp$3 = childrenEndTime;
-                  if (supportsUserTiming) {
+                  if (supportsUserTiming && 0 <= childrenEndTime$jscomp$3) {
                     var env$jscomp$2 = componentInfo$jscomp$4.env,
                       name$jscomp$1 = componentInfo$jscomp$4.name,
                       entryName$jscomp$2 =

--- a/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.browser.development.js
@@ -3731,7 +3731,7 @@
                       startTime$jscomp$2 = startTime$jscomp$1,
                       childrenEndTime$jscomp$1 = childrenEndTime$jscomp$0,
                       error = root.reason;
-                    if (supportsUserTiming) {
+                    if (supportsUserTiming && 0 <= childrenEndTime$jscomp$1) {
                       var env = componentInfo$jscomp$2.env,
                         name = componentInfo$jscomp$2.name,
                         entryName$jscomp$0 =
@@ -3994,7 +3994,7 @@
                     trackIdx$jscomp$4 = trackIdx$jscomp$6,
                     startTime$jscomp$5 = time,
                     childrenEndTime$jscomp$3 = childrenEndTime;
-                  if (supportsUserTiming) {
+                  if (supportsUserTiming && 0 <= childrenEndTime$jscomp$3) {
                     var env$jscomp$2 = componentInfo$jscomp$4.env,
                       name$jscomp$1 = componentInfo$jscomp$4.name,
                       entryName$jscomp$2 =

--- a/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
+++ b/packages/next/src/compiled/react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js
@@ -3731,7 +3731,7 @@
                       startTime$jscomp$2 = startTime$jscomp$1,
                       childrenEndTime$jscomp$1 = childrenEndTime$jscomp$0,
                       error = root.reason;
-                    if (supportsUserTiming) {
+                    if (supportsUserTiming && 0 <= childrenEndTime$jscomp$1) {
                       var env = componentInfo$jscomp$2.env,
                         name = componentInfo$jscomp$2.name,
                         entryName$jscomp$0 =
@@ -3994,7 +3994,7 @@
                     trackIdx$jscomp$4 = trackIdx$jscomp$6,
                     startTime$jscomp$5 = time,
                     childrenEndTime$jscomp$3 = childrenEndTime;
-                  if (supportsUserTiming) {
+                  if (supportsUserTiming && 0 <= childrenEndTime$jscomp$3) {
                     var env$jscomp$2 = componentInfo$jscomp$4.env,
                       name$jscomp$1 = componentInfo$jscomp$4.name,
                       entryName$jscomp$2 =

--- a/test/development/app-dir/not-found-performance-measure/app/[slug]/not-found.tsx
+++ b/test/development/app-dir/not-found-performance-measure/app/[slug]/not-found.tsx
@@ -1,0 +1,3 @@
+export default function SlugNotFound() {
+  return <h1 id="slug-not-found">Slug Not Found</h1>
+}

--- a/test/development/app-dir/not-found-performance-measure/app/[slug]/page.tsx
+++ b/test/development/app-dir/not-found-performance-measure/app/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation'
+
+export const dynamic = 'force-dynamic'
+
+export default async function SlugPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  // Trigger notFound for specific slugs
+  if (slug === 'trigger-not-found') {
+    notFound()
+  }
+
+  return <h1 id="slug-page">Slug: {slug}</h1>
+}

--- a/test/development/app-dir/not-found-performance-measure/app/layout.tsx
+++ b/test/development/app-dir/not-found-performance-measure/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/not-found-performance-measure/app/not-found.tsx
+++ b/test/development/app-dir/not-found-performance-measure/app/not-found.tsx
@@ -1,0 +1,3 @@
+export default function NotFound() {
+  return <h1 id="not-found">Not Found</h1>
+}

--- a/test/development/app-dir/not-found-performance-measure/app/page.tsx
+++ b/test/development/app-dir/not-found-performance-measure/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1 id="home">Home Page</h1>
+}

--- a/test/development/app-dir/not-found-performance-measure/next.config.js
+++ b/test/development/app-dir/not-found-performance-measure/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/not-found-performance-measure/not-found-performance-measure.test.ts
+++ b/test/development/app-dir/not-found-performance-measure/not-found-performance-measure.test.ts
@@ -1,0 +1,185 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+/**
+ * Regression test for https://github.com/vercel/next.js/issues/86060
+ *
+ * This issue reports an error:
+ * "Failed to execute 'measure' on 'Performance': '​SlugPage' cannot have a negative time stamp"
+ *
+ * The error occurs in development mode with Turbopack when:
+ * - Navigating to a 404 page
+ * - When notFound() is called in a dynamic route
+ * - After HMR updates on not-found pages
+ *
+ * The error originates from React's performance tracking in
+ * react-server-dom-turbopack-client.browser.development.js where
+ * performance.measure() is called with timestamps that can become negative
+ * due to timing issues.
+ *
+ * The issue is intermittent and more likely to occur:
+ * - On WSL (Windows Subsystem for Linux)
+ * - With rapid HMR updates
+ * - When not-found.tsx is in the same dynamic directory as the page calling notFound()
+ */
+describe('not-found-performance-measure', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // This test reproduces https://github.com/vercel/next.js/issues/86060
+  // The error "Failed to execute 'measure' on 'Performance': '​SlugPage' cannot have a negative time stamp"
+  // occurs in development mode with Turbopack when navigating to a 404 page or when notFound() is called.
+  it('should not throw performance.measure error when notFound() is called in dynamic route', async () => {
+    const browser = await next.browser('/trigger-not-found')
+
+    // Wait for the not-found page to render
+    await retry(async () => {
+      const element = await browser.elementByCss('#slug-not-found')
+      expect(await element.text()).toBe('Slug Not Found')
+    })
+
+    // Check for the specific error in browser console
+    const logs = await browser.log()
+    const performanceMeasureErrors = logs.filter(
+      (log) =>
+        log.source === 'error' && log.message.includes('negative time stamp')
+    )
+
+    expect(performanceMeasureErrors).toEqual([])
+  })
+
+  it('should not throw performance.measure error after HMR on dynamic route not-found page', async () => {
+    // Navigate to a route that triggers notFound()
+    const browser = await next.browser('/trigger-not-found')
+
+    await retry(async () => {
+      const element = await browser.elementByCss('#slug-not-found')
+      expect(await element.text()).toBe('Slug Not Found')
+    })
+
+    // Make a change to the not-found file to trigger HMR
+    const originalContent = await next.readFile('app/[slug]/not-found.tsx')
+    await next.patchFile(
+      'app/[slug]/not-found.tsx',
+      originalContent.replace('Slug Not Found', 'Slug Not Found Updated')
+    )
+
+    // Wait for HMR to complete
+    await retry(async () => {
+      const element = await browser.elementByCss('#slug-not-found')
+      expect(await element.text()).toBe('Slug Not Found Updated')
+    })
+
+    // Restore original content
+    await next.patchFile('app/[slug]/not-found.tsx', originalContent)
+
+    // Check for the specific error in browser console
+    const logs = await browser.log()
+    const performanceMeasureErrors = logs.filter(
+      (log) =>
+        log.source === 'error' && log.message.includes('negative time stamp')
+    )
+
+    expect(performanceMeasureErrors).toEqual([])
+  })
+
+  it('should not throw performance.measure error when navigating between pages and triggering notFound()', async () => {
+    // Start at home page
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      const element = await browser.elementByCss('#home')
+      expect(await element.text()).toBe('Home Page')
+    })
+
+    // Navigate to a route that triggers notFound()
+    await browser.eval('window.location.href = "/trigger-not-found"')
+
+    await retry(async () => {
+      const element = await browser.elementByCss('#slug-not-found')
+      expect(await element.text()).toBe('Slug Not Found')
+    })
+
+    // Check for the specific error in browser console
+    const logs = await browser.log()
+    const performanceMeasureErrors = logs.filter(
+      (log) =>
+        log.source === 'error' && log.message.includes('negative time stamp')
+    )
+
+    expect(performanceMeasureErrors).toEqual([])
+  })
+
+  it('should not throw performance.measure error with rapid HMR updates on not-found page', async () => {
+    // Navigate to a route that triggers notFound()
+    const browser = await next.browser('/trigger-not-found')
+
+    await retry(async () => {
+      const element = await browser.elementByCss('#slug-not-found')
+      expect(await element.text()).toBe('Slug Not Found')
+    })
+
+    const originalContent = await next.readFile('app/[slug]/not-found.tsx')
+
+    // Perform multiple rapid HMR updates to try to trigger timing issues
+    for (let i = 0; i < 5; i++) {
+      await next.patchFile(
+        'app/[slug]/not-found.tsx',
+        originalContent.replace('Slug Not Found', `Slug Not Found ${i}`)
+      )
+
+      await retry(async () => {
+        const element = await browser.elementByCss('#slug-not-found')
+        expect(await element.text()).toBe(`Slug Not Found ${i}`)
+      })
+    }
+
+    // Restore original content
+    await next.patchFile('app/[slug]/not-found.tsx', originalContent)
+
+    // Check for the specific error in browser console
+    const logs = await browser.log()
+    const performanceMeasureErrors = logs.filter(
+      (log) =>
+        log.source === 'error' && log.message.includes('negative time stamp')
+    )
+
+    expect(performanceMeasureErrors).toEqual([])
+  })
+
+  it('should not throw performance.measure error when rapidly navigating to notFound routes', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      const element = await browser.elementByCss('#home')
+      expect(await element.text()).toBe('Home Page')
+    })
+
+    // Rapidly navigate between home and not-found routes
+    for (let i = 0; i < 5; i++) {
+      await browser.eval('window.location.href = "/trigger-not-found"')
+
+      await retry(async () => {
+        const element = await browser.elementByCss('#slug-not-found')
+        expect(await element.text()).toBe('Slug Not Found')
+      })
+
+      await browser.eval('window.location.href = "/"')
+
+      await retry(async () => {
+        const element = await browser.elementByCss('#home')
+        expect(await element.text()).toBe('Home Page')
+      })
+    }
+
+    // Check for the specific error in browser console
+    const logs = await browser.log()
+    const performanceMeasureErrors = logs.filter(
+      (log) =>
+        log.source === 'error' && log.message.includes('negative time stamp')
+    )
+
+    expect(performanceMeasureErrors).toEqual([])
+  })
+})


### PR DESCRIPTION
Fixes #86060

### What?

This PR fixes the error `Failed to execute 'measure' on 'Performance': '​SlugPage' cannot have a negative time stamp` that occurs in development mode when `notFound()` is called in a dynamic route.

### Why?

The error originates from React's performance tracking code in `react-server-dom-turbopack-client.browser.development.js`. When a component is rejected (e.g., when `notFound()` is called) or aborted, the code calls `performance.measure()` without validating that `childrenEndTime` is non-negative.

The `childrenEndTime` variable is initialized to `-Infinity` and only gets updated when children are processed. If no children have been processed yet (which can happen with `notFound()` calls that interrupt rendering), `childrenEndTime` remains `-Infinity`, causing `performance.measure()` to throw an error.

The normal (non-error) code path already has this check:
```javascript
if (supportsUserTiming && 0 <= childrenEndTime$jscomp$2 && 10 > trackIdx$jscomp$2)
```

But the rejected/error and aborted code paths were missing the `0 <= childrenEndTime` check:
```javascript
if (supportsUserTiming) {  // Missing the childrenEndTime check
```

### How?

Added the missing `0 <= childrenEndTime` check to the two affected code paths:

1. **Rejected/Error case**: When a component is rejected (e.g., `notFound()` is called)
2. **Aborted case**: When a component is aborted before finishing rendering

The fix was applied to all four affected compiled React files:
- `react-server-dom-turbopack/cjs/react-server-dom-turbopack-client.browser.development.js`
- `react-server-dom-turbopack-experimental/cjs/react-server-dom-turbopack-client.browser.development.js`
- `react-server-dom-webpack/cjs/react-server-dom-webpack-client.browser.development.js`
- `react-server-dom-webpack-experimental/cjs/react-server-dom-webpack-client.browser.development.js`

### Testing

Added a regression test at `test/development/app-dir/not-found-performance-measure/` that verifies no "negative time stamp" errors appear in the browser console when:
- `notFound()` is called in a dynamic route
- HMR updates occur on not-found pages
- Rapid navigation between pages triggers `notFound()`
- Rapid HMR updates occur on not-found pages

### Notes

This is a patch to React's compiled code bundled with Next.js. The upstream fix should be reported to React.
