### PR TITLE
docs: clarify quick start defaults and Node.js requirements

### DIFF
--- a/docs/01-app/01-getting-started/01-installation.mdx
+++ b/docs/01-app/01-getting-started/01-installation.mdx
@@ -11,7 +11,7 @@ Create a new Next.js app and run it locally.
 
 ## Quick start
 
-1. Create a new Next.js app named `my-app`
+1. Create a new Next.js app named `my-app` using the default recommended configuration
 2. `cd my-app` and start the dev server.
 3. Visit `http://localhost:3000`.
 
@@ -47,7 +47,7 @@ bun dev
 
 Before you begin, make sure your development environment meets the following requirements:
 
-- Minimum Node.js version: [20.9](https://nodejs.org/)
+- Minimum Node.js version: [20.9](https://nodejs.org/) (LTS recommended)
 - Operating systems: macOS, Windows (including WSL), and Linux.
 
 ## Supported browsers


### PR DESCRIPTION
This PR adds small clarifications to the Installation guide:

- Clarifies that the Quick Start uses the default recommended configuration.
- Adds an LTS recommendation to the minimum Node.js version.

No functional changes, documentation-only improvement.
