### PR TITLE
Turbopack: allow key block without hash in SST files

### DIFF
--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -86,6 +86,7 @@ The hashes are sorted.
 #### Key Block
 
 - 1 byte block type (1: key block)
+- 1 byte hash_len (0-8, number of hash bytes stored per entry)
 - 3 bytes entry count
 - foreach entry
   - 1 byte type
@@ -94,23 +95,31 @@ The hashes are sorted.
 
 A Key block contains n keys, which specify n key value pairs.
 
+The `hash_len` field determines how many bytes of the key hash are stored per entry:
+
+- `hash_len = 0`: No hash stored (for small keys ≤ 8 bytes where key data fits directly)
+- `hash_len = 1-7`: Partial hash (first n bytes, big-endian order)
+- `hash_len = 8`: Full 8-byte hash
+
+During lookup, if `hash_len < 8` and the partial hash matches, the full hash is recomputed from the key data to verify.
+
 Depending on the `type` field entry has a different format:
 
 - 0: normal key (small value)
-  - 8 bytes key hash
+  - hash_len bytes key hash
   - key data
   - 2 byte block index
   - 2 bytes size
   - 4 bytes position in block
 - 1: blob reference
-  - 8 bytes key hash
+  - hash_len bytes key hash
   - key data
   - 4 bytes sequence number
 - 2: deleted key / tombstone (no data)
-  - 8 bytes key hash
+  - hash_len bytes key hash
   - key data
 - 3: normal key (medium sized value)
-  - 8 bytes key hash
+  - hash_len bytes key hash
   - key data
   - 2 byte block index
 - 7: merge key (future)
@@ -119,13 +128,11 @@ Depending on the `type` field entry has a different format:
   - 3 bytes size
   - 4 bytes position in block
 - 8..255: inlined key (future)
-  - 8 bytes key hash
+  - hash_len bytes key hash
   - key data
   - type - 8 bytes value data
 
 The entries are sorted by key hash and key.
-
-TODO: 8 bytes key hash is a bit inefficient for small keys.
 
 #### Value Block
 

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -85,8 +85,7 @@ The hashes are sorted.
 
 #### Key Block
 
-- 1 byte block type (1: key block)
-- 1 byte has_hash (0 or 1, whether 8-byte hash is stored per entry)
+- 1 byte block type (1: key block with hash, 2: key block without hash)
 - 3 bytes entry count
 - foreach entry
   - 1 byte type
@@ -95,30 +94,30 @@ The hashes are sorted.
 
 A Key block contains n keys, which specify n key value pairs.
 
-The `has_hash` field determines whether the key hash is stored per entry:
+The block type determines whether the key hash is stored per entry:
 
-- `has_hash = 0`: No hash stored (for keys ≤ 32 bytes)
-- `has_hash = 1`: Full 8-byte hash stored
+- Block type 1 (with hash): Full 8-byte hash stored per entry
+- Block type 2 (no hash): No hash stored (for keys ≤ 32 bytes)
 
-During lookup, if `has_hash = 0`, the full hash is recomputed from the key data.
+During lookup, if block type is 2, the full hash is recomputed from the key data.
 
 Depending on the `type` field entry has a different format:
 
 - 0: normal key (small value)
-  - 8 bytes key hash (if has_hash)
+  - 8 bytes key hash (if block type 1)
   - key data
   - 2 byte block index
   - 2 bytes size
   - 4 bytes position in block
 - 1: blob reference
-  - 8 bytes key hash (if has_hash)
+  - 8 bytes key hash (if block type 1)
   - key data
   - 4 bytes sequence number
 - 2: deleted key / tombstone (no data)
-  - 8 bytes key hash (if has_hash)
+  - 8 bytes key hash (if block type 1)
   - key data
 - 3: normal key (medium sized value)
-  - 8 bytes key hash (if has_hash)
+  - 8 bytes key hash (if block type 1)
   - key data
   - 2 byte block index
 - 7: merge key (future)
@@ -127,7 +126,7 @@ Depending on the `type` field entry has a different format:
   - 3 bytes size
   - 4 bytes position in block
 - 8..255: inlined key (future)
-  - 8 bytes key hash (if has_hash)
+  - 8 bytes key hash (if block type 1)
   - key data
   - type - 8 bytes value data
 

--- a/turbopack/crates/turbo-persistence/README.md
+++ b/turbopack/crates/turbo-persistence/README.md
@@ -86,7 +86,7 @@ The hashes are sorted.
 #### Key Block
 
 - 1 byte block type (1: key block)
-- 1 byte hash_len (0-8, number of hash bytes stored per entry)
+- 1 byte has_hash (0 or 1, whether 8-byte hash is stored per entry)
 - 3 bytes entry count
 - foreach entry
   - 1 byte type
@@ -95,31 +95,30 @@ The hashes are sorted.
 
 A Key block contains n keys, which specify n key value pairs.
 
-The `hash_len` field determines how many bytes of the key hash are stored per entry:
+The `has_hash` field determines whether the key hash is stored per entry:
 
-- `hash_len = 0`: No hash stored (for small keys ≤ 8 bytes where key data fits directly)
-- `hash_len = 1-7`: Partial hash (first n bytes, big-endian order)
-- `hash_len = 8`: Full 8-byte hash
+- `has_hash = 0`: No hash stored (for keys ≤ 32 bytes)
+- `has_hash = 1`: Full 8-byte hash stored
 
-During lookup, if `hash_len < 8` and the partial hash matches, the full hash is recomputed from the key data to verify.
+During lookup, if `has_hash = 0`, the full hash is recomputed from the key data.
 
 Depending on the `type` field entry has a different format:
 
 - 0: normal key (small value)
-  - hash_len bytes key hash
+  - 8 bytes key hash (if has_hash)
   - key data
   - 2 byte block index
   - 2 bytes size
   - 4 bytes position in block
 - 1: blob reference
-  - hash_len bytes key hash
+  - 8 bytes key hash (if has_hash)
   - key data
   - 4 bytes sequence number
 - 2: deleted key / tombstone (no data)
-  - hash_len bytes key hash
+  - 8 bytes key hash (if has_hash)
   - key data
 - 3: normal key (medium sized value)
-  - hash_len bytes key hash
+  - 8 bytes key hash (if has_hash)
   - key data
   - 2 byte block index
 - 7: merge key (future)
@@ -128,7 +127,7 @@ Depending on the `type` field entry has a different format:
   - 3 bytes size
   - 4 bytes position in block
 - 8..255: inlined key (future)
-  - hash_len bytes key hash
+  - 8 bytes key hash (if has_hash)
   - key data
   - type - 8 bytes value data
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -221,18 +221,6 @@ impl StaticSortedFile {
         let offsets = &block[..entry_count * 4];
         let entries = &block[entry_count * 4..];
 
-        // Mask the search hash to only compare stored bytes (high bytes in BE)
-        // When hash_len >= 8, use full hash; otherwise mask to stored bytes
-        let masked_key_hash = if hash_len >= 8 {
-            key_hash
-        } else if hash_len == 0 {
-            0
-        } else {
-            // Mask to keep only the first hash_len bytes (high bytes in BE)
-            let mask = !((1u64 << ((8 - hash_len) * 8)) - 1);
-            key_hash & mask
-        };
-
         let mut l = 0;
         let mut r = entry_count;
         // binary search for the key
@@ -245,20 +233,7 @@ impl StaticSortedFile {
                 val: mid_val,
             } = get_key_entry(offsets, entries, entry_count, m, hash_len)?;
 
-            // When hash_len < 8, we need to compute full hash from entry's key for proper comparison
-            // Entries are sorted by full hash, so we must compare full hashes
-            let comparison = if hash_len < 8 {
-                // Partial hash match (or no hash) - compute full hash from key data
-                if masked_key_hash == mid_hash {
-                    let full_entry_hash = crate::key::hash_key(&mid_key);
-                    key_hash.cmp(&full_entry_hash).then_with(|| key.cmp(mid_key))
-                } else {
-                    masked_key_hash.cmp(&mid_hash)
-                }
-            } else {
-                // Full hash stored - compare directly
-                key_hash.cmp(&mid_hash).then_with(|| key.cmp(mid_key))
-            };
+            let comparison = compare_hash_key(mid_hash, mid_key, key_hash, key);
 
             match comparison {
                 Ordering::Less => {
@@ -526,11 +501,11 @@ impl<'l> StaticSortedFileIter<'l> {
             {
                 let GetKeyEntryResult { hash, key, ty, val } =
                     get_key_entry(&offsets, &entries, entry_count, index, hash_len)?;
-                // If hash_len < 8, we need to compute the full hash from key data
-                let full_hash = if hash_len < 8 {
+                // Convert hash slice to u64, computing from key if partial hash stored
+                let full_hash = if hash.len() < 8 {
                     crate::key::hash_key(&key)
                 } else {
-                    hash
+                    u64::from_be_bytes(hash.try_into().unwrap())
                 };
                 let value = if ty == KEY_BLOCK_ENTRY_TYPE_MEDIUM {
                     let mut val = val;
@@ -586,10 +561,42 @@ impl<'l> StaticSortedFileIter<'l> {
 }
 
 struct GetKeyEntryResult<'l> {
-    hash: u64,
+    hash: &'l [u8],
     key: &'l [u8],
     ty: u8,
     val: &'l [u8],
+}
+
+/// Compares a query (full_hash + query_key) against an entry (partial_hash + entry_key).
+/// Returns the ordering of query relative to entry.
+/// When partial_hash.len() < 8, computes full hash from entry_key only if partial bytes match.
+fn compare_hash_key<K: QueryKey>(
+    partial_hash: &[u8],
+    entry_key: &[u8],
+    full_hash: u64,
+    query_key: &K,
+) -> Ordering {
+    let full_hash_bytes = full_hash.to_be_bytes();
+
+    // Compare query's hash bytes against entry's partial hash bytes
+    let partial_cmp = full_hash_bytes[..partial_hash.len()].cmp(partial_hash);
+
+    if partial_cmp != Ordering::Equal {
+        return partial_cmp;
+    }
+
+    // Partial bytes match - need full comparison
+    if partial_hash.len() < 8 {
+        // Compute full hash from entry key
+        let entry_full_hash = crate::key::hash_key(&entry_key);
+        match full_hash.cmp(&entry_full_hash) {
+            Ordering::Equal => query_key.cmp(entry_key),
+            ord => ord,
+        }
+    } else {
+        // Full hash stored - just compare keys
+        query_key.cmp(entry_key)
+    }
 }
 
 /// Reads a key entry from a key block.
@@ -609,14 +616,8 @@ fn get_key_entry<'l>(
     } else {
         (&offsets[(index + 1) * 4 + 1..]).read_u24::<BE>()? as usize
     };
-    // Read partial hash and extend to u64 (stored bytes are the high bytes in BE order)
-    let hash = if hash_len == 0 {
-        0
-    } else {
-        let mut hash_bytes = [0u8; 8];
-        hash_bytes[..hash_len_usize].copy_from_slice(&entries[start..start + hash_len_usize]);
-        u64::from_be_bytes(hash_bytes)
-    };
+    // Return the raw hash bytes slice (0-8 bytes depending on hash_len)
+    let hash = &entries[start..start + hash_len_usize];
     Ok(match ty {
         KEY_BLOCK_ENTRY_TYPE_SMALL => GetKeyEntryResult {
             hash,

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -21,8 +21,10 @@ use crate::{
 
 /// The block header for an index block.
 pub const BLOCK_TYPE_INDEX: u8 = 0;
-/// The block header for a key block.
-pub const BLOCK_TYPE_KEY: u8 = 1;
+/// The block header for a key block with 8-byte hash per entry.
+pub const BLOCK_TYPE_KEY_WITH_HASH: u8 = 1;
+/// The block header for a key block without hash.
+pub const BLOCK_TYPE_KEY_NO_HASH: u8 = 2;
 
 /// The tag for a small-sized value.
 pub const KEY_BLOCK_ENTRY_TYPE_SMALL: u8 = 0;
@@ -152,8 +154,15 @@ impl StaticSortedFile {
                 BLOCK_TYPE_INDEX => {
                     current_block = self.lookup_index_block(block, key_hash)?;
                 }
-                BLOCK_TYPE_KEY => {
-                    return self.lookup_key_block(block, key_hash, key, value_block_cache);
+                BLOCK_TYPE_KEY_WITH_HASH | BLOCK_TYPE_KEY_NO_HASH => {
+                    let has_hash = block_type == BLOCK_TYPE_KEY_WITH_HASH;
+                    return self.lookup_key_block(
+                        block,
+                        key_hash,
+                        key,
+                        has_hash,
+                        value_block_cache,
+                    );
                 }
                 _ => {
                     bail!("Invalid block type");
@@ -214,10 +223,10 @@ impl StaticSortedFile {
         mut block: &[u8],
         key_hash: u64,
         key: &K,
+        has_hash: bool,
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
-        let has_hash = block.read_u8()?;
-        let hash_len = if has_hash != 0 { 8 } else { 0 };
+        let hash_len: u8 = if has_hash { 8 } else { 0 };
         let entry_count = block.read_u24::<BE>()? as usize;
         let offsets = &block[..entry_count * 4];
         let entries = &block[entry_count * 4..];
@@ -467,12 +476,12 @@ impl<'l> StaticSortedFileIter<'l> {
                     index: 0,
                 });
             }
-            BLOCK_TYPE_KEY => {
-                let has_hash = block.read_u8()?;
-                let hash_len = if has_hash != 0 { 8 } else { 0 };
+            BLOCK_TYPE_KEY_WITH_HASH | BLOCK_TYPE_KEY_NO_HASH => {
+                let has_hash = block_type == BLOCK_TYPE_KEY_WITH_HASH;
+                let hash_len = if has_hash { 8 } else { 0 };
                 let entry_count = block.read_u24::<BE>()? as usize;
-                let offsets_range = 5..5 + entry_count * 4;
-                let entries_range = 5 + entry_count * 4..block_arc.len();
+                let offsets_range = 4..4 + entry_count * 4;
+                let entries_range = 4 + entry_count * 4..block_arc.len();
                 let offsets = block_arc.clone().slice(offsets_range);
                 let entries = block_arc.slice(entries_range);
                 self.current_key_block = Some(CurrentKeyBlock {

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -216,7 +216,8 @@ impl StaticSortedFile {
         key: &K,
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
-        let hash_len = block.read_u8()?;
+        let has_hash = block.read_u8()?;
+        let hash_len = if has_hash != 0 { 8 } else { 0 };
         let entry_count = block.read_u24::<BE>()? as usize;
         let offsets = &block[..entry_count * 4];
         let entries = &block[entry_count * 4..];
@@ -467,7 +468,8 @@ impl<'l> StaticSortedFileIter<'l> {
                 });
             }
             BLOCK_TYPE_KEY => {
-                let hash_len = block.read_u8()?;
+                let has_hash = block.read_u8()?;
+                let hash_len = if has_hash != 0 { 8 } else { 0 };
                 let entry_count = block.read_u24::<BE>()? as usize;
                 let offsets_range = 5..5 + entry_count * 4;
                 let entries_range = 5 + entry_count * 4..block_arc.len();
@@ -501,8 +503,8 @@ impl<'l> StaticSortedFileIter<'l> {
             {
                 let GetKeyEntryResult { hash, key, ty, val } =
                     get_key_entry(&offsets, &entries, entry_count, index, hash_len)?;
-                // Convert hash slice to u64, computing from key if partial hash stored
-                let full_hash = if hash.len() < 8 {
+                // Convert hash slice to u64, computing from key if no hash stored
+                let full_hash = if hash.is_empty() {
                     crate::key::hash_key(&key)
                 } else {
                     u64::from_be_bytes(hash.try_into().unwrap())
@@ -567,35 +569,29 @@ struct GetKeyEntryResult<'l> {
     val: &'l [u8],
 }
 
-/// Compares a query (full_hash + query_key) against an entry (partial_hash + entry_key).
+/// Compares a query (full_hash + query_key) against an entry (entry_hash + entry_key).
 /// Returns the ordering of query relative to entry.
-/// When partial_hash.len() < 8, computes full hash from entry_key only if partial bytes match.
+/// When entry_hash is empty, computes full hash from entry_key.
 fn compare_hash_key<K: QueryKey>(
-    partial_hash: &[u8],
+    entry_hash: &[u8],
     entry_key: &[u8],
     full_hash: u64,
     query_key: &K,
 ) -> Ordering {
-    let full_hash_bytes = full_hash.to_be_bytes();
-
-    // Compare query's hash bytes against entry's partial hash bytes
-    let partial_cmp = full_hash_bytes[..partial_hash.len()].cmp(partial_hash);
-
-    if partial_cmp != Ordering::Equal {
-        return partial_cmp;
-    }
-
-    // Partial bytes match - need full comparison
-    if partial_hash.len() < 8 {
-        // Compute full hash from entry key
+    if entry_hash.is_empty() {
+        // No hash stored - compute full hash from entry key
         let entry_full_hash = crate::key::hash_key(&entry_key);
         match full_hash.cmp(&entry_full_hash) {
             Ordering::Equal => query_key.cmp(entry_key),
             ord => ord,
         }
     } else {
-        // Full hash stored - just compare keys
-        query_key.cmp(entry_key)
+        // Full 8-byte hash stored - compare hashes first
+        let full_hash_bytes = full_hash.to_be_bytes();
+        match full_hash_bytes[..].cmp(entry_hash) {
+            Ordering::Equal => query_key.cmp(entry_key),
+            ord => ord,
+        }
     }
 }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -216,9 +216,22 @@ impl StaticSortedFile {
         key: &K,
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
+        let hash_len = block.read_u8()?;
         let entry_count = block.read_u24::<BE>()? as usize;
         let offsets = &block[..entry_count * 4];
         let entries = &block[entry_count * 4..];
+
+        // Mask the search hash to only compare stored bytes (high bytes in BE)
+        // When hash_len >= 8, use full hash; otherwise mask to stored bytes
+        let masked_key_hash = if hash_len >= 8 {
+            key_hash
+        } else if hash_len == 0 {
+            0
+        } else {
+            // Mask to keep only the first hash_len bytes (high bytes in BE)
+            let mask = !((1u64 << ((8 - hash_len) * 8)) - 1);
+            key_hash & mask
+        };
 
         let mut l = 0;
         let mut r = entry_count;
@@ -230,8 +243,24 @@ impl StaticSortedFile {
                 key: mid_key,
                 ty,
                 val: mid_val,
-            } = get_key_entry(offsets, entries, entry_count, m)?;
-            match key_hash.cmp(&mid_hash).then_with(|| key.cmp(mid_key)) {
+            } = get_key_entry(offsets, entries, entry_count, m, hash_len)?;
+
+            // When hash_len < 8, we need to compute full hash from entry's key for proper comparison
+            // Entries are sorted by full hash, so we must compare full hashes
+            let comparison = if hash_len < 8 {
+                // Partial hash match (or no hash) - compute full hash from key data
+                if masked_key_hash == mid_hash {
+                    let full_entry_hash = crate::key::hash_key(&mid_key);
+                    key_hash.cmp(&full_entry_hash).then_with(|| key.cmp(mid_key))
+                } else {
+                    masked_key_hash.cmp(&mid_hash)
+                }
+            } else {
+                // Full hash stored - compare directly
+                key_hash.cmp(&mid_hash).then_with(|| key.cmp(mid_key))
+            };
+
+            match comparison {
                 Ordering::Less => {
                     r = m;
                 }
@@ -429,6 +458,7 @@ struct CurrentKeyBlock {
     entries: ArcSlice<u8>,
     entry_count: usize,
     index: usize,
+    hash_len: u8,
 }
 
 struct CurrentIndexBlock {
@@ -462,9 +492,10 @@ impl<'l> StaticSortedFileIter<'l> {
                 });
             }
             BLOCK_TYPE_KEY => {
+                let hash_len = block.read_u8()?;
                 let entry_count = block.read_u24::<BE>()? as usize;
-                let offsets_range = 4..4 + entry_count * 4;
-                let entries_range = 4 + entry_count * 4..block_arc.len();
+                let offsets_range = 5..5 + entry_count * 4;
+                let entries_range = 5 + entry_count * 4..block_arc.len();
                 let offsets = block_arc.clone().slice(offsets_range);
                 let entries = block_arc.slice(entries_range);
                 self.current_key_block = Some(CurrentKeyBlock {
@@ -472,6 +503,7 @@ impl<'l> StaticSortedFileIter<'l> {
                     entries,
                     entry_count,
                     index: 0,
+                    hash_len,
                 });
             }
             _ => {
@@ -489,10 +521,17 @@ impl<'l> StaticSortedFileIter<'l> {
                 entries,
                 entry_count,
                 index,
+                hash_len,
             }) = self.current_key_block.take()
             {
                 let GetKeyEntryResult { hash, key, ty, val } =
-                    get_key_entry(&offsets, &entries, entry_count, index)?;
+                    get_key_entry(&offsets, &entries, entry_count, index, hash_len)?;
+                // If hash_len < 8, we need to compute the full hash from key data
+                let full_hash = if hash_len < 8 {
+                    crate::key::hash_key(&key)
+                } else {
+                    hash
+                };
                 let value = if ty == KEY_BLOCK_ENTRY_TYPE_MEDIUM {
                     let mut val = val;
                     let block = val.read_u16::<BE>()?;
@@ -508,7 +547,7 @@ impl<'l> StaticSortedFileIter<'l> {
                     LazyLookupValue::Eager(value)
                 };
                 let entry = LookupEntry {
-                    hash,
+                    hash: full_hash,
                     // Safety: The key is a valid slice of the entries.
                     key: unsafe { ArcSlice::new_unchecked(key, ArcSlice::full_arc(&entries)) },
                     value,
@@ -519,6 +558,7 @@ impl<'l> StaticSortedFileIter<'l> {
                         entries,
                         entry_count,
                         index: index + 1,
+                        hash_len,
                     });
                 }
                 return Ok(Some(entry));
@@ -558,7 +598,9 @@ fn get_key_entry<'l>(
     entries: &'l [u8],
     entry_count: usize,
     index: usize,
+    hash_len: u8,
 ) -> Result<GetKeyEntryResult<'l>> {
+    let hash_len_usize = hash_len as usize;
     let mut offset = &offsets[index * 4..];
     let ty = offset.read_u8()?;
     let start = offset.read_u24::<BE>()? as usize;
@@ -567,29 +609,36 @@ fn get_key_entry<'l>(
     } else {
         (&offsets[(index + 1) * 4 + 1..]).read_u24::<BE>()? as usize
     };
-    let hash = (&entries[start..start + 8]).read_u64::<BE>()?;
+    // Read partial hash and extend to u64 (stored bytes are the high bytes in BE order)
+    let hash = if hash_len == 0 {
+        0
+    } else {
+        let mut hash_bytes = [0u8; 8];
+        hash_bytes[..hash_len_usize].copy_from_slice(&entries[start..start + hash_len_usize]);
+        u64::from_be_bytes(hash_bytes)
+    };
     Ok(match ty {
         KEY_BLOCK_ENTRY_TYPE_SMALL => GetKeyEntryResult {
             hash,
-            key: &entries[start + 8..end - 8],
+            key: &entries[start + hash_len_usize..end - 8],
             ty,
             val: &entries[end - 8..end],
         },
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => GetKeyEntryResult {
             hash,
-            key: &entries[start + 8..end - 2],
+            key: &entries[start + hash_len_usize..end - 2],
             ty,
             val: &entries[end - 2..end],
         },
         KEY_BLOCK_ENTRY_TYPE_BLOB => GetKeyEntryResult {
             hash,
-            key: &entries[start + 8..end - 4],
+            key: &entries[start + hash_len_usize..end - 4],
             ty,
             val: &entries[end - 4..end],
         },
         KEY_BLOCK_ENTRY_TYPE_DELETED => GetKeyEntryResult {
             hash,
-            key: &entries[start + 8..end],
+            key: &entries[start + hash_len_usize..end],
             ty,
             val: &[],
         },

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -45,6 +45,20 @@ const COMPRESSION_DICTIONARY_SAMPLE_PER_ENTRY: usize = 100;
 /// The minimum bytes that are used per key entry for a sample.
 const MIN_COMPRESSION_DICTIONARY_SAMPLE_PER_ENTRY: usize = 16;
 
+/// Computes the number of hash bytes to store per entry based on max key length and entry count.
+fn compute_hash_len(max_key_len: usize, entry_count: usize) -> u8 {
+    if max_key_len <= 8 {
+        0 // No hash needed, key data fits in 8 bytes
+    } else if max_key_len > 128 {
+        8 // Full hash for long keys
+    } else {
+        // Enough bytes to have good collision avoidance
+        // log2(entry_count) bits + 8 bits margin, rounded up to bytes
+        let bits_needed = (entry_count as f64).log2().ceil() as u32 + 8;
+        ((bits_needed + 7) / 8).min(8) as u8
+    }
+}
+
 /// Trait for entries from that SST files can be created
 pub trait Entry {
     /// Returns the hash of the key
@@ -431,9 +445,11 @@ fn write_key_blocks_and_compute_amqf(
     }
     let mut current_block_start = 0;
     let mut current_block_size = 0;
+    let mut current_block_max_key_len = 0;
     let mut last_hash = 0;
     for (i, entry) in entries.iter().enumerate() {
         let key_hash = entry.key_hash();
+        let key_len = entry.key_len();
 
         // Add to AMQF
         filter
@@ -443,13 +459,15 @@ fn write_key_blocks_and_compute_amqf(
 
         // Accumulate until the block is full
         if current_block_size > 0
-                && (current_block_size + entry.key_len() + KEY_BLOCK_ENTRY_META_OVERHEAD
+                && (current_block_size + key_len + KEY_BLOCK_ENTRY_META_OVERHEAD
                     > MAX_KEY_BLOCK_SIZE
                     || i - current_block_start >= MAX_KEY_BLOCK_ENTRIES) &&
                     // avoid breaking the block in the middle of a hash conflict
                     last_hash != key_hash
         {
-            let mut block = KeyBlockBuilder::new(buffer, (i - current_block_start) as u32);
+            let entry_count = i - current_block_start;
+            let hash_len = compute_hash_len(current_block_max_key_len, entry_count);
+            let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, hash_len);
             for j in current_block_start..i {
                 let entry = &entries[j];
                 let value_location = &value_locations[j];
@@ -463,15 +481,19 @@ fn write_key_blocks_and_compute_amqf(
             writer.write_key_block(buffer, key_compression_dictionary)?;
             buffer.clear();
             current_block_size = 0;
+            current_block_max_key_len = 0;
             current_block_start = i;
         }
         current_block_size += entry.key_len() + KEY_BLOCK_ENTRY_META_OVERHEAD;
+        current_block_max_key_len = current_block_max_key_len.max(key_len);
         last_hash = key_hash;
     }
 
     // Finish the last block
     if current_block_size > 0 {
-        let mut block = KeyBlockBuilder::new(buffer, (entries.len() - current_block_start) as u32);
+        let entry_count = entries.len() - current_block_start;
+        let hash_len = compute_hash_len(current_block_max_key_len, entry_count);
+        let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, hash_len);
         for j in current_block_start..entries.len() {
             let entry = &entries[j];
             let value_location = &value_locations[j];
@@ -510,20 +532,23 @@ fn write_key_blocks_and_compute_amqf(
 pub struct KeyBlockBuilder<'l> {
     current_entry: usize,
     header_size: usize,
+    hash_len: u8,
     buffer: &'l mut Vec<u8>,
 }
 
-/// The size of the key block header.
-const KEY_BLOCK_HEADER_SIZE: usize = 4;
+/// The size of the key block header (block type + hash_len + entry count).
+const KEY_BLOCK_HEADER_SIZE: usize = 5;
 
 impl<'l> KeyBlockBuilder<'l> {
     /// Creates a new key block builder for the number of entries.
-    pub fn new(buffer: &'l mut Vec<u8>, entry_count: u32) -> Self {
+    pub fn new(buffer: &'l mut Vec<u8>, entry_count: u32, hash_len: u8) -> Self {
         debug_assert!(entry_count < (1 << 24));
+        debug_assert!(hash_len <= 8);
 
         const ESTIMATED_KEY_SIZE: usize = 16;
         buffer.reserve(entry_count as usize * ESTIMATED_KEY_SIZE);
         buffer.write_u8(BLOCK_TYPE_KEY).unwrap();
+        buffer.write_u8(hash_len).unwrap();
         buffer.write_u24::<BE>(entry_count).unwrap();
         for _ in 0..entry_count {
             buffer.write_u32::<BE>(0).unwrap();
@@ -531,8 +556,16 @@ impl<'l> KeyBlockBuilder<'l> {
         Self {
             current_entry: 0,
             header_size: buffer.len(),
+            hash_len,
             buffer,
         }
+    }
+
+    /// Writes the first `hash_len` bytes of the hash (big-endian order).
+    fn write_hash<E: Entry>(&mut self, entry: &E) {
+        let hash_bytes = entry.key_hash().to_be_bytes();
+        self.buffer
+            .extend_from_slice(&hash_bytes[..self.hash_len as usize]);
     }
 
     /// Writes a small-sized value to the buffer.
@@ -548,7 +581,7 @@ impl<'l> KeyBlockBuilder<'l> {
         let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_SMALL as u32) << 24);
         BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
 
-        self.buffer.write_u64::<BE>(entry.key_hash()).unwrap();
+        self.write_hash(entry);
         entry.write_key_to(self.buffer);
         self.buffer.write_u16::<BE>(value_block).unwrap();
         self.buffer.write_u16::<BE>(value_size).unwrap();
@@ -564,7 +597,7 @@ impl<'l> KeyBlockBuilder<'l> {
         let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_MEDIUM as u32) << 24);
         BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
 
-        self.buffer.write_u64::<BE>(entry.key_hash()).unwrap();
+        self.write_hash(entry);
         entry.write_key_to(self.buffer);
         self.buffer.write_u16::<BE>(value_block).unwrap();
 
@@ -578,7 +611,7 @@ impl<'l> KeyBlockBuilder<'l> {
         let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_DELETED as u32) << 24);
         BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
 
-        self.buffer.write_u64::<BE>(entry.key_hash()).unwrap();
+        self.write_hash(entry);
         entry.write_key_to(self.buffer);
 
         self.current_entry += 1;
@@ -591,7 +624,7 @@ impl<'l> KeyBlockBuilder<'l> {
         let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_BLOB as u32) << 24);
         BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
 
-        self.buffer.write_u64::<BE>(entry.key_hash()).unwrap();
+        self.write_hash(entry);
         entry.write_key_to(self.buffer);
         self.buffer.write_u32::<BE>(blob).unwrap();
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -45,18 +45,9 @@ const COMPRESSION_DICTIONARY_SAMPLE_PER_ENTRY: usize = 100;
 /// The minimum bytes that are used per key entry for a sample.
 const MIN_COMPRESSION_DICTIONARY_SAMPLE_PER_ENTRY: usize = 16;
 
-/// Computes the number of hash bytes to store per entry based on max key length and entry count.
-fn compute_hash_len(max_key_len: usize, entry_count: usize) -> u8 {
-    if max_key_len <= 8 {
-        0 // No hash needed, key data fits in 8 bytes
-    } else if max_key_len > 128 {
-        8 // Full hash for long keys
-    } else {
-        // Enough bytes to have good collision avoidance
-        // log2(entry_count) bits + 8 bits margin, rounded up to bytes
-        let bits_needed = (entry_count as f64).log2().ceil() as u32 + 8;
-        bits_needed.div_ceil(8).min(8) as u8
-    }
+/// Determines whether to store the hash per entry based on max key length.
+fn use_hash(max_key_len: usize) -> bool {
+    max_key_len > 32
 }
 
 /// Trait for entries from that SST files can be created
@@ -466,8 +457,8 @@ fn write_key_blocks_and_compute_amqf(
                     last_hash != key_hash
         {
             let entry_count = i - current_block_start;
-            let hash_len = compute_hash_len(current_block_max_key_len, entry_count);
-            let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, hash_len);
+            let has_hash = use_hash(current_block_max_key_len);
+            let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, has_hash);
             for j in current_block_start..i {
                 let entry = &entries[j];
                 let value_location = &value_locations[j];
@@ -492,8 +483,8 @@ fn write_key_blocks_and_compute_amqf(
     // Finish the last block
     if current_block_size > 0 {
         let entry_count = entries.len() - current_block_start;
-        let hash_len = compute_hash_len(current_block_max_key_len, entry_count);
-        let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, hash_len);
+        let has_hash = use_hash(current_block_max_key_len);
+        let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, has_hash);
         for j in current_block_start..entries.len() {
             let entry = &entries[j];
             let value_location = &value_locations[j];
@@ -532,7 +523,7 @@ fn write_key_blocks_and_compute_amqf(
 pub struct KeyBlockBuilder<'l> {
     current_entry: usize,
     header_size: usize,
-    hash_len: u8,
+    has_hash: bool,
     buffer: &'l mut Vec<u8>,
 }
 
@@ -541,14 +532,13 @@ const KEY_BLOCK_HEADER_SIZE: usize = 5;
 
 impl<'l> KeyBlockBuilder<'l> {
     /// Creates a new key block builder for the number of entries.
-    pub fn new(buffer: &'l mut Vec<u8>, entry_count: u32, hash_len: u8) -> Self {
+    pub fn new(buffer: &'l mut Vec<u8>, entry_count: u32, has_hash: bool) -> Self {
         debug_assert!(entry_count < (1 << 24));
-        debug_assert!(hash_len <= 8);
 
         const ESTIMATED_KEY_SIZE: usize = 16;
         buffer.reserve(entry_count as usize * ESTIMATED_KEY_SIZE);
         buffer.write_u8(BLOCK_TYPE_KEY).unwrap();
-        buffer.write_u8(hash_len).unwrap();
+        buffer.write_u8(has_hash as u8).unwrap();
         buffer.write_u24::<BE>(entry_count).unwrap();
         for _ in 0..entry_count {
             buffer.write_u32::<BE>(0).unwrap();
@@ -556,16 +546,17 @@ impl<'l> KeyBlockBuilder<'l> {
         Self {
             current_entry: 0,
             header_size: buffer.len(),
-            hash_len,
+            has_hash,
             buffer,
         }
     }
 
-    /// Writes the first `hash_len` bytes of the hash (big-endian order).
+    /// Writes the 8-byte hash if `has_hash` is true.
     fn write_hash<E: Entry>(&mut self, entry: &E) {
-        let hash_bytes = entry.key_hash().to_be_bytes();
-        self.buffer
-            .extend_from_slice(&hash_bytes[..self.hash_len as usize]);
+        if self.has_hash {
+            let hash_bytes = entry.key_hash().to_be_bytes();
+            self.buffer.extend_from_slice(&hash_bytes);
+        }
     }
 
     /// Writes a small-sized value to the buffer.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -14,8 +14,9 @@ use crate::{
     compression::compress_into_buffer,
     meta_file::{AmqfBincodeWrapper, MetaEntryFlags},
     static_sorted_file::{
-        BLOCK_TYPE_INDEX, BLOCK_TYPE_KEY, KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_DELETED,
-        KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
+        BLOCK_TYPE_INDEX, BLOCK_TYPE_KEY_NO_HASH, BLOCK_TYPE_KEY_WITH_HASH,
+        KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_DELETED, KEY_BLOCK_ENTRY_TYPE_MEDIUM,
+        KEY_BLOCK_ENTRY_TYPE_SMALL,
     },
 };
 
@@ -527,8 +528,8 @@ pub struct KeyBlockBuilder<'l> {
     buffer: &'l mut Vec<u8>,
 }
 
-/// The size of the key block header (block type + hash_len + entry count).
-const KEY_BLOCK_HEADER_SIZE: usize = 5;
+/// The size of the key block header (block type + entry count).
+const KEY_BLOCK_HEADER_SIZE: usize = 4;
 
 impl<'l> KeyBlockBuilder<'l> {
     /// Creates a new key block builder for the number of entries.
@@ -537,8 +538,12 @@ impl<'l> KeyBlockBuilder<'l> {
 
         const ESTIMATED_KEY_SIZE: usize = 16;
         buffer.reserve(entry_count as usize * ESTIMATED_KEY_SIZE);
-        buffer.write_u8(BLOCK_TYPE_KEY).unwrap();
-        buffer.write_u8(has_hash as u8).unwrap();
+        let block_type = if has_hash {
+            BLOCK_TYPE_KEY_WITH_HASH
+        } else {
+            BLOCK_TYPE_KEY_NO_HASH
+        };
+        buffer.write_u8(block_type).unwrap();
         buffer.write_u24::<BE>(entry_count).unwrap();
         for _ in 0..entry_count {
             buffer.write_u32::<BE>(0).unwrap();

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -55,7 +55,7 @@ fn compute_hash_len(max_key_len: usize, entry_count: usize) -> u8 {
         // Enough bytes to have good collision avoidance
         // log2(entry_count) bits + 8 bits margin, rounded up to bytes
         let bits_needed = (entry_count as f64).log2().ceil() as u32 + 8;
-        ((bits_needed + 7) / 8).min(8) as u8
+        bits_needed.div_ceil(8).min(8) as u8
     }
 }
 


### PR DESCRIPTION
### What?

Change the SST format to allow a variable hash len.
For short keys avoid storing the hashes and recompute them on demand instead.
For short keys use bit rotation instead of a real hash.

This avoid wasting storage for hashes which can be cheaply recomputed