### PR TITLE
[mcp] change the mcp endpoint response to JSON

### DIFF
--- a/packages/next/src/server/mcp/tools/get-errors.ts
+++ b/packages/next/src/server/mcp/tools/get-errors.ts
@@ -51,7 +51,10 @@ export function registerGetErrorsTool(
             content: [
               {
                 type: 'text',
-                text: 'No browser sessions connected. Please open your application in a browser to retrieve error state.',
+                text: JSON.stringify({
+                  error:
+                    'No browser sessions connected. Please open your application in a browser to retrieve error state.',
+                }),
               },
             ],
           }
@@ -83,10 +86,10 @@ export function registerGetErrorsTool(
             content: [
               {
                 type: 'text',
-                text:
-                  responses.length === 0
-                    ? 'No browser sessions responded.'
-                    : `No errors detected in ${responses.length} browser session(s).`,
+                text: JSON.stringify({
+                  configErrors: [],
+                  sessionErrors: [],
+                }),
               },
             ],
           }
@@ -101,7 +104,7 @@ export function registerGetErrorsTool(
           content: [
             {
               type: 'text',
-              text: output,
+              text: JSON.stringify(output),
             },
           ],
         }
@@ -110,7 +113,9 @@ export function registerGetErrorsTool(
           content: [
             {
               type: 'text',
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/get-logs.ts
+++ b/packages/next/src/server/mcp/tools/get-logs.ts
@@ -31,7 +31,9 @@ export function registerGetLogsTool(server: McpServer, distDir: string) {
             content: [
               {
                 type: 'text',
-                text: `Log file not found at ${logFilePath}.`,
+                text: JSON.stringify({
+                  error: `Log file not found at ${logFilePath}.`,
+                }),
               },
             ],
           }
@@ -41,7 +43,9 @@ export function registerGetLogsTool(server: McpServer, distDir: string) {
           content: [
             {
               type: 'text',
-              text: `Next.js log file path: ${logFilePath}`,
+              text: JSON.stringify({
+                logFilePath,
+              }),
             },
           ],
         }
@@ -50,7 +54,9 @@ export function registerGetLogsTool(server: McpServer, distDir: string) {
           content: [
             {
               type: 'text',
-              text: `Error getting log file path: ${error instanceof Error ? error.message : String(error)}`,
+              text: JSON.stringify({
+                error: `Error getting log file path: ${error instanceof Error ? error.message : String(error)}`,
+              }),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/get-page-metadata.ts
+++ b/packages/next/src/server/mcp/tools/get-page-metadata.ts
@@ -39,7 +39,10 @@ export function registerGetPageMetadataTool(
             content: [
               {
                 type: 'text',
-                text: 'No browser sessions connected. Please open your application in a browser to retrieve page metadata.',
+                text: JSON.stringify({
+                  error:
+                    'No browser sessions connected. Please open your application in a browser to retrieve page metadata.',
+                }),
               },
             ],
           }
@@ -57,7 +60,9 @@ export function registerGetPageMetadataTool(
             content: [
               {
                 type: 'text',
-                text: 'No browser sessions responded.',
+                text: JSON.stringify({
+                  sessions: [],
+                }),
               },
             ],
           }
@@ -78,7 +83,9 @@ export function registerGetPageMetadataTool(
             content: [
               {
                 type: 'text',
-                text: `No page metadata available from ${responses.length} browser session(s).`,
+                text: JSON.stringify({
+                  sessions: [],
+                }),
               },
             ],
           }
@@ -90,7 +97,7 @@ export function registerGetPageMetadataTool(
           content: [
             {
               type: 'text',
-              text: output,
+              text: JSON.stringify(output),
             },
           ],
         }
@@ -99,7 +106,9 @@ export function registerGetPageMetadataTool(
           content: [
             {
               type: 'text',
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
             },
           ],
         }
@@ -150,10 +159,27 @@ function convertSegmentTrieToPageMetadata(data: SegmentTrieData): PageMetadata {
   }
 }
 
+interface FormattedSegment {
+  path: string
+  type: string
+  isBoundary: boolean
+  isBuiltin: boolean
+}
+
+interface FormattedSession {
+  url: string
+  routerType: string
+  segments: FormattedSegment[]
+}
+
+interface FormattedPageMetadataOutput {
+  sessions: FormattedSession[]
+}
+
 function formatPageMetadata(
   sessionMetadata: Array<{ url: string; metadata: PageMetadata }>
-): string {
-  let output = `# Page metadata from ${sessionMetadata.length} browser session(s)\n\n`
+): FormattedPageMetadataOutput {
+  const sessions: FormattedSession[] = []
 
   for (const { url, metadata } of sessionMetadata) {
     let displayUrl = url
@@ -164,56 +190,50 @@ function formatPageMetadata(
       // If URL parsing fails, use the original URL
     }
 
-    output += `## Session: ${displayUrl}\n\n`
-    output += `**Router type:** ${metadata.routerType}\n\n`
-
-    if (metadata.segments.length === 0) {
-      output += '*No segments found*\n\n'
-    } else {
-      output += '### Files powering this page:\n\n'
-
-      // Ensure consistent output to avoid flaky tests
-      const sortedSegments = [...metadata.segments].sort((a, b) => {
-        const typeOrder = (segment: PageSegment): number => {
-          const type = segment.boundaryType || segment.type
-          if (type === 'layout') return 0
-          if (type.startsWith('boundary:')) return 1
-          if (type === 'page') return 2
-          return 3
-        }
-        const aOrder = typeOrder(a)
-        const bOrder = typeOrder(b)
-        if (aOrder !== bOrder) return aOrder - bOrder
-        return a.pagePath.localeCompare(b.pagePath)
-      })
-
-      for (const segment of sortedSegments) {
-        const path = segment.pagePath
-        const isBuiltin = path.startsWith('__next_builtin__')
+    // Ensure consistent output to avoid flaky tests
+    const sortedSegments = [...metadata.segments].sort((a, b) => {
+      const typeOrder = (segment: PageSegment): number => {
         const type = segment.boundaryType || segment.type
-        const isBoundary = type.startsWith('boundary:')
-
-        let displayPath = path
-          .replace(/@boundary$/, '')
-          .replace(/^__next_builtin__/, '')
-
-        if (!isBuiltin && !displayPath.startsWith('app/')) {
-          displayPath = `app/${displayPath}`
-        }
-
-        const descriptors: string[] = []
-        if (isBoundary) descriptors.push('boundary')
-        if (isBuiltin) descriptors.push('builtin')
-
-        const descriptor =
-          descriptors.length > 0 ? ` (${descriptors.join(', ')})` : ''
-        output += `- ${displayPath}${descriptor}\n`
+        if (type === 'layout') return 0
+        if (type.startsWith('boundary:')) return 1
+        if (type === 'page') return 2
+        return 3
       }
-      output += '\n'
+      const aOrder = typeOrder(a)
+      const bOrder = typeOrder(b)
+      if (aOrder !== bOrder) return aOrder - bOrder
+      return a.pagePath.localeCompare(b.pagePath)
+    })
+
+    const formattedSegments: FormattedSegment[] = []
+    for (const segment of sortedSegments) {
+      const path = segment.pagePath
+      const isBuiltin = path.startsWith('__next_builtin__')
+      const type = segment.boundaryType || segment.type
+      const isBoundary = type.startsWith('boundary:')
+
+      let displayPath = path
+        .replace(/@boundary$/, '')
+        .replace(/^__next_builtin__/, '')
+
+      if (!isBuiltin && !displayPath.startsWith('app/')) {
+        displayPath = `app/${displayPath}`
+      }
+
+      formattedSegments.push({
+        path: displayPath,
+        type,
+        isBoundary,
+        isBuiltin,
+      })
     }
 
-    output += '---\n\n'
+    sessions.push({
+      url: displayUrl,
+      routerType: metadata.routerType,
+      segments: formattedSegments,
+    })
   }
 
-  return output.trim()
+  return { sessions }
 }

--- a/packages/next/src/server/mcp/tools/get-project-metadata.ts
+++ b/packages/next/src/server/mcp/tools/get-project-metadata.ts
@@ -23,7 +23,10 @@ export function registerGetProjectMetadataTool(
             content: [
               {
                 type: 'text',
-                text: 'Unable to determine the absolute path of the Next.js project.',
+                text: JSON.stringify({
+                  error:
+                    'Unable to determine the absolute path of the Next.js project.',
+                }),
               },
             ],
           }
@@ -47,7 +50,9 @@ export function registerGetProjectMetadataTool(
           content: [
             {
               type: 'text',
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/get-routes.ts
+++ b/packages/next/src/server/mcp/tools/get-routes.ts
@@ -69,7 +69,9 @@ export function registerGetRoutesTool(
             content: [
               {
                 type: 'text',
-                text: 'No pages or app directory found in the project.',
+                text: JSON.stringify({
+                  error: 'No pages or app directory found in the project.',
+                }),
               },
             ],
           }
@@ -180,7 +182,10 @@ export function registerGetRoutesTool(
             content: [
               {
                 type: 'text',
-                text: 'No routes found in the project.',
+                text: JSON.stringify({
+                  appRouter: [],
+                  pagesRouter: [],
+                }),
               },
             ],
           }
@@ -215,7 +220,9 @@ export function registerGetRoutesTool(
           content: [
             {
               type: 'text',
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/get-server-action-by-id.ts
+++ b/packages/next/src/server/mcp/tools/get-server-action-by-id.ts
@@ -41,7 +41,9 @@ export function registerGetActionByIdTool(server: McpServer, distDir: string) {
             content: [
               {
                 type: 'text',
-                text: 'Error: actionId parameter is required',
+                text: JSON.stringify({
+                  error: 'actionId parameter is required',
+                }),
               },
             ],
           }
@@ -61,7 +63,9 @@ export function registerGetActionByIdTool(server: McpServer, distDir: string) {
             content: [
               {
                 type: 'text',
-                text: `Error: Could not read server-reference-manifest.json at ${manifestPath}.`,
+                text: JSON.stringify({
+                  error: `Could not read server-reference-manifest.json at ${manifestPath}.`,
+                }),
               },
             ],
           }
@@ -129,7 +133,9 @@ export function registerGetActionByIdTool(server: McpServer, distDir: string) {
           content: [
             {
               type: 'text',
-              text: `Error: Action ID "${actionId}" not found in server-reference-manifest.json`,
+              text: JSON.stringify({
+                error: `Action ID "${actionId}" not found in server-reference-manifest.json`,
+              }),
             },
           ],
         }
@@ -138,7 +144,9 @@ export function registerGetActionByIdTool(server: McpServer, distDir: string) {
           content: [
             {
               type: 'text',
-              text: `Error: ${error instanceof Error ? error.message : String(error)}`,
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
             },
           ],
         }

--- a/packages/next/src/server/mcp/tools/utils/format-errors.ts
+++ b/packages/next/src/server/mcp/tools/utils/format-errors.ts
@@ -35,25 +35,56 @@ async function resolveStackFrames(
   return stackFrameResolver(request)
 }
 
-const formatStackFrame = (frame: StackFrameForFormatting): string => {
-  const file = frame.file || '<unknown>'
-  const method = frame.methodName || '<anonymous>'
-  const { line1: line, column1: column } = frame
-  return line && column
-    ? `  at ${method} (${file}:${line}:${column})`
-    : line
-      ? `  at ${method} (${file}:${line})`
-      : `  at ${method} (${file})`
+interface StackFrame {
+  file: string
+  methodName: string
+  line: number | null
+  column: number | null
 }
 
-const formatErrorFrames = async (
+interface FormattedRuntimeError {
+  type: string
+  errorName: string
+  message: string
+  stack: StackFrame[]
+}
+
+interface FormattedSessionError {
+  url: string
+  buildError: string | null
+  runtimeErrors: FormattedRuntimeError[]
+}
+
+interface FormattedConfigError {
+  name: string
+  message: string
+  stack: string | null
+}
+
+export interface FormattedErrorsOutput {
+  configErrors: FormattedConfigError[]
+  sessionErrors: FormattedSessionError[]
+}
+
+const formatStackFrameToObject = (
+  frame: StackFrameForFormatting
+): StackFrame => {
+  return {
+    file: frame.file || '<unknown>',
+    methodName: frame.methodName || '<anonymous>',
+    line: frame.line1,
+    column: frame.column1,
+  }
+}
+
+const resolveErrorFrames = async (
   frames: readonly StackFrameForFormatting[],
   context: {
     isServer: boolean
     isEdgeServer: boolean
     isAppDirectory: boolean
   }
-): Promise<string> => {
+): Promise<StackFrame[]> => {
   try {
     const resolvedFrames = await resolveStackFrames({
       frames: frames.map((frame) => ({
@@ -68,132 +99,108 @@ const formatErrorFrames = async (
       isAppDirectory: context.isAppDirectory,
     })
 
-    return (
-      resolvedFrames
-        .filter(
-          (resolvedFrame) =>
-            !(
-              resolvedFrame.status === 'fulfilled' &&
-              resolvedFrame.value.originalStackFrame?.ignored
-            )
-        )
-        .map((resolvedFrame, j) =>
-          resolvedFrame.status === 'fulfilled' &&
-          resolvedFrame.value.originalStackFrame
-            ? formatStackFrame(resolvedFrame.value.originalStackFrame)
-            : formatStackFrame(frames[j])
-        )
-        .join('\n') + '\n'
-    )
+    return resolvedFrames
+      .filter(
+        (resolvedFrame) =>
+          !(
+            resolvedFrame.status === 'fulfilled' &&
+            resolvedFrame.value.originalStackFrame?.ignored
+          )
+      )
+      .map((resolvedFrame, j) =>
+        resolvedFrame.status === 'fulfilled' &&
+        resolvedFrame.value.originalStackFrame
+          ? formatStackFrameToObject(resolvedFrame.value.originalStackFrame)
+          : formatStackFrameToObject(frames[j])
+      )
   } catch {
-    return frames.map(formatStackFrame).join('\n') + '\n'
+    return frames.map(formatStackFrameToObject)
   }
 }
 
-async function formatRuntimeError(
+async function formatRuntimeErrorsToObjects(
   errors: readonly SupportedErrorEvent[],
   isAppDirectory: boolean
-): Promise<string> {
-  const formatError = async (
-    error: SupportedErrorEvent,
-    index: number
-  ): Promise<string> => {
-    const errorHeader = `\n#### Error ${index + 1} (Type: ${error.type})\n\n`
+): Promise<FormattedRuntimeError[]> {
+  const formattedErrors: FormattedRuntimeError[] = []
+
+  for (const error of errors) {
     const errorName = error.error?.name || 'Error'
     const errorMsg = error.error?.message || 'Unknown error'
-    const errorMessage = `**${errorName}**: ${errorMsg}\n\n`
 
-    if (!error.frames?.length) {
-      const stack = error.error?.stack || ''
-      return (
-        errorHeader + errorMessage + (stack ? `\`\`\`\n${stack}\n\`\`\`\n` : '')
-      )
+    let stack: StackFrame[] = []
+    if (error.frames?.length) {
+      const errorSource = getErrorSource(error.error)
+      stack = await resolveErrorFrames(error.frames, {
+        isServer: errorSource === 'server',
+        isEdgeServer: errorSource === 'edge-server',
+        isAppDirectory,
+      })
     }
 
-    const errorSource = getErrorSource(error.error)
-    const frames = await formatErrorFrames(error.frames, {
-      isServer: errorSource === 'server',
-      isEdgeServer: errorSource === 'edge-server',
-      isAppDirectory,
+    formattedErrors.push({
+      type: error.type,
+      errorName,
+      message: errorMsg,
+      stack,
     })
-
-    return errorHeader + errorMessage + `\`\`\`\n${frames}\`\`\`\n`
   }
 
-  const formattedErrors = await Promise.all(errors.map(formatError))
-  return '### Runtime Errors\n' + formattedErrors.join('\n---\n')
+  return formattedErrors
 }
 
 export async function formatErrors(
   errorsByUrl: Map<string, OverlayState>,
   nextInstanceErrors: { nextConfig: unknown[] } = { nextConfig: [] }
-): Promise<string> {
-  let output = ''
-
-  // Format Next.js instance errors first (e.g., next.config.js errors)
-  if (nextInstanceErrors.nextConfig.length > 0) {
-    output += `# Next.js Configuration Errors\n\n`
-    output += `**${nextInstanceErrors.nextConfig.length} error(s) found in next.config**\n\n`
-
-    nextInstanceErrors.nextConfig.forEach((error, index) => {
-      output += `## Error ${index + 1}\n\n`
-      output += '```\n'
-      if (error instanceof Error) {
-        output += `${error.name}: ${error.message}\n`
-        if (error.stack) {
-          output += error.stack
-        }
-      } else {
-        output += String(error)
-      }
-      output += '\n```\n\n'
-    })
-
-    output += '---\n\n'
+): Promise<FormattedErrorsOutput> {
+  const output: FormattedErrorsOutput = {
+    configErrors: [],
+    sessionErrors: [],
   }
 
-  // Format browser session errors
-  if (errorsByUrl.size > 0) {
-    output += `# Found errors in ${errorsByUrl.size} browser session(s)\n\n`
-
-    for (const [url, overlayState] of errorsByUrl) {
-      const totalErrorCount =
-        overlayState.errors.length + (overlayState.buildError ? 1 : 0)
-
-      if (totalErrorCount === 0) continue
-
-      let displayUrl = url
-      try {
-        const urlObj = new URL(url)
-        displayUrl = urlObj.pathname + urlObj.search + urlObj.hash
-      } catch {
-        // If URL parsing fails, use the original URL
-      }
-
-      output += `## Session: ${displayUrl}\n\n`
-      output += `**${totalErrorCount} error(s) found**\n\n`
-
-      // Build errors
-      if (overlayState.buildError) {
-        output += '### Build Error\n\n'
-        output += '```\n'
-        output += overlayState.buildError
-        output += '\n```\n\n'
-      }
-
-      // Runtime errors with source-mapped stack traces
-      if (overlayState.errors.length > 0) {
-        const runtimeErrors = await formatRuntimeError(
-          overlayState.errors,
-          overlayState.routerType === 'app'
-        )
-        output += runtimeErrors
-        output += '\n'
-      }
-
-      output += '---\n\n'
+  // Format Next.js instance errors first (e.g., next.config.js errors)
+  for (const error of nextInstanceErrors.nextConfig) {
+    if (error instanceof Error) {
+      output.configErrors.push({
+        name: error.name,
+        message: error.message,
+        stack: error.stack || null,
+      })
+    } else {
+      output.configErrors.push({
+        name: 'Error',
+        message: String(error),
+        stack: null,
+      })
     }
   }
 
-  return output.trim()
+  // Format browser session errors
+  for (const [url, overlayState] of errorsByUrl) {
+    const totalErrorCount =
+      overlayState.errors.length + (overlayState.buildError ? 1 : 0)
+
+    if (totalErrorCount === 0) continue
+
+    let displayUrl = url
+    try {
+      const urlObj = new URL(url)
+      displayUrl = urlObj.pathname + urlObj.search + urlObj.hash
+    } catch {
+      // If URL parsing fails, use the original URL
+    }
+
+    const runtimeErrors = await formatRuntimeErrorsToObjects(
+      overlayState.errors,
+      overlayState.routerType === 'app'
+    )
+
+    output.sessionErrors.push({
+      url: displayUrl,
+      buildError: overlayState.buildError || null,
+      runtimeErrors,
+    })
+  }
+
+  return output
 }

--- a/test/development/mcp-server/mcp-server-get-errors.test.ts
+++ b/test/development/mcp-server/mcp-server-get-errors.test.ts
@@ -66,23 +66,23 @@ describe('mcp-server get_errors tool', () => {
       expect(errors.sessionErrors[0].runtimeErrors).toHaveLength(1)
     })
 
-    // Verify proper URL display in session header (now shows pathname only)
-    expect(errors.sessionErrors[0].url).toBe('/runtime-error')
-
-    // Check the structure of the error
-    const sessionError = errors.sessionErrors[0]
-    expect(sessionError.buildError).toBeNull()
-    expect(sessionError.runtimeErrors[0].type).toBe('runtime')
-    expect(sessionError.runtimeErrors[0].errorName).toBe('Error')
-    expect(sessionError.runtimeErrors[0].message).toBe('Test runtime error')
-    expect(sessionError.runtimeErrors[0].stack).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          file: expect.stringContaining('app/runtime-error/page.tsx'),
-          methodName: 'RuntimeErrorPage',
-        }),
-      ])
-    )
+    expect(errors.sessionErrors[0]).toMatchObject({
+      url: '/runtime-error',
+      buildError: null,
+      runtimeErrors: [
+        {
+          type: 'runtime',
+          errorName: 'Error',
+          message: 'Test runtime error',
+          stack: expect.arrayContaining([
+            expect.objectContaining({
+              file: expect.stringContaining('app/runtime-error/page.tsx'),
+              methodName: 'RuntimeErrorPage',
+            }),
+          ]),
+        },
+      ],
+    })
   })
 
   it('should capture build errors when directly visiting error page', async () => {
@@ -97,16 +97,18 @@ describe('mcp-server get_errors tool', () => {
       expect(errors.sessionErrors[0].buildError).toBeTruthy()
     })
 
-    // Verify proper URL display in session header (now shows pathname only)
-    expect(errors.sessionErrors[0].url).toBe('/build-error')
-
-    const sessionError = errors.sessionErrors[0]
+    expect(errors.sessionErrors[0]).toMatchObject({
+      url: '/build-error',
+      buildError: expect.any(String),
+    })
 
     // Check the build error contains the expected syntax error message
-    expect(stripAnsi(sessionError.buildError)).toContain(
+    expect(stripAnsi(errors.sessionErrors[0].buildError)).toContain(
       'Unexpected token. Did you mean'
     )
-    expect(stripAnsi(sessionError.buildError)).toContain('build-error/page.tsx')
+    expect(stripAnsi(errors.sessionErrors[0].buildError)).toContain(
+      'build-error/page.tsx'
+    )
   })
 
   it('should capture errors from multiple browser sessions', async () => {
@@ -144,34 +146,37 @@ describe('mcp-server get_errors tool', () => {
         (s: any) => s.url === '/runtime-error-2'
       )
 
-      expect(session1).toBeTruthy()
-      expect(session2).toBeTruthy()
+      expect(session1).toMatchObject({
+        url: '/runtime-error',
+        runtimeErrors: [
+          {
+            type: 'runtime',
+            message: 'Test runtime error',
+            stack: expect.arrayContaining([
+              expect.objectContaining({
+                file: expect.stringContaining('app/runtime-error/page.tsx'),
+                methodName: 'RuntimeErrorPage',
+              }),
+            ]),
+          },
+        ],
+      })
 
-      // Check session 1
-      expect(session1.runtimeErrors).toHaveLength(1)
-      expect(session1.runtimeErrors[0].type).toBe('runtime')
-      expect(session1.runtimeErrors[0].message).toBe('Test runtime error')
-      expect(session1.runtimeErrors[0].stack).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            file: expect.stringContaining('app/runtime-error/page.tsx'),
-            methodName: 'RuntimeErrorPage',
-          }),
-        ])
-      )
-
-      // Check session 2
-      expect(session2.runtimeErrors).toHaveLength(1)
-      expect(session2.runtimeErrors[0].type).toBe('runtime')
-      expect(session2.runtimeErrors[0].message).toBe('Test runtime error 2')
-      expect(session2.runtimeErrors[0].stack).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            file: expect.stringContaining('app/runtime-error-2/page.tsx'),
-            methodName: 'RuntimeErrorPage',
-          }),
-        ])
-      )
+      expect(session2).toMatchObject({
+        url: '/runtime-error-2',
+        runtimeErrors: [
+          {
+            type: 'runtime',
+            message: 'Test runtime error 2',
+            stack: expect.arrayContaining([
+              expect.objectContaining({
+                file: expect.stringContaining('app/runtime-error-2/page.tsx'),
+                methodName: 'RuntimeErrorPage',
+              }),
+            ]),
+          },
+        ],
+      })
     } finally {
       await s1.close()
       await s2.close()
@@ -206,10 +211,11 @@ describe('mcp-server get_errors tool', () => {
       expect(errors.configErrors.length).toBeGreaterThan(0)
     })
 
-    // Check config error content
-    expect(errors.configErrors[0].message).toContain(
-      'Invalid next.config.js options detected'
-    )
+    expect(errors.configErrors[0]).toMatchObject({
+      message: expect.stringContaining(
+        'Invalid next.config.js options detected'
+      ),
+    })
     expect(errors.configErrors[0].message).toContain('invalidTestProperty')
 
     // Stop server, fix the config, and restart

--- a/test/development/mcp-server/mcp-server-get-errors.test.ts
+++ b/test/development/mcp-server/mcp-server-get-errors.test.ts
@@ -32,202 +32,81 @@ describe('mcp-server get_errors tool', () => {
   }
 
   it('should handle no browser sessions gracefully', async () => {
-    const errors = await callGetErrors('test-no-session')
-    expect(stripAnsi(errors)).toMatchInlineSnapshot(
-      `"No browser sessions connected. Please open your application in a browser to retrieve error state."`
-    )
+    const errorsText = await callGetErrors('test-no-session')
+    const errors = JSON.parse(errorsText)
+    expect(errors).toMatchInlineSnapshot(`
+      {
+        "error": "No browser sessions connected. Please open your application in a browser to retrieve error state.",
+      }
+    `)
   })
 
   it('should return no errors for clean page', async () => {
     await next.browser('/')
-    const errors = await callGetErrors('test-1')
-    expect(stripAnsi(errors)).toMatchInlineSnapshot(
-      `"No errors detected in 1 browser session(s)."`
-    )
+    const errorsText = await callGetErrors('test-1')
+    const errors = JSON.parse(errorsText)
+    expect(errors).toMatchInlineSnapshot(`
+      {
+        "configErrors": [],
+        "sessionErrors": [],
+      }
+    `)
   })
 
   it('should capture runtime errors with source-mapped stack frames', async () => {
     const browser = await next.browser('/')
     await browser.elementByCss('a[href="/runtime-error"]').click()
 
-    let errors: string = ''
+    let errors: any = null
     await retry(async () => {
       const sessionId = 'test-2-' + Date.now()
-      errors = await callGetErrors(sessionId)
-      expect(errors).toContain('Runtime Errors')
-      expect(errors).toContain('Found errors in 1 browser session')
+      const errorsText = await callGetErrors(sessionId)
+      errors = JSON.parse(errorsText)
+      expect(errors.sessionErrors).toHaveLength(1)
+      expect(errors.sessionErrors[0].runtimeErrors).toHaveLength(1)
     })
 
-    const strippedErrors = stripAnsi(errors)
-      // Replace dynamic port with placeholder
-      .replace(/localhost:\d+/g, 'localhost:PORT')
-
     // Verify proper URL display in session header (now shows pathname only)
-    expect(strippedErrors).toContain('Session: /runtime-error')
+    expect(errors.sessionErrors[0].url).toBe('/runtime-error')
 
-    expect(strippedErrors).toMatchInlineSnapshot(`
-      "# Found errors in 1 browser session(s)
-
-      ## Session: /runtime-error
-
-      **1 error(s) found**
-
-      ### Runtime Errors
-
-      #### Error 1 (Type: runtime)
-
-      **Error**: Test runtime error
-
-      \`\`\`
-        at RuntimeErrorPage (app/runtime-error/page.tsx:2:9)
-      \`\`\`
-
-      ---"
-    `)
+    // Check the structure of the error
+    const sessionError = errors.sessionErrors[0]
+    expect(sessionError.buildError).toBeNull()
+    expect(sessionError.runtimeErrors[0].type).toBe('runtime')
+    expect(sessionError.runtimeErrors[0].errorName).toBe('Error')
+    expect(sessionError.runtimeErrors[0].message).toBe('Test runtime error')
+    expect(sessionError.runtimeErrors[0].stack).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          file: expect.stringContaining('app/runtime-error/page.tsx'),
+          methodName: 'RuntimeErrorPage',
+        }),
+      ])
+    )
   })
 
   it('should capture build errors when directly visiting error page', async () => {
     await next.browser('/build-error')
 
-    let errors: string = ''
+    let errors: any = null
     await retry(async () => {
       const sessionId = 'test-4-' + Date.now()
-      errors = await callGetErrors(sessionId)
-      expect(errors).toContain('Build Error')
-      expect(errors).toContain('Found errors in 1 browser session')
+      const errorsText = await callGetErrors(sessionId)
+      errors = JSON.parse(errorsText)
+      expect(errors.sessionErrors).toHaveLength(1)
+      expect(errors.sessionErrors[0].buildError).toBeTruthy()
     })
 
-    let strippedErrors = stripAnsi(errors)
-      // Replace dynamic port with placeholder
-      .replace(/localhost:\d+/g, 'localhost:PORT')
-
     // Verify proper URL display in session header (now shows pathname only)
-    expect(strippedErrors).toContain('Session: /build-error')
+    expect(errors.sessionErrors[0].url).toBe('/build-error')
 
-    const isTurbopack = process.env.IS_TURBOPACK_TEST === '1'
+    const sessionError = errors.sessionErrors[0]
 
-    const isRspack = !!process.env.NEXT_RSPACK
-
-    // Normalize paths in turbopack output to remove temp directory prefix
-    if (isTurbopack) {
-      strippedErrors = strippedErrors.replace(/\.\/test\/tmp\/[^/]+\//g, './')
-    }
-
-    if (isTurbopack) {
-      // Turbopack output
-      expect(strippedErrors).toMatchInlineSnapshot(`
-       "# Found errors in 1 browser session(s)
-
-       ## Session: /build-error
-
-       **2 error(s) found**
-
-       ### Build Error
-
-       \`\`\`
-       ./app/build-error/page.tsx:4:1
-       Parsing ecmascript source code failed
-         2 |   // Syntax error - missing closing brace
-         3 |   return <div>Page
-       > 4 | }
-           | ^
-
-       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-       \`\`\`
-
-       ### Runtime Errors
-
-       #### Error 1 (Type: runtime)
-
-       **Error**: ./app/build-error/page.tsx:4:1
-       Parsing ecmascript source code failed
-         2 |   // Syntax error - missing closing brace
-         3 |   return <div>Page
-       > 4 | }
-           | ^
-
-       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-
-
-
-       \`\`\`
-         at <unknown> (Error: ./app/build-error/page.tsx:4:1)
-         at <unknown> (Error: (./app/build-error/page.tsx:4:1)
-       \`\`\`
-
-       ---"
-      `)
-    } else if (isRspack) {
-      // Webpack output
-      expect(strippedErrors).toMatchInlineSnapshot(`
-       "# Found errors in 1 browser session(s)
-
-       ## Session: /build-error
-
-       **1 error(s) found**
-
-       ### Build Error
-
-       \`\`\`
-       ./app/build-error/page.tsx
-         ╰─▶   × Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-               │    ,-[4:1]
-               │  1 | export default function BuildErrorPage() {
-               │  2 |   // Syntax error - missing closing brace
-               │  3 |   return <div>Page
-               │  4 | }
-               │    : ^
-               │    \`----
-               │   x Expected '</', got '<eof>'
-               │    ,-[4:1]
-               │  1 | export default function BuildErrorPage() {
-               │  2 |   // Syntax error - missing closing brace
-               │  3 |   return <div>Page
-               │  4 | }
-               │    \`----
-               │
-               │
-               │ Caused by:
-               │     Syntax Error
-       \`\`\`
-
-       ---"
-      `)
-    } else {
-      expect(strippedErrors).toMatchInlineSnapshot(`
-       "# Found errors in 1 browser session(s)
-
-       ## Session: /build-error
-
-       **1 error(s) found**
-
-       ### Build Error
-
-       \`\`\`
-       ./app/build-error/page.tsx
-       Error:   x Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
-          ,-[4:1]
-        1 | export default function BuildErrorPage() {
-        2 |   // Syntax error - missing closing brace
-        3 |   return <div>Page
-        4 | }
-          : ^
-          \`----
-         x Expected '</', got '<eof>'
-          ,-[4:1]
-        1 | export default function BuildErrorPage() {
-        2 |   // Syntax error - missing closing brace
-        3 |   return <div>Page
-        4 | }
-          \`----
-
-       Caused by:
-           Syntax Error
-       \`\`\`
-
-       ---"
-      `)
-    }
+    // Check the build error contains the expected syntax error message
+    expect(stripAnsi(sessionError.buildError)).toContain(
+      'Unexpected token. Did you mean'
+    )
+    expect(stripAnsi(sessionError.buildError)).toContain('build-error/page.tsx')
   })
 
   it('should capture errors from multiple browser sessions', async () => {
@@ -244,68 +123,55 @@ describe('mcp-server get_errors tool', () => {
     try {
       // Wait for server to be ready
       await new Promise((resolve) => setTimeout(resolve, 1000))
-      let errors: string = ''
+      let errors: any = null
       await retry(async () => {
         const sessionId = 'test-multi-' + Date.now()
-        errors = await callGetErrors(sessionId)
+        const errorsText = await callGetErrors(sessionId)
+        errors = JSON.parse(errorsText)
         // Check that we have at least the 2 sessions we created
-        expect(errors).toMatch(/Found errors in \d+ browser session/)
+        expect(errors.sessionErrors.length).toBeGreaterThanOrEqual(2)
         // Ensure both our sessions are present
-        expect(errors).toContain('/runtime-error')
-        expect(errors).toContain('/runtime-error-2')
+        const urls = errors.sessionErrors.map((s: any) => s.url)
+        expect(urls).toContain('/runtime-error')
+        expect(urls).toContain('/runtime-error-2')
       })
 
-      const strippedErrors = stripAnsi(errors).replace(
-        /localhost:\d+/g,
-        'localhost:PORT'
+      // Find each session's errors
+      const session1 = errors.sessionErrors.find(
+        (s: any) => s.url === '/runtime-error'
+      )
+      const session2 = errors.sessionErrors.find(
+        (s: any) => s.url === '/runtime-error-2'
       )
 
-      // Extract each session's content to check them independently
-      const session1Match = strippedErrors.match(
-        /## Session: \/runtime-error\n[\s\S]*?(?=---)/
+      expect(session1).toBeTruthy()
+      expect(session2).toBeTruthy()
+
+      // Check session 1
+      expect(session1.runtimeErrors).toHaveLength(1)
+      expect(session1.runtimeErrors[0].type).toBe('runtime')
+      expect(session1.runtimeErrors[0].message).toBe('Test runtime error')
+      expect(session1.runtimeErrors[0].stack).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: expect.stringContaining('app/runtime-error/page.tsx'),
+            methodName: 'RuntimeErrorPage',
+          }),
+        ])
       )
-      const session2Match = strippedErrors.match(
-        /## Session: \/runtime-error-2\n[\s\S]*?(?=---)/
+
+      // Check session 2
+      expect(session2.runtimeErrors).toHaveLength(1)
+      expect(session2.runtimeErrors[0].type).toBe('runtime')
+      expect(session2.runtimeErrors[0].message).toBe('Test runtime error 2')
+      expect(session2.runtimeErrors[0].stack).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: expect.stringContaining('app/runtime-error-2/page.tsx'),
+            methodName: 'RuntimeErrorPage',
+          }),
+        ])
       )
-
-      expect(session1Match).toBeTruthy()
-      expect(session2Match).toBeTruthy()
-
-      expect(session1Match?.[0]).toMatchInlineSnapshot(`
-        "## Session: /runtime-error
-
-        **1 error(s) found**
-
-        ### Runtime Errors
-
-        #### Error 1 (Type: runtime)
-
-        **Error**: Test runtime error
-
-        \`\`\`
-          at RuntimeErrorPage (app/runtime-error/page.tsx:2:9)
-        \`\`\`
-
-        "
-      `)
-
-      expect(session2Match?.[0]).toMatchInlineSnapshot(`
-        "## Session: /runtime-error-2
-
-        **1 error(s) found**
-
-        ### Runtime Errors
-
-        #### Error 1 (Type: runtime)
-
-        **Error**: Test runtime error 2
-
-        \`\`\`
-          at RuntimeErrorPage (app/runtime-error-2/page.tsx:2:9)
-        \`\`\`
-
-        "
-      `)
     } finally {
       await s1.close()
       await s2.close()
@@ -332,18 +198,19 @@ describe('mcp-server get_errors tool', () => {
     await next.browser('/')
 
     // Check that the config error is captured
-    let errors: string = ''
+    let errors: any = null
     await retry(async () => {
       const sessionId = 'test-config-error-' + Date.now()
-      errors = await callGetErrors(sessionId)
-      expect(errors).toContain('Next.js Configuration Errors')
-      expect(errors).toContain('error(s) found in next.config')
+      const errorsText = await callGetErrors(sessionId)
+      errors = JSON.parse(errorsText)
+      expect(errors.configErrors.length).toBeGreaterThan(0)
     })
 
-    const strippedErrors = stripAnsi(errors)
-    expect(strippedErrors).toContain('Next.js Configuration Errors')
-    expect(strippedErrors).toContain('Invalid next.config.js options detected')
-    expect(strippedErrors).toContain('invalidTestProperty')
+    // Check config error content
+    expect(errors.configErrors[0].message).toContain(
+      'Invalid next.config.js options detected'
+    )
+    expect(errors.configErrors[0].message).toContain('invalidTestProperty')
 
     // Stop server, fix the config, and restart
     await next.stop()
@@ -356,11 +223,10 @@ describe('mcp-server get_errors tool', () => {
     // Verify the config error is now gone
     await retry(async () => {
       const sessionId = 'test-config-fixed-' + Date.now()
-      const fixedErrors = await callGetErrors(sessionId)
-      const strippedFixed = stripAnsi(fixedErrors)
-      expect(strippedFixed).not.toContain('Next.js Configuration Errors')
-      expect(strippedFixed).not.toContain('invalidTestProperty')
-      expect(strippedFixed).toContain('No errors detected')
+      const fixedErrorsText = await callGetErrors(sessionId)
+      const fixedErrors = JSON.parse(fixedErrorsText)
+      expect(fixedErrors.configErrors).toHaveLength(0)
+      expect(fixedErrors.sessionErrors).toHaveLength(0)
     })
   })
 })

--- a/test/development/mcp-server/mcp-server-get-logs.test.ts
+++ b/test/development/mcp-server/mcp-server-get-logs.test.ts
@@ -41,12 +41,13 @@ describe('get-logs MCP tool', () => {
 
     await retry(async () => {
       const sessionId = 'test-mcp-logs-' + Date.now()
-      const response = await callGetLogs(sessionId)
+      const responseText = await callGetLogs(sessionId)
+      const response = JSON.parse(responseText)
 
       // Should return the log file path
-      expect(response).toContain('Next.js log file path:')
-      expect(response).toContain('logs/next-development.log')
-      expect(response).not.toContain('Log file not found at')
+      expect(response.logFilePath).toBeTruthy()
+      expect(response.logFilePath).toContain('logs/next-development.log')
+      expect(response.error).toBeUndefined()
     })
   })
 })

--- a/test/development/mcp-server/mcp-server-get-logs.test.ts
+++ b/test/development/mcp-server/mcp-server-get-logs.test.ts
@@ -44,10 +44,9 @@ describe('get-logs MCP tool', () => {
       const responseText = await callGetLogs(sessionId)
       const response = JSON.parse(responseText)
 
-      // Should return the log file path
-      expect(response.logFilePath).toBeTruthy()
-      expect(response.logFilePath).toContain('logs/next-development.log')
-      expect(response.error).toBeUndefined()
+      expect(response).toMatchObject({
+        logFilePath: expect.stringContaining('logs/next-development.log'),
+      })
     })
   })
 })

--- a/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
+++ b/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
@@ -1,7 +1,6 @@
 import { FileRef, nextTestSetup } from 'e2e-utils'
 import path from 'path'
 import { retry } from 'next-test-utils'
-import stripAnsi from 'strip-ansi'
 import { launchStandaloneSession } from './test-utils'
 
 describe('mcp-server get_page_metadata tool', () => {
@@ -35,68 +34,70 @@ describe('mcp-server get_page_metadata tool', () => {
 
     it('should return metadata for basic page', async () => {
       await next.browser('/')
-      const metadata = await callGetPageMetadata(next.url, 'test-basic')
+      const metadataText = await callGetPageMetadata(next.url, 'test-basic')
+      const metadata = JSON.parse(metadataText)
 
-      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
-       "# Page metadata from 1 browser session(s)
-
-       ## Session: /
-
-       **Router type:** app
-
-       ### Files powering this page:
-
-       - app/layout.tsx
-       - global-error.js (boundary, builtin)
-       - app/error.tsx (boundary)
-       - app/loading.tsx (boundary)
-       - app/not-found.tsx (boundary)
-       - app/page.tsx
-
-       ---"
-      `)
+      expect(metadata.sessions).toHaveLength(1)
+      expect(metadata.sessions[0].url).toBe('/')
+      expect(metadata.sessions[0].routerType).toBe('app')
+      expect(metadata.sessions[0].segments).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: 'app/layout.tsx' }),
+          expect.objectContaining({
+            path: 'global-error.js',
+            isBoundary: true,
+            isBuiltin: true,
+          }),
+          expect.objectContaining({ path: 'app/error.tsx', isBoundary: true }),
+          expect.objectContaining({
+            path: 'app/loading.tsx',
+            isBoundary: true,
+          }),
+          expect.objectContaining({
+            path: 'app/not-found.tsx',
+            isBoundary: true,
+          }),
+          expect.objectContaining({ path: 'app/page.tsx' }),
+        ])
+      )
     })
 
     it('should return metadata for parallel routes', async () => {
       await next.browser('/parallel')
 
-      let metadata: string = ''
+      let metadata: any = null
       await retry(async () => {
         const sessionId = 'test-parallel-' + Date.now()
-        metadata = await callGetPageMetadata(next.url, sessionId)
-        expect(metadata).toContain('Page metadata from 1 browser session')
-        expect(metadata).toContain('Files powering this page')
+        const metadataText = await callGetPageMetadata(next.url, sessionId)
+        metadata = JSON.parse(metadataText)
+        expect(metadata.sessions).toHaveLength(1)
         // Ensure we have the parallel route files
-        expect(metadata).toContain('app/parallel/@sidebar/page.tsx')
-        expect(metadata).toContain('app/parallel/@content/page.tsx')
-        expect(metadata).toContain('app/parallel/page.tsx')
+        const paths = metadata.sessions[0].segments.map((s: any) => s.path)
+        expect(paths).toContain('app/parallel/@sidebar/page.tsx')
+        expect(paths).toContain('app/parallel/@content/page.tsx')
+        expect(paths).toContain('app/parallel/page.tsx')
       })
 
-      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
-       "# Page metadata from 1 browser session(s)
-
-       ## Session: /parallel
-
-       **Router type:** app
-
-       ### Files powering this page:
-
-       - app/layout.tsx
-       - app/parallel/layout.tsx
-       - global-error.js (boundary, builtin)
-       - app/error.tsx (boundary)
-       - app/loading.tsx (boundary)
-       - app/not-found.tsx (boundary)
-       - app/parallel/@content/error.tsx (boundary)
-       - app/parallel/@sidebar/loading.tsx (boundary)
-       - app/parallel/error.tsx (boundary)
-       - app/parallel/loading.tsx (boundary)
-       - app/parallel/@content/page.tsx
-       - app/parallel/@sidebar/page.tsx
-       - app/parallel/page.tsx
-
-       ---"
-      `)
+      expect(metadata.sessions[0].url).toBe('/parallel')
+      expect(metadata.sessions[0].routerType).toBe('app')
+      expect(metadata.sessions[0].segments).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: 'app/layout.tsx' }),
+          expect.objectContaining({ path: 'app/parallel/layout.tsx' }),
+          expect.objectContaining({
+            path: 'global-error.js',
+            isBoundary: true,
+            isBuiltin: true,
+          }),
+          expect.objectContaining({
+            path: 'app/parallel/@content/page.tsx',
+          }),
+          expect.objectContaining({
+            path: 'app/parallel/@sidebar/page.tsx',
+          }),
+          expect.objectContaining({ path: 'app/parallel/page.tsx' }),
+        ])
+      )
     })
 
     it('should handle multiple browser sessions', async () => {
@@ -107,73 +108,47 @@ describe('mcp-server get_page_metadata tool', () => {
       try {
         await new Promise((resolve) => setTimeout(resolve, 1000))
 
-        let metadata: string = ''
+        let metadata: any = null
         await retry(async () => {
           const sessionId = 'test-multi-' + Date.now()
-          metadata = await callGetPageMetadata(next.url, sessionId)
-          expect(metadata).toMatch(/Page metadata from \d+ browser session/)
+          const metadataText = await callGetPageMetadata(next.url, sessionId)
+          metadata = JSON.parse(metadataText)
+          expect(metadata.sessions.length).toBeGreaterThanOrEqual(2)
           // Ensure both our sessions are present
-          expect(metadata).toContain('Session: /')
-          expect(metadata).toContain('Session: /parallel')
+          const urls = metadata.sessions.map((s: any) => s.url)
+          expect(urls).toContain('/')
+          expect(urls).toContain('/parallel')
         })
 
-        const strippedMetadata = stripAnsi(metadata)
-
-        // Extract each session's content to check them independently
-        const session1Match = strippedMetadata.match(
-          /## Session: \/\n[\s\S]*?(?=(\n## Session:|\n?$))/
-        )
-        const session2Match = strippedMetadata.match(
-          /## Session: \/parallel\n[\s\S]*?(?=(\n## Session:|\n?$))/
+        // Find each session's metadata
+        const rootSession = metadata.sessions.find((s: any) => s.url === '/')
+        const parallelSession = metadata.sessions.find(
+          (s: any) => s.url === '/parallel'
         )
 
-        // Trim trailing newline if present
-        if (session1Match) session1Match[0] = session1Match[0].trimEnd()
-        if (session2Match) session2Match[0] = session2Match[0].trimEnd()
+        expect(rootSession).toBeTruthy()
+        expect(parallelSession).toBeTruthy()
 
-        expect(session1Match).toBeTruthy()
-        expect(session2Match).toBeTruthy()
+        // Check root session
+        expect(rootSession.routerType).toBe('app')
+        expect(rootSession.segments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ path: 'app/layout.tsx' }),
+            expect.objectContaining({ path: 'app/page.tsx' }),
+          ])
+        )
 
-        expect(session1Match?.[0]).toMatchInlineSnapshot(`
-         "## Session: /
-
-         **Router type:** app
-
-         ### Files powering this page:
-
-         - app/layout.tsx
-         - global-error.js (boundary, builtin)
-         - app/error.tsx (boundary)
-         - app/loading.tsx (boundary)
-         - app/not-found.tsx (boundary)
-         - app/page.tsx
-
-         ---"
-        `)
-
-        expect(session2Match?.[0]).toMatchInlineSnapshot(`
-         "## Session: /parallel
-
-         **Router type:** app
-
-         ### Files powering this page:
-
-         - app/layout.tsx
-         - app/parallel/layout.tsx
-         - global-error.js (boundary, builtin)
-         - app/error.tsx (boundary)
-         - app/loading.tsx (boundary)
-         - app/not-found.tsx (boundary)
-         - app/parallel/@content/error.tsx (boundary)
-         - app/parallel/@sidebar/loading.tsx (boundary)
-         - app/parallel/error.tsx (boundary)
-         - app/parallel/loading.tsx (boundary)
-         - app/parallel/@content/page.tsx
-         - app/parallel/@sidebar/page.tsx
-         - app/parallel/page.tsx
-
-         ---"
-        `)
+        // Check parallel session
+        expect(parallelSession.routerType).toBe('app')
+        expect(parallelSession.segments).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ path: 'app/layout.tsx' }),
+            expect.objectContaining({ path: 'app/parallel/layout.tsx' }),
+            expect.objectContaining({ path: 'app/parallel/@content/page.tsx' }),
+            expect.objectContaining({ path: 'app/parallel/@sidebar/page.tsx' }),
+            expect.objectContaining({ path: 'app/parallel/page.tsx' }),
+          ])
+        )
       } finally {
         // Clean up sessions
         await session1.close()
@@ -190,17 +165,20 @@ describe('mcp-server get_page_metadata tool', () => {
       try {
         await new Promise((resolve) => setTimeout(resolve, 1000))
 
-        let metadata: string = ''
+        let metadata: any = null
         await retry(async () => {
           const sessionId = 'test-same-url-' + Date.now()
-          metadata = await callGetPageMetadata(next.url, sessionId)
-          const rootSessions = (metadata.match(/## Session: \/(?!\w)/g) || [])
-            .length
+          const metadataText = await callGetPageMetadata(next.url, sessionId)
+          metadata = JSON.parse(metadataText)
+          const rootSessions = metadata.sessions.filter(
+            (s: any) => s.url === '/'
+          ).length
           expect(rootSessions).toBeGreaterThanOrEqual(2)
         })
 
-        const rootSessions = (metadata.match(/## Session: \/(?!\w)/g) || [])
-          .length
+        const rootSessions = metadata.sessions.filter(
+          (s: any) => s.url === '/'
+        ).length
         expect(rootSessions).toBeGreaterThanOrEqual(2)
       } finally {
         await session1.close()
@@ -219,47 +197,33 @@ describe('mcp-server get_page_metadata tool', () => {
     it('should return metadata showing pages router type', async () => {
       await next.browser('/')
 
-      let metadata: string = ''
+      let metadata: any = null
       await retry(async () => {
         const sessionId = 'test-pages-' + Date.now()
-        metadata = await callGetPageMetadata(next.url, sessionId)
-        expect(metadata).toContain('Page metadata from 1 browser session')
+        const metadataText = await callGetPageMetadata(next.url, sessionId)
+        metadata = JSON.parse(metadataText)
+        expect(metadata.sessions).toHaveLength(1)
       })
 
-      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
-          "# Page metadata from 1 browser session(s)
-
-          ## Session: /
-
-          **Router type:** pages
-
-          *No segments found*
-
-          ---"
-        `)
+      expect(metadata.sessions[0].url).toBe('/')
+      expect(metadata.sessions[0].routerType).toBe('pages')
+      expect(metadata.sessions[0].segments).toHaveLength(0)
     })
 
     it('should show pages router type for about page', async () => {
       await next.browser('/about')
 
-      let metadata: string = ''
+      let metadata: any = null
       await retry(async () => {
         const sessionId = 'test-pages-about-' + Date.now()
-        metadata = await callGetPageMetadata(next.url, sessionId)
-        expect(metadata).toContain('Page metadata from 1 browser session')
+        const metadataText = await callGetPageMetadata(next.url, sessionId)
+        metadata = JSON.parse(metadataText)
+        expect(metadata.sessions).toHaveLength(1)
       })
 
-      expect(stripAnsi(metadata)).toMatchInlineSnapshot(`
-          "# Page metadata from 1 browser session(s)
-
-          ## Session: /about
-
-          **Router type:** pages
-
-          *No segments found*
-
-          ---"
-        `)
+      expect(metadata.sessions[0].url).toBe('/about')
+      expect(metadata.sessions[0].routerType).toBe('pages')
+      expect(metadata.sessions[0].segments).toHaveLength(0)
     })
   })
 })

--- a/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
+++ b/test/development/mcp-server/mcp-server-get-page-metadata.test.ts
@@ -38,8 +38,10 @@ describe('mcp-server get_page_metadata tool', () => {
       const metadata = JSON.parse(metadataText)
 
       expect(metadata.sessions).toHaveLength(1)
-      expect(metadata.sessions[0].url).toBe('/')
-      expect(metadata.sessions[0].routerType).toBe('app')
+      expect(metadata.sessions[0]).toMatchObject({
+        url: '/',
+        routerType: 'app',
+      })
       expect(metadata.sessions[0].segments).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ path: 'app/layout.tsx' }),
@@ -78,8 +80,10 @@ describe('mcp-server get_page_metadata tool', () => {
         expect(paths).toContain('app/parallel/page.tsx')
       })
 
-      expect(metadata.sessions[0].url).toBe('/parallel')
-      expect(metadata.sessions[0].routerType).toBe('app')
+      expect(metadata.sessions[0]).toMatchObject({
+        url: '/parallel',
+        routerType: 'app',
+      })
       expect(metadata.sessions[0].segments).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ path: 'app/layout.tsx' }),
@@ -89,12 +93,8 @@ describe('mcp-server get_page_metadata tool', () => {
             isBoundary: true,
             isBuiltin: true,
           }),
-          expect.objectContaining({
-            path: 'app/parallel/@content/page.tsx',
-          }),
-          expect.objectContaining({
-            path: 'app/parallel/@sidebar/page.tsx',
-          }),
+          expect.objectContaining({ path: 'app/parallel/@content/page.tsx' }),
+          expect.objectContaining({ path: 'app/parallel/@sidebar/page.tsx' }),
           expect.objectContaining({ path: 'app/parallel/page.tsx' }),
         ])
       )
@@ -126,11 +126,10 @@ describe('mcp-server get_page_metadata tool', () => {
           (s: any) => s.url === '/parallel'
         )
 
-        expect(rootSession).toBeTruthy()
-        expect(parallelSession).toBeTruthy()
-
-        // Check root session
-        expect(rootSession.routerType).toBe('app')
+        expect(rootSession).toMatchObject({
+          url: '/',
+          routerType: 'app',
+        })
         expect(rootSession.segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({ path: 'app/layout.tsx' }),
@@ -138,8 +137,10 @@ describe('mcp-server get_page_metadata tool', () => {
           ])
         )
 
-        // Check parallel session
-        expect(parallelSession.routerType).toBe('app')
+        expect(parallelSession).toMatchObject({
+          url: '/parallel',
+          routerType: 'app',
+        })
         expect(parallelSession.segments).toEqual(
           expect.arrayContaining([
             expect.objectContaining({ path: 'app/layout.tsx' }),
@@ -205,9 +206,11 @@ describe('mcp-server get_page_metadata tool', () => {
         expect(metadata.sessions).toHaveLength(1)
       })
 
-      expect(metadata.sessions[0].url).toBe('/')
-      expect(metadata.sessions[0].routerType).toBe('pages')
-      expect(metadata.sessions[0].segments).toHaveLength(0)
+      expect(metadata.sessions[0]).toMatchObject({
+        url: '/',
+        routerType: 'pages',
+        segments: [],
+      })
     })
 
     it('should show pages router type for about page', async () => {
@@ -221,9 +224,11 @@ describe('mcp-server get_page_metadata tool', () => {
         expect(metadata.sessions).toHaveLength(1)
       })
 
-      expect(metadata.sessions[0].url).toBe('/about')
-      expect(metadata.sessions[0].routerType).toBe('pages')
-      expect(metadata.sessions[0].segments).toHaveLength(0)
+      expect(metadata.sessions[0]).toMatchObject({
+        url: '/about',
+        routerType: 'pages',
+        segments: [],
+      })
     })
   })
 })

--- a/test/development/mcp-server/mcp-server-get-server-action-by-id.test.ts
+++ b/test/development/mcp-server/mcp-server-get-server-action-by-id.test.ts
@@ -53,20 +53,21 @@ describe('mcp-server get_server_action_by_id tool', () => {
     expect(callToolDataMatch).toBeTruthy()
 
     const callToolResult = JSON.parse(callToolDataMatch![1])
-    expect(callToolResult.jsonrpc).toBe('2.0')
-    expect(callToolResult.id).toBe('call-tool-1')
+    expect(callToolResult).toMatchObject({
+      jsonrpc: '2.0',
+      id: 'call-tool-1',
+      result: {
+        content: [{ type: 'text', text: expect.any(String) }],
+      },
+    })
 
-    const content = callToolResult.result?.content
-    expect(content).toBeInstanceOf(Array)
-    expect(content?.[0]?.type).toBe('text')
-
-    const actionDetails = JSON.parse(content?.[0]?.text)
-
-    // Verify the action details
-    expect(actionDetails.actionId).toBe(actionId)
-    expect(actionDetails.runtime).toBe('node')
-    expect(actionDetails.filename).toContain('app/actions.ts')
-    expect(actionDetails.functionName).toBeTruthy()
+    const actionDetails = JSON.parse(callToolResult.result.content[0].text)
+    expect(actionDetails).toMatchObject({
+      actionId,
+      runtime: 'node',
+      filename: expect.stringContaining('app/actions.ts'),
+      functionName: expect.any(String),
+    })
   })
 
   it('should return error for non-existent action ID', async () => {
@@ -97,15 +98,18 @@ describe('mcp-server get_server_action_by_id tool', () => {
     expect(callToolDataMatch).toBeTruthy()
 
     const callToolResult = JSON.parse(callToolDataMatch![1])
-    expect(callToolResult.jsonrpc).toBe('2.0')
-    expect(callToolResult.id).toBe('call-tool-2')
+    expect(callToolResult).toMatchObject({
+      jsonrpc: '2.0',
+      id: 'call-tool-2',
+      result: {
+        content: [{ type: 'text', text: expect.any(String) }],
+      },
+    })
 
-    const content = callToolResult.result?.content
-    expect(content).toBeInstanceOf(Array)
-    expect(content?.[0]?.type).toBe('text')
-
-    const errorResponse = JSON.parse(content?.[0]?.text)
-    expect(errorResponse.error).toContain('not found')
+    const errorResponse = JSON.parse(callToolResult.result.content[0].text)
+    expect(errorResponse).toMatchObject({
+      error: expect.stringContaining('not found'),
+    })
   })
 
   it('should return inline server action details', async () => {
@@ -159,19 +163,20 @@ describe('mcp-server get_server_action_by_id tool', () => {
     expect(callToolDataMatch).toBeTruthy()
 
     const callToolResult = JSON.parse(callToolDataMatch![1])
-    expect(callToolResult.jsonrpc).toBe('2.0')
-    expect(callToolResult.id).toBe('call-tool-3')
+    expect(callToolResult).toMatchObject({
+      jsonrpc: '2.0',
+      id: 'call-tool-3',
+      result: {
+        content: [{ type: 'text', text: expect.any(String) }],
+      },
+    })
 
-    const content = callToolResult.result?.content
-    expect(content).toBeInstanceOf(Array)
-    expect(content?.[0]?.type).toBe('text')
-
-    const actionDetails = JSON.parse(content?.[0]?.text)
-
-    // Verify the inline action details
-    expect(actionDetails.actionId).toBe(inlineActionId)
-    expect(actionDetails.runtime).toBe('node')
-    expect(actionDetails.filename).toBeTruthy()
-    expect(actionDetails.functionName).toBe('inline server action')
+    const actionDetails = JSON.parse(callToolResult.result.content[0].text)
+    expect(actionDetails).toMatchObject({
+      actionId: inlineActionId,
+      runtime: 'node',
+      filename: expect.any(String),
+      functionName: 'inline server action',
+    })
   })
 })

--- a/test/development/mcp-server/mcp-server-get-server-action-by-id.test.ts
+++ b/test/development/mcp-server/mcp-server-get-server-action-by-id.test.ts
@@ -103,7 +103,9 @@ describe('mcp-server get_server_action_by_id tool', () => {
     const content = callToolResult.result?.content
     expect(content).toBeInstanceOf(Array)
     expect(content?.[0]?.type).toBe('text')
-    expect(content?.[0]?.text).toContain('not found')
+
+    const errorResponse = JSON.parse(content?.[0]?.text)
+    expect(errorResponse.error).toContain('not found')
   })
 
   it('should return inline server action details', async () => {


### PR DESCRIPTION
We're using normal text output before which is not super efficient for some agent to grep the text. With JSON format, agent can do special match to extract the content easily since JSON is following a certain format.

Note: the response type is still `"text"` cause there's JSON is also part of it, model can still handle it well