### PR TITLE
[test] Deflake `test/development/app-dir/hydration-error-count/hydration-error-count.test.ts`

### DIFF
--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -334,11 +334,11 @@ describe('hydration-error-count', () => {
   it('should display runtime error separately from hydration errors', async () => {
     const browser = await next.browser('/hydration-with-runtime-errors')
 
-    if (process.env.__NEXT_CACHE_COMPONENTS) {
-      await expect(browser).toDisplayRedbox(`
-       [
-         {
-           "componentStack": "...
+    await expect(browser).toDisplayRedbox(`
+     [
+       {
+         "componentStack": "...
+         <Next.js Internal Component>
            <Next.js Internal Component>
              <Next.js Internal Component>
                <Next.js Internal Component>
@@ -349,55 +349,49 @@ describe('hydration-error-count', () => {
                          <Next.js Internal Component>
                            <Next.js Internal Component>
                              <Next.js Internal Component>
-                               <Next.js Internal Component>
-                               <Next.js Internal Component>
-                                 <Page params={Promise} searchParams={Promise}>
-       >                           <p>
-       >                             <p>
-                             ...
+                             <Next.js Internal Component>
+                               <Page params={Promise} searchParams={Promise}>
+     >                           <p>
+     >                             <p>
                            ...
-                 ...",
-           "description": "In HTML, <p> cannot be a descendant of <p>.
-       This will cause a hydration error.",
-           "environmentLabel": null,
-           "label": "Console Error",
-           "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
-       > 12 |       sneaky <p>very sneaky</p>
-            |              ^",
-           "stack": [
-             "p <anonymous>",
-             "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
-           ],
-         },
-         {
-           "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
-           "environmentLabel": null,
-           "label": "Recoverable Error",
-           "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
-       > 12 |       sneaky <p>very sneaky</p>
-            |              ^",
-           "stack": [
-             "p <anonymous>",
-             "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
-           ],
-         },
-         {
-           "description": "runtime error",
-           "environmentLabel": null,
-           "label": "Runtime Error",
-           "source": "app/hydration-with-runtime-errors/page.tsx (7:11) @ Page.useEffect
-       >  7 |     throw new Error('runtime error')
-            |           ^",
-           "stack": [
-             "Page.useEffect app/hydration-with-runtime-errors/page.tsx (7:11)",
-           ],
-         },
-       ]
-      `)
-    } else {
-      await expect(browser).toDisplayCollapsedRedbox(
-        `"Redbox is already open. Use \`toDisplayRedbox\` instead."`
-      )
-    }
+                         ...
+               ...",
+         "description": "In HTML, <p> cannot be a descendant of <p>.
+     This will cause a hydration error.",
+         "environmentLabel": null,
+         "label": "Console Error",
+         "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
+     > 12 |       sneaky <p>very sneaky</p>
+          |              ^",
+         "stack": [
+           "p <anonymous>",
+           "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
+         ],
+       },
+       {
+         "description": "Hydration failed because the server rendered HTML didn't match the client. As a result this tree will be regenerated on the client. This can happen if a SSR-ed Client Component used:",
+         "environmentLabel": null,
+         "label": "Recoverable Error",
+         "source": "app/hydration-with-runtime-errors/page.tsx (12:14) @ Page
+     > 12 |       sneaky <p>very sneaky</p>
+          |              ^",
+         "stack": [
+           "p <anonymous>",
+           "Page app/hydration-with-runtime-errors/page.tsx (12:14)",
+         ],
+       },
+       {
+         "description": "runtime error",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/hydration-with-runtime-errors/page.tsx (7:11) @ Page.useEffect
+     >  7 |     throw new Error('runtime error')
+          |           ^",
+         "stack": [
+           "Page.useEffect app/hydration-with-runtime-errors/page.tsx (7:11)",
+         ],
+       },
+     ]
+    `)
   })
 })


### PR DESCRIPTION
`toDisplayCollapsedRedbox` was just used to avoid having to update the snapshot with internals when we were burning down Cache Component issues. With https://github.com/vercel/next.js/issues/85420, we are coupled less to Next.js implementation detail and can unfork the assertion.

Fixes https://github.com/vercel/next.js/actions/runs/21143919092/job/60805285699?pr=88746#step:33:1477