### PR TITLE
Simplify `getImplicitTags` to accept pathname instead of url object

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2023,15 +2023,12 @@ async function renderToHTMLOrFlightImpl(
   // fetch cache. Using the destination path ensures that
   // revalidatePath('/dest') invalidates cache entries for pages rewritten to
   // that destination.
-  // TODO: simplify getImplicitTags to accept pathname instead of url object.
-  const rewrittenPathname = getRequestMeta(req, 'rewrittenPathname')
-  const implicitTagsUrl = rewrittenPathname
-    ? { ...url, pathname: rewrittenPathname }
-    : url
+  const implicitTagsPathname =
+    getRequestMeta(req, 'rewrittenPathname') || url.pathname
 
   const implicitTags = await getImplicitTags(
     workStore.page,
-    implicitTagsUrl,
+    implicitTagsPathname,
     fallbackRouteParams
   )
 

--- a/packages/next/src/server/lib/implicit-tags.test.ts
+++ b/packages/next/src/server/lib/implicit-tags.test.ts
@@ -4,49 +4,49 @@ import { getImplicitTags } from './implicit-tags'
 describe('getImplicitTags()', () => {
   it.each<{
     page: string
-    url: { pathname: string; search: string }
+    pathname: string
     fallbackRouteParams: null | OpaqueFallbackRouteParams
     expectedTags: string[]
   }>([
     {
       page: '/',
-      url: { pathname: '/', search: '' },
+      pathname: '/',
       fallbackRouteParams: null,
       expectedTags: ['_N_T_/layout', '_N_T_/', '_N_T_/index'],
     },
     {
       page: '',
-      url: { pathname: '/', search: '' },
+      pathname: '/',
       fallbackRouteParams: null,
       expectedTags: ['_N_T_/layout', '_N_T_/', '_N_T_/index'],
     },
     {
       page: '/',
-      url: { pathname: '', search: '' },
+      pathname: '',
       fallbackRouteParams: null,
       expectedTags: ['_N_T_/layout'],
     },
     {
       page: '/page',
-      url: { pathname: '', search: '' },
+      pathname: '',
       fallbackRouteParams: null,
       expectedTags: ['_N_T_/layout', '_N_T_/page'],
     },
     {
       page: '/page',
-      url: { pathname: '/', search: '' },
+      pathname: '/',
       fallbackRouteParams: null,
       expectedTags: ['_N_T_/layout', '_N_T_/page', '_N_T_/', '_N_T_/index'],
     },
     {
       page: '/page',
-      url: { pathname: '/page', search: '' },
+      pathname: '/page',
       fallbackRouteParams: null,
       expectedTags: ['_N_T_/layout', '_N_T_/page'],
     },
     {
       page: '/index',
-      url: { pathname: '/', search: '' },
+      pathname: '/',
       fallbackRouteParams: null,
       expectedTags: [
         '_N_T_/layout',
@@ -57,13 +57,13 @@ describe('getImplicitTags()', () => {
     },
     {
       page: '/hello',
-      url: { pathname: '/hello', search: '' },
+      pathname: '/hello',
       fallbackRouteParams: null,
       expectedTags: ['_N_T_/layout', '_N_T_/hello/layout', '_N_T_/hello'],
     },
     {
       page: '/foo/bar/baz',
-      url: { pathname: '/foo/bar/baz', search: '' },
+      pathname: '/foo/bar/baz',
       fallbackRouteParams: null,
       expectedTags: [
         '_N_T_/layout',
@@ -74,9 +74,9 @@ describe('getImplicitTags()', () => {
       ],
     },
   ])(
-    'for page $page with url $url and $fallback',
-    async ({ page, url, fallbackRouteParams, expectedTags }) => {
-      const result = await getImplicitTags(page, url, fallbackRouteParams)
+    'for page $page with pathname $pathname',
+    async ({ page, pathname, fallbackRouteParams, expectedTags }) => {
+      const result = await getImplicitTags(page, pathname, fallbackRouteParams)
       expect(result.tags).toEqual(expectedTags)
     }
   )

--- a/packages/next/src/server/lib/implicit-tags.ts
+++ b/packages/next/src/server/lib/implicit-tags.ts
@@ -73,10 +73,7 @@ function createTagsExpirationsByCacheKind(
 
 export async function getImplicitTags(
   page: string,
-  url: {
-    pathname: string
-    search?: string
-  },
+  pathname: string,
   fallbackRouteParams: null | OpaqueFallbackRouteParams
 ): Promise<ImplicitTags> {
   const tags = new Set<string>()
@@ -90,11 +87,8 @@ export async function getImplicitTags(
 
   // Add the tags from the pathname. If the route has unknown params, we don't
   // want to add the pathname as a tag, as it will be invalid.
-  if (
-    url.pathname &&
-    (!fallbackRouteParams || fallbackRouteParams.size === 0)
-  ) {
-    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${url.pathname}`
+  if (pathname && (!fallbackRouteParams || fallbackRouteParams.size === 0)) {
+    const tag = `${NEXT_CACHE_IMPLICIT_TAG_ID}${pathname}`
     tags.add(tag)
   }
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -703,7 +703,7 @@ export class AppRouteRouteModule extends RouteModule<
 
     const implicitTags = await getImplicitTags(
       this.definition.page,
-      req.nextUrl,
+      req.nextUrl.pathname,
       // App Routes don't support unknown route params.
       null
     )

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -283,7 +283,7 @@ export async function adapter(
 
             const implicitTags = await getImplicitTags(
               page,
-              request.nextUrl,
+              request.nextUrl.pathname,
               fallbackRouteParams
             )
 


### PR DESCRIPTION
The function only used `url.pathname`, not `url.search`.