### PR TITLE
Turbopack: selective reads of defined env vars in module analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,6 +4419,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "smallvec",
  "swc_core",
  "swc_sourcemap",
  "thiserror 1.0.69",

--- a/crates/next-core/Cargo.toml
+++ b/crates/next-core/Cargo.toml
@@ -34,6 +34,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_path_to_error = { workspace = true }
+smallvec = { workspace = true }
 swc_sourcemap = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use anyhow::{Result, bail};
 use once_cell::sync::Lazy;
 use regex::Regex;
+use smallvec::smallvec;
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
@@ -13,7 +14,8 @@ use turbopack_core::{
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext},
     code_builder::CodeBuilder,
     compile_time_info::{
-        CompileTimeDefineValue, CompileTimeInfo, DefinableNameSegment, FreeVarReference,
+        CompileTimeDefineValue, CompileTimeInfo, DefinableNameSegmentRef, DefinableNameSegmentRefs,
+        FreeVarReference,
     },
     context::AssetContext,
     ident::AssetIdent,
@@ -193,12 +195,7 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
 
             let mut code = CodeBuilder::default();
             if !env_vars.is_empty() {
-                let replacements = module
-                    .compile_time_info
-                    .await?
-                    .free_var_references
-                    .individual()
-                    .await?;
+                let replacements = module.compile_time_info.await?.free_var_references;
                 code += "var process = {env:\n";
                 writeln!(
                     code,
@@ -209,20 +206,14 @@ impl EcmascriptChunkItem for RawEcmascriptChunkItem {
                             .map(async |name| {
                                 Ok((
                                     name,
-                                    if let Some(value) =
-                                        replacements.get(&DefinableNameSegment::Name(name.into()))
-                                        && let Some((_, value)) =
-                                            value.0.iter().find(|(path, _)| {
-                                                matches!(
-                                                    path.as_slice(),
-                                                    [
-                                                        DefinableNameSegment::Name(a),
-                                                        DefinableNameSegment::Name(b)
-                                                    ] if a == "process" && b == "env"
-                                                )
-                                            })
+                                    if let Some(value) = replacements
+                                        .get(&DefinableNameSegmentRefs(smallvec![
+                                            DefinableNameSegmentRef::Name("process"),
+                                            DefinableNameSegmentRef::Name("env"),
+                                            DefinableNameSegmentRef::Name(name),
+                                        ]))
+                                        .await?
                                     {
-                                        let value = value.await?;
                                         let value = match &*value {
                                             FreeVarReference::Value(
                                                 CompileTimeDefineValue::String(value),

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -566,4 +566,56 @@ mod tests {
         };
         assert_eq!(STR, RcStr::from("hello"));
     }
+
+    #[test]
+    fn test_hash_matches_str() {
+        use std::hash::{Hash, Hasher};
+
+        use rustc_hash::FxHasher;
+
+        fn fxhash<T: Hash>(value: T) -> u64 {
+            let mut hasher = FxHasher::default();
+            value.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        // Test various string lengths covering inline and prehashed storage
+        let test_strings = [
+            "",
+            "a",
+            "ab",
+            "abc",
+            "abcdef",  // max inline (6 chars)
+            "abcdefg", // just beyond inline (7 chars)
+            "abcdefgh",
+            "a very long string that exceeds sixteen bytes",
+        ];
+
+        // Test RcStr vs &str
+        for s in test_strings {
+            let rcstr = RcStr::from(s);
+            assert_eq!(
+                fxhash(&rcstr),
+                fxhash(s),
+                "Hash mismatch for string of length {}: {:?}",
+                s.len(),
+                s
+            );
+        }
+
+        // Test (RcStr, RcStr) vs (&str, &str)
+        for s1 in test_strings {
+            for s2 in test_strings {
+                let rcstr1 = RcStr::from(s1);
+                let rcstr2 = RcStr::from(s2);
+                assert_eq!(
+                    fxhash((&rcstr1, &rcstr2)),
+                    fxhash((s1, s2)),
+                    "Tuple hash mismatch for ({:?}, {:?})",
+                    s1,
+                    s2
+                );
+            }
+        }
+    }
 }

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -368,9 +368,18 @@ impl FreeVarReferences {
     pub fn members(&self) -> Vc<FreeVarReferencesMembers> {
         let mut members = FxHashSet::default();
         for (key, _) in self.0.iter() {
-            if let Some(DefinableNameSegment::Name(name)) = key
+            if let Some(name) = key
                 .iter()
-                .rfind(|segment| matches!(segment, DefinableNameSegment::Name(_)))
+                .rfind(|segment| {
+                    matches!(
+                        segment,
+                        DefinableNameSegment::Name(_) | DefinableNameSegment::Call(_)
+                    )
+                })
+                .and_then(|segment| match segment {
+                    DefinableNameSegment::Name(n) | DefinableNameSegment::Call(n) => Some(n),
+                    _ => None,
+                })
             {
                 members.insert(name.clone());
             }

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,5 +1,8 @@
 use anyhow::Result;
 use bincode::{Decode, Encode};
+use indexmap::Equivalent;
+use rustc_hash::FxHashSet;
+use smallvec::SmallVec;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
@@ -157,6 +160,7 @@ impl From<serde_json::Value> for CompileTimeDefineValue {
 #[derive(Debug, Clone, Hash, PartialOrd, Ord)]
 pub enum DefinableNameSegment {
     Name(RcStr),
+    Call(RcStr),
     TypeOf,
 }
 
@@ -178,18 +182,46 @@ impl From<String> for DefinableNameSegment {
     }
 }
 
-#[turbo_tasks::value(transparent)]
+#[derive(Hash, PartialEq, Eq)]
+pub enum DefinableNameSegmentRef<'a> {
+    Name(&'a str),
+    Call(&'a str),
+    TypeOf,
+}
+
+impl Equivalent<DefinableNameSegment> for DefinableNameSegmentRef<'_> {
+    fn equivalent(&self, key: &DefinableNameSegment) -> bool {
+        match (self, key) {
+            (DefinableNameSegmentRef::Name(a), DefinableNameSegment::Name(b)) => **a == *b.as_str(),
+            (DefinableNameSegmentRef::Call(a), DefinableNameSegment::Call(b)) => **a == *b.as_str(),
+            (DefinableNameSegmentRef::TypeOf, DefinableNameSegment::TypeOf) => true,
+            _ => false,
+        }
+    }
+}
+
+#[derive(Hash, PartialEq, Eq)]
+pub struct DefinableNameSegmentRefs<'a>(pub SmallVec<[DefinableNameSegmentRef<'a>; 4]>);
+
+impl Equivalent<Vec<DefinableNameSegment>> for DefinableNameSegmentRefs<'_> {
+    fn equivalent(&self, key: &Vec<DefinableNameSegment>) -> bool {
+        if self.0.len() != key.len() {
+            return false;
+        }
+        for (a, b) in self.0.iter().zip(key.iter()) {
+            if !a.equivalent(b) {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[turbo_tasks::value(transparent, cell = "keyed")]
 #[derive(Debug, Clone)]
 pub struct CompileTimeDefines(
     #[bincode(with = "turbo_bincode::indexmap")]
     pub  FxIndexMap<Vec<DefinableNameSegment>, CompileTimeDefineValue>,
-);
-
-#[turbo_tasks::value(transparent)]
-#[derive(Debug, Clone)]
-pub struct CompileTimeDefinesIndividual(
-    #[bincode(with = "turbo_bincode::indexmap")]
-    pub  FxIndexMap<Vec<DefinableNameSegment>, ResolvedVc<CompileTimeDefineValue>>,
 );
 
 impl IntoIterator for CompileTimeDefines {
@@ -206,20 +238,6 @@ impl CompileTimeDefines {
     #[turbo_tasks::function]
     pub fn empty() -> Vc<Self> {
         Vc::cell(FxIndexMap::default())
-    }
-
-    #[turbo_tasks::function]
-    pub fn individual(&self) -> Vc<CompileTimeDefinesIndividual> {
-        let mut map: FxIndexMap<Vec<DefinableNameSegment>, ResolvedVc<CompileTimeDefineValue>> =
-            self.0
-                .iter()
-                .map(|(key, value)| (key.clone(), value.clone().resolved_cell()))
-                .collect();
-
-        // Sort keys to make order as deterministic as possible
-        map.sort_keys();
-
-        Vc::cell(map)
     }
 }
 
@@ -275,26 +293,15 @@ impl From<CompileTimeDefineValue> for FreeVarReference {
     }
 }
 
-#[turbo_tasks::value(transparent)]
+#[turbo_tasks::value(transparent, cell = "keyed")]
 #[derive(Debug, Clone)]
 pub struct FreeVarReferences(
     #[bincode(with = "turbo_bincode::indexmap")]
     pub  FxIndexMap<Vec<DefinableNameSegment>, FreeVarReference>,
 );
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, TraceRawVcs, NonLocalValue, Encode, Decode)]
-pub struct FreeVarReferenceVcs(
-    #[bincode(with = "turbo_bincode::indexmap")]
-    pub  FxIndexMap<Vec<DefinableNameSegment>, ResolvedVc<FreeVarReference>>,
-);
-
-/// A map from the last element (the member prop) to a map of the rest of the name to the value.
-#[turbo_tasks::value(transparent)]
-#[derive(Debug, Clone)]
-pub struct FreeVarReferencesIndividual(
-    #[bincode(with = "turbo_bincode::indexmap")]
-    pub  FxIndexMap<DefinableNameSegment, FreeVarReferenceVcs>,
-);
+#[turbo_tasks::value(transparent, cell = "keyed")]
+pub struct FreeVarReferencesMembers(FxHashSet<RcStr>);
 
 #[turbo_tasks::value_impl]
 impl FreeVarReferences {
@@ -304,24 +311,17 @@ impl FreeVarReferences {
     }
 
     #[turbo_tasks::function]
-    pub fn individual(&self) -> Vc<FreeVarReferencesIndividual> {
-        let mut result: FxIndexMap<DefinableNameSegment, FreeVarReferenceVcs> =
-            FxIndexMap::default();
-
-        for (key, value) in &self.0 {
-            let (last_key, key) = key.split_last().unwrap();
-            result
-                .entry(last_key.clone())
-                .or_default()
-                .0
-                .insert(key.to_vec(), value.clone().resolved_cell());
+    pub fn members(&self) -> Vc<FreeVarReferencesMembers> {
+        let mut members = FxHashSet::default();
+        for (key, _) in self.0.iter() {
+            if let Some(DefinableNameSegment::Name(name)) = key
+                .iter()
+                .rfind(|segment| matches!(segment, DefinableNameSegment::Name(_)))
+            {
+                members.insert(name.clone());
+            }
         }
-
-        // Sort keys to make order as deterministic as possible
-        result.sort_keys();
-        result.iter_mut().for_each(|(_, inner)| inner.0.sort_keys());
-
-        Vc::cell(result)
+        Vc::cell(members)
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -104,8 +104,7 @@ macro_rules! free_var_references {
 
 // TODO: replace with just a `serde_json::Value`
 // https://linear.app/vercel/issue/WEB-1641/compiletimedefinevalue-should-just-use-serde-jsonvalue
-#[turbo_tasks::value]
-#[derive(Debug, Clone, Hash)]
+#[derive(Debug, Clone, Hash, TraceRawVcs, NonLocalValue, Encode, Decode, PartialEq, Eq)]
 pub enum CompileTimeDefineValue {
     Null,
     Bool(bool),
@@ -303,8 +302,7 @@ pub enum InputRelativeConstant {
     FileName,
 }
 
-#[turbo_tasks::value]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, TraceRawVcs, NonLocalValue, Encode, Decode, PartialEq, Eq)]
 pub enum FreeVarReference {
     EcmaScriptModule {
         request: RcStr,

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -157,11 +157,32 @@ impl From<serde_json::Value> for CompileTimeDefineValue {
 }
 
 #[turbo_tasks::value]
-#[derive(Debug, Clone, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialOrd, Ord)]
 pub enum DefinableNameSegment {
     Name(RcStr),
     Call(RcStr),
     TypeOf,
+}
+
+// Hash can't be derived because DefinableNameSegmentRef must have a matching
+// Hash implementation for Equivalent lookups, and derived discriminants are
+// not guaranteed to match between different enum types.
+impl std::hash::Hash for DefinableNameSegment {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Name(s) => {
+                0u8.hash(state);
+                s.hash(state);
+            }
+            Self::Call(s) => {
+                1u8.hash(state);
+                s.hash(state);
+            }
+            Self::TypeOf => {
+                2u8.hash(state);
+            }
+        }
+    }
 }
 
 impl From<RcStr> for DefinableNameSegment {
@@ -182,11 +203,32 @@ impl From<String> for DefinableNameSegment {
     }
 }
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub enum DefinableNameSegmentRef<'a> {
     Name(&'a str),
     Call(&'a str),
     TypeOf,
+}
+
+// Hash can't be derived because it must match DefinableNameSegment's Hash
+// implementation for Equivalent lookups, and derived discriminants are
+// not guaranteed to match between different enum types.
+impl std::hash::Hash for DefinableNameSegmentRef<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Name(s) => {
+                0u8.hash(state);
+                s.hash(state);
+            }
+            Self::Call(s) => {
+                1u8.hash(state);
+                s.hash(state);
+            }
+            Self::TypeOf => {
+                2u8.hash(state);
+            }
+        }
+    }
 }
 
 impl Equivalent<DefinableNameSegment> for DefinableNameSegmentRef<'_> {
@@ -200,8 +242,18 @@ impl Equivalent<DefinableNameSegment> for DefinableNameSegmentRef<'_> {
     }
 }
 
-#[derive(Hash, PartialEq, Eq)]
+#[derive(PartialEq, Eq)]
 pub struct DefinableNameSegmentRefs<'a>(pub SmallVec<[DefinableNameSegmentRef<'a>; 4]>);
+
+// Hash can't be derived because it must match Vec<DefinableNameSegment>'s Hash.
+impl std::hash::Hash for DefinableNameSegmentRefs<'_> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.0.len().hash(state);
+        for segment in &self.0 {
+            segment.hash(state);
+        }
+    }
+}
 
 impl Equivalent<Vec<DefinableNameSegment>> for DefinableNameSegmentRefs<'_> {
     fn equivalent(&self, key: &Vec<DefinableNameSegment>) -> bool {

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -167,16 +167,18 @@ pub enum DefinableNameSegment {
 // Hash can't be derived because DefinableNameSegmentRef must have a matching
 // Hash implementation for Equivalent lookups, and derived discriminants are
 // not guaranteed to match between different enum types.
+// Also, we must use s.as_str().hash() instead of s.hash() because RcStr's Hash
+// implementation for prehashed strings is not compatible with str's Hash.
 impl std::hash::Hash for DefinableNameSegment {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         match self {
             Self::Name(s) => {
                 0u8.hash(state);
-                s.hash(state);
+                s.as_str().hash(state);
             }
             Self::Call(s) => {
                 1u8.hash(state);
-                s.hash(state);
+                s.as_str().hash(state);
             }
             Self::TypeOf => {
                 2u8.hash(state);
@@ -454,10 +456,114 @@ impl CompileTimeInfoBuilder {
 
 #[cfg(test)]
 mod test {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+
+    use smallvec::smallvec;
     use turbo_rcstr::rcstr;
     use turbo_tasks::FxIndexMap;
 
-    use crate::compile_time_info::{DefinableNameSegment, FreeVarReference, FreeVarReferences};
+    use crate::compile_time_info::{
+        DefinableNameSegment, DefinableNameSegmentRef, DefinableNameSegmentRefs, FreeVarReference,
+        FreeVarReferences,
+    };
+
+    fn hash_value<T: Hash>(value: &T) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        value.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    #[test]
+    fn hash_segment_name_matches() {
+        let segment = DefinableNameSegment::Name(rcstr!("process"));
+        let segment_ref = DefinableNameSegmentRef::Name("process");
+        assert_eq!(
+            hash_value(&segment),
+            hash_value(&segment_ref),
+            "DefinableNameSegment::Name and DefinableNameSegmentRef::Name must have matching Hash"
+        );
+    }
+
+    #[test]
+    fn hash_segment_call_matches() {
+        let segment = DefinableNameSegment::Call(rcstr!("foo"));
+        let segment_ref = DefinableNameSegmentRef::Call("foo");
+        assert_eq!(
+            hash_value(&segment),
+            hash_value(&segment_ref),
+            "DefinableNameSegment::Call and DefinableNameSegmentRef::Call must have matching Hash"
+        );
+    }
+
+    #[test]
+    fn hash_segment_typeof_matches() {
+        let segment = DefinableNameSegment::TypeOf;
+        let segment_ref = DefinableNameSegmentRef::TypeOf;
+        assert_eq!(
+            hash_value(&segment),
+            hash_value(&segment_ref),
+            "DefinableNameSegment::TypeOf and DefinableNameSegmentRef::TypeOf must have matching \
+             Hash"
+        );
+    }
+
+    #[test]
+    fn hash_segments_vec_matches() {
+        let segments: Vec<DefinableNameSegment> = vec![
+            DefinableNameSegment::Name(rcstr!("process")),
+            DefinableNameSegment::Name(rcstr!("env")),
+            DefinableNameSegment::Name(rcstr!("NODE_ENV")),
+        ];
+        let segments_ref = DefinableNameSegmentRefs(smallvec![
+            DefinableNameSegmentRef::Name("process"),
+            DefinableNameSegmentRef::Name("env"),
+            DefinableNameSegmentRef::Name("NODE_ENV"),
+        ]);
+        assert_eq!(
+            hash_value(&segments),
+            hash_value(&segments_ref),
+            "Vec<DefinableNameSegment> and DefinableNameSegmentRefs must have matching Hash"
+        );
+    }
+
+    #[test]
+    fn hash_segments_with_typeof_matches() {
+        let segments: Vec<DefinableNameSegment> = vec![
+            DefinableNameSegment::Name(rcstr!("process")),
+            DefinableNameSegment::TypeOf,
+        ];
+        let segments_ref = DefinableNameSegmentRefs(smallvec![
+            DefinableNameSegmentRef::Name("process"),
+            DefinableNameSegmentRef::TypeOf,
+        ]);
+        assert_eq!(
+            hash_value(&segments),
+            hash_value(&segments_ref),
+            "Vec<DefinableNameSegment> with TypeOf and DefinableNameSegmentRefs must have \
+             matching Hash"
+        );
+    }
+
+    #[test]
+    fn hash_segments_with_call_matches() {
+        let segments: Vec<DefinableNameSegment> = vec![
+            DefinableNameSegment::Name(rcstr!("foo")),
+            DefinableNameSegment::Call(rcstr!("bar")),
+        ];
+        let segments_ref = DefinableNameSegmentRefs(smallvec![
+            DefinableNameSegmentRef::Name("foo"),
+            DefinableNameSegmentRef::Call("bar"),
+        ]);
+        assert_eq!(
+            hash_value(&segments),
+            hash_value(&segments_ref),
+            "Vec<DefinableNameSegment> with Call and DefinableNameSegmentRefs must have matching \
+             Hash"
+        );
+    }
 
     #[test]
     fn macro_parser() {
@@ -532,6 +638,60 @@ mod test {
                     FreeVarReference::Value(rcstr!("c").into())
                 )
             ]))
+        );
+    }
+
+    #[test]
+    fn indexmap_lookup_with_equivalent() {
+        // Test that DefinableNameSegmentRefs can be used to look up Vec<DefinableNameSegment>
+        // in an IndexMap using the Equivalent trait
+        let mut map: FxIndexMap<Vec<DefinableNameSegment>, &str> = FxIndexMap::default();
+        map.insert(
+            vec![
+                DefinableNameSegment::Name(rcstr!("process")),
+                DefinableNameSegment::Name(rcstr!("env")),
+                DefinableNameSegment::Name(rcstr!("NODE_ENV")),
+            ],
+            "production",
+        );
+        map.insert(
+            vec![
+                DefinableNameSegment::Name(rcstr!("process")),
+                DefinableNameSegment::Name(rcstr!("turbopack")),
+            ],
+            "true",
+        );
+
+        // Lookup using DefinableNameSegmentRefs
+        let key = DefinableNameSegmentRefs(smallvec![
+            DefinableNameSegmentRef::Name("process"),
+            DefinableNameSegmentRef::Name("env"),
+            DefinableNameSegmentRef::Name("NODE_ENV"),
+        ]);
+        assert_eq!(
+            map.get(&key),
+            Some(&"production"),
+            "IndexMap lookup with Equivalent trait should work"
+        );
+
+        let key2 = DefinableNameSegmentRefs(smallvec![
+            DefinableNameSegmentRef::Name("process"),
+            DefinableNameSegmentRef::Name("turbopack"),
+        ]);
+        assert_eq!(
+            map.get(&key2),
+            Some(&"true"),
+            "IndexMap lookup with Equivalent trait should work for shorter keys"
+        );
+
+        let key3 = DefinableNameSegmentRefs(smallvec![
+            DefinableNameSegmentRef::Name("process"),
+            DefinableNameSegmentRef::Name("nonexistent"),
+        ]);
+        assert_eq!(
+            map.get(&key3),
+            None,
+            "IndexMap lookup should return None for nonexistent keys"
         );
     }
 }

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -694,4 +694,35 @@ mod test {
             "IndexMap lookup should return None for nonexistent keys"
         );
     }
+
+    #[test]
+    fn fxhashset_rcstr_lookup_with_str() {
+        // Test that &str can be used to look up RcStr in a FxHashSet
+        // This is used by FreeVarReferencesMembers::contains_key
+        use rustc_hash::FxHashSet;
+
+        let mut set: FxHashSet<turbo_rcstr::RcStr> = FxHashSet::default();
+        set.insert(rcstr!("process"));
+        set.insert(rcstr!("env"));
+        set.insert(rcstr!("NODE_ENV"));
+
+        // This tests whether &str can look up RcStr in the set
+        // It requires RcStr: Borrow<str> AND hash(&str) == hash(&RcStr)
+        assert!(
+            set.contains("process"),
+            "FxHashSet<RcStr> lookup with &str should work for 'process'"
+        );
+        assert!(
+            set.contains("env"),
+            "FxHashSet<RcStr> lookup with &str should work for 'env'"
+        );
+        assert!(
+            set.contains("NODE_ENV"),
+            "FxHashSet<RcStr> lookup with &str should work for 'NODE_ENV'"
+        );
+        assert!(
+            !set.contains("nonexistent"),
+            "FxHashSet<RcStr> lookup with &str should return false for nonexistent keys"
+        );
+    }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -1975,9 +1975,12 @@ impl JsValue {
                 }
                 JsValue::WellKnownObject(obj) => {
                     if let Some(name) = obj.as_define_name() {
-                        for segment in name.iter().rev() {
-                            segments.push(DefinableNameSegmentRef::Name(segment));
-                        }
+                        segments.extend(
+                            name.iter()
+                                .rev()
+                                .copied()
+                                .map(DefinableNameSegmentRef::Name),
+                        );
                         break;
                     } else {
                         return None;
@@ -1985,9 +1988,12 @@ impl JsValue {
                 }
                 JsValue::WellKnownFunction(func) => {
                     if let Some(name) = func.as_define_name() {
-                        for segment in name.iter().rev() {
-                            segments.push(DefinableNameSegmentRef::Name(segment));
-                        }
+                        segments.extend(
+                            name.iter()
+                                .rev()
+                                .copied()
+                                .map(DefinableNameSegmentRef::Name),
+                        );
                         break;
                     } else {
                         return None;

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -9,11 +9,11 @@ use std::{
 };
 
 use anyhow::{Result, bail};
-use graph::VarGraph;
 use num_bigint::BigInt;
 use num_traits::identities::Zero;
 use once_cell::sync::Lazy;
 use rustc_hash::FxHasher;
+use smallvec::SmallVec;
 use swc_core::{
     atoms::Wtf8Atom,
     common::Mark,
@@ -24,9 +24,9 @@ use swc_core::{
 };
 use turbo_esregex::EsRegex;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
 use turbopack_core::compile_time_info::{
-    CompileTimeDefineValue, DefinableNameSegment, FreeVarReference, FreeVarReferenceVcs,
+    CompileTimeDefineValue, DefinableNameSegmentRef, DefinableNameSegmentRefs, FreeVarReference,
 };
 
 use self::imports::ImportAnnotations;
@@ -1949,158 +1949,67 @@ impl JsValue {
 
 // Definable name management
 impl JsValue {
-    /// When the value has a user-definable name, return the length of it (in segments). Otherwise
+    /// When the value has a user-definable name, return it in segments. Otherwise
     /// returns None.
     /// - any free var has itself as user-definable name: ["foo"]
     /// - any member access adds the identifier as segment after the object: ["foo", "prop"]
     /// - some well-known objects/functions have a user-definable names: ["import"]
-    /// - member calls without arguments also have a user-definable name which is the property with
-    ///   `()` appended: ["foo", "prop()"]
+    /// - member calls without arguments also have a user-definable name: ["foo", Call("func")]
     /// - typeof expressions add `typeof` after the argument's segments: ["foo", "typeof"]
-    pub fn get_definable_name_len(&self) -> Option<usize> {
-        match self {
-            JsValue::FreeVar(_) => Some(1),
-            JsValue::Member(_, obj, prop) if prop.as_str().is_some() => {
-                Some(obj.get_definable_name_len()? + 1)
-            }
-            JsValue::WellKnownObject(obj) => obj.as_define_name().map(|d| d.len()),
-            JsValue::WellKnownFunction(func) => func.as_define_name().map(|d| d.len()),
-            JsValue::MemberCall(_, callee, prop, args)
-                if args.is_empty() && prop.as_str().is_some() =>
-            {
-                Some(callee.get_definable_name_len()? + 1)
-            }
-            JsValue::TypeOf(_, arg) => Some(arg.get_definable_name_len()? + 1),
-
-            _ => None,
-        }
-    }
-
-    /// Returns a reverse iterator over the segments of the user-definable
-    /// name. e. g. `foo.bar().baz` would yield `baz`, `bar()`, `foo`.
-    /// `(1+2).foo.baz` would also yield `baz`, `foo` even while the value is
-    /// not a complete user-definable name. Before calling this method you must
-    /// use [JsValue::get_definable_name_len] to determine if the value has a
-    /// user-definable name at all.
-    pub fn iter_definable_name_rev(&self) -> DefinableNameIter<'_> {
-        DefinableNameIter {
-            next: Some(self),
-            index: 0,
-        }
-    }
-
-    /// Returns any matching defined replacement that matches this value (the replacement that
-    /// matches `$self.$prop`).
-    ///
-    /// Uses the `VarGraph` to verify that the first segment is not a local
-    /// variable/was not reassigned.
-    pub fn match_free_var_reference(
-        &self,
-        var_graph: &VarGraph,
-        free_var_references: &FxIndexMap<DefinableNameSegment, FreeVarReferenceVcs>,
-        prop: &DefinableNameSegment,
-    ) -> Option<ResolvedVc<FreeVarReference>> {
-        if let Some(def_name_len) = self.get_definable_name_len()
-            && let Some(references) = free_var_references.get(prop)
-        {
-            for (name, value) in &references.0 {
-                if name.len() != def_name_len {
-                    continue;
+    pub fn get_definable_name(&self) -> Option<DefinableNameSegmentRefs<'_>> {
+        let mut current = self;
+        let mut segments = SmallVec::new();
+        loop {
+            match current {
+                JsValue::FreeVar(name) => {
+                    segments.push(DefinableNameSegmentRef::Name(&name));
+                    break;
                 }
-
-                let name_rev_it = name.iter().map(Cow::Borrowed).rev();
-                if name_rev_it.eq(self.iter_definable_name_rev()) {
-                    if let DefinableNameSegment::Name(first_str) = name.first().unwrap() {
-                        let first_str: &str = first_str;
-                        if var_graph
-                            .free_var_ids
-                            .get(&Atom::from(first_str))
-                            .is_some_and(|id| var_graph.values.contains_key(id))
-                        {
-                            // `typeof foo...` but `foo` was reassigned
-                            return None;
-                        }
+                JsValue::Member(_, obj, prop) => {
+                    if let Some(prop) = prop.as_str() {
+                        segments.push(DefinableNameSegmentRef::Name(prop));
+                    } else {
+                        return None;
                     }
-
-                    return Some(*value);
+                    current = obj;
                 }
+                JsValue::WellKnownObject(obj) => {
+                    if let Some(name) = obj.as_define_name() {
+                        for segment in name.iter().rev() {
+                            segments.push(DefinableNameSegmentRef::Name(*segment));
+                        }
+                        break;
+                    } else {
+                        return None;
+                    }
+                }
+                JsValue::WellKnownFunction(func) => {
+                    if let Some(name) = func.as_define_name() {
+                        for segment in name.iter().rev() {
+                            segments.push(DefinableNameSegmentRef::Name(*segment));
+                        }
+                        break;
+                    } else {
+                        return None;
+                    }
+                }
+                JsValue::MemberCall(_, callee, prop, args) if args.is_empty() => {
+                    if let Some(prop) = prop.as_str() {
+                        segments.push(DefinableNameSegmentRef::Call(prop));
+                    } else {
+                        return None;
+                    }
+                    current = callee;
+                }
+                JsValue::TypeOf(_, arg) => {
+                    segments.push(DefinableNameSegmentRef::TypeOf);
+                    current = arg;
+                }
+                _ => return None,
             }
         }
-
-        None
-    }
-
-    /// Returns any matching defined replacement that matches this value.
-    pub fn match_define<'a, T>(
-        &self,
-        defines: &'a FxIndexMap<Vec<DefinableNameSegment>, T>,
-    ) -> Option<&'a T> {
-        if let Some(def_name_len) = self.get_definable_name_len() {
-            for (name, value) in defines.iter() {
-                if name.len() != def_name_len {
-                    continue;
-                }
-
-                if name
-                    .iter()
-                    .map(Cow::Borrowed)
-                    .rev()
-                    .eq(self.iter_definable_name_rev())
-                {
-                    return Some(value);
-                }
-            }
-        }
-
-        None
-    }
-}
-
-pub struct DefinableNameIter<'a> {
-    next: Option<&'a JsValue>,
-    index: usize,
-}
-
-impl<'a> Iterator for DefinableNameIter<'a> {
-    type Item = Cow<'a, DefinableNameSegment>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        let value = self.next.take()?;
-        Some(Cow::Owned(match value {
-            JsValue::FreeVar(kind) => (&**kind).into(),
-            JsValue::Member(_, obj, prop) => {
-                self.next = Some(obj);
-                prop.as_str()?.into()
-            }
-            JsValue::WellKnownObject(obj) => {
-                let name = obj.as_define_name()?;
-                let i = self.index;
-                self.index += 1;
-                if self.index < name.len() {
-                    self.next = Some(value);
-                }
-                name[name.len() - i - 1].into()
-            }
-            JsValue::WellKnownFunction(func) => {
-                let name = func.as_define_name()?;
-                let i = self.index;
-                self.index += 1;
-                if self.index < name.len() {
-                    self.next = Some(value);
-                }
-                name[name.len() - i - 1].into()
-            }
-            JsValue::MemberCall(_, callee, prop, args) if args.is_empty() => {
-                self.next = Some(callee);
-                format!("{}()", prop.as_str()?).into()
-            }
-            JsValue::TypeOf(_, arg) => {
-                self.next = Some(arg);
-                DefinableNameSegment::TypeOf
-            }
-
-            _ => return None,
-        }))
+        segments.reverse();
+        Some(DefinableNameSegmentRefs(segments))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -32,7 +32,8 @@ use turbopack_core::compile_time_info::{
 use self::imports::ImportAnnotations;
 pub(crate) use self::imports::ImportMap;
 use crate::{
-    analyzer::graph::EvalContext, references::require_context::RequireContextMap,
+    analyzer::graph::{EvalContext, VarGraph},
+    references::require_context::RequireContextMap,
     utils::StringifyJs,
 };
 
@@ -1951,17 +1952,31 @@ impl JsValue {
 impl JsValue {
     /// When the value has a user-definable name, return it in segments. Otherwise
     /// returns None.
+    /// It also returns a boolean whether the variable was potentially reassigned.
     /// - any free var has itself as user-definable name: ["foo"]
     /// - any member access adds the identifier as segment after the object: ["foo", "prop"]
     /// - some well-known objects/functions have a user-definable names: ["import"]
     /// - member calls without arguments also have a user-definable name: ["foo", Call("func")]
     /// - typeof expressions add `typeof` after the argument's segments: ["foo", "typeof"]
-    pub fn get_definable_name(&self) -> Option<DefinableNameSegmentRefs<'_>> {
+    pub fn get_definable_name(
+        &self,
+        var_graph: Option<&VarGraph>,
+    ) -> Option<(DefinableNameSegmentRefs<'_>, bool)> {
         let mut current = self;
         let mut segments = SmallVec::new();
+        let mut potentially_reassigned = false;
         loop {
             match current {
                 JsValue::FreeVar(name) => {
+                    if var_graph.is_some_and(|var_graph| {
+                        var_graph
+                            .free_var_ids
+                            .get(name)
+                            .is_some_and(|id| var_graph.values.contains_key(id))
+                    }) {
+                        // `foo` was potentially reassigned
+                        potentially_reassigned = true;
+                    }
                     segments.push(DefinableNameSegmentRef::Name(name));
                     break;
                 }
@@ -2015,7 +2030,7 @@ impl JsValue {
             }
         }
         segments.reverse();
-        Some(DefinableNameSegmentRefs(segments))
+        Some((DefinableNameSegmentRefs(segments), potentially_reassigned))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -1962,7 +1962,7 @@ impl JsValue {
         loop {
             match current {
                 JsValue::FreeVar(name) => {
-                    segments.push(DefinableNameSegmentRef::Name(&name));
+                    segments.push(DefinableNameSegmentRef::Name(name));
                     break;
                 }
                 JsValue::Member(_, obj, prop) => {
@@ -1976,7 +1976,7 @@ impl JsValue {
                 JsValue::WellKnownObject(obj) => {
                     if let Some(name) = obj.as_define_name() {
                         for segment in name.iter().rev() {
-                            segments.push(DefinableNameSegmentRef::Name(*segment));
+                            segments.push(DefinableNameSegmentRef::Name(segment));
                         }
                         break;
                     } else {
@@ -1986,7 +1986,7 @@ impl JsValue {
                 JsValue::WellKnownFunction(func) => {
                     if let Some(name) = func.as_define_name() {
                         for segment in name.iter().rev() {
-                            segments.push(DefinableNameSegmentRef::Name(*segment));
+                            segments.push(DefinableNameSegmentRef::Name(segment));
                         }
                         break;
                     } else {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -496,7 +496,7 @@ impl AnalysisState<'_> {
                     *self.origin,
                     value,
                     *self.compile_time_info,
-                    &*self.compile_time_info_ref,
+                    &self.compile_time_info_ref,
                     attributes,
                     self.allow_project_root_tracing,
                 )
@@ -2794,7 +2794,7 @@ async fn handle_member(
                     .get(&name)
                     .await?
                 {
-                    handle_free_var_reference(ast_path, &*value, span, state, analysis).await?;
+                    handle_free_var_reference(ast_path, &value, span, state, analysis).await?;
                     return Ok(());
                 }
             }
@@ -2826,7 +2826,7 @@ async fn handle_typeof(
             .get(&name)
             .await?
         {
-            handle_free_var_reference(ast_path, &*value, span, state, analysis).await?;
+            handle_free_var_reference(ast_path, &value, span, state, analysis).await?;
             return Ok(());
         }
     }
@@ -2841,16 +2841,15 @@ async fn handle_free_var(
     state: &AnalysisState<'_>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
-    if let Some(name) = var.get_definable_name() {
-        if let Some(value) = state
+    if let Some(name) = var.get_definable_name()
+        && let Some(value) = state
             .compile_time_info_ref
             .free_var_references
             .get(&name)
             .await?
-        {
-            handle_free_var_reference(ast_path, &*value, span, state, analysis).await?;
-            return Ok(());
-        }
+    {
+        handle_free_var_reference(ast_path, &value, span, state, analysis).await?;
+        return Ok(());
     }
 
     Ok(())

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -497,6 +497,7 @@ impl AnalysisState<'_> {
                     value,
                     *self.compile_time_info,
                     &self.compile_time_info_ref,
+                    self.var_graph,
                     attributes,
                     self.allow_project_root_tracing,
                 )
@@ -2759,7 +2760,7 @@ async fn handle_member(
 
         if has_member {
             let obj = obj.as_ref().unwrap();
-            if let Some(mut name) = obj.get_definable_name() {
+            if let Some((mut name, false)) = obj.get_definable_name(Some(state.var_graph)) {
                 name.0.push(DefinableNameSegmentRef::Name(prop));
                 if let Some(value) = state
                     .compile_time_info_ref
@@ -2791,7 +2792,7 @@ async fn handle_typeof(
     state: &AnalysisState<'_>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
-    if let Some(mut name) = arg.get_definable_name() {
+    if let Some((mut name, false)) = arg.get_definable_name(Some(state.var_graph)) {
         name.0.push(DefinableNameSegmentRef::TypeOf);
         if let Some(value) = state
             .compile_time_info_ref
@@ -2814,7 +2815,7 @@ async fn handle_free_var(
     state: &AnalysisState<'_>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
-    if let Some(name) = var.get_definable_name()
+    if let Some((name, _)) = var.get_definable_name(None)
         && let Some(value) = state
             .compile_time_info_ref
             .free_var_references
@@ -3168,6 +3169,7 @@ async fn value_visitor(
     v: JsValue,
     compile_time_info: Vc<CompileTimeInfo>,
     compile_time_info_ref: &CompileTimeInfo,
+    var_graph: &VarGraph,
     attributes: &ImportAttributes,
     allow_project_root_tracing: bool,
 ) -> Result<(JsValue, bool)> {
@@ -3176,6 +3178,7 @@ async fn value_visitor(
         v,
         compile_time_info,
         compile_time_info_ref,
+        var_graph,
         attributes,
         allow_project_root_tracing,
     )
@@ -3189,11 +3192,12 @@ async fn value_visitor_inner(
     v: JsValue,
     compile_time_info: Vc<CompileTimeInfo>,
     compile_time_info_ref: &CompileTimeInfo,
+    var_graph: &VarGraph,
     attributes: &ImportAttributes,
     allow_project_root_tracing: bool,
 ) -> Result<(JsValue, bool)> {
     let ImportAttributes { ignore, .. } = *attributes;
-    if let Some(name) = v.get_definable_name()
+    if let Some((name, _)) = v.get_definable_name(Some(var_graph))
         && let Some(value) = compile_time_info_ref.defines.get(&name).await?
     {
         return Ok(((&*value).try_into()?, true));

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -20,7 +20,6 @@ pub mod util;
 pub mod worker;
 
 use std::{
-    borrow::Cow,
     collections::BTreeMap,
     future::Future,
     mem::take,
@@ -70,7 +69,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     compile_time_info::{
         CompileTimeDefineValue, CompileTimeDefines, CompileTimeInfo, DefinableNameSegment,
-        FreeVarReference, FreeVarReferenceVcs, FreeVarReferences, FreeVarReferencesIndividual,
+        DefinableNameSegmentRef, FreeVarReference, FreeVarReferences, FreeVarReferencesMembers,
         InputRelativeConstant,
     },
     environment::Rendering,
@@ -456,6 +455,8 @@ struct AnalysisState<'a> {
     source: ResolvedVc<Box<dyn Source>>,
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     compile_time_info: ResolvedVc<CompileTimeInfo>,
+    free_var_references_members: ResolvedVc<FreeVarReferencesMembers>,
+    compile_time_info_ref: ReadRef<CompileTimeInfo>,
     var_graph: &'a VarGraph,
     /// Whether to allow tracing to reference files from the project root. This is used to prevent
     /// random node_modules packages from tracing the entire project due to some dynamic
@@ -475,7 +476,6 @@ struct AnalysisState<'a> {
     import_externals: bool,
     ignore_dynamic_requests: bool,
     url_rewrite_behavior: Option<UrlRewriteBehavior>,
-    free_var_references: ReadRef<FreeVarReferencesIndividual>,
     // Whether we should collect affecting sources from referenced files. Only usedful when
     // tracing.
     collect_affecting_sources: bool,
@@ -496,8 +496,7 @@ impl AnalysisState<'_> {
                     *self.origin,
                     value,
                     *self.compile_time_info,
-                    &self.free_var_references,
-                    self.var_graph,
+                    &*self.compile_time_info_ref,
                     attributes,
                     self.allow_project_root_tracing,
                 )
@@ -1067,6 +1066,7 @@ async fn analyze_ecmascript_module_internal(
     let span = tracing::trace_span!("effects processing");
     async {
         let effects = take(&mut var_graph.effects);
+        let compile_time_info_ref = compile_time_info.await?;
 
         let mut analysis_state = AnalysisState {
             handler: &handler,
@@ -1074,6 +1074,12 @@ async fn analyze_ecmascript_module_internal(
             source,
             origin,
             compile_time_info,
+            free_var_references_members: compile_time_info_ref
+                .free_var_references
+                .members()
+                .to_resolved()
+                .await?,
+            compile_time_info_ref,
             var_graph: &var_graph,
             allow_project_root_tracing: !source.ident().path().await?.is_in_node_modules(),
             fun_args_values: Default::default(),
@@ -1084,11 +1090,6 @@ async fn analyze_ecmascript_module_internal(
             import_externals: options.import_externals,
             ignore_dynamic_requests: options.ignore_dynamic_requests,
             url_rewrite_behavior: options.url_rewrite_behavior,
-            free_var_references: compile_time_info
-                .await?
-                .free_var_references
-                .individual()
-                .await?,
             collect_affecting_sources: options.analyze_mode.is_tracing_assets(),
             tracing_only: !options.analyze_mode.is_code_gen(),
         };
@@ -2773,39 +2774,28 @@ async fn handle_member(
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
     if let Some(prop) = prop.as_str() {
-        let prop_seg = DefinableNameSegment::Name(prop.into());
-
-        let references = state.free_var_references.get(&prop_seg);
+        let has_member = state.free_var_references_members.contains_key(prop).await?;
         let is_prop_cache = prop == "cache";
 
         // This isn't pretty, but we cannot await the future twice in the two branches below.
-        let obj = if references.is_some() || is_prop_cache {
+        let obj = if has_member || is_prop_cache {
             Some(link_obj.await?)
         } else {
             None
         };
 
-        if let Some(references) = references {
+        if has_member {
             let obj = obj.as_ref().unwrap();
-            if let Some(def_name_len) = obj.get_definable_name_len() {
-                for (name, value) in &references.0 {
-                    if name.len() != def_name_len {
-                        continue;
-                    }
-
-                    let it = name.iter().map(Cow::Borrowed).rev();
-                    if it.eq(obj.iter_definable_name_rev())
-                        && handle_free_var_reference(
-                            ast_path,
-                            &*value.await?,
-                            span,
-                            state,
-                            analysis,
-                        )
-                        .await?
-                    {
-                        return Ok(());
-                    }
+            if let Some(mut name) = obj.get_definable_name() {
+                name.0.push(DefinableNameSegmentRef::Name(prop));
+                if let Some(value) = state
+                    .compile_time_info_ref
+                    .free_var_references
+                    .get(&name)
+                    .await?
+                {
+                    handle_free_var_reference(ast_path, &*value, span, state, analysis).await?;
+                    return Ok(());
                 }
             }
         }
@@ -2828,12 +2818,17 @@ async fn handle_typeof(
     state: &AnalysisState<'_>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
-    if let Some(value) = arg.match_free_var_reference(
-        state.var_graph,
-        &state.free_var_references,
-        &DefinableNameSegment::TypeOf,
-    ) {
-        handle_free_var_reference(ast_path, &*value.await?, span, state, analysis).await?;
+    if let Some(mut name) = arg.get_definable_name() {
+        name.0.push(DefinableNameSegmentRef::TypeOf);
+        if let Some(value) = state
+            .compile_time_info_ref
+            .free_var_references
+            .get(&name)
+            .await?
+        {
+            handle_free_var_reference(ast_path, &*value, span, state, analysis).await?;
+            return Ok(());
+        }
     }
 
     Ok(())
@@ -2846,21 +2841,15 @@ async fn handle_free_var(
     state: &AnalysisState<'_>,
     analysis: &mut AnalyzeEcmascriptModuleResultBuilder,
 ) -> Result<()> {
-    if let Some(def_name_len) = var.get_definable_name_len() {
-        let first = var.iter_definable_name_rev().next().unwrap();
-        if let Some(references) = state.free_var_references.get(&*first) {
-            for (name, value) in &references.0 {
-                if name.len() + 1 != def_name_len {
-                    continue;
-                }
-
-                let it = name.iter().map(Cow::Borrowed).rev();
-                if it.eq(var.iter_definable_name_rev().skip(1)) {
-                    handle_free_var_reference(ast_path, &*value.await?, span, state, analysis)
-                        .await?;
-                    return Ok(());
-                }
-            }
+    if let Some(name) = var.get_definable_name() {
+        if let Some(value) = state
+            .compile_time_info_ref
+            .free_var_references
+            .get(&name)
+            .await?
+        {
+            handle_free_var_reference(ast_path, &*value, span, state, analysis).await?;
+            return Ok(());
         }
     }
 
@@ -3206,8 +3195,7 @@ async fn value_visitor(
     origin: Vc<Box<dyn ResolveOrigin>>,
     v: JsValue,
     compile_time_info: Vc<CompileTimeInfo>,
-    free_var_references: &FxIndexMap<DefinableNameSegment, FreeVarReferenceVcs>,
-    var_graph: &VarGraph,
+    compile_time_info_ref: &CompileTimeInfo,
     attributes: &ImportAttributes,
     allow_project_root_tracing: bool,
 ) -> Result<(JsValue, bool)> {
@@ -3215,8 +3203,7 @@ async fn value_visitor(
         origin,
         v,
         compile_time_info,
-        free_var_references,
-        var_graph,
+        compile_time_info_ref,
         attributes,
         allow_project_root_tracing,
     )
@@ -3229,27 +3216,19 @@ async fn value_visitor_inner(
     origin: Vc<Box<dyn ResolveOrigin>>,
     v: JsValue,
     compile_time_info: Vc<CompileTimeInfo>,
-    free_var_references: &FxIndexMap<DefinableNameSegment, FreeVarReferenceVcs>,
-    var_graph: &VarGraph,
+    compile_time_info_ref: &CompileTimeInfo,
     attributes: &ImportAttributes,
     allow_project_root_tracing: bool,
 ) -> Result<(JsValue, bool)> {
     let ImportAttributes { ignore, .. } = *attributes;
     // This check is just an optimization
-    if v.get_definable_name_len().is_some() {
-        let compile_time_info = compile_time_info.await?;
-        if let JsValue::TypeOf(_, arg) = &v
-            && let Some(value) = arg.match_free_var_reference(
-                var_graph,
-                free_var_references,
-                &DefinableNameSegment::TypeOf,
-            )
-        {
-            return Ok(((&*value.await?).try_into()?, true));
+    if let Some(name) = v.get_definable_name() {
+        if let Some(value) = compile_time_info_ref.free_var_references.get(&name).await? {
+            return Ok(((&*value).try_into()?, true));
         }
 
-        if let Some(value) = v.match_define(&*compile_time_info.defines.individual().await?) {
-            return Ok(((&*value.await?).try_into()?, true));
+        if let Some(value) = compile_time_info_ref.defines.get(&name).await? {
+            return Ok(((&*value).try_into()?, true));
         }
     }
     let value = match v {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1582,79 +1582,66 @@ async fn compile_time_info_for_module_options(
 ) -> Result<Vc<CompileTimeInfo>> {
     let compile_time_info = compile_time_info.await?;
     let free_var_references = compile_time_info.free_var_references;
+    let defines = compile_time_info.defines;
 
     let mut free_var_references = free_var_references.owned().await?;
-    let (typeof_exports, typeof_module, require) = if is_esm {
-        ("undefined", "undefined", TURBOPACK_REQUIRE_STUB)
+    let mut defines = defines.owned().await?;
+
+    let (typeof_exports, typeof_module, typeof_this, require) = if is_esm {
+        (
+            rcstr!("undefined"),
+            rcstr!("undefined"),
+            rcstr!("undefined"),
+            TURBOPACK_REQUIRE_STUB,
+        )
     } else {
-        ("object", "object", TURBOPACK_REQUIRE_REAL)
+        (
+            rcstr!("object"),
+            rcstr!("object"),
+            rcstr!("object"),
+            TURBOPACK_REQUIRE_REAL,
+        )
     };
-    free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(rcstr!("import")),
-            DefinableNameSegment::Name(rcstr!("meta")),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(rcstr!("object").into());
-    free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(rcstr!("exports")),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(typeof_exports.into());
-    free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(rcstr!("module")),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(typeof_module.into());
-    free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(rcstr!("require")),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(rcstr!("function").into());
+    let typeofs: [(&[RcStr], RcStr); _] = [
+        (&[rcstr!("import"), rcstr!("meta")], rcstr!("object")),
+        (&[rcstr!("exports")], typeof_exports),
+        (&[rcstr!("module")], typeof_module),
+        (&[rcstr!("this")], typeof_this),
+        (&[rcstr!("require")], rcstr!("function")),
+        (&[rcstr!("__dirname")], rcstr!("string")),
+        (&[rcstr!("__filename")], rcstr!("string")),
+        (&[rcstr!("global")], rcstr!("object")),
+    ];
+    for (typeof_path, typeof_value) in typeofs {
+        let name = typeof_path
+            .iter()
+            .map(|s| DefinableNameSegment::Name(s.clone()))
+            .chain(std::iter::once(DefinableNameSegment::TypeOf))
+            .collect::<Vec<_>>();
+        free_var_references
+            .entry(name.clone())
+            .or_insert(typeof_value.clone().into());
+        defines.entry(name).or_insert(typeof_value.into());
+    }
+
     free_var_references
         .entry(vec![DefinableNameSegment::Name(rcstr!("require"))])
         .or_insert(require.into());
-
-    let dir_name = rcstr!("__dirname");
     free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(dir_name.clone()),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(rcstr!("string").into());
-    free_var_references
-        .entry(vec![DefinableNameSegment::Name(dir_name)])
+        .entry(vec![DefinableNameSegment::Name(rcstr!("__dirname"))])
         .or_insert(FreeVarReference::InputRelative(
             InputRelativeConstant::DirName,
         ));
-    let file_name = rcstr!("__filename");
-
     free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(file_name.clone()),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(rcstr!("string").into());
-    free_var_references
-        .entry(vec![DefinableNameSegment::Name(file_name)])
+        .entry(vec![DefinableNameSegment::Name(rcstr!("__filename"))])
         .or_insert(FreeVarReference::InputRelative(
             InputRelativeConstant::FileName,
         ));
 
     // Compiletime rewrite the nodejs `global` to `__turbopack_context_.g` which is a shortcut for
     // `globalThis` that cannot be shadowed by a local variable.
-    let global = rcstr!("global");
     free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(global.clone()),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(rcstr!("object").into());
-    free_var_references
-        .entry(vec![DefinableNameSegment::Name(global)])
+        .entry(vec![DefinableNameSegment::Name(rcstr!("global"))])
         .or_insert(TURBOPACK_GLOBAL.into());
 
     free_var_references.extend(TURBOPACK_RUNTIME_FUNCTION_SHORTCUTS.into_iter().map(
@@ -1669,9 +1656,8 @@ async fn compile_time_info_for_module_options(
     // Compile time replace it so we can represent module-factories as arrow functions without
     // needing to be defensive about rebinding this. Do the same for CJS modules while we are
     // here.
-    let this = rcstr!("this");
     free_var_references
-        .entry(vec![DefinableNameSegment::Name(this.clone())])
+        .entry(vec![DefinableNameSegment::Name(rcstr!("this"))])
         .or_insert(if is_esm {
             FreeVarReference::Value(CompileTimeDefineValue::Undefined)
         } else {
@@ -1679,43 +1665,30 @@ async fn compile_time_info_for_module_options(
             // not be shadowed by user symbols.
             TURBOPACK_EXPORTS.into()
         });
-    free_var_references
-        .entry(vec![
-            DefinableNameSegment::Name(this),
-            DefinableNameSegment::TypeOf,
-        ])
-        .or_insert(if is_esm {
-            rcstr!("undefined").into()
-        } else {
-            rcstr!("object").into()
-        });
 
-    let mut defines = compile_time_info.defines;
     if let Some(enable_typeof_window_inlining) = enable_typeof_window_inlining {
         let value = match enable_typeof_window_inlining {
             TypeofWindow::Object => rcstr!("object"),
             TypeofWindow::Undefined => rcstr!("undefined"),
         };
         let window = rcstr!("window");
-        let mut defines_value = defines.owned().await?;
-        defines_value
+        free_var_references
             .entry(vec![
                 DefinableNameSegment::Name(window.clone()),
                 DefinableNameSegment::TypeOf,
             ])
             .or_insert(value.clone().into());
-        free_var_references
+        defines
             .entry(vec![
                 DefinableNameSegment::Name(window),
                 DefinableNameSegment::TypeOf,
             ])
             .or_insert(value.into());
-        defines = CompileTimeDefines(defines_value).resolved_cell()
     }
 
     Ok(CompileTimeInfo {
         environment: compile_time_info.environment,
-        defines,
+        defines: CompileTimeDefines(defines).resolved_cell(),
         free_var_references: FreeVarReferences(free_var_references).resolved_cell(),
     }
     .cell())
@@ -3220,15 +3193,10 @@ async fn value_visitor_inner(
     allow_project_root_tracing: bool,
 ) -> Result<(JsValue, bool)> {
     let ImportAttributes { ignore, .. } = *attributes;
-    // This check is just an optimization
-    if let Some(name) = v.get_definable_name() {
-        if let Some(value) = compile_time_info_ref.free_var_references.get(&name).await? {
-            return Ok(((&*value).try_into()?, true));
-        }
-
-        if let Some(value) = compile_time_info_ref.defines.get(&name).await? {
-            return Ok(((&*value).try_into()?, true));
-        }
+    if let Some(name) = v.get_definable_name()
+        && let Some(value) = compile_time_info_ref.defines.get(&name).await?
+    {
+        return Ok(((&*value).try_into()?, true));
     }
     let value = match v {
         JsValue::Call(


### PR DESCRIPTION
### What?

Use selective reads to read defined env vars in module analysis.

This allows to add/remove env vars without invalidating all modules.