### PR TITLE
remove gt workflow from agents.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,62 +39,6 @@ The main Next.js framework lives in `packages/next/`. This is what gets publishe
 - `packages/font/` - `next/font` implementation
 - `packages/third-parties/` - Third-party script integrations
 
-## Git Workflow
-
-**CRITICAL: Use Graphite (`gt`) instead of git for ALL branch and commit operations.**
-
-NEVER use these git commands directly:
-
-- `git push` → use `gt submit --no-edit`
-- `git branch` → use `gt create`
-
-**Graphite commands:**
-
-- `gt create <branch-name> -m "message"` - Create a new branch with commit
-- `gt modify -a --no-edit` - Stage all and amend current branch's commit
-- `gt checkout <branch>` - Switch branches
-- `gt sync` - Sync and restack all branches
-- `gt submit --no-edit` - Push and create/update PRs
-- `gt log short` - View stack status
-
-**Note**: `gt submit` runs in interactive mode by default and won't push in automated contexts. Always use `gt submit --no-edit` or `gt submit -q` when running from Claude.
-
-**Creating PRs with descriptions**: All PRs created require a description. `gt submit --no-edit` creates PRs in draft mode without a description. To add a PR title and description, use `gh pr edit` immediately after submitting. The PR description needs to follow the mandatory format of .github/pull_request_template.md in the repository:
-
-```bash
-gt submit --no-edit
-gh pr edit <pr-number> --body "Place description here"
-```
-
-**Graphite Stack Safety Rules:**
-
-- Graphite force-pushes everything - old commits only recoverable via reflog
-- Never have uncommitted changes when switching branches - they get lost during restack
-- Never use `git stash` with Graphite - causes conflicts when `gt modify` restacks
-- Never use `git checkout HEAD -- <file>` after editing - silently restores unfixed version
-- Always use `gt checkout` (not `git checkout`) to switch branches
-- `gt modify --no-edit` with unstaged/untracked files stages ALL changes
-- `gt sync` pulls FROM remote, doesn't push TO remote
-- `gt modify` restacks children locally but doesn't push them
-- Always verify with `git status -sb` after stack operations
-- When resuming from summarized conversation, never trust cached IDs - re-fetch from git/GitHub API
-
-**Safe multi-branch fix workflow:**
-
-```bash
-gt checkout parent-branch
-# make edits
-gt modify -a --no-edit        # Stage all, amend, restack children
-git show HEAD -- <files>      # VERIFY fix is in commit
-gt submit --no-edit           # Push immediately
-
-gt checkout child-branch      # Already restacked from gt modify
-# make edits
-gt modify -a --no-edit
-git show HEAD -- <files>      # VERIFY
-gt submit --no-edit
-```
-
 ## Build Commands
 
 ```bash
@@ -135,7 +79,7 @@ Only use full `pnpm --filter=next build` for one-off builds (after branch switch
 **Always rebuild after switching branches:**
 
 ```bash
-gt checkout <branch>
+git checkout <branch>
 pnpm build   # Required before running tests (Turborepo dedupes if unchanged)
 ```
 


### PR DESCRIPTION
graphite workflow should be optional not required to do all changes. agents sometimes are aware of the `gt` cmd existence and force to update PR even didn't plan to push