### PR TITLE
perf: deduplicate chunk and promise tracking in CacheSignal

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1886,7 +1886,8 @@ async function renderToHTMLOrFlightImpl(
     const __next_chunk_load__: typeof instrumented.loadChunk = (...args) => {
       const loadingChunk = instrumented.loadChunk(...args)
       if (shouldTrackModuleLoading()) {
-        trackPendingChunkLoad(loadingChunk)
+        // args[0] is the chunk ID (string | number)
+        trackPendingChunkLoad(loadingChunk, args[0])
       }
       return loadingChunk
     }

--- a/packages/next/src/server/app-render/cache-signal.ts
+++ b/packages/next/src/server/app-render/cache-signal.ts
@@ -16,6 +16,13 @@ export class CacheSignal {
 
   private subscribedSignals: Set<CacheSignal> | null = null
 
+  // Track promises we've already begun tracking to avoid duplicate counting.
+  // During SSR prerenders, multiple parallel render contexts may request the same
+  // chunk, receiving the same Promise reference from Turbopack's cache. Without
+  // deduplication, each call to trackRead increments count, causing cacheReady()
+  // to wait for N begin/end cycles instead of 1.
+  private trackedPromises: WeakSet<Promise<unknown>> | null = null
+
   constructor() {
     if (process.env.NEXT_RUNTIME === 'edge') {
       // we rely on `process.nextTick`, which is not supported in edge
@@ -141,6 +148,18 @@ export class CacheSignal {
   }
 
   trackRead<T>(promise: Promise<T>) {
+    // Deduplicate by promise identity to avoid counting the same promise multiple times.
+    // This is critical for SSR prerenders where multiple render contexts may receive
+    // the same Promise reference from Turbopack's chunk cache.
+    if (this.trackedPromises === null) {
+      this.trackedPromises = new WeakSet()
+    }
+    if (this.trackedPromises.has(promise)) {
+      // Already tracking this promise, skip to avoid duplicate counting
+      return promise
+    }
+    this.trackedPromises.add(promise)
+
     this.beginRead()
     // `promise.finally()` still rejects, so don't use it here to avoid unhandled rejections
     const onFinally = this.endRead.bind(this)

--- a/packages/next/src/server/app-render/module-loading/track-module-loading.instance.ts
+++ b/packages/next/src/server/app-render/module-loading/track-module-loading.instance.ts
@@ -13,7 +13,28 @@ function getModuleLoadingSignal() {
   return _moduleLoadingSignal
 }
 
-export function trackPendingChunkLoad(promise: Promise<unknown>) {
+// Track all chunk IDs that have ever been tracked in this process.
+// Once a chunk is loaded in Node.js, it stays loaded (module caching).
+// Subsequent requests for the same chunk are instant and don't need tracking.
+// This prevents duplicate tracking across server/client prerender phases.
+const _trackedChunks = new Set<string>()
+
+export function trackPendingChunkLoad(
+  promise: Promise<unknown>,
+  chunkId?: string | number
+) {
+  const chunkIdStr = chunkId !== undefined ? String(chunkId) : undefined
+
+  // Deduplicate by chunk ID - if this chunk was already tracked, skip it.
+  // This is safe because Node.js caches modules, so subsequent "loads" are instant.
+  // We intentionally do NOT remove from the Set after completion - once tracked, always tracked.
+  if (chunkIdStr !== undefined && _trackedChunks.has(chunkIdStr)) {
+    return
+  }
+  if (chunkIdStr !== undefined) {
+    _trackedChunks.add(chunkIdStr)
+  }
+
   const moduleLoadingSignal = getModuleLoadingSignal()
   moduleLoadingSignal.trackRead(promise)
 }


### PR DESCRIPTION
## What?

Eliminates duplicate tracking in the CacheSignal system during SSR prerenders.

**Changes:**

1. **Promise Deduplication in CacheSignal**
   - Added `trackedPromises` WeakSet to prevent counting the same promise multiple times

2. **Chunk ID-Based Deduplication**
   - Track chunk IDs globally to avoid redundant tracking since Node.js caches loaded modules

## Why?

During SSR prerenders, multiple parallel render contexts may request the same chunk, receiving the same Promise reference from Turbopack's cache. Without deduplication:
- Each call to `trackRead` increments the pending count
- `cacheReady()` waits for N begin/end cycles instead of 1
- This causes unnecessary delays in prerender completion

## How?

1. **CacheSignal.trackRead()**: Added WeakSet-based promise identity tracking to skip already-tracked promises
2. **trackPendingChunkLoad()**: Added Set-based chunk ID tracking to skip already-loaded chunks (chunks stay loaded due to Node.js module caching)

Modified files:
- `packages/next/src/server/app-render/cache-signal.ts`
- `packages/next/src/server/app-render/module-loading/track-module-loading.instance.ts`
- `packages/next/src/server/app-render/app-render.tsx`

Closes NEXT-
Fixes #