### PR TITLE
docs: fix punctuation in docs intro

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -18,6 +18,8 @@ It also automatically configures lower-level tools like bundlers and compilers. 
 
 Whether you're an individual developer or part of a larger team, Next.js can help you build interactive, dynamic, and fast React applications.
 
+If you are new here, start with the App Router documentation.
+
 ## How to use the docs
 
 The docs are organized into 3 sections:


### PR DESCRIPTION
Fix punctuation in docs/index.mdx to improve readability.
