### PR TITLE
[devtools] Fix notch coloring of error overlay in forced colors mode

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/overlay/styles.tsx
@@ -15,6 +15,8 @@ const styles = css`
     align-items: center;
     flex-direction: column;
     padding: 10vh 15px 0;
+    /* color schemes we handle. Every other scheme the UA would need to overwrite */
+    color-scheme: dark light;
   }
 
   @media (max-height: 812px) {


### PR DESCRIPTION
When chrome://flags/#enable-force-dark is enabled:

https://github.com/user-attachments/assets/a4a22f01-b7e3-4a42-b92d-1eec472dec25

When chrome://flags/#enable-force-dark is disabled (default):


https://github.com/user-attachments/assets/6b5de6ae-4fef-4c03-9835-1ce9a6c89239

