### PR TITLE
docs: Fix grammar in Server Components section

### DIFF
--- a/docs/01-app/01-getting-started/05-server-and-client-components.mdx
+++ b/docs/01-app/01-getting-started/05-server-and-client-components.mdx
@@ -23,7 +23,7 @@ Use **Client Components** when you need:
 - Browser-only APIs. E.g. `localStorage`, `window`, `Navigator.geolocation`, etc.
 - [Custom hooks](https://react.dev/learn/reusing-logic-with-custom-hooks).
 
-Use **Server Components** when you need:
+Use **Server Components** when you need to:
 
 - Fetch data from databases or APIs close to the source.
 - Use API keys, tokens, and other secrets without exposing them to the client.


### PR DESCRIPTION
### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Description

I fixed a small grammatical inconsistency in the **Server Components** section of `server-and-client-components.mdx`.

**What changed?**
Updated the introductory sentence from:
> "Use **Server Components** when you need:"

To:
> "Use **Server Components** when you need **to**:"

**Why?**
The list items following this header are actions (verbs) like "Fetch data..." and "Use API keys...". Adding "to" makes the sentence grammatically correct and consistent with the list items.

### For Maintainers

- [x] Minimal description
- [ ] Link both the Linear (Fixes NEXT-xxx) and the GitHub issues