### PR TITLE
fix(next-font): respect custom font-family declarations in local fonts (Turbopack)

### DIFF
--- a/crates/next-core/src/next_font/local/font_fallback.rs
+++ b/crates/next-core/src/next_font/local/font_fallback.rs
@@ -38,8 +38,21 @@ pub(super) async fn get_font_fallbacks(
     options_vc: Vc<NextFontLocalOptions>,
 ) -> Result<Vc<FontFallbackResult>> {
     let options = &*options_vc.await?;
-    let scoped_font_family =
-        get_scoped_font_family(FontFamilyType::Fallback, options_vc.font_family().await?);
+
+    // Check if `font-family` is explicitly defined in `declarations`
+    // If so, use that value instead of the variable name for the fallback
+    let font_family_name = options
+        .declarations
+        .as_ref()
+        .and_then(|declarations| {
+            declarations
+                .iter()
+                .find(|decl| decl.prop == "font-family")
+                .map(|decl| decl.value.clone())
+        })
+        .unwrap_or_else(|| options.variable_name.clone());
+
+    let scoped_font_family = get_scoped_font_family(FontFamilyType::Fallback, font_family_name);
 
     let mut font_fallbacks = vec![];
     match options.adjust_font_fallback {

--- a/crates/next-core/src/next_font/local/util.rs
+++ b/crates/next-core/src/next_font/local/util.rs
@@ -14,10 +14,25 @@ pub(super) async fn build_font_family_string(
     options: Vc<NextFontLocalOptions>,
     font_fallbacks: Vc<FontFallbacks>,
 ) -> Result<Vc<RcStr>> {
+    let options = &*options.await?;
+
+    // Check if `font-family` is explicitly defined in `declarations`
+    // If so, use that value instead of the variable name
+    let font_family_name: RcStr = options
+        .declarations
+        .as_ref()
+        .and_then(|declarations| {
+            declarations
+                .iter()
+                .find(|decl| decl.prop == "font-family")
+                .map(|decl| decl.value.clone())
+        })
+        .unwrap_or_else(|| options.variable_name.clone());
+
     let mut font_families = vec![
         format!(
             "'{}'",
-            get_scoped_font_family(FontFamilyType::WebFont, options.font_family().await?)
+            get_scoped_font_family(FontFamilyType::WebFont, font_family_name)
         )
         .into(),
     ];

--- a/test/e2e/next-font/app/pages/with-local-fonts.js
+++ b/test/e2e/next-font/app/pages/with-local-fonts.js
@@ -23,6 +23,18 @@ const myFont1Override = localFont({
   ],
 })
 
+// Test custom font-family with space - verifies fix for font-family mismatch bug
+const customFamilyWithSpace = localFont({
+  src: '../fonts/my-font.woff2',
+  declarations: [
+    {
+      prop: 'font-family',
+      value: 'My Custom Font',
+    },
+  ],
+  preload: false,
+})
+
 const roboto = localFont({
   preload: false,
   src: [
@@ -145,6 +157,12 @@ export default function WithFonts() {
       </div>
       <div id="first-local-font-override" className={myFont1Override.className}>
         {JSON.stringify(myFont1Override)}
+      </div>
+      <div
+        id="custom-family-with-space"
+        className={customFamilyWithSpace.className}
+      >
+        {JSON.stringify(customFamilyWithSpace)}
       </div>
       <div id="roboto-local-font" className={roboto.className}>
         {JSON.stringify(roboto)}

--- a/test/e2e/next-font/index.test.ts
+++ b/test/e2e/next-font/index.test.ts
@@ -153,6 +153,18 @@ describe('next/font', () => {
           fontFamily: expect.stringMatching(/^'myFont2', 'myFont2 Fallback'$/),
         },
       })
+
+      // Test custom font-family with space in declarations
+      // This verifies the fix for the bug where @font-face and className
+      // used different font-family names when a custom declaration had a space
+      expect(JSON.parse($('#custom-family-with-space').text())).toEqual({
+        className: expect.stringMatching(getClassNameRegex('className')),
+        style: {
+          fontFamily: expect.stringMatching(
+            /^'My Custom Font', 'My Custom Font Fallback'$/
+          ),
+        },
+      })
     })
 
     test('Variable font without weight range', async () => {
@@ -664,6 +676,27 @@ describe('next/font', () => {
       expect(stylesheets).toContainEqual(
         expect.stringContaining('font-family: foobar;')
       )
+    })
+
+    test('custom font-family with space matches between @font-face and className', async () => {
+      const browser = await webdriver(next.url, '/with-local-fonts')
+
+      // Get the font data from the page to verify fontFamily matches
+      const fontData = await browser.eval(
+        `JSON.parse(document.querySelector('#custom-family-with-space').textContent)`
+      )
+
+      // The fontFamily should use the custom declaration value "My Custom Font"
+      // not the JS variable name "customFamilyWithSpace"
+      expect(fontData.style.fontFamily).toMatch(/My Custom Font/)
+
+      // Verify the font is actually loaded with the correct family name
+      const loadedFonts = await browser.eval(`
+        Array.from(document.fonts.values())
+          .map(font => font.family)
+          .filter(family => family.includes('My Custom Font'))
+      `)
+      expect(loadedFonts.length).toBeGreaterThan(0)
     })
   })
 })


### PR DESCRIPTION
### What?

Fixes a bug in Turbopack where `next/font/local` with a custom `font-family` declaration would generate mismatched CSS:
- `@font-face` correctly used the custom declaration value (e.g., `"My Custom Font"`)
- But `.className` incorrectly used the JS variable name (e.g., `"myCustomFont"`)

This caused the font not to apply because the names didn't match.

### Why?

When users specify a custom `font-family` in declarations:

```js
const myCustomFont = localFont({
  src: './font.woff2',
  declarations: [{ prop: 'font-family', value: 'My Custom Font' }]
})
```

The generated CSS had a mismatch:
- `@font-face { font-family: 'My Custom Font'; ... }` 
- `.className { font-family: 'myCustomFont', ... }` 

Note: This bug only affects **Turbopack**. The Webpack implementation already handles this correctly via `postcss-next-font`.

### How?

Updated the Turbopack implementation to check for custom `font-family` declarations when building:

1. **`util.rs`**: `build_font_family_string` now checks declarations for a custom `font-family` value before falling back to the variable name
2. **`font_fallback.rs`**: `get_font_fallbacks` now uses the custom `font-family` for fallback naming (e.g., `"My Custom Font Fallback"` instead of `"myCustomFont Fallback"`)

### Test Plan

- Added test fixture with custom `font-family` containing a space
- Added test verifying `fontFamily` matches the custom declaration
- Webpack: ✅ Already passes (not affected)
- Turbopack: ✅ Now passes with fix

Fixes #88894
