### PR TITLE
[Reapply] Add `useEffectEvent` to disallowed React APIs in Server Components

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -633,6 +633,7 @@ impl ReactServerComponentValidator {
                         "PureComponent",
                         "useDeferredValue",
                         "useEffect",
+                        "useEffectEvent",
                         "useImperativeHandle",
                         "useInsertionEffect",
                         "useLayoutEffect",

--- a/packages/next/src/lib/format-server-error.ts
+++ b/packages/next/src/lib/format-server-error.ts
@@ -1,6 +1,7 @@
 const invalidServerComponentReactHooks = [
   'useDeferredValue',
   'useEffect',
+  'useEffectEvent',
   'useImperativeHandle',
   'useInsertionEffect',
   'useLayoutEffect',

--- a/packages/next/src/server/typescript/constant.ts
+++ b/packages/next/src/server/typescript/constant.ts
@@ -26,6 +26,7 @@ export const LEGACY_CONFIG_EXPORT = 'config'
 export const DISALLOWED_SERVER_REACT_APIS: string[] = [
   'useState',
   'useEffect',
+  'useEffectEvent',
   'useLayoutEffect',
   'useDeferredValue',
   'useImperativeHandle',

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useeffectevent/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/server-with-errors/react-apis/useeffectevent/page.js
@@ -1,0 +1,7 @@
+import { useEffectEvent } from 'react'
+
+console.log({ useEffectEvent })
+
+export default function Page() {
+  return null
+}

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -205,6 +205,7 @@ describe('Error overlay - RSC build errors', () => {
     'PureComponent',
     'useDeferredValue',
     'useEffect',
+    'useEffectEvent',
     'useImperativeHandle',
     'useInsertionEffect',
     'useLayoutEffect',


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
### What?
Add `useEffectEvent` to the list of invalid React APIs in Server Components.

### Why?
Using `useEffectEvent` in a Server Component results in a **runtime error**: TypeError: (0 , react_1.useEffectEvent) is not a function.
Without this fix, developers only discover the mistake at runtime. This change improves the **Developer Experience (DX) by catching the error immediately in the IDE.**

#### Expected Behavior
<img width="999" height="566" alt="image" src="https://github.com/user-attachments/assets/79c1cbf9-ae0e-4ad7-b163-f650fb289a3a" />

#### Currently
<img width="1708" height="805" alt="image" src="https://github.com/user-attachments/assets/a33f73e5-24fd-4405-826a-53f1810154a7" />
<img width="2091" height="812" alt="image" src="https://github.com/user-attachments/assets/ed3f191e-a34d-42dd-8779-1d524f6f035d" />

### How?
- Added `useEffectEvent` to Rust RSC transform (`react_server_components.rs`)
- Added `useEffectEvent` to TypeScript constants (`constant.ts`)
- Added `useEffectEvent` to error formatting (`format-server-error.ts`)
- Added test fixture and updated test file

## Note

This is a reapply of the previous [PR](https://github.com/vercel/next.js/pull/88950).
With help from @timneutkens, I all previously worked code to ensure nothing was missed before resubmitting.

