### PR TITLE
docs: Update Partytown URLs and package reference

### DIFF
--- a/docs/01-app/02-guides/scripts.mdx
+++ b/docs/01-app/02-guides/scripts.mdx
@@ -127,7 +127,7 @@ Refer to the [`next/script`](/docs/app/api-reference/components/script#strategy)
 
 > **Warning:** The `worker` strategy is not yet stable and does not yet work with the App Router. Use with caution.
 
-Scripts that use the `worker` strategy are offloaded and executed in a web worker with [Partytown](https://partytown.builder.io/). This can improve the performance of your site by dedicating the main thread to the rest of your application code.
+Scripts that use the `worker` strategy are offloaded and executed in a web worker with [Partytown](https://partytown.qwik.dev/). This can improve the performance of your site by dedicating the main thread to the rest of your application code.
 
 This strategy is still experimental and can only be used if the `nextScriptWorkers` flag is enabled in `next.config.js`:
 
@@ -145,7 +145,7 @@ Then, run `next` (normally `npm run dev` or `yarn dev`) and Next.js will guide y
 npm run dev
 ```
 
-You'll see instructions like these: Please install Partytown by running `npm install @builder.io/partytown`
+You'll see instructions like these: Please install Partytown by running `npm install @qwik.dev/partytown`
 
 Once setup is complete, defining `strategy="worker"` will automatically instantiate Partytown in your application and offload the script to a web worker.
 
@@ -173,7 +173,7 @@ export default function Home() {
 }
 ```
 
-There are a number of trade-offs that need to be considered when loading a third-party script in a web worker. Please see Partytown's [tradeoffs](https://partytown.builder.io/trade-offs) documentation for more information.
+There are a number of trade-offs that need to be considered when loading a third-party script in a web worker. Please see Partytown's [tradeoffs](https://partytown.qwik.dev/trade-offs) documentation for more information.
 
 <PagesOnly>
 
@@ -218,7 +218,7 @@ In order to modify Partytown's configuration, the following conditions must be m
 
 > **Note**: If you are using an [asset prefix](/docs/pages/api-reference/config/next-config-js/assetPrefix) and would like to modify Partytown's default configuration, you must include it as part of the `lib` path.
 
-Take a look at Partytown's [configuration options](https://partytown.builder.io/configuration) to see the full list of other properties that can be added.
+Take a look at Partytown's [configuration options](https://partytown.qwik.dev/configuration) to see the full list of other properties that can be added.
 
 </PagesOnly>
 


### PR DESCRIPTION
- Update Partytown documentation links from `builder.io` to `qwik.dev`.
- Update Partytown installation package reference in the guide.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making: -->

## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- [ ] Related issues linked using `fixes #number`
- [ ] Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- [ ] Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- [ ] Related issues/discussions are linked using `fixes #number`
- [ ] e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- [ ] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.
- [ ] Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- [ ] Minimal description (aim for explaining to someone not on the team to understand the PR)
- [ ] When linking to a Slack thread, you might want to share details of the conclusion
- [ ] Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- [ ] Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Updated Partytown documentation URLs and the installation package reference in the `next/script` guide.

### Why?
Partytown documentation and packages have moved from `builder.io` to `qwik.dev`. The old links were outdated, and the package reference needed to be updated to `@qwik.dev/partytown` to ensure users install the correct version.

### How?
Updated [docs/01-app/02-guides/scripts.mdx](cci:7://file:///home/hanzala/Projects/personal/next.js/docs/01-app/02-guides/scripts.mdx:0:0-0:0) to replace `partytown.builder.io` with `partytown.qwik.dev` and updated the `npm install` instruction.

Closes NEXT-
Fixes #