### PR TITLE
[turbopack] Distribute SST write IO across threads

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -29,6 +29,7 @@ use crate::{
         KEY_BLOCK_CACHE_SIZE, MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE,
         VALUE_BLOCK_CACHE_SIZE,
     },
+    io_semaphore::{IoSemaphore, max_concurrent_sst_writes},
     key::{StoreKey, hash_key},
     lookup_entry::{LookupEntry, LookupValue},
     merge_iter::MergeIter,
@@ -128,6 +129,8 @@ pub struct TurboPersistence<S: ParallelScheduler, const FAMILIES: usize> {
     /// Statistics for the database.
     #[cfg(feature = "stats")]
     stats: TrackedStats,
+    /// Semaphore to limit concurrent SST file writes.
+    io_semaphore: IoSemaphore,
 }
 
 /// The inner state of the database.
@@ -204,6 +207,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             ),
             #[cfg(feature = "stats")]
             stats: TrackedStats::default(),
+            io_semaphore: IoSemaphore::new(max_concurrent_sst_writes()),
         }
     }
 
@@ -416,7 +420,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// This data will only become visible after the WriteBatch is committed.
     pub fn write_batch<K: StoreKey + Send + Sync + 'static>(
         &self,
-    ) -> Result<WriteBatch<K, S, FAMILIES>> {
+    ) -> Result<WriteBatch<'_, K, S, FAMILIES>> {
         if self.read_only {
             bail!("Cannot write to a read-only database");
         }
@@ -435,6 +439,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             self.path.clone(),
             current,
             self.parallel_scheduler.clone(),
+            &self.io_semaphore,
         ))
     }
 
@@ -454,7 +459,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
     /// visible to readers.
     pub fn commit_write_batch<K: StoreKey + Send + Sync + 'static>(
         &self,
-        mut write_batch: WriteBatch<K, S, FAMILIES>,
+        mut write_batch: WriteBatch<'_, K, S, FAMILIES>,
     ) -> Result<()> {
         if self.read_only {
             unreachable!("It's not possible to create a write batch for a read-only database");
@@ -993,6 +998,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
                                 fn create_sst_file<'l, S: ParallelScheduler>(
                                     parallel_scheduler: &S,
+                                    io_semaphore: &IoSemaphore,
                                     entries: &[LookupEntry<'l>],
                                     total_key_size: usize,
                                     path: &Path,
@@ -1002,6 +1008,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 {
                                     let _span =
                                         tracing::trace_span!("write merged sst file").entered();
+                                    let _permit = io_semaphore.acquire();
                                     let (meta, file) = parallel_scheduler.block_in_place(|| {
                                         write_static_stored_file(
                                             entries,
@@ -1096,6 +1103,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                                     flags.set_cold(!is_used);
                                                     collector.new_sst_files.push(create_sst_file(
                                                         &self.parallel_scheduler,
+                                                        &self.io_semaphore,
                                                         &collector.entries,
                                                         selected_total_key_size,
                                                         path,
@@ -1145,6 +1153,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         keys_written += collector.entries.len() as u64;
                                         collector.new_sst_files.push(create_sst_file(
                                             &self.parallel_scheduler,
+                                            &self.io_semaphore,
                                             &collector.entries,
                                             collector.total_key_size,
                                             path,
@@ -1173,6 +1182,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         keys_written += part1.len() as u64;
                                         collector.new_sst_files.push(create_sst_file(
                                             &self.parallel_scheduler,
+                                            &self.io_semaphore,
                                             part1,
                                             // We don't know the exact sizes so we estimate them
                                             collector.last_entries_total_key_size / 2,
@@ -1184,6 +1194,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         keys_written += part2.len() as u64;
                                         collector.new_sst_files.push(create_sst_file(
                                             &self.parallel_scheduler,
+                                            &self.io_semaphore,
                                             part2,
                                             collector.last_entries_total_key_size / 2,
                                             path,

--- a/turbopack/crates/turbo-persistence/src/io_semaphore.rs
+++ b/turbopack/crates/turbo-persistence/src/io_semaphore.rs
@@ -1,0 +1,61 @@
+use std::sync::LazyLock;
+
+use parking_lot::{Condvar, Mutex};
+
+/// Default maximum number of concurrent SST file write operations.
+///
+/// We write a lot of smallish files where high concurrency will cause metadata thrashing.
+/// 4 is a safe cross-platform value that balances throughput with avoiding excessive disk
+/// contention.
+const DEFAULT_WRITE_CONCURRENCY: usize = 4;
+
+/// Returns the configured maximum number of concurrent SST file write operations.
+///
+/// This can be overridden via the `TURBO_ENGINE_WRITE_CONCURRENCY` environment variable.
+/// A value of 0 in the env var is ignored (uses default).
+pub fn max_concurrent_sst_writes() -> usize {
+    static WRITE_CONCURRENCY: LazyLock<usize> = LazyLock::new(|| {
+        std::env::var("TURBO_ENGINE_WRITE_CONCURRENCY")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .filter(|&v| v != 0)
+            .unwrap_or(DEFAULT_WRITE_CONCURRENCY)
+    });
+    *WRITE_CONCURRENCY
+}
+
+/// A simple counting semaphore for limiting concurrent IO operations.
+pub struct IoSemaphore {
+    state: Mutex<usize>,
+    condvar: Condvar,
+}
+
+impl IoSemaphore {
+    pub fn new(permits: usize) -> Self {
+        Self {
+            state: Mutex::new(permits),
+            condvar: Condvar::new(),
+        }
+    }
+
+    pub fn acquire(&self) -> IoPermit<'_> {
+        let mut available = self.state.lock();
+        while *available == 0 {
+            self.condvar.wait(&mut available);
+        }
+        *available -= 1;
+        IoPermit { semaphore: self }
+    }
+}
+
+pub struct IoPermit<'a> {
+    semaphore: &'a IoSemaphore,
+}
+
+impl Drop for IoPermit<'_> {
+    fn drop(&mut self) {
+        let mut available = self.semaphore.state.lock();
+        *available += 1;
+        self.semaphore.condvar.notify_one();
+    }
+}

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -10,6 +10,7 @@ mod compaction;
 mod compression;
 mod constants;
 mod db;
+mod io_semaphore;
 mod key;
 mod lookup_entry;
 mod merge_iter;

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::SyncUnsafeCell,
+    collections::VecDeque,
     fs::File,
     io::Write,
     mem::{replace, take},
@@ -82,6 +83,9 @@ pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: 
     /// The list of new SST files that have been created.
     /// Tuple of (sequence number, file).
     new_sst_files: Mutex<Vec<(u32, File)>>,
+    /// Queue of full collectors waiting to be written to disk.
+    /// Tuple of (family, collector). Any thread may drain this queue to help with IO work.
+    pending_writes: Mutex<VecDeque<(u32, Collector<K>)>>,
 }
 
 impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
@@ -101,6 +105,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
                 .map(|_| Mutex::new(GlobalCollectorState::Unsharded(Collector::new()))),
             meta_collectors: [(); FAMILIES].map(|_| Mutex::new(Vec::new())),
             new_sst_files: Mutex::new(Vec::new()),
+            pending_writes: Mutex::new(VecDeque::new()),
         }
     }
 
@@ -175,29 +180,24 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
                 }
             }
         }
-        // After flushing write all the full global collectors to disk.
-        // TODO: This can distribute work unfairly
-        // * a thread could fill up multiple global collectors and then get stuck writing them all
-        //   out, if multiple threads could work on it we could take care of spare IO parallism
-        // * we can also have too much IO parallism with many threads concurrently writing files.
-        //
-        // Ideally we would limit the amount of data buffered in memory and control the amount of IO
-        // parallism.  Consider:
-        // * store full-buffers as a field on WireBatch (queued writes)
-        // * each thread will attempt to poll and flush a full buffer after flushing its local
-        //   buffer.
-        // This will distribute the writing work more fairly, but now we have the problem of to
-        // many concurrent writes contending for filesystem locks.  So we could also use a semaphore
-        // to restrict how many concurrent writes occur.  But then we would accumulate 'fullBuffers'
-        // leading to too much memory consumption.  So really we also need to slow down the threads
-        // submitting work data.  To do this we could simply use a tokio semaphore and make all
-        // these operations async, or we could integrate with the parallel::map operation that is
-        // driving the work to slow down task submission in this case.
-        for mut global_collector in full_collectors {
-            // When the global collector is full, we create a new SST file.
-            let sst = self.create_sst_file(family, global_collector.sorted())?;
+
+        // Queue full collectors to be written to disk.
+        // Any thread may help drain this queue, distributing IO work more fairly.
+        // TODO: Consider adding back-pressure by making collector acquisition async, which would
+        // allow using a tokio semaphore to limit memory consumption when disk IO is slow.
+        if !full_collectors.is_empty() {
+            let mut pending = self.pending_writes.lock();
+            for collector in full_collectors {
+                pending.push_back((family, collector));
+            }
+        }
+
+        // Opportunistically drain pending writes. By pushing to a shared queue and then looping
+        // here we give other threads an opportunity to help drain.
+        while let Some((family, mut collector)) = self.pending_writes.lock().pop_front() {
+            let sst = self.create_sst_file(family, collector.sorted())?;
             self.new_sst_files.lock().push(sst);
-            drop(global_collector);
+            drop(collector);
         }
         Ok(())
     }

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -21,6 +21,7 @@ use crate::{
     collector_entry::CollectorEntry,
     compression::compress_into_buffer,
     constants::{MAX_MEDIUM_VALUE_SIZE, THREAD_LOCAL_SIZE_SHIFT},
+    io_semaphore::IoSemaphore,
     key::StoreKey,
     meta_file::MetaEntryFlags,
     meta_file_builder::MetaFileBuilder,
@@ -67,7 +68,7 @@ enum GlobalCollectorState<K: StoreKey + Send> {
 }
 
 /// A write batch.
-pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: usize> {
+pub struct WriteBatch<'db, K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: usize> {
     /// Parallel scheduler
     parallel_scheduler: S,
     /// The database path
@@ -86,13 +87,20 @@ pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: 
     /// Queue of full collectors waiting to be written to disk.
     /// Tuple of (family, collector). Any thread may drain this queue to help with IO work.
     pending_writes: Mutex<VecDeque<(u32, Collector<K>)>>,
+    /// Semaphore to limit concurrent SST file writes.
+    io_semaphore: &'db IoSemaphore,
 }
 
-impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
-    WriteBatch<K, S, FAMILIES>
+impl<'db, K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
+    WriteBatch<'db, K, S, FAMILIES>
 {
     /// Creates a new write batch for a database.
-    pub(crate) fn new(path: PathBuf, current: u32, parallel_scheduler: S) -> Self {
+    pub(crate) fn new(
+        path: PathBuf,
+        current: u32,
+        parallel_scheduler: S,
+        io_semaphore: &'db IoSemaphore,
+    ) -> Self {
         const {
             assert!(FAMILIES <= usize_from_u32(u32::MAX));
         };
@@ -106,6 +114,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
             meta_collectors: [(); FAMILIES].map(|_| Mutex::new(Vec::new())),
             new_sst_files: Mutex::new(Vec::new()),
             pending_writes: Mutex::new(VecDeque::new()),
+            io_semaphore,
         }
     }
 
@@ -437,6 +446,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
         let seq = self.current_sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
 
         let path = self.db_path.join(format!("{seq:08}.sst"));
+        let _permit = self.io_semaphore.acquire();
         let (meta, file) = self
             .parallel_scheduler
             .block_in_place(|| {

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -168,8 +168,12 @@ fn do_compact(
 }
 
 pub struct TurboWriteBatch<'a> {
-    batch:
-        turbo_persistence::WriteBatch<WriteBuffer<'static>, TurboTasksParallelScheduler, FAMILIES>,
+    batch: turbo_persistence::WriteBatch<
+        'a,
+        WriteBuffer<'static>,
+        TurboTasksParallelScheduler,
+        FAMILIES,
+    >,
     db: &'a Arc<TurboPersistence<TurboTasksParallelScheduler, FAMILIES>>,
     compact_join_handle: Option<&'a Mutex<Option<JoinHandle<Result<()>>>>>,
 }


### PR DESCRIPTION
When we flush a thread local buffer and fill a global collector, push those fulll collectors into a shared queue.  That way every thread that fills its local buffer can help flush data to disk instead of just whatever thread happens to fill the buffer(s).

This will help during the writing process and at the end when we flush all collectors by ensuring that all threads can contribute to filling writing out files.

Additionally use an IO semaphore to reduce io parallism to 4, in line with other parts of turbopack.

