### PR TITLE
[devtools] Wrap long file names of stack frames in the error overlay

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.tsx
@@ -144,5 +144,6 @@ export const CALL_STACK_FRAME_STYLES = `
     color: var(--color-gray-900);
     font-size: var(--size-14);
     line-height: var(--size-20);
+    word-wrap: break-word;
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/call-stack-frame/call-stack-frame.tsx
@@ -2,7 +2,7 @@ import type { OriginalStackFrame } from '../../../shared/stack-frame'
 
 import { HotlinkedText } from '../hot-linked-text'
 import { ExternalIcon, SourceMappingErrorIcon } from '../../icons/external'
-import { getFrameSource } from '../../../shared/stack-frame'
+import { getStackFrameFile } from '../../../shared/stack-frame'
 import { useOpenInEditor } from '../../utils/use-open-in-editor'
 
 export const CallStackFrame: React.FC<{
@@ -11,9 +11,9 @@ export const CallStackFrame: React.FC<{
   // TODO: ability to expand resolved frames
 
   const f = frame.originalStackFrame ?? frame.sourceStackFrame
-  const hasSource = Boolean(frame.originalCodeFrame)
+  const hasOriginalCodeFrame = Boolean(frame.originalCodeFrame)
   const open = useOpenInEditor(
-    hasSource
+    hasOriginalCodeFrame
       ? {
           file: f.file,
           line1: f.line1 ?? 1,
@@ -24,21 +24,21 @@ export const CallStackFrame: React.FC<{
 
   // Formatted file source could be empty. e.g. <anonymous> will be formatted to empty string,
   // we'll skip rendering the frame in this case.
-  const fileSource = getFrameSource(f)
+  const stackFrameFile = getStackFrameFile(f)
 
-  if (!fileSource) {
+  if (!stackFrameFile) {
     return null
   }
 
   return (
     <div
       data-nextjs-call-stack-frame
-      data-nextjs-call-stack-frame-no-source={!hasSource}
+      data-nextjs-call-stack-frame-no-source={!hasOriginalCodeFrame}
       data-nextjs-call-stack-frame-ignored={frame.ignored}
     >
       <div className="call-stack-frame-method-name">
         <HotlinkedText text={f.methodName} />
-        {hasSource && (
+        {hasOriginalCodeFrame && (
           <button
             onClick={open}
             className="open-in-editor-button"
@@ -58,10 +58,10 @@ export const CallStackFrame: React.FC<{
         ) : null}
       </div>
       <span
-        className="call-stack-frame-file-source"
-        data-has-source={hasSource}
+        className="call-stack-frame-file"
+        data-has-original-code-frame={hasOriginalCodeFrame}
       >
-        {fileSource}
+        {stackFrameFile}
       </span>
     </div>
   )
@@ -140,7 +140,7 @@ export const CALL_STACK_FRAME_STYLES = `
     }
   }
 
-  .call-stack-frame-file-source {
+  .call-stack-frame-file {
     color: var(--color-gray-900);
     font-size: var(--size-14);
     line-height: var(--size-20);

--- a/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/code-frame/code-frame.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { HotlinkedText } from '../hot-linked-text'
-import { getFrameSource, type StackFrame } from '../../../shared/stack-frame'
+import { getStackFrameFile, type StackFrame } from '../../../shared/stack-frame'
 import { useOpenInEditor } from '../../utils/use-open-in-editor'
 import { ExternalIcon } from '../../icons/external'
 import { FileIcon } from '../../icons/file'
@@ -49,7 +49,7 @@ export function CodeFrame({ stackFrame, codeFrame }: CodeFrameProps) {
             <FileIcon lang={fileExtension} />
           </span>
           <span data-text>
-            {getFrameSource(stackFrame)} @{' '}
+            {getStackFrameFile(stackFrame)} @{' '}
             <HotlinkedText text={stackFrame.methodName} />
           </span>
           <button

--- a/packages/next/src/next-devtools/dev-overlay/components/terminal/terminal.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/terminal/terminal.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { HotlinkedText } from '../hot-linked-text'
 import { EditorLink } from './editor-link'
 import { ExternalIcon } from '../../icons/external'
-import { getFrameSource, type StackFrame } from '../../../shared/stack-frame'
+import { getStackFrameFile, type StackFrame } from '../../../shared/stack-frame'
 import { useOpenInEditor } from '../../utils/use-open-in-editor'
 import { FileIcon } from '../../icons/file'
 
@@ -99,7 +99,7 @@ export const Terminal: React.FC<TerminalProps> = function Terminal({
           </span>
           <span data-text>
             {/* TODO: Unlike the CodeFrame component, the `methodName` is unavailable. */}
-            {getFrameSource(stackFrame)}
+            {getStackFrameFile(stackFrame)}
           </span>
           <button
             aria-label="Open in editor"

--- a/packages/next/src/next-devtools/shared/stack-frame.ts
+++ b/packages/next/src/next-devtools/shared/stack-frame.ts
@@ -6,7 +6,7 @@ import type {
 } from '../server/shared'
 import {
   isWebpackInternalResource,
-  formatFrameSourceFile,
+  formatStackFrameFile,
 } from './webpack-module-path'
 
 export type { StackFrame }
@@ -125,7 +125,7 @@ export async function getOriginalStackFrames(
   )
 }
 
-export function getFrameSource(frame: StackFrame): string {
+export function getStackFrameFile(frame: StackFrame): string {
   if (!frame.file) return ''
 
   const isWebpackFrame = isWebpackInternalResource(frame.file)
@@ -133,7 +133,7 @@ export function getFrameSource(frame: StackFrame): string {
   let str = ''
   // Skip URL parsing for webpack internal file paths.
   if (isWebpackFrame) {
-    str = formatFrameSourceFile(frame.file)
+    str = formatStackFrameFile(frame.file)
   } else {
     try {
       const u = new URL(frame.file)
@@ -153,9 +153,9 @@ export function getFrameSource(frame: StackFrame): string {
       // Strip query string information as it's typically too verbose to be
       // meaningful.
       parsedPath += u.pathname
-      str = formatFrameSourceFile(parsedPath)
+      str = formatStackFrameFile(parsedPath)
     } catch {
-      str = formatFrameSourceFile(frame.file)
+      str = formatStackFrameFile(frame.file)
     }
   }
 

--- a/packages/next/src/next-devtools/shared/webpack-module-path.test.ts
+++ b/packages/next/src/next-devtools/shared/webpack-module-path.test.ts
@@ -1,5 +1,5 @@
 import {
-  formatFrameSourceFile,
+  formatStackFrameFile,
   isWebpackInternalResource,
 } from './webpack-module-path'
 
@@ -25,16 +25,16 @@ describe('webpack-module-path', () => {
 
   describe('formatFrameSourceFile', () => {
     it('should return the original file path', () => {
-      expect(formatFrameSourceFile('webpack-internal:///./src/hello.tsx')).toBe(
+      expect(formatStackFrameFile('webpack-internal:///./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )
-      expect(formatFrameSourceFile('webpack://_N_E/./src/hello.tsx')).toBe(
+      expect(formatStackFrameFile('webpack://_N_E/./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )
-      expect(formatFrameSourceFile('webpack://./src/hello.tsx')).toBe(
+      expect(formatStackFrameFile('webpack://./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )
-      expect(formatFrameSourceFile('webpack:///./src/hello.tsx')).toBe(
+      expect(formatStackFrameFile('webpack:///./src/hello.tsx')).toBe(
         './src/hello.tsx'
       )
     })

--- a/packages/next/src/next-devtools/shared/webpack-module-path.ts
+++ b/packages/next/src/next-devtools/shared/webpack-module-path.ts
@@ -21,7 +21,7 @@ export function isWebpackInternalResource(file: string) {
  * webpack://./src/hello.tsx => ./src/hello.tsx
  * webpack:///./src/hello.tsx => ./src/hello.tsx
  */
-export function formatFrameSourceFile(file: string) {
+export function formatStackFrameFile(file: string) {
   for (const regex of replacementRegExes) {
     file = file.replace(regex, '')
   }

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -28,7 +28,7 @@ import type {
   NullableMappedPosition,
   RawSourceMap,
 } from 'next/dist/compiled/source-map08'
-import { formatFrameSourceFile } from '../../next-devtools/shared/webpack-module-path'
+import { formatStackFrameFile } from '../../next-devtools/shared/webpack-module-path'
 import type { MappedPosition } from 'source-map'
 import { inspect } from 'util'
 
@@ -140,7 +140,7 @@ export function getIgnoredSources(
     // bundlerFilePath case: webpack://./app/page.tsx
     const webpackSourceURL = moduleFilenames[index]
     // Format the path to the normal file path
-    const formattedFilePath = formatFrameSourceFile(webpackSourceURL)
+    const formattedFilePath = formatStackFrameFile(webpackSourceURL)
     if (shouldIgnoreSource(formattedFilePath)) {
       ignoreList.add(index)
     }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1780,16 +1780,16 @@ export async function getStackFramesContent(browser) {
     await Promise.all(
       stackFrameElements.map(async (frame) => {
         const functionNameEl = await frame.$('.call-stack-frame-method-name')
-        const sourceEl = await frame.$('[data-has-source="true"]')
+        const fileEl = await frame.$('[data-has-original-code-frame="true"]')
         const functionName = functionNameEl
           ? await functionNameEl.innerText()
           : ''
-        const source = sourceEl ? await sourceEl.innerText() : ''
+        const file = fileEl ? await fileEl.innerText() : ''
 
         if (!functionName) {
           return ''
         }
-        return `at ${functionName} (${source})`
+        return `at ${functionName} (${file})`
       })
     )
   )


### PR DESCRIPTION


https://github.com/user-attachments/assets/0594744b-5dd5-4550-90b8-77071962f666

See [overflow-wrap docs](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow-wrap) for break-word vs anywhere.


Just a one-line CSS change. The other changes are renaming functions to disambiguate source/codeframe and the filename.
