### PR TITLE
create-next-app: enable typedRoutes by default for TypeScript

### DIFF
--- a/packages/create-next-app/templates/app-api/ts/next.config.ts
+++ b/packages/create-next-app/templates/app-api/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/app-empty/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/app-tw-empty/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app-tw/ts/next.config.ts
+++ b/packages/create-next-app/templates/app-tw/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/packages/create-next-app/templates/app/ts/next.config.ts
+++ b/packages/create-next-app/templates/app/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/packages/create-next-app/templates/default-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/default-empty/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
   reactStrictMode: true,
 };
 

--- a/packages/create-next-app/templates/default-tw-empty/ts/next.config.ts
+++ b/packages/create-next-app/templates/default-tw-empty/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
   reactStrictMode: true,
 };
 

--- a/packages/create-next-app/templates/default-tw/ts/next.config.ts
+++ b/packages/create-next-app/templates/default-tw/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
   reactStrictMode: true,
 };
 

--- a/packages/create-next-app/templates/default/ts/next.config.ts
+++ b/packages/create-next-app/templates/default/ts/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  typedRoutes: true,
   reactStrictMode: true,
 };
 


### PR DESCRIPTION
### What?

Enable `typedRoutes: true` by default in all TypeScript `next.config.ts` templates for `create-next-app`.

### Why?

Typed routes provide type-safe routing via the `Link` component and `useRouter()` hooks, catching routing errors at compile time. This improves the developer experience for TypeScript users by providing autocomplete and type checking for route paths out of the box.

### How?

Added `typedRoutes: true` to the `NextConfig` object in all 9 TypeScript templates:
- `app/ts/next.config.ts`
- `app-api/ts/next.config.ts`
- `app-empty/ts/next.config.ts`
- `app-tw/ts/next.config.ts`
- `app-tw-empty/ts/next.config.ts`
- `default/ts/next.config.ts`
- `default-empty/ts/next.config.ts`
- `default-tw/ts/next.config.ts`
- `default-tw-empty/ts/next.config.ts`