### PR TITLE
chore: use startTransition for AppRouterAnnouncer state updates

### DIFF
--- a/packages/next/src/client/components/app-router-announcer.tsx
+++ b/packages/next/src/client/components/app-router-announcer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, startTransition } from 'react'
 import { createPortal } from 'react-dom'
 import type { FlightRouterState } from '../../shared/lib/app-router-types'
 
@@ -32,7 +32,9 @@ export function AppRouterAnnouncer({ tree }: { tree: FlightRouterState }) {
 
   useEffect(() => {
     const announcer = getAnnouncerNode()
-    setPortalNode(announcer)
+    startTransition(() => {
+      setPortalNode(announcer)
+    })
     return () => {
       const container = document.getElementsByTagName(ANNOUNCER_TYPE)[0]
       if (container?.isConnected) {
@@ -61,7 +63,9 @@ export function AppRouterAnnouncer({ tree }: { tree: FlightRouterState }) {
       previousTitle.current !== undefined &&
       previousTitle.current !== currentTitle
     ) {
-      setRouteAnnouncement(currentTitle)
+      startTransition(() => {
+        setRouteAnnouncement(currentTitle)
+      })
     }
     previousTitle.current = currentTitle
   }, [tree])


### PR DESCRIPTION
## What?

Wraps the `setState` calls in `AppRouterAnnouncer` with `startTransition`.

## Why?

This is a minor consistency change. The `AppRouterAnnouncer` state updates (`setPortalNode`, `setRouteAnnouncement`) are non-urgent - they update a visually hidden accessibility element in a shadow DOM for screen readers.

Using `startTransition` for non-urgent state updates is the established pattern throughout the App Router codebase (e.g., `redirect-boundary.tsx`, `app-router.tsx`, `app-router-instance.ts`).

Note: This component's re-renders are isolated and don't affect the rest of the page - it renders to a separate portal node and has purely local state.

## How?

Wrapped both `setPortalNode` and `setRouteAnnouncement` in `startTransition`.

## Test Plan

- [x] `pnpm test-dev-turbo test/e2e/app-dir/app-a11y/index.test.ts` - 4/4 tests passed
- [x] `pnpm test-dev-turbo test/integration/client-navigation-a11y/` - 6/6 tests passed