### PR TITLE
Turbopack: [chore] Fix Rust check warnings

### DIFF
--- a/crates/napi/src/next_api/turbopack_ctx.rs
+++ b/crates/napi/src/next_api/turbopack_ctx.rs
@@ -158,7 +158,7 @@ pub struct NapiNextTurbopackCallbacks {
     throw_turbopack_internal_error: ThreadsafeFunction<TurbopackInternalErrorOpts>,
 }
 
-/// Arguments for [`NapiNextTurbopackCallbacks::throw_turbopack_internal_error`].
+/// Arguments for `NapiNextTurbopackCallbacks::throw_turbopack_internal_error`.
 #[napi(object)]
 pub struct TurbopackInternalErrorOpts {
     pub message: String,

--- a/turbopack/crates/turbopack-cli/benches/small_apps.rs
+++ b/turbopack/crates/turbopack-cli/benches/small_apps.rs
@@ -3,10 +3,7 @@
 #[global_allocator]
 static ALLOC: turbo_tasks_malloc::TurboMalloc = turbo_tasks_malloc::TurboMalloc;
 
-use std::{
-    path::{Path, PathBuf},
-    process::Command,
-};
+use std::path::{Path, PathBuf};
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use turbopack_cli::arguments::{BuildArguments, CommonArguments};


### PR DESCRIPTION
# What?

Fix some unimportant `check` warnings that appear as noise in the build logs.