### PR TITLE
Fix SWC minifier bug with __NEXT_DATA__.autoExport

### DIFF
--- a/packages/next/src/client/index.tsx
+++ b/packages/next/src/client/index.tsx
@@ -300,6 +300,15 @@ function AppContainer({
   const adaptedForAppRouter = React.useMemo(() => {
     return adaptForAppRouterInstance(router)
   }, [])
+
+  // Extract autoExport value to work around SWC minifier bug (swc_ecma_minifier)
+  // where nullish coalescing in JSX props creates incorrectly scoped variables
+  const isAutoExport =
+    self.__NEXT_DATA__.autoExport !== undefined &&
+    self.__NEXT_DATA__.autoExport !== null
+      ? self.__NEXT_DATA__.autoExport
+      : false
+
   return (
     <Container
       fn={(error) =>
@@ -312,7 +321,7 @@ function AppContainer({
         <SearchParamsContext.Provider value={adaptForSearchParams(router)}>
           <PathnameContextProviderAdapter
             router={router}
-            isAutoExport={self.__NEXT_DATA__.autoExport ?? false}
+            isAutoExport={isAutoExport}
           >
             <PathParamsContext.Provider value={adaptForPathParams(router)}>
               <RouterContext.Provider value={makePublicRouterInstance(router)}>

--- a/test/development/turbopack-autoexport-minification/next.config.js
+++ b/test/development/turbopack-autoexport-minification/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  // Default configuration - uses Turbopack in development
+}

--- a/test/development/turbopack-autoexport-minification/pages/dynamic/[slug].tsx
+++ b/test/development/turbopack-autoexport-minification/pages/dynamic/[slug].tsx
@@ -1,0 +1,13 @@
+import { useRouter } from 'next/router'
+
+export default function DynamicPage() {
+  const router = useRouter()
+  const { slug } = router.query
+
+  return (
+    <div>
+      <h1>Dynamic Page</h1>
+      <p id="dynamic-content">Slug: {slug}</p>
+    </div>
+  )
+}

--- a/test/development/turbopack-autoexport-minification/pages/index.tsx
+++ b/test/development/turbopack-autoexport-minification/pages/index.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Turbopack autoExport Test</h1>
+      <p id="test-content">Page loaded successfully</p>
+    </div>
+  )
+}

--- a/test/development/turbopack-autoexport-minification/turbopack-autoexport-minification.test.ts
+++ b/test/development/turbopack-autoexport-minification/turbopack-autoexport-minification.test.ts
@@ -1,0 +1,77 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('Turbopack autoExport minification', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+    // This test is specifically for Turbopack minification
+    skipDeployment: true,
+  })
+
+  // This test is only relevant in development mode with Turbopack
+  if (!isNextDev) {
+    it('skipped - only runs in development', () => {})
+    return
+  }
+
+  it('should not throw ReferenceError for __NEXT_DATA__.autoExport', async () => {
+    const browser = await next.browser('/')
+
+    // Wait for page to load
+    await browser.waitForElementByCss('#test-content')
+
+    // Check that the page rendered correctly
+    const text = await browser.elementByCss('#test-content').text()
+    expect(text).toBe('Page loaded successfully')
+
+    // Get any console errors
+    const logs = await browser.log('browser')
+    const errors = logs.filter(
+      (log: { level: string; message: string }) =>
+        log.level === 'SEVERE' || log.message.includes('ReferenceError')
+    )
+
+    // Ensure no ReferenceError for _self___NEXT_DATA___autoExport
+    const autoExportError = errors.find((e: { message: string }) =>
+      e.message.includes('_self___NEXT_DATA___autoExport')
+    )
+
+    expect(autoExportError).toBeUndefined()
+  })
+
+  it('should correctly access __NEXT_DATA__.autoExport value', async () => {
+    const browser = await next.browser('/')
+
+    // Wait for page to load
+    await browser.waitForElementByCss('#test-content')
+
+    // Execute script to check if __NEXT_DATA__.autoExport is accessible
+    const autoExportValue = await browser.eval(
+      'typeof window.__NEXT_DATA__.autoExport'
+    )
+
+    // autoExport should be either boolean or undefined, not cause an error
+    expect(['boolean', 'undefined']).toContain(autoExportValue)
+  })
+
+  it('should render PathnameContextProviderAdapter without errors', async () => {
+    const browser = await next.browser('/dynamic/test-param')
+
+    // Wait for page to load - this tests a dynamic route which uses isAutoExport
+    await browser.waitForElementByCss('#dynamic-content')
+
+    const text = await browser.elementByCss('#dynamic-content').text()
+    expect(text).toContain('test-param')
+
+    // Check for errors
+    const logs = await browser.log('browser')
+    const errors = logs.filter(
+      (log: { level: string; message: string }) =>
+        log.level === 'SEVERE' ||
+        log.message.includes('ReferenceError') ||
+        log.message.includes('is not defined')
+    )
+
+    // Should have no errors
+    expect(errors.length).toBe(0)
+  })
+})


### PR DESCRIPTION
### Fixing a bug

- [ ] Related issues linked using `fixes #number` (no existing issue found - see description below)
- [x] Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- [x] Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md (N/A - runtime error from SWC minifier, not a Next.js error)

### What?

Fix a ReferenceError caused by SWC's minifier when processing nullish coalescing operators in JSX props.

### Why?

When Turbopack (using SWC minifier) processes this code in `packages/next/src/client/index.tsx`:

```tsx
isAutoExport={self.__NEXT_DATA__.autoExport ?? false}
```
The minifier creates a temporary variable _self___NEXT_DATA___autoExport that is incorrectly scoped, causing:
```
ReferenceError: _self___NEXT_DATA___autoExport is not defined
```
This could be a known class of bugs in SWC's minifier (swc_ecma_minifier):
- ~https://github.com/swc-project/swc/issues/847~
- https://github.com/swc-project/swc/issues/2078
- https://github.com/swc-project/swc/issues/9460

Webpack does not exhibit this bug because it uses Terser for minification.

### How?

Extract the autoExport value into an explicit const variable before passing to the JSX prop, avoiding the problematic inline nullish coalescing pattern:
```tsx
const isAutoExport =
  self.__NEXT_DATA__.autoExport !== undefined &&
  self.__NEXT_DATA__.autoExport !== null
    ? self.__NEXT_DATA__.autoExport
    : false

// Then use the variable:
<PathnameContextProviderAdapter
  router={router}
  isAutoExport={isAutoExport}
>
```
Added regression test suite at test/development/turbopack-autoexport-minification/ to prevent recurrence.