### PR TITLE
Turbopack: Resolve aliases from import location for transitive deps

### DIFF
--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -118,7 +118,6 @@ pub async fn get_next_client_import_map(
 
     insert_alias_option(
         &mut import_map,
-        &project_path,
         next_config.resolve_alias_options(),
         ["browser"],
     )
@@ -334,13 +333,7 @@ pub async fn get_next_server_import_map(
     )
     .await?;
 
-    insert_alias_option(
-        &mut import_map,
-        &project_path,
-        next_config.resolve_alias_options(),
-        [],
-    )
-    .await?;
+    insert_alias_option(&mut import_map, next_config.resolve_alias_options(), []).await?;
 
     let external = ImportMapping::External(None, ExternalType::CommonJs, ExternalTraced::Traced)
         .resolved_cell();
@@ -484,13 +477,7 @@ pub async fn get_next_edge_import_map(
 
     insert_optimized_module_aliases(&mut import_map, project_path.clone()).await?;
 
-    insert_alias_option(
-        &mut import_map,
-        &project_path,
-        next_config.resolve_alias_options(),
-        [],
-    )
-    .await?;
+    insert_alias_option(&mut import_map, next_config.resolve_alias_options(), []).await?;
 
     match &ty {
         ServerContextType::Pages { .. }
@@ -1330,13 +1317,12 @@ pub async fn try_get_next_package(
 
 pub async fn insert_alias_option<const N: usize>(
     import_map: &mut ImportMap,
-    project_path: &FileSystemPath,
     alias_options: Vc<ResolveAliasMap>,
     conditions: [&'static str; N],
 ) -> Result<()> {
     let conditions = BTreeMap::from(conditions.map(|c| (c.into(), ConditionValue::Set)));
     for (alias, value) in &alias_options.await? {
-        if let Some(mapping) = export_value_to_import_mapping(value, &conditions, project_path) {
+        if let Some(mapping) = export_value_to_import_mapping(value, &conditions) {
             import_map.insert_alias(alias, mapping);
         }
     }
@@ -1346,7 +1332,6 @@ pub async fn insert_alias_option<const N: usize>(
 fn export_value_to_import_mapping(
     value: &SubpathValue,
     conditions: &BTreeMap<RcStr, ConditionValue>,
-    project_path: &FileSystemPath,
 ) -> Option<ResolvedVc<ImportMapping>> {
     let mut result = Vec::new();
     value.add_results(
@@ -1358,16 +1343,17 @@ fn export_value_to_import_mapping(
     if result.is_empty() {
         None
     } else {
+        // We need to make sure the alias resolves from the original import location, because we
+        // could have transitive dependencies where the aliased package only exists in the
+        // importing package's node_modules, not in the project root's node_modules.
         Some(if result.len() == 1 {
-            ImportMapping::PrimaryAlternative(result[0].0.into(), Some(project_path.clone()))
-                .resolved_cell()
+            ImportMapping::PrimaryAlternative(result[0].0.into(), None).resolved_cell()
         } else {
             ImportMapping::Alternatives(
                 result
                     .iter()
                     .map(|(m, _)| {
-                        ImportMapping::PrimaryAlternative((*m).into(), Some(project_path.clone()))
-                            .resolved_cell()
+                        ImportMapping::PrimaryAlternative((*m).into(), None).resolved_cell()
                     })
                     .collect(),
             )

--- a/test/e2e/resolve-alias-transitive/app/layout.tsx
+++ b/test/e2e/resolve-alias-transitive/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/resolve-alias-transitive/app/page.tsx
+++ b/test/e2e/resolve-alias-transitive/app/page.tsx
@@ -1,0 +1,9 @@
+import { getValue } from 'wrapper-pkg'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="result">{getValue()}</p>
+    </div>
+  )
+}

--- a/test/e2e/resolve-alias-transitive/next.config.js
+++ b/test/e2e/resolve-alias-transitive/next.config.js
@@ -1,0 +1,15 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  turbopack: {
+    resolveAlias: {
+      'test-pkg/foo': 'test-pkg/foo/alt',
+    },
+  },
+  webpack(config) {
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      'test-pkg/foo': 'test-pkg/foo/alt',
+    }
+    return config
+  },
+}

--- a/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/index.js
+++ b/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/index.js
@@ -1,0 +1,5 @@
+const { value } = require('test-pkg/foo')
+
+module.exports.getValue = function getValue() {
+  return value
+}

--- a/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/node_modules/test-pkg/foo/alt.js
+++ b/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/node_modules/test-pkg/foo/alt.js
@@ -1,0 +1,2 @@
+// Should be what we get if the alias works
+module.exports.value = 'alt'

--- a/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/node_modules/test-pkg/foo/default.js
+++ b/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/node_modules/test-pkg/foo/default.js
@@ -1,0 +1,2 @@
+// If we get this, things are banjaxed
+module.exports.value = 'default'

--- a/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/node_modules/test-pkg/package.json
+++ b/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/node_modules/test-pkg/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "test-pkg",
+  "version": "1.0.0",
+  "exports": {
+    "./foo": "./foo/default.js",
+    "./foo/alt": "./foo/alt.js"
+  }
+}

--- a/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/package.json
+++ b/test/e2e/resolve-alias-transitive/node_modules/wrapper-pkg/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "wrapper-pkg",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/e2e/resolve-alias-transitive/resolve-alias-transitive.test.ts
+++ b/test/e2e/resolve-alias-transitive/resolve-alias-transitive.test.ts
@@ -1,0 +1,17 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('resolve-alias-transitive', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should apply resolveAlias to imports from transitive dependencies', async () => {
+    const $ = await next.render$('/')
+    expect($('#result').text()).toBe('alt')
+  })
+
+  it('should apply resolveAlias on client navigation', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('#result').text()).toBe('alt')
+  })
+})


### PR DESCRIPTION
When resolveAlias is configured, the alias is currently resolved from project_path instead of from the original import location. This can cause issues when transitive dependencies try to import the aliased package, because the package might only exist in the transitive dependency's `node_modules`, not in the project root's `node_modules`.

The bug was introduced in commit f8cd413786.  The intent there was to add support for conditional aliases, but it also changed the resolution base from the import site to the project root, which causes this issue.

Use None for the lookup path, which allows the resolver to use the original import location. This means:

- Direct dependencies continue to work (resolution happens from project root)
- Transitive dependencies now work (resolution happens from their location)

Fixes: #88540