### PR TITLE
Use rewritten pathname for implicit cache tags

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2017,9 +2017,22 @@ async function renderToHTMLOrFlightImpl(
 
   const isPossibleActionRequest = getIsPossibleServerAction(req)
 
+  // For implicit tags, we need to use the rewritten pathname (if a rewrite
+  // occurred) rather than the original request pathname. Implicit tags are used
+  // to check cache staleness on read (for 'use cache') and as soft tags for
+  // fetch cache. Using the destination path ensures that
+  // revalidatePath('/dest') invalidates cache entries for pages rewritten to
+  // that destination.
+  // TODO: simplify getImplicitTags to accept pathname instead of url object,
+  // and rename 'rewroteURL' to 'rewrittenPathname' in request-meta.ts.
+  const rewrittenPathname = getRequestMeta(req, 'rewroteURL')
+  const implicitTagsUrl = rewrittenPathname
+    ? { ...url, pathname: rewrittenPathname }
+    : url
+
   const implicitTags = await getImplicitTags(
     workStore.page,
-    url,
+    implicitTagsUrl,
     fallbackRouteParams
   )
 

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/app/api/revalidate/route.ts
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/app/api/revalidate/route.ts
@@ -1,0 +1,20 @@
+import { revalidatePath } from 'next/cache'
+import { NextRequest, NextResponse } from 'next/server'
+
+const isCacheComponentsEnabled = !!process.env.__NEXT_CACHE_COMPONENTS
+
+export async function GET(request: NextRequest) {
+  const sourcePath = request.nextUrl.searchParams.get('path')
+
+  if (!sourcePath) {
+    return NextResponse.json(
+      { error: 'Missing path parameter' },
+      { status: 400 }
+    )
+  }
+
+  const prefix = isCacheComponentsEnabled ? '/cache-components' : '/legacy'
+  revalidatePath(`${prefix}${sourcePath}`)
+
+  return NextResponse.json({ revalidated: true })
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/app/cache-components/dynamic/page.tsx
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/app/cache-components/dynamic/page.tsx
@@ -1,0 +1,21 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import SharedPage from '../../shared-page'
+
+async function CachedContent() {
+  'use cache: remote'
+  return <SharedPage isDynamic={true} />
+}
+
+async function Content() {
+  await connection()
+  return <CachedContent />
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/app/cache-components/static/page.tsx
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/app/cache-components/static/page.tsx
@@ -1,0 +1,6 @@
+import SharedPage from '../../shared-page'
+
+export default async function Page() {
+  'use cache'
+  return <SharedPage isDynamic={false} />
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/app/layout.tsx
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/app/legacy/dynamic/page.tsx
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/app/legacy/dynamic/page.tsx
@@ -1,0 +1,8 @@
+import SharedPage from '../../shared-page'
+
+export const dynamic = 'force-dynamic'
+export const fetchCache = 'force-cache'
+
+export default function Page() {
+  return <SharedPage isDynamic={true} />
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/app/legacy/static/page.tsx
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/app/legacy/static/page.tsx
@@ -1,0 +1,8 @@
+import SharedPage from '../../shared-page'
+
+export const revalidate = 900
+export const fetchCache = 'force-cache'
+
+export default function Page() {
+  return <SharedPage isDynamic={false} />
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/app/shared-page.tsx
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/app/shared-page.tsx
@@ -1,0 +1,23 @@
+async function getData() {
+  const res = await fetch(
+    'https://next-data-api-endpoint.vercel.app/api/random'
+  )
+  return res.text()
+}
+
+export default async function SharedPage({
+  isDynamic,
+}: {
+  isDynamic: boolean
+}) {
+  const data = await getData()
+
+  return (
+    <div>
+      <h1>{isDynamic ? 'Dynamic' : 'Static'} Page</h1>
+      <p>
+        Random data: <span id="random-data">{data}</span>
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/next.config.js
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/next.config.js
@@ -1,0 +1,21 @@
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
+/**
+ * @type {import('next').NextConfig}
+ */
+module.exports = {
+  rewrites: async () => [
+    {
+      source: '/static',
+      destination: isCacheComponentsEnabled
+        ? '/cache-components/static'
+        : '/legacy/static',
+    },
+    {
+      source: '/dynamic',
+      destination: isCacheComponentsEnabled
+        ? '/cache-components/dynamic'
+        : '/legacy/dynamic',
+    },
+  ],
+}

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/next.config.js
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/next.config.js
@@ -1,21 +1,24 @@
-const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-
 /**
  * @type {import('next').NextConfig}
  */
 module.exports = {
-  rewrites: async () => [
-    {
-      source: '/static',
-      destination: isCacheComponentsEnabled
-        ? '/cache-components/static'
-        : '/legacy/static',
-    },
-    {
-      source: '/dynamic',
-      destination: isCacheComponentsEnabled
-        ? '/cache-components/dynamic'
-        : '/legacy/dynamic',
-    },
-  ],
+  rewrites: async () => {
+    const isCacheComponentsEnabled =
+      process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
+    return [
+      {
+        source: '/static',
+        destination: isCacheComponentsEnabled
+          ? '/cache-components/static'
+          : '/legacy/static',
+      },
+      {
+        source: '/dynamic',
+        destination: isCacheComponentsEnabled
+          ? '/cache-components/dynamic'
+          : '/legacy/dynamic',
+      },
+    ]
+  },
 }

--- a/test/e2e/app-dir/revalidate-path-with-rewrites/revalidate-path-with-rewrites.test.ts
+++ b/test/e2e/app-dir/revalidate-path-with-rewrites/revalidate-path-with-rewrites.test.ts
@@ -1,0 +1,70 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
+
+describe('revalidatePath with rewrites', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    buildArgs: [
+      '--debug-build-paths',
+      isCacheComponentsEnabled
+        ? '!app/legacy/**/*'
+        : '!app/cache-components/**/*',
+    ],
+  })
+
+  describe('static page', () => {
+    it('should revalidate a static page that was rewritten', async () => {
+      const browser = await next.browser('/static')
+      const initialRandomData = await browser.elementById('random-data').text()
+
+      expect(initialRandomData).toBeTruthy()
+
+      // Verify the data is cached after refresh
+      await browser.refresh()
+      const refreshedRandomData = await browser
+        .elementById('random-data')
+        .text()
+      expect(refreshedRandomData).toBe(initialRandomData)
+
+      // Trigger revalidation via route handler
+      const revalidateRes = await next.fetch('/api/revalidate?path=/static')
+      expect(revalidateRes.status).toBe(200)
+
+      // Verify the data changed after revalidation
+      await retry(async () => {
+        await browser.refresh()
+        const randomData = await browser.elementById('random-data').text()
+        expect(randomData).not.toBe(initialRandomData)
+      })
+    })
+  })
+
+  describe('dynamic page', () => {
+    it('should revalidate a dynamic page that was rewritten', async () => {
+      const browser = await next.browser('/dynamic')
+      const initialRandomData = await browser.elementById('random-data').text()
+
+      expect(initialRandomData).toBeTruthy()
+
+      // Verify the data is cached after refresh
+      await browser.refresh()
+      const refreshedRandomData = await browser
+        .elementById('random-data')
+        .text()
+      expect(refreshedRandomData).toBe(initialRandomData)
+
+      // Trigger revalidation via route handler
+      const revalidateRes = await next.fetch('/api/revalidate?path=/dynamic')
+      expect(revalidateRes.status).toBe(200)
+
+      // Verify the data changed after revalidation
+      await retry(async () => {
+        await browser.refresh()
+        const randomData = await browser.elementById('random-data').text()
+        expect(randomData).not.toBe(initialRandomData)
+      })
+    })
+  })
+})


### PR DESCRIPTION
When a page is accessed via a rewrite, use the destination path (not the source path) when computing implicit tags. This ensures that calling `revalidatePath('/dest')` correctly invalidates cache entries for pages rewritten to that destination.

Fixes `'use cache'` and fetch cache with rewrites. ISR page cache was not affected because it already uses the rewritten pathname as the cache key (via `resolvedUrlPathname` in `base-server.ts`).