### PR TITLE
Turbopack: Tree-shake auto-detected barrel files

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -167,12 +167,8 @@ pub async fn follow_reexports(
             }));
         };
 
-        if !ignore_side_effects
-            && *module.side_effects().await? != ModuleSideEffects::SideEffectFree
+        if !ignore_side_effects && *module.side_effects().await? == ModuleSideEffects::SideEffectful
         {
-            // TODO It's unfortunate that we have to use the whole module here.
-            // This is often the Facade module, which includes all reexports.
-            // Often we could use Locals + the followed reexports instead.
             return Ok(FollowExportsResult::cell(FollowExportsResult {
                 module,
                 export_name: Some(export_name),

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/asset.rs
@@ -254,7 +254,7 @@ async fn follow_reexports_with_side_effects(
     let mut current_module = module;
     let mut current_export_name = export_name;
     let result = loop {
-        if *current_module.side_effects().await? != ModuleSideEffects::SideEffectFree {
+        if *current_module.side_effects().await? == ModuleSideEffects::SideEffectful {
             side_effects.push(only_effects(*current_module).to_resolved().await?);
         }
 

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/index.js
@@ -1,0 +1,15 @@
+import { foo } from './lib/index.js'
+
+it('should tree-shake barrel files with only re-exports even without sideEffects: false', () => {
+  expect(foo).toBe('foo-value')
+
+  const modules = Array.from(__turbopack_modules__.keys())
+  expect(modules).toContainEqual(expect.stringContaining('input/lib/foo'))
+
+  // The barrel file (index) should NOT be included - it only has re-exports
+  // and should be recognized as ModuleEvaluationIsSideEffectFree
+  expect(modules).not.toContainEqual(expect.stringContaining('input/lib/index'))
+
+  // Unused re-exports should NOT be included
+  expect(modules).not.toContainEqual(expect.stringContaining('input/lib/bar'))
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/lib/bar.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/lib/bar.js
@@ -1,0 +1,1 @@
+export const bar = 'bar-value'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/lib/foo.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/lib/foo.js
@@ -1,0 +1,1 @@
+export const foo = 'foo-value'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/lib/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/input/lib/index.js
@@ -1,0 +1,6 @@
+// This is a barrel file with ONLY re-exports (no directive, no sideEffects: false)
+// The bundler should detect this as ModuleEvaluationIsSideEffectFree
+// and tree-shake unused exports.
+
+export { foo } from './foo'
+export { bar } from './bar'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/options.json
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/side-effects-optimization/reexport-barrel-no-directive/options.json
@@ -1,0 +1,3 @@
+{
+  "scopeHoisting": false
+}


### PR DESCRIPTION
When following re-export chains, Turbopack would stop and include the entire module if it isn't marked `sideEffects: false` in package.json. This causes barrel files to pull in all their dependencies even when only one export is used.

As the existing comment notes, it is unfortunate that we have to use the whole module here, but we can fix that by allowing modules marked ModuleEvaluationIsSideEffectFree to be followed through in re-export chains. This fixes tree-shaking for packages like zod/mini where intermediate barrel files don't explicitly set `sideEffects: false`.

Fixes: #88643 