### PR TITLE
Optimistic routing: client-side route prediction

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -357,6 +357,8 @@ export function getDefineEnv({
       config.experimental.transitionIndicator ?? false,
     'process.env.__NEXT_GESTURE_TRANSITION':
       config.experimental.gestureTransition ?? false,
+    'process.env.__NEXT_OPTIMISTIC_ROUTING':
+      config.experimental.optimisticRouting ?? false,
     'process.env.__NEXT_CACHE_LIFE': config.cacheLife,
     'process.env.__NEXT_CLIENT_PARAM_PARSING_ORIGINS':
       config.experimental.clientParamParsingOrigins || [],

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -318,6 +318,8 @@ export async function hydrate(
       initialFlightData: initialRSCPayload.f,
       initialCanonicalUrlParts: initialRSCPayload.c,
       initialRenderedSearch: initialRSCPayload.q,
+      initialCouldBeIntercepted: initialRSCPayload.i,
+      initialPrerendered: initialRSCPayload.S,
       location: window.location,
     }),
     instrumentationHooks

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -24,6 +24,7 @@ import {
   dispatchAppRouterAction,
   dispatchGestureState,
 } from './use-action-queue'
+import { resetKnownRoutes } from './segment-cache/optimistic-routes'
 import { FreshnessPolicy } from './router-reducer/ppr-navigations'
 import { addBasePath } from '../add-base-path'
 import { isExternalURL } from './app-router-utils'
@@ -456,6 +457,9 @@ export const publicAppRouterInstance: AppRouterInstance = {
         'hmrRefresh can only be used in development mode. Please use refresh instead.'
       )
     } else {
+      // Reset the known routes table so that route predictions are cleared
+      // when routes change during development.
+      resetKnownRoutes()
       startTransition(() => {
         dispatchAppRouterAction({
           type: ACTION_HMR_REFRESH,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -7,6 +7,7 @@ import type { AppRouterState } from './router-reducer-types'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
 import { createInitialCacheNodeForHydration } from './ppr-navigations'
 import { convertRootFlightRouterStateToRouteTree } from '../segment-cache/cache'
+import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
 
 export interface InitialRouterStateParameters {
@@ -14,6 +15,8 @@ export interface InitialRouterStateParameters {
   initialCanonicalUrlParts: string[]
   initialRenderedSearch: string
   initialFlightData: FlightDataPath[]
+  initialCouldBeIntercepted: boolean
+  initialPrerendered: boolean
   location: Location | null
 }
 
@@ -22,6 +25,8 @@ export function createInitialRouterState({
   initialFlightData,
   initialCanonicalUrlParts,
   initialRenderedSearch,
+  initialCouldBeIntercepted,
+  initialPrerendered,
   location,
 }: InitialRouterStateParameters): AppRouterState {
   // When initialized on the server, the canonical URL is provided as an array of parts.
@@ -56,12 +61,30 @@ export function createInitialRouterState({
     initialRenderedSearch as NormalizedSearch,
     acc
   )
+  const metadataVaryPath = acc.metadataVaryPath
   const initialTask = createInitialCacheNodeForHydration(
     navigatedAt,
     initialRouteTree,
     initialSeedData,
     initialHead
   )
+
+  // Learn the route pattern so we can predict it for future navigations.
+  // Only do this in the browser (location !== null) since route learning
+  // state doesn't persist from SSR to client.
+  if (location !== null && metadataVaryPath !== null) {
+    discoverKnownRoute(
+      Date.now(),
+      location.pathname,
+      null, // No pending entry
+      initialRouteTree,
+      metadataVaryPath,
+      initialCouldBeIntercepted,
+      canonicalUrl,
+      initialPrerendered,
+      false // hasDynamicRewrite
+    )
+  }
 
   // NOTE: We intentionally don't check if any data needs to be fetched from the
   // server. We assume the initial hydration payload is sufficient to render
@@ -96,8 +119,8 @@ export function createInitialRouterState({
     },
     canonicalUrl,
     renderedSearch: initialRenderedSearch,
+    // the || operator is intentional, the pathname can be an empty string
     nextUrl:
-      // the || operator is intentional, the pathname can be an empty string
       (extractPathFromFlightRouterState(initialTree) || location?.pathname) ??
       null,
     previousNextUrl: null,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -27,11 +27,15 @@ import {
 import {
   type RouteTree,
   type RefreshState,
+  type FulfilledRouteCacheEntry,
   convertReusedFlightRouterStateToRouteTree,
   readSegmentCacheEntry,
   waitForSegmentCacheEntry,
+  markRouteEntryAsDynamicRewrite,
+  invalidateRouteCacheEntries,
   EntryStatus,
 } from '../segment-cache/cache'
+import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
 import {
   getRenderedSearchFromVaryPath,
@@ -1110,6 +1114,25 @@ function createCacheNodeForSegment(
       }
     }
 
+    if (process.env.__NEXT_OPTIMISTIC_ROUTING && isCachedHeadPartial) {
+      // TODO: When optimistic routing is enabled, don't block on waiting for
+      // the viewport to resolve. This is a temporary workaround until Vary
+      // Params are tracked when rendering the metadata. We'll fix it before
+      // this feature is stable. However, it's not a critical issue because 1)
+      // it will stream in eventually anyway 2) metadata is wrapped in an
+      // internal Suspense boundary, so is always non-blocking; this only
+      // affects the viewport node, which is meant to blocking, however... 3)
+      // before Segment Cache landed this wasn't always the case, anyway, so
+      // it's unlikely that many people are relying on this behavior. Still,
+      // will be fixed before stable. It's the very next step in the sequence of
+      // work on this project.
+      //
+      // This line of code works because the App Router treats `null` as
+      // "no renderable head available", rather than an empty head. React treats
+      // an empty string as empty.
+      cachedHead = ''
+    }
+
     if (seedHead !== null) {
       if (isCachedHeadPartial) {
         prefetchHead = cachedHead
@@ -1194,7 +1217,12 @@ export function spawnDynamicRequests(
   primaryUrl: URL,
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
-  accumulation: NavigationRequestAccumulation
+  accumulation: NavigationRequestAccumulation,
+  // The route cache entry used for this navigation, if it came from route
+  // prediction. Passed through so it can be marked as having a dynamic rewrite
+  // if the server returns a different pathname than expected (indicating
+  // dynamic rewrite behavior that varies by param value).
+  routeCacheEntry: FulfilledRouteCacheEntry | null
 ): void {
   const dynamicRequestTree = task.dynamicRequestTree
   if (dynamicRequestTree === null) {
@@ -1281,7 +1309,8 @@ export function spawnDynamicRequests(
     task,
     nextUrl,
     primaryRequestPromise,
-    refreshRequestPromises
+    refreshRequestPromises,
+    routeCacheEntry
   )
   // `finishNavigationTask` is responsible for error handling, so we can attach
   // noop callbacks to this promise.
@@ -1294,7 +1323,8 @@ async function finishNavigationTask(
   primaryRequestPromise: ReturnType<typeof fetchMissingDynamicData>,
   refreshRequestPromises: Array<
     ReturnType<typeof fetchMissingDynamicData>
-  > | null
+  > | null,
+  routeCacheEntry: FulfilledRouteCacheEntry | null
 ): Promise<void> {
   // Wait for all the requests to finish, or for the first one to fail.
   let exitStatus = await waitForRequestsToFinish(
@@ -1330,7 +1360,8 @@ async function finishNavigationTask(
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
-        task.route
+        task.route,
+        routeCacheEntry
       )
       return
     }
@@ -1350,7 +1381,8 @@ async function finishNavigationTask(
         primaryRequestResult.url,
         nextUrl,
         primaryRequestResult.seed,
-        task.route
+        task.route,
+        routeCacheEntry
       )
       return
     }
@@ -1414,8 +1446,43 @@ function dispatchRetryDueToTreeMismatch(
   retryUrl: URL,
   retryNextUrl: string | null,
   seed: NavigationSeed | null,
-  baseTree: FlightRouterState
+  baseTree: FlightRouterState,
+  // The route cache entry used for this navigation, if it came from route
+  // prediction. If the navigation results in a mismatch, we mark it as having
+  // a dynamic rewrite so future predictions bail out.
+  routeCacheEntry: FulfilledRouteCacheEntry | null
 ) {
+  // If the navigation used a route prediction, mark it as having a dynamic
+  // rewrite since it resulted in a mismatch.
+  if (routeCacheEntry !== null) {
+    markRouteEntryAsDynamicRewrite(routeCacheEntry)
+  } else if (seed !== null) {
+    // Even without a direct reference to the route cache entry, we can still
+    // mark the route as having a dynamic rewrite by traversing the known route
+    // tree. This handles cases where the navigation didn't originate from a
+    // route prediction, but still needs to mark the pattern.
+    const metadataVaryPath = seed.metadataVaryPath
+    if (metadataVaryPath !== null) {
+      const now = Date.now()
+      discoverKnownRoute(
+        now,
+        retryUrl.pathname,
+        null,
+        seed.routeTree,
+        metadataVaryPath,
+        false, // couldBeIntercepted - doesn't matter, we're just marking hasDynamicRewrite
+        createHrefFromUrl(retryUrl),
+        false, // isPPREnabled - doesn't matter, we're just marking hasDynamicRewrite
+        true // hasDynamicRewrite
+      )
+    }
+  }
+
+  // Invalidate all route cache entries. Other entries may have been derived
+  // from the template before we knew it had a dynamic rewrite. This also
+  // triggers re-prefetching of visible links.
+  invalidateRouteCacheEntries(retryNextUrl, baseTree)
+
   // If this is the second time in a row that a navigation resulted in a
   // mismatch, fall back to a hard (MPA) refresh.
   isHardRetry = isHardRetry || previousNavigationDidMismatch

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -72,6 +72,11 @@ export function refreshDynamicData(
     nextUrlForRefresh,
     shouldScroll,
     navigateType,
+    null,
+    // Refresh navigations don't use route prediction, so there's no route
+    // cache entry to mark as having a dynamic rewrite on mismatch. If a
+    // mismatch occurs, the retry handler will traverse the known route tree
+    // to find and mark the entry.
     null
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -76,7 +76,12 @@ export function restoreReducer(
     restoredUrl,
     restoredNextUrl,
     FreshnessPolicy.HistoryTraversal,
-    accumulation
+    accumulation,
+    // History traversal doesn't use route prediction, so there's no route
+    // cache entry to mark as having a dynamic rewrite on mismatch. If a
+    // mismatch occurs, the retry handler will traverse the known route tree
+    // to find and mark the entry.
+    null
   )
   return completeTraverseNavigation(
     state,

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -54,6 +54,7 @@ import {
   navigateToKnownRoute,
   navigate,
 } from '../../segment-cache/navigation'
+import { discoverKnownRoute } from '../../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../../segment-cache/cache-key'
 import {
   ActionDidNotRevalidate,
@@ -92,6 +93,7 @@ type FetchServerActionResult = {
   actionFlightData: NormalizedFlightData[] | string | undefined
   actionFlightDataRenderedSearch: NormalizedSearch | undefined
   isPrerender: boolean
+  couldBeIntercepted: boolean
 }
 
 async function fetchServerAction(
@@ -209,6 +211,7 @@ async function fetchServerAction(
   let actionResult: FetchServerActionResult['actionResult']
   let actionFlightData: FetchServerActionResult['actionFlightData']
   let actionFlightDataRenderedSearch: FetchServerActionResult['actionFlightDataRenderedSearch']
+  let couldBeIntercepted: boolean = false
 
   if (isRscResponse) {
     const response: ActionFlightResponse = await createFromFetch(
@@ -223,6 +226,7 @@ async function fetchServerAction(
 
     // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
     actionResult = redirectLocation ? undefined : response.a
+    couldBeIntercepted = response.i
     const maybeFlightData = normalizeFlightData(response.f)
     if (maybeFlightData !== '') {
       actionFlightData = maybeFlightData
@@ -243,6 +247,7 @@ async function fetchServerAction(
     redirectType,
     revalidationKind,
     isPrerender,
+    couldBeIntercepted,
   }
 }
 
@@ -279,6 +284,8 @@ export function serverActionReducer(
       actionFlightDataRenderedSearch: flightDataRenderedSearch,
       redirectLocation,
       redirectType,
+      isPrerender,
+      couldBeIntercepted,
     }) => {
       if (revalidationKind !== ActionDidNotRevalidate) {
         // There was either a revalidation or a refresh, or maybe both.
@@ -414,6 +421,23 @@ export function serverActionReducer(
           flightDataRenderedSearch
         )
         const now = Date.now()
+
+        // Learn the route pattern so we can predict it for future navigations.
+        const metadataVaryPath = redirectSeed.metadataVaryPath
+        if (metadataVaryPath !== null) {
+          discoverKnownRoute(
+            now,
+            redirectUrl.pathname,
+            null, // No pending entry
+            redirectSeed.routeTree,
+            metadataVaryPath,
+            couldBeIntercepted,
+            redirectCanonicalUrl,
+            isPrerender,
+            false // hasDynamicRewrite
+          )
+        }
+
         return navigateToKnownRoute(
           now,
           state,
@@ -428,6 +452,11 @@ export function serverActionReducer(
           nextUrl,
           shouldScroll,
           navigateType,
+          null,
+          // Server action redirects don't use route prediction - we already
+          // have the route tree from the server response. If a mismatch occurs
+          // during dynamic data fetch, the retry handler will traverse the
+          // known route tree to mark the entry as having a dynamic rewrite.
           null
         )
       }

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -57,6 +57,10 @@ export function serverPatchReducer(
     retryNextUrl,
     shouldScroll,
     navigateType,
+    null,
+    // Server patch (retry) navigations don't use route prediction. This is
+    // typically a retry after a previous mismatch, so the route was already
+    // marked as having a dynamic rewrite when the mismatch was detected.
     null
   )
 }

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -47,11 +47,15 @@ import {
   finalizeMetadataVaryPath,
   getPartialPageVaryPath,
   getPartialLayoutVaryPath,
+  getRenderedSearchFromVaryPath,
 } from './vary-path'
 import { getAppBuildId } from '../../app-build-id'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
-import type { NormalizedSearch, RouteCacheKey } from './cache-key'
-// TODO: Rename this module to avoid confusion with other types of cache keys
+import type {
+  NormalizedPathname,
+  NormalizedSearch,
+  RouteCacheKey,
+} from './cache-key'
 import { createCacheKey as createPrefetchRequestKey } from './cache-key'
 import {
   doesStaticSegmentAppearInURL,
@@ -95,6 +99,7 @@ import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 import { readFromBFCacheDuringRegularNavigation } from './bfcache'
+import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
 
 /**
  * Ensures a minimum stale time of 30s to avoid issues where the server sends a too
@@ -192,7 +197,7 @@ export const enum EntryStatus {
   Rejected = 3,
 }
 
-type PendingRouteCacheEntry = RouteCacheEntryShared & {
+export type PendingRouteCacheEntry = RouteCacheEntryShared & {
   status: EntryStatus.Empty | EntryStatus.Pending
   blockedTasks: Set<PrefetchTask> | null
   canonicalUrl: null
@@ -220,6 +225,12 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   isPPREnabled: boolean
+  // When true, this entry should not be used as a template for route
+  // prediction. Set when we discover that the URL was rewritten by middleware
+  // to a different route structure (e.g., /foo was rewritten to /bar). Since
+  // rewrite behavior can vary by param value, we can't safely predict the
+  // route structure for other URLs matching this pattern.
+  hasDynamicRewrite: boolean
 }
 
 export type RouteCacheEntry =
@@ -428,13 +439,24 @@ export function readRouteCacheEntry(
     key.nextUrl
   )
   const isRevalidation = false
-  return getFromCacheMap(
+  const existingEntry = getFromCacheMap(
     now,
     getCurrentRouteCacheVersion(),
     routeCacheMap,
     varyPath,
     isRevalidation
   )
+  if (existingEntry !== null) {
+    return existingEntry
+  }
+
+  // No cache hit. Attempt to construct from template using the new
+  // optimistic routing mechanism (pattern-based matching).
+  if (process.env.__NEXT_OPTIMISTIC_ROUTING) {
+    return matchKnownRoute(key.pathname, key.search)
+  }
+
+  return null
 }
 
 export function readSegmentCacheEntry(
@@ -480,23 +502,8 @@ export function waitForSegmentCacheEntry(
   return promiseWithResolvers.promise
 }
 
-/**
- * Checks if an entry for a route exists in the cache. If so, it returns the
- * entry, If not, it adds an empty entry to the cache and returns it.
- */
-export function readOrCreateRouteCacheEntry(
-  now: number,
-  task: PrefetchTask,
-  key: RouteCacheKey
-): RouteCacheEntry {
-  attachInvalidationListener(task)
-
-  const existingEntry = readRouteCacheEntry(now, key)
-  if (existingEntry !== null) {
-    return existingEntry
-  }
-  // Create a pending entry and add it to the cache.
-  const pendingEntry: PendingRouteCacheEntry = {
+function createDetachedRouteCacheEntry(): PendingRouteCacheEntry {
+  return {
     canonicalUrl: null,
     status: EntryStatus.Empty,
     blockedTasks: null,
@@ -518,6 +525,25 @@ export function readOrCreateRouteCacheEntry(
     staleAt: Infinity,
     version: getCurrentRouteCacheVersion(),
   }
+}
+
+/**
+ * Checks if an entry for a route exists in the cache. If so, it returns the
+ * entry, If not, it adds an empty entry to the cache and returns it.
+ */
+export function readOrCreateRouteCacheEntry(
+  now: number,
+  task: PrefetchTask,
+  key: RouteCacheKey
+): RouteCacheEntry {
+  attachInvalidationListener(task)
+
+  const existingEntry = readRouteCacheEntry(now, key)
+  if (existingEntry !== null) {
+    return existingEntry
+  }
+  // Create a pending entry and add it to the cache.
+  const pendingEntry = createDetachedRouteCacheEntry()
   const varyPath: RouteVaryPath = getRouteVaryPath(
     key.pathname,
     key.search,
@@ -528,7 +554,12 @@ export function readOrCreateRouteCacheEntry(
   return pendingEntry
 }
 
-export function requestOptimisticRouteCacheEntry(
+// TODO: This function predates the new optimisticRouting feature and will be
+// removed once optimisticRouting is stable. The new mechanism (matchKnownRoute)
+// handles search param variations more robustly as part of the general route
+// prediction system. This fallback remains for when optimisticRouting is
+// disabled (staticChildren is null).
+export function deprecated_requestOptimisticRouteCacheEntry(
   now: number,
   requestedUrl: URL,
   nextUrl: string | null
@@ -613,11 +644,11 @@ export function requestOptimisticRouteCacheEntry(
   optimisticUrl.search = optimisticCanonicalSearch
   const optimisticCanonicalUrl = createHrefFromUrl(optimisticUrl)
 
-  const optimisticRouteTree = createOptimisticRouteTree(
+  const optimisticRouteTree = deprecated_createOptimisticRouteTree(
     routeWithNoSearchParams.tree,
     optimisticRenderedSearch
   )
-  const optimisticMetadataTree = createOptimisticRouteTree(
+  const optimisticMetadataTree = deprecated_createOptimisticRouteTree(
     routeWithNoSearchParams.metadata,
     optimisticRenderedSearch
   )
@@ -634,6 +665,7 @@ export function requestOptimisticRouteCacheEntry(
     metadata: optimisticMetadataTree,
     couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
     isPPREnabled: routeWithNoSearchParams.isPPREnabled,
+    hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
 
     // Override the rendered search with the optimistic value.
     renderedSearch: optimisticRenderedSearch,
@@ -650,7 +682,7 @@ export function requestOptimisticRouteCacheEntry(
   return optimisticEntry
 }
 
-function createOptimisticRouteTree(
+function deprecated_createOptimisticRouteTree(
   tree: RouteTree,
   newRenderedSearch: NormalizedSearch
 ): RouteTree {
@@ -663,7 +695,7 @@ function createOptimisticRouteTree(
     clonedSlots = {}
     for (const parallelRouteKey in originalSlots) {
       const childTree = originalSlots[parallelRouteKey]
-      clonedSlots[parallelRouteKey] = createOptimisticRouteTree(
+      clonedSlots[parallelRouteKey] = deprecated_createOptimisticRouteTree(
         childTree,
         newRenderedSearch
       )
@@ -961,16 +993,9 @@ function pingBlockedTasks(entry: {
   }
 }
 
-function fulfillRouteCacheEntry(
-  now: number,
-  entry: RouteCacheEntry,
-  tree: RouteTree,
-  metadataVaryPath: PageVaryPath,
-  couldBeIntercepted: boolean,
-  canonicalUrl: string,
-  renderedSearch: NormalizedSearch,
-  isPPREnabled: boolean
-): FulfilledRouteCacheEntry {
+export function createMetadataRouteTree(
+  metadataVaryPath: PageVaryPath
+): RouteTree {
   // The Head is not actually part of the route tree, but other than that, it's
   // fetched and cached like a segment. Some functions expect a RouteTree
   // object, so rather than fork the logic in all those places, we use this
@@ -989,10 +1014,25 @@ function fulfillRouteCacheEntry(
     hasLoadingBoundary: HasLoadingBoundary.SubtreeHasNoLoadingBoundary,
     hasRuntimePrefetch: false,
   }
+  return metadata
+}
+
+export function fulfillRouteCacheEntry(
+  now: number,
+  entry: PendingRouteCacheEntry,
+  tree: RouteTree,
+  metadataVaryPath: PageVaryPath,
+  couldBeIntercepted: boolean,
+  canonicalUrl: string,
+  isPPREnabled: boolean
+): FulfilledRouteCacheEntry {
+  // Get the rendered search from the vary path
+  const renderedSearch =
+    getRenderedSearchFromVaryPath(metadataVaryPath) ?? ('' as NormalizedSearch)
   const fulfilledEntry: FulfilledRouteCacheEntry = entry as any
   fulfilledEntry.status = EntryStatus.Fulfilled
   fulfilledEntry.tree = tree
-  fulfilledEntry.metadata = metadata
+  fulfilledEntry.metadata = createMetadataRouteTree(metadataVaryPath)
   // Route structure is essentially static — it only changes on deploy.
   // Always use the static stale time.
   // NOTE: An exception is rewrites/redirects in middleware or proxy, which can
@@ -1002,8 +1042,55 @@ function fulfillRouteCacheEntry(
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.isPPREnabled = isPPREnabled
+  fulfilledEntry.hasDynamicRewrite = false
   pingBlockedTasks(entry)
   return fulfilledEntry
+}
+
+export function writeRouteIntoCache(
+  now: number,
+  pathname: NormalizedPathname,
+  tree: RouteTree,
+  metadataVaryPath: PageVaryPath,
+  couldBeIntercepted: boolean,
+  canonicalUrl: string,
+  isPPREnabled: boolean
+): FulfilledRouteCacheEntry {
+  const pendingEntry = createDetachedRouteCacheEntry()
+  const fulfilledEntry = fulfillRouteCacheEntry(
+    now,
+    pendingEntry,
+    tree,
+    metadataVaryPath,
+    couldBeIntercepted,
+    canonicalUrl,
+    isPPREnabled
+  )
+  // nextUrl is always null here because we only write to the route cache for
+  // non-intercepted routes. Intercepted routes are deopted in attemptOptimisticRouting.
+  const renderedSearch = fulfilledEntry.renderedSearch
+  const varyPath = getRouteVaryPath(pathname, renderedSearch, null)
+  const isRevalidation = false
+  setInCacheMap(routeCacheMap, varyPath, fulfilledEntry, isRevalidation)
+  return fulfilledEntry
+}
+
+/**
+ * Marks a route cache entry as having a dynamic rewrite. Called when we
+ * discover that a route pattern has dynamic rewrite behavior - i.e., we used
+ * an optimistic route tree for prediction, but the server responded with a
+ * different rendered pathname.
+ *
+ * Once marked, attempts to use this entry as a template for prediction will
+ * bail out to server resolution.
+ */
+export function markRouteEntryAsDynamicRewrite(
+  entry: FulfilledRouteCacheEntry
+): void {
+  entry.hasDynamicRewrite = true
+  // Note: The caller is responsible for also calling invalidateRouteCacheEntries
+  // to invalidate other entries that may have been derived from this template
+  // before we knew it had a dynamic rewrite.
 }
 
 function fulfillSegmentCacheEntry(
@@ -1629,15 +1716,16 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
 
-      fulfillRouteCacheEntry(
+      discoverKnownRoute(
         Date.now(),
+        pathname,
         entry,
         routeTree,
         metadataVaryPath,
         couldBeIntercepted,
         canonicalUrl,
-        renderedSearch,
-        routeIsPPREnabled
+        routeIsPPREnabled,
+        false // hasDynamicRewrite
       )
     } else {
       // PPR is not enabled for this route. The server responds with a
@@ -1679,7 +1767,8 @@ export async function fetchRouteOnCacheMiss(
         entry,
         couldBeIntercepted,
         canonicalUrl,
-        routeIsPPREnabled
+        routeIsPPREnabled,
+        pathname
       )
     }
 
@@ -1996,10 +2085,9 @@ function writeDynamicTreeResponseIntoCache(
   entry: PendingRouteCacheEntry,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
-  routeIsPPREnabled: boolean
+  routeIsPPREnabled: boolean,
+  originalPathname: string
 ) {
-  // Get the URL that was used to render the target page. This may be different
-  // from the URL in the request URL, if the page was rewritten.
   const renderedSearch = getRenderedSearch(response)
 
   const normalizedFlightDataResult = normalizeFlightData(serverData.f)
@@ -2044,15 +2132,16 @@ function writeDynamicTreeResponseIntoCache(
     return
   }
 
-  const fulfilledEntry = fulfillRouteCacheEntry(
+  const fulfilledEntry = discoverKnownRoute(
     now,
+    originalPathname,
     entry,
     routeTree,
     metadataVaryPath,
     couldBeIntercepted,
     canonicalUrl,
-    renderedSearch,
-    routeIsPPREnabled
+    routeIsPPREnabled,
+    false // hasDynamicRewrite
   )
 
   // If the server sent segment data as part of the response, we should write

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -17,11 +17,12 @@ import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
 import {
   EntryStatus,
   readRouteCacheEntry,
-  requestOptimisticRouteCacheEntry,
+  deprecated_requestOptimisticRouteCacheEntry,
   convertRootFlightRouterStateToRouteTree,
   type RouteTree,
   type FulfilledRouteCacheEntry,
 } from './cache'
+import { discoverKnownRoute } from './optimistic-routes'
 import { createCacheKey, type NormalizedSearch } from './cache-key'
 import type { PageVaryPath } from './vary-path'
 import type { AppRouterState } from '../router-reducer/router-reducer-types'
@@ -72,7 +73,9 @@ export function navigate(
   }
 
   // There was no matching route tree in the cache. Let's see if we can
-  // construct an "optimistic" route tree.
+  // construct an "optimistic" route tree using the deprecated search-params
+  // based matching. This is only used when the new optimisticRouting flag is
+  // disabled.
   //
   // Do not construct an optimistic route tree if there was a cache hit, but
   // the entry has a rejected status, since it may have been rejected due to a
@@ -80,29 +83,36 @@ export function navigate(
   //
   // TODO: There are multiple reasons a prefetch might be rejected; we should
   // track them explicitly and choose what to do here based on that.
-  if (route === null || route.status !== EntryStatus.Rejected) {
-    const optimisticRoute = requestOptimisticRouteCacheEntry(now, url, nextUrl)
-    if (optimisticRoute !== null) {
-      // We have an optimistic route tree. Proceed with the normal flow.
-      return navigateUsingPrefetchedRouteTree(
+  if (!process.env.__NEXT_OPTIMISTIC_ROUTING) {
+    if (route === null || route.status !== EntryStatus.Rejected) {
+      const optimisticRoute = deprecated_requestOptimisticRouteCacheEntry(
         now,
-        state,
         url,
-        currentUrl,
-        currentRenderedSearch,
-        nextUrl,
-        currentCacheNode,
-        currentFlightRouterState,
-        freshnessPolicy,
-        shouldScroll,
-        navigateType,
-        optimisticRoute
+        nextUrl
       )
+      if (optimisticRoute !== null) {
+        // We have an optimistic route tree. Proceed with the normal flow.
+        return navigateUsingPrefetchedRouteTree(
+          now,
+          state,
+          url,
+          currentUrl,
+          currentRenderedSearch,
+          nextUrl,
+          currentCacheNode,
+          currentFlightRouterState,
+          freshnessPolicy,
+          shouldScroll,
+          navigateType,
+          optimisticRoute
+        )
+      }
     }
   }
 
-  // There's no matching prefetch for this route in the cache.
-  // TODO: If this is an optimistic navigation, instead of performing a
+  // There's no matching prefetch for this route in the cache. We must lazily
+  // fetch it from the server before we can perform the navigation.
+  // TODO: If this is an gesture navigation, instead of performing a
   // dynamic request, we should do a runtime prefetch.
   return navigateToUnknownRoute(
     now,
@@ -136,7 +146,19 @@ export function navigateToKnownRoute(
   nextUrl: string | null,
   shouldScroll: boolean,
   navigateType: 'push' | 'replace',
-  debugInfo: Array<unknown> | null
+  debugInfo: Array<unknown> | null,
+  // The route cache entry used for this navigation, if it came from route
+  // prediction. Passed through so it can be marked as having a dynamic rewrite
+  // if the server returns a different pathname (indicating dynamic rewrite
+  // behavior).
+  //
+  // When null, the navigation did not use route prediction - either because
+  // the route was already fully cached, or it's a navigation that doesn't
+  // involve prediction (refresh, history traversal, server action, etc.).
+  // In these cases, if a mismatch occurs, we still mark the route as having a
+  // dynamic rewrite by traversing the known route tree (see
+  // dispatchRetryDueToTreeMismatch).
+  routeCacheEntry: FulfilledRouteCacheEntry | null
 ): AppRouterState {
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
@@ -178,11 +200,15 @@ export function navigateToKnownRoute(
     accumulation
   )
   if (task !== null) {
-    // Skip spawning dynamic requests for gesture navigations. Only the
-    // cached UI will be shown. The gesture state will be discarded when
-    // the canonical navigation completes.
     if (freshnessPolicy !== FreshnessPolicy.Gesture) {
-      spawnDynamicRequests(task, url, nextUrl, freshnessPolicy, accumulation)
+      spawnDynamicRequests(
+        task,
+        url,
+        nextUrl,
+        freshnessPolicy,
+        accumulation,
+        routeCacheEntry
+      )
     }
     return completeSoftNavigation(
       state,
@@ -240,7 +266,8 @@ function navigateUsingPrefetchedRouteTree(
     nextUrl,
     shouldScroll,
     navigateType,
-    null
+    null,
+    route
   )
 }
 
@@ -310,7 +337,14 @@ async function navigateToUnknownRoute(
     return completeHardNavigation(state, redirectUrl, navigateType)
   }
 
-  const { flightData, canonicalUrl, renderedSearch, debugInfo } = result
+  const {
+    flightData,
+    canonicalUrl,
+    renderedSearch,
+    couldBeIntercepted,
+    prerendered,
+    debugInfo,
+  } = result
 
   // Since the response format of dynamic requests and prefetches is slightly
   // different, we'll need to massage the data a bit. Create FlightRouterState
@@ -320,6 +354,26 @@ async function navigateToUnknownRoute(
     flightData,
     renderedSearch
   )
+
+  // Learn the route pattern so we can predict it for future navigations.
+  // hasDynamicRewrite is false because this is a fresh navigation to an
+  // unknown route - any rewrite detection happens during the traversal inside
+  // discoverKnownRoute. The hasDynamicRewrite param is only set to true when
+  // retrying after a tree mismatch (see dispatchRetryDueToTreeMismatch).
+  const metadataVaryPath = navigationSeed.metadataVaryPath
+  if (metadataVaryPath !== null) {
+    discoverKnownRoute(
+      now,
+      url.pathname,
+      null, // No pending entry
+      navigationSeed.routeTree,
+      metadataVaryPath,
+      couldBeIntercepted,
+      createHrefFromUrl(canonicalUrl),
+      prerendered,
+      false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
+    )
+  }
 
   return navigateToKnownRoute(
     now,
@@ -335,7 +389,12 @@ async function navigateToUnknownRoute(
     nextUrl,
     shouldScroll,
     navigateType,
-    debugInfo
+    debugInfo,
+    // Unknown route navigations don't use route prediction - the route tree
+    // came directly from the server. If a mismatch occurs during dynamic data
+    // fetch, the retry handler will traverse the known route tree to mark the
+    // entry as having a dynamic rewrite.
+    null
   )
 }
 

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -1,0 +1,832 @@
+/**
+ * Optimistic Routing (Known Routes)
+ *
+ * This module enables the client to predict route structure for URLs that
+ * haven't been prefetched yet, based on previously learned route patterns.
+ * When successful, this allows skipping the route tree prefetch request
+ * entirely.
+ *
+ * The core idea is that many URLs map to the same route structure. For example,
+ * /blog/post-1 and /blog/post-2 both resolve to /blog/[slug]. Once we've
+ * prefetched one, we can predict the structure of the other.
+ *
+ * However, we can't always make this prediction. Static siblings (like
+ * /blog/featured alongside /blog/[slug]) have different route structures.
+ * When we learn a dynamic route, we also learn its static siblings so we
+ * know when NOT to apply the prediction.
+ *
+ * Main entry points:
+ *
+ * 1. discoverKnownRoute: Called after receiving a route tree from the server.
+ *    Traverses the route tree, compares URL parts to segments, and populates
+ *    the known route tree if they match. Routes are always inserted into the
+ *    cache.
+ *
+ * 2. matchKnownRoute: Called when looking up a route with no cache entry.
+ *    Matches the candidate URL against learned patterns. Returns a synthetic
+ *    cache entry if successful, or null to fall back to server resolution.
+ *
+ * Rewrite detection happens during traversal: if a URL path part doesn't match
+ * the corresponding route segment, we stop populating the known route tree
+ * (since the mapping is incorrect) but still insert the route into the cache.
+ *
+ * The known route tree is append-only with no eviction. Route patterns are
+ * derived from the filesystem, so they don't become stale within a session.
+ * Cache invalidation on deploy clears everything anyway.
+ *
+ * Current limitations (deopt to server resolution):
+ * - Rewrites: Detected during traversal (tree not populated, but route cached)
+ * - Intercepted routes: Routes using (.), (..), (...) patterns
+ */
+
+import type { DynamicParamTypesShort } from '../../../shared/lib/app-router-types'
+import type { RouteTree, FulfilledRouteCacheEntry } from './cache'
+import {
+  EntryStatus,
+  writeRouteIntoCache,
+  fulfillRouteCacheEntry,
+  type PendingRouteCacheEntry,
+  createMetadataRouteTree,
+} from './cache'
+import { doesStaticSegmentAppearInURL } from '../../route-params'
+import type { NormalizedPathname, NormalizedSearch } from './cache-key'
+import {
+  appendLayoutVaryPath,
+  finalizeLayoutVaryPath,
+  finalizePageVaryPath,
+  finalizeMetadataVaryPath,
+  type PartialSegmentVaryPath,
+  type PageVaryPath,
+} from './vary-path'
+
+/**
+ * The known route tree is analogous to a route table. A different routing
+ * implementation might use regexes or URLPattern; ours uses a trie indexed
+ * by URL path segments.
+ *
+ * Each node (KnownRoutePart) represents a position in the URL and can have:
+ * - staticChildren: Map of literal segments to child nodes
+ * - dynamicChild: A single dynamic segment node ([slug], [...params], etc.)
+ * - pattern: A cache entry template for routes that terminate here
+ *
+ * This tree only contains segments that correspond to actual filesystem routes.
+ * Route groups like (marketing) and parallel routes like @modal are not
+ * included since they don't appear in URLs. Similarly, if a URL is rewritten
+ * to a different filesystem path, the original URL segments don't appear here
+ * — only the resolved filesystem route structure is stored.
+ *
+ * Example tree after learning /blog/[slug], /blog/featured, and /about:
+ *
+ *   ├── about
+ *   └── blog
+ *       ├── featured
+ *       └── [slug]
+ *
+ * When matching /blog/hello:
+ *   1. "blog" matches static child
+ *   2. "hello" doesn't match "featured", falls through to [slug]
+ *   3. Returns [slug]'s pattern with resolved param { slug: "hello" }
+ */
+type KnownRoutePartBase = {
+  // Known static paths at this level. The null vs Map distinction is
+  // semantically meaningful:
+  // - null: Static siblings are UNKNOWN at this level (e.g., webpack dev mode
+  //   where routes are compiled on-demand). If there's a dynamicChild, we
+  //   can't safely match it because the URL might be an unknown static sibling.
+  // - Map (even if empty): Static siblings are KNOWN. We can safely match a
+  //   dynamicChild if the URL doesn't match any entry in the Map.
+  staticChildren: Map<string, KnownRoutePart> | null
+
+  // The cache entry that serves as a pattern for this route.
+  // When a URL matches, we clone this and substitute param values.
+  // null means we know this path exists (from static siblings) but haven't
+  // learned its structure yet.
+  pattern: FulfilledRouteCacheEntry | null
+
+  // TODO: For prefix rewrite support. When true, this part may not appear in
+  // the candidate URL because it was injected by a rewrite.
+  // mayBeSkippedInURL: boolean
+}
+
+// The dynamic child fields are structured as a union so that narrowing on
+// dynamicChild also narrows dynamicChildParamName and dynamicChildParamType.
+type KnownRoutePartWithoutDynamicChild = KnownRoutePartBase & {
+  dynamicChild: null
+  dynamicChildParamName: null
+  dynamicChildParamType: null
+}
+
+type KnownRoutePartWithDynamicChild = KnownRoutePartBase & {
+  dynamicChild: KnownRoutePart
+  dynamicChildParamName: string
+  dynamicChildParamType: DynamicParamTypesShort
+}
+
+type KnownRoutePart =
+  | KnownRoutePartWithoutDynamicChild
+  | KnownRoutePartWithDynamicChild
+
+/**
+ * Param values extracted during URL matching. Used to reify the template.
+ * - string for regular dynamic [param]
+ * - string[] for catch-all [...param] and optional catch-all [[...param]]
+ */
+type ResolvedParams = Map<string, string | string[]>
+
+function createEmptyPart(): KnownRoutePart {
+  return {
+    staticChildren: null,
+    dynamicChild: null,
+    dynamicChildParamName: null,
+    dynamicChildParamType: null,
+    pattern: null,
+  }
+}
+
+// The root of the known route tree.
+let knownRouteTreeRoot: KnownRoutePart = createEmptyPart()
+
+/**
+ * Learns a route pattern from a server response and inserts it into the cache.
+ *
+ * Called after receiving a route tree from the server (initial load, navigation,
+ * or prefetch). Traverses the route tree, compares URL parts to segments, and
+ * populates the known route tree if they match. Routes are always inserted into
+ * the cache regardless of whether the URL matches the route structure.
+ *
+ * When pendingEntry is provided, it's fulfilled and used. When null, an entry
+ * is created and inserted into the route cache map.
+ *
+ * When hasDynamicRewrite is true, the route entry is marked as having a
+ * dynamic rewrite, which prevents it from being used as a template for future
+ * predictions. This is set when we detect a mismatch between what we predicted
+ * and what the server returned.
+ *
+ * Returns the fulfilled route cache entry.
+ */
+export function discoverKnownRoute(
+  now: number,
+  pathname: string,
+  pendingEntry: PendingRouteCacheEntry | null,
+  routeTree: RouteTree,
+  metadataVaryPath: PageVaryPath,
+  couldBeIntercepted: boolean,
+  canonicalUrl: string,
+  isPPREnabled: boolean,
+  hasDynamicRewrite: boolean
+): FulfilledRouteCacheEntry {
+  const tree = routeTree
+
+  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const firstPart = pathnameParts.length > 0 ? pathnameParts[0] : null
+  const remainingParts = pathnameParts.length > 0 ? pathnameParts.slice(1) : []
+
+  if (pendingEntry !== null) {
+    // Fulfill the pending entry first
+    const fulfilledEntry = fulfillRouteCacheEntry(
+      now,
+      pendingEntry,
+      tree,
+      metadataVaryPath,
+      couldBeIntercepted,
+      canonicalUrl,
+      isPPREnabled
+    )
+    if (hasDynamicRewrite) {
+      fulfilledEntry.hasDynamicRewrite = true
+    }
+    // Populate the known route tree (handles rewrite detection internally).
+    // The entry is already in the cache; this just stores it as a pattern
+    // if the URL matches the route structure.
+    discoverKnownRoutePart(
+      knownRouteTreeRoot,
+      tree,
+      firstPart,
+      remainingParts,
+      fulfilledEntry,
+      now,
+      pathname,
+      tree,
+      metadataVaryPath,
+      couldBeIntercepted,
+      canonicalUrl,
+      isPPREnabled,
+      hasDynamicRewrite
+    )
+    return fulfilledEntry
+  }
+
+  // No pending entry - discoverKnownRoutePart will create one and insert it
+  // into the cache, or return an existing pattern if one exists.
+  return discoverKnownRoutePart(
+    knownRouteTreeRoot,
+    tree,
+    firstPart,
+    remainingParts,
+    null,
+    now,
+    pathname,
+    tree,
+    metadataVaryPath,
+    couldBeIntercepted,
+    canonicalUrl,
+    isPPREnabled,
+    hasDynamicRewrite
+  )
+}
+
+/**
+ * Gets or creates the dynamic child node for a KnownRoutePart.
+ * A node can have at most one dynamic child (you can't have both [slug] and
+ * [id] at the same route level), so we either return existing or create new.
+ */
+function discoverDynamicChild(
+  part: KnownRoutePart,
+  paramName: string,
+  paramType: DynamicParamTypesShort
+): KnownRoutePart {
+  if (part.dynamicChild !== null) {
+    return part.dynamicChild
+  }
+  const newChild = createEmptyPart()
+  // Type assertion needed because we're converting from "without" to "with"
+  // dynamic child variant.
+  const mutablePart = part as unknown as KnownRoutePartWithDynamicChild
+  mutablePart.dynamicChild = newChild
+  mutablePart.dynamicChildParamName = paramName
+  mutablePart.dynamicChildParamType = paramType
+  return newChild
+}
+
+/**
+ * Recursive workhorse for discoverKnownRoute.
+ *
+ * Walks the route tree and URL parts in parallel, building out the known
+ * route tree as it goes. At each step:
+ * 1. Determines if the current segment appears in the URL (dynamic/static)
+ * 2. Validates URL matches route structure (detects rewrites)
+ * 3. Creates/updates the corresponding KnownRoutePart node
+ * 4. Records static siblings for future matching
+ * 5. Recurses into child slots (parallel routes)
+ *
+ * If a URL/route mismatch is detected (rewrite), we stop building the known
+ * route tree but still cache the route entry for direct lookup.
+ */
+function discoverKnownRoutePart(
+  parentKnownRoutePart: KnownRoutePart,
+  routeTree: RouteTree,
+  urlPart: string | null,
+  remainingParts: string[],
+  existingEntry: FulfilledRouteCacheEntry | null,
+  // These are passed through unchanged for entry creation at the leaf
+  now: number,
+  pathname: string,
+  fullTree: RouteTree,
+  metadataVaryPath: PageVaryPath,
+  couldBeIntercepted: boolean,
+  canonicalUrl: string,
+  isPPREnabled: boolean,
+  hasDynamicRewrite: boolean
+): FulfilledRouteCacheEntry {
+  const segment = routeTree.segment
+
+  let segmentAppearsInURL: boolean
+  let paramName: string | null = null
+  let paramType: DynamicParamTypesShort | null = null
+  let staticSiblings: readonly string[] | null = null
+
+  if (typeof segment === 'string') {
+    segmentAppearsInURL = doesStaticSegmentAppearInURL(segment)
+  } else {
+    // Dynamic segment tuple: [paramName, paramCacheKey, paramType, staticSiblings]
+    paramName = segment[0]
+    paramType = segment[2]
+    staticSiblings = segment[3]
+    segmentAppearsInURL = true
+  }
+
+  let knownRoutePart: KnownRoutePart = parentKnownRoutePart
+  let nextUrlPart: string | null = urlPart
+  let nextRemainingParts: string[] = remainingParts
+
+  if (segmentAppearsInURL) {
+    // Check for mismatch: if this is a static segment, the URL part must match
+    if (paramName === null && urlPart !== segment) {
+      // URL doesn't match route structure (likely a rewrite).
+      // Don't populate the known route tree, just write the route into the
+      // cache and return immediately.
+      if (existingEntry !== null) {
+        return existingEntry
+      }
+      return writeRouteIntoCache(
+        now,
+        pathname as NormalizedPathname,
+        fullTree,
+        metadataVaryPath,
+        couldBeIntercepted,
+        canonicalUrl,
+        isPPREnabled
+      )
+    }
+
+    // URL matches route structure. Build the known route tree.
+    if (paramName !== null && paramType !== null) {
+      // Dynamic segment
+      knownRoutePart = discoverDynamicChild(
+        parentKnownRoutePart,
+        paramName,
+        paramType
+      )
+
+      // Record static siblings as placeholder parts.
+      // IMPORTANT: We use the null vs Map distinction to track whether
+      // siblings are known at this level:
+      // - staticChildren: null = siblings unknown (can't safely match dynamic)
+      // - staticChildren: Map = siblings known (even if empty)
+      // This matters in dev mode where webpack may not know all siblings yet.
+      if (staticSiblings !== null) {
+        // Siblings are known - ensure we have a Map (even if empty)
+        if (parentKnownRoutePart.staticChildren === null) {
+          parentKnownRoutePart.staticChildren = new Map()
+        }
+        for (const sibling of staticSiblings) {
+          if (!parentKnownRoutePart.staticChildren.has(sibling)) {
+            parentKnownRoutePart.staticChildren.set(sibling, createEmptyPart())
+          }
+        }
+      }
+    } else {
+      // Static segment
+      if (parentKnownRoutePart.staticChildren === null) {
+        parentKnownRoutePart.staticChildren = new Map()
+      }
+      let existingChild = parentKnownRoutePart.staticChildren.get(urlPart!)
+      if (existingChild === undefined) {
+        existingChild = createEmptyPart()
+        parentKnownRoutePart.staticChildren.set(urlPart!, existingChild)
+      }
+      knownRoutePart = existingChild
+    }
+
+    // Advance to next URL part
+    nextUrlPart = remainingParts.length > 0 ? remainingParts[0] : null
+    nextRemainingParts =
+      remainingParts.length > 0 ? remainingParts.slice(1) : []
+  }
+  // else: Transparent segment (route group, __PAGE__, etc.)
+  // Stay at the same known route part, don't advance URL parts
+
+  // Recurse into child routes. A route tree can have multiple parallel routes
+  // (e.g., @modal alongside children). Each parallel route is a separate
+  // branch, but they all share the same URL - we just need to traverse all
+  // branches to build out the known route tree.
+  const slots = routeTree.slots
+  let resultFromChildren: FulfilledRouteCacheEntry | null = null
+  if (slots !== null) {
+    for (const parallelRouteKey in slots) {
+      const childRouteTree = slots[parallelRouteKey]
+      // Skip branches with refreshState set - these were reused from a
+      // different route (e.g., a "default" parallel slot) and don't represent
+      // the actual route structure for this URL.
+      if (childRouteTree.refreshState !== null) {
+        continue
+      }
+      const result = discoverKnownRoutePart(
+        knownRoutePart,
+        childRouteTree,
+        nextUrlPart,
+        nextRemainingParts,
+        existingEntry,
+        now,
+        pathname,
+        fullTree,
+        metadataVaryPath,
+        couldBeIntercepted,
+        canonicalUrl,
+        isPPREnabled,
+        hasDynamicRewrite
+      )
+      // All parallel route branches share the same URL, so they should all
+      // reach compatible leaf nodes. We capture any result.
+      resultFromChildren = result
+    }
+    if (resultFromChildren !== null) {
+      return resultFromChildren
+    }
+    // Defensive fallback: no children returned a result. This shouldn't happen
+    // for valid route trees, but handle it gracefully.
+    if (existingEntry !== null) {
+      return existingEntry
+    }
+    return writeRouteIntoCache(
+      now,
+      pathname as NormalizedPathname,
+      fullTree,
+      metadataVaryPath,
+      couldBeIntercepted,
+      canonicalUrl,
+      isPPREnabled
+    )
+  }
+
+  // Reached a page node. Create/get the route cache entry and store as a
+  // pattern. First, check if there's already a pattern for this route.
+  if (knownRoutePart.pattern !== null) {
+    // If this route has a dynamic rewrite, mark the existing pattern.
+    if (hasDynamicRewrite) {
+      knownRoutePart.pattern.hasDynamicRewrite = true
+    }
+    return knownRoutePart.pattern
+  }
+
+  // Get or create the entry
+  let entry: FulfilledRouteCacheEntry
+  if (existingEntry !== null) {
+    // Already have a fulfilled entry, use it directly. It's already in the
+    // route cache map.
+    entry = existingEntry
+  } else {
+    // Create the entry and insert it into the route cache map.
+    entry = writeRouteIntoCache(
+      now,
+      pathname as NormalizedPathname,
+      fullTree,
+      metadataVaryPath,
+      couldBeIntercepted,
+      canonicalUrl,
+      isPPREnabled
+    )
+  }
+
+  if (hasDynamicRewrite) {
+    entry.hasDynamicRewrite = true
+  }
+
+  // Store as pattern
+  knownRoutePart.pattern = entry
+  return entry
+}
+
+/**
+ * Attempts to match a URL against learned route patterns.
+ *
+ * Returns a synthetic FulfilledRouteCacheEntry if the URL matches a known
+ * pattern, or null if no match is found (fall back to server resolution).
+ */
+export function matchKnownRoute(
+  pathname: string,
+  search: NormalizedSearch
+): FulfilledRouteCacheEntry | null {
+  const pathnameParts = pathname.split('/').filter((p) => p !== '')
+  const resolvedParams: ResolvedParams = new Map()
+  const match = matchKnownRoutePart(
+    knownRouteTreeRoot,
+    pathnameParts,
+    0,
+    resolvedParams
+  )
+
+  if (match === null) {
+    return null
+  }
+
+  const matchedPart = match.part
+  const pattern = match.pattern
+
+  // If the pattern could be intercepted, we can't safely use it for prediction
+  // because the route structure may vary based on the Next-Url header.
+  if (pattern.couldBeIntercepted) {
+    return null
+  }
+
+  // "Reify" the pattern: clone the template tree with concrete param values.
+  // This substitutes resolved params (e.g., slug: "hello") into dynamic
+  // segments and recomputes vary paths for correct segment cache keying.
+  const acc: ReifyAccumulator = { metadataVaryPath: null }
+  const reifiedTree = reifyRouteTree(
+    pattern.tree,
+    resolvedParams,
+    search,
+    null, // Start with null partial vary path at the root
+    acc
+  )
+
+  // The metadata tree is a flat page node without the intermediate layout
+  // structure. Clone it with the updated metadata vary path collected during
+  // the main tree traversal.
+  const metadataVaryPath = acc.metadataVaryPath
+  if (metadataVaryPath === null) {
+    // This shouldn't be reachable for a valid route tree.
+    return null
+  }
+  const reifiedMetadata = createMetadataRouteTree(metadataVaryPath)
+
+  // Create a synthetic (predicted) entry and store it as the new pattern.
+  //
+  // Why replace the pattern? We intentionally update the pattern with this
+  // synthetic entry so that if our prediction was wrong (server returns a
+  // different pathname due to dynamic rewrite), the entry gets marked with
+  // hasDynamicRewrite. Future predictions for this route will see the flag
+  // and bail out to server resolution instead of making the same mistake.
+  const syntheticEntry: FulfilledRouteCacheEntry = {
+    canonicalUrl: pathname + search,
+    status: EntryStatus.Fulfilled,
+    blockedTasks: null,
+    tree: reifiedTree,
+    metadata: reifiedMetadata,
+    couldBeIntercepted: pattern.couldBeIntercepted,
+    isPPREnabled: pattern.isPPREnabled,
+    hasDynamicRewrite: false,
+    renderedSearch: search,
+    ref: null,
+    size: pattern.size,
+    staleAt: pattern.staleAt,
+    version: pattern.version,
+  }
+
+  matchedPart.pattern = syntheticEntry
+
+  return syntheticEntry
+}
+
+/**
+ * Result of a successful match: the matched tree node and its pattern.
+ * We return both because the caller needs to update the pattern after
+ * creating a synthetic entry (for dynamic rewrite detection).
+ */
+type KnownRouteMatch = {
+  part: KnownRoutePart
+  pattern: FulfilledRouteCacheEntry
+} | null
+
+/**
+ * Recursively matches a URL against the known route tree.
+ *
+ * Matching priority (most specific first):
+ * 1. Static children - exact path segment match
+ * 2. Dynamic child - [param], [...param], [[...param]]
+ * 3. Direct pattern - when no more URL parts remain
+ *
+ * Collects resolved param values in resolvedParams as it traverses.
+ * Returns null if no match found (caller should fall back to server).
+ */
+function matchKnownRoutePart(
+  part: KnownRoutePart,
+  pathnameParts: string[],
+  partIndex: number,
+  resolvedParams: ResolvedParams
+): KnownRouteMatch {
+  const urlPart =
+    partIndex < pathnameParts.length ? pathnameParts[partIndex] : null
+
+  // If staticChildren is null, we don't know what static routes exist at this
+  // level. This happens in webpack dev mode where routes are compiled
+  // on-demand. We can't safely match a dynamicChild because the URL part might
+  // be a static sibling we haven't discovered yet. Example: We know
+  // /blog/[slug] exists, but haven't compiled /blog/featured. A request for
+  // /blog/featured would incorrectly match /blog/[slug].
+  if (part.staticChildren === null) {
+    // The only safe match is a direct pattern when no URL parts remain.
+    if (urlPart === null) {
+      const pattern = part.pattern
+      if (pattern !== null && !pattern.hasDynamicRewrite) {
+        return { part, pattern }
+      }
+    }
+    return null
+  }
+
+  // Static children take priority over dynamic. This ensures /blog/featured
+  // matches its own route rather than /blog/[slug].
+  if (urlPart !== null) {
+    const staticChild = part.staticChildren.get(urlPart)
+    if (staticChild !== undefined) {
+      // Check if this is an "unknown" placeholder part. These are created when
+      // we learn about static siblings (from the route tree's staticSiblings
+      // field) but haven't prefetched them yet. We know the path exists but
+      // don't know its structure, so we can't predict it.
+      if (
+        staticChild.pattern === null &&
+        staticChild.dynamicChild === null &&
+        staticChild.staticChildren === null
+      ) {
+        // Bail out - server must resolve this route.
+        return null
+      }
+      const match = matchKnownRoutePart(
+        staticChild,
+        pathnameParts,
+        partIndex + 1,
+        resolvedParams
+      )
+      if (match !== null) {
+        return match
+      }
+      // Static child exists but didn't match (e.g., wrong depth).
+      // Fall through to try dynamic.
+    }
+  }
+
+  // Try dynamic child
+  if (part.dynamicChild !== null) {
+    const dynamicPart = part.dynamicChild
+    const paramName = part.dynamicChildParamName
+    const paramType = part.dynamicChildParamType
+    const dynamicPattern = dynamicPart.pattern
+
+    switch (paramType) {
+      case 'c':
+        // Required catch-all [...param]: consumes 1+ URL parts
+        if (
+          dynamicPattern !== null &&
+          !dynamicPattern.hasDynamicRewrite &&
+          urlPart !== null
+        ) {
+          resolvedParams.set(paramName, pathnameParts.slice(partIndex))
+          return { part: dynamicPart, pattern: dynamicPattern }
+        }
+        break
+      case 'oc':
+        // Optional catch-all [[...param]]: consumes 0+ URL parts
+        if (dynamicPattern !== null && !dynamicPattern.hasDynamicRewrite) {
+          if (urlPart !== null) {
+            resolvedParams.set(paramName, pathnameParts.slice(partIndex))
+            return { part: dynamicPart, pattern: dynamicPattern }
+          }
+          // urlPart is null - can match with zero parts, but a direct pattern
+          // (e.g., page.tsx alongside [[...param]]) takes precedence.
+          if (part.pattern === null || part.pattern.hasDynamicRewrite) {
+            resolvedParams.set(paramName, [])
+            return { part: dynamicPart, pattern: dynamicPattern }
+          }
+        }
+        break
+      case 'd':
+        // Regular dynamic [param]: consumes exactly 1 URL part.
+        // Unlike catch-all which terminates here, regular dynamic must
+        // continue recursing to find the leaf pattern.
+        if (urlPart !== null) {
+          resolvedParams.set(paramName, urlPart)
+          return matchKnownRoutePart(
+            dynamicPart,
+            pathnameParts,
+            partIndex + 1,
+            resolvedParams
+          )
+        }
+        break
+      // Intercepted routes use relative path markers like (.), (..), (...)
+      // Their behavior depends on navigation context (soft vs hard nav),
+      // so we can't predict them client-side. Defer to server.
+      case 'ci(..)(..)':
+      case 'ci(.)':
+      case 'ci(..)':
+      case 'ci(...)':
+      case 'di(..)(..)':
+      case 'di(.)':
+      case 'di(..)':
+      case 'di(...)':
+        return null
+      default:
+        paramType satisfies never
+    }
+  }
+
+  // No children matched. If we've consumed all URL parts, check for a direct
+  // pattern at this node (the route terminates here).
+  if (urlPart === null) {
+    const pattern = part.pattern
+    if (pattern !== null && !pattern.hasDynamicRewrite) {
+      return { part, pattern }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Accumulator for collecting data during reifyRouteTree traversal.
+ * metadataVaryPath is collected from the first page node encountered
+ * (parallel routes may have multiple pages, but metadata uses the first).
+ */
+type ReifyAccumulator = {
+  metadataVaryPath: PageVaryPath | null
+}
+
+/**
+ * "Reify" means to make concrete - we take an abstract pattern (the template
+ * route tree) and produce a concrete instance with actual param values.
+ *
+ * This function clones a RouteTree, substituting dynamic segment values from
+ * resolvedParams and computing new vary paths. The vary path encodes param
+ * values so segment cache entries can be correctly keyed.
+ *
+ * Example: Pattern for /blog/[slug] with resolvedParams { slug: "hello" }
+ * produces a tree where segment [slug] has cacheKey "hello".
+ */
+function reifyRouteTree(
+  pattern: RouteTree,
+  resolvedParams: ResolvedParams,
+  search: NormalizedSearch,
+  parentPartialVaryPath: PartialSegmentVaryPath | null,
+  acc: ReifyAccumulator
+): RouteTree {
+  const originalSegment = pattern.segment
+
+  let newSegment = originalSegment
+  let partialVaryPath: PartialSegmentVaryPath | null
+
+  if (typeof originalSegment !== 'string') {
+    // Dynamic segment: compute new cache key and append to partial vary path
+    const paramName = originalSegment[0]
+    const paramType = originalSegment[2]
+    const staticSiblings = originalSegment[3]
+    const newValue = resolvedParams.get(paramName)
+    if (newValue !== undefined) {
+      const newCacheKey = Array.isArray(newValue)
+        ? newValue.join('/')
+        : newValue
+      newSegment = [paramName, newCacheKey, paramType, staticSiblings]
+      partialVaryPath = appendLayoutVaryPath(
+        parentPartialVaryPath,
+        newCacheKey,
+        paramName
+      )
+    } else {
+      // Param not found in resolvedParams - keep original and inherit partial
+      // TODO: This should never happen. Bail out with null.
+      partialVaryPath = parentPartialVaryPath
+    }
+  } else {
+    // Static segment: inherit partial vary path from parent
+    partialVaryPath = parentPartialVaryPath
+  }
+
+  // Recurse into children with the (possibly updated) partial vary path
+  let newSlots: Record<string, RouteTree> | null = null
+  if (pattern.slots !== null) {
+    newSlots = {}
+    for (const key in pattern.slots) {
+      newSlots[key] = reifyRouteTree(
+        pattern.slots[key],
+        resolvedParams,
+        search,
+        partialVaryPath,
+        acc
+      )
+    }
+  }
+
+  if (pattern.isPage) {
+    // Page segment: finalize with search params
+    const newVaryPath = finalizePageVaryPath(
+      pattern.requestKey,
+      search,
+      partialVaryPath
+    )
+    // Collect metadata vary path (first page wins, same as original algorithm)
+    if (acc.metadataVaryPath === null) {
+      acc.metadataVaryPath = finalizeMetadataVaryPath(
+        pattern.requestKey,
+        search,
+        partialVaryPath
+      )
+    }
+    return {
+      requestKey: pattern.requestKey,
+      segment: newSegment,
+      refreshState: pattern.refreshState,
+      slots: newSlots,
+      isRootLayout: pattern.isRootLayout,
+      hasLoadingBoundary: pattern.hasLoadingBoundary,
+      hasRuntimePrefetch: pattern.hasRuntimePrefetch,
+      isPage: true,
+      varyPath: newVaryPath,
+    }
+  } else {
+    // Layout segment: finalize without search params
+    const newVaryPath = finalizeLayoutVaryPath(
+      pattern.requestKey,
+      partialVaryPath
+    )
+    return {
+      requestKey: pattern.requestKey,
+      segment: newSegment,
+      refreshState: pattern.refreshState,
+      slots: newSlots,
+      isRootLayout: pattern.isRootLayout,
+      hasLoadingBoundary: pattern.hasLoadingBoundary,
+      hasRuntimePrefetch: pattern.hasRuntimePrefetch,
+      isPage: false,
+      varyPath: newVaryPath,
+    }
+  }
+}
+
+/**
+ * Resets the known route tree. Called during development when routes may
+ * change due to hot reloading.
+ */
+export function resetKnownRoutes(): void {
+  knownRouteTreeRoot = createEmptyPart()
+}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1720,6 +1720,8 @@ function App<T>({
     initialFlightData: response.f,
     initialCanonicalUrlParts: response.c,
     initialRenderedSearch: response.q,
+    initialCouldBeIntercepted: response.i,
+    initialPrerendered: response.S,
     // location is not initialized in the SSR render
     // it's set to window.location during hydration
     location: null,
@@ -1783,6 +1785,8 @@ function ErrorApp<T>({
     initialFlightData: response.f,
     initialCanonicalUrlParts: response.c,
     initialRenderedSearch: response.q,
+    initialCouldBeIntercepted: response.i,
+    initialPrerendered: response.S,
     // location is not initialized in the SSR render
     // it's set to window.location during hydration
     location: null,

--- a/test/e2e/app-dir/optimistic-routing/app/actual/[slug]/loading.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/actual/[slug]/loading.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useParams } from 'next/navigation'
+
+function LoadingWithSlug() {
+  const params = useParams<{ slug: string }>()
+  return <p id="loading-message">Loading {params.slug}...</p>
+}
+
+export default function Loading() {
+  return (
+    <div id="loading-boundary">
+      <Suspense fallback={<p id="loading-message">Loading...</p>}>
+        <LoadingWithSlug />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/actual/[slug]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/actual/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import { connection } from 'next/server'
+
+export default async function ActualPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  await connection()
+
+  return (
+    <div id="actual-page">
+      <h1>Actual page</h1>
+      <p data-slug={slug}>Slug: {slug}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/blog/[slug]/loading.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/blog/[slug]/loading.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useParams } from 'next/navigation'
+
+function LoadingWithSlug() {
+  const params = useParams<{ slug: string }>()
+  return <p id="loading-message">Loading {params.slug}...</p>
+}
+
+export default function Loading() {
+  return (
+    <div id="loading-boundary">
+      <Suspense fallback="Loading...">
+        <LoadingWithSlug />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/blog/[slug]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/blog/[slug]/page.tsx
@@ -1,0 +1,23 @@
+import { connection } from 'next/server'
+import Link from 'next/link'
+
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  // Make this component dynamic
+  await connection()
+
+  return (
+    <div id="blog-post">
+      <h1 id="post-title">Blog Post: {slug}</h1>
+      <p id="post-slug">Slug: {slug}</p>
+      <Link href="/" id="back-link">
+        Back to home
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/blog/featured/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/blog/featured/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+// This is a static sibling to /blog/[slug]. Route prediction should NOT
+// apply to this route - it should be resolved via a tree prefetch, not
+// by matching the dynamic [slug] pattern.
+export default function FeaturedPage() {
+  return (
+    <div id="featured-page">
+      <h1 id="featured-title">Featured Blog Post</h1>
+      <p id="featured-description">
+        This is a static route that exists alongside the dynamic /blog/[slug]
+        route.
+      </p>
+      <Link href="/" id="back-link">
+        Back to home
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/docs/[[...slug]]/loading.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/docs/[[...slug]]/loading.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useParams } from 'next/navigation'
+
+function LoadingWithParams() {
+  const params = useParams<{ slug?: string[] }>()
+  const path = params.slug ? params.slug.join('/') : '(index)'
+  return <p id="loading-message">Loading docs {path}...</p>
+}
+
+export default function Loading() {
+  return (
+    <div id="loading-boundary">
+      <Suspense fallback={<p id="loading-message">Loading docs...</p>}>
+        <LoadingWithParams />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/docs/[[...slug]]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,23 @@
+import { connection } from 'next/server'
+import Link from 'next/link'
+
+export default async function DocsPage({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>
+}) {
+  const { slug } = await params
+  await connection()
+
+  const path = slug ? slug.join('/') : '(index)'
+
+  return (
+    <div id="docs-page">
+      <h1 id="docs-title">Docs: {path}</h1>
+      <p id="docs-path">Path: {path}</p>
+      <Link href="/" id="back-link">
+        Back to home
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/files/[...path]/loading.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/files/[...path]/loading.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useParams } from 'next/navigation'
+
+function LoadingWithParams() {
+  const params = useParams<{ path: string[] }>()
+  const filePath = params.path.join('/')
+  return <p id="loading-message">Loading file {filePath}...</p>
+}
+
+export default function Loading() {
+  return (
+    <div id="loading-boundary">
+      <Suspense fallback={<p id="loading-message">Loading file...</p>}>
+        <LoadingWithParams />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/files/[...path]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/files/[...path]/page.tsx
@@ -1,0 +1,23 @@
+import { connection } from 'next/server'
+import Link from 'next/link'
+
+export default async function FilesPage({
+  params,
+}: {
+  params: Promise<{ path: string[] }>
+}) {
+  const { path } = await params
+  await connection()
+
+  const filePath = path.join('/')
+
+  return (
+    <div id="files-page">
+      <h1 id="files-title">File: {filePath}</h1>
+      <p id="files-path">Path: {filePath}</p>
+      <Link href="/" id="back-link">
+        Back to home
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/layout.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode, Suspense } from 'react'
+import { ParamsHistory } from '../components/params-history'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <Suspense fallback={null}>
+          <ParamsHistory />
+        </Suspense>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/page.tsx
@@ -1,0 +1,131 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Optimistic Routing Test</h1>
+      <p>
+        This test verifies that route prediction works correctly. When a route
+        pattern is learned from one URL, navigating to a different URL with the
+        same pattern should show the loading state instantly.
+      </p>
+
+      <h2>Basic Dynamic Route</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/blog/post-1">Blog Post 1</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/blog/post-2" prefetch={false}>
+            Blog Post 2 (prefetch disabled)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/blog/post-3" prefetch={false}>
+            Blog Post 3 (prefetch disabled)
+          </LinkAccordion>
+        </li>
+      </ul>
+
+      <h2>Nested Dynamic Route</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/products/electronics/phone-1">
+            Electronics - Phone 1
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/products/electronics/phone-2" prefetch={false}>
+            Electronics - Phone 2 (prefetch disabled)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/products/clothing/shirt-1" prefetch={false}>
+            Clothing - Shirt 1 (prefetch disabled)
+          </LinkAccordion>
+        </li>
+      </ul>
+
+      <h2>Optional Catch-All Route</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/docs">Docs Index</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/docs/intro">Docs Intro</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/docs/guide/getting-started" prefetch={false}>
+            Docs Guide - Getting Started (prefetch disabled)
+          </LinkAccordion>
+        </li>
+      </ul>
+
+      <h2>Required Catch-All Route</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/files/documents/report.pdf">
+            Files - Report
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/files/images/photo.jpg" prefetch={false}>
+            Files - Photo (prefetch disabled)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/files/a/b/c/d" prefetch={false}>
+            Files - Deep Path (prefetch disabled)
+          </LinkAccordion>
+        </li>
+      </ul>
+
+      <h2>Static Sibling Detection</h2>
+      <ul>
+        <li>
+          <LinkAccordion href="/blog/featured" prefetch={false}>
+            Featured (static sibling, prefetch disabled)
+          </LinkAccordion>
+        </li>
+      </ul>
+
+      <h2>Rewrite Detection (Route Params)</h2>
+      <p>
+        These URLs are rewritten by proxy to /actual/[slug]. The route should be
+        marked as having a dynamic rewrite since the URL doesn&apos;t match the
+        route structure.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/rewritten/first">
+            Rewritten First (learns pattern, marks as dynamic rewrite)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/rewritten/second" prefetch={false}>
+            Rewritten Second (should not use cached pattern)
+          </LinkAccordion>
+        </li>
+      </ul>
+
+      <h2>Rewrite Detection (Search Params)</h2>
+      <p>
+        These URLs are rewritten based on search params. /search-rewrite?v=X
+        becomes /rewrite-target?content=X. Since the page is static, if we
+        incorrectly use a cached pattern, we&apos;d show wrong content.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/search-rewrite?v=alpha">
+            Search Rewrite Alpha (v=alpha → content=alpha)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/search-rewrite?v=beta" prefetch={false}>
+            Search Rewrite Beta (v=beta → content=beta)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/products/[category]/[id]/loading.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/products/[category]/[id]/loading.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { Suspense } from 'react'
+import { useParams } from 'next/navigation'
+
+function LoadingWithParams() {
+  const params = useParams<{ category: string; id: string }>()
+  return (
+    <p id="loading-message">
+      Loading {params.category}/{params.id}...
+    </p>
+  )
+}
+
+export default function Loading() {
+  return (
+    <div id="loading-boundary">
+      <Suspense fallback={<p id="loading-message">Loading product...</p>}>
+        <LoadingWithParams />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/products/[category]/[id]/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/products/[category]/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { connection } from 'next/server'
+import Link from 'next/link'
+
+export default async function ProductPage({
+  params,
+}: {
+  params: Promise<{ category: string; id: string }>
+}) {
+  const { category, id } = await params
+  await connection()
+
+  return (
+    <div id="product-page">
+      <h1 id="product-title">
+        Product: {category}/{id}
+      </h1>
+      <p id="product-category">Category: {category}</p>
+      <p id="product-id">ID: {id}</p>
+      <Link href="/" id="back-link">
+        Back to home
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/rewrite-alpha/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/rewrite-alpha/page.tsx
@@ -1,0 +1,11 @@
+// Fully static page - no dynamic data access
+export default function RewriteAlphaPage() {
+  return (
+    <div id="rewrite-target-page">
+      <h1>Rewrite Target</h1>
+      <p id="rewrite-content" data-content="alpha">
+        Content: alpha
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/app/rewrite-beta/page.tsx
+++ b/test/e2e/app-dir/optimistic-routing/app/rewrite-beta/page.tsx
@@ -1,0 +1,11 @@
+// Fully static page - no dynamic data access
+export default function RewriteBetaPage() {
+  return (
+    <div id="rewrite-target-page">
+      <h1>Rewrite Target</h1>
+      <p id="rewrite-content" data-content="beta">
+        Content: beta
+      </p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/components/link-accordion.tsx
+++ b/test/e2e/app-dir/optimistic-routing/components/link-accordion.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: LinkProps['href']
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  // This component controls when prefetching happens by hiding the Link until
+  // the checkbox is clicked. Prefetch triggers when the Link enters the viewport.
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/components/params-history.tsx
+++ b/test/e2e/app-dir/optimistic-routing/components/params-history.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { useState } from 'react'
+import { useParams } from 'next/navigation'
+
+/**
+ * Accumulates all param values rendered throughout the app's lifetime.
+ * Uses the setState-in-render pattern to capture changes synchronously,
+ * before React commits. This catches any intermediate/wrong params that
+ * might flash briefly due to incorrect route prediction.
+ */
+export function ParamsHistory() {
+  const params = useParams()
+  const paramsJson = JSON.stringify(params)
+
+  const [history, setHistory] = useState<string[]>([paramsJson])
+  const [prevParams, setPrevParams] = useState(paramsJson)
+
+  // setState-in-render pattern: update state synchronously during render
+  // if the params have changed. This captures intermediate states.
+  if (paramsJson !== prevParams) {
+    setPrevParams(paramsJson)
+    setHistory((prev) => [...prev, paramsJson])
+  }
+
+  return (
+    <div
+      id="params-history"
+      data-history={JSON.stringify(history)}
+      style={{
+        padding: '8px',
+        marginTop: '16px',
+        background: '#f5f5f5',
+        borderRadius: '4px',
+        fontSize: '12px',
+        fontFamily: 'monospace',
+      }}
+    >
+      <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
+        Params History (debug)
+      </div>
+      <div>Current: {paramsJson}</div>
+      <div style={{ marginTop: '4px' }}>
+        History:{' '}
+        {history.map((h, i) => (
+          <span key={i}>
+            {i > 0 && ' → '}
+            {h}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/optimistic-routing/next.config.js
+++ b/test/e2e/app-dir/optimistic-routing/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    optimisticRouting: true,
+  },
+  productionBrowserSourceMaps: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/optimistic-routing/optimistic-routing.test.ts
+++ b/test/e2e/app-dir/optimistic-routing/optimistic-routing.test.ts
@@ -1,0 +1,433 @@
+/**
+ * Optimistic Routing Tests
+ *
+ * These tests verify that route prediction works correctly. The key behavior
+ * being tested is that after learning a route pattern from one URL, navigating
+ * to a different URL with the same pattern should show the loading state
+ * instantly - without waiting for a tree prefetch.
+ *
+ * The testing strategy uses the fact that loading boundaries are cached and
+ * can be reused across different param values. If route prediction works:
+ * 1. We predict the route structure without a tree prefetch
+ * 2. We know there's a loading boundary from the predicted structure
+ * 3. The loading boundary segment is already cached
+ * 4. The loading UI appears instantly with the new param value
+ *
+ * We use RouterAct and assert on the loading state inside the act scope,
+ * where network responses haven't reached the client yet.
+ */
+
+import { nextTestSetup } from 'e2e-utils'
+import { createRouterAct } from 'router-act'
+
+describe('optimistic-routing', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    // Route prediction with static siblings requires production build
+    // because dev mode uses on-demand compilation (staticChildren is null)
+    test('skipped in dev mode', () => {})
+    return
+  }
+
+  it('basic dynamic route prediction: shows loading state instantly for unprefetched route', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Reveal and prefetch the first blog post link.
+    // This learns the /blog/[slug] route pattern and caches the loading boundary.
+    const revealPost1 = await browser.elementByCss(
+      'input[data-link-accordion="/blog/post-1"]'
+    )
+    await act(
+      async () => {
+        await revealPost1.click()
+      },
+      {
+        // Wait for prefetch to complete by matching loading boundary text in response
+        includes: 'Loading',
+      }
+    )
+
+    // Step 2: Reveal the second link and navigate to it.
+    // This link has prefetch={false} to test route prediction - we want to
+    // confirm the loading state appears instantly WITHOUT any prefetch.
+    await act(async () => {
+      const revealPost2 = await browser.elementByCss(
+        'input[data-link-accordion="/blog/post-2"]'
+      )
+      await revealPost2.click()
+    }, 'no-requests') // Assert: prefetch={false} means no requests on reveal
+
+    const linkPost2 = await browser.elementByCss('a[href="/blog/post-2"]')
+    await act(async () => {
+      await linkPost2.click()
+
+      // Assert inside the act scope - at this point, network responses haven't
+      // reached the client yet. If the loading state is visible, it proves
+      // route prediction worked.
+      const loadingMessage = await browser.elementById('loading-message')
+      expect(await loadingMessage.text()).toBe('Loading post-2...')
+    })
+
+    // Step 3: After act completes, verify the full page eventually loads
+    const postTitle = await browser.elementById('post-title')
+    expect(await postTitle.text()).toBe('Blog Post: post-2')
+  })
+
+  it('nested dynamic routes: predicts through multiple dynamic segments', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Reveal and prefetch the first product link.
+    // This learns the /products/[category]/[id] route pattern.
+    const revealProduct1 = await browser.elementByCss(
+      'input[data-link-accordion="/products/electronics/phone-1"]'
+    )
+    await act(
+      async () => {
+        await revealProduct1.click()
+      },
+      {
+        includes: 'Loading',
+      }
+    )
+
+    // Step 2: Navigate to a different product with different category AND id.
+    // This link has prefetch={false} to test route prediction - we want to
+    // confirm the loading state appears instantly WITHOUT any prefetch.
+    await act(async () => {
+      const revealProduct2 = await browser.elementByCss(
+        'input[data-link-accordion="/products/clothing/shirt-1"]'
+      )
+      await revealProduct2.click()
+    }, 'no-requests') // Assert: prefetch={false} means no requests on reveal
+
+    const linkProduct2 = await browser.elementByCss(
+      'a[href="/products/clothing/shirt-1"]'
+    )
+    await act(async () => {
+      await linkProduct2.click()
+
+      // Both category and id should be predicted correctly
+      const loadingMessage = await browser.elementById('loading-message')
+      expect(await loadingMessage.text()).toBe('Loading clothing/shirt-1...')
+    })
+
+    // Verify final page content
+    const productTitle = await browser.elementById('product-title')
+    expect(await productTitle.text()).toBe('Product: clothing/shirt-1')
+  })
+
+  it('optional catch-all: predicts from index to path with segments', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Prefetch /docs (index route, no slug segments)
+    const revealDocsIndex = await browser.elementByCss(
+      'input[data-link-accordion="/docs"]'
+    )
+    await act(
+      async () => {
+        await revealDocsIndex.click()
+      },
+      {
+        includes: 'Loading',
+      }
+    )
+
+    // Step 2: Navigate to /docs/intro (one segment)
+    const revealDocsIntro = await browser.elementByCss(
+      'input[data-link-accordion="/docs/intro"]'
+    )
+    await revealDocsIntro.click()
+
+    const linkDocsIntro = await browser.elementByCss('a[href="/docs/intro"]')
+    await act(async () => {
+      await linkDocsIntro.click()
+
+      const loadingMessage = await browser.elementById('loading-message')
+      expect(await loadingMessage.text()).toBe('Loading docs intro...')
+    })
+
+    const docsTitle = await browser.elementById('docs-title')
+    expect(await docsTitle.text()).toBe('Docs: intro')
+  })
+
+  it('optional catch-all: predicts between paths with different segment counts', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Prefetch /docs/intro (one segment)
+    const revealDocsIntro = await browser.elementByCss(
+      'input[data-link-accordion="/docs/intro"]'
+    )
+    await act(
+      async () => {
+        await revealDocsIntro.click()
+      },
+      {
+        includes: 'Loading',
+      }
+    )
+
+    // Step 2: Navigate to /docs/guide/getting-started (two segments).
+    // This link has prefetch={false} to test route prediction - we want to
+    // confirm the loading state appears instantly WITHOUT any prefetch.
+    await act(async () => {
+      const revealDocsGuide = await browser.elementByCss(
+        'input[data-link-accordion="/docs/guide/getting-started"]'
+      )
+      await revealDocsGuide.click()
+    }, 'no-requests') // Assert: prefetch={false} means no requests on reveal
+
+    const linkDocsGuide = await browser.elementByCss(
+      'a[href="/docs/guide/getting-started"]'
+    )
+    await act(async () => {
+      await linkDocsGuide.click()
+
+      const loadingMessage = await browser.elementById('loading-message')
+      expect(await loadingMessage.text()).toBe(
+        'Loading docs guide/getting-started...'
+      )
+    })
+
+    const docsTitle = await browser.elementById('docs-title')
+    expect(await docsTitle.text()).toBe('Docs: guide/getting-started')
+  })
+
+  it('required catch-all: predicts between paths with different segment counts', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Prefetch /files/documents/report.pdf (three segments)
+    const revealFiles1 = await browser.elementByCss(
+      'input[data-link-accordion="/files/documents/report.pdf"]'
+    )
+    await act(
+      async () => {
+        await revealFiles1.click()
+      },
+      {
+        includes: 'Loading',
+      }
+    )
+
+    // Step 2: Navigate to /files/a/b/c/d (four segments).
+    // This link has prefetch={false} to test route prediction - we want to
+    // confirm the loading state appears instantly WITHOUT any prefetch.
+    await act(async () => {
+      const revealFiles2 = await browser.elementByCss(
+        'input[data-link-accordion="/files/a/b/c/d"]'
+      )
+      await revealFiles2.click()
+    }, 'no-requests') // Assert: prefetch={false} means no requests on reveal
+
+    const linkFiles2 = await browser.elementByCss('a[href="/files/a/b/c/d"]')
+    await act(async () => {
+      await linkFiles2.click()
+
+      const loadingMessage = await browser.elementById('loading-message')
+      expect(await loadingMessage.text()).toBe('Loading file a/b/c/d...')
+    })
+
+    const filesTitle = await browser.elementById('files-title')
+    expect(await filesTitle.text()).toBe('File: a/b/c/d')
+  })
+
+  it('static sibling detection: does not incorrectly match static route to dynamic pattern', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Prefetch /blog/post-1 to learn the /blog/[slug] pattern.
+    // This also learns that /blog/featured is a static sibling.
+    const revealPost1 = await browser.elementByCss(
+      'input[data-link-accordion="/blog/post-1"]'
+    )
+    await act(
+      async () => {
+        await revealPost1.click()
+      },
+      {
+        includes: 'Loading',
+      }
+    )
+
+    // Step 2: Navigate to /blog/featured (static sibling).
+    // This link has prefetch={false} - route prediction should NOT apply because
+    // /blog/featured is recognized as a static sibling of /blog/[slug].
+    await act(async () => {
+      const revealFeatured = await browser.elementByCss(
+        'input[data-link-accordion="/blog/featured"]'
+      )
+      await revealFeatured.click()
+    }, 'no-requests') // Assert: prefetch={false} means no requests on reveal
+
+    const linkFeatured = await browser.elementByCss('a[href="/blog/featured"]')
+    await act(async () => {
+      await linkFeatured.click()
+
+      // The loading message should NOT be visible because:
+      // 1. /blog/featured is recognized as a static sibling
+      // 2. Route prediction doesn't apply
+      // 3. We need to wait for server response
+      const loadingMessage = await browser
+        .elementById('loading-message')
+        .catch(() => null)
+      expect(loadingMessage).toBeNull()
+    })
+
+    // After navigation completes, we should see the featured page
+    const featuredTitle = await browser.elementById('featured-title')
+    expect(await featuredTitle.text()).toBe('Featured Blog Post')
+  })
+
+  it('rewrite detection: detects dynamic rewrite when URL does not match route structure', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Navigate to /rewritten/first.
+    // This URL is rewritten by proxy to /actual/first.
+    // Because the URL path part ("rewritten") doesn't match the route segment
+    // ("actual"), the route is marked as having a dynamic rewrite.
+    await act(async () => {
+      const revealFirst = await browser.elementByCss(
+        'input[data-link-accordion="/rewritten/first"]'
+      )
+      await revealFirst.click()
+      const linkFirst = await browser.elementByCss('a[href="/rewritten/first"]')
+      await linkFirst.click()
+    })
+
+    // Wait for navigation to complete
+    await browser.elementById('actual-page')
+
+    // Step 2: Navigate back to home using browser back button
+    await browser.back()
+    await browser.elementById('params-history')
+
+    // Step 3: Navigate to /rewritten/second.
+    // This link has prefetch={false}. Even though we've "learned" the route
+    // from step 1, the route should be marked as having a dynamic rewrite,
+    // so we should NOT use the cached pattern.
+    await act(async () => {
+      const revealSecond = await browser.elementByCss(
+        'input[data-link-accordion="/rewritten/second"]'
+      )
+      await revealSecond.click()
+    }, 'no-requests') // Assert: prefetch={false} means no requests on reveal
+
+    const linkSecond = await browser.elementByCss('a[href="/rewritten/second"]')
+    await act(async () => {
+      await linkSecond.click()
+    })
+
+    // Wait for navigation to complete
+    await browser.elementById('actual-page')
+
+    // Verify using params history that no wrong params were rendered.
+    // The history accumulator captures every params change during render.
+    // If route prediction incorrectly used a pattern, we'd see "first"
+    // briefly flash before "second".
+    const historyEl = await browser.elementById('params-history')
+    const historyAttr = await historyEl.getAttribute('data-history')
+    const history: string[] = JSON.parse(historyAttr)
+
+    // The history should only contain params from actual navigations,
+    // not any intermediate wrong values from incorrect prediction.
+    // Expected: [{}, {slug: "first"}, {}, {slug: "second"}]
+    // The {} entries are from the home page.
+    const slugHistory = history
+      .map((h) => JSON.parse(h))
+      .filter((p) => p.slug !== undefined)
+      .map((p) => p.slug)
+
+    // We should see exactly [first, second] - no duplicates or wrong values
+    expect(slugHistory).toEqual(['first', 'second'])
+  })
+
+  it('rewrite detection (search params): does not use cached pattern when search params cause different rewrite', async () => {
+    let act: ReturnType<typeof createRouterAct>
+    const browser = await next.browser('/', {
+      beforePageLoad(page) {
+        act = createRouterAct(page)
+      },
+    })
+
+    // Step 1: Navigate to /search-rewrite?v=alpha
+    // This is rewritten by proxy to /rewrite-target?content=alpha
+    // The page is fully static, displaying the content param.
+    await act(async () => {
+      const revealAlpha = await browser.elementByCss(
+        'input[data-link-accordion="/search-rewrite?v=alpha"]'
+      )
+      await revealAlpha.click()
+      const linkAlpha = await browser.elementByCss(
+        'a[href="/search-rewrite?v=alpha"]'
+      )
+      await linkAlpha.click()
+    })
+
+    // Wait for navigation and verify we see "alpha"
+    const contentAlpha = await browser.elementById('rewrite-content')
+    expect(await contentAlpha.getAttribute('data-content')).toBe('alpha')
+
+    // Step 2: Go back to home
+    await browser.back()
+    await browser.elementById('params-history')
+
+    // Step 3: Navigate to /search-rewrite?v=beta.
+    // This link has prefetch={false} - if the route was incorrectly cached as
+    // predictable, we'd see "alpha" instead of "beta" because the static page
+    // would be served from cache.
+    await act(async () => {
+      const revealBeta = await browser.elementByCss(
+        'input[data-link-accordion="/search-rewrite?v=beta"]'
+      )
+      await revealBeta.click()
+    }, 'no-requests') // Assert: prefetch={false} means no requests on reveal
+
+    const linkBeta = await browser.elementByCss(
+      'a[href="/search-rewrite?v=beta"]'
+    )
+    await act(async () => {
+      await linkBeta.click()
+    })
+
+    // Verify we see "beta", not "alpha"
+    // If this shows "alpha", the route was incorrectly using a cached pattern.
+    const contentBeta = await browser.elementById('rewrite-content')
+    expect(await contentBeta.getAttribute('data-content')).toBe('beta')
+  })
+})

--- a/test/e2e/app-dir/optimistic-routing/proxy.ts
+++ b/test/e2e/app-dir/optimistic-routing/proxy.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname
+
+  // Rewrite /rewritten/[slug] to /actual/[slug]
+  // This creates a mismatch between URL and route structure that should
+  // mark the route as having a dynamic rewrite.
+  if (pathname.startsWith('/rewritten/')) {
+    const slug = pathname.replace('/rewritten/', '')
+    const url = request.nextUrl.clone()
+    url.pathname = `/actual/${slug}`
+    return NextResponse.rewrite(url)
+  }
+
+  // Rewrite /search-rewrite?v=alpha to /rewrite-alpha
+  // Rewrite /search-rewrite?v=beta to /rewrite-beta
+  // This tests that search param rewrites are correctly detected.
+  // The destination pages are fully static, so if we incorrectly use a cached
+  // pattern, we'd show the wrong content.
+  if (pathname === '/search-rewrite') {
+    const v = request.nextUrl.searchParams.get('v')
+    const url = request.nextUrl.clone()
+    url.pathname = v === 'beta' ? '/rewrite-beta' : '/rewrite-alpha'
+    url.searchParams.delete('v')
+    return NextResponse.rewrite(url)
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: ['/rewritten/:path*', '/search-rewrite'],
+}


### PR DESCRIPTION
Based on:

- https://github.com/vercel/next.js/pull/88834
- https://github.com/vercel/next.js/pull/88989
- https://github.com/vercel/next.js/pull/88998

---

Adds optimistic routing, enabling the client to predict route structure for URLs that haven't been prefetched yet. When navigating to a URL like /blog/post-2, if we've previously learned the pattern from /blog/post-1, we can predict the route structure without waiting for a server response.

The client learns route patterns from server responses and builds a trie indexed by URL parts. When a cache miss occurs, we check if the URL matches a known pattern. If so, we create a synthetic cache entry from the template, allowing immediate rendering of loading boundaries.

Static siblings (like /blog/featured alongside /blog/[slug]) are tracked to avoid incorrect predictions — we only predict dynamic routes when we're confident no static sibling matches.