### PR TITLE
[metadata] match the Metadata and ResolvedMetadata type

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -387,6 +387,18 @@ async function mergeMetadata(
           newResolvedMetadata.other,
           metadata.other
         )
+        if (metadata.other) {
+          if ('apple-touch-fullscreen' in metadata.other) {
+            buildState.warnings.add(
+              `Use appleWebApp instead\nRead more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata`
+            )
+          }
+          if ('apple-touch-icon-precomposed' in metadata.other) {
+            buildState.warnings.add(
+              `Use icons.apple instead\nRead more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata`
+            )
+          }
+        }
         break
       case 'metadataBase':
         newResolvedMetadata.metadataBase = metadataBase

--- a/packages/next/src/lib/metadata/types/extra-types.ts
+++ b/packages/next/src/lib/metadata/types/extra-types.ts
@@ -92,7 +92,7 @@ export type ResolvedAppleWebApp = {
   statusBarStyle?: 'default' | 'black' | 'black-translucent' | undefined
 }
 
-export type Facebook = FacebookAppId | FacebookAdmins
+export type Facebook = FacebookAppId | FacebookAdmins | ResolvedFacebook
 export type FacebookAppId = {
   appId: string
   admins?: never | undefined
@@ -106,7 +106,7 @@ export type ResolvedFacebook = {
   admins?: string[] | undefined
 }
 
-export type Pinterest = PinterestRichPin
+export type Pinterest = PinterestRichPin | ResolvedPinterest
 export type PinterestRichPin = {
   richPin: string | boolean
 }

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -557,9 +557,9 @@ interface Metadata extends DeprecatedMetadataFields {
    * ```
    */
   other?:
-    | ({
+    | {
         [name: string]: string | number | Array<string | number>
-      } & DeprecatedMetadataFields)
+      }
     | undefined
 }
 

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -567,7 +567,7 @@ interface Metadata extends DeprecatedMetadataFields {
  * ResolvedMetadataWithURLs represents the fully processed metadata after
  * defaults are applied and relative URLs are composed with `metadataBase`.
  */
-interface ResolvedMetadataWithURLs extends DeprecatedMetadataFields {
+interface ResolvedMetadataWithURLs {
   // origin and base path for absolute urls for various metadata links such as
   // opengraph-image
   metadataBase: string | null | URL
@@ -657,11 +657,9 @@ interface ResolvedMetadataWithURLs extends DeprecatedMetadataFields {
   // meta name properties
   category: null | string
   classification: null | string
-  other:
-    | null
-    | ({
-        [name: string]: string | number | Array<string | number>
-      } & DeprecatedMetadataFields)
+  other: null | {
+    [name: string]: string | number | Array<string | number>
+  }
 }
 
 export type WithStringifiedURLs<T> = T extends URL

--- a/packages/next/src/lib/metadata/types/opengraph-types.ts
+++ b/packages/next/src/lib/metadata/types/opengraph-types.ts
@@ -45,7 +45,7 @@ type OpenGraphMetadata = {
   images?: OGImage | Array<OGImage> | undefined
   audio?: OGAudio | Array<OGAudio> | undefined
   videos?: OGVideo | Array<OGVideo> | undefined
-  url?: string | URL | undefined
+  url?: null | string | URL | undefined
   countryName?: string | undefined
   ttl?: number | undefined
 }

--- a/packages/next/src/lib/metadata/types/twitter-types.ts
+++ b/packages/next/src/lib/metadata/types/twitter-types.ts
@@ -11,11 +11,11 @@ export type Twitter =
 
 type TwitterMetadata = {
   // defaults to card="summary"
-  site?: string | undefined // username for account associated to the site itself
-  siteId?: string | undefined // id for account associated to the site itself
-  creator?: string | undefined // username for the account associated to the creator of the content on the site
-  creatorId?: string | undefined // id for the account associated to the creator of the content on the site
-  description?: string | undefined
+  site?: null | string | undefined // username for account associated to the site itself
+  siteId?: null | string | undefined // id for account associated to the site itself
+  creator?: null | string | undefined // username for the account associated to the creator of the content on the site
+  creatorId?: null | string | undefined // id for the account associated to the creator of the content on the site
+  description?: null | string | undefined
   title?: string | TemplateString | undefined
   images?: TwitterImage | Array<TwitterImage> | undefined
 }

--- a/test/e2e/app-dir/metadata-warnings/app/deprecated-other-fields/page.js
+++ b/test/e2e/app-dir/metadata-warnings/app/deprecated-other-fields/page.js
@@ -1,0 +1,10 @@
+export default function Page() {
+  return 'deprecated other fields'
+}
+
+export const metadata = {
+  other: {
+    'apple-touch-fullscreen': 'yes',
+    'apple-touch-icon-precomposed': '/icon.png',
+  },
+}

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
@@ -70,4 +70,12 @@ describe('app dir - metadata missing metadataBase', () => {
     const output = next.cliOutput.slice(outputLength)
     expect(output).not.toContain('Unsupported metadata viewport')
   })
+
+  it('should warn for deprecated fields in other property', async () => {
+    const logStartPosition = next.cliOutput.length
+    await next.fetch('/deprecated-other-fields')
+    const output = getCliOutput(logStartPosition)
+    expect(output).toInclude('Use appleWebApp instead')
+    expect(output).toInclude('Use icons.apple instead')
+  })
 })

--- a/test/production/app-dir/metadata-spread-types/app/layout.tsx
+++ b/test/production/app-dir/metadata-spread-types/app/layout.tsx
@@ -1,0 +1,27 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Layout title',
+  description: 'Layout description',
+  openGraph: {
+    title: 'Layout OG title',
+    description: 'Layout OG description',
+    url: 'https://example.com',
+    siteName: 'Example Site',
+  },
+  twitter: {
+    card: 'summary',
+    title: 'Layout Twitter title',
+    description: 'Layout Twitter description',
+    site: '@example',
+    creator: '@creator',
+  },
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/metadata-spread-types/app/page.tsx
+++ b/test/production/app-dir/metadata-spread-types/app/page.tsx
@@ -1,0 +1,27 @@
+import type { Metadata, ResolvingMetadata } from 'next'
+
+export default function Page() {
+  return <p>Spread parent metadata test</p>
+}
+
+export async function generateMetadata(
+  _: unknown,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  const resolvedParent = await parent
+
+  return {
+    title: 'Page title',
+    description: 'Page description',
+    openGraph: {
+      ...resolvedParent.openGraph,
+      title: 'Page OG title',
+      description: 'Page OG description',
+    },
+    twitter: {
+      ...resolvedParent.twitter,
+      title: 'Page Twitter title',
+      description: 'Page Twitter description',
+    },
+  }
+}

--- a/test/production/app-dir/metadata-spread-types/app/spread-all/page.tsx
+++ b/test/production/app-dir/metadata-spread-types/app/spread-all/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata, ResolvingMetadata } from 'next'
+
+export async function generateMetadata(
+  _: unknown,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+  const parentMeta = await parent
+
+  return { ...parentMeta, title: 'Spread all page' }
+}
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Spread all page</h1>
+      <p>This page spreads the entire parent metadata</p>
+    </div>
+  )
+}

--- a/test/production/app-dir/metadata-spread-types/metadata-spread-types.test.ts
+++ b/test/production/app-dir/metadata-spread-types/metadata-spread-types.test.ts
@@ -1,0 +1,46 @@
+import { nextTestSetup } from 'e2e-utils'
+import { createMultiDomMatcher } from 'next-test-utils'
+
+describe('metadata spread types', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should allow spreading resolved parent metadata into child metadata', async () => {
+    const browser = await next.browser('/')
+    const matchMultiDom = createMultiDomMatcher(browser)
+
+    // Verify page title from child's generateMetadata
+    expect(await browser.eval(`document.title`)).toBe('Page title')
+
+    // Verify openGraph metadata is correctly merged
+    await matchMultiDom('meta', 'property', 'content', {
+      'og:title': 'Page OG title',
+      'og:description': 'Page OG description',
+      'og:url': 'https://example.com',
+      'og:site_name': 'Example Site',
+    })
+
+    // Verify twitter metadata is correctly merged
+    await matchMultiDom('meta', 'name', 'content', {
+      'twitter:title': 'Page Twitter title',
+      'twitter:description': 'Page Twitter description',
+      'twitter:site': '@example',
+      'twitter:creator': '@creator',
+    })
+  })
+
+  it('should allow spreading entire resolved parent metadata', async () => {
+    const browser = await next.browser('/spread-all')
+
+    // Verify page title is overridden
+    expect(await browser.eval(`document.title`)).toBe('Spread all page')
+
+    // Verify parent metadata is inherited
+    expect(
+      await browser.eval(
+        `document.querySelector('meta[name="description"]')?.content`
+      )
+    ).toBe('Layout description')
+  })
+})

--- a/test/production/app-dir/metadata-spread-types/next.config.js
+++ b/test/production/app-dir/metadata-spread-types/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/test/unit/metadata-types-compatibility.test.ts
+++ b/test/unit/metadata-types-compatibility.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Type compatibility tests for Metadata and ResolvedMetadata.
+ *
+ * These tests verify that ResolvedMetadata properties can be assigned to
+ * Metadata input types. This is important because users often want to
+ * extend parent metadata in generateMetadata:
+ *
+ * ```ts
+ * export async function generateMetadata(_, parent: ResolvingMetadata) {
+ *   const resolved = await parent
+ *   return {
+ *     openGraph: {
+ *       ...resolved.openGraph,  // Should not cause type errors
+ *       title: 'Override title',
+ *     },
+ *   }
+ * }
+ * ```
+ *
+ * If these tests fail, it means ResolvedMetadata has properties
+ * that are not assignable to Metadata (e.g., `null` vs `undefined` mismatch).
+ */
+
+import type { Metadata, ResolvedMetadata } from 'next'
+import { expectTypeOf } from 'expect-type'
+
+// Extract property types for comparison
+type ResolvedOpenGraphUrl = NonNullable<ResolvedMetadata['openGraph']>['url']
+type MetadataOpenGraphUrl = NonNullable<Metadata['openGraph']>['url']
+
+type ResolvedTwitterSite = NonNullable<ResolvedMetadata['twitter']>['site']
+type MetadataTwitterSite = NonNullable<Metadata['twitter']>['site']
+
+type ResolvedTwitterCreator = NonNullable<
+  ResolvedMetadata['twitter']
+>['creator']
+type MetadataTwitterCreator = NonNullable<Metadata['twitter']>['creator']
+
+type ResolvedTwitterSiteId = NonNullable<ResolvedMetadata['twitter']>['siteId']
+type MetadataTwitterSiteId = NonNullable<Metadata['twitter']>['siteId']
+
+type ResolvedTwitterCreatorId = NonNullable<
+  ResolvedMetadata['twitter']
+>['creatorId']
+type MetadataTwitterCreatorId = NonNullable<Metadata['twitter']>['creatorId']
+
+type ResolvedTwitterDescription = NonNullable<
+  ResolvedMetadata['twitter']
+>['description']
+type MetadataTwitterDescription = NonNullable<
+  Metadata['twitter']
+>['description']
+
+type ResolvedFacebookType = NonNullable<ResolvedMetadata['facebook']>
+type MetadataFacebookType = NonNullable<Metadata['facebook']>
+
+type ResolvedPinterestType = NonNullable<ResolvedMetadata['pinterest']>
+type MetadataPinterestType = NonNullable<Metadata['pinterest']>
+
+describe('Metadata and ResolvedMetadata type compatibility', () => {
+  describe('top-level ResolvedMetadata', () => {
+    it('should have ResolvedMetadata assignable to Metadata', () => {
+      // This tests spreading the entire resolved metadata: { ...parentMeta, title: 'Test' }
+      expectTypeOf<ResolvedMetadata>().toMatchTypeOf<Metadata>()
+    })
+  })
+
+  describe('openGraph property types', () => {
+    it('should have ResolvedOpenGraph.url assignable to Metadata.openGraph.url', () => {
+      expectTypeOf<ResolvedOpenGraphUrl>().toMatchTypeOf<MetadataOpenGraphUrl>()
+    })
+  })
+
+  describe('twitter property types', () => {
+    it('should have ResolvedTwitter.site assignable to Metadata.twitter.site', () => {
+      expectTypeOf<ResolvedTwitterSite>().toMatchTypeOf<MetadataTwitterSite>()
+    })
+
+    it('should have ResolvedTwitter.siteId assignable to Metadata.twitter.siteId', () => {
+      expectTypeOf<ResolvedTwitterSiteId>().toMatchTypeOf<MetadataTwitterSiteId>()
+    })
+
+    it('should have ResolvedTwitter.creator assignable to Metadata.twitter.creator', () => {
+      expectTypeOf<ResolvedTwitterCreator>().toMatchTypeOf<MetadataTwitterCreator>()
+    })
+
+    it('should have ResolvedTwitter.creatorId assignable to Metadata.twitter.creatorId', () => {
+      expectTypeOf<ResolvedTwitterCreatorId>().toMatchTypeOf<MetadataTwitterCreatorId>()
+    })
+
+    it('should have ResolvedTwitter.description assignable to Metadata.twitter.description', () => {
+      expectTypeOf<ResolvedTwitterDescription>().toMatchTypeOf<MetadataTwitterDescription>()
+    })
+  })
+
+  describe('facebook property types', () => {
+    it('should have ResolvedFacebook assignable to Metadata.facebook', () => {
+      expectTypeOf<ResolvedFacebookType>().toMatchTypeOf<MetadataFacebookType>()
+    })
+  })
+
+  describe('pinterest property types', () => {
+    it('should have ResolvedPinterest assignable to Metadata.pinterest', () => {
+      expectTypeOf<ResolvedPinterestType>().toMatchTypeOf<MetadataPinterestType>()
+    })
+  })
+})


### PR DESCRIPTION
Fix type compatibility between ResolvedMetadata and Metadata to allow spreading resolved parent metadata in generateMetadata.

### Problem
Users couldn't spread resolved metadata into new metadata objects:

```tsx
export async function generateMetadata(_, parent: ResolvingMetadata) {
  const resolved = await parent
  return { ...resolved, title: 'Page' }
}
```

### Changes
- Add `null` to og's `url`
- Add `null` to twitter's `site`, `siteId`, `creator`, `creatorId`, `description`
- Add `ResolvedFacebook` and `ResolvedPinterest` to input union types
- Remove `DeprecatedMetadataFields` from `ResolvedMetadataWithURLs` and resolved `other` type, show warnings instead

Closes #59950 
Closes #88720
Closes NXT-135