### PR TITLE
perf(turbopack): adjust chunking config to reduce chunk count

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -496,9 +496,9 @@ pub async fn get_client_chunking_context(
             .chunking_config(
                 Vc::<EcmascriptChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
-                    min_chunk_size: 50_000,
-                    max_chunk_count_per_group: 40,
-                    max_merge_chunk_size: 200_000,
+                    min_chunk_size: 100_000,
+                    max_chunk_count_per_group: 20,
+                    max_merge_chunk_size: 500_000,
                     ..Default::default()
                 },
             )

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1070,16 +1070,16 @@ pub async fn get_server_chunking_context_with_client_assets(
             .chunking_config(
                 Vc::<EcmascriptChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
-                    min_chunk_size: 20_000,
-                    max_chunk_count_per_group: 100,
-                    max_merge_chunk_size: 100_000,
+                    min_chunk_size: 100_000,
+                    max_chunk_count_per_group: 20,
+                    max_merge_chunk_size: 500_000,
                     ..Default::default()
                 },
             )
             .chunking_config(
                 Vc::<CssChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
-                    max_merge_chunk_size: 100_000,
+                    max_merge_chunk_size: 500_000,
                     ..Default::default()
                 },
             )
@@ -1152,16 +1152,16 @@ pub async fn get_server_chunking_context(
             .chunking_config(
                 Vc::<EcmascriptChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
-                    min_chunk_size: 20_000,
-                    max_chunk_count_per_group: 100,
-                    max_merge_chunk_size: 100_000,
+                    min_chunk_size: 100_000,
+                    max_chunk_count_per_group: 20,
+                    max_merge_chunk_size: 500_000,
                     ..Default::default()
                 },
             )
             .chunking_config(
                 Vc::<CssChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
-                    max_merge_chunk_size: 100_000,
+                    max_merge_chunk_size: 500_000,
                     ..Default::default()
                 },
             )

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1079,7 +1079,7 @@ pub async fn get_server_chunking_context_with_client_assets(
             .chunking_config(
                 Vc::<CssChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
-                    max_merge_chunk_size: 500_000,
+                    max_merge_chunk_size: 100_000,
                     ..Default::default()
                 },
             )
@@ -1161,7 +1161,7 @@ pub async fn get_server_chunking_context(
             .chunking_config(
                 Vc::<CssChunkType>::default().to_resolved().await?,
                 ChunkingConfig {
-                    max_merge_chunk_size: 500_000,
+                    max_merge_chunk_size: 100_000,
                     ..Default::default()
                 },
             )


### PR DESCRIPTION
## What?

Adjusts Turbopack's chunking configuration for both client and server contexts to produce fewer, larger chunks.

**Changes:**
- **Client**: Increased `min_chunk_size` (50KB → 100KB), reduced `max_chunk_count_per_group` (40 → 20), increased `max_merge_chunk_size` (200KB → 500KB)
- **Server**: Increased `min_chunk_size` (20KB → 100KB), reduced `max_chunk_count_per_group` (100 → 20), increased `max_merge_chunk_size` (100KB → 500KB)

## Why?

Having too many small chunks increases overhead during module loading, particularly during SSR prerenders where many chunks may need to be loaded.

## How?

Modified the `ChunkingConfig` values in:
- `crates/next-core/src/next_client/context.rs`
- `crates/next-core/src/next_server/context.rs`