### PR TITLE
[ci] Exclude `test/production` from deploy tests

### DIFF
--- a/scripts/get-changed-tests.mjs
+++ b/scripts/get-changed-tests.mjs
@@ -17,7 +17,7 @@ export default async function getChangedTests() {
 
   if (isCanary) {
     console.log(`Skipping flake detection for canary`)
-    return { devTests: [], prodTests: [] }
+    return { devTests: [], prodTests: [], deployTests: [] }
   }
 
   const diffRevision = await getDiffRevision()
@@ -44,6 +44,7 @@ export default async function getChangedTests() {
   // and if any fail it's flakey
   const devTests = []
   const prodTests = []
+  const deployTests = []
 
   for (let file of changedFiles) {
     // normalize slashes
@@ -54,10 +55,11 @@ export default async function getChangedTests() {
       .catch(() => false)
 
     if (fileExists && file.match(/^test\/.*?\.test\.(js|ts|tsx)$/)) {
-      if (
-        file.startsWith('test/e2e/') ||
-        file.startsWith('test/integration/')
-      ) {
+      if (file.startsWith('test/e2e/')) {
+        devTests.push(file)
+        prodTests.push(file)
+        deployTests.push(file)
+      } else if (file.startsWith('test/integration/')) {
         devTests.push(file)
         prodTests.push(file)
       } else if (file.startsWith('test/prod')) {
@@ -74,11 +76,12 @@ export default async function getChangedTests() {
       {
         devTests,
         prodTests,
+        deployTests,
       },
       null,
       2
     )
   )
 
-  return { devTests, prodTests, commitSha }
+  return { devTests, prodTests, deployTests, commitSha }
 }

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -41,9 +41,15 @@ async function main() {
   /** @type import('execa').Options */
   const EXECA_OPTS_STDIO = { ...EXECA_OPTS, stdio: 'inherit' }
 
-  const { devTests, prodTests, commitSha } = await getChangedTests()
+  const { devTests, prodTests, deployTests, commitSha } =
+    await getChangedTests()
 
-  let currentTests = testMode === 'dev' ? devTests : prodTests
+  let currentTests =
+    testMode === 'dev'
+      ? devTests
+      : testMode === 'deploy'
+        ? deployTests
+        : prodTests
 
   /**
     @type {Array<string[]>}

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -46,10 +46,7 @@
     }
   },
   "rules": {
-    "include": [
-      "test/e2e/**/*.test.{t,j}s{,x}",
-      "test/production/**/*.test.{t,j}s{,x}"
-    ],
+    "include": ["test/e2e/**/*.test.{t,j}s{,x}"],
     "exclude": [
       "test/e2e/cancel-request/stream-cancel.test.ts",
       "test/e2e/new-link-behavior/material-ui.test.ts",


### PR DESCRIPTION
Only `test/e2e` tests should run in deploy mode. Production tests often test `next start` specific behavior that would fail when deployed.

The intended test mode mapping is:
- `development` → `next dev`
- `production` → `next start`
- `e2e` → dev/start/deploy
- `integration` -> deprecated, `next start` and/or `next dev`

Previously, `test/production` was inconsistently included in deploy tests: the manifest included it, but the workflow used `--type e2e` which excluded it. Meanwhile, `get-changed-tests.mjs` added `test/prod*` to `prodTests` which was then used for deploy mode in the "Test new tests when deployed" jobs. This change makes the behavior consistent across all paths.