### PR TITLE
Turbopack: unignore module evaluation frames at the start

### DIFF
--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -164,6 +164,25 @@ function ignoreListAnonymousStackFramesIfSandwiched(
   )
 }
 
+function unignoreModuleEvaluationFramesIfLeading(
+  sourceMappedFrames: Array<{
+    stack: IgnorableStackFrame
+    code: string | null
+  }>
+): void {
+  // Un-ignore "module evaluation" frames at the top of the stack
+  // when there are no non-ignored frames before them.
+  // These frames represent meaningful error locations during module initialization.
+  for (const frame of sourceMappedFrames) {
+    if (!frame.stack.ignored) {
+      break
+    }
+    if (frame.stack.methodName === 'module evaluation') {
+      frame.stack.ignored = false
+    }
+  }
+}
+
 /**
  * @param frame
  * @param sourceMapCache
@@ -418,6 +437,7 @@ function parseAndSourceMap(
   }
 
   ignoreListAnonymousStackFramesIfSandwiched(sourceMappedFrames)
+  unignoreModuleEvaluationFramesIfLeading(sourceMappedFrames)
 
   let sourceMappedStack = ''
   for (let i = 0; i < sourceMappedFrames.length; i++) {


### PR DESCRIPTION
### What?

Un-ignore "module evaluation" stack frames when they appear at the top (leading position) of an error stack trace in Turbopack dev server output.

### Why?

When an error occurs during module initialization (e.g., a top-level throw in a module), the stack trace's top frames are "module evaluation" frames. These frames are potentially on the ignore list because they are inside of `node_modules`. However, when they are the *leading* frames in a stack trace (no non-ignored frames above them), they represent the actual meaningful error location. Hiding them makes it harder to debug module-level errors since the user sees no useful location information at the top of the trace.

### How?

Added a new `unignoreModuleEvaluationFramesIfLeading()` function in `packages/next/src/server/patch-error-inspect.ts` that iterates through source-mapped frames from the top of the stack. For each leading ignored frame, if its method name is `"module evaluation"`, it marks it as not ignored. The iteration stops as soon as a non-ignored frame is encountered, ensuring only truly leading module evaluation frames are un-ignored.

This runs as a post-processing step after the existing `ignoreListAnonymousStackFramesIfSandwiched()` call.