### PR TITLE
[test] Deflake `test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts`

### DIFF
--- a/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
@@ -15,6 +15,7 @@ describe('browser-log-forwarding verbose level', () => {
       expect(output).toContain('browser error:')
       expect(output).toContain('browser warn:')
       expect(output).toContain('browser log:')
+      expect(output).toContain('browser debug:')
     })
 
     // Get final output after logs are forwarded


### PR DESCRIPTION

Fixes

```
  browser-log-forwarding verbose level › should forward all logs to terminal

  expect(received).toMatchInlineSnapshot(snapshot)

  Snapshot name: `browser-log-forwarding verbose level should forward all logs to terminal 1`

  - Snapshot  - 1
  + Received  + 0

  [browser] browser log: this is a log message (app/page.tsx:7:13)
  [browser] browser info: this is an info message (app/page.tsx:8:13)
  [browser] browser warn: this is a warning message (app/page.tsx:9:13)
  [browser] browser error: this is an error message 
- [browser] browser debug: this is a debug message (app/page.tsx:11:13)
```

-- https://github.com/vercel/next.js/actions/runs/21144881207/job/60808114267#step:33:281