### PR TITLE
Turbopack: use special hasher for short keys

### DIFF
--- a/turbopack/crates/turbo-persistence/src/key.rs
+++ b/turbopack/crates/turbo-persistence/src/key.rs
@@ -200,11 +200,50 @@ impl<T: StoreKey> StoreKey for &'_ T {
     }
 }
 
+/// A hasher for short keys (len <= 8) that collects bytes directly into a [u8; 8].
+struct ShortKeyHasher {
+    bytes: [u8; 8],
+    pos: usize,
+}
+
+impl ShortKeyHasher {
+    fn new() -> Self {
+        Self {
+            bytes: [0u8; 8],
+            pos: 0,
+        }
+    }
+}
+
+impl Hasher for ShortKeyHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        for &b in bytes {
+            if self.pos < 8 {
+                self.bytes[self.pos] = b;
+                self.pos += 1;
+            }
+        }
+    }
+
+    fn finish(&self) -> u64 {
+        // Convert bytes to u64 and rotate right by 2 bits
+        // This moves the 2 LSBs to become the 2 MSBs
+        u64::from_be_bytes(self.bytes).rotate_right(2 + 8 * (8 - self.pos as u32))
+    }
+}
+
 /// Hashes a key with a fast, deterministic hash function.
 pub fn hash_key(key: &impl KeyBase) -> u64 {
-    let mut hasher = twox_hash::XxHash64::with_seed(0);
-    key.hash(&mut hasher);
-    hasher.finish()
+    let key_len = key.len();
+    if key_len <= 8 {
+        let mut hasher = ShortKeyHasher::new();
+        key.hash(&mut hasher);
+        hasher.finish()
+    } else {
+        let mut hasher = twox_hash::XxHash64::with_seed(0);
+        key.hash(&mut hasher);
+        hasher.finish()
+    }
 }
 
 #[cfg(test)]
@@ -230,10 +269,71 @@ mod tests {
 
     #[test]
     fn hash() {
+        // Small keys (len <= 8) - uses ShortKeyHasher
         let h1 = hash_key(&[1, 2, 3, 4]);
         let h2 = hash_key(&(&[1, 2], &[3, 4]));
         let h3 = hash_key(&(vec![1, 2, 3], 4u8));
         assert_eq!(h2, h1);
         assert_eq!(h3, h1);
+
+        // Exactly 8 bytes - still uses ShortKeyHasher
+        let h4 = hash_key(&[1, 2, 3, 4, 5, 6, 7, 8]);
+        let h5 = hash_key(&(&[1, 2, 3, 4], &[5, 6, 7, 8]));
+        assert_eq!(h5, h4);
+
+        // Big keys (len > 8) - uses XxHash64
+        let h6 = hash_key(&[1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        let h7 = hash_key(&(&[1, 2, 3, 4, 5], &[6, 7, 8, 9]));
+        assert_eq!(h7, h6);
+
+        // Longer key
+        let h8 = hash_key(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
+        let h9 = hash_key(&(&[1, 2, 3, 4, 5, 6, 7, 8], &[9, 10, 11, 12, 13, 14, 15, 16]));
+        assert_eq!(h9, h8);
+    }
+
+    #[test]
+    fn hash_short_keys_exact_values() {
+        // Test exact hash values for short keys of various lengths (0-8 bytes)
+        // Values computed as: u64::from_be_bytes([bytes padded with zeros]).rotate_right(2)
+
+        // Empty key (0 bytes)
+        assert_eq!(hash_key(&[0u8; 0]), 0x0000_0000_0000_0000);
+
+        // 1 byte
+        assert_eq!(hash_key(&[0x01]), 0x4000_0000_0000_0000);
+
+        // 2 bytes
+        assert_eq!(hash_key(&[0x01, 0x02]), 0x8000_0000_0000_0040);
+
+        // 3 bytes
+        assert_eq!(hash_key(&[0x01, 0x02, 0x03]), 0xC000_0000_0000_4080);
+
+        // 4 bytes
+        assert_eq!(hash_key(&[0x01, 0x02, 0x03, 0x04]), 0x0000_0000_0040_80C1);
+
+        // 5 bytes
+        assert_eq!(
+            hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05]),
+            0x4000_0000_4080_C101
+        );
+
+        // 6 bytes
+        assert_eq!(
+            hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
+            0x8000_0040_80C1_0141
+        );
+
+        // 7 bytes
+        assert_eq!(
+            hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
+            0xC000_4080_C101_4181
+        );
+
+        // 8 bytes
+        assert_eq!(
+            hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
+            0x0040_80C1_0141_81C2
+        );
     }
 }

--- a/turbopack/crates/turbo-persistence/src/key.rs
+++ b/turbopack/crates/turbo-persistence/src/key.rs
@@ -226,9 +226,24 @@ impl Hasher for ShortKeyHasher {
     }
 
     fn finish(&self) -> u64 {
-        // Convert bytes to u64 and rotate right by 2 bits
-        // This moves the 2 LSBs to become the 2 MSBs
-        u64::from_be_bytes(self.bytes).rotate_right(2 + 8 * (8 - self.pos as u32))
+        // Convert collected bytes to u64 (big-endian: first byte is most significant)
+        let raw = u64::from_be_bytes(self.bytes);
+
+        // Rotate right by (8 - pos) bytes to align the key bytes to the LSB side.
+        // This makes trailing zeros significant: [1] and [1, 0] produce different hashes
+        // because they have different pos values and thus different rotations.
+        let shift = 8 * (8 - self.pos as u32);
+        let rotated = raw.rotate_right(shift);
+
+        // Create bit-reversed version for mixing.
+        // reverse_bits() mirrors all 64 bits: bit 0 ↔ bit 63, bit 1 ↔ bit 62, etc.
+        let reversed = rotated.reverse_bits();
+
+        // Interleave bits from original and reversed using mask 0xCCCC...
+        // Binary: 0xC = 1100, so this selects bits 2-3, 6-7, 10-11, ... from each nibble.
+        // Each output nibble gets bits 2-3 from original OR'd with bits 2-3 from reversed,
+        // combining nearby bits with their distant mirror positions for better distribution.
+        (rotated & 0xCCCC_CCCC_CCCC_CCCC) | (reversed & 0xCCCC_CCCC_CCCC_CCCC)
     }
 }
 
@@ -295,45 +310,48 @@ mod tests {
     #[test]
     fn hash_short_keys_exact_values() {
         // Test exact hash values for short keys of various lengths (0-8 bytes)
-        // Values computed as: u64::from_be_bytes([bytes padded with zeros]).rotate_right(2)
+        // Values computed using bit interleaving
 
         // Empty key (0 bytes)
         assert_eq!(hash_key(&[0u8; 0]), 0x0000_0000_0000_0000);
 
         // 1 byte
-        assert_eq!(hash_key(&[0x01]), 0x4000_0000_0000_0000);
+        assert_eq!(hash_key(&[0x01]), 0x8000_0000_0000_0000);
+        assert_eq!(hash_key(&[0x02]), 0x4000_0000_0000_0000);
+        assert_eq!(hash_key(&[0x04]), 0x0000_0000_0000_0004);
+        assert_eq!(hash_key(&[0x08]), 0x0000_0000_0000_0008);
 
         // 2 bytes
-        assert_eq!(hash_key(&[0x01, 0x02]), 0x8000_0000_0000_0040);
+        assert_eq!(hash_key(&[0x01, 0x02]), 0x4080_0000_0000_0000);
 
         // 3 bytes
-        assert_eq!(hash_key(&[0x01, 0x02, 0x03]), 0xC000_0000_0000_4080);
+        assert_eq!(hash_key(&[0x01, 0x02, 0x03]), 0xC040_8000_0000_0000);
 
         // 4 bytes
-        assert_eq!(hash_key(&[0x01, 0x02, 0x03, 0x04]), 0x0000_0000_0040_80C1);
+        assert_eq!(hash_key(&[0x01, 0x02, 0x03, 0x04]), 0x00C0_4080_0000_0004);
 
         // 5 bytes
         assert_eq!(
             hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05]),
-            0x4000_0000_4080_C101
+            0x8000_C040_8000_0404
         );
 
         // 6 bytes
         assert_eq!(
             hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06]),
-            0x8000_0040_80C1_0141
+            0x4080_00C0_4084_0404
         );
 
         // 7 bytes
         assert_eq!(
             hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]),
-            0xC000_4080_C101_4181
+            0xC040_8000_C444_8404
         );
 
         // 8 bytes
         assert_eq!(
             hash_key(&[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08]),
-            0x0040_80C1_0141_81C2
+            0x00C0_4084_04C4_4488
         );
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -41,7 +41,7 @@ struct IntKey([u8; 4]);
 
 impl IntKey {
     fn new(value: u32) -> Self {
-        Self(value.to_le_bytes())
+        Self(value.to_be_bytes())
     }
 }
 
@@ -52,7 +52,7 @@ impl AsRef<[u8]> for IntKey {
 }
 
 fn as_u32(bytes: impl Borrow<[u8]>) -> Result<u32> {
-    let n = u32::from_le_bytes(bytes.borrow().try_into()?);
+    let n = u32::from_be_bytes(bytes.borrow().try_into()?);
     Ok(n)
 }
 
@@ -326,7 +326,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                                     .put(
                                         KeySpace::TaskCache,
                                         WriteBuffer::Borrowed(&task_type_bytes),
-                                        WriteBuffer::Borrowed(&task_id.to_le_bytes()),
+                                        WriteBuffer::Borrowed(&task_id.to_be_bytes()),
                                     )
                                     .with_context(|| {
                                         format!(
@@ -409,7 +409,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                             .put(
                                 KeySpace::TaskCache,
                                 WriteBuffer::Borrowed(&task_type_bytes),
-                                WriteBuffer::Borrowed(&task_id.to_le_bytes()),
+                                WriteBuffer::Borrowed(&task_id.to_be_bytes()),
                             )
                             .with_context(|| {
                                 format!("Unable to write task cache {task_type:?} => {task_id}")
@@ -463,7 +463,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
                 return Ok(None);
             };
             let bytes = bytes.borrow().try_into()?;
-            let id = TaskId::try_from(u32::from_le_bytes(bytes)).unwrap();
+            let id = TaskId::try_from(u32::from_be_bytes(bytes)).unwrap();
             Ok(Some(id))
         }
         if inner.database.is_empty() {
@@ -565,7 +565,7 @@ where
             KeySpace::Infra,
             IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref(),
         )? {
-            Some(bytes) => u32::from_le_bytes(Borrow::<[u8]>::borrow(&bytes).try_into()?),
+            Some(bytes) => u32::from_be_bytes(Borrow::<[u8]>::borrow(&bytes).try_into()?),
             None => 1,
         },
     )
@@ -585,7 +585,7 @@ where
             .put(
                 KeySpace::Infra,
                 WriteBuffer::Borrowed(IntKey::new(META_KEY_NEXT_FREE_TASK_ID).as_ref()),
-                WriteBuffer::Borrowed(&next_task_id.to_le_bytes()),
+                WriteBuffer::Borrowed(&next_task_id.to_be_bytes()),
             )
             .context("Unable to write next free task id")?;
     }


### PR DESCRIPTION
### What?

Use a special "hash" function for short keys, which is very cheap and still good enough.
This allows to recompute the hash as needed from the key and not storing it in the SST file is fine