### PR TITLE
Enable pnpm dependency caching in e2e deploy tests

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -85,11 +85,6 @@ on:
         required: false
         type: string
         default: 'chromium'
-      enablePnpmCache:
-        description: 'Whether to enable pnpm store caching (useful for GitHub-hosted runners)'
-        required: false
-        type: string
-        default: ''
 env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.5.5
@@ -205,15 +200,14 @@ jobs:
         with:
           fetch-depth: 25
 
-      # Cache pnpm store when enabled and running on GitHub-hosted runners
-      # (self-hosted runners have their own persistent storage)
+      # Cache pnpm store on GitHub-hosted runners (self-hosted runners have their own persistent storage)
       - name: Get pnpm store directory
-        if: ${{ inputs.enablePnpmCache == 'yes' && contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
         id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        if: ${{ inputs.enablePnpmCache == 'yes' && contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
         uses: actions/cache@v4
         timeout-minutes: 5
         id: cache-pnpm-store

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -200,21 +200,6 @@ jobs:
         with:
           fetch-depth: 25
 
-      # Cache pnpm store for GitHub-hosted ubuntu runners (must be after checkout for hashFiles)
-      - name: Get pnpm store directory
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
-        id: get-store-path
-        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
-
-      - name: Cache pnpm store
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        id: cache-pnpm-store
-        with:
-          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
-          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
-
       # local action -> needs to run after checkout
       - name: Install Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -202,12 +202,12 @@ jobs:
 
       # Cache pnpm store on GitHub-hosted runners (self-hosted runners have their own persistent storage)
       - name: Get pnpm store directory
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        if: ${{ runner.environment == 'github-hosted' }}
         id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        if: ${{ runner.environment == 'github-hosted' }}
         uses: actions/cache@v4
         timeout-minutes: 5
         id: cache-pnpm-store

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -85,6 +85,11 @@ on:
         required: false
         type: string
         default: 'chromium'
+      enablePnpmCache:
+        description: 'Whether to enable pnpm store caching (useful for GitHub-hosted runners)'
+        required: false
+        type: string
+        default: ''
 env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.5.5
@@ -199,6 +204,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 25
+
+      # Cache pnpm store when enabled (must be after checkout for hashFiles)
+      - name: Get pnpm store directory
+        if: ${{ inputs.enablePnpmCache == 'yes' }}
+        id: get-store-path
+        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        if: ${{ inputs.enablePnpmCache == 'yes' }}
+        uses: actions/cache@v4
+        timeout-minutes: 5
+        id: cache-pnpm-store
+        with:
+          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
+          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
 
       # local action -> needs to run after checkout
       - name: Install Rust

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -214,6 +214,7 @@ jobs:
         with:
           path: ${{ steps.get-store-path.outputs.STORE_PATH }}
           key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+          # Do not use restore-keys since it leads to indefinite growth of the cache.
 
       # local action -> needs to run after checkout
       - name: Install Rust

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -205,14 +205,15 @@ jobs:
         with:
           fetch-depth: 25
 
-      # Cache pnpm store when enabled (must be after checkout for hashFiles)
+      # Cache pnpm store when enabled and running on GitHub-hosted runners
+      # (self-hosted runners have their own persistent storage)
       - name: Get pnpm store directory
-        if: ${{ inputs.enablePnpmCache == 'yes' }}
+        if: ${{ inputs.enablePnpmCache == 'yes' && contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
         id: get-store-path
         run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
 
       - name: Cache pnpm store
-        if: ${{ inputs.enablePnpmCache == 'yes' }}
+        if: ${{ inputs.enablePnpmCache == 'yes' && contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
         uses: actions/cache@v4
         timeout-minutes: 5
         id: cache-pnpm-store

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -200,6 +200,21 @@ jobs:
         with:
           fetch-depth: 25
 
+      # Cache pnpm store for GitHub-hosted ubuntu runners (must be after checkout for hashFiles)
+      - name: Get pnpm store directory
+        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        id: get-store-path
+        run: echo STORE_PATH=$(pnpm store path) >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        if: ${{ contains(fromJson(inputs.runs_on_labels), 'ubuntu-latest') }}
+        uses: actions/cache@v4
+        timeout-minutes: 5
+        id: cache-pnpm-store
+        with:
+          path: ${{ steps.get-store-path.outputs.STORE_PATH }}
+          key: pnpm-store-v2-${{ hashFiles('pnpm-lock.yaml') }}
+
       # local action -> needs to run after checkout
       - name: Install Rust
         uses: ./.github/actions/setup-rust

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -88,6 +88,7 @@ jobs:
       stepName: 'test-deploy-${{ matrix.group }}'
       timeout_minutes: 180
       runs_on_labels: '["ubuntu-latest"]'
+      enablePnpmCache: 'yes'
       overrideProxyAddress: ${{ inputs.overrideProxyAddress || '' }}
 
   test-deploy-adapter:

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -88,7 +88,6 @@ jobs:
       stepName: 'test-deploy-${{ matrix.group }}'
       timeout_minutes: 180
       runs_on_labels: '["ubuntu-latest"]'
-      enablePnpmCache: 'yes'
       overrideProxyAddress: ${{ inputs.overrideProxyAddress || '' }}
 
   test-deploy-adapter:


### PR DESCRIPTION
Adds pnpm dependency caching to the e2e deploy test workflow. Basically all workflows using build_reusable in a GitHub hosted runners now get pnpm dependency caching. Self-hosted runners relied on the persisted worker environment.

It's also nice for forks/mirrors that use GitHub-hosted runners.

For e2e deploy test this is mostly relevant for a retry. Right now the lockfile changes for every release anyway since we have to use exact versions in the package.json (which change for every release). Ideally we'd use `workspace:*` and `pnpm publish` to avoid lockfile changes on release.

### test plan

- [x] [e2e deploy tests get cached dependencies on retry](https://github.com/vercel/next.js/actions/runs/21353951846/job/61456884599#step:14:41) (cache hit on 1st attempt because we already had a cache entry for this lockfile)
- [x] [build_and_test does not use actions/cache](https://github.com/vercel/next.js/actions/runs/21353640715/job/61456303806?pr=88953)

---
[Slack Thread](https://vercel.slack.com/archives/D0A6SL1TGVA/p1769177717239639?thread_ts=1769177717.239639&cid=D0A6SL1TGVA)

<a href="https://cursor.com/background-agent?bcId=bc-7bb4fe61-31eb-44f2-b5fd-493ffcf2911c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7bb4fe61-31eb-44f2-b5fd-493ffcf2911c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

