### PR TITLE
[devtools] Allow switching codeframe

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.stories.tsx
@@ -57,12 +57,29 @@ export const HasSource: Story = {
       ...frame,
       originalCodeFrame: 'export default function MyComponent() {',
     },
+    index: 0,
+    isSelected: false,
+    onSelect: () => {},
+  },
+}
+
+export const HasSourceSelected: Story = {
+  args: {
+    frame: {
+      ...frame,
+      originalCodeFrame: 'export default function MyComponent() {',
+    },
+    index: 0,
+    isSelected: true,
+    onSelect: () => {},
   },
 }
 
 export const NoSource: Story = {
   args: {
     frame,
+    index: 0,
+    isSelected: false,
   },
 }
 
@@ -75,5 +92,7 @@ export const AnonymousSource: Story = {
         file: '<anonymous>',
       },
     },
+    index: 0,
+    isSelected: false,
   },
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.tsx
@@ -1,25 +1,48 @@
 import type { OriginalStackFrame } from '../../../shared/stack-frame'
 
+import { useCallback } from 'react'
 import { HotlinkedText } from '../hot-linked-text'
 import { ExternalIcon, SourceMappingErrorIcon } from '../../icons/external'
 import { getStackFrameFile } from '../../../shared/stack-frame'
 import { useOpenInEditor } from '../../utils/use-open-in-editor'
 
-export const CallStackFrame: React.FC<{
+export function CallStackFrame({
+  frame,
+  index,
+  isSelected,
+  onSelect,
+  tabGroupId,
+}: {
   frame: OriginalStackFrame
-}> = function CallStackFrame({ frame }) {
+  index: number
+  isSelected: boolean
+  onSelect?: (index: number) => void
+  tabGroupId: string
+}) {
   // TODO: ability to expand resolved frames
 
   const f = frame.originalStackFrame ?? frame.sourceStackFrame
-  const hasOriginalCodeFrame = Boolean(frame.originalCodeFrame)
+  const hasSource = Boolean(frame.originalCodeFrame)
+  const isSelectable = Boolean(onSelect)
   const open = useOpenInEditor(
-    hasOriginalCodeFrame
+    hasSource
       ? {
           file: f.file,
           line1: f.line1 ?? 1,
           column1: f.column1 ?? 1,
         }
       : undefined
+  )
+
+  const handleSelect = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (event.metaKey) {
+        open()
+      } else if (onSelect) {
+        onSelect(index)
+      }
+    },
+    [onSelect, index, open]
   )
 
   // Formatted file source could be empty. e.g. <anonymous> will be formatted to empty string,
@@ -30,26 +53,61 @@ export const CallStackFrame: React.FC<{
     return null
   }
 
+  const tabPanelId = `${tabGroupId}-panel-${index}`
+  const tabId = `${tabGroupId}-tab-${index}`
+  const describedById = `${tabGroupId}-tab-${index}-label`
+  const labelledById = `${tabGroupId}-tab-${index}-description`
+
+  // Using the "faux nested interactive controls" pattern:
+  // https://piccalil.li/blog/accessible-faux-nested-interactive-controls/
+  // The main button uses a ::after pseudo-element to cover the whole frame area.
+  // Other buttons are positioned with higher z-index to be clickable above it.
   return (
     <div
       data-nextjs-call-stack-frame
-      data-nextjs-call-stack-frame-no-source={!hasOriginalCodeFrame}
+      data-nextjs-call-stack-frame-index={index}
+      data-nextjs-call-stack-frame-no-source={!hasSource}
       data-nextjs-call-stack-frame-ignored={frame.ignored}
+      data-nextjs-call-stack-frame-selectable={isSelectable}
+      role="tab"
+      id={tabId}
+      aria-controls={tabPanelId}
+      aria-describedby={describedById}
+      aria-labelledby={labelledById}
+      aria-selected={isSelected}
+      tabIndex={isSelected ? 0 : -1}
     >
       <div className="call-stack-frame-method-name">
-        <HotlinkedText text={f.methodName} />
-        {hasOriginalCodeFrame && (
+        {isSelectable ? (
           <button
+            type="button"
+            onClick={handleSelect}
+            className="call-stack-frame-select-button"
+            id={labelledById}
+            tabIndex={-1}
+          >
+            <HotlinkedText text={f.methodName} />
+          </button>
+        ) : (
+          <span>
+            <HotlinkedText text={f.methodName} />
+          </span>
+        )}
+        {hasSource && (
+          <button
+            type="button"
             onClick={open}
-            className="open-in-editor-button"
+            className="call-stack-frame-action-button open-in-editor-button"
             aria-label={`Open ${f.methodName} in editor`}
+            tabIndex={-1}
           >
             <ExternalIcon width={16} height={16} />
           </button>
         )}
         {frame.error ? (
           <button
-            className="source-mapping-error-button"
+            type="button"
+            className="call-stack-frame-action-button source-mapping-error-button"
             onClick={() => console.error(frame.reason)}
             title="Sourcemapping failed. Click to log cause of error."
           >
@@ -58,8 +116,9 @@ export const CallStackFrame: React.FC<{
         ) : null}
       </div>
       <span
-        className="call-stack-frame-file"
-        data-has-original-code-frame={hasOriginalCodeFrame}
+        className="call-stack-frame-file-source"
+        data-has-source={hasSource}
+        id={describedById}
       >
         {stackFrameFile}
       </span>
@@ -83,8 +142,9 @@ export const CALL_STACK_FRAME_STYLES = `
     opacity: 0.6;
   }
 
+  /* Container for the faux nested interactive controls pattern */
   [data-nextjs-call-stack-frame] {
-    user-select: text;
+    position: relative;
     display: block;
     box-sizing: border-box;
 
@@ -96,6 +156,21 @@ export const CALL_STACK_FRAME_STYLES = `
     padding: 6px 8px;
 
     border-radius: var(--rounded-lg);
+    transition: background-color 150ms ease;
+  }
+
+  [data-nextjs-call-stack-frame]:focus-visible {
+    outline: var(--focus-ring);
+    /* offset --focus-right width. Chrome's default choice to restrict the childs outline by the parent looks bad. */
+    outline-offset: -2px;
+  }
+
+  [data-nextjs-call-stack-frame-selectable="true"]:hover {
+    background-color: var(--color-gray-100);
+  }
+
+  [data-nextjs-call-stack-frame][aria-selected="true"] {
+    background-color: var(--color-gray-200);
   }
 
   .call-stack-frame-method-name {
@@ -117,6 +192,32 @@ export const CALL_STACK_FRAME_STYLES = `
     }
   }
 
+  /* Main select button with ::after covering the whole frame */
+  .call-stack-frame-select-button {
+    all: unset;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  /* The ::after pseudo-element covers the whole frame area */
+  .call-stack-frame-select-button::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
+
+  .call-stack-frame-select-button:focus-visible {
+    outline: var(--focus-ring);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* Action buttons positioned above the select button's ::after */
+  .call-stack-frame-action-button {
+    position: relative;
+    z-index: 1;
+  }
+
   .open-in-editor-button, .source-mapping-error-button {
     display: flex;
     align-items: center;
@@ -136,14 +237,19 @@ export const CALL_STACK_FRAME_STYLES = `
     }
 
     &:hover {
-      background: var(--color-gray-100);
+      /* 
+       * if we're hovering the secondary actions, we're also hovering the parent.
+       * Invert back to create sufficient contrast against the parent's hover background color.
+       */
+      background: var(--color-background-100);
+      outline: 1px solid var(--color-font);
     }
   }
 
-  .call-stack-frame-file {
+  .call-stack-frame-file-source {
+    display: block;
     color: var(--color-gray-900);
     font-size: var(--size-14);
     line-height: var(--size-20);
-    word-wrap: break-word;
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack/call-stack.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack/call-stack.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
 import { CallStack } from './call-stack'
 import { withShadowPortal } from '../../storybook/with-shadow-portal'
 
@@ -59,31 +60,52 @@ const ignoredFrame = {
 export const SingleFrame: Story = {
   args: {
     frames: [frame],
+    isIgnoreListOpen: false,
+    ignoredFramesTally: 0,
+    onToggleIgnoreList: () => {},
+    selectedFrameIndex: 0,
+    onFrameSelect: () => {},
+    tabGroupId: 'storybook-call-stack',
   },
 }
 
-export const MultipleFrames: Story = {
-  args: {
-    frames: [
-      frame,
-      {
-        ...frame,
-        originalStackFrame: {
-          ...frame.originalStackFrame,
-          methodName: 'ParentComponent',
-          lineNumber: 5,
-        },
-      },
-      ...Array(5).fill(ignoredFrame),
-      {
-        ...frame,
-        originalStackFrame: {
-          ...frame.originalStackFrame,
-          methodName: 'GrandparentComponent',
-          lineNumber: 1,
-        },
-      },
-      ...Array(5).fill(ignoredFrame),
-    ],
+const multipleFrames = [
+  frame,
+  {
+    ...frame,
+    originalStackFrame: {
+      ...frame.originalStackFrame,
+      methodName: 'ParentComponent',
+      lineNumber: 5,
+    },
   },
+  ...Array(5).fill(ignoredFrame),
+  {
+    ...frame,
+    originalStackFrame: {
+      ...frame.originalStackFrame,
+      methodName: 'GrandparentComponent',
+      lineNumber: 1,
+    },
+  },
+  ...Array(5).fill(ignoredFrame),
+]
+
+function InteractiveCallStack() {
+  const [selectedFrameIndex, setSelectedFrameIndex] = useState<number | null>(0)
+  return (
+    <CallStack
+      frames={multipleFrames}
+      isIgnoreListOpen={false}
+      ignoredFramesTally={10}
+      onToggleIgnoreList={() => {}}
+      selectedFrameIndex={selectedFrameIndex}
+      onFrameSelect={setSelectedFrameIndex}
+      tabGroupId="storybook-call-stack"
+    />
+  )
+}
+
+export const MultipleFrames: Story = {
+  render: () => <InteractiveCallStack />,
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack/call-stack.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack/call-stack.tsx
@@ -3,18 +3,146 @@ import type { OriginalStackFrame } from '../../../shared/stack-frame'
 import { CallStackFrame } from '../call-stack-frame/call-stack-frame'
 import { ChevronUpDownIcon } from '../../icons/chevron-up-down'
 import { css } from '../../utils/css'
+import { useOpenInEditor } from '../../utils/use-open-in-editor'
+import { useRef } from 'react'
+
+/**
+ * If there are no frames, just return -1
+ * Ensure we don't start out-of-bounds
+ */
+function findNextSelectableFrameIndex(
+  frames: readonly OriginalStackFrame[],
+  startIndex: number | null,
+  isIgnoreListOpen: boolean,
+  direction: 1 | -1
+): number | null {
+  const length = frames.length
+
+  if (length === 0) {
+    return null
+  }
+  if (startIndex === null) {
+    return direction === 1 ? 0 : length - 1
+  }
+
+  let nextIndex = startIndex
+
+  do {
+    nextIndex = (nextIndex + direction + length) % length
+    const frame = frames[nextIndex]
+    const hasSource = Boolean(frame.originalCodeFrame)
+    if (hasSource && (!frame.ignored || isIgnoreListOpen)) {
+      return nextIndex
+    }
+  } while (nextIndex !== startIndex)
+
+  return null
+}
 
 export function CallStack({
   frames,
   isIgnoreListOpen,
   ignoredFramesTally,
   onToggleIgnoreList,
+  selectedFrameIndex,
+  onFrameSelect,
+  tabGroupId,
 }: {
   frames: readonly OriginalStackFrame[]
   isIgnoreListOpen: boolean
   ignoredFramesTally: number
   onToggleIgnoreList: () => void
+  selectedFrameIndex: number | null
+  onFrameSelect: (index: number) => void
+  tabGroupId: string
 }) {
+  const selectedFrame =
+    selectedFrameIndex !== null ? frames[selectedFrameIndex] : null
+  const anyFrame =
+    selectedFrame !== null
+      ? (selectedFrame.originalStackFrame ?? selectedFrame.sourceStackFrame)
+      : null
+  const hasSource = Boolean(selectedFrame?.originalCodeFrame)
+  const open = useOpenInEditor(
+    hasSource && anyFrame !== null
+      ? {
+          file: anyFrame.file,
+          line1: anyFrame.line1 ?? 1,
+          column1: anyFrame.column1 ?? 1,
+        }
+      : undefined
+  )
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    let nextIndex: number | null = null
+    switch (event.key) {
+      case 'ArrowDown': {
+        nextIndex = findNextSelectableFrameIndex(
+          frames,
+          selectedFrameIndex,
+          isIgnoreListOpen,
+          1
+        )
+
+        break
+      }
+      case 'ArrowUp': {
+        nextIndex = findNextSelectableFrameIndex(
+          frames,
+          selectedFrameIndex,
+          isIgnoreListOpen,
+          -1
+        )
+
+        break
+      }
+      case 'Home': {
+        nextIndex = findNextSelectableFrameIndex(
+          frames,
+          frames.length - 1,
+          isIgnoreListOpen,
+          1
+        )
+        break
+      }
+      case 'End': {
+        nextIndex = findNextSelectableFrameIndex(
+          frames,
+          0,
+          isIgnoreListOpen,
+          -1
+        )
+        break
+      }
+      case 'Enter':
+      case ' ': {
+        if (event.metaKey && selectedFrame !== null) {
+          event.preventDefault()
+          open()
+        }
+
+        break
+      }
+
+      default:
+        break
+    }
+
+    if (nextIndex !== null && nextIndex !== selectedFrameIndex) {
+      event.preventDefault()
+      onFrameSelect(nextIndex)
+      const container = containerRef.current!
+      const nextTab = container.querySelector<HTMLButtonElement>(
+        `#${tabGroupId}-tab-${nextIndex}`
+      )!
+
+      // nextTab.scrollIntoView({ block: 'nearest' })
+      nextTab.focus()
+    }
+  }
+
   return (
     <div data-nextjs-call-stack-container>
       <div data-nextjs-call-stack-header>
@@ -32,11 +160,27 @@ export function CallStack({
           </button>
         )}
       </div>
-      {frames.map((frame, frameIndex) => {
-        return !frame.ignored || isIgnoreListOpen ? (
-          <CallStackFrame key={frameIndex} frame={frame} />
-        ) : null
-      })}
+      <div
+        data-nextjs-call-stack-frames
+        role="tablist"
+        aria-orientation="vertical"
+        onKeyDown={handleKeyDown}
+        ref={containerRef}
+      >
+        {frames.map((frame, frameIndex) => {
+          const hasCodeFrame = Boolean(frame.originalCodeFrame)
+          return !frame.ignored || isIgnoreListOpen ? (
+            <CallStackFrame
+              key={frameIndex}
+              frame={frame}
+              index={frameIndex}
+              isSelected={selectedFrameIndex === frameIndex}
+              onSelect={hasCodeFrame ? onFrameSelect : undefined}
+              tabGroupId={tabGroupId}
+            />
+          ) : null
+        })}
+      </div>
     </div>
   )
 }
@@ -54,6 +198,11 @@ export const CALL_STACK_STYLES = css`
     min-height: var(--size-28);
     padding: 8px 8px 12px 4px;
     width: 100%;
+  }
+
+  [data-nextjs-call-stack-frames] {
+    max-height: 15rem;
+    overflow: auto;
   }
 
   [data-nextjs-call-stack-title] {

--- a/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
@@ -10,12 +10,19 @@ import {
   parseLineNumberFromCodeFrameLine,
 } from './parse-code-frame'
 
-type CodeFrameProps = {
+interface CodeFrameProps {
   stackFrame: StackFrame
   codeFrame: string
+  selectedFrameIndex: number
+  tabGroupId: string
 }
 
-export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
+export function CodeFrame({
+  stackFrame,
+  codeFrame,
+  selectedFrameIndex,
+  tabGroupId,
+}: CodeFrameProps) {
   const parsedLineStates = useMemo(() => {
     const decodedLines = groupCodeFrameLines(formatCodeFrame(codeFrame))
 
@@ -34,10 +41,17 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
   })
 
   const fileExtension = stackFrame?.file?.split('.').pop()
+  const tabPanelId = `${tabGroupId}-panel-${selectedFrameIndex}`
+  const tabId = `${tabGroupId}-tab-${selectedFrameIndex}`
 
   // TODO: make the caret absolute
   return (
-    <div data-nextjs-codeframe>
+    <div
+      data-nextjs-codeframe
+      role="tabpanel"
+      id={tabPanelId}
+      aria-labelledby={tabId}
+    >
       <div className="code-frame-header">
         {/* TODO: This is <div> in `Terminal` component.
         Changing now will require multiple test snapshots updates.

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.stories.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { useState, useRef } from 'react'
 import { ErrorOverlayCallStack } from './error-overlay-call-stack'
 import { withShadowPortal } from '../../../storybook/with-shadow-portal'
 
@@ -59,31 +60,53 @@ const ignoredFrame = {
 export const SingleFrame: Story = {
   args: {
     frames: [frame],
+    selectedFrameIndex: 0,
+    onFrameSelect: () => {},
+    isIgnoreListOpen: false,
+    setIsIgnoreListOpen: () => {},
+    tabGroupId: 'storybook-error-overlay-call-stack',
   },
 }
 
-export const MultipleFrames: Story = {
-  args: {
-    frames: [
-      frame,
-      {
-        ...frame,
-        originalStackFrame: {
-          ...frame.originalStackFrame,
-          methodName: 'ParentComponent',
-          lineNumber: 5,
-        },
-      },
-      ...Array(5).fill(ignoredFrame),
-      {
-        ...frame,
-        originalStackFrame: {
-          ...frame.originalStackFrame,
-          methodName: 'GrandparentComponent',
-          lineNumber: 1,
-        },
-      },
-      ...Array(5).fill(ignoredFrame),
-    ],
+const multipleFrames = [
+  frame,
+  {
+    ...frame,
+    originalStackFrame: {
+      ...frame.originalStackFrame,
+      methodName: 'ParentComponent',
+      lineNumber: 5,
+    },
   },
+  ...Array(5).fill(ignoredFrame),
+  {
+    ...frame,
+    originalStackFrame: {
+      ...frame.originalStackFrame,
+      methodName: 'GrandparentComponent',
+      lineNumber: 1,
+    },
+  },
+  ...Array(5).fill(ignoredFrame),
+]
+
+function InteractiveErrorOverlayCallStack() {
+  const [selectedFrameIndex, setSelectedFrameIndex] = useState<number | null>(0)
+  const [isIgnoreListOpen, setIsIgnoreListOpen] = useState(false)
+  const dialogResizerRef = useRef<HTMLDivElement>(null)
+  return (
+    <ErrorOverlayCallStack
+      frames={multipleFrames}
+      dialogResizerRef={dialogResizerRef}
+      selectedFrameIndex={selectedFrameIndex}
+      onFrameSelect={setSelectedFrameIndex}
+      isIgnoreListOpen={isIgnoreListOpen}
+      setIsIgnoreListOpen={setIsIgnoreListOpen}
+      tabGroupId="storybook-error-overlay-call-stack"
+    />
+  )
+}
+
+export const MultipleFrames: Story = {
+  render: () => <InteractiveErrorOverlayCallStack />,
 }

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-call-stack/error-overlay-call-stack.tsx
@@ -1,18 +1,27 @@
 import type { OriginalStackFrame } from '../../../../shared/stack-frame'
-import { useMemo, useState, useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { CallStack } from '../../call-stack/call-stack'
 
 interface CallStackProps {
   frames: readonly OriginalStackFrame[]
   dialogResizerRef: React.RefObject<HTMLDivElement | null>
+  selectedFrameIndex: number | null
+  onFrameSelect: (index: number) => void
+  isIgnoreListOpen: boolean
+  setIsIgnoreListOpen: (open: boolean) => void
+  tabGroupId: string
 }
 
 export function ErrorOverlayCallStack({
   frames,
   dialogResizerRef,
+  selectedFrameIndex,
+  onFrameSelect,
+  isIgnoreListOpen,
+  setIsIgnoreListOpen,
+  tabGroupId,
 }: CallStackProps) {
   const initialDialogHeight = useRef<number>(NaN)
-  const [isIgnoreListOpen, setIsIgnoreListOpen] = useState(false)
 
   const ignoredFramesTally = useMemo(() => {
     return frames.reduce((tally, frame) => tally + (frame.ignored ? 1 : 0), 0)
@@ -62,6 +71,9 @@ export function ErrorOverlayCallStack({
       isIgnoreListOpen={isIgnoreListOpen}
       onToggleIgnoreList={onToggleIgnoreList}
       ignoredFramesTally={ignoredFramesTally}
+      selectedFrameIndex={selectedFrameIndex}
+      onFrameSelect={onFrameSelect}
+      tabGroupId={tabGroupId}
     />
   )
 }

--- a/packages/next/src/next-devtools/dev-overlay/container/runtime-error/error-cause.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/runtime-error/error-cause.tsx
@@ -1,27 +1,119 @@
-import { useMemo } from 'react'
+import { useCallback, useId, useReducer } from 'react'
 import React from 'react'
 import { CodeFrame } from '../../components/code-frame/code-frame'
 import { ErrorOverlayCallStack } from '../../components/errors/error-overlay-call-stack/error-overlay-call-stack'
 import type { ReadyErrorCause } from '../../utils/get-error-by-type'
+import type { OriginalStackFrame } from '../../../shared/stack-frame'
 
 type ErrorCauseProps = {
   cause: ReadyErrorCause
   dialogResizerRef: React.RefObject<HTMLDivElement | null>
 }
 
+interface SelectedFrameState {
+  isIgnoreListOpen: boolean
+  selectedFrameIndex: number | null
+}
+
+function getDefaultSelectedFrameState(
+  frames: readonly OriginalStackFrame[]
+): SelectedFrameState {
+  const defaultIsIgnoreListOpen = false
+  const defaultSelectedFrameIndex = frames.findIndex(
+    (frame) => defaultIsIgnoreListOpen || !frame.ignored
+  )
+
+  return {
+    isIgnoreListOpen: defaultIsIgnoreListOpen,
+    selectedFrameIndex:
+      defaultSelectedFrameIndex === -1 ? null : defaultSelectedFrameIndex,
+  }
+}
+
 export function ErrorCause({ cause, dialogResizerRef }: ErrorCauseProps) {
   const frames = React.use(cause.frames())
   const trimmedMessage = cause.error.message.trim()
 
-  const firstFrame = useMemo(() => {
-    const index = frames.findIndex(
-      (entry) =>
-        !entry.ignored &&
-        Boolean(entry.originalCodeFrame) &&
-        Boolean(entry.originalStackFrame)
-    )
-    return frames[index] ?? null
-  }, [frames])
+  const [{ isIgnoreListOpen, selectedFrameIndex }, dispatch] = useReducer(
+    (
+      prevState: SelectedFrameState,
+      action:
+        | { type: 'toggleIgnoreList' }
+        | { type: 'selectFrame'; index: number }
+    ) => {
+      switch (action.type) {
+        case 'toggleIgnoreList':
+          const nextIsIgnoreListOpen = !prevState.isIgnoreListOpen
+          const previouslySelectedFrameIndex = prevState.selectedFrameIndex
+          if (nextIsIgnoreListOpen || previouslySelectedFrameIndex === null) {
+            return {
+              ...prevState,
+              isIgnoreListOpen: nextIsIgnoreListOpen,
+            }
+          } else {
+            if (frames[previouslySelectedFrameIndex].ignored) {
+              for (let i = previouslySelectedFrameIndex - 1; i >= 0; i--) {
+                if (!frames[i].ignored) {
+                  return {
+                    ...prevState,
+                    selectedFrameIndex: i,
+                    isIgnoreListOpen: nextIsIgnoreListOpen,
+                  }
+                }
+              }
+              for (
+                let i = previouslySelectedFrameIndex + 1;
+                i < frames.length;
+                i++
+              ) {
+                if (!frames[i].ignored) {
+                  return {
+                    ...prevState,
+                    selectedFrameIndex: i,
+                    isIgnoreListOpen: nextIsIgnoreListOpen,
+                  }
+                }
+              }
+
+              return {
+                ...prevState,
+                selectedFrameIndex: null,
+                isIgnoreListOpen: nextIsIgnoreListOpen,
+              }
+            } else {
+              return {
+                ...prevState,
+                isIgnoreListOpen: nextIsIgnoreListOpen,
+              }
+            }
+          }
+        case 'selectFrame':
+          return {
+            ...prevState,
+            selectedFrameIndex: action.index,
+          }
+        default:
+          return prevState
+      }
+    },
+    frames,
+    getDefaultSelectedFrameState
+  )
+
+  const setIsIgnoreListOpen = useCallback(
+    () => dispatch({ type: 'toggleIgnoreList' }),
+    []
+  )
+
+  const selectedFrame =
+    selectedFrameIndex !== null ? frames[selectedFrameIndex] : null
+
+  const handleFrameSelect = useCallback(
+    (index: number) => dispatch({ type: 'selectFrame', index }),
+    []
+  )
+
+  const codeFrameTabGroupId = useId()
 
   return (
     <div data-nextjs-error-cause>
@@ -34,17 +126,27 @@ export function ErrorCause({ cause, dialogResizerRef }: ErrorCauseProps) {
         <p className="error-cause-message">{trimmedMessage}</p>
       ) : null}
 
-      {firstFrame && (
-        <CodeFrame
-          stackFrame={firstFrame.originalStackFrame!}
-          codeFrame={firstFrame.originalCodeFrame!}
-        />
-      )}
+      {selectedFrameIndex !== null &&
+        selectedFrame !== null &&
+        selectedFrame.originalStackFrame &&
+        selectedFrame.originalCodeFrame && (
+          <CodeFrame
+            stackFrame={selectedFrame.originalStackFrame}
+            codeFrame={selectedFrame.originalCodeFrame}
+            selectedFrameIndex={selectedFrameIndex}
+            tabGroupId={codeFrameTabGroupId}
+          />
+        )}
 
       {frames.length > 0 && (
         <ErrorOverlayCallStack
           dialogResizerRef={dialogResizerRef}
           frames={frames}
+          selectedFrameIndex={selectedFrameIndex}
+          onFrameSelect={handleFrameSelect}
+          isIgnoreListOpen={isIgnoreListOpen}
+          setIsIgnoreListOpen={setIsIgnoreListOpen}
+          tabGroupId={codeFrameTabGroupId}
         />
       )}
 

--- a/packages/next/src/next-devtools/dev-overlay/container/runtime-error/index.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/runtime-error/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useId, useReducer } from 'react'
 import { CodeFrame } from '../../components/code-frame/code-frame'
 import { ErrorOverlayCallStack } from '../../components/errors/error-overlay-call-stack/error-overlay-call-stack'
 import { PSEUDO_HTML_DIFF_STYLES } from './component-stack-pseudo-html'
@@ -13,33 +13,137 @@ type RuntimeErrorProps = {
   dialogResizerRef: React.RefObject<HTMLDivElement | null>
 }
 
+interface SelectedFrameState {
+  isIgnoreListOpen: boolean
+  selectedFrameIndex: number | null
+}
+
+function getDefaultSelectedFrameState(
+  frames: ReturnType<typeof useFrames>
+): SelectedFrameState {
+  const defaultIsIgnoreListOpen = false
+  const defaultSelectedFrameIndex = frames.findIndex(
+    (frame) => defaultIsIgnoreListOpen || !frame.ignored
+  )
+
+  return {
+    isIgnoreListOpen: defaultIsIgnoreListOpen,
+    selectedFrameIndex:
+      defaultSelectedFrameIndex === -1 ? null : defaultSelectedFrameIndex,
+  }
+}
+
 export function RuntimeError({ error, dialogResizerRef }: RuntimeErrorProps) {
   const frames = useFrames(error)
+  const [{ isIgnoreListOpen, selectedFrameIndex }, dispatch] = useReducer(
+    (
+      prevState: SelectedFrameState,
+      action:
+        | { type: 'toggleIgnoreList' }
+        | { type: 'selectFrame'; index: number }
+    ) => {
+      switch (action.type) {
+        case 'toggleIgnoreList':
+          const nextIsIgnoreListOpen = !prevState.isIgnoreListOpen
+          const previouslySelectedFrameIndex = prevState.selectedFrameIndex
+          if (nextIsIgnoreListOpen || previouslySelectedFrameIndex === null) {
+            // When we show ignore-listed, the current selected frame is still visible.
+            // No need to change the index
+            return {
+              ...prevState,
+              isIgnoreListOpen: nextIsIgnoreListOpen,
+            }
+          } else {
+            // The selected frame may have been hidden, find the next best one.
+            if (frames[previouslySelectedFrameIndex].ignored) {
+              // prefer a frame closer to the callsite
+              for (let i = previouslySelectedFrameIndex - 1; i >= 0; i--) {
+                if (!frames[i].ignored) {
+                  return {
+                    ...prevState,
+                    selectedFrameIndex: i,
+                    isIgnoreListOpen: nextIsIgnoreListOpen,
+                  }
+                }
+              }
+              // fallback to a deeper one
+              for (
+                let i = previouslySelectedFrameIndex + 1;
+                i < frames.length;
+                i++
+              ) {
+                if (!frames[i].ignored) {
+                  return {
+                    ...prevState,
+                    selectedFrameIndex: i,
+                    isIgnoreListOpen: nextIsIgnoreListOpen,
+                  }
+                }
+              }
 
-  const firstFrame = useMemo(() => {
-    const firstFirstPartyFrameIndex = frames.findIndex(
-      (entry) =>
-        !entry.ignored &&
-        Boolean(entry.originalCodeFrame) &&
-        Boolean(entry.originalStackFrame)
-    )
+              // Found no suitable frame to select e.g. all frames are ignore-listed
+              // or there are no frames at all.
+              return {
+                ...prevState,
+                selectedFrameIndex: null,
+                isIgnoreListOpen: nextIsIgnoreListOpen,
+              }
+            } else {
+              return {
+                ...prevState,
+                isIgnoreListOpen: nextIsIgnoreListOpen,
+              }
+            }
+          }
+        case 'selectFrame':
+          return {
+            ...prevState,
+            selectedFrameIndex: action.index,
+          }
+        default:
+          return prevState
+      }
+    },
+    frames,
+    getDefaultSelectedFrameState
+  )
+  const setIsIgnoreListOpen = useCallback(
+    () => dispatch({ type: 'toggleIgnoreList' }),
+    []
+  )
 
-    return frames[firstFirstPartyFrameIndex] ?? null
-  }, [frames])
+  const selectedFrame =
+    selectedFrameIndex !== null ? frames[selectedFrameIndex] : null
+
+  const handleFrameSelect = useCallback(
+    (index: number) => dispatch({ type: 'selectFrame', index }),
+    []
+  )
+
+  const codeFrameTabGroupId = useId()
 
   return (
     <>
-      {firstFrame && (
-        <CodeFrame
-          stackFrame={firstFrame.originalStackFrame!}
-          codeFrame={firstFrame.originalCodeFrame!}
-        />
-      )}
+      {selectedFrame !== null &&
+        selectedFrame.originalStackFrame &&
+        selectedFrame.originalCodeFrame && (
+          <CodeFrame
+            stackFrame={selectedFrame.originalStackFrame}
+            codeFrame={selectedFrame.originalCodeFrame}
+            selectedFrameIndex={selectedFrameIndex!}
+            tabGroupId={codeFrameTabGroupId}
+          />
+        )}
 
       {frames.length > 0 && (
         <ErrorOverlayCallStack
           dialogResizerRef={dialogResizerRef}
           frames={frames}
+          selectedFrameIndex={selectedFrameIndex}
+          onFrameSelect={handleFrameSelect}
+          isIgnoreListOpen={isIgnoreListOpen}
+          setIsIgnoreListOpen={setIsIgnoreListOpen}
+          tabGroupId={codeFrameTabGroupId}
         />
       )}
 

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -85,12 +85,13 @@ async function batchedTraceSource(
   let source = null
   const originalFile = sourceFrame.originalFile
 
-  // Don't look up source for node_modules or internals. These can often be large bundled files.
   const ignored =
     // Check the sourcemap's ignoreList (e.g. from 3rd party packages)
     !!sourceFrame.isIgnored ||
     shouldIgnorePath(originalFile ?? sourceFrame.file)
-  if (originalFile && !ignored) {
+
+  // Load source for all frames to support codeframe display for ignored frames too
+  if (originalFile) {
     let sourcePromise = currentSourcesByFile.get(originalFile)
     if (!sourcePromise) {
       sourcePromise = project.getSourceForAsset(originalFile)

--- a/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
+++ b/test/development/app-dir/error-overlay/error-ignored-frames/error-ignored-frames.test.ts
@@ -3,11 +3,52 @@ import {
   waitForRedbox,
   getStackFramesContent,
   toggleCollapseCallStackFrames,
+  getRedboxSource,
 } from 'next-test-utils'
 
 describe('error-ignored-frames', () => {
   const { isTurbopack, next } = nextTestSetup({
     files: __dirname,
+  })
+
+  it('should update codeframe when clicking on a different stack frame', async () => {
+    const browser = await next.browser('/interleaved')
+    await waitForRedbox(browser)
+
+    // Initially, the first non-ignored frame with codeframe should be selected
+    const initialSource = await getRedboxSource(browser)
+    expect(initialSource).toContain('app/interleaved/page.tsx')
+
+    // Get the initially selected frame to verify it changes
+    const initialSelectedFrame = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame][aria-selected="true"]'
+    )
+    const initialFrameText = await initialSelectedFrame.text()
+
+    // Get all selectable frames (frames with select buttons)
+    const selectableFrames = await browser.elementsByCss(
+      '[data-nextjs-call-stack-frame-selectable="true"]'
+    )
+    // Should have at least 2 selectable frames
+    expect(selectableFrames.length).toBeGreaterThanOrEqual(2)
+
+    // Click on a different selectable frame to change selection
+    // Using the select button which covers the whole frame area
+    const secondFrameButton = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame-selectable="true"]:not([data-nextjs-call-stack-frame][aria-selected="true"]) .call-stack-frame-select-button'
+    )
+    await secondFrameButton.click()
+
+    // The selected frame should have changed
+    const newSelectedFrame = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame][aria-selected="true"]'
+    )
+    const newFrameText = await newSelectedFrame.text()
+    expect(newFrameText).not.toBe(initialFrameText)
+
+    // The codeframe should still show content from the interleaved page
+    const newSource = await getRedboxSource(browser)
+    expect(newSource).toContain('app/interleaved/page.tsx')
   })
 
   it('should be able to collapse ignored frames in server component', async () => {
@@ -90,5 +131,70 @@ describe('error-ignored-frames', () => {
     // It'll contain implementation details that may change and
     // shouldn't break this test.
     expect(ignoreListedStack.trim()).toMatch(/at .*/)
+  })
+
+  it('should navigate call stack frames with keyboard', async () => {
+    const browser = await next.browser('/interleaved')
+    await waitForRedbox(browser)
+
+    // Click the selected frame to ensure focus is in the call stack
+    const initialFrame = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame][aria-selected="true"]'
+    )
+    const initialIndex = await initialFrame.getAttribute(
+      'data-nextjs-call-stack-frame-index'
+    )
+    await initialFrame.click()
+
+    // Press ArrowDown to move to the next frame
+    await browser.keydown('ArrowDown')
+    await browser.keyup('ArrowDown')
+
+    const afterDownFrame = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame][aria-selected="true"]'
+    )
+    const afterDownIndex = await afterDownFrame.getAttribute(
+      'data-nextjs-call-stack-frame-index'
+    )
+    expect(afterDownIndex).not.toBe(initialIndex)
+
+    // The code frame should still show relevant source
+    const source = await getRedboxSource(browser)
+    expect(source).toContain('app/interleaved/page.tsx')
+
+    // Press ArrowUp to move back
+    await browser.keydown('ArrowUp')
+    await browser.keyup('ArrowUp')
+
+    const afterUpFrame = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame][aria-selected="true"]'
+    )
+    const afterUpIndex = await afterUpFrame.getAttribute(
+      'data-nextjs-call-stack-frame-index'
+    )
+    expect(afterUpIndex).toBe(initialIndex)
+
+    // Press End to jump to the last frame, then Home to jump to the first
+    await browser.keydown('End')
+    await browser.keyup('End')
+
+    const endFrame = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame][aria-selected="true"]'
+    )
+    const endIndex = await endFrame.getAttribute(
+      'data-nextjs-call-stack-frame-index'
+    )
+
+    await browser.keydown('Home')
+    await browser.keyup('Home')
+
+    const homeFrame = await browser.elementByCss(
+      '[data-nextjs-call-stack-frame][aria-selected="true"]'
+    )
+    const homeIndex = await homeFrame.getAttribute(
+      'data-nextjs-call-stack-frame-index'
+    )
+
+    expect(Number(homeIndex)).toBeLessThan(Number(endIndex))
   })
 })

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1866,7 +1866,7 @@ export async function getStackFramesContent(browser) {
     await Promise.all(
       stackFrameElements.map(async (frame) => {
         const functionNameEl = await frame.$('.call-stack-frame-method-name')
-        const fileEl = await frame.$('[data-has-original-code-frame="true"]')
+        const fileEl = await frame.$('[data-has-source="true"]')
         const functionName = functionNameEl
           ? await functionNameEl.innerText()
           : ''


### PR DESCRIPTION
[Cursor task](https://cursor.com/agents?id=bc-0eb7f7f6-2653-4757-970e-873f2d865f21) needed too much hand-holding. Used Cursor for scaffolding and then fixed manually.

Next.js will ignore-list 3rd party modules by default and show the codeframe of the top stackframe. While this is sufficient for most cases, it's not always suitable. Ignore-listing is just a binary flag while modules are really spread across different "levels of interest" (e.g. product code vs repo library code vs framework code). 

Sometimes you do want to look at frames below or above or maybe even in ignore-lists. Interactive terminals like the one browser devtools provide already have affordances to freely navigate between stackframes.

This PR also adds these affordances to the Redbox. Codeframes can be switched either by clicking a different stackframe or via keyboard navigation. Only stackframes that have a codeframe are selectable.

Complexity mostly comes from having to reconcile selection when the ignore-listing is toggled and considering what is selectable during navigation.

## Test plan

- [ ] Storybook
- [ ] added tests