### PR TITLE
[ci] Fix Rspack/Turbopack test manifest generation

### DIFF
--- a/.github/workflows/integration_tests_reusable.yml
+++ b/.github/workflows/integration_tests_reusable.yml
@@ -94,6 +94,7 @@ jobs:
         export NEXT_TEST_MODE=${{
           inputs.test_type == 'development' && 'dev' || 'start'
         }}
+        export NEXT_TEST_EMIT_ALL_OUTPUT=1
 
         ${{ inputs.run_before_test }}
 
@@ -129,6 +130,7 @@ jobs:
             'TURBOPACK_DEV=1' ||
             'TURBOPACK_BUILD=1'
         }}
+        export NEXT_TEST_EMIT_ALL_OUTPUT=1
 
         ${{ inputs.run_before_test }}
 

--- a/run-tests.js
+++ b/run-tests.js
@@ -695,8 +695,9 @@ ${ENDGROUP}`)
       console.error(`${test.file} failed to pass within ${numRetries} retries`)
     }
 
-    // Emit test output, parsed by the commenter webhook to notify about failing tests
-    if (!passed && isTestJob) {
+    // Emit test output, parsed by the commenter webhook to notify about failing tests.
+    // Also emit for all tests when NEXT_TEST_EMIT_ALL_OUTPUT is set (for manifest generation).
+    if ((!passed || process.env.NEXT_TEST_EMIT_ALL_OUTPUT) && isTestJob) {
       try {
         const testsOutput = await fsp.readFile(
           `${test.file}${RESULTS_EXT}`,


### PR DESCRIPTION
The recent change to always run all tests without aborting on failure (#88435) inadvertently broke manifest generation. Previously, test output was emitted for all tests when `NEXT_TEST_CONTINUE_ON_ERROR` was set, but that variable was removed. Now test output is only emitted for failing tests, causing the manifest to lose all passing test entries.

This adds a new `NEXT_TEST_EMIT_ALL_OUTPUT` environment variable that restores the full output behavior specifically for the manifest generation workflows.