### PR TITLE
Fix buildManifest.js deployment tests

### DIFF
--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-asset-prefix.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-asset-prefix.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-app-asset-prefix', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       assetPrefix: '/assets',
@@ -9,9 +9,9 @@ describe('invalid-static-asset-404-app-asset-prefix', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/assets/_next/static/${
-      isNextDev ? 'development' : next.buildId
-    }/_buildManifest.js`
+    const buildManifestPath = isNextDeploy
+      ? '/assets/_next/static/_buildManifest.js'
+      : `/assets/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-app-base-path', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       basePath: '/base',
@@ -9,9 +9,9 @@ describe('invalid-static-asset-404-app-base-path', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/base/_next/static/${
-      isNextDev ? 'development' : next.buildId
-    }/_buildManifest.js`
+    const buildManifestPath = isNextDeploy
+      ? '/base/_next/static/_buildManifest.js'
+      : `/base/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app.test.ts
@@ -1,14 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-app', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/_next/static/${
-      isNextDev ? 'development' : next.buildId
-    }/_buildManifest.js`
+    const buildManifestPath = isNextDeploy
+      ? '/_next/static/_buildManifest.js'
+      : `/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-asset-prefix.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-asset-prefix.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-pages-asset-prefix', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       assetPrefix: '/assets',
@@ -9,9 +9,9 @@ describe('invalid-static-asset-404-pages-asset-prefix', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/assets/_next/static/${
-      isNextDev ? 'development' : next.buildId
-    }/_buildManifest.js`
+    const buildManifestPath = isNextDeploy
+      ? '/assets/_next/static/_buildManifest.js'
+      : `/assets/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-base-path.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-base-path.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-pages-base-path', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       basePath: '/base',
@@ -9,9 +9,9 @@ describe('invalid-static-asset-404-pages-base-path', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/base/_next/static/${
-      isNextDev ? 'development' : next.buildId
-    }/_buildManifest.js`
+    const buildManifestPath = isNextDeploy
+      ? '/base/_next/static/_buildManifest.js'
+      : `/base/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
@@ -1,14 +1,14 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-pages', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/_next/static/${
-      isNextDev ? 'development' : next.buildId
-    }/_buildManifest.js`
+    const buildManifestPath = isNextDeploy
+      ? '/_next/static/_buildManifest.js'
+      : `/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
@@ -4,22 +4,14 @@
 import { join } from 'path'
 import webdriver from 'next-webdriver'
 import { fetchViaHTTP } from 'next-test-utils'
-import { createNext, FileRef } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
+import { FileRef, isNextDeploy, nextTestSetup } from 'e2e-utils'
 
 const itif = (condition: boolean) => (condition ? it : it.skip)
 
-const isModeDeploy = process.env.NEXT_TEST_MODE === 'deploy'
-
 describe('Middleware custom matchers i18n', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: new FileRef(join(__dirname, '../app')),
-    })
+  const { next } = nextTestSetup({
+    files: new FileRef(join(__dirname, '../app')),
   })
-  afterAll(() => next.destroy())
 
   it.each(['/hello', '/en/hello', '/nl-NL/hello', '/nl-NL/about'])(
     'should match %s',
@@ -41,7 +33,7 @@ describe('Middleware custom matchers i18n', () => {
 
   // FIXME:
   // See https://linear.app/vercel/issue/EC-160/header-value-set-on-middleware-is-not-propagated-on-client-request-of
-  itif(!isModeDeploy).each(['hello', 'en_hello', 'nl-NL_hello', 'nl-NL_about'])(
+  itif(!isNextDeploy).each(['hello', 'en_hello', 'nl-NL_hello', 'nl-NL_about'])(
     'should match has query on client routing %s',
     async (id) => {
       const browser = await webdriver(next.url, '/routes')
@@ -56,41 +48,37 @@ describe('Middleware custom matchers i18n', () => {
 })
 
 describe('Middleware custom matchers with root', () => {
-  let next: NextInstance
+  const { next, isNextDeploy } = nextTestSetup({
+    files: {
+      pages: new FileRef(join(__dirname, '../app', 'pages')),
+      'next.config.js': new FileRef(
+        join(__dirname, '../app', 'next.config.js')
+      ),
+      'middleware.js': `
+      import { NextResponse } from 'next/server'
+      
+      export const config = {
+        matcher: [
+          '/',
+          '/((?!api|_next/static|favicon|.well-known|auth|sitemap|robots.txt|files).*)',
+        ],
+      };
 
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        pages: new FileRef(join(__dirname, '../app', 'pages')),
-        'next.config.js': new FileRef(
-          join(__dirname, '../app', 'next.config.js')
-        ),
-        'middleware.js': `
-        import { NextResponse } from 'next/server'
-        
-        export const config = {
-          matcher: [
-            '/',
-            '/((?!api|_next/static|favicon|.well-known|auth|sitemap|robots.txt|files).*)',
-          ],
-        };
-  
-        export default function middleware(request) {
-          const nextUrl = request.nextUrl.clone()
-          nextUrl.pathname = '/'
-          const res = NextResponse.rewrite(nextUrl)
-          res.headers.set('X-From-Middleware', 'true')
-          return res
-        }`,
-      },
-    })
+      export default function middleware(request) {
+        const nextUrl = request.nextUrl.clone()
+        nextUrl.pathname = '/'
+        const res = NextResponse.rewrite(nextUrl)
+        res.headers.set('X-From-Middleware', 'true')
+        return res
+      }`,
+    },
   })
-  afterAll(() => next.destroy())
 
   it('should not match', async () => {
-    const res = await fetchViaHTTP(
-      next.url,
-      `/_next/static/${next.buildId}/_buildManifest.js`
+    const res = await next.fetch(
+      isNextDeploy
+        ? '/_next/static/_buildManifest.js'
+        : `/_next/static/${next.buildId}/_buildManifest.js`
     )
     expect(res.status).toBe(200)
     expect(res.headers.get('x-from-middleware')).toBeFalsy()


### PR DESCRIPTION
When `NEXT_DEPLOYMENT_ID` is set (and thus skew protection is enabled), then these pages router manifests are actually on a different path (so that the output paths doesn't change with the build id anymore)

Fixup for https://github.com/vercel/next.js/pull/88641