### PR TITLE
[test] Skip flaky `prefetch-runtime` tests for deploy tests

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -11,6 +11,43 @@
         "app dir client cache semantics (experimental staleTimes) static: 180 prefetch={undefined} - default should re-use the loading boundary for the custom static override time (3 minutes)"
       ]
     },
+    "test/e2e/app-dir/segment-cache/prefetch-runtime/prefetch-runtime.test.ts": {
+      "flakey": [
+        "runtime prefetching cache stale time handling includes private caches with cacheLife(\"seconds\")",
+        "runtime prefetching cache stale time handling includes public caches with cacheLife(\"seconds\")",
+        "runtime prefetching cache stale time handling includes short-lived public caches with a long enough staleTime",
+        "runtime prefetching cache stale time handling omits private caches with a short enough staleTime",
+        "runtime prefetching cache stale time handling omits short-lived public caches with a short enough staleTime",
+        "runtime prefetching errors aborts the prerender without logging an error when sync IO is used after awaiting a quickly-expiring public cache",
+        "runtime prefetching errors aborts the prerender without logging an error when sync IO is used after awaiting a private cache",
+        "runtime prefetching errors aborts the prerender without logging an error when sync IO is used after awaiting cookies()",
+        "runtime prefetching errors aborts the prerender without logging an error when sync IO is used after awaiting dynamic params",
+        "runtime prefetching errors aborts the prerender without logging an error when sync IO is used after awaiting headers()",
+        "runtime prefetching errors aborts the prerender without logging an error when sync IO is used after awaiting searchParams",
+        "runtime prefetching errors should trigger error boundaries for errors that occurred in runtime-prefetched content",
+        "runtime prefetching in a page can completely prefetch a page that uses cookies and no uncached IO",
+        "runtime prefetching in a page includes cookies, but not dynamic content",
+        "runtime prefetching in a page includes dynamic params, but not dynamic content",
+        "runtime prefetching in a page includes headers, but not dynamic content",
+        "runtime prefetching in a page includes root params, but not dynamic content",
+        "runtime prefetching in a page includes search params, but not dynamic content",
+        "runtime prefetching in a private cache can completely prefetch a page that uses cookies and no uncached IO",
+        "runtime prefetching in a private cache includes cookies, but not dynamic content",
+        "runtime prefetching in a private cache includes dynamic params, but not dynamic content",
+        "runtime prefetching in a private cache includes headers, but not dynamic content",
+        "runtime prefetching in a private cache includes root params, but not dynamic content",
+        "runtime prefetching in a private cache includes search params, but not dynamic content",
+        "runtime prefetching passed to a public cache can completely prefetch a page that uses cookies and no uncached IO",
+        "runtime prefetching passed to a public cache includes cookies, but not dynamic content",
+        "runtime prefetching passed to a public cache includes dynamic params, but not dynamic content",
+        "runtime prefetching passed to a public cache includes headers, but not dynamic content",
+        "runtime prefetching passed to a public cache includes root params, but not dynamic content",
+        "runtime prefetching passed to a public cache includes search params, but not dynamic content",
+        "runtime prefetching should not cache runtime prefetch responses in the browser cache or server-side different cookies should return different prefetch results - in a page",
+        "runtime prefetching should not cache runtime prefetch responses in the browser cache or server-side different cookies should return different prefetch results - in a private cache",
+        "runtime prefetching should not cache runtime prefetch responses in the browser cache or server-side private caches should return new results on each request"
+      ]
+    },
     "test/e2e/app-dir/actions/app-action.test.ts": {
       "failed": [
         "app-dir action handling fetch actions should invalidate client cache when path is revalidated",


### PR DESCRIPTION
These are [all the prefetch-runtime tests that caused e2e release deploy test to fail ultimately](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40ci.pipeline.name%3Atest-e2e-deploy-release%20%40ci.pipeline.url%3A%2A%2Fattempts%2F2%20%40test.status%3Afail%20%40test.source.file%3Atest%2Fe2e%2Fapp-dir%2Fsegment-cache%2Fprefetch-runtime%2Fprefetch-runtime.test.ts&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=history&eventStack=&fromUser=true&index=citest&test-detail-history=log_test.status%2Ctimestamp%2Clog_git.branch%2Clog_git.commit.sha%2Clog_test.is_known_flaky&top_n=30&top_o=top&viz=query_table&x_missing=true&start=1767729717464&end=1768939317464&paused=true) (i.e. tests failing the 2nd and final attempt).

Skipping it unless we find out why until Thursday.

Part of https://linear.app/vercel/issue/NAR-719/