### PR TITLE
Apply `buildArgs` also for deploy tests (via `package.json`)

### DIFF
--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -281,6 +281,9 @@ export class NextInstance {
                   ...pkgScripts,
                   build:
                     (pkgScripts['build'] || this.buildCommand || 'next build') +
+                    (this.buildArgs?.length
+                      ? ` ${this.buildArgs.join(' ')}`
+                      : '') +
                     ' && pnpm post-build',
                 },
               },

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -3,7 +3,6 @@ import path from 'path'
 const { version: nextVersion } = require('next/package.json')
 
 const cacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-
 const pprEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 describe('build-output-prerender', () => {

--- a/test/production/app-dir/no-mangling/no-mangling.test.ts
+++ b/test/production/app-dir/no-mangling/no-mangling.test.ts
@@ -16,7 +16,7 @@ describe('no-mangling', () => {
 
       expect(next.cliOutput).toInclude(`
 Error: Kaputt!
-    at `) // mangled function name omitted because it's undeterministic
+    at `) // mangled function name omitted because it's not deterministic
 
       // `Page` is the original function name that is mangled because `next
       // build` was called without `--no-mangling`.


### PR DESCRIPTION
This change ensures that the `buildArgs` specified in `nextTestSetup` are also applied when running deploy tests. This is achieved by modifying the build command in the `package.json` file used for deploy tests to include the specified `buildArgs`.

See also https://vercel.com/docs/builds/configure-a-build#build-command.

The only current e2e test that uses the `buildArgs` option is `test/e2e/react-compiler/react-compiler.test.ts`, but that one is excluded from deploy tests via `deploy-tests-manifest.json`.