### PR TITLE
Decouple route and segment cache lifecycles

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -6,18 +6,19 @@ import {
   convertServerPatchToFullTree,
   navigateToKnownRoute,
 } from '../../segment-cache/navigation'
-import { revalidateEntireCache } from '../../segment-cache/cache'
+import { invalidateSegmentCacheEntries } from '../../segment-cache/cache'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
 import { FreshnessPolicy } from '../ppr-navigations'
 import { invalidateBfCache } from '../../segment-cache/bfcache'
 
 export function refreshReducer(state: ReadonlyReducerState): ReducerState {
-  // TODO: Currently, all refreshes purge the prefetch cache. In the future,
-  // only client-side refreshes will have this behavior; the server-side
-  // `refresh` should send new data without purging the prefetch cache.
+  // During a refresh, we invalidate the segment cache but not the route cache.
+  // The route cache contains the tree structure (which segments exist at a
+  // given URL) which doesn't change during a refresh. The segment cache
+  // contains the actual RSC data which needs to be re-fetched.
   const currentNextUrl = state.nextUrl
   const currentRouterState = state.tree
-  revalidateEntireCache(currentNextUrl, currentRouterState)
+  invalidateSegmentCacheEntries(currentNextUrl, currentRouterState)
   return refreshDynamicData(state, FreshnessPolicy.RefreshAll)
 }
 

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -45,7 +45,8 @@ import {
   extractInfoFromServerReferenceId,
   omitUnusedArgs,
 } from '../../../../shared/lib/server-reference-info'
-import { revalidateEntireCache } from '../../segment-cache/cache'
+import { invalidateEntirePrefetchCache } from '../../segment-cache/cache'
+import { startRevalidationCooldown } from '../../segment-cache/scheduler'
 import { getDeploymentId } from '../../../../shared/lib/deployment-id'
 import {
   completeHardNavigation,
@@ -291,11 +292,19 @@ export function serverActionReducer(
         // (ie, due to a navigation, before the action completed)
         action.didRevalidate = true
 
-        // If there was a revalidation, evict the entire prefetch cache.
+        // If there was a revalidation, evict the prefetch cache.
         // TODO: Evict only segments with matching tags and/or paths.
+        // TODO: We should only invalidate the route cache if cookies were
+        // mutated, since route trees may vary based on cookies. For now we
+        // invalidate both caches until we have a way to detect cookie
+        // mutations on the client.
         if (revalidationKind === ActionDidRevalidateStaticAndDynamic) {
-          revalidateEntireCache(nextUrl, state.tree)
+          invalidateEntirePrefetchCache(nextUrl, state.tree)
         }
+
+        // Start a cooldown before re-prefetching to allow CDN cache
+        // propagation.
+        startRevalidationCooldown()
       }
 
       const navigateType = redirectType || 'push'

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -679,16 +679,17 @@ function createOptimisticRouteTree(
 export function readOrCreateSegmentCacheEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  route: FulfilledRouteCacheEntry,
   tree: RouteTree
 ): SegmentCacheEntry {
   const existingEntry = readSegmentCacheEntry(now, tree.varyPath)
   if (existingEntry !== null) {
     return existingEntry
   }
-  // Create a pending entry and add it to the cache.
+  // Create a pending entry and add it to the cache. The stale time is set to a
+  // default value; the actual stale time will be set when the entry is
+  // fulfilled with data from the server response.
   const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
-  const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
+  const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = false
   setInCacheMap(
     segmentCacheMap,
@@ -702,7 +703,6 @@ export function readOrCreateSegmentCacheEntry(
 export function readOrCreateRevalidatingSegmentEntry(
   now: number,
   fetchStrategy: FetchStrategy,
-  route: FulfilledRouteCacheEntry,
   tree: RouteTree
 ): SegmentCacheEntry {
   // This function is called when we've already confirmed that a particular
@@ -736,9 +736,11 @@ export function readOrCreateRevalidatingSegmentEntry(
   if (existingEntry !== null) {
     return existingEntry
   }
-  // Create a pending entry and add it to the cache.
+  // Create a pending entry and add it to the cache. The stale time is set to a
+  // default value; the actual stale time will be set when the entry is
+  // fulfilled with data from the server response.
   const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
-  const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
+  const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = true
   setInCacheMap(
     segmentCacheMap,
@@ -750,15 +752,17 @@ export function readOrCreateRevalidatingSegmentEntry(
 }
 
 export function overwriteRevalidatingSegmentCacheEntry(
+  now: number,
   fetchStrategy: FetchStrategy,
-  route: FulfilledRouteCacheEntry,
   tree: RouteTree
 ) {
   // This function is called when we've already decided to replace an existing
   // revalidation entry. Create a new entry and write it into the cache,
-  // overwriting the previous value.
+  // overwriting the previous value. The stale time is set to a default value;
+  // the actual stale time will be set when the entry is fulfilled with data
+  // from the server response.
   const varyPathForRequest = getSegmentVaryPathForRequest(fetchStrategy, tree)
-  const pendingEntry = createDetachedSegmentCacheEntry(route.staleAt)
+  const pendingEntry = createDetachedSegmentCacheEntry(now)
   const isRevalidation = true
   setInCacheMap(
     segmentCacheMap,
@@ -824,8 +828,11 @@ export function upsertSegmentEntry(
 }
 
 export function createDetachedSegmentCacheEntry(
-  staleAt: number
+  now: number
 ): EmptySegmentCacheEntry {
+  // Default stale time for pending segment cache entries. The actual stale time
+  // is set when the entry is fulfilled with data from the server response.
+  const staleAt = now + 30 * 1000
   const emptyEntry: EmptySegmentCacheEntry = {
     status: EntryStatus.Empty,
     // Default to assuming the fetch strategy will be PPR. This will be updated
@@ -1765,13 +1772,12 @@ export async function fetchSegmentOnCacheMiss(
       rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
       return null
     }
+    const staleAt = Date.now() + getStaleTimeMs(serverData.staleTime)
     return {
       value: fulfillSegmentCacheEntry(
         segmentCacheEntry,
         serverData.rsc,
-        // TODO: The server does not currently provide per-segment stale time.
-        // So we use the stale time of the route.
-        route.staleAt,
+        staleAt,
         serverData.isPartial
       ),
       // Return a promise that resolves when the network connection closes, so
@@ -2105,7 +2111,6 @@ function writeDynamicRenderResponseIntoCache(
         now,
         task,
         fetchStrategy,
-        route,
         tree,
         staleAt,
         seedData,
@@ -2119,7 +2124,6 @@ function writeDynamicRenderResponseIntoCache(
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
         fetchStrategy,
-        route,
         head,
         flightData.isHeadPartial,
         staleAt,
@@ -2153,7 +2157,6 @@ function writeSeedDataIntoCache(
     | FetchStrategy.LoadingBoundary
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
-  route: FulfilledRouteCacheEntry,
   tree: RouteTree,
   staleAt: number,
   seedData: CacheNodeSeedData,
@@ -2170,7 +2173,6 @@ function writeSeedDataIntoCache(
   fulfillEntrySpawnedByRuntimePrefetch(
     now,
     fetchStrategy,
-    route,
     rsc,
     isPartial,
     staleAt,
@@ -2191,7 +2193,6 @@ function writeSeedDataIntoCache(
           now,
           task,
           fetchStrategy,
-          route,
           childTree,
           staleAt,
           childSeedData,
@@ -2209,7 +2210,6 @@ function fulfillEntrySpawnedByRuntimePrefetch(
     | FetchStrategy.LoadingBoundary
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
-  route: FulfilledRouteCacheEntry,
   rsc: React.ReactNode,
   isPartial: boolean,
   staleAt: number,
@@ -2233,7 +2233,6 @@ function fulfillEntrySpawnedByRuntimePrefetch(
     const possiblyNewEntry = readOrCreateSegmentCacheEntry(
       now,
       fetchStrategy,
-      route,
       tree
     )
     if (possiblyNewEntry.status === EntryStatus.Empty) {
@@ -2250,7 +2249,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       // replace it with the new one from the server.
       const newEntry = fulfillSegmentCacheEntry(
         upgradeToPendingSegment(
-          createDetachedSegmentCacheEntry(staleAt),
+          createDetachedSegmentCacheEntry(now),
           fetchStrategy
         ),
         rsc,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -29,7 +29,6 @@ import {
   isPrefetchTaskDirty,
   type PrefetchTask,
   type PrefetchSubtaskResult,
-  startRevalidationCooldown,
 } from './scheduler'
 import {
   type RouteVaryPath,
@@ -298,40 +297,69 @@ let segmentCacheMap: CacheMap<SegmentCacheEntry> = createCacheMap()
 // prefetch task if desired.
 let invalidationListeners: Set<PrefetchTask> | null = null
 
-// Incrementing counter used to track cache invalidations.
-let currentCacheVersion = 0
+// Incrementing counters used to track cache invalidations. Route and segment
+// caches have separate versions so they can be invalidated independently.
+// Invalidation does not eagerly evict anything from the cache; entries are
+// lazily evicted when read.
+let currentRouteCacheVersion = 0
+let currentSegmentCacheVersion = 0
 
-export function getCurrentCacheVersion(): number {
-  return currentCacheVersion
+export function getCurrentRouteCacheVersion(): number {
+  return currentRouteCacheVersion
+}
+
+export function getCurrentSegmentCacheVersion(): number {
+  return currentSegmentCacheVersion
 }
 
 /**
- * Used to clear the client prefetch cache when a server action calls
- * revalidatePath or revalidateTag. Eventually we will support only clearing the
- * segments that were actually affected, but there's more work to be done on the
- * server before the client is able to do this correctly.
+ * Invalidates all prefetch cache entries (both route and segment caches).
+ *
+ * After invalidation, triggers re-prefetching of visible links and notifies
+ * invalidation listeners.
  */
-export function revalidateEntireCache(
+export function invalidateEntirePrefetchCache(
   nextUrl: string | null,
   tree: FlightRouterState
-) {
-  // Increment the current cache version. This does not eagerly evict anything
-  // from the cache, but because all the entries are versioned, and we check
-  // the version when reading from the cache, this effectively causes all
-  // entries to be evicted lazily. We do it lazily because in the future,
-  // actions like revalidateTag or refresh will not evict the entire cache,
-  // but rather some subset of the entries.
-  currentCacheVersion++
+): void {
+  currentRouteCacheVersion++
+  currentSegmentCacheVersion++
 
-  // Start a cooldown before re-prefetching to allow CDN cache propagation.
-  startRevalidationCooldown()
-
-  // Prefetch all the currently visible links again, to re-fill the cache.
   pingVisibleLinks(nextUrl, tree)
+  pingInvalidationListeners(nextUrl, tree)
+}
 
-  // Similarly, notify all invalidation listeners (i.e. those passed to
-  // `router.prefetch(onInvalidate)`), so they can trigger a new prefetch
-  // if needed.
+/**
+ * Invalidates all route cache entries. Route entries contain the tree structure
+ * (which segments exist at a given URL) but not the segment data itself.
+ *
+ * After invalidation, triggers re-prefetching of visible links and notifies
+ * invalidation listeners.
+ */
+export function invalidateRouteCacheEntries(
+  nextUrl: string | null,
+  tree: FlightRouterState
+): void {
+  currentRouteCacheVersion++
+
+  pingVisibleLinks(nextUrl, tree)
+  pingInvalidationListeners(nextUrl, tree)
+}
+
+/**
+ * Invalidates all segment cache entries. Segment entries contain the actual
+ * RSC data for each segment.
+ *
+ * After invalidation, triggers re-prefetching of visible links and notifies
+ * invalidation listeners.
+ */
+export function invalidateSegmentCacheEntries(
+  nextUrl: string | null,
+  tree: FlightRouterState
+): void {
+  currentSegmentCacheVersion++
+
+  pingVisibleLinks(nextUrl, tree)
   pingInvalidationListeners(nextUrl, tree)
 }
 
@@ -401,7 +429,7 @@ export function readRouteCacheEntry(
   const isRevalidation = false
   return getFromCacheMap(
     now,
-    getCurrentCacheVersion(),
+    getCurrentRouteCacheVersion(),
     routeCacheMap,
     varyPath,
     isRevalidation
@@ -415,7 +443,7 @@ export function readSegmentCacheEntry(
   const isRevalidation = false
   return getFromCacheMap(
     now,
-    getCurrentCacheVersion(),
+    getCurrentSegmentCacheVersion(),
     segmentCacheMap,
     varyPath,
     isRevalidation
@@ -429,7 +457,7 @@ function readRevalidatingSegmentCacheEntry(
   const isRevalidation = true
   return getFromCacheMap(
     now,
-    getCurrentCacheVersion(),
+    getCurrentSegmentCacheVersion(),
     segmentCacheMap,
     varyPath,
     isRevalidation
@@ -487,7 +515,7 @@ export function readOrCreateRouteCacheEntry(
     // Since this is an empty entry, there's no reason to ever evict it. It will
     // be updated when the data is populated.
     staleAt: Infinity,
-    version: getCurrentCacheVersion(),
+    version: getCurrentRouteCacheVersion(),
   }
   const varyPath: RouteVaryPath = getRouteVaryPath(
     key.pathname,
@@ -785,7 +813,7 @@ export function upsertSegmentEntry(
   // since the request was made. We can do that by passing the "owner" entry to
   // this function and confirming it's the same as `existingEntry`.
 
-  if (isValueExpired(now, getCurrentCacheVersion(), candidateEntry)) {
+  if (isValueExpired(now, getCurrentSegmentCacheVersion(), candidateEntry)) {
     // The entry is expired. We cannot upsert it.
     return null
   }
@@ -867,11 +895,11 @@ export function upgradeToPendingSegment(
   }
 
   // Set the version here, since this is right before the request is initiated.
-  // The next time the global cache version is incremented, the entry will
+  // The next time the segment cache version is incremented, the entry will
   // effectively be evicted. This happens before initiating the request, rather
   // than when receiving the response, because it's guaranteed to happen
   // before the data is read on the server.
-  pendingEntry.version = getCurrentCacheVersion()
+  pendingEntry.version = getCurrentSegmentCacheVersion()
   return pendingEntry
 }
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -961,10 +961,10 @@ function pingBlockedTasks(entry: {
 }
 
 function fulfillRouteCacheEntry(
+  now: number,
   entry: RouteCacheEntry,
   tree: RouteTree,
   metadataVaryPath: PageVaryPath,
-  staleAt: number,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   renderedSearch: NormalizedSearch,
@@ -992,7 +992,11 @@ function fulfillRouteCacheEntry(
   fulfilledEntry.status = EntryStatus.Fulfilled
   fulfilledEntry.tree = tree
   fulfilledEntry.metadata = metadata
-  fulfilledEntry.staleAt = staleAt
+  // Route structure is essentially static — it only changes on deploy.
+  // Always use the static stale time.
+  // NOTE: An exception is rewrites/redirects in middleware or proxy, which can
+  // change routes dynamically. We have other strategies for handling those.
+  fulfilledEntry.staleAt = now + STATIC_STALETIME_MS
   fulfilledEntry.couldBeIntercepted = couldBeIntercepted
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
@@ -1618,12 +1622,11 @@ export async function fetchRouteOnCacheMiss(
         return null
       }
 
-      const staleTimeMs = getStaleTimeMs(serverData.staleTime)
       fulfillRouteCacheEntry(
+        Date.now(),
         entry,
         routeTree,
         metadataVaryPath,
-        Date.now() + staleTimeMs,
         couldBeIntercepted,
         canonicalUrl,
         renderedSearch,
@@ -1987,16 +1990,6 @@ function writeDynamicTreeResponseIntoCache(
   }
 
   const flightRouterState = flightData.tree
-  // For runtime prefetches, stale time is in the payload at rp[1].
-  // For other responses, fall back to the header.
-  const staleTimeSeconds =
-    typeof serverData.rp?.[1] === 'number'
-      ? serverData.rp[1]
-      : parseInt(response.headers.get(NEXT_ROUTER_STALE_TIME_HEADER) ?? '', 10)
-  const staleTimeMs = !isNaN(staleTimeSeconds)
-    ? getStaleTimeMs(staleTimeSeconds)
-    : STATIC_STALETIME_MS
-
   // If the response contains dynamic holes, then we must conservatively assume
   // that any individual segment might contain dynamic holes, and also the
   // head. If it did not contain dynamic holes, then we can assume every segment
@@ -2022,10 +2015,10 @@ function writeDynamicTreeResponseIntoCache(
   }
 
   const fulfilledEntry = fulfillRouteCacheEntry(
+    now,
     entry,
     routeTree,
     metadataVaryPath,
-    now + staleTimeMs,
     couldBeIntercepted,
     canonicalUrl,
     renderedSearch,

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -35,7 +35,10 @@ import {
   type PrefetchTaskFetchStrategy,
   PrefetchPriority,
 } from './types'
-import { getCurrentCacheVersion } from './cache'
+import {
+  getCurrentRouteCacheVersion,
+  getCurrentSegmentCacheVersion,
+} from './cache'
 import {
   addSearchParamsIfPageSegment,
   PAGE_SEGMENT_KEY,
@@ -65,10 +68,13 @@ export type PrefetchTask = {
   treeAtTimeOfPrefetch: FlightRouterState
 
   /**
-   * The cache version at the time the task was initiated. This is used to
-   * determine if the cache was invalidated since the task was initiated.
+   * The cache versions at the time the task was initiated. Used to determine
+   * if the cache was invalidated since the task was initiated. Route and
+   * segment caches have separate versions so they can be invalidated
+   * independently.
    */
-  cacheVersion: number
+  routeCacheVersion: number
+  segmentCacheVersion: number
 
   /**
    * Whether to prefetch dynamic data, in addition to static data. This is
@@ -249,7 +255,8 @@ export function schedulePrefetchTask(
   const task: PrefetchTask = {
     key,
     treeAtTimeOfPrefetch,
-    cacheVersion: getCurrentCacheVersion(),
+    routeCacheVersion: getCurrentRouteCacheVersion(),
+    segmentCacheVersion: getCurrentSegmentCacheVersion(),
     priority,
     phase: PrefetchPhase.RouteTree,
     hasBackgroundWork: false,
@@ -336,9 +343,9 @@ export function isPrefetchTaskDirty(
   // strictly an optimization — theoretically, if it always returned true, no
   // behavior should change because a full prefetch task will effectively
   // perform the same checks.
-  const currentCacheVersion = getCurrentCacheVersion()
   return (
-    task.cacheVersion !== currentCacheVersion ||
+    task.routeCacheVersion !== getCurrentRouteCacheVersion() ||
+    task.segmentCacheVersion !== getCurrentSegmentCacheVersion() ||
     task.treeAtTimeOfPrefetch !== tree ||
     task.key.nextUrl !== nextUrl
   )
@@ -477,7 +484,8 @@ function processQueueInMicrotask() {
   // Process the task queue until we run out of network bandwidth.
   let task = heapPeek(taskHeap)
   while (task !== null && hasNetworkBandwidth(task)) {
-    task.cacheVersion = getCurrentCacheVersion()
+    task.routeCacheVersion = getCurrentRouteCacheVersion()
+    task.segmentCacheVersion = getCurrentSegmentCacheVersion()
 
     const exitStatus = pingRoute(now, task)
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -788,12 +788,7 @@ function pingStaticHead(
     now,
     task,
     route,
-    readOrCreateSegmentCacheEntry(
-      now,
-      FetchStrategy.PPR,
-      route,
-      route.metadata
-    ),
+    readOrCreateSegmentCacheEntry(now, FetchStrategy.PPR, route.metadata),
     task.key,
     route.metadata
   )
@@ -848,7 +843,6 @@ function pingSharedPartOfCacheComponentsTree(
   const segment = readOrCreateSegmentCacheEntry(
     now,
     task.fetchStrategy,
-    route,
     newTree
   )
   pingStaticSegmentData(now, task, route, segment, task.key, newTree)
@@ -946,12 +940,7 @@ function pingNewPartOfCacheComponentsTree(
   }
 
   // This segment should not be runtime prefetched. Prefetch its static data.
-  const segment = readOrCreateSegmentCacheEntry(
-    now,
-    task.fetchStrategy,
-    route,
-    tree
-  )
+  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
   pingStaticSegmentData(now, task, route, segment, task.key, tree)
   if (tree.slots !== null) {
     if (!hasNetworkBandwidth(task)) {
@@ -1146,12 +1135,7 @@ function pingPPRDisabledRouteTreeUpToLoadingBoundary(
   let refetchMarker: 'refetch' | 'inside-shared-layout' | null =
     refetchMarkerContext === null ? 'inside-shared-layout' : null
 
-  const segment = readOrCreateSegmentCacheEntry(
-    now,
-    task.fetchStrategy,
-    route,
-    tree
-  )
+  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
   switch (segment.status) {
     case EntryStatus.Empty: {
       // This segment is not cached. Add a refetch marker so the server knows
@@ -1262,7 +1246,6 @@ function pingRouteTreeAndIncludeDynamicData(
     // always use runtime prefetching (via `export const prefetch`), and those should check for
     // entries that include search params.
     fetchStrategy,
-    route,
     tree
   )
 
@@ -1301,12 +1284,7 @@ function pingRouteTreeAndIncludeDynamicData(
         //   - we have a static prefetch, and we're doing a runtime prefetch
         //   - we have a static or runtime prefetch, and we're doing a Full prefetch (or a navigation).
         // In either case, we need to include it in the request to get a more specific (or full) version.
-        spawnedSegment = pingFullSegmentRevalidation(
-          now,
-          route,
-          tree,
-          fetchStrategy
-        )
+        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
       }
       break
     }
@@ -1320,12 +1298,7 @@ function pingRouteTreeAndIncludeDynamicData(
           fetchStrategy
         )
       ) {
-        spawnedSegment = pingFullSegmentRevalidation(
-          now,
-          route,
-          tree,
-          fetchStrategy
-        )
+        spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
       }
       break
     }
@@ -1514,7 +1487,6 @@ function pingPPRSegmentRevalidation(
   const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
     now,
     FetchStrategy.PPR,
-    route,
     tree
   )
   switch (revalidatingSegment.status) {
@@ -1549,14 +1521,12 @@ function pingPPRSegmentRevalidation(
 
 function pingFullSegmentRevalidation(
   now: number,
-  route: FulfilledRouteCacheEntry,
   tree: RouteTree,
   fetchStrategy: FetchStrategy.Full | FetchStrategy.PPRRuntime
 ): PendingSegmentCacheEntry | null {
   const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
     now,
     fetchStrategy,
-    route,
     tree
   )
   if (revalidatingSegment.status === EntryStatus.Empty) {
@@ -1586,8 +1556,8 @@ function pingFullSegmentRevalidation(
       // The existing revalidation was fetched using a less specific strategy.
       // Reset it and start a new revalidation.
       const emptySegment = overwriteRevalidatingSegmentCacheEntry(
+        now,
         fetchStrategy,
-        route,
         tree
       )
       const pendingSegment = upgradeToPendingSegment(

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -80,6 +80,7 @@ export type SegmentPrefetch = {
   buildId: string
   rsc: React.ReactNode | null
   isPartial: boolean
+  staleTime: number
 }
 
 const filterStackFrame =
@@ -241,6 +242,7 @@ async function PrefetchTreeData({
     isClientParamParsingEnabled,
     flightRouterState,
     buildId,
+    staleTime,
     seedData,
     clientModules,
     ROOT_SEGMENT_REQUEST_KEY,
@@ -253,7 +255,13 @@ async function PrefetchTreeData({
   // the client cache.
   segmentTasks.push(
     waitAtLeastOneReactRenderTask().then(() =>
-      renderSegmentPrefetch(buildId, head, HEAD_REQUEST_KEY, clientModules)
+      renderSegmentPrefetch(
+        buildId,
+        staleTime,
+        head,
+        HEAD_REQUEST_KEY,
+        clientModules
+      )
     )
   )
 
@@ -275,6 +283,7 @@ function collectSegmentDataImpl(
   isClientParamParsingEnabled: boolean,
   route: FlightRouterState,
   buildId: string,
+  staleTime: number,
   seedData: CacheNodeSeedData | null,
   clientModules: ManifestNode,
   requestKey: SegmentRequestKey,
@@ -301,6 +310,7 @@ function collectSegmentDataImpl(
       isClientParamParsingEnabled,
       childRoute,
       buildId,
+      staleTime,
       childSeedData,
       clientModules,
       childRequestKey,
@@ -320,7 +330,13 @@ function collectSegmentDataImpl(
       // Since we're already in the middle of a render, wait until after the
       // current task to escape the current rendering context.
       waitAtLeastOneReactRenderTask().then(() =>
-        renderSegmentPrefetch(buildId, seedData[0], requestKey, clientModules)
+        renderSegmentPrefetch(
+          buildId,
+          staleTime,
+          seedData[0],
+          requestKey,
+          clientModules
+        )
       )
     )
   } else {
@@ -361,17 +377,17 @@ function collectSegmentDataImpl(
 
 async function renderSegmentPrefetch(
   buildId: string,
+  staleTime: number,
   rsc: React.ReactNode,
   requestKey: SegmentRequestKey,
   clientModules: ManifestNode
 ): Promise<[SegmentRequestKey, Buffer]> {
   // Render the segment data to a stream.
-  // In the future, this is where we can include additional metadata, like the
-  // stale time and cache tags.
   const segmentPrefetch: SegmentPrefetch = {
     buildId,
     rsc,
     isPartial: await isPartialRSCData(rsc, clientModules),
+    staleTime,
   }
   // Since all we're doing is decoding and re-encoding a cached prerender, if
   // it takes longer than a microtask, it must because of hanging promises

--- a/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/page.tsx
@@ -11,23 +11,23 @@ export default function Page() {
       </p>
       <ul>
         <li>
-          <LinkAccordion href="/stale-5-minutes">
-            Page with stale time of 5 minutes
+          <LinkAccordion href="/stale-2-minutes">
+            Page with stale time of 2 minutes
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/stale-10-minutes">
-            Page with stale time of 10 minutes
+          <LinkAccordion href="/stale-4-minutes">
+            Page with stale time of 4 minutes
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-stale-5-minutes">
-            Page whose runtime prefetch has a stale time of 5 minutes
+          <LinkAccordion href="/runtime-stale-2-minutes">
+            Page whose runtime prefetch has a stale time of 2 minutes
           </LinkAccordion>
         </li>
         <li>
-          <LinkAccordion href="/runtime-stale-10-minutes">
-            Page whose runtime prefetch has a stale time of 10 minutes
+          <LinkAccordion href="/runtime-stale-4-minutes">
+            Page whose runtime prefetch has a stale time of 4 minutes
           </LinkAccordion>
         </li>
         <li>

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
@@ -27,6 +27,6 @@ async function RuntimePrefetchable() {
 async function Content() {
   'use cache'
   await new Promise((resolve) => setTimeout(resolve, 0))
-  cacheLife({ stale: 10 * 60 })
-  return 'Content with stale time of 10 minutes'
+  cacheLife({ stale: 2 * 60 })
+  return 'Content with stale time of 2 minutes'
 }

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
@@ -27,6 +27,6 @@ async function RuntimePrefetchable() {
 async function Content() {
   'use cache'
   await new Promise((resolve) => setTimeout(resolve, 0))
-  cacheLife({ stale: 5 * 60 })
-  return 'Content with stale time of 5 minutes'
+  cacheLife({ stale: 4 * 60 })
+  return 'Content with stale time of 4 minutes'
 }

--- a/test/e2e/app-dir/segment-cache/staleness/app/stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/stale-2-minutes/page.tsx
@@ -4,8 +4,8 @@ import { cacheLife } from 'next/cache'
 async function Content() {
   'use cache'
   await new Promise((resolve) => setTimeout(resolve, 0))
-  cacheLife({ stale: 5 * 60 })
-  return 'Content with stale time of 5 minutes'
+  cacheLife({ stale: 2 * 60 })
+  return 'Content with stale time of 2 minutes'
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/segment-cache/staleness/app/stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/stale-4-minutes/page.tsx
@@ -4,8 +4,8 @@ import { cacheLife } from 'next/cache'
 async function Content() {
   'use cache'
   await new Promise((resolve) => setTimeout(resolve, 0))
-  cacheLife({ stale: 10 * 60 })
-  return 'Content with stale time of 10 minutes'
+  cacheLife({ stale: 4 * 60 })
+  return 'Content with stale time of 4 minutes'
 }
 
 export default function Page() {

--- a/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
+++ b/test/e2e/app-dir/segment-cache/staleness/segment-cache-stale-time.test.ts
@@ -23,57 +23,57 @@ describe('segment cache (staleness)', () => {
     await page.clock.install()
 
     // Reveal the link to trigger a prefetch
-    const toggle5MinutesLink = await browser.elementByCss(
-      'input[data-link-accordion="/stale-5-minutes"]'
+    const toggle2MinutesLink = await browser.elementByCss(
+      'input[data-link-accordion="/stale-2-minutes"]'
     )
-    const toggle10MinutesLink = await browser.elementByCss(
-      'input[data-link-accordion="/stale-10-minutes"]'
+    const toggle4MinutesLink = await browser.elementByCss(
+      'input[data-link-accordion="/stale-4-minutes"]'
     )
     await act(
       async () => {
-        await toggle5MinutesLink.click()
-        await browser.elementByCss('a[href="/stale-5-minutes"]')
+        await toggle2MinutesLink.click()
+        await browser.elementByCss('a[href="/stale-2-minutes"]')
       },
       {
-        includes: 'Content with stale time of 5 minutes',
+        includes: 'Content with stale time of 2 minutes',
       }
     )
     await act(
       async () => {
-        await toggle10MinutesLink.click()
-        await browser.elementByCss('a[href="/stale-10-minutes"]')
+        await toggle4MinutesLink.click()
+        await browser.elementByCss('a[href="/stale-4-minutes"]')
       },
       {
-        includes: 'Content with stale time of 10 minutes',
+        includes: 'Content with stale time of 4 minutes',
       }
     )
 
     // Hide the links
-    await toggle5MinutesLink.click()
-    await toggle10MinutesLink.click()
+    await toggle2MinutesLink.click()
+    await toggle4MinutesLink.click()
 
-    // Fast forward 5 minutes and 1 millisecond
-    await page.clock.fastForward(5 * 60 * 1000 + 1)
+    // Fast forward 2 minutes and 1 millisecond
+    await page.clock.fastForward(2 * 60 * 1000 + 1)
 
     // Reveal the links again to trigger new prefetch tasks
     await act(
       async () => {
-        await toggle5MinutesLink.click()
-        await browser.elementByCss('a[href="/stale-5-minutes"]')
+        await toggle2MinutesLink.click()
+        await browser.elementByCss('a[href="/stale-2-minutes"]')
       },
-      // The page with a stale time of 5 minutes is requested again
+      // The page with a stale time of 2 minutes is requested again
       // because its stale time elapsed.
       {
-        includes: 'Content with stale time of 5 minutes',
+        includes: 'Content with stale time of 2 minutes',
       }
     )
 
     await act(
       async () => {
-        await toggle10MinutesLink.click()
-        await browser.elementByCss('a[href="/stale-10-minutes"]')
+        await toggle4MinutesLink.click()
+        await browser.elementByCss('a[href="/stale-4-minutes"]')
       },
-      // The page with a stale time of 10 minutes is *not* requested again
+      // The page with a stale time of 4 minutes is *not* requested again
       // because it's still fresh.
       'no-requests'
     )
@@ -91,57 +91,57 @@ describe('segment cache (staleness)', () => {
     await page.clock.install()
 
     // Reveal the links to trigger a runtime prefetch
-    const toggle5MinutesLink = await browser.elementByCss(
-      'input[data-link-accordion="/runtime-stale-5-minutes"]'
+    const toggle2MinutesLink = await browser.elementByCss(
+      'input[data-link-accordion="/runtime-stale-2-minutes"]'
     )
-    const toggle10MinutesLink = await browser.elementByCss(
-      'input[data-link-accordion="/runtime-stale-10-minutes"]'
+    const toggle4MinutesLink = await browser.elementByCss(
+      'input[data-link-accordion="/runtime-stale-4-minutes"]'
     )
     await act(
       async () => {
-        await toggle5MinutesLink.click()
-        await browser.elementByCss('a[href="/runtime-stale-5-minutes"]')
+        await toggle2MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-2-minutes"]')
       },
       {
-        includes: 'Content with stale time of 5 minutes',
+        includes: 'Content with stale time of 2 minutes',
       }
     )
     await act(
       async () => {
-        await toggle10MinutesLink.click()
-        await browser.elementByCss('a[href="/runtime-stale-10-minutes"]')
+        await toggle4MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-4-minutes"]')
       },
       {
-        includes: 'Content with stale time of 10 minutes',
+        includes: 'Content with stale time of 4 minutes',
       }
     )
 
     // Hide the links
-    await toggle5MinutesLink.click()
-    await toggle10MinutesLink.click()
+    await toggle2MinutesLink.click()
+    await toggle4MinutesLink.click()
 
-    // Fast forward 5 minutes and 1 millisecond
-    await page.clock.fastForward(5 * 60 * 1000 + 1)
+    // Fast forward 2 minutes and 1 millisecond
+    await page.clock.fastForward(2 * 60 * 1000 + 1)
 
     // Reveal the links again to trigger new prefetch tasks
     await act(
       async () => {
-        await toggle5MinutesLink.click()
-        await browser.elementByCss('a[href="/runtime-stale-5-minutes"]')
+        await toggle2MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-2-minutes"]')
       },
-      // The page with a stale time of 5 minutes is requested again
+      // The page with a stale time of 2 minutes is requested again
       // because its stale time elapsed.
       {
-        includes: 'Content with stale time of 5 minutes',
+        includes: 'Content with stale time of 2 minutes',
       }
     )
 
     await act(
       async () => {
-        await toggle10MinutesLink.click()
-        await browser.elementByCss('a[href="/runtime-stale-10-minutes"]')
+        await toggle4MinutesLink.click()
+        await browser.elementByCss('a[href="/runtime-stale-4-minutes"]')
       },
-      // The page with a stale time of 10 minutes is *not* requested again
+      // The page with a stale time of 4 minutes is *not* requested again
       // because it's still fresh.
       'no-requests'
     )


### PR DESCRIPTION
Based on:

- https://github.com/vercel/next.js/pull/88834

---

Follows from the previous commits that decoupled route stale time from segment data. Now that routes have their own lifecycle, we can simplify the implementation: route stale times are always the static constant, rather than being derived from server-provided values.

Route structure is essentially static — it only changes on deploy. The exception is rewrites/redirects in middleware or proxy, which can change routes dynamically based on request state. But we have other strategies for handling those cases (e.g., route interception headers, cache invalidation on auth state changes).

This simplification removes the need to thread stale time through various call sites. The `fulfillRouteCacheEntry` function now computes the stale time internally from a `now` timestamp parameter, following the convention used elsewhere in the codebase.