### PR TITLE
Turbopack: add `rules.*.type` config to allow changing the type of a module

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -833,11 +833,14 @@ impl TryFrom<ConfigConditionItem> for ConditionItem {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct RuleConfigItem {
+    #[serde(default)]
     pub loaders: Vec<LoaderItem>,
     #[serde(default, alias = "as")]
     pub rename_as: Option<RcStr>,
     #[serde(default)]
     pub condition: Option<ConfigConditionItem>,
+    #[serde(default, alias = "type")]
+    pub module_type: Option<RcStr>,
 }
 
 #[derive(
@@ -1563,6 +1566,7 @@ impl NextConfig {
                                 loaders: transform_loaders(&mut [loaders].into_iter()),
                                 rename_as: None,
                                 condition: None,
+                                module_type: None,
                             },
                         ));
                     }
@@ -1570,6 +1574,7 @@ impl NextConfig {
                         loaders,
                         rename_as,
                         condition,
+                        module_type,
                     }) => {
                         // If the extension contains a wildcard, and the rename_as does not,
                         // emit an issue to prevent users from encountering duplicate module
@@ -1618,6 +1623,7 @@ impl NextConfig {
                                 loaders: transform_loaders(&mut loaders.iter()),
                                 rename_as: rename_as.clone(),
                                 condition,
+                                module_type: module_type.clone(),
                             },
                         ));
                     }
@@ -2172,6 +2178,7 @@ mod tests {
             RuleConfigItem {
                 loaders: vec![],
                 rename_as: Some(rcstr!("*.js")),
+                module_type: None,
                 condition: Some(ConfigConditionItem::All(
                     [
                         ConfigConditionItem::Builtin(WebpackLoaderBuiltinCondition::Production),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2208,7 +2208,6 @@ mod tests {
                     ]
                     .into(),
                 )),
-                module_type: None,
             }
         );
     }

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2208,6 +2208,7 @@ mod tests {
                     ]
                     .into(),
                 )),
+                module_type: None,
             }
         );
     }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -230,6 +230,7 @@ pub async fn get_babel_loader_rules(
             }]),
             rename_as: Some(rcstr!("*")),
             condition: Some(ConditionItem::All(loader_conditions.into())),
+            module_type: None,
         },
     )])
 }

--- a/crates/next-core/src/next_shared/webpack_rules/sass.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/sass.rs
@@ -119,6 +119,7 @@ pub async fn get_sass_loader_rules(
                 loaders,
                 rename_as: Some(rename),
                 condition: None,
+                module_type: None,
             },
         ));
     }

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -256,6 +256,47 @@ module.exports = {
 
 > **Good to know**: All matching rules are executed in order.
 
+### Module types
+
+You can set the module type directly without using a loader. This is useful for changing how files are processed, similar to webpack's [`type`](https://webpack.js.org/configuration/module/#ruletype) option.
+
+```js filename="next.config.js"
+module.exports = {
+  turbopack: {
+    rules: {
+      '*.svg': {
+        type: 'asset',
+      },
+    },
+  },
+}
+```
+
+When using `type: 'asset'`, importing the file returns its URL:
+
+```tsx filename="app/page.tsx"
+import svgUrl from './icon.svg'
+
+export default function Page() {
+  return <img src={svgUrl} alt="Icon" />
+}
+```
+
+The `type` option can be combined with `loaders` - loaders run first, then the result is processed according to the specified type.
+
+Available module types:
+
+| Type         | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| `asset`      | Emit file and return URL (like webpack `asset/resource`) |
+| `ecmascript` | Process as JavaScript                                    |
+| `typescript` | Process as TypeScript                                    |
+| `css`        | Process as CSS                                           |
+| `css-module` | Process as CSS module                                    |
+| `wasm`       | Process as WebAssembly                                   |
+| `raw`        | Return raw contents as string                            |
+| `bytes`      | Inline contents as bytes                                 |
+
 ### Resolving aliases
 
 Turbopack can be configured to modify module resolution through aliases, similar to webpack's [`resolve.alias`](https://webpack.js.org/configuration/resolve/#resolvealias) configuration.
@@ -315,6 +356,7 @@ The option automatically adds a polyfill for debug IDs to the JavaScript bundle 
 
 | Version  | Changes                                              |
 | -------- | ---------------------------------------------------- |
+| `16.2.0` | `turbopack.rules.*.type` was added.                  |
 | `16.2.0` | `turbopack.rules.*.condition.contentType` was added. |
 | `16.2.0` | `turbopack.rules.*.condition.query` was added.       |
 | `16.0.0` | `turbopack.debugIds` was added.                      |

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1021,10 +1021,13 @@ function bindingToApi(
     for (const [glob, rule] of Object.entries(turbopackRules)) {
       if (Array.isArray(rule)) {
         serializedRules[glob] = rule.map((item) => {
-          if (typeof item !== 'string' && 'loaders' in item) {
-            return serializeConfigItem(item, glob)
+          if (
+            typeof item !== 'string' &&
+            ('loaders' in item || 'type' in item || 'condition' in item)
+          ) {
+            return serializeConfigItem(item as TurbopackRuleConfigItem, glob)
           } else {
-            checkLoaderItem(item, glob)
+            checkLoaderItem(item as TurbopackLoaderItem, glob)
             return item
           }
         })
@@ -1040,8 +1043,10 @@ function bindingToApi(
       glob: string
     ): any {
       if (!rule) return rule
-      for (const item of rule.loaders) {
-        checkLoaderItem(item, glob)
+      if (rule.loaders) {
+        for (const item of rule.loaders) {
+          checkLoaderItem(item, glob)
+        }
       }
       let serializedRule: any = rule
       if (rule.condition != null) {

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -134,11 +134,24 @@ const zTurbopackCondition: zod.ZodType<TurbopackRuleCondition> = z.union([
   }),
 ])
 
+const zTurbopackModuleType = z.enum([
+  'asset',
+  'ecmascript',
+  'typescript',
+  'css',
+  'css-module',
+  'wasm',
+  'raw',
+  'node',
+  'bytes',
+])
+
 const zTurbopackRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> =
   z.strictObject({
-    loaders: z.array(zTurbopackLoaderItem),
+    loaders: z.array(zTurbopackLoaderItem).optional(),
     as: z.string().optional(),
     condition: zTurbopackCondition.optional(),
+    type: zTurbopackModuleType.optional(),
   })
 
 const zTurbopackRuleConfigCollection: zod.ZodType<TurbopackRuleConfigCollection> =

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -122,10 +122,22 @@ export type TurbopackRuleCondition =
       contentType?: string | RegExp
     }
 
+export type TurbopackModuleType =
+  | 'asset'
+  | 'ecmascript'
+  | 'typescript'
+  | 'css'
+  | 'css-module'
+  | 'wasm'
+  | 'raw'
+  | 'node'
+  | 'bytes'
+
 export type TurbopackRuleConfigItem = {
-  loaders: TurbopackLoaderItem[]
+  loaders?: TurbopackLoaderItem[]
   as?: string
   condition?: TurbopackRuleCondition
+  type?: TurbopackModuleType
 }
 
 /**

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -122,6 +122,22 @@ export type TurbopackRuleCondition =
       contentType?: string | RegExp
     }
 
+/**
+ * The module type to use for matched files. This determines how files are
+ * processed without requiring a custom loader.
+ *
+ * - `'asset'` - Emit the file and return its URL (like webpack's `asset/resource`)
+ * - `'ecmascript'` - Process as JavaScript module
+ * - `'typescript'` - Process as TypeScript module
+ * - `'css'` - Process as CSS file
+ * - `'css-module'` - Process as CSS module
+ * - `'wasm'` - Process as WebAssembly module
+ * - `'raw'` - Return raw file contents as a string
+ * - `'node'` - Process as native Node.js addon
+ * - `'bytes'` - Inline file contents as bytes in JavaScript
+ *
+ * @see [Module Types](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#module-types)
+ */
 export type TurbopackModuleType =
   | 'asset'
   | 'ecmascript'
@@ -134,9 +150,16 @@ export type TurbopackModuleType =
   | 'bytes'
 
 export type TurbopackRuleConfigItem = {
+  /** Loaders to apply to matched files. */
   loaders?: TurbopackLoaderItem[]
+  /** Rename the file extension for loader output (e.g., `'*.js'`). */
   as?: string
+  /** Additional conditions for when this rule applies. */
   condition?: TurbopackRuleCondition
+  /**
+   * Set the module type directly without using a loader.
+   * @see [Module Types](https://nextjs.org/docs/app/api-reference/config/next-config-js/turbopack#module-types)
+   */
   type?: TurbopackModuleType
 }
 

--- a/test/e2e/app-dir/webpack-loader-module-type/app/layout.tsx
+++ b/test/e2e/app-dir/webpack-loader-module-type/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/webpack-loader-module-type/app/page.tsx
+++ b/test/e2e/app-dir/webpack-loader-module-type/app/page.tsx
@@ -1,10 +1,19 @@
 import svgUrl from './test.svg'
+import dataBytes from './test.data'
 
 export default function Page() {
+  const bytesText =
+    typeof dataBytes !== 'undefined' && dataBytes instanceof Uint8Array
+      ? new TextDecoder().decode(dataBytes)
+      : String(dataBytes)
+
   return (
     <div>
       <p id="svg-url">{svgUrl}</p>
       <img src={svgUrl} alt="test svg" />
+      <p id="bytes-type">{dataBytes?.constructor?.name}</p>
+      <p id="bytes-length">{dataBytes?.length ?? dataBytes?.byteLength}</p>
+      <p id="bytes-text">{bytesText}</p>
     </div>
   )
 }

--- a/test/e2e/app-dir/webpack-loader-module-type/app/page.tsx
+++ b/test/e2e/app-dir/webpack-loader-module-type/app/page.tsx
@@ -1,0 +1,10 @@
+import svgUrl from './test.svg'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="svg-url">{svgUrl}</p>
+      <img src={svgUrl} alt="test svg" />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/webpack-loader-module-type/app/test.data
+++ b/test/e2e/app-dir/webpack-loader-module-type/app/test.data
@@ -1,0 +1,1 @@
+hello world

--- a/test/e2e/app-dir/webpack-loader-module-type/app/test.svg
+++ b/test/e2e/app-dir/webpack-loader-module-type/app/test.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <circle cx="50" cy="50" r="40" fill="red" />
+</svg>

--- a/test/e2e/app-dir/webpack-loader-module-type/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-module-type/next.config.js
@@ -1,0 +1,11 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  webpack(config) {
+    // Override the default svg handling to use asset/resource
+    config.module.rules.push({
+      test: /\.svg$/,
+      type: 'asset/resource',
+    })
+    return config
+  },
+}

--- a/test/e2e/app-dir/webpack-loader-module-type/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-module-type/next.config.js
@@ -1,5 +1,12 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
+  turbopack: {
+    rules: {
+      '*.svg': {
+        type: 'asset',
+      },
+    },
+  },
   webpack(config) {
     // Override the default svg handling to use asset/resource
     config.module.rules.push({

--- a/test/e2e/app-dir/webpack-loader-module-type/next.config.js
+++ b/test/e2e/app-dir/webpack-loader-module-type/next.config.js
@@ -5,6 +5,9 @@ module.exports = {
       '*.svg': {
         type: 'asset',
       },
+      '*.data': {
+        type: 'bytes',
+      },
     },
   },
   webpack(config) {
@@ -12,6 +15,11 @@ module.exports = {
     config.module.rules.push({
       test: /\.svg$/,
       type: 'asset/resource',
+    })
+    // Use asset/source for .data files (returns string, not Uint8Array like Turbopack's bytes)
+    config.module.rules.push({
+      test: /\.data$/,
+      type: 'asset/source',
     })
     return config
   },

--- a/test/e2e/app-dir/webpack-loader-module-type/types.d.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/types.d.ts
@@ -1,0 +1,4 @@
+declare module '*.data' {
+  const content: Uint8Array
+  export default content
+}

--- a/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
@@ -1,12 +1,15 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('webpack-loader-module-type', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next, isTurbopack, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
   })
 
   if (skipped) return
+
+  // bytes type is Turbopack-only, webpack doesn't have a direct equivalent
+  const itTurbopackOnly = isTurbopack ? it : it.skip
 
   it('should load svg as asset/resource and return URL', async () => {
     const $ = await next.render$('/')
@@ -14,4 +17,21 @@ describe('webpack-loader-module-type', () => {
     // asset/resource should emit the file and return URL path
     expect(src).toMatch(/\/_next\/static\/media\/test\.[a-f0-9]+\.svg$/)
   })
+
+  itTurbopackOnly(
+    'should load data file as bytes and return Uint8Array',
+    async () => {
+      const $ = await next.render$('/')
+      const bytesType = $('#bytes-type').text()
+      const bytesLength = $('#bytes-length').text()
+      const bytesText = $('#bytes-text').text()
+
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(bytesType).toBe('Uint8Array')
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(bytesLength).toBe('11')
+      // eslint-disable-next-line jest/no-standalone-expect
+      expect(bytesText).toBe('hello world')
+    }
+  )
 })

--- a/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
@@ -1,0 +1,21 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Skip test in Turbopack - only run in webpack
+;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
+  'webpack-loader-module-type',
+  () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+    })
+
+    if (skipped) return
+
+    it('should load svg as asset/resource and return URL', async () => {
+      const $ = await next.render$('/')
+      const src = $('#svg-url').text()
+      // asset/resource should emit the file and return URL path
+      expect(src).toMatch(/\/_next\/static\/media\/test\.[a-f0-9]+\.svg$/)
+    })
+  }
+)

--- a/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
+++ b/test/e2e/app-dir/webpack-loader-module-type/webpack-loader-module-type.test.ts
@@ -1,21 +1,17 @@
 import { nextTestSetup } from 'e2e-utils'
 
-// Skip test in Turbopack - only run in webpack
-;(process.env.IS_TURBOPACK_TEST ? describe.skip : describe)(
-  'webpack-loader-module-type',
-  () => {
-    const { next, skipped } = nextTestSetup({
-      files: __dirname,
-      skipDeployment: true,
-    })
+describe('webpack-loader-module-type', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
 
-    if (skipped) return
+  if (skipped) return
 
-    it('should load svg as asset/resource and return URL', async () => {
-      const $ = await next.render$('/')
-      const src = $('#svg-url').text()
-      // asset/resource should emit the file and return URL path
-      expect(src).toMatch(/\/_next\/static\/media\/test\.[a-f0-9]+\.svg$/)
-    })
-  }
-)
+  it('should load svg as asset/resource and return URL', async () => {
+    const $ = await next.render$('/')
+    const src = $('#svg-url').text()
+    // asset/resource should emit the file and return URL path
+    expect(src).toMatch(/\/_next\/static\/media\/test\.[a-f0-9]+\.svg$/)
+  })
+})

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -434,16 +434,15 @@ impl ModuleOptions {
                     }
 
                     // Add module type if specified
-                    if let Some(module_type) = rule.module_type.as_ref().and_then(|s| {
-                        ModuleType::from_str_with_defaults(
-                            s,
+                    if let Some(type_str) = rule.module_type.as_ref() {
+                        let module_type = ModuleType::from_str_with_defaults(
+                            type_str,
                             ecma_preprocess,
                             main,
                             postprocess,
                             ecmascript_options_vc,
                             environment,
-                        )
-                    }) {
+                        )?;
                         effects.push(ModuleRuleEffect::ModuleType(module_type));
                     }
 

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -434,17 +434,17 @@ impl ModuleOptions {
                     }
 
                     // Add module type if specified
-                    if let Some(module_type_str) = &rule.module_type {
-                        if let Some(module_type) = ModuleType::from_str_with_defaults(
-                            module_type_str,
+                    if let Some(module_type) = rule.module_type.as_ref().and_then(|s| {
+                        ModuleType::from_str_with_defaults(
+                            s,
                             ecma_preprocess,
                             main,
                             postprocess,
                             ecmascript_options_vc,
                             environment,
-                        ) {
-                            effects.push(ModuleRuleEffect::ModuleType(module_type));
-                        }
+                        )
+                    }) {
+                        effects.push(ModuleRuleEffect::ModuleType(module_type));
                     }
 
                     if !effects.is_empty() {

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -407,9 +407,11 @@ impl ModuleOptions {
                 let mut all_rule_condition = RuleCondition::All(rule_conditions);
                 all_rule_condition.flatten();
                 if !matches!(all_rule_condition, RuleCondition::False) {
-                    rules.push(ModuleRule::new(
-                        all_rule_condition,
-                        vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
+                    let mut effects = Vec::new();
+
+                    // Add source transforms if loaders are specified
+                    if !rule.loaders.await?.is_empty() {
+                        effects.push(ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
                             ResolvedVc::upcast(
                                 WebpackLoaders::new(
                                     node_evaluate_asset_context(
@@ -428,8 +430,26 @@ impl ModuleOptions {
                                 .to_resolved()
                                 .await?,
                             ),
-                        ]))],
-                    ));
+                        ])));
+                    }
+
+                    // Add module type if specified
+                    if let Some(module_type_str) = &rule.module_type {
+                        if let Some(module_type) = ModuleType::from_str_with_defaults(
+                            module_type_str,
+                            ecma_preprocess,
+                            main,
+                            postprocess,
+                            ecmascript_options_vc,
+                            environment,
+                        ) {
+                            effects.push(ModuleRuleEffect::ModuleType(module_type));
+                        }
+                    }
+
+                    if !effects.is_empty() {
+                        rules.push(ModuleRule::new(all_rule_condition, effects));
+                    }
                 }
             }
         }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -30,6 +30,7 @@ pub struct LoaderRuleItem {
     pub loaders: ResolvedVc<WebpackLoaderItems>,
     pub rename_as: Option<RcStr>,
     pub condition: Option<ConditionItem>,
+    pub module_type: Option<RcStr>,
 }
 
 /// This is a list of instructions for the rule engine to process. The first element in each tuple

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -176,3 +176,46 @@ impl Display for ModuleType {
         }
     }
 }
+
+impl ModuleType {
+    /// Creates a ModuleType from a string identifier.
+    /// This is used for user-configured module types in turbopack rules.
+    pub fn from_str_with_defaults(
+        type_str: &str,
+        preprocess: ResolvedVc<EcmascriptInputTransforms>,
+        main: ResolvedVc<EcmascriptInputTransforms>,
+        postprocess: ResolvedVc<EcmascriptInputTransforms>,
+        options: ResolvedVc<EcmascriptOptions>,
+        environment: Option<ResolvedVc<Environment>>,
+    ) -> Option<Self> {
+        match type_str {
+            "asset" => Some(ModuleType::StaticUrlJs { tag: None }),
+            "ecmascript" => Some(ModuleType::Ecmascript {
+                preprocess,
+                main,
+                postprocess,
+                options,
+            }),
+            "typescript" => Some(ModuleType::Typescript {
+                preprocess,
+                main,
+                postprocess,
+                tsx: false,
+                analyze_types: false,
+                options,
+            }),
+            "css" => Some(ModuleType::Css {
+                ty: CssModuleAssetType::Default,
+                environment,
+            }),
+            "css-module" => Some(ModuleType::CssModule),
+            "wasm" => Some(ModuleType::WebAssembly {
+                source_ty: WebAssemblySourceType::Binary,
+            }),
+            "raw" => Some(ModuleType::Raw),
+            "node" => Some(ModuleType::NodeAddon),
+            "bytes" => Some(ModuleType::InlinedBytesJs),
+            _ => None,
+        }
+    }
+}

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use anyhow::Result;
+use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, trace::TraceRawVcs};
@@ -187,35 +187,38 @@ impl ModuleType {
         postprocess: ResolvedVc<EcmascriptInputTransforms>,
         options: ResolvedVc<EcmascriptOptions>,
         environment: Option<ResolvedVc<Environment>>,
-    ) -> Option<Self> {
-        match type_str {
-            "asset" => Some(ModuleType::StaticUrlJs { tag: None }),
-            "ecmascript" => Some(ModuleType::Ecmascript {
+    ) -> Result<Self> {
+        Ok(match type_str {
+            "asset" => ModuleType::StaticUrlJs { tag: None },
+            "ecmascript" => ModuleType::Ecmascript {
                 preprocess,
                 main,
                 postprocess,
                 options,
-            }),
-            "typescript" => Some(ModuleType::Typescript {
+            },
+            "typescript" => ModuleType::Typescript {
                 preprocess,
                 main,
                 postprocess,
                 tsx: false,
                 analyze_types: false,
                 options,
-            }),
-            "css" => Some(ModuleType::Css {
+            },
+            "css" => ModuleType::Css {
                 ty: CssModuleAssetType::Default,
                 environment,
-            }),
-            "css-module" => Some(ModuleType::CssModule),
-            "wasm" => Some(ModuleType::WebAssembly {
+            },
+            "css-module" => ModuleType::CssModule,
+            "wasm" => ModuleType::WebAssembly {
                 source_ty: WebAssemblySourceType::Binary,
-            }),
-            "raw" => Some(ModuleType::Raw),
-            "node" => Some(ModuleType::NodeAddon),
-            "bytes" => Some(ModuleType::InlinedBytesJs),
-            _ => None,
-        }
+            },
+            "raw" => ModuleType::Raw,
+            "node" => ModuleType::NodeAddon,
+            "bytes" => ModuleType::InlinedBytesJs,
+            _ => bail!(
+                "Unknown module type: {type_str:?}. Valid types are: asset, ecmascript, \
+                 typescript, css, css-module, wasm, raw, node, bytes"
+            ),
+        })
     }
 }


### PR DESCRIPTION
### What?

This PR adds support for the `type` option in Turbopack rules, enabling users to set the module type directly without requiring a custom loader. This mirrors webpack's [`type`](https://webpack.js.org/configuration/module/#ruletype) option (e.g., `type: 'asset/resource'`).

Users can now configure how files are processed by setting the module type directly:

```js
// next.config.js
module.exports = {
  turbopack: {
    rules: {
      '*.svg': {
        type: 'asset',
      },
    },
  },
}
```

When using type: 'asset', importing the file returns its URL:

```
import svgUrl from './icon.svg'

export default function Page() {
  return <img src={svgUrl} alt="Icon" />
}
```

More types are available. See docs