### PR TITLE
Reapply "[turbopack] Add bundling support for worker_threads" (#88725)

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,4 @@
+edition = "2024"
 max_width = 100
 
 comment_width = 100

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -14,10 +14,7 @@ use turbo_tasks::{Completion, ResolvedVc, Vc};
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
-    chunk::{
-        ChunkingContext, ChunkingContextExt, EntryChunkGroupResult,
-        availability_info::AvailabilityInfo,
-    },
+    chunk::{ChunkingContextExt, EntryChunkGroupResult, availability_info::AvailabilityInfo},
     context::AssetContext,
     module::Module,
     module_graph::{
@@ -138,7 +135,7 @@ impl MiddlewareEndpoint {
         };
 
         let EntryChunkGroupResult { asset: chunk, .. } = *chunking_context
-            .entry_chunk_group(
+            .root_entry_chunk_group(
                 this.project
                     .node_root()
                     .await?
@@ -147,7 +144,6 @@ impl MiddlewareEndpoint {
                 module_graph,
                 OutputAssets::empty(),
                 OutputAssets::empty(),
-                AvailabilityInfo::root(),
             )
             .await?;
         Ok(*chunk)

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -76,30 +76,27 @@ impl OutputAsset for NftJsonAsset {
     }
 }
 
-#[turbo_tasks::value(transparent)]
-pub struct OutputSpecifier(Option<RcStr>);
-
 fn get_output_specifier(
-    path_ref: &FileSystemPath,
+    chunk_path: &FileSystemPath,
     ident_folder: &FileSystemPath,
     ident_folder_in_project_fs: &FileSystemPath,
     output_root: &FileSystemPath,
     project_root: &FileSystemPath,
-) -> Result<RcStr> {
+) -> Option<RcStr> {
     // include assets in the outputs such as referenced chunks
-    if path_ref.is_inside_ref(output_root) {
-        return Ok(ident_folder.get_relative_path_to(path_ref).unwrap());
+    if chunk_path.is_inside_ref(output_root) {
+        return Some(ident_folder.get_relative_path_to(chunk_path).unwrap());
     }
 
     // include assets in the project root such as images and traced references (externals)
-    if path_ref.is_inside_ref(project_root) {
-        return Ok(ident_folder_in_project_fs
-            .get_relative_path_to(path_ref)
-            .unwrap());
+    if chunk_path.is_inside_ref(project_root) {
+        return Some(
+            ident_folder_in_project_fs
+                .get_relative_path_to(chunk_path)
+                .unwrap(),
+        );
     }
-
-    // This should effectively be unreachable
-    bail!("NftJsonAsset: cannot handle filepath {path_ref}");
+    None
 }
 
 /// Apply outputFileTracingIncludes patterns to find additional files
@@ -285,13 +282,21 @@ impl Asset for NftJsonAsset {
                     }
                 }
 
-                let specifier = get_output_specifier(
+                let Some(specifier) = get_output_specifier(
                     &referenced_chunk_path,
                     &ident_folder,
                     &ident_folder_in_project_fs,
                     &output_root_ref,
                     &project_root_ref,
-                )?;
+                ) else {
+                    // This should effectively be unreachable
+                    bail!(
+                        "NftJsonAsset: cannot handle filepath '{chunk_path}' for \
+                         {referenced_chunk:?} it is not under the output_root: \
+                         '{output_root_ref}' or the project_root: '{project_root_ref}'",
+                        chunk_path = referenced_chunk_path.value_to_string().await?
+                    );
+                };
 
                 result.insert(specifier);
             }

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -77,26 +77,25 @@ impl OutputAsset for NftJsonAsset {
 }
 
 fn get_output_specifier(
-    chunk_path: &FileSystemPath,
+    path_ref: &FileSystemPath,
     ident_folder: &FileSystemPath,
     ident_folder_in_project_fs: &FileSystemPath,
     output_root: &FileSystemPath,
     project_root: &FileSystemPath,
-) -> Option<RcStr> {
+) -> Result<RcStr> {
     // include assets in the outputs such as referenced chunks
-    if chunk_path.is_inside_ref(output_root) {
-        return Some(ident_folder.get_relative_path_to(chunk_path).unwrap());
+    if path_ref.is_inside_ref(output_root) {
+        return Ok(ident_folder.get_relative_path_to(path_ref).unwrap());
     }
 
     // include assets in the project root such as images and traced references (externals)
-    if chunk_path.is_inside_ref(project_root) {
-        return Some(
-            ident_folder_in_project_fs
-                .get_relative_path_to(chunk_path)
-                .unwrap(),
-        );
+    if path_ref.is_inside_ref(project_root) {
+        return Ok(ident_folder_in_project_fs
+            .get_relative_path_to(path_ref)
+            .unwrap());
     }
-    None
+    // This should effectively be unreachable
+    bail!("NftJsonAsset: cannot handle filepath '{path_ref}'");
 }
 
 /// Apply outputFileTracingIncludes patterns to find additional files
@@ -282,20 +281,22 @@ impl Asset for NftJsonAsset {
                     }
                 }
 
-                let Some(specifier) = get_output_specifier(
+                let specifier = match get_output_specifier(
                     &referenced_chunk_path,
                     &ident_folder,
                     &ident_folder_in_project_fs,
                     &output_root_ref,
                     &project_root_ref,
-                ) else {
-                    // This should effectively be unreachable
-                    bail!(
-                        "NftJsonAsset: cannot handle filepath '{chunk_path}' for \
-                         {referenced_chunk:?} it is not under the output_root: \
-                         '{output_root_ref}' or the project_root: '{project_root_ref}'",
-                        chunk_path = referenced_chunk_path.value_to_string().await?
-                    );
+                ) {
+                    Ok(specifier) => specifier,
+                    Err(err) => {
+                        return Err(err.context(format!(
+                            "NftJsonAsset: cannot handle filepath '{chunk_path}' for \
+                             {referenced_chunk:?} it is not under the output_root: \
+                             '{output_root_ref}' or the project_root: '{project_root_ref}'",
+                            chunk_path = referenced_chunk_path.value_to_string().await?
+                        )));
+                    }
                 };
 
                 result.insert(specifier);

--- a/test/e2e/app-dir/node-worker-threads/app/api/pino-test/route.ts
+++ b/test/e2e/app-dir/node-worker-threads/app/api/pino-test/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import pino from 'pino'
+
+export async function GET() {
+  try {
+    // Create a pino logger with a transport
+    // This internally uses thread-stream which creates worker_threads
+    const logger = pino({
+      transport: {
+        target: 'pino/file',
+        options: { destination: 1 }, // stdout
+      },
+    })
+
+    // Log a test message - this triggers the transport worker
+    logger.info('pino test message')
+
+    // Flush the logger to ensure the message is sent
+    // Use nextTick to allow async initialization of the transport
+    await new Promise((resolve) => process.nextTick(resolve))
+
+    return NextResponse.json({
+      success: true,
+      message: 'pino logger with transport initialized successfully',
+    })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/test/e2e/app-dir/node-worker-threads/app/api/simple-worker-test/route.ts
+++ b/test/e2e/app-dir/node-worker-threads/app/api/simple-worker-test/route.ts
@@ -1,0 +1,41 @@
+import { Worker } from 'node:worker_threads'
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  try {
+    // Test with a relative path instead of __filename
+    const worker = new Worker('./app/worker-dir/simple-worker.ts')
+
+    const message = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Worker timeout'))
+      }, 5000)
+
+      worker.on('message', (msg) => {
+        clearTimeout(timeout)
+        resolve(msg)
+      })
+      worker.on('error', (err) => {
+        clearTimeout(timeout)
+        reject(err)
+      })
+      worker.on('exit', (code) => {
+        if (code !== 0) {
+          clearTimeout(timeout)
+          reject(new Error(`Worker stopped with exit code ${code}`))
+        }
+      })
+
+      worker.postMessage('ping')
+    })
+
+    await worker.terminate()
+
+    return NextResponse.json({ success: true, message })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/test/e2e/app-dir/node-worker-threads/app/api/worker-test/route.ts
+++ b/test/e2e/app-dir/node-worker-threads/app/api/worker-test/route.ts
@@ -1,0 +1,62 @@
+import { Worker, isMainThread, parentPort } from 'node:worker_threads'
+import { NextResponse } from 'next/server'
+
+// This file tests self-referencing worker threads using __filename
+// This pattern is used by libraries like @duckdb/duckdb-wasm
+
+if (!isMainThread && parentPort) {
+  // Worker thread - handle messages
+  parentPort.on('message', (msg) => {
+    if (msg === 'ping') {
+      parentPort!.postMessage('pong')
+    }
+  })
+}
+
+export async function GET() {
+  if (!isMainThread) {
+    // If we're in a worker, don't try to create another worker
+    return NextResponse.json({ error: 'Already in worker' }, { status: 500 })
+  }
+
+  // Log __filename for debugging
+  console.log('__filename:', __filename)
+  console.log('typeof __filename:', typeof __filename)
+
+  try {
+    // Create a worker using __filename - this is the pattern that triggers the cycle bug
+    const worker = new Worker(__filename)
+
+    const message = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error('Worker timeout'))
+      }, 5000)
+
+      worker.on('message', (msg) => {
+        clearTimeout(timeout)
+        resolve(msg)
+      })
+      worker.on('error', (err) => {
+        clearTimeout(timeout)
+        reject(err)
+      })
+      worker.on('exit', (code) => {
+        if (code !== 0) {
+          clearTimeout(timeout)
+          reject(new Error(`Worker stopped with exit code ${code}`))
+        }
+      })
+
+      worker.postMessage('ping')
+    })
+
+    await worker.terminate()
+
+    return NextResponse.json({ success: true, message })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, error: String(error) },
+      { status: 500 }
+    )
+  }
+}

--- a/test/e2e/app-dir/node-worker-threads/app/layout.tsx
+++ b/test/e2e/app-dir/node-worker-threads/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/node-worker-threads/app/worker-dir/simple-worker.ts
+++ b/test/e2e/app-dir/node-worker-threads/app/worker-dir/simple-worker.ts
@@ -1,0 +1,9 @@
+import { parentPort } from 'node:worker_threads'
+
+if (parentPort) {
+  parentPort.on('message', (msg) => {
+    if (msg === 'ping') {
+      parentPort!.postMessage('pong from simple worker')
+    }
+  })
+}

--- a/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
+++ b/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
@@ -4,6 +4,9 @@ describe('node-worker-threads', () => {
   const { next, skipped, isTurbopack } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
+    dependencies: {
+      pino: '9.6.0',
+    },
   })
 
   if (skipped) {
@@ -32,5 +35,17 @@ describe('node-worker-threads', () => {
     expect(res.status).toBe(200)
     expect(data.success).toBe(true)
     expect(data.message).toBe('pong')
+  })
+
+  it('should handle pino logger with transport (thread-stream)', async () => {
+    // Pino with transports uses thread-stream internally, which creates worker_threads
+    // with a broad pattern like join(__dirname, 'lib', 'worker.js') that can match
+    // non-evaluatable files like package.json. This tests that we properly downgrade
+    // those errors to warnings via loose_errors.
+    const res = await next.fetch('/api/pino-test')
+    const data = await res.json()
+    console.log('Pino test response:', data)
+    expect(res.status).toBe(200)
+    expect(data.success).toBe(true)
   })
 })

--- a/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
+++ b/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
@@ -1,0 +1,36 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('node-worker-threads', () => {
+  const { next, skipped, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  // These tests are Turbopack-specific since they rely on Turbopack's worker bundling
+  if (!isTurbopack) {
+    it.skip('webpack doesnt support bundling worker-threads', () => {})
+    return
+  }
+
+  it('should handle simple worker with relative path', async () => {
+    const res = await next.fetch('/api/simple-worker-test')
+    const data = await res.json()
+    console.log('Simple worker response:', data)
+    expect(res.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(data.message).toBe('pong from simple worker')
+  })
+
+  it('should handle self-referencing worker with __filename', async () => {
+    const res = await next.fetch('/api/worker-test')
+    const data = await res.json()
+    console.log('Self-ref worker response:', data)
+    expect(res.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(data.message).toBe('pong')
+  })
+})

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -372,10 +372,7 @@ impl BrowserChunkingContext {
         }
     }
 }
-
-#[turbo_tasks::value_impl]
 impl BrowserChunkingContext {
-    #[turbo_tasks::function]
     fn generate_evaluate_chunk(
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
@@ -392,8 +389,6 @@ impl BrowserChunkingContext {
             module_graph,
         ))
     }
-
-    #[turbo_tasks::function]
     fn generate_chunk_list_register_chunk(
         self: Vc<Self>,
         ident: Vc<AssetIdent>,
@@ -409,26 +404,30 @@ impl BrowserChunkingContext {
             source,
         ))
     }
-
-    #[turbo_tasks::function]
     async fn generate_chunk(
         self: Vc<Self>,
         chunk: ResolvedVc<Box<dyn Chunk>>,
-    ) -> Result<Vc<Box<dyn OutputAsset>>> {
+    ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
         Ok(
             if let Some(ecmascript_chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk)
             {
-                Vc::upcast(EcmascriptBrowserChunk::new(self, *ecmascript_chunk))
+                ResolvedVc::upcast(
+                    EcmascriptBrowserChunk::new(self, *ecmascript_chunk)
+                        .to_resolved()
+                        .await?,
+                )
             } else if let Some(output_asset) =
                 ResolvedVc::try_sidecast::<Box<dyn OutputAsset>>(chunk)
             {
-                *output_asset
+                output_asset
             } else {
                 bail!("Unable to generate output asset for chunk");
             },
         )
     }
-
+}
+#[turbo_tasks::value_impl]
+impl BrowserChunkingContext {
     #[turbo_tasks::function]
     pub fn current_chunk_method(&self) -> Vc<CurrentChunkMethod> {
         self.current_chunk_method.cell()
@@ -724,7 +723,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let mut assets = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(**chunk).to_resolved())
+                .map(|chunk| self.generate_chunk(*chunk))
                 .try_join()
                 .await?;
 
@@ -787,7 +786,7 @@ impl ChunkingContext for BrowserChunkingContext {
 
             let mut assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(**chunk).to_resolved())
+                .map(|chunk| self.generate_chunk(*chunk))
                 .try_join()
                 .await?;
 

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -286,7 +286,7 @@ async fn build_internal(
                 let ty = ReferenceType::Entry(EntryReferenceSubType::Undefined);
                 let request = request_vc.await?;
                 origin
-                    .resolve_asset(request_vc, origin.resolve_options(ty.clone()), ty)
+                    .resolve_asset(request_vc, origin.resolve_options(), ty)
                     .await?
                     .first_module()
                     .await?

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -139,7 +139,7 @@ pub async fn create_web_entry_source(
         .map(|request| async move {
             let ty = ReferenceType::Entry(EntryReferenceSubType::Web);
             Ok(origin
-                .resolve_asset(request, origin.resolve_options(ty.clone()), ty)
+                .resolve_asset(request, origin.resolve_options(), ty)
                 .await?
                 .resolve()
                 .await?

--- a/turbopack/crates/turbopack-core/src/context.rs
+++ b/turbopack/crates/turbopack-core/src/context.rs
@@ -69,11 +69,7 @@ pub trait AssetContext {
 
     /// Gets the resolve options for a given path.
     #[turbo_tasks::function]
-    fn resolve_options(
-        self: Vc<Self>,
-        origin_path: FileSystemPath,
-        reference_type: ReferenceType,
-    ) -> Vc<ResolveOptions>;
+    fn resolve_options(self: Vc<Self>, origin_path: FileSystemPath) -> Vc<ResolveOptions>;
 
     /// Resolves an request to an [ModuleResolveResult].
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/issue/code_gen.rs
+++ b/turbopack/crates/turbopack-core/src/issue/code_gen.rs
@@ -1,7 +1,10 @@
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
-use super::{Issue, IssueSeverity, IssueStage, OptionStyledString, StyledString};
+use super::{
+    Issue, IssueSeverity, IssueSource, IssueStage, OptionIssueSource, OptionStyledString,
+    StyledString,
+};
 
 #[turbo_tasks::value(shared)]
 pub struct CodeGenerationIssue {
@@ -9,6 +12,8 @@ pub struct CodeGenerationIssue {
     pub path: FileSystemPath,
     pub title: ResolvedVc<StyledString>,
     pub message: ResolvedVc<StyledString>,
+    /// Optional source location that points to where the issue originates
+    pub source: Option<IssueSource>,
 }
 
 #[turbo_tasks::value_impl]
@@ -35,5 +40,10 @@ impl Issue for CodeGenerationIssue {
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
         Vc::cell(Some(self.message))
+    }
+
+    #[turbo_tasks::function]
+    fn source(&self) -> Vc<OptionIssueSource> {
+        Vc::cell(self.source)
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1654,7 +1654,7 @@ pub async fn url_resolve(
     issue_source: Option<IssueSource>,
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
-    let resolve_options = origin.resolve_options(reference_type.clone());
+    let resolve_options = origin.resolve_options();
     let rel_request = request.as_relative();
     let origin_path_parent = origin.origin_path().await?.parent();
     let rel_result = resolve(

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -34,13 +34,10 @@ pub trait ResolveOrigin {
 
     /// Get the resolve options that apply for this origin.
     #[turbo_tasks::function]
-    async fn resolve_options(
-        self: Vc<Self>,
-        reference_type: ReferenceType,
-    ) -> Result<Vc<ResolveOptions>> {
+    async fn resolve_options(self: Vc<Self>) -> Result<Vc<ResolveOptions>> {
         Ok(self
             .asset_context()
-            .resolve_options(self.origin_path().owned().await?, reference_type))
+            .resolve_options(self.origin_path().owned().await?))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -284,6 +284,7 @@ async fn module_factory_with_code_generation_issue(
                 title: StyledString::Text(rcstr!("Code generation for chunk item errored"))
                     .resolved_cell(),
                 message: StyledString::Text(error_message).resolved_cell(),
+                source: None,
             }
             .resolved_cell()
             .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -197,14 +197,15 @@ pub enum AnalyzeMode {
     /// For bundling only, no tracing of referenced files.
     #[default]
     CodeGeneration,
-    /// For bundling and tracing of referenced files.
+    /// For bundling and finding references to external referenced files
     CodeGenerationAndTracing,
-    /// For tracing of referenced files only, no bundling (i.e. no codegen).
+    /// For tracing transitive external references (i.e. no codegen).
     Tracing,
 }
 
 impl AnalyzeMode {
-    pub fn is_tracing(self) -> bool {
+    /// Are we currently collecting references to external assets. e.g. filesystem dependencies
+    pub fn is_tracing_assets(self) -> bool {
         match self {
             AnalyzeMode::Tracing | AnalyzeMode::CodeGenerationAndTracing => true,
             AnalyzeMode::CodeGeneration => false,

--- a/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/external_module.rs
@@ -311,7 +311,7 @@ impl Module for CachedExternalModule {
                         origin
                             .resolve_asset(
                                 Request::parse_string(self.request.clone()),
-                                origin.resolve_options(ReferenceType::Undefined),
+                                origin.resolve_options(),
                                 ReferenceType::Undefined,
                             )
                             .await?

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -139,7 +139,7 @@ use crate::{
         exports_info::{ExportsInfoBinding, ExportsInfoRef},
         ident::IdentReplacement,
         member::MemberReplacement,
-        node::{FilePathModuleReference, PackageJsonReference},
+        node::PackageJsonReference,
         raw::{DirAssetReference, FileSourceReference},
         require_context::{RequireContextAssetReference, RequireContextMap},
         type_issue::SpecifiedModuleTypeIssue,
@@ -479,6 +479,9 @@ struct AnalysisState<'a> {
     // Whether we should collect affecting sources from referenced files. Only usedful when
     // tracing.
     collect_affecting_sources: bool,
+    // Whether we are only tracing dependencies (no code generation). When true, synthetic
+    // wrapper modules like WorkerLoaderModule should not be created.
+    tracing_only: bool,
 }
 
 impl AnalysisState<'_> {
@@ -1086,7 +1089,8 @@ async fn analyze_ecmascript_module_internal(
                 .free_var_references
                 .individual()
                 .await?,
-            collect_affecting_sources: options.analyze_mode.is_tracing(),
+            collect_affecting_sources: options.analyze_mode.is_tracing_assets(),
+            tracing_only: !options.analyze_mode.is_code_gen(),
         };
 
         enum Action {
@@ -1735,6 +1739,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
         ignore_dynamic_requests,
         url_rewrite_behavior,
         collect_affecting_sources,
+        tracing_only,
         allow_project_root_tracing: _,
         ..
     } = state;
@@ -1795,6 +1800,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                         in_try,
                         state,
                         collect_affecting_sources,
+                        tracing_only,
                     )
                     .await?;
                 }
@@ -1817,6 +1823,7 @@ async fn handle_call<G: Fn(Vec<Effect>) + Send + Sync>(
                 in_try,
                 state,
                 collect_affecting_sources,
+                tracing_only,
             )
             .await?;
         }
@@ -1842,6 +1849,7 @@ async fn handle_well_known_function_call<'a, F, Fut>(
     in_try: bool,
     state: &'a AnalysisState<'a>,
     collect_affecting_sources: bool,
+    tracing_only: bool,
 ) -> Result<()>
 where
     F: Fn() -> Fut,
@@ -1945,12 +1953,13 @@ where
 
                     if *compile_time_info.environment().rendering().await? == Rendering::Client {
                         analysis.add_reference_code_gen(
-                            WorkerAssetReference::new(
+                            WorkerAssetReference::new_web_worker(
                                 origin,
                                 Request::parse(pat).to_resolved().await?,
                                 issue_source(source, span),
                                 in_try,
                                 worker_type,
+                                tracing_only,
                             ),
                             ast_path.to_vec().into(),
                         );
@@ -1961,8 +1970,7 @@ where
                 // Ignore (e.g. dynamic parameter or string literal), just as Webpack does
                 return Ok(());
             }
-            WellKnownFunctionKind::NodeWorkerConstructor if analysis.analyze_mode.is_tracing() => {
-                // Only for tracing, not for bundling (yet?)
+            WellKnownFunctionKind::NodeWorkerConstructor => {
                 let args = linked_args().await?;
                 if !args.is_empty() {
                     let pat = js_value_to_pattern(&args[0]);
@@ -1979,17 +1987,21 @@ where
                             return Ok(());
                         }
                     }
-                    analysis.add_reference(
-                        FilePathModuleReference::new(
-                            origin.asset_context(),
+
+                    analysis.add_reference_code_gen(
+                        WorkerAssetReference::new_node_worker_thread(
+                            origin,
+                            // WorkerThreads resolve filepaths relative to the process root
                             get_traced_project_dir().await?,
-                            Pattern::new(pat),
+                            Pattern::new(pat).to_resolved().await?,
                             collect_affecting_sources,
                             get_issue_source(),
-                        )
-                        .to_resolved()
-                        .await?,
+                            in_try,
+                            tracing_only,
+                        ),
+                        ast_path.to_vec().into(),
                     );
+
                     return Ok(());
                 }
                 let (args, hints) = explain_args(args);
@@ -2199,7 +2211,7 @@ where
             );
         }
 
-        WellKnownFunctionKind::FsReadMethod(name) if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::FsReadMethod(name) if analysis.analyze_mode.is_tracing_assets() => {
             let args = linked_args().await?;
             if !args.is_empty() {
                 let pat = js_value_to_pattern(&args[0]);
@@ -2236,7 +2248,7 @@ where
             )
         }
 
-        WellKnownFunctionKind::PathResolve(..) if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::PathResolve(..) if analysis.analyze_mode.is_tracing_assets() => {
             let parent_path = origin.origin_path().owned().await?.parent();
             let args = linked_args().await?;
 
@@ -2280,7 +2292,7 @@ where
             return Ok(());
         }
 
-        WellKnownFunctionKind::PathJoin if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::PathJoin if analysis.analyze_mode.is_tracing_assets() => {
             let context_path = source.ident().path().await?;
             // ignore path.join in `node-gyp`, it will includes too many files
             if context_path.path.contains("node_modules/node-gyp") {
@@ -2322,7 +2334,7 @@ where
             return Ok(());
         }
         WellKnownFunctionKind::ChildProcessSpawnMethod(name)
-            if analysis.analyze_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing_assets() =>
         {
             let args = linked_args().await?;
 
@@ -2399,7 +2411,7 @@ where
                 ),
             )
         }
-        WellKnownFunctionKind::ChildProcessFork if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::ChildProcessFork if analysis.analyze_mode.is_tracing_assets() => {
             let args = linked_args().await?;
             if !args.is_empty() {
                 let first_arg = &args[0];
@@ -2438,7 +2450,7 @@ where
                 ),
             )
         }
-        WellKnownFunctionKind::NodePreGypFind if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::NodePreGypFind if analysis.analyze_mode.is_tracing_assets() => {
             use turbopack_resolve::node_native_binding::NodePreGypConfigReference;
 
             let args = linked_args().await?;
@@ -2481,7 +2493,7 @@ where
                 ),
             )
         }
-        WellKnownFunctionKind::NodeGypBuild if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::NodeGypBuild if analysis.analyze_mode.is_tracing_assets() => {
             use turbopack_resolve::node_native_binding::NodeGypBuildReference;
 
             let args = linked_args().await?;
@@ -2520,7 +2532,7 @@ where
                     ),
                 )
         }
-        WellKnownFunctionKind::NodeBindings if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::NodeBindings if analysis.analyze_mode.is_tracing_assets() => {
             use turbopack_resolve::node_native_binding::NodeBindingsReference;
 
             let args = linked_args().await?;
@@ -2550,7 +2562,7 @@ where
                 ),
             )
         }
-        WellKnownFunctionKind::NodeExpressSet if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::NodeExpressSet if analysis.analyze_mode.is_tracing_assets() => {
             let args = linked_args().await?;
             if args.len() == 2
                 && let Some(s) = args.first().and_then(|arg| arg.as_str())
@@ -2634,7 +2646,7 @@ where
             )
         }
         WellKnownFunctionKind::NodeStrongGlobalizeSetRootDir
-            if analysis.analyze_mode.is_tracing() =>
+            if analysis.analyze_mode.is_tracing_assets() =>
         {
             let args = linked_args().await?;
             if let Some(p) = args.first().and_then(|arg| arg.as_str()) {
@@ -2681,7 +2693,7 @@ where
                 ),
             )
         }
-        WellKnownFunctionKind::NodeResolveFrom if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::NodeResolveFrom if analysis.analyze_mode.is_tracing_assets() => {
             let args = linked_args().await?;
             if args.len() == 2 && args.get(1).and_then(|arg| arg.as_str()).is_some() {
                 analysis.add_reference(
@@ -2705,7 +2717,7 @@ where
                 ),
             )
         }
-        WellKnownFunctionKind::NodeProtobufLoad if analysis.analyze_mode.is_tracing() => {
+        WellKnownFunctionKind::NodeProtobufLoad if analysis.analyze_mode.is_tracing_assets() => {
             let args = linked_args().await?;
             if args.len() == 2
                 && let Some(JsValue::Object { parts, .. }) = args.get(1)

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3965,8 +3965,7 @@ async fn resolve_as_webpack_runtime(
     request: Vc<Request>,
     transforms: Vc<EcmascriptInputTransforms>,
 ) -> Result<Vc<WebpackRuntime>> {
-    let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-    let options = origin.resolve_options(ty.clone());
+    let options = origin.resolve_options();
 
     let options = apply_cjs_specific_options(options);
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -78,7 +78,7 @@ use turbopack_core::{
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, analyze::AnalyzeIssue},
     module::{Module, ModuleSideEffects},
     reference::{ModuleReference, ModuleReferences},
-    reference_type::{CommonJsReferenceSubType, ReferenceType, WorkerReferenceSubType},
+    reference_type::{CommonJsReferenceSubType, ReferenceType},
     resolve::{
         FindContextFileResult, ImportUsage, ModulePart, find_context_file,
         origin::{PlainResolveOrigin, ResolveOrigin},
@@ -1927,13 +1927,9 @@ where
             | WellKnownFunctionKind::SharedWorkerConstructor => {
                 let args = linked_args().await?;
                 if let Some(url @ JsValue::Url(_, JsValueUrlKind::Relative)) = args.first() {
-                    let (name, worker_type) = match func {
-                        WellKnownFunctionKind::WorkerConstructor => {
-                            ("Worker", WorkerReferenceSubType::WebWorker)
-                        }
-                        WellKnownFunctionKind::SharedWorkerConstructor => {
-                            ("SharedWorker", WorkerReferenceSubType::SharedWorker)
-                        }
+                    let (name, is_shared) = match func {
+                        WellKnownFunctionKind::WorkerConstructor => ("Worker", false),
+                        WellKnownFunctionKind::SharedWorkerConstructor => ("SharedWorker", true),
                         _ => unreachable!(),
                     };
                     let pat = js_value_to_pattern(url);
@@ -1958,8 +1954,8 @@ where
                                 Request::parse(pat).to_resolved().await?,
                                 issue_source(source, span),
                                 in_try,
-                                worker_type,
                                 tracing_only,
+                                is_shared,
                             ),
                             ast_path.to_vec().into(),
                         );

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -1,20 +1,11 @@
 use anyhow::Result;
-use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
-    context::AssetContext,
-    file_source::FileSource,
-    issue::IssueSource,
-    raw_module::RawModule,
-    reference::ModuleReference,
-    reference_type::{ReferenceType, WorkerReferenceSubType},
-    resolve::{ModuleResolveResult, pattern::Pattern, resolve_raw},
+    file_source::FileSource, raw_module::RawModule, reference::ModuleReference,
+    resolve::ModuleResolveResult,
 };
-
-use crate::references::util::check_and_emit_too_many_matches_warning;
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug)]
@@ -52,92 +43,6 @@ impl ValueToString for PackageJsonReference {
                 self.package_json.value_to_string().await?
             )
             .into(),
-        ))
-    }
-}
-
-#[turbo_tasks::value]
-#[derive(Hash, Debug)]
-pub struct FilePathModuleReference {
-    asset_context: ResolvedVc<Box<dyn AssetContext>>,
-    context_dir: FileSystemPath,
-    path: ResolvedVc<Pattern>,
-    collect_affecting_sources: bool,
-    issue_source: IssueSource,
-}
-
-#[turbo_tasks::value_impl]
-impl FilePathModuleReference {
-    #[turbo_tasks::function]
-    pub fn new(
-        asset_context: ResolvedVc<Box<dyn AssetContext>>,
-        context_dir: FileSystemPath,
-        path: ResolvedVc<Pattern>,
-        collect_affecting_sources: bool,
-        issue_source: IssueSource,
-    ) -> Vc<Self> {
-        Self {
-            asset_context,
-            context_dir,
-            path,
-            collect_affecting_sources,
-            issue_source,
-        }
-        .cell()
-    }
-}
-
-// A reference to an module by absolute or cwd-relative file path (e.g. for the
-// worker-threads `new Worker` which has the resolving behavior of `fs.readFile` but should treat
-// the resolve result as an module instead of a raw source).
-#[turbo_tasks::value_impl]
-impl ModuleReference for FilePathModuleReference {
-    #[turbo_tasks::function]
-    async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let span = tracing::info_span!(
-            "trace module",
-            pattern = display(self.path.to_string().await?)
-        );
-        async {
-            let result = resolve_raw(
-                self.context_dir.clone(),
-                *self.path,
-                self.collect_affecting_sources,
-                /* force_in_lookup_dir */ false,
-            );
-            let result = self.asset_context.process_resolve_result(
-                result,
-                ReferenceType::Worker(WorkerReferenceSubType::NodeWorker),
-            );
-
-            check_and_emit_too_many_matches_warning(
-                result,
-                self.issue_source,
-                self.context_dir.clone(),
-                self.path,
-            )
-            .await?;
-
-            Ok(result)
-        }
-        .instrument(span)
-        .await
-    }
-}
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for FilePathModuleReference {
-    #[turbo_tasks::function]
-    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::Traced))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for FilePathModuleReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("raw asset {}", self.path.to_string().await?,).into(),
         ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -345,6 +345,7 @@ async fn to_single_pattern_mapping(
                 )
                 .resolved_cell(),
                 path: origin.origin_path().owned().await?,
+                source: None,
             }
             .resolved_cell()
             .emit();
@@ -376,6 +377,7 @@ async fn to_single_pattern_mapping(
         ))
         .resolved_cell(),
         path: origin.origin_path().owned().await?,
+        source: None,
     }
     .resolved_cell()
     .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -355,7 +355,7 @@ impl WorkerAssetReferenceCodeGen {
                                 require: Expr = pm.create_require(*key_expr.take())
                             );
 
-                            // For web workers, modify the options to set type: undefined
+                            // For web workers, remove type: "module" if it exists
                             if matches!(
                                 reference.worker_type,
                                 WorkerType::WebWorker | WorkerType::SharedWebWorker

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -173,15 +173,6 @@ impl ModuleReference for WorkerAssetReference {
         let result_ref = result.await?;
         let mut primary = Vec::with_capacity(result_ref.primary.len());
 
-        let get_issue_severity = || async {
-            let resolve_options = self.origin.resolve_options().await?;
-            Ok::<_, anyhow::Error>(if self.in_try || resolve_options.loose_errors {
-                IssueSeverity::Warning
-            } else {
-                IssueSeverity::Error
-            })
-        };
-
         for (request_key, resolve_item) in result_ref.primary.iter() {
             match resolve_item {
                 ModuleResolveResultItem::Module(module) => {
@@ -191,7 +182,7 @@ impl ModuleReference for WorkerAssetReference {
                         ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*module)
                     else {
                         CodeGenerationIssue {
-                            severity: get_issue_severity().await?,
+                            severity: self.get_module_type_issue_severity().await?,
                             title: StyledString::Text(rcstr!("non-chunkable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
@@ -219,7 +210,7 @@ impl ModuleReference for WorkerAssetReference {
                             .is_none()
                     {
                         CodeGenerationIssue {
-                            severity: get_issue_severity().await?,
+                            severity: self.get_module_type_issue_severity().await?,
                             title: StyledString::Text(rcstr!("non-evaluatable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
@@ -263,6 +254,19 @@ impl ModuleReference for WorkerAssetReference {
             affecting_sources: result_ref.affecting_sources.clone(),
         }
         .cell())
+    }
+}
+
+impl WorkerAssetReference {
+    /// Downgrade errors to warnings if we are in a try context or if loos errors is enabled
+    async fn get_module_type_issue_severity(&self) -> Result<IssueSeverity> {
+        Ok(
+            if self.in_try || self.origin.resolve_options().await?.loose_errors {
+                IssueSeverity::Warning
+            } else {
+                IssueSeverity::Error
+            },
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -14,6 +14,7 @@ use turbopack_core::{
     chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext, EvaluatableAsset},
     context::AssetContext,
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, code_gen::CodeGenerationIssue},
+    module::Module,
     reference::ModuleReference,
     reference_type::{ReferenceType, WorkerReferenceSubType},
     resolve::{
@@ -178,6 +179,8 @@ impl ModuleReference for WorkerAssetReference {
         for (request_key, resolve_item) in result_ref.primary.iter() {
             match resolve_item {
                 ModuleResolveResultItem::Module(module) => {
+                    let module_ident = module.ident().to_string().await?;
+
                     let Some(chunkable) =
                         ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*module)
                     else {
@@ -185,9 +188,18 @@ impl ModuleReference for WorkerAssetReference {
                             severity: IssueSeverity::Bug,
                             title: StyledString::Text(rcstr!("non-chunkable module"))
                                 .resolved_cell(),
-                            message: StyledString::Text(rcstr!("asset is not chunkable"))
-                                .resolved_cell(),
+                            message: StyledString::Text(
+                                format!(
+                                    "Worker entry point module '{}' is not chunkable and cannot \
+                                     be used as a worker module. This may happen if the module \
+                                     type doesn't support bundling.",
+                                    module_ident
+                                )
+                                .into(),
+                            )
+                            .resolved_cell(),
                             path: self.origin.origin_path().owned().await?,
+                            source: Some(self.issue_source),
                         }
                         .resolved_cell()
                         .emit();
@@ -204,11 +216,19 @@ impl ModuleReference for WorkerAssetReference {
                             severity: IssueSeverity::Bug,
                             title: StyledString::Text(rcstr!("non-evaluatable module"))
                                 .resolved_cell(),
-                            message: StyledString::Text(rcstr!(
-                                "Worker thread module must be evaluatable"
-                            ))
+                            message: StyledString::Text(
+                                format!(
+                                    "Worker thread entry point module '{}' must be evaluatable to \
+                                     serve as an entry point. This module cannot be used as a \
+                                     Node.js worker_threads Worker entry point because it doesn't \
+                                     support direct evaluation.",
+                                    module_ident
+                                )
+                                .into(),
+                            )
                             .resolved_cell(),
                             path: self.origin.origin_path().owned().await?,
+                            source: Some(self.issue_source),
                         }
                         .resolved_cell()
                         .emit();

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -43,8 +43,6 @@ pub struct WorkerAssetReference {
     pub request: WorkerRequest,
     pub issue_source: IssueSource,
     pub in_try: bool,
-    /// For web workers, the subtype (Worker vs SharedWorker)
-    pub web_worker_type: Option<WorkerReferenceSubType>,
     /// When true, skip creating WorkerLoaderModule and return the inner module directly.
     /// This is used when we're only tracing dependencies, not generating code.
     pub tracing_only: bool,
@@ -71,16 +69,19 @@ impl WorkerAssetReference {
         request: ResolvedVc<Request>,
         issue_source: IssueSource,
         in_try: bool,
-        worker_type: WorkerReferenceSubType,
         tracing_only: bool,
+        is_shared: bool,
     ) -> Self {
         WorkerAssetReference {
-            worker_type: WorkerType::WebWorker,
+            worker_type: if is_shared {
+                WorkerType::SharedWebWorker
+            } else {
+                WorkerType::WebWorker
+            },
             origin,
             request: WorkerRequest::Url(request),
             issue_source,
             in_try,
-            web_worker_type: Some(worker_type),
             tracing_only,
         }
     }
@@ -104,7 +105,6 @@ impl WorkerAssetReference {
             },
             issue_source,
             in_try,
-            web_worker_type: None,
             tracing_only,
         }
     }
@@ -117,15 +117,12 @@ impl ModuleReference for WorkerAssetReference {
         let asset_context = self.origin.asset_context().to_resolved().await?;
 
         let result = match (&self.worker_type, &self.request) {
-            (WorkerType::WebWorker, WorkerRequest::Url(request)) => {
+            (WorkerType::WebWorker | WorkerType::SharedWebWorker, WorkerRequest::Url(request)) => {
                 // Web worker resolution uses url_resolve
                 url_resolve(
                     *self.origin,
                     **request,
-                    ReferenceType::Worker(
-                        self.web_worker_type
-                            .unwrap_or(WorkerReferenceSubType::WebWorker),
-                    ),
+                    ReferenceType::Worker(self.worker_type.reference_sub_type()),
                     Some(self.issue_source),
                     self.in_try,
                 )
@@ -185,7 +182,7 @@ impl ModuleReference for WorkerAssetReference {
                         ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*module)
                     else {
                         CodeGenerationIssue {
-                            severity: IssueSeverity::Bug,
+                            severity: IssueSeverity::Error,
                             title: StyledString::Text(rcstr!("non-chunkable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
@@ -213,7 +210,7 @@ impl ModuleReference for WorkerAssetReference {
                             .is_none()
                     {
                         CodeGenerationIssue {
-                            severity: IssueSeverity::Bug,
+                            severity: IssueSeverity::Error,
                             title: StyledString::Text(rcstr!("non-evaluatable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
@@ -235,15 +232,10 @@ impl ModuleReference for WorkerAssetReference {
                         continue;
                     }
 
-                    let loader = WorkerLoaderModule::new(
-                        *chunkable,
-                        self.worker_type,
-                        self.web_worker_type
-                            .unwrap_or(WorkerReferenceSubType::WebWorker),
-                        *asset_context,
-                    )
-                    .to_resolved()
-                    .await?;
+                    let loader =
+                        WorkerLoaderModule::new(*chunkable, self.worker_type, *asset_context)
+                            .to_resolved()
+                            .await?;
 
                     primary.push((
                         request_key.clone(),
@@ -274,6 +266,7 @@ impl ValueToString for WorkerAssetReference {
                 "new {}({})",
                 match self.worker_type {
                     WorkerType::WebWorker => "WebWorker",
+                    WorkerType::SharedWebWorker => "SharedbWorker",
                     WorkerType::NodeWorkerThread => "NodeWorkerThread",
                 },
                 match &self.request {

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -151,7 +151,7 @@ impl ModuleReference for WorkerAssetReference {
                     reference_type.clone(),
                     *self.origin,
                     Request::parse(path.owned().await?),
-                    self.origin.resolve_options(reference_type),
+                    self.origin.resolve_options(),
                     self.in_try,
                     Some(self.issue_source),
                 )
@@ -174,8 +174,7 @@ impl ModuleReference for WorkerAssetReference {
         let mut primary = Vec::with_capacity(result_ref.primary.len());
 
         let get_issue_severity = || async {
-            let reference_type = ReferenceType::Worker(self.worker_type.reference_sub_type());
-            let resolve_options = self.origin.resolve_options(reference_type).await?;
+            let resolve_options = self.origin.resolve_options().await?;
             Ok::<_, anyhow::Error>(if self.in_try || resolve_options.loose_errors {
                 IssueSeverity::Warning
             } else {

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -356,8 +356,10 @@ impl WorkerAssetReferenceCodeGen {
                             );
 
                             // For web workers, modify the options to set type: undefined
-                            if reference.worker_type == WorkerType::WebWorker
-                                && let Some(opts) = args.get_mut(1)
+                            if matches!(
+                                reference.worker_type,
+                                WorkerType::WebWorker | WorkerType::SharedWebWorker
+                            ) && let Some(opts) = args.get_mut(1)
                                 && opts.spread.is_none()
                             {
                                 *opts.expr = *quote_expr!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use bincode::{Decode, Encode};
 use swc_core::{
     common::util::take::Take,
@@ -9,83 +9,103 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext},
+    chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext, EvaluatableAsset},
+    context::AssetContext,
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, code_gen::CodeGenerationIssue},
-    module::Module,
     reference::ModuleReference,
     reference_type::{ReferenceType, WorkerReferenceSubType},
-    resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request, url_resolve},
+    resolve::{
+        ModuleResolveResult, ModuleResolveResultItem, handle_resolve_error, origin::ResolveOrigin,
+        parse::Request, pattern::Pattern, resolve_raw, url_resolve,
+    },
 };
 
 use crate::{
     code_gen::{CodeGen, CodeGeneration, IntoCodeGenReference},
     create_visitor,
-    references::AstPath,
-    runtime_functions::TURBOPACK_REQUIRE,
-    utils::module_id_to_lit,
-    worker_chunk::module::WorkerLoaderModule,
+    references::{
+        AstPath,
+        pattern_mapping::{PatternMapping, ResolveType},
+    },
+    worker_chunk::{WorkerType, module::WorkerLoaderModule},
 };
 
+/// A unified reference to a Worker (web or Node.js) that creates an isolated chunk group
+/// for the worker module.
 #[turbo_tasks::value]
 #[derive(Hash, Debug)]
 pub struct WorkerAssetReference {
+    pub worker_type: WorkerType,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-    pub request: ResolvedVc<Request>,
+    pub request: WorkerRequest,
     pub issue_source: IssueSource,
     pub in_try: bool,
-    pub worker_type: WorkerReferenceSubType,
+    /// For web workers, the subtype (Worker vs SharedWorker)
+    pub web_worker_type: Option<WorkerReferenceSubType>,
+    /// When true, skip creating WorkerLoaderModule and return the inner module directly.
+    /// This is used when we're only tracing dependencies, not generating code.
+    pub tracing_only: bool,
+}
+
+/// The request type varies between web and Node.js workers
+#[turbo_tasks::value]
+#[derive(Hash, Debug, Clone)]
+pub enum WorkerRequest {
+    /// Web workers use Request (URLs)
+    Url(ResolvedVc<Request>),
+    /// Node.js workers use Pattern (file paths) with a context directory that should be the server
+    /// working directory
+    Pattern {
+        context_dir: FileSystemPath,
+        path: ResolvedVc<Pattern>,
+        collect_affecting_sources: bool,
+    },
 }
 
 impl WorkerAssetReference {
-    pub fn new(
+    pub fn new_web_worker(
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: ResolvedVc<Request>,
         issue_source: IssueSource,
         in_try: bool,
         worker_type: WorkerReferenceSubType,
+        tracing_only: bool,
     ) -> Self {
         WorkerAssetReference {
+            worker_type: WorkerType::WebWorker,
             origin,
-            request,
+            request: WorkerRequest::Url(request),
             issue_source,
             in_try,
-            worker_type,
+            web_worker_type: Some(worker_type),
+            tracing_only,
         }
     }
-}
 
-impl WorkerAssetReference {
-    async fn worker_loader_module(&self) -> Result<Option<Vc<WorkerLoaderModule>>> {
-        let module = url_resolve(
-            *self.origin,
-            *self.request,
-            ReferenceType::Worker(self.worker_type),
-            Some(self.issue_source),
-            self.in_try,
-        );
-
-        let Some(module) = *module.first_module().await? else {
-            return Ok(None);
-        };
-        let Some(chunkable) = ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(module) else {
-            CodeGenerationIssue {
-                severity: IssueSeverity::Bug,
-                title: StyledString::Text(rcstr!("non-ecmascript placeable asset")).resolved_cell(),
-                message: StyledString::Text(rcstr!("asset is not placeable in ESM chunks"))
-                    .resolved_cell(),
-                path: self.origin.origin_path().owned().await?,
-            }
-            .resolved_cell()
-            .emit();
-            return Ok(None);
-        };
-
-        Ok(Some(WorkerLoaderModule::new(
-            *chunkable,
-            self.worker_type,
-            *self.origin.asset_context().to_resolved().await?,
-        )))
+    pub fn new_node_worker_thread(
+        origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+        context_dir: FileSystemPath,
+        path: ResolvedVc<Pattern>,
+        collect_affecting_sources: bool,
+        issue_source: IssueSource,
+        in_try: bool,
+        tracing_only: bool,
+    ) -> Self {
+        WorkerAssetReference {
+            worker_type: WorkerType::NodeWorkerThread,
+            origin,
+            request: WorkerRequest::Pattern {
+                context_dir,
+                path,
+                collect_affecting_sources,
+            },
+            issue_source,
+            in_try,
+            web_worker_type: None,
+            tracing_only,
+        }
     }
 }
 
@@ -93,13 +113,135 @@ impl WorkerAssetReference {
 impl ModuleReference for WorkerAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        if let Some(worker_loader_module) = self.worker_loader_module().await? {
-            Ok(*ModuleResolveResult::module(ResolvedVc::upcast(
-                worker_loader_module.to_resolved().await?,
-            )))
-        } else {
-            Ok(*ModuleResolveResult::unresolvable())
+        let asset_context = self.origin.asset_context().to_resolved().await?;
+
+        let result = match (&self.worker_type, &self.request) {
+            (WorkerType::WebWorker, WorkerRequest::Url(request)) => {
+                // Web worker resolution uses url_resolve
+                url_resolve(
+                    *self.origin,
+                    **request,
+                    ReferenceType::Worker(
+                        self.web_worker_type
+                            .unwrap_or(WorkerReferenceSubType::WebWorker),
+                    ),
+                    Some(self.issue_source),
+                    self.in_try,
+                )
+            }
+            (
+                WorkerType::NodeWorkerThread,
+                WorkerRequest::Pattern {
+                    context_dir,
+                    path,
+                    collect_affecting_sources,
+                },
+            ) => {
+                // Node.js worker resolution uses resolve_raw
+                let result = resolve_raw(
+                    context_dir.clone(),
+                    **path,
+                    *collect_affecting_sources,
+                    /* force_in_lookup_dir */ false,
+                );
+                let reference_type = ReferenceType::Worker(WorkerReferenceSubType::NodeWorker);
+                let result = asset_context.process_resolve_result(result, reference_type.clone());
+
+                // Report an error if we cannot resolve
+                handle_resolve_error(
+                    result,
+                    reference_type.clone(),
+                    *self.origin,
+                    Request::parse(path.owned().await?),
+                    self.origin.resolve_options(reference_type),
+                    self.in_try,
+                    Some(self.issue_source),
+                )
+                .await?
+            }
+            _ => {
+                // This should never happen due to our constructor functions
+                unreachable!("WorkerType and WorkerRequest mismatch");
+            }
+        };
+
+        // When tracing only (no code generation), return the resolved modules directly
+        // without wrapping them in WorkerLoaderModule
+        if self.tracing_only {
+            return Ok(result);
         }
+
+        // Wrap each resolved module in a WorkerLoaderModule
+        let result_ref = result.await?;
+        let mut primary = Vec::with_capacity(result_ref.primary.len());
+
+        for (request_key, resolve_item) in result_ref.primary.iter() {
+            match resolve_item {
+                ModuleResolveResultItem::Module(module) => {
+                    let Some(chunkable) =
+                        ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*module)
+                    else {
+                        CodeGenerationIssue {
+                            severity: IssueSeverity::Bug,
+                            title: StyledString::Text(rcstr!("non-chunkable module"))
+                                .resolved_cell(),
+                            message: StyledString::Text(rcstr!("asset is not chunkable"))
+                                .resolved_cell(),
+                            path: self.origin.origin_path().owned().await?,
+                        }
+                        .resolved_cell()
+                        .emit();
+                        continue;
+                    };
+
+                    // For Node.js worker threads, the module must also be evaluatable since
+                    // it becomes an entry point
+                    if matches!(self.worker_type, WorkerType::NodeWorkerThread)
+                        && ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(chunkable)
+                            .is_none()
+                    {
+                        CodeGenerationIssue {
+                            severity: IssueSeverity::Bug,
+                            title: StyledString::Text(rcstr!("non-evaluatable module"))
+                                .resolved_cell(),
+                            message: StyledString::Text(rcstr!(
+                                "Worker thread module must be evaluatable"
+                            ))
+                            .resolved_cell(),
+                            path: self.origin.origin_path().owned().await?,
+                        }
+                        .resolved_cell()
+                        .emit();
+                        continue;
+                    }
+
+                    let loader = WorkerLoaderModule::new(
+                        *chunkable,
+                        self.worker_type,
+                        self.web_worker_type
+                            .unwrap_or(WorkerReferenceSubType::WebWorker),
+                        *asset_context,
+                    )
+                    .to_resolved()
+                    .await?;
+
+                    primary.push((
+                        request_key.clone(),
+                        ModuleResolveResultItem::Module(ResolvedVc::upcast(loader)),
+                    ));
+                }
+                // Pass through other result types (External, Ignore, etc.)
+                _ => {
+                    primary.push((request_key.clone(), resolve_item.clone()));
+                }
+            }
+        }
+
+        Ok(ModuleResolveResult {
+            primary: primary.into_boxed_slice(),
+            affecting_sources: result_ref.affecting_sources.clone(),
+        }
+        .cell())
     }
 }
 
@@ -108,7 +250,18 @@ impl ValueToString for WorkerAssetReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         Ok(Vc::cell(
-            format!("new Worker {}", self.request.to_string().await?,).into(),
+            format!(
+                "new {}({})",
+                match self.worker_type {
+                    WorkerType::WebWorker => "WebWorker",
+                    WorkerType::NodeWorkerThread => "NodeWorkerThread",
+                },
+                match &self.request {
+                    WorkerRequest::Url(request) => request.to_string().await?,
+                    WorkerRequest::Pattern { path, .. } => path.to_string().await?,
+                }
+            )
+            .into(),
         ))
     }
 }
@@ -142,29 +295,43 @@ impl WorkerAssetReferenceCodeGen {
         &self,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<CodeGeneration> {
-        let Some(loader) = self.reference.await?.worker_loader_module().await? else {
-            bail!("Worker loader could not be created");
+        let reference = self.reference.await?;
+
+        // Build the request for PatternMapping
+        let request = match &reference.request {
+            WorkerRequest::Url(request) => **request,
+            WorkerRequest::Pattern { path, .. } => Request::parse(path.owned().await?),
         };
 
-        let item_id = chunking_context
-            .chunk_item_id_strategy()
-            .await?
-            .get_id_from_ident(loader.ident())
-            .await?;
+        // Use PatternMapping to handle both single and multiple (dynamic) worker results
+        let pm = PatternMapping::resolve_request(
+            request,
+            *reference.origin,
+            chunking_context,
+            self.reference.resolve_reference(),
+            ResolveType::ChunkItem,
+        )
+        .await?;
 
         let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
             let message = if let Expr::New(NewExpr { args, .. }) = expr {
                 if let Some(args) = args {
                     match args.first_mut() {
-                        Some(ExprOrSpread { spread: None, expr }) => {
-                            let item_id = module_id_to_lit(&item_id);
-                            *expr = quote_expr!(
-                                "$turbopack_require($item_id)",
-                                turbopack_require: Expr = TURBOPACK_REQUIRE.into(),
-                                item_id: Expr = item_id
+                        Some(ExprOrSpread {
+                            spread: None,
+                            expr: key_expr,
+                        }) => {
+                            // Replace the first argument (the URL/path) with a turbopack_require
+                            // call that uses the pattern mapping to resolve to the correct loader
+                            // module
+                            *key_expr = quote_expr!(
+                                "$require",
+                                require: Expr = pm.create_require(*key_expr.take())
                             );
 
-                            if let Some(opts) = args.get_mut(1)
+                            // For web workers, modify the options to set type: undefined
+                            if reference.worker_type == WorkerType::WebWorker
+                                && let Some(opts) = args.get_mut(1)
                                 && opts.spread.is_none()
                             {
                                 *opts.expr = *quote_expr!(

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -173,6 +173,16 @@ impl ModuleReference for WorkerAssetReference {
         let result_ref = result.await?;
         let mut primary = Vec::with_capacity(result_ref.primary.len());
 
+        let get_issue_severity = || async {
+            let reference_type = ReferenceType::Worker(self.worker_type.reference_sub_type());
+            let resolve_options = self.origin.resolve_options(reference_type).await?;
+            Ok::<_, anyhow::Error>(if self.in_try || resolve_options.loose_errors {
+                IssueSeverity::Warning
+            } else {
+                IssueSeverity::Error
+            })
+        };
+
         for (request_key, resolve_item) in result_ref.primary.iter() {
             match resolve_item {
                 ModuleResolveResultItem::Module(module) => {
@@ -182,7 +192,7 @@ impl ModuleReference for WorkerAssetReference {
                         ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*module)
                     else {
                         CodeGenerationIssue {
-                            severity: IssueSeverity::Error,
+                            severity: get_issue_severity().await?,
                             title: StyledString::Text(rcstr!("non-chunkable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
@@ -210,7 +220,7 @@ impl ModuleReference for WorkerAssetReference {
                             .is_none()
                     {
                         CodeGenerationIssue {
-                            severity: IssueSeverity::Error,
+                            severity: get_issue_severity().await?,
                             title: StyledString::Text(rcstr!("non-evaluatable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
@@ -266,7 +276,7 @@ impl ValueToString for WorkerAssetReference {
                 "new {}({})",
                 match self.worker_type {
                     WorkerType::WebWorker => "WebWorker",
-                    WorkerType::SharedWebWorker => "SharedbWorker",
+                    WorkerType::SharedWebWorker => "SharedWorker",
                     WorkerType::NodeWorkerThread => "NodeWorkerThread",
                 },
                 match &self.request {

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -122,7 +122,7 @@ impl ModuleReference for WorkerAssetReference {
                 url_resolve(
                     *self.origin,
                     **request,
-                    ReferenceType::Worker(self.worker_type.reference_sub_type()),
+                    self.worker_type.reference_type(),
                     Some(self.issue_source),
                     self.in_try,
                 )

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     module::{Module, ModuleSideEffects},
     raw_module::RawModule,
     reference::{ModuleReference, ModuleReferences},
-    reference_type::{CommonJsReferenceSubType, ReferenceType},
+    reference_type::CommonJsReferenceSubType,
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
     source::Source,
 };
@@ -55,10 +55,7 @@ impl Module for TsConfigModuleAsset {
         let configs = read_tsconfigs(
             self.source.content().file_content(),
             self.source,
-            apply_cjs_specific_options(
-                self.origin
-                    .resolve_options(ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined)),
-            ),
+            apply_cjs_specific_options(self.origin.resolve_options()),
         )
         .await?;
         references.extend(

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -159,8 +159,7 @@ pub struct WebpackRuntimeAssetReference {
 impl ModuleReference for WebpackRuntimeAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let ty = ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined);
-        let options = self.origin.resolve_options(ty.clone());
+        let options = self.origin.resolve_options();
 
         let options = apply_cjs_specific_options(options);
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -12,7 +12,6 @@ use turbopack_core::{
     module::Module,
     module_graph::{ModuleGraph, chunk_group_info::ChunkGroup},
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
-    reference_type::WorkerReferenceSubType,
 };
 
 use super::{module::WorkerLoaderModule, worker_type::WorkerType};
@@ -31,7 +30,6 @@ pub struct WorkerLoaderChunkItem {
     pub module_graph: ResolvedVc<ModuleGraph>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     pub worker_type: WorkerType,
-    pub web_worker_type: WorkerReferenceSubType,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
@@ -42,12 +40,17 @@ impl WorkerLoaderChunkItem {
         let module = self.module.await?;
 
         Ok(match self.worker_type {
-            WorkerType::WebWorker => self.chunking_context.evaluated_chunk_group_assets(
-                module.inner.ident().with_modifier(rcstr!("worker")),
-                ChunkGroup::Isolated(ResolvedVc::upcast(module.inner)),
-                *self.module_graph,
-                AvailabilityInfo::root(),
-            ),
+            WorkerType::WebWorker | WorkerType::SharedWebWorker => {
+                self.chunking_context.evaluated_chunk_group_assets(
+                    module
+                        .inner
+                        .ident()
+                        .with_modifier(self.worker_type.chunk_modifier_str()),
+                    ChunkGroup::Isolated(ResolvedVc::upcast(module.inner)),
+                    *self.module_graph,
+                    AvailabilityInfo::root(),
+                )
+            }
             // WorkerThreads are treated as an entry point, webworkers probably should too but
             // currently it would lead to a cascade that we need to address.
             WorkerType::NodeWorkerThread => {
@@ -115,7 +118,7 @@ impl EcmascriptChunkItem for WorkerLoaderChunkItem {
         let this = self.await?;
 
         let code = match this.worker_type {
-            WorkerType::WebWorker => {
+            WorkerType::WebWorker | WorkerType::SharedWebWorker => {
                 // For web workers, generate code that creates a worker URL using the real
                 // entrypoint
                 let asset_context = *this.asset_context;
@@ -141,8 +144,7 @@ impl EcmascriptChunkItem for WorkerLoaderChunkItem {
                     .collect();
 
                 // Determine if this is a SharedWorker
-                let is_shared =
-                    matches!(this.web_worker_type, WorkerReferenceSubType::SharedWorker);
+                let is_shared = matches!(this.worker_type, WorkerType::SharedWebWorker);
 
                 formatdoc! {
                     r#"
@@ -208,7 +210,7 @@ impl OutputAssetsReference for WorkerLoaderChunkItem {
     async fn references(self: Vc<Self>) -> Result<Vc<OutputAssetsWithReferenced>> {
         let this = self.await?;
         match this.worker_type {
-            WorkerType::WebWorker => {
+            WorkerType::WebWorker | WorkerType::SharedWebWorker => {
                 let asset_context = *this.asset_context;
                 Ok(self
                     .chunk_group()

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/chunk_item.rs
@@ -1,21 +1,21 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use indoc::formatdoc;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc};
 use turbopack_core::{
     chunk::{
-        ChunkData, ChunkItem, ChunkType, ChunkingContext, ChunkingContextExt, ChunksData,
-        availability_info::AvailabilityInfo,
+        AsyncModuleInfo, ChunkData, ChunkItem, ChunkType, ChunkingContext, ChunkingContextExt,
+        ChunksData, EvaluatableAsset, EvaluatableAssets, availability_info::AvailabilityInfo,
     },
     context::AssetContext,
     ident::AssetIdent,
     module::Module,
     module_graph::{ModuleGraph, chunk_group_info::ChunkGroup},
-    output::{OutputAsset, OutputAssetsReference, OutputAssetsWithReferenced},
+    output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
     reference_type::WorkerReferenceSubType,
 };
 
-use super::module::WorkerLoaderModule;
+use super::{module::WorkerLoaderModule, worker_type::WorkerType};
 use crate::{
     chunk::{
         EcmascriptChunkItem, EcmascriptChunkItemContent, EcmascriptChunkType,
@@ -30,8 +30,9 @@ pub struct WorkerLoaderChunkItem {
     pub module: ResolvedVc<WorkerLoaderModule>,
     pub module_graph: ResolvedVc<ModuleGraph>,
     pub chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
+    pub worker_type: WorkerType,
+    pub web_worker_type: WorkerReferenceSubType,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
-    pub worker_type: WorkerReferenceSubType,
 }
 
 #[turbo_tasks::value_impl]
@@ -39,12 +40,53 @@ impl WorkerLoaderChunkItem {
     #[turbo_tasks::function]
     async fn chunk_group(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
         let module = self.module.await?;
-        Ok(self.chunking_context.evaluated_chunk_group_assets(
-            module.inner.ident().with_modifier(rcstr!("worker")),
-            ChunkGroup::Isolated(ResolvedVc::upcast(module.inner)),
-            *self.module_graph,
-            AvailabilityInfo::root(),
-        ))
+
+        Ok(match self.worker_type {
+            WorkerType::WebWorker => self.chunking_context.evaluated_chunk_group_assets(
+                module.inner.ident().with_modifier(rcstr!("worker")),
+                ChunkGroup::Isolated(ResolvedVc::upcast(module.inner)),
+                *self.module_graph,
+                AvailabilityInfo::root(),
+            ),
+            // WorkerThreads are treated as an entry point, webworkers probably should too but
+            // currently it would lead to a cascade that we need to address.
+            WorkerType::NodeWorkerThread => {
+                let Some(evaluatable) =
+                    ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module.inner)
+                else {
+                    bail!("Worker module must be evaluatable");
+                };
+
+                let worker_path = self
+                    .chunking_context
+                    .chunk_path(
+                        None,
+                        module.inner.ident(),
+                        Some(rcstr!("[worker thread]")),
+                        rcstr!(".js"),
+                    )
+                    .owned()
+                    .await?;
+
+                let entry_result = self
+                    .chunking_context
+                    .root_entry_chunk_group(
+                        worker_path,
+                        EvaluatableAssets::one(*evaluatable),
+                        *self.module_graph,
+                        OutputAssets::empty(),
+                        OutputAssets::empty(),
+                    )
+                    .await?;
+
+                OutputAssetsWithReferenced {
+                    assets: ResolvedVc::cell(vec![entry_result.asset]),
+                    referenced_assets: ResolvedVc::cell(vec![]),
+                    references: ResolvedVc::cell(vec![]),
+                }
+                .cell()
+            }
+        })
     }
 
     #[turbo_tasks::function]
@@ -60,43 +102,96 @@ impl WorkerLoaderChunkItem {
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for WorkerLoaderChunkItem {
     #[turbo_tasks::function]
-    async fn content(self: Vc<Self>) -> Result<Vc<EcmascriptChunkItemContent>> {
+    fn content(self: Vc<Self>) -> Vc<EcmascriptChunkItemContent> {
+        panic!("should not be called");
+    }
+
+    #[turbo_tasks::function]
+    async fn content_with_async_module_info(
+        self: Vc<Self>,
+        _async_module_info: Option<Vc<AsyncModuleInfo>>,
+        estimated: bool,
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
         let this = self.await?;
 
-        // Get the worker entrypoint for this chunking context
-        let asset_context = *this.asset_context;
-        let entrypoint_full_path = this
-            .chunking_context
-            .worker_entrypoint(asset_context)
-            .path()
-            .await?;
+        let code = match this.worker_type {
+            WorkerType::WebWorker => {
+                // For web workers, generate code that creates a worker URL using the real
+                // entrypoint
+                let asset_context = *this.asset_context;
+                let entrypoint_full_path = this
+                    .chunking_context
+                    .worker_entrypoint(asset_context)
+                    .path()
+                    .await?;
 
-        // Get the entrypoint path relative to output root
-        let output_root = this.chunking_context.output_root().owned().await?;
-        let entrypoint_path = output_root
-            .get_path_to(&entrypoint_full_path)
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| entrypoint_full_path.path.to_string());
+                // Get the entrypoint path relative to output root
+                let output_root = this.chunking_context.output_root().owned().await?;
+                let entrypoint_path = output_root
+                    .get_path_to(&entrypoint_full_path)
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| entrypoint_full_path.path.to_string());
 
-        // Get the chunk data for the worker module
-        let chunks_data = self.chunks_data().await?;
-        let chunks_data = chunks_data.iter().try_join().await?;
-        let chunks_data: Vec<_> = chunks_data
-            .iter()
-            .map(|chunk_data| EcmascriptChunkData::new(chunk_data))
-            .collect();
+                // Get the chunk data for the worker module
+                let chunks_data = self.chunks_data().await?;
+                let chunks_data = chunks_data.iter().try_join().await?;
+                let chunks_data: Vec<_> = chunks_data
+                    .iter()
+                    .map(|chunk_data| EcmascriptChunkData::new(chunk_data))
+                    .collect();
 
-        // Determine if this is a SharedWorker
-        let is_shared = matches!(this.worker_type, WorkerReferenceSubType::SharedWorker);
+                // Determine if this is a SharedWorker
+                let is_shared =
+                    matches!(this.web_worker_type, WorkerReferenceSubType::SharedWorker);
 
-        // Generate code that creates a worker URL with the entrypoint and chunk paths
-        let code = formatdoc! {
-            r#"
-                {TURBOPACK_EXPORT_VALUE}({TURBOPACK_WORKER_URL}({entrypoint}, {chunks}, {shared}));
-            "#,
-            entrypoint = StringifyJs(&entrypoint_path),
-            chunks = StringifyJs(&chunks_data),
-            shared = is_shared,
+                formatdoc! {
+                    r#"
+                        {TURBOPACK_EXPORT_VALUE}({TURBOPACK_WORKER_URL}({entrypoint}, {chunks}, {shared}));
+                    "#,
+                    entrypoint = StringifyJs(&entrypoint_path),
+                    chunks = StringifyJs(&chunks_data),
+                    shared = is_shared,
+                }
+            }
+            WorkerType::NodeWorkerThread => {
+                // For Node.js workers, export the path to the worker entry chunk
+                if estimated {
+                    // In estimation mode we cannot call into chunking context APIs otherwise we
+                    // will induce a turbo tasks cycle. But we only need an approximate solution.
+                    formatdoc! {
+                        r#"
+                            {TURBOPACK_EXPORT_VALUE}(__dirname + "/" + {worker_path:#});
+                        "#,
+                        worker_path = StringifyJs(&"a_fake_path_for_size_estimation"),
+                    }
+                } else {
+                    let chunk_group = self.chunk_group().await?;
+                    let assets = chunk_group.assets.await?;
+
+                    // The last asset is the evaluate chunk (entry point) for the worker.
+                    // The evaluated_chunk_group adds regular chunks first, then pushes the
+                    // evaluate chunk last. The evaluate chunk contains the bootstrap code that
+                    // loads the runtime and other chunks. For Node.js workers, we need a single
+                    // file path (not a blob URL like browser workers), so we use the evaluate
+                    // chunk which serves as the entry point.
+                    let Some(entry_asset) = assets.last() else {
+                        bail!("cannot find worker entry point asset");
+                    };
+                    let entry_path = entry_asset.path().await?;
+
+                    // Get the filename of the worker entry chunk
+                    // We use just the filename because both the loader module and the worker
+                    // entry chunk are in the same directory (typically server/chunks/), so we
+                    // don't need a relative path - __dirname will already point to the correct
+                    // directory
+                    formatdoc! {
+                        r#"
+                            {TURBOPACK_EXPORT_VALUE}(__dirname + "/" + {worker_path:#});
+                        "#,
+                        worker_path = StringifyJs(entry_path.file_name()),
+                    }
+                }
+            }
         };
 
         Ok(EcmascriptChunkItemContent {
@@ -112,10 +207,18 @@ impl OutputAssetsReference for WorkerLoaderChunkItem {
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<OutputAssetsWithReferenced>> {
         let this = self.await?;
-        let asset_context = *this.asset_context;
-        Ok(self
-            .chunk_group()
-            .concatenate_asset(this.chunking_context.worker_entrypoint(asset_context)))
+        match this.worker_type {
+            WorkerType::WebWorker => {
+                let asset_context = *this.asset_context;
+                Ok(self
+                    .chunk_group()
+                    .concatenate_asset(this.chunking_context.worker_entrypoint(asset_context)))
+            }
+            WorkerType::NodeWorkerThread => {
+                // Node.js workers don't need a separate entrypoint asset
+                Ok(self.chunk_group())
+            }
+        }
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/mod.rs
@@ -1,2 +1,5 @@
 pub mod chunk_item;
 pub mod module;
+pub mod worker_type;
+
+pub use worker_type::WorkerType;

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
@@ -15,14 +15,16 @@ use turbopack_core::{
     resolve::ModuleResolveResult,
 };
 
-use super::chunk_item::WorkerLoaderChunkItem;
+use super::{chunk_item::WorkerLoaderChunkItem, worker_type::WorkerType};
 
 /// The WorkerLoaderModule is a module that creates a separate root chunk group for the given module
-/// and exports a URL to pass to the worker constructor.
+/// and exports a URL (for web workers) or file path (for Node.js workers) to pass to the worker
+/// constructor.
 #[turbo_tasks::value]
 pub struct WorkerLoaderModule {
     pub inner: ResolvedVc<Box<dyn ChunkableModule>>,
-    pub worker_type: WorkerReferenceSubType,
+    pub worker_type: WorkerType,
+    pub web_worker_type: WorkerReferenceSubType,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
@@ -31,19 +33,16 @@ impl WorkerLoaderModule {
     #[turbo_tasks::function]
     pub fn new(
         module: ResolvedVc<Box<dyn ChunkableModule>>,
-        worker_type: WorkerReferenceSubType,
+        worker_type: WorkerType,
+        web_worker_type: WorkerReferenceSubType,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
     ) -> Vc<Self> {
         Self::cell(WorkerLoaderModule {
             inner: module,
             worker_type,
+            web_worker_type,
             asset_context,
         })
-    }
-
-    #[turbo_tasks::function]
-    pub fn asset_ident_for(module: Vc<Box<dyn ChunkableModule>>) -> Vc<AssetIdent> {
-        module.ident().with_modifier(rcstr!("worker loader"))
     }
 }
 
@@ -51,7 +50,9 @@ impl WorkerLoaderModule {
 impl Module for WorkerLoaderModule {
     #[turbo_tasks::function]
     fn ident(&self) -> Vc<AssetIdent> {
-        Self::asset_ident_for(*self.inner)
+        self.inner
+            .ident()
+            .with_modifier(self.worker_type.modifier_str())
     }
 
     #[turbo_tasks::function]
@@ -61,8 +62,9 @@ impl Module for WorkerLoaderModule {
 
     #[turbo_tasks::function]
     async fn references(self: Vc<Self>) -> Result<Vc<ModuleReferences>> {
+        let this = self.await?;
         Ok(Vc::cell(vec![ResolvedVc::upcast(
-            WorkerModuleReference::new(*ResolvedVc::upcast(self.await?.inner))
+            WorkerModuleReference::new(*ResolvedVc::upcast(this.inner), this.worker_type)
                 .to_resolved()
                 .await?,
         )]))
@@ -89,6 +91,7 @@ impl ChunkableModule for WorkerLoaderModule {
                 module_graph,
                 chunking_context,
                 worker_type: this.worker_type,
+                web_worker_type: this.web_worker_type,
                 asset_context: this.asset_context,
             }
             .cell(),
@@ -99,22 +102,29 @@ impl ChunkableModule for WorkerLoaderModule {
 #[turbo_tasks::value]
 struct WorkerModuleReference {
     module: ResolvedVc<Box<dyn Module>>,
+    worker_type: WorkerType,
 }
 
 #[turbo_tasks::value_impl]
 impl WorkerModuleReference {
     #[turbo_tasks::function]
-    pub fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
-        Self::cell(WorkerModuleReference { module })
+    pub fn new(module: ResolvedVc<Box<dyn Module>>, worker_type: WorkerType) -> Vc<Self> {
+        Self::cell(WorkerModuleReference {
+            module,
+            worker_type,
+        })
     }
 }
 
 #[turbo_tasks::value_impl]
 impl ChunkableModuleReference for WorkerModuleReference {
     #[turbo_tasks::function]
-    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Isolated {
-            _ty: ChunkGroupType::Evaluated,
+            _ty: match self.worker_type {
+                WorkerType::WebWorker => ChunkGroupType::Evaluated,
+                WorkerType::NodeWorkerThread => ChunkGroupType::Entry,
+            },
             merge_tag: None,
         }))
     }
@@ -132,6 +142,6 @@ impl ModuleReference for WorkerModuleReference {
 impl ValueToString for WorkerModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("worker module"))
+        Vc::cell(self.worker_type.reference_str())
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -11,7 +11,6 @@ use turbopack_core::{
     module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
     reference::{ModuleReference, ModuleReferences},
-    reference_type::WorkerReferenceSubType,
     resolve::ModuleResolveResult,
 };
 
@@ -24,7 +23,6 @@ use super::{chunk_item::WorkerLoaderChunkItem, worker_type::WorkerType};
 pub struct WorkerLoaderModule {
     pub inner: ResolvedVc<Box<dyn ChunkableModule>>,
     pub worker_type: WorkerType,
-    pub web_worker_type: WorkerReferenceSubType,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
@@ -34,13 +32,11 @@ impl WorkerLoaderModule {
     pub fn new(
         module: ResolvedVc<Box<dyn ChunkableModule>>,
         worker_type: WorkerType,
-        web_worker_type: WorkerReferenceSubType,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
     ) -> Vc<Self> {
         Self::cell(WorkerLoaderModule {
             inner: module,
             worker_type,
-            web_worker_type,
             asset_context,
         })
     }
@@ -91,7 +87,6 @@ impl ChunkableModule for WorkerLoaderModule {
                 module_graph,
                 chunking_context,
                 worker_type: this.worker_type,
-                web_worker_type: this.web_worker_type,
                 asset_context: this.asset_context,
             }
             .cell(),
@@ -122,7 +117,7 @@ impl ChunkableModuleReference for WorkerModuleReference {
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Isolated {
             _ty: match self.worker_type {
-                WorkerType::WebWorker => ChunkGroupType::Evaluated,
+                WorkerType::SharedWebWorker | WorkerType::WebWorker => ChunkGroupType::Evaluated,
                 WorkerType::NodeWorkerThread => ChunkGroupType::Entry,
             },
             merge_tag: None,

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
@@ -137,6 +137,10 @@ impl ModuleReference for WorkerModuleReference {
 impl ValueToString for WorkerModuleReference {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.worker_type.reference_str())
+        Vc::cell(match self.worker_type {
+            WorkerType::WebWorker => rcstr!("web worker module"),
+            WorkerType::NodeWorkerThread => rcstr!("node worker thread module"),
+            WorkerType::SharedWebWorker => rcstr!("shared web worker module"),
+        })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
@@ -1,0 +1,34 @@
+use bincode::{Decode, Encode};
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
+
+#[derive(
+    Debug, Clone, Copy, Hash, PartialEq, Eq, Encode, Decode, TraceRawVcs, NonLocalValue, TaskInput,
+)]
+pub enum WorkerType {
+    WebWorker,
+    NodeWorkerThread,
+}
+
+impl WorkerType {
+    pub fn modifier_str(&self) -> RcStr {
+        match self {
+            WorkerType::WebWorker => rcstr!("worker loader"),
+            WorkerType::NodeWorkerThread => rcstr!("node worker thread loader"),
+        }
+    }
+
+    pub fn chunk_modifier_str(&self) -> RcStr {
+        match self {
+            WorkerType::WebWorker => rcstr!("worker"),
+            WorkerType::NodeWorkerThread => rcstr!("node worker thread"),
+        }
+    }
+
+    pub fn reference_str(&self) -> RcStr {
+        match self {
+            WorkerType::WebWorker => rcstr!("worker module"),
+            WorkerType::NodeWorkerThread => rcstr!("node worker thread module"),
+        }
+    }
+}

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
@@ -1,20 +1,23 @@
 use bincode::{Decode, Encode};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
+use turbopack_core::reference_type::WorkerReferenceSubType;
 
 #[derive(
     Debug, Clone, Copy, Hash, PartialEq, Eq, Encode, Decode, TraceRawVcs, NonLocalValue, TaskInput,
 )]
 pub enum WorkerType {
     WebWorker,
+    SharedWebWorker,
     NodeWorkerThread,
 }
 
 impl WorkerType {
     pub fn modifier_str(&self) -> RcStr {
         match self {
-            WorkerType::WebWorker => rcstr!("worker loader"),
+            WorkerType::WebWorker => rcstr!("web worker loader"),
             WorkerType::NodeWorkerThread => rcstr!("node worker thread loader"),
+            WorkerType::SharedWebWorker => rcstr!("shared web worker loader"),
         }
     }
 
@@ -22,13 +25,23 @@ impl WorkerType {
         match self {
             WorkerType::WebWorker => rcstr!("worker"),
             WorkerType::NodeWorkerThread => rcstr!("node worker thread"),
+            WorkerType::SharedWebWorker => rcstr!("shared worker"),
         }
     }
 
     pub fn reference_str(&self) -> RcStr {
         match self {
-            WorkerType::WebWorker => rcstr!("worker module"),
+            WorkerType::WebWorker => rcstr!("web worker module"),
             WorkerType::NodeWorkerThread => rcstr!("node worker thread module"),
+            WorkerType::SharedWebWorker => rcstr!("shared web worker module"),
+        }
+    }
+
+    pub fn reference_sub_type(&self) -> WorkerReferenceSubType {
+        match self {
+            WorkerType::WebWorker => WorkerReferenceSubType::WebWorker,
+            WorkerType::SharedWebWorker => WorkerReferenceSubType::SharedWorker,
+            WorkerType::NodeWorkerThread => WorkerReferenceSubType::NodeWorker,
         }
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
@@ -1,7 +1,7 @@
 use bincode::{Decode, Encode};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
-use turbopack_core::reference_type::WorkerReferenceSubType;
+use turbopack_core::reference_type::{ReferenceType, WorkerReferenceSubType};
 
 #[derive(
     Debug, Clone, Copy, Hash, PartialEq, Eq, Encode, Decode, TraceRawVcs, NonLocalValue, TaskInput,
@@ -15,33 +15,23 @@ pub enum WorkerType {
 impl WorkerType {
     pub fn modifier_str(&self) -> RcStr {
         match self {
-            WorkerType::WebWorker => rcstr!("web worker loader"),
+            WorkerType::SharedWebWorker | WorkerType::WebWorker => rcstr!("worker loader"),
             WorkerType::NodeWorkerThread => rcstr!("node worker thread loader"),
-            WorkerType::SharedWebWorker => rcstr!("shared web worker loader"),
         }
     }
 
     pub fn chunk_modifier_str(&self) -> RcStr {
         match self {
-            WorkerType::WebWorker => rcstr!("worker"),
+            WorkerType::SharedWebWorker | WorkerType::WebWorker => rcstr!("worker"),
             WorkerType::NodeWorkerThread => rcstr!("node worker thread"),
-            WorkerType::SharedWebWorker => rcstr!("shared worker"),
         }
     }
 
-    pub fn reference_str(&self) -> RcStr {
-        match self {
-            WorkerType::WebWorker => rcstr!("web worker module"),
-            WorkerType::NodeWorkerThread => rcstr!("node worker thread module"),
-            WorkerType::SharedWebWorker => rcstr!("shared web worker module"),
-        }
-    }
-
-    pub fn reference_sub_type(&self) -> WorkerReferenceSubType {
-        match self {
+    pub fn reference_type(&self) -> ReferenceType {
+        ReferenceType::Worker(match self {
             WorkerType::WebWorker => WorkerReferenceSubType::WebWorker,
             WorkerType::SharedWebWorker => WorkerReferenceSubType::SharedWorker,
             WorkerType::NodeWorkerThread => WorkerReferenceSubType::NodeWorker,
-        }
+        })
     }
 }

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -266,25 +266,6 @@ impl NodeJsChunkingContext {
 
 #[turbo_tasks::value_impl]
 impl NodeJsChunkingContext {
-    #[turbo_tasks::function]
-    async fn generate_chunk(
-        self: Vc<Self>,
-        chunk: ResolvedVc<Box<dyn Chunk>>,
-    ) -> Result<Vc<Box<dyn OutputAsset>>> {
-        Ok(
-            if let Some(ecmascript_chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk)
-            {
-                Vc::upcast(EcmascriptBuildNodeChunk::new(self, *ecmascript_chunk))
-            } else if let Some(output_asset) =
-                ResolvedVc::try_sidecast::<Box<dyn OutputAsset>>(chunk)
-            {
-                *output_asset
-            } else {
-                bail!("Unable to generate output asset for chunk");
-            },
-        )
-    }
-
     /// Returns the kind of runtime to include in output chunks.
     ///
     /// This is defined directly on `NodeJsChunkingContext` so it is zero-cost
@@ -303,6 +284,30 @@ impl NodeJsChunkingContext {
     #[turbo_tasks::function]
     pub fn asset_prefix(&self) -> Vc<Option<RcStr>> {
         Vc::cell(self.asset_prefix.clone())
+    }
+}
+
+impl NodeJsChunkingContext {
+    async fn generate_chunk(
+        self: Vc<Self>,
+        chunk: ResolvedVc<Box<dyn Chunk>>,
+    ) -> Result<ResolvedVc<Box<dyn OutputAsset>>> {
+        Ok(
+            if let Some(ecmascript_chunk) = ResolvedVc::try_downcast_type::<EcmascriptChunk>(chunk)
+            {
+                ResolvedVc::upcast(
+                    EcmascriptBuildNodeChunk::new(self, *ecmascript_chunk)
+                        .to_resolved()
+                        .await?,
+                )
+            } else if let Some(output_asset) =
+                ResolvedVc::try_sidecast::<Box<dyn OutputAsset>>(chunk)
+            {
+                output_asset
+            } else {
+                bail!("Unable to generate output asset for chunk");
+            },
+        )
     }
 }
 
@@ -499,7 +504,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
             let assets = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(**chunk).to_resolved())
+                .map(|chunk| self.generate_chunk(*chunk))
                 .try_join()
                 .await?;
 
@@ -551,7 +556,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             let extra_chunks = extra_chunks.await?;
             let mut other_chunks = chunks
                 .iter()
-                .map(|chunk| self.generate_chunk(**chunk).to_resolved())
+                .map(|chunk| self.generate_chunk(*chunk))
                 .try_join()
                 .await?;
             other_chunks.extend(extra_chunks.iter().copied());

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -166,7 +166,7 @@ impl EcmascriptBuildNodeEntryChunk {
 impl ValueToString for EcmascriptBuildNodeEntryChunk {
     #[turbo_tasks::function]
     fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Build Node Evaluate Chunk"))
+        Vc::cell(rcstr!("Ecmascript Build Node Entry Chunk"))
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/ecmascript.rs
+++ b/turbopack/crates/turbopack-resolve/src/ecmascript.rs
@@ -94,7 +94,7 @@ pub async fn esm_resolve(
     issue_source: Option<IssueSource>,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::EcmaScriptModules(ty);
-    let options = apply_esm_specific_options(origin.resolve_options(ty.clone()), &ty)
+    let options = apply_esm_specific_options(origin.resolve_options(), &ty)
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -109,7 +109,7 @@ pub async fn cjs_resolve(
     is_optional: bool,
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::CommonJs(ty);
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
+    let options = apply_cjs_specific_options(origin.resolve_options())
         .resolve()
         .await?;
     specific_resolve(origin, request, options, ty, is_optional, issue_source).await
@@ -124,7 +124,7 @@ pub async fn cjs_resolve_source(
     is_optional: bool,
 ) -> Result<Vc<ResolveResult>> {
     let ty = ReferenceType::CommonJs(ty);
-    let options = apply_cjs_specific_options(origin.resolve_options(ty.clone()))
+    let options = apply_cjs_specific_options(origin.resolve_options())
         .resolve()
         .await?;
     let result = resolve(

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -417,7 +417,7 @@ pub async fn type_resolve(
 ) -> Result<Vc<ModuleResolveResult>> {
     let ty = ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined);
     let context_path = origin.origin_path().await?.parent();
-    let options = origin.resolve_options(ty.clone());
+    let options = origin.resolve_options();
     let options = apply_typescript_types_options(options);
     let types_request = if let Request::Module {
         module: m,

--- a/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
+++ b/turbopack/crates/turbopack-test-utils/src/noop_asset_context.rs
@@ -32,7 +32,6 @@ impl AssetContext for NoopAssetContext {
     async fn resolve_options(
         self: Vc<Self>,
         _origin_path: FileSystemPath,
-        _reference_type: ReferenceType,
     ) -> Result<Vc<ResolveOptions>> {
         Ok(ResolveOptions::default().cell())
     }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -437,6 +437,8 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
         ResolveOptionsContext {
             enable_typescript: true,
             enable_node_modules: Some(project_root.clone()),
+            enable_node_native_modules: true,
+            enable_node_externals: true,
             custom_conditions: vec![rcstr!("development")],
             rules: vec![(
                 ContextCondition::InNodeModules,

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/index.js
@@ -1,0 +1,81 @@
+const { Worker, isMainThread, parentPort } = require('node:worker_threads')
+const path = require('path')
+
+if (isMainThread) {
+  it('should run a worker thread with separate file', async () => {
+    const worker = new Worker(path.join(__dirname, 'worker.js'))
+
+    const message = await new Promise((resolve, reject) => {
+      worker.on('message', resolve)
+      worker.on('error', reject)
+      worker.on('exit', (code) => {
+        if (code !== 0) {
+          reject(new Error(`Worker stopped with exit code ${code}`))
+        }
+      })
+
+      worker.postMessage('ping')
+    })
+
+    expect(message).toBe('pong')
+    await worker.terminate()
+  })
+
+  it('should handle self-referencing worker (__filename)', async () => {
+    const worker = new Worker(__filename)
+
+    const message = await new Promise((resolve, reject) => {
+      worker.on('message', resolve)
+      worker.on('error', reject)
+      worker.on('exit', (code) => {
+        if (code !== 0) {
+          reject(new Error(`Worker stopped with exit code ${code}`))
+        }
+      })
+
+      worker.postMessage('self-ref-ping')
+    })
+
+    expect(message).toBe('self-ref-pong')
+    await worker.terminate()
+  })
+
+  async function runDynamicWorker(workerType, args) {
+    const worker = new Worker(`./${workerType}-worker.js`)
+
+    try {
+      return await new Promise((resolve, reject) => {
+        worker.on('message', resolve)
+        worker.on('error', reject)
+        worker.on('exit', (code) => {
+          if (code !== 0) {
+            reject(new Error(`Worker stopped with exit code ${code}`))
+          }
+        })
+
+        worker.postMessage(args)
+      })
+    } finally {
+      await worker.terminate()
+    }
+  }
+
+  it('should handle dynamic worker selection with pattern', async () => {
+    const response = await runDynamicWorker('math', { a: 5, b: 3 })
+
+    expect(response).toEqual({ type: 'math', result: 8 })
+  })
+
+  it('should handle another dynamic worker type', async () => {
+    const response = await runDynamicWorker('string', { text: 'hello' })
+
+    expect(response).toEqual({ type: 'string', result: 'HELLO' })
+  })
+} else {
+  // Worker thread - handle self-referencing worker messages
+  parentPort.on('message', (msg) => {
+    if (msg === 'self-ref-ping') {
+      parentPort.postMessage('self-ref-pong')
+    }
+  })
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/math-worker.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/math-worker.js
@@ -1,0 +1,8 @@
+const { parentPort } = require('node:worker_threads')
+
+if (parentPort) {
+  parentPort.on('message', (data) => {
+    const result = data.a + data.b
+    parentPort.postMessage({ type: 'math', result })
+  })
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/string-worker.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/string-worker.js
@@ -1,0 +1,8 @@
+const { parentPort } = require('node:worker_threads')
+
+if (parentPort) {
+  parentPort.on('message', (data) => {
+    const result = data.text.toUpperCase()
+    parentPort.postMessage({ type: 'string', result })
+  })
+}

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/worker.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/basic/worker-threads/input/worker.js
@@ -1,0 +1,11 @@
+const { parentPort } = require('node:worker_threads')
+
+// Worker thread code
+parentPort.on('message', (msg) => {
+  if (msg === 'ping') {
+    parentPort.postMessage('pong')
+  } else if (msg.type === 'compute') {
+    const result = msg.a + msg.b
+    parentPort.postMessage({ type: 'result', value: result })
+  }
+})

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -797,7 +797,6 @@ impl AssetContext for ModuleAssetContext {
     async fn resolve_options(
         self: Vc<Self>,
         origin_path: FileSystemPath,
-        _reference_type: ReferenceType,
     ) -> Result<Vc<ResolveOptions>> {
         let this = self.await?;
         let module_asset_context = if let Some(transition) = this.transition {


### PR DESCRIPTION
## What?

This PR reapplies #87746 which adds bundling support for Node.js `worker_threads` in Turbopack.

## Why?

The original PR (#87746) was reverted in #88725 because it broke builds that use packages like `pino` with transports. These packages use dynamic patterns like `join(__dirname, 'lib', 'worker.js')` to resolve worker entry points, which can match non-evaluatable files like `package.json` or `tsconfig.json`.

## How?

This PR reapplies the original changes with the following fixes:

1. **Downgrade errors to warnings in tracing contexts**: When `loose_errors` is enabled (tracing mode) or `in_try` is true, worker entry point validation errors are now emitted as warnings instead of errors. This follows the established Turbopack pattern used in `handle_resolve_error` and other resolve error handling.

2. **Improved error messages**: Error messages for non-chunkable and non-evaluatable worker entry point modules now include:
   - The module identifier (so you can see which file caused the issue)
   - The issue source location (pointing to the `new Worker()` call in source code)

3. **Added regression test**: A new pino-based test case exercises the `thread-stream` worker pattern that caused the original failure. This test runs in `CodeGenerationAndTracing` mode via `test-start-turbo`.

## Changes from original PR

- Added `source` field to `CodeGenerationIssue` to support showing issue source locations
- Added `get_issue_severity()` helper that checks `loose_errors` and `in_try` to determine severity
- Fixed typo: `"SharedbWorker"` → `"SharedWorker"` in `to_string` implementation
- Added pino regression test in `test/e2e/app-dir/node-worker-threads/`

## Testing

- ✅ `pnpm test-dev-turbo test/e2e/app-dir/node-worker-threads/` - all tests pass
- ✅ `pnpm test-start-turbo test/e2e/app-dir/node-worker-threads/` - all tests pass (exercises bundling mode)
- ✅ Verified test fails without the `loose_errors` fix
- ✅ Verified vercel-docs build succeeds with warnings instead of errors
