### PR TITLE
Turbopack: improve selective read support to allow `Equivalent` keys

### DIFF
--- a/turbopack/crates/turbo-tasks/src/keyed.rs
+++ b/turbopack/crates/turbo-tasks/src/keyed.rs
@@ -1,25 +1,71 @@
 use std::{
+    borrow::Borrow,
     collections::{HashMap, HashSet},
     hash::{BuildHasher, Hash},
 };
 
-use indexmap::{IndexMap, IndexSet};
+use indexmap::{Equivalent, IndexMap, IndexSet};
 use smallvec::SmallVec;
 
-pub trait Keyed {
+pub trait KeyedEq {
     type Key;
-    type Value;
 
     fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]>;
-    fn get(&self, key: &Self::Key) -> Option<&Self::Value>;
-    fn contains_key(&self, key: &Self::Key) -> bool {
+}
+
+pub trait KeyedAccess<Q: ?Sized> {
+    type Value;
+
+    fn get(&self, key: &Q) -> Option<&Self::Value>;
+    fn contains_key(&self, key: &Q) -> bool {
         self.get(key).is_some()
     }
 }
 
-impl<K: Eq + Hash, V: PartialEq, H: BuildHasher> Keyed for HashMap<K, V, H> {
+impl<K: Eq + Hash, V: PartialEq, H: BuildHasher> KeyedEq for HashMap<K, V, H> {
     type Key = K;
+
+    fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
+        let mut different_keys = SmallVec::new();
+
+        for (key, value) in self.iter() {
+            if let Some(other_value) = HashMap::get(other, key) {
+                if value != other_value {
+                    different_keys.push(key);
+                }
+            } else {
+                different_keys.push(key);
+            }
+        }
+
+        if other.len() != self.len() || !different_keys.is_empty() {
+            for key in other.keys() {
+                if !self.contains_key(key) {
+                    different_keys.push(key);
+                }
+            }
+        }
+
+        different_keys
+    }
+}
+
+impl<K: Eq + Hash + Borrow<Q>, V, H: BuildHasher, Q: Eq + Hash + ?Sized> KeyedAccess<Q>
+    for HashMap<K, V, H>
+{
     type Value = V;
+
+    fn get(&self, key: &Q) -> Option<&Self::Value> {
+        HashMap::get(self, key)
+    }
+
+    fn contains_key(&self, key: &Q) -> bool {
+        HashMap::contains_key(self, key)
+    }
+}
+
+impl<K: Eq + Hash, V: PartialEq, H: BuildHasher> KeyedEq for IndexMap<K, V, H> {
+    type Key = K;
 
     fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
         let mut different_keys = SmallVec::new();
@@ -44,56 +90,22 @@ impl<K: Eq + Hash, V: PartialEq, H: BuildHasher> Keyed for HashMap<K, V, H> {
 
         different_keys
     }
-
-    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
-        self.get(key)
-    }
-
-    fn contains_key(&self, key: &Self::Key) -> bool {
-        self.contains_key(key)
-    }
 }
 
-impl<K: Eq + Hash, V: PartialEq, H: BuildHasher> Keyed for IndexMap<K, V, H> {
-    type Key = K;
+impl<K, V, H: BuildHasher, Q: Equivalent<K> + Hash + ?Sized> KeyedAccess<Q> for IndexMap<K, V, H> {
     type Value = V;
 
-    fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
-        let mut different_keys = SmallVec::new();
-
-        for (key, value) in self.iter() {
-            if let Some(other_value) = other.get(key) {
-                if value != other_value {
-                    different_keys.push(key);
-                }
-            } else {
-                different_keys.push(key);
-            }
-        }
-
-        if other.len() != self.len() || !different_keys.is_empty() {
-            for key in other.keys() {
-                if !self.contains_key(key) {
-                    different_keys.push(key);
-                }
-            }
-        }
-
-        different_keys
-    }
-
-    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+    fn get(&self, key: &Q) -> Option<&Self::Value> {
         self.get(key)
     }
 
-    fn contains_key(&self, key: &Self::Key) -> bool {
+    fn contains_key(&self, key: &Q) -> bool {
         self.contains_key(key)
     }
 }
 
-impl<K: Eq + Hash, H: BuildHasher> Keyed for HashSet<K, H> {
+impl<K: Eq + Hash, H: BuildHasher> KeyedEq for HashSet<K, H> {
     type Key = K;
-    type Value = ();
 
     fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
         let mut different_keys = SmallVec::new();
@@ -114,19 +126,24 @@ impl<K: Eq + Hash, H: BuildHasher> Keyed for HashSet<K, H> {
 
         different_keys
     }
+}
 
-    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+impl<K: Eq + Hash + Borrow<Q>, Q: Eq + Hash + ?Sized, H: BuildHasher> KeyedAccess<Q>
+    for HashSet<K, H>
+{
+    type Value = ();
+
+    fn get(&self, key: &Q) -> Option<&Self::Value> {
         if self.contains(key) { Some(&()) } else { None }
     }
 
-    fn contains_key(&self, key: &Self::Key) -> bool {
+    fn contains_key(&self, key: &Q) -> bool {
         self.contains(key)
     }
 }
 
-impl<K: Eq + Hash, H: BuildHasher> Keyed for IndexSet<K, H> {
+impl<K: Eq + Hash, H: BuildHasher> KeyedEq for IndexSet<K, H> {
     type Key = K;
-    type Value = ();
 
     fn different_keys<'l>(&'l self, other: &'l Self) -> SmallVec<[&'l Self::Key; 2]> {
         let mut different_keys = SmallVec::new();
@@ -147,12 +164,16 @@ impl<K: Eq + Hash, H: BuildHasher> Keyed for IndexSet<K, H> {
 
         different_keys
     }
+}
 
-    fn get(&self, key: &Self::Key) -> Option<&Self::Value> {
+impl<K, Q: Equivalent<K> + Hash + ?Sized, H: BuildHasher> KeyedAccess<Q> for IndexSet<K, H> {
+    type Value = ();
+
+    fn get(&self, key: &Q) -> Option<&Self::Value> {
         if self.contains(key) { Some(&()) } else { None }
     }
 
-    fn contains_key(&self, key: &Self::Key) -> bool {
+    fn contains_key(&self, key: &Q) -> bool {
         self.contains(key)
     }
 }
@@ -181,7 +202,7 @@ mod tests {
         [("e", 5), ("d", 4), ("c", 3), ("b", 2), ("a", 1)]
     }
 
-    fn assert_diff<T: Keyed>(a: &T, b: &T, expected: &[&T::Key])
+    fn assert_diff<T: KeyedEq>(a: &T, b: &T, expected: &[&T::Key])
     where
         T::Key: std::fmt::Debug + PartialEq,
     {

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -35,7 +35,7 @@ use crate::{
     event::{Event, EventListener},
     id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TraitTypeId},
     id_factory::IdFactoryWithReuse,
-    keyed::Keyed,
+    keyed::KeyedEq,
     macro_helpers::NativeFunction,
     magic_any::MagicAny,
     message_queue::{CompilationEvent, CompilationEventQueue},
@@ -2040,8 +2040,8 @@ impl CurrentCellRef {
     pub fn keyed_compare_and_update<T>(&self, new_value: T)
     where
         T: PartialEq + VcValueType,
-        VcReadTarget<T>: Keyed,
-        <VcReadTarget<T> as Keyed>::Key: std::hash::Hash,
+        VcReadTarget<T>: KeyedEq,
+        <VcReadTarget<T> as KeyedEq>::Key: std::hash::Hash,
     {
         self.conditional_update(|old_value| {
             let Some(old_value) = old_value else {
@@ -2069,8 +2069,8 @@ impl CurrentCellRef {
         new_shared_reference: SharedReference,
     ) where
         T: VcValueType + PartialEq,
-        VcReadTarget<T>: Keyed,
-        <VcReadTarget<T> as Keyed>::Key: std::hash::Hash,
+        VcReadTarget<T>: KeyedEq,
+        <VcReadTarget<T> as KeyedEq>::Key: std::hash::Hash,
     {
         self.conditional_update_with_shared_reference(|old_sr| {
             let Some(old_sr) = old_sr else {

--- a/turbopack/crates/turbo-tasks/src/mapped_read_ref.rs
+++ b/turbopack/crates/turbo-tasks/src/mapped_read_ref.rs
@@ -4,7 +4,6 @@ use serde::Serialize;
 
 use crate::{
     debug::{ValueDebugFormat, ValueDebugFormatString},
-    keyed::Keyed,
     trace::{TraceRawVcs, TraceRawVcsContext},
 };
 
@@ -128,7 +127,6 @@ where
 
 impl<A, T, I, J: Iterator<Item = I>> IntoIterator for &MappedReadRef<A, T>
 where
-    T: Keyed,
     for<'b> &'b T: IntoIterator<Item = I, IntoIter = J>,
 {
     type Item = I;

--- a/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/cell_mode.rs
@@ -2,7 +2,7 @@ use std::{any::type_name, marker::PhantomData};
 
 use super::{read::VcRead, traits::VcValueType};
 use crate::{
-    RawVc, Vc, backend::VerificationMode, keyed::Keyed, manager::find_cell_by_type,
+    RawVc, Vc, backend::VerificationMode, keyed::KeyedEq, manager::find_cell_by_type,
     task::shared_reference::TypedSharedReference,
 };
 
@@ -93,8 +93,8 @@ pub struct VcCellKeyedCompareMode<T> {
 impl<T> VcCellMode<T> for VcCellKeyedCompareMode<T>
 where
     T: VcValueType + PartialEq,
-    VcReadTarget<T>: Keyed,
-    <VcReadTarget<T> as Keyed>::Key: std::hash::Hash,
+    VcReadTarget<T>: KeyedEq,
+    <VcReadTarget<T> as KeyedEq>::Key: std::hash::Hash,
 {
     fn cell(inner: VcReadTarget<T>) -> Vc<T> {
         let cell = find_cell_by_type::<T>();

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -34,7 +34,7 @@ pub use self::{
 use crate::{
     CellId, RawVc, ResolveTypeError,
     debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
-    keyed::Keyed,
+    keyed::{KeyedAccess, KeyedEq},
     registry,
     trace::{TraceRawVcs, TraceRawVcsContext},
     vc::read::{ReadContainsKeyedVcFuture, ReadKeyedVcFuture},
@@ -674,22 +674,26 @@ where
 impl<T> Vc<T>
 where
     T: VcValueType,
-    VcReadTarget<T>: Keyed,
-    <VcReadTarget<T> as Keyed>::Key: Hash,
+    VcReadTarget<T>: KeyedEq,
 {
     /// Read the value and selects a keyed value from it. Only depends on the used key instead of
     /// the full value.
-    pub fn get<'l>(self, key: &'l <VcReadTarget<T> as Keyed>::Key) -> ReadKeyedVcFuture<'l, T> {
+    pub fn get<'l, Q>(self, key: &'l Q) -> ReadKeyedVcFuture<'l, T, Q>
+    where
+        Q: Hash + ?Sized,
+        VcReadTarget<T>: KeyedAccess<Q>,
+    {
         let future: ReadVcFuture<T> = self.node.into_read(T::has_serialization()).into();
         future.get(key)
     }
 
     /// Read the value and checks if it contains the given key. Only depends on the used key instead
     /// of the full value.
-    pub fn contains_key<'l>(
-        self,
-        key: &'l <VcReadTarget<T> as Keyed>::Key,
-    ) -> ReadContainsKeyedVcFuture<'l, T> {
+    pub fn contains_key<'l, Q>(self, key: &'l Q) -> ReadContainsKeyedVcFuture<'l, T, Q>
+    where
+        Q: Hash + ?Sized,
+        VcReadTarget<T>: KeyedAccess<Q>,
+    {
         let future: ReadVcFuture<T> = self.node.into_read(T::has_serialization()).into();
         future.contains_key(key)
     }

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -15,7 +15,8 @@ use rustc_hash::FxBuildHasher;
 use super::traits::VcValueType;
 use crate::{
     MappedReadRef, ReadRawVcFuture, ReadRef, VcCast, VcValueTrait, VcValueTraitCast,
-    VcValueTypeCast, keyed::Keyed,
+    VcValueTypeCast,
+    keyed::{KeyedAccess, KeyedEq},
 };
 
 type VcReadTarget<T> = <<T as VcValueType>::Read as VcRead<T>>::Target;
@@ -193,12 +194,15 @@ where
 impl<T> ReadVcFuture<T, VcValueTypeCast<T>>
 where
     T: VcValueType,
-    VcReadTarget<T>: Keyed,
-    <VcReadTarget<T> as Keyed>::Key: Hash,
+    VcReadTarget<T>: KeyedEq,
 {
     /// Read the value and selects a keyed value from it. Only depends on the used key instead of
     /// the full value.
-    pub fn get<'l>(mut self, key: &'l <VcReadTarget<T> as Keyed>::Key) -> ReadKeyedVcFuture<'l, T> {
+    pub fn get<'l, Q>(mut self, key: &'l Q) -> ReadKeyedVcFuture<'l, T, Q>
+    where
+        Q: Hash + ?Sized,
+        VcReadTarget<T>: KeyedAccess<Q>,
+    {
         self.raw = self.raw.track_with_key(FxBuildHasher.hash_one(key));
         ReadKeyedVcFuture { future: self, key }
     }
@@ -208,10 +212,11 @@ where
     ///
     /// Note: This is also invalidated when the value of the key changes, not only when the presence
     /// of the key changes.
-    pub fn contains_key<'l>(
-        mut self,
-        key: &'l <VcReadTarget<T> as Keyed>::Key,
-    ) -> ReadContainsKeyedVcFuture<'l, T> {
+    pub fn contains_key<'l, Q>(mut self, key: &'l Q) -> ReadContainsKeyedVcFuture<'l, T, Q>
+    where
+        Q: Hash + ?Sized,
+        VcReadTarget<T>: KeyedAccess<Q>,
+    {
         self.raw = self.raw.track_with_key(FxBuildHasher.hash_one(key));
         ReadContainsKeyedVcFuture { future: self, key }
     }
@@ -284,23 +289,26 @@ where
 }
 
 pin_project! {
-    pub struct ReadKeyedVcFuture<'l, T>
+    pub struct ReadKeyedVcFuture<'l, T, Q>
     where
         T: VcValueType,
-        VcReadTarget<T>: Keyed,
+        Q: ?Sized,
+        VcReadTarget<T>: KeyedAccess<Q>,
+
     {
         #[pin]
         future: ReadVcFuture<T, VcValueTypeCast<T>>,
-        key: &'l <VcReadTarget<T> as Keyed>::Key,
+        key: &'l Q,
     }
 }
 
-impl<'l, T> Future for ReadKeyedVcFuture<'l, T>
+impl<'l, T, Q> Future for ReadKeyedVcFuture<'l, T, Q>
 where
     T: VcValueType,
-    VcReadTarget<T>: Keyed,
+    Q: ?Sized,
+    VcReadTarget<T>: KeyedAccess<Q>,
 {
-    type Output = Result<Option<MappedReadRef<T, <VcReadTarget<T> as Keyed>::Value>>>;
+    type Output = Result<Option<MappedReadRef<T, <VcReadTarget<T> as KeyedAccess<Q>>::Value>>>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         // Safety: We never move the contents of `self`
@@ -322,21 +330,23 @@ where
 }
 
 pin_project! {
-    pub struct ReadContainsKeyedVcFuture<'l, T>
+    pub struct ReadContainsKeyedVcFuture<'l, T, Q>
     where
         T: VcValueType,
-        VcReadTarget<T>: Keyed,
+        Q: ?Sized,
+        VcReadTarget<T>: KeyedAccess<Q>,
     {
         #[pin]
         future: ReadVcFuture<T, VcValueTypeCast<T>>,
-        key: &'l <VcReadTarget<T> as Keyed>::Key,
+        key: &'l Q,
     }
 }
 
-impl<'l, T> Future for ReadContainsKeyedVcFuture<'l, T>
+impl<'l, T, Q> Future for ReadContainsKeyedVcFuture<'l, T, Q>
 where
     T: VcValueType,
-    VcReadTarget<T>: Keyed,
+    Q: ?Sized,
+    VcReadTarget<T>: KeyedAccess<Q>,
 {
     type Output = Result<bool>;
 


### PR DESCRIPTION
### What?

Allow keys for selective reads to be something equivalent to the key instead of only exactly a reference of the key.