### PR TITLE
Turbopack: reduce cache size

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -47,7 +47,9 @@ pub enum RewriteSourcePath {
     None,
 }
 
-#[turbo_tasks::value(shared)]
+// Note we don't want to persist this as `module_factory_with_code_generation_issue` is already
+// persisted and we want to avoid duplicating it.
+#[turbo_tasks::value(shared, serialization = "none")]
 #[derive(Default, Clone)]
 pub struct EcmascriptChunkItemContent {
     pub inner_code: Rope,


### PR DESCRIPTION
### What?

do not persist EcmascriptChunkItemContent
It's already stored as part of the module factory