### PR TITLE
Turbopack: Use operations for global information and module graph

### DIFF
--- a/crates/next-api/src/analyze.rs
+++ b/crates/next-api/src/analyze.rs
@@ -437,8 +437,8 @@ pub async fn analyze_module_graphs(module_graphs: Vc<ModuleGraphs>) -> Result<Vc
     let mut all_modules = FxIndexSet::default();
     let mut all_edges = FxIndexSet::default();
     let mut all_async_edges = FxIndexSet::default();
-    for &module_graph in module_graphs.await? {
-        let module_graph = module_graph.await?;
+    for module_graph in module_graphs.await?.iter() {
+        let module_graph = module_graph.connect().await?;
         module_graph.traverse_edges_unordered(|parent, node| {
             if let Some((parent_node, reference)) = parent {
                 all_modules.insert(parent_node);

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1008,8 +1008,8 @@ impl AppProject {
                 };
 
                 Ok(BaseAndFullModuleGraph {
-                    base: base.connect().to_resolved().await?,
-                    full: full.connect().to_resolved().await?,
+                    base,
+                    full,
                     binding_usage_info,
                 }
                 .cell())
@@ -1287,7 +1287,7 @@ impl AppEndpoint {
                 AssetIdent::from_path(project.project_path().owned().await?)
                     .with_modifier(rcstr!("client-shared-chunks")),
                 this.app_project.client_runtime_entries(),
-                *module_graphs.full,
+                module_graphs.full.connect(),
                 *client_chunking_context,
             );
 
@@ -1305,14 +1305,14 @@ impl AppEndpoint {
         let per_page_module_graph = *project.per_page_module_graph().await?;
 
         let next_dynamic_imports =
-            NextDynamicGraphs::new(*module_graphs.base, per_page_module_graph)
+            NextDynamicGraphs::new(module_graphs.base.connect(), per_page_module_graph)
                 .get_next_dynamic_imports_for_endpoint(*rsc_entry)
                 .await?;
 
         let is_production = project.next_mode().await?.is_production();
 
         let client_references =
-            ClientReferencesGraphs::new(*module_graphs.base, per_page_module_graph)
+            ClientReferencesGraphs::new(module_graphs.base.connect(), per_page_module_graph)
                 .get_client_references_for_endpoint(
                     *rsc_entry,
                     matches!(this.ty, AppEndpointType::Page { .. }),
@@ -1324,7 +1324,7 @@ impl AppEndpoint {
 
         let client_references_chunks = get_app_client_references_chunks(
             *client_references,
-            *module_graphs.full,
+            module_graphs.full.connect(),
             *client_chunking_context,
             availability_info,
             ssr_chunking_context.map(|ctx| *ctx),
@@ -1432,7 +1432,7 @@ impl AppEndpoint {
             }
         }
 
-        let actions = ServerActionsGraphs::new(*module_graphs.base, per_page_module_graph)
+        let actions = ServerActionsGraphs::new(module_graphs.base.connect(), per_page_module_graph)
             .get_server_actions_for_endpoint(
                 *rsc_entry,
                 match runtime {
@@ -1451,7 +1451,7 @@ impl AppEndpoint {
                 NextRuntime::Edge => Vc::upcast(this.app_project.edge_rsc_module_context()),
                 NextRuntime::NodeJs => Vc::upcast(this.app_project.rsc_module_context()),
             },
-            *module_graphs.full,
+            module_graphs.full.connect(),
             this.app_project
                 .project()
                 .runtime_chunking_context(process_client_assets, runtime),
@@ -1469,7 +1469,7 @@ impl AppEndpoint {
                 *server_action_manifest_loader,
                 server_path.clone(),
                 process_client_assets,
-                *module_graphs.full,
+                module_graphs.full.connect(),
             )
             .to_resolved()
             .await?;
@@ -1491,7 +1491,12 @@ impl AppEndpoint {
                     client_references_chunks,
                     client_chunking_context,
                     ssr_chunking_context,
-                    async_module_info: module_graphs.full.async_module_info().to_resolved().await?,
+                    async_module_info: module_graphs
+                        .full
+                        .connect()
+                        .async_module_info()
+                        .to_resolved()
+                        .await?,
                     next_config: project.next_config().to_resolved().await?,
                     runtime,
                     mode: *project.next_mode().await?,
@@ -1574,7 +1579,7 @@ impl AppEndpoint {
 
                 if emit_manifests == EmitManifests::Full {
                     let dynamic_import_entries = collect_next_dynamic_chunks(
-                        *module_graphs.full,
+                        module_graphs.full.connect(),
                         *client_chunking_context,
                         next_dynamic_imports,
                         NextDynamicChunkAvailability::ClientReferences(
@@ -1698,7 +1703,7 @@ impl AppEndpoint {
                 let loadable_manifest_output = if emit_manifests == EmitManifests::Full {
                     // create react-loadable-manifest for next/dynamic
                     let dynamic_import_entries = collect_next_dynamic_chunks(
-                        *module_graphs.full,
+                        module_graphs.full.connect(),
                         *client_chunking_context,
                         next_dynamic_imports,
                         NextDynamicChunkAvailability::ClientReferences(

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -30,7 +30,7 @@ use crate::{
     paths::{
         all_asset_paths, get_js_paths_from_root, get_wasm_paths_from_root, wasm_paths_to_bindings,
     },
-    project::Project,
+    project::{Project, get_module_graph_operation},
     route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs},
 };
 
@@ -247,9 +247,11 @@ impl Endpoint for InstrumentationEndpoint {
     #[turbo_tasks::function]
     async fn module_graphs(self: Vc<Self>) -> Result<Vc<ModuleGraphs>> {
         let this = self.await?;
-        let module = self.entry_module();
-        let module_graph = this.project.module_graph(module).to_resolved().await?;
-        Ok(Vc::cell(vec![module_graph]))
+        let module = self.entry_module().to_resolved().await?;
+        Ok(Vc::cell(vec![get_module_graph_operation(
+            this.project,
+            module,
+        )]))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -33,7 +33,7 @@ use crate::{
         all_asset_paths, all_paths_in_root, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
-    project::Project,
+    project::{Project, get_module_graph_operation},
     route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs},
 };
 
@@ -394,12 +394,11 @@ impl Endpoint for MiddlewareEndpoint {
     #[turbo_tasks::function]
     async fn module_graphs(self: Vc<Self>) -> Result<Vc<ModuleGraphs>> {
         let this = self.await?;
-        let module_graph = this
-            .project
-            .module_graph(self.entry_module())
-            .to_resolved()
-            .await?;
-        Ok(Vc::cell(vec![module_graph]))
+        let module = self.entry_module().to_resolved().await?;
+        Ok(Vc::cell(vec![get_module_graph_operation(
+            this.project,
+            module,
+        )]))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -78,7 +78,7 @@ use crate::{
         all_asset_paths, all_paths_in_root, get_asset_paths_from_root, get_js_paths_from_root,
         get_wasm_paths_from_root, paths_to_bindings, wasm_paths_to_bindings,
     },
-    project::Project,
+    project::{Project, get_module_graph_for_modules_operation},
     route::{Endpoint, EndpointOutput, EndpointOutputPaths, ModuleGraphs, Route, Routes},
     sri_manifest::get_sri_manifest_asset,
 };
@@ -699,71 +699,13 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn client_module_graph(self: Vc<Self>) -> Result<Vc<ModuleGraph>> {
-        let this = self.await?;
-        let project = this.pages_project.project();
-        let evaluatable_assets = self.client_evaluatable_assets();
-        Ok(project.module_graph_for_modules(evaluatable_assets))
+    async fn client_module_graph(self: ResolvedVc<Self>) -> Result<Vc<ModuleGraph>> {
+        Ok(get_pages_client_module_graph_operation(self).connect())
     }
 
     #[turbo_tasks::function]
-    async fn ssr_module_graph(self: Vc<Self>) -> Result<Vc<ModuleGraph>> {
-        let this = self.await?;
-        let project = this.pages_project.project();
-
-        if *project.per_page_module_graph().await? {
-            let next_mode = project.next_mode();
-            let next_mode_ref = next_mode.await?;
-            let should_trace = next_mode_ref.is_production();
-            let should_read_binding_usage = next_mode_ref.is_production();
-
-            let ssr_chunk_module = self.internal_ssr_chunk_module().await?;
-            // Implements layout segment optimization to compute a graph "chain" for document, app,
-            // page
-            let mut graphs = vec![];
-            let mut visited_modules = VisitedModules::empty();
-            for module in [
-                ssr_chunk_module.document_module,
-                ssr_chunk_module.app_module,
-            ]
-            .into_iter()
-            .flatten()
-            {
-                let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                    vec![ChunkGroupEntry::Shared(module)],
-                    visited_modules,
-                    should_trace,
-                    should_read_binding_usage,
-                );
-                graphs.push(graph);
-                visited_modules = VisitedModules::concatenate(visited_modules, graph);
-            }
-
-            let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                vec![ChunkGroupEntry::Entry(vec![ssr_chunk_module.ssr_module])],
-                visited_modules,
-                should_trace,
-                should_read_binding_usage,
-            );
-            graphs.push(graph);
-
-            let remove_unused_imports = *project
-                .next_config()
-                .turbopack_remove_unused_imports(next_mode)
-                .await?;
-
-            let graph = if remove_unused_imports {
-                let graph = ModuleGraph::from_graphs(graphs.clone());
-                let binding_usage_info = compute_binding_usage_info(graph, true);
-                ModuleGraph::from_graphs_without_unused_references(graphs, binding_usage_info)
-            } else {
-                ModuleGraph::from_graphs(graphs)
-            };
-
-            Ok(graph.connect())
-        } else {
-            Ok(*project.whole_app_module_graphs().await?.full)
-        }
+    async fn ssr_module_graph(self: ResolvedVc<Self>) -> Result<Vc<ModuleGraph>> {
+        Ok(get_pages_ssr_module_graph_operation(self).connect())
     }
 
     #[turbo_tasks::function]
@@ -1712,13 +1654,12 @@ impl Endpoint for PageEndpoint {
 
     #[turbo_tasks::function]
     async fn module_graphs(self: Vc<Self>) -> Result<Vc<ModuleGraphs>> {
-        let client_module_graph = self.client_module_graph().to_resolved().await?;
-        let ssr_module_graph = self.ssr_module_graph().to_resolved().await?;
-        Ok(Vc::cell(if client_module_graph != ssr_module_graph {
-            vec![client_module_graph, ssr_module_graph]
-        } else {
-            vec![ssr_module_graph]
-        }))
+        let this = self.to_resolved().await?;
+        let client_module_graph = get_pages_client_module_graph_operation(this);
+        let ssr_module_graph = get_pages_ssr_module_graph_operation(this);
+        // Note: We can't easily deduplicate these anymore since OperationVc
+        // doesn't implement Eq, but that's fine - they're operation references
+        Ok(Vc::cell(vec![client_module_graph, ssr_module_graph]))
     }
 
     #[turbo_tasks::function]
@@ -1786,4 +1727,76 @@ pub enum SsrChunk {
         dynamic_import_entries: ResolvedVc<DynamicImportedChunks>,
         regions: Option<Vec<RcStr>>,
     },
+}
+
+#[turbo_tasks::function(operation)]
+async fn get_pages_client_module_graph_operation(
+    endpoint: ResolvedVc<PageEndpoint>,
+) -> Result<Vc<ModuleGraph>> {
+    let this = endpoint.await?;
+    let project = this.pages_project.project().to_resolved().await?;
+    let evaluatable_assets = endpoint.client_evaluatable_assets().to_resolved().await?;
+    Ok(get_module_graph_for_modules_operation(project, evaluatable_assets).connect())
+}
+
+#[turbo_tasks::function(operation)]
+async fn get_pages_ssr_module_graph_operation(
+    endpoint: ResolvedVc<PageEndpoint>,
+) -> Result<Vc<ModuleGraph>> {
+    let this = endpoint.await?;
+    let project = this.pages_project.project();
+
+    if *project.per_page_module_graph().await? {
+        let next_mode = project.next_mode();
+        let next_mode_ref = next_mode.await?;
+        let should_trace = next_mode_ref.is_production();
+        let should_read_binding_usage = next_mode_ref.is_production();
+
+        let ssr_chunk_module = endpoint.internal_ssr_chunk_module().await?;
+        // Implements layout segment optimization to compute a graph "chain" for document, app,
+        // page
+        let mut graphs = vec![];
+        let mut visited_modules = VisitedModules::empty();
+        for module in [
+            ssr_chunk_module.document_module,
+            ssr_chunk_module.app_module,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let graph = SingleModuleGraph::new_with_entries_visited_intern(
+                vec![ChunkGroupEntry::Shared(module)],
+                visited_modules,
+                should_trace,
+                should_read_binding_usage,
+            );
+            graphs.push(graph);
+            visited_modules = VisitedModules::concatenate(visited_modules, graph);
+        }
+
+        let graph = SingleModuleGraph::new_with_entries_visited_intern(
+            vec![ChunkGroupEntry::Entry(vec![ssr_chunk_module.ssr_module])],
+            visited_modules,
+            should_trace,
+            should_read_binding_usage,
+        );
+        graphs.push(graph);
+
+        let remove_unused_imports = *project
+            .next_config()
+            .turbopack_remove_unused_imports(next_mode)
+            .await?;
+
+        let graph = if remove_unused_imports {
+            let graph = ModuleGraph::from_graphs(graphs.clone());
+            let binding_usage_info = compute_binding_usage_info(graph, true);
+            ModuleGraph::from_graphs_without_unused_references(graphs, binding_usage_info)
+        } else {
+            ModuleGraph::from_graphs(graphs)
+        };
+
+        Ok(graph.connect())
+    } else {
+        Ok(project.whole_app_module_graphs().await?.full.connect())
+    }
 }

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1744,7 +1744,7 @@ async fn get_pages_ssr_module_graph_operation(
     endpoint: ResolvedVc<PageEndpoint>,
 ) -> Result<Vc<ModuleGraph>> {
     let this = endpoint.await?;
-    let project = this.pages_project.project();
+    let project = this.pages_project.project().to_resolved().await?;
 
     if *project.per_page_module_graph().await? {
         let next_mode = project.next_mode();

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -66,9 +66,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{
         GraphEntries, ModuleGraph, SingleModuleGraph, VisitedModules,
-        binding_usage_info::{
-            BindingUsageInfo, OptionBindingUsageInfo, compute_binding_usage_info,
-        },
+        binding_usage_info::{BindingUsageInfo, compute_binding_usage_info, get_unused_references},
         chunk_group_info::ChunkGroupEntry,
     },
     output::{
@@ -1441,17 +1439,8 @@ impl Project {
         self: Vc<Self>,
         entry: ResolvedVc<Box<dyn Module>>,
     ) -> Result<Vc<ModuleGraph>> {
-        Ok(if *self.per_page_module_graph().await? {
-            let is_production = self.next_mode().await?.is_production();
-            ModuleGraph::from_single_graph(SingleModuleGraph::new_with_entry(
-                ChunkGroupEntry::Entry(vec![entry]),
-                is_production,
-                is_production,
-            ))
-            .connect()
-        } else {
-            *self.whole_app_module_graphs().await?.full
-        })
+        let this = self.to_resolved().await?;
+        Ok(get_module_graph_operation(this, entry).connect())
     }
 
     #[turbo_tasks::function]
@@ -1459,23 +1448,9 @@ impl Project {
         self: Vc<Self>,
         evaluatable_assets: Vc<EvaluatableAssets>,
     ) -> Result<Vc<ModuleGraph>> {
-        Ok(if *self.per_page_module_graph().await? {
-            let is_production = self.next_mode().await?.is_production();
-            let entries = evaluatable_assets
-                .await?
-                .iter()
-                .copied()
-                .map(ResolvedVc::upcast)
-                .collect();
-            ModuleGraph::from_single_graph(SingleModuleGraph::new_with_entries(
-                ResolvedVc::cell(vec![ChunkGroupEntry::Entry(entries)]),
-                is_production,
-                is_production,
-            ))
-            .connect()
-        } else {
-            *self.whole_app_module_graphs().await?.full
-        })
+        let this = self.to_resolved().await?;
+        let evaluatable_assets = evaluatable_assets.to_resolved().await?;
+        Ok(get_module_graph_for_modules_operation(this, evaluatable_assets).connect())
     }
 
     #[turbo_tasks::function]
@@ -1544,7 +1519,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) async fn client_chunking_context(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
     ) -> Result<Vc<Box<dyn ChunkingContext>>> {
         let css_url_suffix = self.next_config().asset_suffix_path();
         Ok(get_client_chunking_context(ClientChunkingContextOptions {
@@ -1555,7 +1530,7 @@ impl Project {
             asset_prefix: self.next_config().computed_asset_prefix(),
             environment: self.client_compile_time_info().environment(),
             module_id_strategy: self.module_ids(),
-            export_usage: self.export_usage(),
+            export_usage: self.export_usage().await?,
             unused_references: self.unused_references(),
             minify: self.next_config().turbo_minify(self.next_mode()),
             source_maps: self.next_config().client_source_maps(self.next_mode()),
@@ -1572,7 +1547,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) async fn server_chunking_context(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         client_assets: bool,
     ) -> Result<Vc<NodeJsChunkingContext>> {
         let css_url_suffix = self.next_config().asset_suffix_path();
@@ -1583,7 +1558,7 @@ impl Project {
             node_root_to_root_path: self.node_root_to_root_path().owned().await?,
             environment: self.server_compile_time_info().environment(),
             module_id_strategy: self.module_ids(),
-            export_usage: self.export_usage(),
+            export_usage: self.export_usage().await?,
             unused_references: self.unused_references(),
             minify: self.next_config().turbo_minify(self.next_mode()),
             source_maps: self.next_config().server_source_maps(),
@@ -1606,7 +1581,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) async fn edge_chunking_context(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         client_assets: bool,
     ) -> Result<Vc<Box<dyn ChunkingContext>>> {
         let css_url_suffix = self.next_config().asset_suffix_path();
@@ -1617,7 +1592,7 @@ impl Project {
             output_root_to_root_path: self.node_root_to_root_path(),
             environment: self.edge_compile_time_info().environment(),
             module_id_strategy: self.module_ids(),
-            export_usage: self.export_usage(),
+            export_usage: self.export_usage().await?,
             unused_references: self.unused_references(),
             turbo_minify: self.next_config().turbo_minify(self.next_mode()),
             turbo_source_maps: self.next_config().server_source_maps(),
@@ -2358,63 +2333,6 @@ impl Project {
         Ok(Vc::cell(modules))
     }
 
-    /// Gets the module id strategy for the project.
-    #[turbo_tasks::function]
-    pub async fn module_ids(self: Vc<Self>) -> Result<Vc<ModuleIdStrategy>> {
-        let module_id_strategy = *self.next_config().module_ids(self.next_mode()).await?;
-        match module_id_strategy {
-            ModuleIdStrategyConfig::Named => Ok(ModuleIdStrategy {
-                module_id_map: None,
-                fallback: ModuleIdFallback::Ident,
-            }
-            .cell()),
-            ModuleIdStrategyConfig::Deterministic => {
-                let module_graphs = self.whole_app_module_graphs().await?;
-                Ok(get_global_module_id_strategy(*module_graphs.full))
-            }
-        }
-    }
-
-    /// Compute the used exports and unused imports for each module.
-    #[turbo_tasks::function]
-    async fn binding_usage_info(self: Vc<Self>) -> Result<Vc<BindingUsageInfo>> {
-        let module_graphs = self.whole_app_module_graphs().await?;
-        Ok(module_graphs
-            .binding_usage_info
-            .context("No binding usage info")?
-            .connect())
-    }
-
-    /// Compute the used exports for each module.
-    #[turbo_tasks::function]
-    pub async fn export_usage(self: Vc<Self>) -> Result<Vc<OptionBindingUsageInfo>> {
-        if *self
-            .next_config()
-            .turbopack_remove_unused_exports(self.next_mode())
-            .await?
-        {
-            Ok(Vc::cell(Some(
-                self.binding_usage_info().to_resolved().await?,
-            )))
-        } else {
-            Ok(Vc::cell(None))
-        }
-    }
-
-    /// Compute the unused references that were removed (inner graph tree shaking).
-    #[turbo_tasks::function]
-    pub async fn unused_references(self: Vc<Self>) -> Result<Vc<UnusedReferences>> {
-        if *self
-            .next_config()
-            .turbopack_remove_unused_imports(self.next_mode())
-            .await?
-        {
-            Ok(self.binding_usage_info().unused_references())
-        } else {
-            Ok(Vc::cell(Default::default()))
-        }
-    }
-
     #[turbo_tasks::function]
     pub async fn with_next_config(&self, next_config: Vc<NextConfig>) -> Result<Vc<Self>> {
         Ok(Self {
@@ -2422,6 +2340,134 @@ impl Project {
             ..(*self).clone()
         }
         .cell())
+    }
+}
+
+impl Project {
+    /// Gets the module graph for a single entry module.
+    pub fn module_graph_operation(
+        self: ResolvedVc<Self>,
+        entry: ResolvedVc<Box<dyn Module>>,
+    ) -> OperationVc<ModuleGraph> {
+        get_module_graph_operation(self, entry)
+    }
+
+    /// Gets the module graph for a set of evaluatable assets.
+    pub fn module_graph_for_modules_operation(
+        self: ResolvedVc<Self>,
+        evaluatable_assets: ResolvedVc<EvaluatableAssets>,
+    ) -> OperationVc<ModuleGraph> {
+        get_module_graph_for_modules_operation(self, evaluatable_assets)
+    }
+
+    /// Gets the module id strategy for the project.
+    pub fn module_ids(self: ResolvedVc<Self>) -> OperationVc<ModuleIdStrategy> {
+        get_project_module_ids(self)
+    }
+
+    /// Compute the unused references that were removed (inner graph tree shaking).
+    pub fn unused_references(self: ResolvedVc<Self>) -> OperationVc<UnusedReferences> {
+        get_project_unused_references(self)
+    }
+
+    /// Compute the used exports for each module.
+    pub async fn export_usage(
+        self: ResolvedVc<Self>,
+    ) -> Result<Option<OperationVc<BindingUsageInfo>>> {
+        if *self
+            .next_config()
+            .turbopack_remove_unused_exports(self.next_mode())
+            .await?
+        {
+            let module_graphs = self.whole_app_module_graphs().await?;
+            Ok(module_graphs.binding_usage_info)
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+/// Gets the module id strategy for the project.
+#[turbo_tasks::function(operation)]
+async fn get_project_module_ids(project: ResolvedVc<Project>) -> Result<Vc<ModuleIdStrategy>> {
+    let module_id_strategy = *project
+        .next_config()
+        .module_ids(project.next_mode())
+        .await?;
+    match module_id_strategy {
+        ModuleIdStrategyConfig::Named => Ok(ModuleIdStrategy {
+            module_id_map: None,
+            fallback: ModuleIdFallback::Ident,
+        }
+        .cell()),
+        ModuleIdStrategyConfig::Deterministic => {
+            let module_graphs = project.whole_app_module_graphs().await?;
+            Ok(get_global_module_id_strategy(module_graphs.full).connect())
+        }
+    }
+}
+
+/// Gets the module graph for a single entry module.
+#[turbo_tasks::function(operation)]
+pub async fn get_module_graph_operation(
+    project: ResolvedVc<Project>,
+    entry: ResolvedVc<Box<dyn Module>>,
+) -> Result<Vc<ModuleGraph>> {
+    Ok(if *project.per_page_module_graph().await? {
+        let is_production = project.next_mode().await?.is_production();
+        ModuleGraph::from_single_graph(SingleModuleGraph::new_with_entry(
+            ChunkGroupEntry::Entry(vec![entry]),
+            is_production,
+            is_production,
+        ))
+        .connect()
+    } else {
+        project.whole_app_module_graphs().await?.full.connect()
+    })
+}
+
+/// Gets the module graph for a set of evaluatable assets.
+#[turbo_tasks::function(operation)]
+pub async fn get_module_graph_for_modules_operation(
+    project: ResolvedVc<Project>,
+    evaluatable_assets: ResolvedVc<EvaluatableAssets>,
+) -> Result<Vc<ModuleGraph>> {
+    Ok(if *project.per_page_module_graph().await? {
+        let is_production = project.next_mode().await?.is_production();
+        let entries = evaluatable_assets
+            .await?
+            .iter()
+            .copied()
+            .map(ResolvedVc::upcast)
+            .collect();
+        ModuleGraph::from_single_graph(SingleModuleGraph::new_with_entries(
+            ResolvedVc::cell(vec![ChunkGroupEntry::Entry(entries)]),
+            is_production,
+            is_production,
+        ))
+        .connect()
+    } else {
+        project.whole_app_module_graphs().await?.full.connect()
+    })
+}
+
+/// Compute the unused references that were removed (inner graph tree shaking).
+#[turbo_tasks::function(operation)]
+async fn get_project_unused_references(
+    project: ResolvedVc<Project>,
+) -> Result<Vc<UnusedReferences>> {
+    if *project
+        .next_config()
+        .turbopack_remove_unused_imports(project.next_mode())
+        .await?
+    {
+        let module_graphs = project.whole_app_module_graphs().await?;
+        let binding_usage_info = module_graphs
+            .binding_usage_info
+            .context("No binding usage info")?;
+        Ok(get_unused_references(binding_usage_info).connect())
+    } else {
+        Ok(Vc::cell(Default::default()))
     }
 }
 
@@ -2506,8 +2552,8 @@ async fn whole_app_module_graph_operation(
         };
 
         Ok(BaseAndFullModuleGraph {
-            base: base.connect().to_resolved().await?,
-            full: full.connect().to_resolved().await?,
+            base,
+            full,
             binding_usage_info,
         }
         .cell())
@@ -2519,9 +2565,9 @@ async fn whole_app_module_graph_operation(
 #[turbo_tasks::value(shared)]
 pub struct BaseAndFullModuleGraph {
     /// The base module graph generated from the entry points.
-    pub base: ResolvedVc<ModuleGraph>,
+    pub base: OperationVc<ModuleGraph>,
     /// `full_with_unused_references` but with unused references removed.
-    pub full: ResolvedVc<ModuleGraph>,
+    pub full: OperationVc<ModuleGraph>,
     /// Information about binding usage in the module graph.
     pub binding_usage_info: Option<OperationVc<BindingUsageInfo>>,
 }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1614,7 +1614,7 @@ impl Project {
 
     #[turbo_tasks::function]
     pub(super) fn runtime_chunking_context(
-        self: Vc<Self>,
+        self: ResolvedVc<Self>,
         client_assets: bool,
         runtime: NextRuntime,
     ) -> Vc<Box<dyn ChunkingContext>> {

--- a/crates/next-api/src/route.rs
+++ b/crates/next-api/src/route.rs
@@ -42,7 +42,7 @@ pub enum Route {
 }
 
 #[turbo_tasks::value(transparent)]
-pub struct ModuleGraphs(Vec<ResolvedVc<ModuleGraph>>);
+pub struct ModuleGraphs(Vec<OperationVc<ModuleGraph>>);
 
 #[turbo_tasks::value_trait]
 pub trait Endpoint {

--- a/crates/next-api/src/routes_hashes_manifest.rs
+++ b/crates/next-api/src/routes_hashes_manifest.rs
@@ -205,8 +205,8 @@ impl Asset for RoutesHashesManifestAsset {
     #[turbo_tasks::function]
     async fn content(&self) -> Result<Vc<AssetContent>> {
         let module_graphs = self.project.whole_app_module_graphs().await?;
-        let base_module_graph = *module_graphs.base;
-        let full_module_graph = *module_graphs.full;
+        let base_module_graph = module_graphs.base.connect();
+        let full_module_graph = module_graphs.full.connect();
 
         let mut entrypoint_hashes = FxIndexMap::default();
 

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
+use turbo_tasks::{OperationVc, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
     CssOptionsContext, EcmascriptOptionsContext, JsxTransformOptions, ModuleRule,
@@ -23,7 +23,7 @@ use turbopack_core::{
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment},
     free_var_references,
     issue::IssueSeverity,
-    module_graph::binding_usage_info::OptionBindingUsageInfo,
+    module_graph::binding_usage_info::BindingUsageInfo,
     resolve::{parse::Request, pattern::Pattern},
 };
 use turbopack_css::chunk::CssChunkType;
@@ -434,9 +434,9 @@ pub struct ClientChunkingContextOptions {
     pub client_root_to_root_path: RcStr,
     pub asset_prefix: Vc<RcStr>,
     pub environment: Vc<Environment>,
-    pub module_id_strategy: Vc<ModuleIdStrategy>,
-    pub export_usage: Vc<OptionBindingUsageInfo>,
-    pub unused_references: Vc<UnusedReferences>,
+    pub module_id_strategy: OperationVc<ModuleIdStrategy>,
+    pub export_usage: Option<OperationVc<BindingUsageInfo>>,
+    pub unused_references: OperationVc<UnusedReferences>,
     pub minify: Vc<bool>,
     pub source_maps: Vc<SourceMapsType>,
     pub no_mangling: Vc<bool>,
@@ -495,9 +495,8 @@ pub async fn get_client_chunking_context(
     .source_maps(*source_maps.await?)
     .asset_base_path(Some(asset_prefix))
     .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
-    .export_usage(*export_usage.await?)
-    .unused_references(unused_references.to_resolved().await?)
-    .module_id_strategy(module_id_strategy.to_resolved().await?)
+    .unused_references(unused_references)
+    .module_id_strategy(module_id_strategy)
     .debug_ids(*debug_ids.await?)
     .should_use_absolute_url_references(*should_use_absolute_url_references.await?)
     .nested_async_availability(*nested_async_chunking.await?)
@@ -506,6 +505,10 @@ pub async fn get_client_chunking_context(
         suffix: AssetSuffix::Inferred,
         static_suffix: css_url_suffix.to_resolved().await?,
     });
+
+    if let Some(export_usage) = export_usage {
+        builder = builder.export_usage(export_usage);
+    }
 
     if next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
+use turbo_tasks::{OperationVc, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_browser::BrowserChunkingContext;
 use turbopack_core::{
@@ -13,7 +13,7 @@ use turbopack_core::{
     environment::{EdgeWorkerEnvironment, Environment, ExecutionEnvironment, NodeJsVersion},
     free_var_references,
     issue::IssueSeverity,
-    module_graph::binding_usage_info::OptionBindingUsageInfo,
+    module_graph::binding_usage_info::BindingUsageInfo,
 };
 use turbopack_css::chunk::CssChunkType;
 use turbopack_ecmascript::chunk::EcmascriptChunkType;
@@ -191,9 +191,9 @@ pub struct EdgeChunkingContextOptions {
     pub node_root: FileSystemPath,
     pub output_root_to_root_path: Vc<RcStr>,
     pub environment: Vc<Environment>,
-    pub module_id_strategy: Vc<ModuleIdStrategy>,
-    pub export_usage: Vc<OptionBindingUsageInfo>,
-    pub unused_references: Vc<UnusedReferences>,
+    pub module_id_strategy: OperationVc<ModuleIdStrategy>,
+    pub export_usage: Option<OperationVc<BindingUsageInfo>>,
+    pub unused_references: OperationVc<UnusedReferences>,
     pub turbo_minify: Vc<bool>,
     pub turbo_source_maps: Vc<SourceMapsType>,
     pub no_mangling: Vc<bool>,
@@ -253,11 +253,14 @@ pub async fn get_edge_chunking_context_with_client_assets(
         MinifyType::NoMinify
     })
     .source_maps(*turbo_source_maps.await?)
-    .module_id_strategy(module_id_strategy.to_resolved().await?)
-    .export_usage(*export_usage.await?)
-    .unused_references(unused_references.to_resolved().await?)
+    .module_id_strategy(module_id_strategy)
+    .unused_references(unused_references)
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
+
+    if let Some(export_usage) = export_usage {
+        builder = builder.export_usage(export_usage);
+    }
 
     if !next_mode.is_development() {
         builder = builder
@@ -344,11 +347,14 @@ pub async fn get_edge_chunking_context(
         MinifyType::NoMinify
     })
     .source_maps(*turbo_source_maps.await?)
-    .module_id_strategy(module_id_strategy.to_resolved().await?)
-    .export_usage(*export_usage.await?)
-    .unused_references(unused_references.to_resolved().await?)
+    .module_id_strategy(module_id_strategy)
+    .unused_references(unused_references)
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
+
+    if let Some(export_usage) = export_usage {
+        builder = builder.export_usage(export_usage);
+    }
 
     if !next_mode.is_development() {
         builder = builder

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeSet;
 use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
+use turbo_tasks::{OperationVc, ResolvedVc, TaskInput, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::{
     module_options::{
@@ -22,7 +22,7 @@ use turbopack_core::{
     compile_time_info::{CompileTimeDefines, CompileTimeInfo, FreeVarReferences},
     environment::{Environment, ExecutionEnvironment, NodeJsEnvironment, NodeJsVersion},
     issue::IssueSeverity,
-    module_graph::binding_usage_info::OptionBindingUsageInfo,
+    module_graph::binding_usage_info::BindingUsageInfo,
     target::CompileTarget,
 };
 use turbopack_css::chunk::CssChunkType;
@@ -992,9 +992,9 @@ pub struct ServerChunkingContextOptions {
     pub node_root: FileSystemPath,
     pub node_root_to_root_path: RcStr,
     pub environment: Vc<Environment>,
-    pub module_id_strategy: Vc<ModuleIdStrategy>,
-    pub export_usage: Vc<OptionBindingUsageInfo>,
-    pub unused_references: Vc<UnusedReferences>,
+    pub module_id_strategy: OperationVc<ModuleIdStrategy>,
+    pub export_usage: Option<OperationVc<BindingUsageInfo>>,
+    pub unused_references: OperationVc<UnusedReferences>,
     pub minify: Vc<bool>,
     pub source_maps: Vc<SourceMapsType>,
     pub no_mangling: Vc<bool>,
@@ -1067,13 +1067,16 @@ pub async fn get_server_chunking_context_with_client_assets(
         MinifyType::NoMinify
     })
     .source_maps(*source_maps.await?)
-    .module_id_strategy(module_id_strategy.to_resolved().await?)
-    .export_usage(*export_usage.await?)
-    .unused_references(unused_references.to_resolved().await?)
+    .module_id_strategy(module_id_strategy)
+    .unused_references(unused_references)
     .file_tracing(next_mode.is_production())
     .debug_ids(*debug_ids.await?)
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
+
+    if let Some(export_usage) = export_usage {
+        builder = builder.export_usage(export_usage);
+    }
 
     builder = builder.source_map_source_type(if next_mode.is_development() {
         SourceMapSourceType::AbsoluteFileUri
@@ -1165,13 +1168,16 @@ pub async fn get_server_chunking_context(
         MinifyType::NoMinify
     })
     .source_maps(*source_maps.await?)
-    .module_id_strategy(module_id_strategy.to_resolved().await?)
-    .export_usage(*export_usage.await?)
-    .unused_references(unused_references.to_resolved().await?)
+    .module_id_strategy(module_id_strategy)
+    .unused_references(unused_references)
     .file_tracing(next_mode.is_production())
     .debug_ids(*debug_ids.await?)
     .nested_async_availability(*nested_async_chunking.await?)
     .worker_forwarded_globals(worker_forwarded_globals());
+
+    if let Some(export_usage) = export_usage {
+        builder = builder.export_usage(export_usage);
+    }
 
     if next_mode.is_development() {
         builder = builder.source_map_source_type(SourceMapSourceType::AbsoluteFileUri);

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, TaskInput, TryJoinIterExt, Upcast, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, OperationVc, ResolvedVc, TaskInput, TryJoinIterExt, Upcast, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::HashAlgorithm;
 use turbopack_core::{
@@ -133,17 +133,17 @@ impl BrowserChunkingContextBuilder {
         self
     }
 
-    pub fn module_id_strategy(mut self, module_id_strategy: ResolvedVc<ModuleIdStrategy>) -> Self {
+    pub fn module_id_strategy(mut self, module_id_strategy: OperationVc<ModuleIdStrategy>) -> Self {
         self.chunking_context.module_id_strategy = Some(module_id_strategy);
         self
     }
 
-    pub fn export_usage(mut self, export_usage: Option<ResolvedVc<BindingUsageInfo>>) -> Self {
-        self.chunking_context.export_usage = export_usage;
+    pub fn export_usage(mut self, export_usage: OperationVc<BindingUsageInfo>) -> Self {
+        self.chunking_context.export_usage = Some(export_usage);
         self
     }
 
-    pub fn unused_references(mut self, unused_references: ResolvedVc<UnusedReferences>) -> Self {
+    pub fn unused_references(mut self, unused_references: OperationVc<UnusedReferences>) -> Self {
         self.chunking_context.unused_references = Some(unused_references);
         self
     }
@@ -301,11 +301,11 @@ pub struct BrowserChunkingContext {
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// The module id strategy to use
-    module_id_strategy: Option<ResolvedVc<ModuleIdStrategy>>,
+    module_id_strategy: Option<OperationVc<ModuleIdStrategy>>,
     /// The module export usage info, if available.
-    export_usage: Option<ResolvedVc<BindingUsageInfo>>,
+    export_usage: Option<OperationVc<BindingUsageInfo>>,
     /// Which references are unused and should be skipped (e.g. during codegen).
-    unused_references: Option<ResolvedVc<UnusedReferences>>,
+    unused_references: Option<OperationVc<UnusedReferences>>,
     /// The chunking configs
     chunking_configs: Vec<(ResolvedVc<Box<dyn ChunkType>>, ChunkingConfig)>,
     /// Whether to use absolute URLs for static assets (e.g. in CSS: `url("/absolute/path")`)
@@ -868,9 +868,9 @@ impl ChunkingContext for BrowserChunkingContext {
 
     #[turbo_tasks::function]
     fn chunk_item_id_strategy(&self) -> Vc<ModuleIdStrategy> {
-        *self
-            .module_id_strategy
-            .unwrap_or_else(|| ModuleIdStrategy::default().resolved_cell())
+        self.module_id_strategy
+            .map(|v| v.connect())
+            .unwrap_or_else(|| ModuleIdStrategy::default().cell())
     }
 
     #[turbo_tasks::function]
@@ -914,7 +914,7 @@ impl ChunkingContext for BrowserChunkingContext {
         module: ResolvedVc<Box<dyn Module>>,
     ) -> Result<Vc<ModuleExportUsage>> {
         if let Some(export_usage) = self.export_usage {
-            Ok(export_usage.await?.used_exports(module).await?)
+            Ok(export_usage.connect().await?.used_exports(module).await?)
         } else {
             Ok(ModuleExportUsage::all())
         }
@@ -923,7 +923,7 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     fn unused_references(&self) -> Vc<UnusedReferences> {
         if let Some(unused_references) = self.unused_references {
-            *unused_references
+            unused_references.connect()
         } else {
             Vc::cell(Default::default())
         }

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -32,7 +32,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{
         ModuleGraph, SingleModuleGraph,
-        binding_usage_info::compute_binding_usage_info,
+        binding_usage_info::{compute_binding_usage_info, get_unused_references},
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
@@ -316,17 +316,11 @@ async fn build_internal(
     );
     let mut module_graph = ModuleGraph::from_single_graph(single_graph);
     let binding_usage = compute_binding_usage_info(module_graph, true);
-    let unused_references = binding_usage
-        .connect()
-        .unused_references()
-        .to_resolved()
-        .await?;
+    let unused_references = get_unused_references(binding_usage);
     module_graph =
         ModuleGraph::from_single_graph_without_unused_references(single_graph, binding_usage);
+    let module_id_strategy = get_global_module_id_strategy(module_graph);
     let module_graph = module_graph.connect();
-    let module_id_strategy = get_global_module_id_strategy(module_graph)
-        .to_resolved()
-        .await?;
 
     let chunking_context: Vc<Box<dyn ChunkingContext>> = match target {
         Target::Browser => {
@@ -352,7 +346,7 @@ async fn build_internal(
             )
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
-            .export_usage(Some(binding_usage.connect().to_resolved().await?))
+            .export_usage(binding_usage)
             .unused_references(unused_references)
             .current_chunk_method(CurrentChunkMethod::DocumentCurrentScript)
             .minify_type(minify_type);
@@ -403,7 +397,7 @@ async fn build_internal(
             )
             .source_maps(source_maps_type)
             .module_id_strategy(module_id_strategy)
-            .export_usage(Some(binding_usage.connect().to_resolved().await?))
+            .export_usage(binding_usage)
             .unused_references(unused_references)
             .minify_type(minify_type);
 

--- a/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/binding_usage_info.rs
@@ -95,6 +95,11 @@ impl BindingUsageInfo {
 }
 
 #[turbo_tasks::function(operation)]
+pub fn get_unused_references(binding_usage: OperationVc<BindingUsageInfo>) -> Vc<UnusedReferences> {
+    binding_usage.connect().unused_references()
+}
+
+#[turbo_tasks::function(operation)]
 pub async fn compute_binding_usage_info(
     graph: OperationVc<ModuleGraph>,
     remove_unused_imports: bool,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result, bail};
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, ResolvedVc, TryJoinIterExt, Upcast, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, OperationVc, ResolvedVc, TryJoinIterExt, Upcast, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::Asset,
@@ -120,17 +120,17 @@ impl NodeJsChunkingContextBuilder {
         self
     }
 
-    pub fn module_id_strategy(mut self, module_id_strategy: ResolvedVc<ModuleIdStrategy>) -> Self {
+    pub fn module_id_strategy(mut self, module_id_strategy: OperationVc<ModuleIdStrategy>) -> Self {
         self.chunking_context.module_id_strategy = Some(module_id_strategy);
         self
     }
 
-    pub fn export_usage(mut self, export_usage: Option<ResolvedVc<BindingUsageInfo>>) -> Self {
-        self.chunking_context.export_usage = export_usage;
+    pub fn export_usage(mut self, export_usage: OperationVc<BindingUsageInfo>) -> Self {
+        self.chunking_context.export_usage = Some(export_usage);
         self
     }
 
-    pub fn unused_references(mut self, unused_references: ResolvedVc<UnusedReferences>) -> Self {
+    pub fn unused_references(mut self, unused_references: OperationVc<UnusedReferences>) -> Self {
         self.chunking_context.unused_references = Some(unused_references);
         self
     }
@@ -219,11 +219,11 @@ pub struct NodeJsChunkingContext {
     /// Whether to use manifest chunks for lazy compilation
     manifest_chunks: bool,
     /// The strategy to use for generating module ids
-    module_id_strategy: Option<ResolvedVc<ModuleIdStrategy>>,
+    module_id_strategy: Option<OperationVc<ModuleIdStrategy>>,
     /// The module export usage info, if available.
-    export_usage: Option<ResolvedVc<BindingUsageInfo>>,
+    export_usage: Option<OperationVc<BindingUsageInfo>>,
     /// Which references are unused and should be skipped (e.g. during codegen).
-    unused_references: Option<ResolvedVc<UnusedReferences>>,
+    unused_references: Option<OperationVc<UnusedReferences>>,
     /// The strategy to use for generating source map source uris
     source_map_source_type: SourceMapSourceType,
     /// The chunking configs
@@ -638,9 +638,9 @@ impl ChunkingContext for NodeJsChunkingContext {
 
     #[turbo_tasks::function]
     fn chunk_item_id_strategy(&self) -> Vc<ModuleIdStrategy> {
-        *self
-            .module_id_strategy
-            .unwrap_or_else(|| ModuleIdStrategy::default().resolved_cell())
+        self.module_id_strategy
+            .map(|v| v.connect())
+            .unwrap_or_else(|| ModuleIdStrategy::default().cell())
     }
 
     #[turbo_tasks::function]
@@ -689,7 +689,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         module: ResolvedVc<Box<dyn Module>>,
     ) -> Result<Vc<ModuleExportUsage>> {
         if let Some(export_usage) = self.export_usage {
-            Ok(export_usage.await?.used_exports(module).await?)
+            Ok(export_usage.connect().await?.used_exports(module).await?)
         } else {
             Ok(ModuleExportUsage::all())
         }
@@ -698,7 +698,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     fn unused_references(&self) -> Vc<UnusedReferences> {
         if let Some(unused_references) = self.unused_references {
-            *unused_references
+            unused_references.connect()
         } else {
             Vc::cell(Default::default())
         }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -39,7 +39,8 @@ use turbopack_core::{
     ident::Layer,
     issue::{CollectibleIssuesExt, IssueFilter},
     module_graph::{
-        ModuleGraph, SingleModuleGraph, binding_usage_info::compute_binding_usage_info,
+        ModuleGraph, SingleModuleGraph,
+        binding_usage_info::{compute_binding_usage_info, get_unused_references},
     },
     reference_type::{InnerAssets, ReferenceType},
     resolve::{
@@ -530,22 +531,14 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         }
     } else {
         MinifyType::NoMinify
-    })
-    .export_usage(if options.remove_unused_exports {
-        Some(binding_usage.unwrap().connect().to_resolved().await?)
-    } else {
-        None
     });
 
+    if options.remove_unused_exports {
+        builder = builder.export_usage(binding_usage.unwrap());
+    }
+
     if options.remove_unused_imports {
-        builder = builder.unused_references(
-            binding_usage
-                .unwrap()
-                .connect()
-                .unused_references()
-                .to_resolved()
-                .await?,
-        );
+        builder = builder.unused_references(get_unused_references(binding_usage.unwrap()));
     }
 
     if options.production_chunking {

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -46,7 +46,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{
         ModuleGraph, SingleModuleGraph,
-        binding_usage_info::compute_binding_usage_info,
+        binding_usage_info::{compute_binding_usage_info, get_unused_references},
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
@@ -497,24 +497,16 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             )
             .minify_type(options.minify_type)
             .module_merging(options.scope_hoisting)
-            .export_usage(if options.remove_unused_exports {
-                Some(binding_usage.unwrap().connect().to_resolved().await?)
-            } else {
-                None
-            })
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type)
             .chunk_loading_global(options.chunk_loading_global.into());
 
+            if options.remove_unused_exports {
+                builder = builder.export_usage(binding_usage.unwrap());
+            }
+
             if options.remove_unused_imports {
-                builder = builder.unused_references(
-                    binding_usage
-                        .unwrap()
-                        .connect()
-                        .unused_references()
-                        .to_resolved()
-                        .await?,
-                );
+                builder = builder.unused_references(get_unused_references(binding_usage.unwrap()));
             }
 
             if options.production_chunking {
@@ -545,23 +537,15 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
             )
             .minify_type(options.minify_type)
             .module_merging(options.scope_hoisting)
-            .export_usage(if options.remove_unused_exports {
-                Some(binding_usage.unwrap().connect().to_resolved().await?)
-            } else {
-                None
-            })
             .debug_ids(options.enable_debug_ids)
             .source_map_source_type(options.source_map_source_type);
 
+            if options.remove_unused_exports {
+                builder = builder.export_usage(binding_usage.unwrap());
+            }
+
             if options.remove_unused_imports {
-                builder = builder.unused_references(
-                    binding_usage
-                        .unwrap()
-                        .connect()
-                        .unused_references()
-                        .to_resolved()
-                        .await?,
-                );
+                builder = builder.unused_references(get_unused_references(binding_usage.unwrap()));
             }
 
             if options.production_chunking {

--- a/turbopack/crates/turbopack/src/global_module_ids.rs
+++ b/turbopack/crates/turbopack/src/global_module_ids.rs
@@ -3,7 +3,7 @@ use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
 use tracing::Instrument;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{OperationVc, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     chunk::{
@@ -16,13 +16,13 @@ use turbopack_core::{
 };
 use turbopack_ecmascript::async_chunk::module::AsyncLoaderModule;
 
-#[turbo_tasks::function]
+#[turbo_tasks::function(operation)]
 pub async fn get_global_module_id_strategy(
-    module_graph: ResolvedVc<ModuleGraph>,
+    module_graph: OperationVc<ModuleGraph>,
 ) -> Result<Vc<ModuleIdStrategy>> {
     let span = tracing::info_span!("compute module id map");
     async move {
-        let module_graph = module_graph.await?;
+        let module_graph = module_graph.connect().await?;
         let graphs = &module_graph.graphs;
 
         // All modules in the graph


### PR DESCRIPTION
### What?

Use OperationVc to enforce correct ordering of global information methods