### PR TITLE
Remove `deploymentId` from App Router `RenderOptsPartial`

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -611,6 +611,7 @@ export async function handler(
         page: normalizedSrcPage,
         sharedContext: {
           buildId,
+          deploymentId,
         },
         serverComponentsHmrCache: getRequestMeta(
           req,
@@ -659,7 +660,6 @@ export async function handler(
           trailingSlash: nextConfig.trailingSlash,
           images: nextConfig.images,
           previewProps: prerenderManifest.preview,
-          deploymentId: deploymentId,
           enableTainting: nextConfig.experimental.taint,
           htmlLimitedBots: nextConfig.htmlLimitedBots,
           reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -106,6 +106,7 @@ async function requestHandler(
 
     sharedContext: {
       buildId,
+      deploymentId,
     },
     fallbackRouteParams: null,
 
@@ -141,7 +142,6 @@ async function requestHandler(
       trailingSlash: nextConfig.trailingSlash,
       images: nextConfig.images,
       previewProps: prerenderManifest.preview,
-      deploymentId,
       enableTainting: nextConfig.experimental.taint,
       htmlLimitedBots: nextConfig.htmlLimitedBots,
       reactMaxHeadersLength: nextConfig.reactMaxHeadersLength,

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -110,6 +110,7 @@ async function requestHandler(
     params,
     buildId,
     nextConfig,
+    deploymentId,
     isNextDataRequest,
     buildManifest,
     prerenderManifest,
@@ -127,7 +128,7 @@ async function requestHandler(
 
     sharedContext: {
       buildId,
-      deploymentId: process.env.NEXT_DEPLOYMENT_ID,
+      deploymentId,
       customServer: undefined,
     },
 

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -500,7 +500,6 @@ async function exportAppImpl(
       join(distDir, 'server', `${NEXT_FONT_MANIFEST}.json`)
     ),
     images: nextConfig.images,
-    deploymentId: nextConfig.deploymentId,
     htmlLimitedBots: nextConfig.htmlLimitedBots.source,
     experimental: {
       clientTraceMetadata: nextConfig.experimental.clientTraceMetadata,
@@ -713,6 +712,7 @@ async function exportAppImpl(
         batches.map(async (batch) =>
           worker.exportPages({
             buildId,
+            deploymentId: nextConfig.deploymentId,
             exportPaths: batch,
             parentSpanId: span.getId(),
             pagesDataDir,

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -23,6 +23,7 @@ export type ExportPathEntry = ExportPathMap[keyof ExportPathMap] & {
 
 export interface ExportPagesInput {
   buildId: string
+  deploymentId: string
   exportPaths: ExportPathEntry[]
   parentSpanId: number
   dir: string
@@ -41,6 +42,7 @@ export interface ExportPagesInput {
 
 export interface ExportPageInput {
   buildId: string
+  deploymentId: string
   exportPath: ExportPathEntry
   distDir: string
   outDir: string

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -85,6 +85,7 @@ async function exportPageImpl(
     renderOpts: commonRenderOpts,
     outDir: commonOutDir,
     buildId,
+    deploymentId,
     renderResumeDataCache,
   } = input
 
@@ -274,7 +275,7 @@ async function exportPageImpl(
 
   // Handle App Pages
   if (isAppDir) {
-    const sharedContext: AppSharedContext = { buildId }
+    const sharedContext: AppSharedContext = { buildId, deploymentId }
 
     return exportAppPage(
       req,
@@ -294,7 +295,7 @@ async function exportPageImpl(
   } else {
     const sharedContext: PagesSharedContext = {
       buildId,
-      deploymentId: commonRenderOpts.deploymentId,
+      deploymentId,
       customServer: undefined,
     }
 
@@ -416,6 +417,7 @@ export async function exportPages(
             enableExperimentalReact: needsExperimentalReact(nextConfig),
             sriEnabled: Boolean(nextConfig.experimental.sri?.algorithm),
             buildId: input.buildId,
+            deploymentId: input.deploymentId,
             renderResumeDataCache,
           }),
           hasDebuggerAttached

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -234,6 +234,7 @@ export type GenerateFlight = typeof generateDynamicFlightRenderResult
 
 export type AppSharedContext = {
   buildId: string
+  deploymentId: string
 }
 
 export type AppRenderContext = {
@@ -2886,7 +2887,7 @@ async function renderToStream(
             ),
             getServerInsertedHTML,
             getServerInsertedMetadata,
-            deploymentId: ctx.renderOpts.deploymentId,
+            deploymentId: ctx.sharedContext.deploymentId,
           })
         }
       }
@@ -2964,7 +2965,7 @@ async function renderToStream(
         isStaticGeneration: generateStaticHTML,
         isBuildTimePrerendering: ctx.workStore.isBuildTimePrerendering === true,
         buildId: ctx.workStore.buildId,
-        deploymentId: ctx.renderOpts.deploymentId,
+        deploymentId: ctx.sharedContext.deploymentId,
         getServerInsertedHTML,
         getServerInsertedMetadata,
         validateRootLayout: dev,
@@ -3134,7 +3135,7 @@ async function renderToStream(
           isBuildTimePrerendering:
             ctx.workStore.isBuildTimePrerendering === true,
           buildId: ctx.workStore.buildId,
-          deploymentId: ctx.renderOpts.deploymentId,
+          deploymentId: ctx.sharedContext.deploymentId,
           getServerInsertedHTML: makeGetServerInsertedHTML({
             polyfills,
             renderServerInsertedHTML,
@@ -4840,7 +4841,7 @@ async function prerenderToStream(
           stream: await continueDynamicPrerender(prelude, {
             getServerInsertedHTML,
             getServerInsertedMetadata,
-            deploymentId: ctx.renderOpts.deploymentId,
+            deploymentId: ctx.sharedContext.deploymentId,
           }),
           dynamicAccess: consumeDynamicAccess(
             serverDynamicTracking,
@@ -4938,7 +4939,7 @@ async function prerenderToStream(
             isBuildTimePrerendering:
               ctx.workStore.isBuildTimePrerendering === true,
             buildId: ctx.workStore.buildId,
-            deploymentId: ctx.renderOpts.deploymentId,
+            deploymentId: ctx.sharedContext.deploymentId,
           })
         } else {
           // Normal static prerender case, no fallback param handling needed
@@ -4953,7 +4954,7 @@ async function prerenderToStream(
             isBuildTimePrerendering:
               ctx.workStore.isBuildTimePrerendering === true,
             buildId: ctx.workStore.buildId,
-            deploymentId: ctx.renderOpts.deploymentId,
+            deploymentId: ctx.sharedContext.deploymentId,
           })
         }
 
@@ -5127,7 +5128,7 @@ async function prerenderToStream(
           stream: await continueDynamicPrerender(prelude, {
             getServerInsertedHTML,
             getServerInsertedMetadata,
-            deploymentId: ctx.renderOpts.deploymentId,
+            deploymentId: ctx.sharedContext.deploymentId,
           }),
           dynamicAccess: dynamicTracking.dynamicAccesses,
           // TODO: Should this include the SSR pass?
@@ -5149,7 +5150,7 @@ async function prerenderToStream(
           stream: await continueDynamicPrerender(prelude, {
             getServerInsertedHTML,
             getServerInsertedMetadata,
-            deploymentId: ctx.renderOpts.deploymentId,
+            deploymentId: ctx.sharedContext.deploymentId,
           }),
           dynamicAccess: dynamicTracking.dynamicAccesses,
           // TODO: Should this include the SSR pass?
@@ -5216,7 +5217,7 @@ async function prerenderToStream(
             isBuildTimePrerendering:
               ctx.workStore.isBuildTimePrerendering === true,
             buildId: ctx.workStore.buildId,
-            deploymentId: ctx.renderOpts.deploymentId,
+            deploymentId: ctx.sharedContext.deploymentId,
           }),
           dynamicAccess: dynamicTracking.dynamicAccesses,
           // TODO: Should this include the SSR pass?
@@ -5317,7 +5318,7 @@ async function prerenderToStream(
           buildId: ctx.workStore.buildId,
           getServerInsertedHTML,
           getServerInsertedMetadata,
-          deploymentId: ctx.renderOpts.deploymentId,
+          deploymentId: ctx.sharedContext.deploymentId,
         }),
         // TODO: Should this include the SSR pass?
         collectedRevalidate: prerenderLegacyStore.revalidate,
@@ -5503,7 +5504,7 @@ async function prerenderToStream(
           }),
           getServerInsertedMetadata,
           validateRootLayout: dev,
-          deploymentId: ctx.renderOpts.deploymentId,
+          deploymentId: ctx.sharedContext.deploymentId,
         }),
         dynamicAccess: null,
         collectedRevalidate:

--- a/packages/next/src/server/app-render/get-asset-query-string.ts
+++ b/packages/next/src/server/app-render/get-asset-query-string.ts
@@ -18,8 +18,8 @@ export function getAssetQueryString(
     qs += `?v=${ctx.requestTimestamp}`
   }
 
-  if (ctx.renderOpts.deploymentId) {
-    qs += `${shouldAddVersion ? '&' : '?'}dpl=${ctx.renderOpts.deploymentId}`
+  if (ctx.sharedContext.deploymentId) {
+    qs += `${shouldAddVersion ? '&' : '?'}dpl=${ctx.sharedContext.deploymentId}`
   }
   return qs
 }

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -126,7 +126,6 @@ export interface RenderOptsPartial {
   nextConfigOutput?: 'standalone' | 'export'
   onInstrumentationRequestError?: ServerOnInstrumentationRequestError
   isDraftMode?: boolean
-  deploymentId?: string
   onUpdateCookies?: (cookies: string[]) => void
   loadConfig?: (
     phase: string,

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -94,6 +94,9 @@ export interface WorkStore {
   isUnstableNoStore?: boolean
   isPrefetchRequest?: boolean
 
+  /**
+   * Prefer `sharedContext.buildId` instead. This only exists because it's needed in use-cache-wrapper
+   */
   buildId: string
 
   readonly reactLoadableManifest?: DeepReadonly<

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -324,6 +324,7 @@ export default abstract class Server<
   protected readonly pagesManifest?: PagesManifest
   protected readonly appPathsManifest?: PagesManifest
   protected readonly buildId: string
+  protected readonly deploymentId: string
   protected readonly minimalMode: boolean
   protected readonly renderOpts: BaseRenderOpts
   protected readonly serverOptions: Readonly<ServerOptions>
@@ -454,20 +455,19 @@ export default abstract class Server<
     // values from causing issues as this can be user provided
     this.nextConfig = conf as NextConfigRuntime
 
-    let deploymentId
     if (this.nextConfig.experimental.runtimeServerDeploymentId) {
       if (!process.env.NEXT_DEPLOYMENT_ID) {
         throw new Error(
           'process.env.NEXT_DEPLOYMENT_ID is missing but runtimeServerDeploymentId is enabled'
         )
       }
-      deploymentId = process.env.NEXT_DEPLOYMENT_ID
+      this.deploymentId = process.env.NEXT_DEPLOYMENT_ID
     } else {
       let id = this.nextConfig.experimental.useSkewCookie
         ? ''
         : this.nextConfig.deploymentId || ''
 
-      deploymentId = id
+      this.deploymentId = id
       process.env.NEXT_DEPLOYMENT_ID = id
     }
 
@@ -530,7 +530,6 @@ export default abstract class Server<
       dir: this.dir,
       supportsDynamicResponse: true,
       trailingSlash: this.nextConfig.trailingSlash,
-      deploymentId: deploymentId,
       poweredByHeader: this.nextConfig.poweredByHeader,
       generateEtags,
       previewProps: this.getPrerenderManifest().preview,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -356,7 +356,7 @@ export default class NextNodeServer extends BaseServer<
     // when using compile mode static env isn't inlined so we
     // need to populate in normal runtime env
     if (this.renderOpts.isExperimentalCompile) {
-      populateStaticEnv(this.nextConfig, this.renderOpts.deploymentId || '')
+      populateStaticEnv(this.nextConfig, this.deploymentId || '')
     }
 
     const shouldRemoveUncaughtErrorAndRejectionListeners = Boolean(
@@ -715,6 +715,7 @@ export default class NextNodeServer extends BaseServer<
           this.getServerComponentsHmrCache(),
           {
             buildId: this.buildId,
+            deploymentId: this.deploymentId,
           }
         )
       } else {
@@ -729,7 +730,7 @@ export default class NextNodeServer extends BaseServer<
           renderOpts as LoadedRenderOpts<PagesModule>,
           {
             buildId: this.buildId,
-            deploymentId: this.renderOpts.deploymentId,
+            deploymentId: this.deploymentId,
             customServer: this.serverOptions.customServer || undefined,
           },
           {

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -306,7 +306,7 @@ export type PagesSharedContext = {
   /**
    * The deployment ID if the user is deploying to a platform that provides one.
    */
-  deploymentId: string | undefined
+  deploymentId: string
 
   /**
    * True if the user is using a custom server.

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -265,7 +265,7 @@ export const getHandler = ({
                     buildId,
                     customServer:
                       Boolean(routerServerContext?.isCustomServer) || undefined,
-                    deploymentId: getDeploymentId(),
+                    deploymentId: getDeploymentId() || '',
                   },
                   renderOpts: {
                     params,


### PR DESCRIPTION
There should only be a single place for it now (`ctx.sharedContext.deploymentId`)