### PR TITLE
feat(app-render): add inlineCss: 'shared' mode for root layout CSS

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -994,7 +994,7 @@ pub struct ExperimentalConfig {
     fully_specified: Option<bool>,
     gzip_size: Option<bool>,
 
-    pub inline_css: Option<bool>,
+    pub inline_css: Option<InlineCssConfig>,
     instrumentation_hook: Option<bool>,
     client_trace_metadata: Option<Vec<String>>,
     large_page_data_bytes: Option<f64>,
@@ -1118,6 +1118,38 @@ fn test_esm_externals_deserialization() {
         config.esm_externals,
         Some(EsmExternals::Loose(EsmExternalsValue::Loose))
     );
+}
+
+/// Value for the `inlineCss` experimental config option.
+/// Can be:
+/// - `false`: No CSS inlining (default)
+/// - `true`: Inline ALL CSS
+/// - `"shared"`: Only inline root layout CSS (safer for client navigations)
+#[derive(
+    Clone, Debug, PartialEq, Deserialize, TraceRawVcs, NonLocalValue, OperationValue, Encode, Decode,
+)]
+#[serde(rename_all = "kebab-case")]
+pub enum InlineCssMode {
+    Shared,
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Deserialize, TraceRawVcs, NonLocalValue, OperationValue, Encode, Decode,
+)]
+#[serde(untagged)]
+pub enum InlineCssConfig {
+    Mode(InlineCssMode),
+    Bool(bool),
+}
+
+impl InlineCssConfig {
+    /// Returns whether CSS inlining is enabled (either `true` or `"shared"`).
+    pub fn is_enabled(&self) -> bool {
+        match self {
+            Self::Bool(enabled) => *enabled,
+            Self::Mode(_) => true,
+        }
+    }
 }
 
 #[derive(
@@ -1630,7 +1662,13 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn inline_css(&self) -> Vc<bool> {
-        Vc::cell(self.experimental.inline_css.unwrap_or(false))
+        Vc::cell(
+            self.experimental
+                .inline_css
+                .as_ref()
+                .map(|c| c.is_enabled())
+                .unwrap_or(false),
+        )
     }
 
     #[turbo_tasks::function]

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx
@@ -6,7 +6,7 @@ version: experimental
 
 ## Usage
 
-Experimental support for inlining CSS in the `<head>`. When this flag is enabled, all places where we normally generate a `<link>` tag will instead have a generated `<style>` tag.
+Experimental support for inlining CSS in the `<head>`. When enabled, CSS that would normally be loaded via `<link>` tags is instead embedded directly in `<style>` tags.
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -31,6 +31,48 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
+### Options
+
+| Value      | Description                               |
+| ---------- | ----------------------------------------- |
+| `false`    | CSS is loaded via `<link>` tags (default) |
+| `true`     | All CSS is inlined                        |
+| `'shared'` | Only root layout CSS is inlined           |
+
+### The `'shared'` Option
+
+When using `inlineCss: 'shared'`, only the CSS from your root layout is inlined. This is particularly useful when using utility-first CSS frameworks like Tailwind CSS, where the root layout CSS is shared across all pages.
+
+```ts filename="next.config.ts" switcher
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    inlineCss: 'shared',
+  },
+}
+
+export default nextConfig
+```
+
+```js filename="next.config.js" switcher
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    inlineCss: 'shared',
+  },
+}
+
+module.exports = nextConfig
+```
+
+With `'shared'` mode:
+
+- **Root layout CSS** is inlined in the initial HTML and excluded from RSC payloads during client-side navigation (since the client already has it)
+- **Page-specific CSS** is loaded via `<link>` tags and included in RSC payloads for navigations
+
+This provides the performance benefits of inlined CSS for shared styles while avoiding potential issues with page-specific CSS during client-side navigation.
+
 ## Trade-Offs
 
 ### When to Use Inline CSS
@@ -43,7 +85,7 @@ Inlining CSS can be beneficial in several scenarios:
 
 - **Slow Connections**: For users on slower networks where each request adds considerable latency, inlining CSS can provide a noticeable performance boost by reducing network roundtrips.
 
-- **Atomic CSS Bundles (e.g., Tailwind)**: With utility-first frameworks like Tailwind CSS, the size of the styles required for a page is often O(1) relative to the complexity of the design. This makes inlining a compelling choice because the entire set of styles for the current page is lightweight and doesn’t grow with the page size. Inlining Tailwind styles ensures minimal payload and eliminates the need for additional network requests, which can further enhance performance.
+- **Atomic CSS Bundles (e.g., Tailwind)**: With utility-first frameworks like Tailwind CSS, the size of the styles required for a page is often O(1) relative to the complexity of the design. This makes inlining a compelling choice because the entire set of styles for the current page is lightweight and doesn't grow with the page size. Inlining Tailwind styles ensures minimal payload and eliminates the need for additional network requests, which can further enhance performance.
 
 ### When Not to Use Inline CSS
 
@@ -61,6 +103,5 @@ Evaluate these trade-offs carefully, and consider combining inlining with other 
 > This feature is currently experimental and has some known limitations:
 >
 > - CSS inlining is applied globally and cannot be configured on a per-page basis
-> - Styles are duplicated during initial page load - once within `<style>` tags for SSR and once in the RSC payload
 > - When navigating to statically rendered pages, styles will use `<link>` tags instead of inline CSS to avoid duplication
 > - This feature is not available in development mode and only works in production builds

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/inlineCss.mdx
@@ -39,9 +39,19 @@ module.exports = nextConfig
 | `true`     | All CSS is inlined                        |
 | `'shared'` | Only root layout CSS is inlined           |
 
-### The `'shared'` Option
+### The `'shared'` Option (Recommended for Tailwind)
 
-When using `inlineCss: 'shared'`, only the CSS from your root layout is inlined. This is particularly useful when using utility-first CSS frameworks like Tailwind CSS, where the root layout CSS is shared across all pages.
+When using `inlineCss: 'shared'`, only the CSS from your root layout is inlined. This mode is ideal for utility-first CSS frameworks like Tailwind CSS, where:
+
+- Tailwind CSS is typically imported once in the root layout
+- The styles are shared across all pages
+- The CSS bundle doesn't grow significantly per page (O(1) complexity)
+
+This mode provides optimized performance by:
+
+- Inlining root layout CSS in the initial HTML for fast First Contentful Paint
+- Excluding root layout CSS from RSC payloads during navigation (client already has it)
+- Loading page-specific CSS via `<link>` tags to avoid duplication issues
 
 ```ts filename="next.config.ts" switcher
 import type { NextConfig } from 'next'
@@ -105,3 +115,4 @@ Evaluate these trade-offs carefully, and consider combining inlining with other 
 > - CSS inlining is applied globally and cannot be configured on a per-page basis
 > - When navigating to statically rendered pages, styles will use `<link>` tags instead of inline CSS to avoid duplication
 > - This feature is not available in development mode and only works in production builds
+> - When using `inlineCss: true`, styles are duplicated during initial page load - once within `<style>` tags for SSR and once in the RSC payload. Consider using `'shared'` mode if this is a concern.

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -689,7 +689,7 @@ export async function handler(
             optimisticRouting: Boolean(
               nextConfig.experimental.optimisticRouting
             ),
-            inlineCss: Boolean(nextConfig.experimental.inlineCss),
+            inlineCss: nextConfig.experimental.inlineCss ?? false,
             authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
             clientTraceMetadata:
               nextConfig.experimental.clientTraceMetadata || ([] as any),

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -157,7 +157,7 @@ async function requestHandler(
         staleTimes: nextConfig.experimental.staleTimes,
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
         optimisticRouting: Boolean(nextConfig.experimental.optimisticRouting),
-        inlineCss: Boolean(nextConfig.experimental.inlineCss),
+        inlineCss: nextConfig.experimental.inlineCss ?? false,
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
         clientTraceMetadata:
           nextConfig.experimental.clientTraceMetadata || ([] as any),

--- a/packages/next/src/build/webpack/config/blocks/css/loaders/client.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/loaders/client.ts
@@ -12,7 +12,7 @@ export function getClientStyleLoader({
   isAppDir?: boolean
   isDevelopment: boolean
   assetPrefix: string
-  experimentalInlineCss?: boolean
+  experimentalInlineCss?: boolean | 'shared'
 }): webpack.RuleSetUseItem {
   const isRspack = Boolean(process.env.NEXT_RSPACK)
   const shouldEnableApp = typeof isAppDir === 'boolean' ? isAppDir : hasAppDir
@@ -54,6 +54,7 @@ export function getClientStyleLoader({
   return {
     loader: MiniCssExtractPlugin.loader,
     options: {
+      // Both `true` and `'shared'` modes inline CSS, so use '/' for both
       publicPath: experimentalInlineCss ? '/' : `${assetPrefix}/_next/`,
       esModule: false,
     },

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2533,7 +2533,10 @@ async function renderToStream(
   // Collector for inline CSS to be injected via ServerInsertedHTML.
   // This prevents CSS from being duplicated in both HTML (as <style> tags)
   // and RSC payload (serialized in <script> tags).
-  const collectedInlineCss: CollectedInlineCss = { styles: [] }
+  const collectedInlineCss: CollectedInlineCss = {
+    styles: [],
+    inlineCssMode: experimental.inlineCss,
+  }
 
   const tracingMetadata = getTracedMetadata(
     getTracer().getTracePropagationData(),
@@ -4147,7 +4150,10 @@ async function prerenderToStream(
   // Collector for inline CSS to be injected via ServerInsertedHTML.
   // This prevents CSS from being duplicated in both HTML (as <style> tags)
   // and RSC payload (serialized in <script> tags).
-  const collectedInlineCss: CollectedInlineCss = { styles: [] }
+  const collectedInlineCss: CollectedInlineCss = {
+    styles: [],
+    inlineCssMode: experimental.inlineCss,
+  }
 
   const tracingMetadata = getTracedMetadata(
     getTracer().getTracePropagationData(),

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -264,6 +264,12 @@ export type AppRenderContext = {
    * work unit store.
    */
   implicitTags: ImplicitTags
+  /**
+   * Collected inline CSS to be injected via ServerInsertedHTML.
+   * This avoids duplicating CSS in both the HTML (as <style> tags)
+   * and the RSC payload (serialized in <script> tags).
+   */
+  collectedInlineCss: CollectedInlineCss
 }
 
 interface ParseRequestHeadersOptions {
@@ -1425,8 +1431,7 @@ function getRenderedSearch(query: NextParsedUrlQuery): string {
 async function getRSCPayload(
   tree: LoaderTree,
   ctx: AppRenderContext,
-  is404: boolean,
-  collectedInlineCss?: CollectedInlineCss
+  is404: boolean
 ): Promise<InitialRSCPayload & { P: ReactNode }> {
   const injectedCSS = new Set<string>()
   const injectedJS = new Set<string>()
@@ -1485,7 +1490,6 @@ async function getRSCPayload(
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
     MetadataOutlet,
-    collectedInlineCss,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -2059,6 +2063,14 @@ async function renderToHTMLOrFlightImpl(
     res,
     sharedContext,
     implicitTags,
+    // Collector for inline CSS to be injected via ServerInsertedHTML.
+    // This prevents CSS from being duplicated in both HTML (as <style> tags)
+    // and RSC payload (serialized in <script> tags).
+    collectedInlineCss: {
+      styles: [],
+      rootLayoutCSSPaths: new Set(),
+      inlineCssMode: renderOpts.experimental.inlineCss,
+    },
   }
 
   getTracer().setRootSpanAttribute('next.route', pagePath)
@@ -2530,15 +2542,6 @@ async function renderToStream(
     createServerInsertedHTML()
   const getServerInsertedMetadata = createServerInsertedMetadata(nonce)
 
-  // Collector for inline CSS to be injected via ServerInsertedHTML.
-  // This prevents CSS from being duplicated in both HTML (as <style> tags)
-  // and RSC payload (serialized in <script> tags).
-  const collectedInlineCss: CollectedInlineCss = {
-    styles: [],
-    rootLayoutCSSPaths: new Set(),
-    inlineCssMode: experimental.inlineCss,
-  }
-
   const tracingMetadata = getTracedMetadata(
     getTracer().getTracePropagationData(),
     experimental.clientTraceMetadata
@@ -2681,8 +2684,7 @@ async function renderToStream(
               getRSCPayload,
               tree,
               ctx,
-              res.statusCode === 404,
-              collectedInlineCss
+              res.statusCode === 404
             )
 
           if (isBypassingCachesInDev(renderOpts, requestStore)) {
@@ -2792,8 +2794,7 @@ async function renderToStream(
             getRSCPayload,
             tree,
             ctx,
-            res.statusCode === 404,
-            collectedInlineCss
+            res.statusCode === 404
           )
 
         const debugChannel = setReactDebugChannel && createDebugChannel()
@@ -2885,7 +2886,7 @@ async function renderToStream(
             serverCapturedErrors: allCapturedErrors,
             basePath,
             tracingMetadata: tracingMetadata,
-            collectedInlineCss,
+            collectedInlineCss: ctx.collectedInlineCss,
           })
           return await continueDynamicHTMLResume(htmlStream, {
             // If the prelude is empty (i.e. is no static shell), we should wait for initial HTML to be rendered
@@ -2949,7 +2950,7 @@ async function renderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
-        collectedInlineCss,
+        collectedInlineCss: ctx.collectedInlineCss,
       })
       /**
        * Rules of Static & Dynamic HTML:
@@ -3157,7 +3158,7 @@ async function renderToStream(
             serverCapturedErrors: [],
             basePath,
             tracingMetadata: tracingMetadata,
-            collectedInlineCss,
+            collectedInlineCss: ctx.collectedInlineCss,
           }),
           getServerInsertedMetadata,
           validateRootLayout: dev,
@@ -4148,15 +4149,6 @@ async function prerenderToStream(
     createServerInsertedHTML()
   const getServerInsertedMetadata = createServerInsertedMetadata(nonce)
 
-  // Collector for inline CSS to be injected via ServerInsertedHTML.
-  // This prevents CSS from being duplicated in both HTML (as <style> tags)
-  // and RSC payload (serialized in <script> tags).
-  const collectedInlineCss: CollectedInlineCss = {
-    styles: [],
-    rootLayoutCSSPaths: new Set(),
-    inlineCssMode: experimental.inlineCss,
-  }
-
   const tracingMetadata = getTracedMetadata(
     getTracer().getTracePropagationData(),
     experimental.clientTraceMetadata
@@ -4343,8 +4335,7 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404,
-        collectedInlineCss
+        res.statusCode === 404
       )
 
       const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
@@ -4618,8 +4609,7 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404,
-        collectedInlineCss
+        res.statusCode === 404
       )
 
       const serverDynamicTracking = createDynamicTrackingState(
@@ -4826,7 +4816,7 @@ async function prerenderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
-        collectedInlineCss,
+        collectedInlineCss: ctx.collectedInlineCss,
       })
 
       const flightData = await streamToBuffer(reactServerResult.asStream())
@@ -5027,8 +5017,7 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404,
-        collectedInlineCss
+        res.statusCode === 404
       )
       const reactServerResult = (reactServerPrerenderResult =
         await createReactServerPrerenderResultFromRender(
@@ -5092,7 +5081,7 @@ async function prerenderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
-        collectedInlineCss,
+        collectedInlineCss: ctx.collectedInlineCss,
       })
 
       // After awaiting here we've waited for the entire RSC render to complete. Crucially this means
@@ -5275,8 +5264,7 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404,
-        collectedInlineCss
+        res.statusCode === 404
       )
 
       const reactServerResult = (reactServerPrerenderResult =
@@ -5333,7 +5321,7 @@ async function prerenderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
-        collectedInlineCss,
+        collectedInlineCss: ctx.collectedInlineCss,
       })
       return {
         digestErrorsMap: reactServerErrorsByDigest,
@@ -5533,7 +5521,7 @@ async function prerenderToStream(
             serverCapturedErrors: [],
             basePath,
             tracingMetadata: tracingMetadata,
-            collectedInlineCss,
+            collectedInlineCss: ctx.collectedInlineCss,
           }),
           getServerInsertedMetadata,
           validateRootLayout: dev,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, ErrorInfo, JSX, ReactNode } from 'react'
-import type { RenderOpts, PreloadCallbacks } from './types'
+import type { RenderOpts, PreloadCallbacks, CollectedInlineCss } from './types'
 import type {
   ActionResult,
   DynamicParamTypesShort,
@@ -1425,7 +1425,8 @@ function getRenderedSearch(query: NextParsedUrlQuery): string {
 async function getRSCPayload(
   tree: LoaderTree,
   ctx: AppRenderContext,
-  is404: boolean
+  is404: boolean,
+  collectedInlineCss?: CollectedInlineCss
 ): Promise<InitialRSCPayload & { P: ReactNode }> {
   const injectedCSS = new Set<string>()
   const injectedJS = new Set<string>()
@@ -1484,6 +1485,7 @@ async function getRSCPayload(
     preloadCallbacks,
     authInterrupts: ctx.renderOpts.experimental.authInterrupts,
     MetadataOutlet,
+    collectedInlineCss,
   })
 
   // When the `vary` response header is present with `Next-URL`, that means there's a chance
@@ -2528,6 +2530,11 @@ async function renderToStream(
     createServerInsertedHTML()
   const getServerInsertedMetadata = createServerInsertedMetadata(nonce)
 
+  // Collector for inline CSS to be injected via ServerInsertedHTML.
+  // This prevents CSS from being duplicated in both HTML (as <style> tags)
+  // and RSC payload (serialized in <script> tags).
+  const collectedInlineCss: CollectedInlineCss = { styles: [] }
+
   const tracingMetadata = getTracedMetadata(
     getTracer().getTracePropagationData(),
     experimental.clientTraceMetadata
@@ -2670,7 +2677,8 @@ async function renderToStream(
               getRSCPayload,
               tree,
               ctx,
-              res.statusCode === 404
+              res.statusCode === 404,
+              collectedInlineCss
             )
 
           if (isBypassingCachesInDev(renderOpts, requestStore)) {
@@ -2780,7 +2788,8 @@ async function renderToStream(
             getRSCPayload,
             tree,
             ctx,
-            res.statusCode === 404
+            res.statusCode === 404,
+            collectedInlineCss
           )
 
         const debugChannel = setReactDebugChannel && createDebugChannel()
@@ -2872,6 +2881,7 @@ async function renderToStream(
             serverCapturedErrors: allCapturedErrors,
             basePath,
             tracingMetadata: tracingMetadata,
+            collectedInlineCss,
           })
           return await continueDynamicHTMLResume(htmlStream, {
             // If the prelude is empty (i.e. is no static shell), we should wait for initial HTML to be rendered
@@ -2935,6 +2945,7 @@ async function renderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
+        collectedInlineCss,
       })
       /**
        * Rules of Static & Dynamic HTML:
@@ -3142,6 +3153,7 @@ async function renderToStream(
             serverCapturedErrors: [],
             basePath,
             tracingMetadata: tracingMetadata,
+            collectedInlineCss,
           }),
           getServerInsertedMetadata,
           validateRootLayout: dev,
@@ -4132,6 +4144,11 @@ async function prerenderToStream(
     createServerInsertedHTML()
   const getServerInsertedMetadata = createServerInsertedMetadata(nonce)
 
+  // Collector for inline CSS to be injected via ServerInsertedHTML.
+  // This prevents CSS from being duplicated in both HTML (as <style> tags)
+  // and RSC payload (serialized in <script> tags).
+  const collectedInlineCss: CollectedInlineCss = { styles: [] }
+
   const tracingMetadata = getTracedMetadata(
     getTracer().getTracePropagationData(),
     experimental.clientTraceMetadata
@@ -4318,7 +4335,8 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404
+        res.statusCode === 404,
+        collectedInlineCss
       )
 
       const initialServerPrerenderStore: PrerenderStore = (prerenderStore = {
@@ -4592,7 +4610,8 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404
+        res.statusCode === 404,
+        collectedInlineCss
       )
 
       const serverDynamicTracking = createDynamicTrackingState(
@@ -4799,6 +4818,7 @@ async function prerenderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
+        collectedInlineCss,
       })
 
       const flightData = await streamToBuffer(reactServerResult.asStream())
@@ -4999,7 +5019,8 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404
+        res.statusCode === 404,
+        collectedInlineCss
       )
       const reactServerResult = (reactServerPrerenderResult =
         await createReactServerPrerenderResultFromRender(
@@ -5063,6 +5084,7 @@ async function prerenderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
+        collectedInlineCss,
       })
 
       // After awaiting here we've waited for the entire RSC render to complete. Crucially this means
@@ -5245,7 +5267,8 @@ async function prerenderToStream(
         getRSCPayload,
         tree,
         ctx,
-        res.statusCode === 404
+        res.statusCode === 404,
+        collectedInlineCss
       )
 
       const reactServerResult = (reactServerPrerenderResult =
@@ -5302,6 +5325,7 @@ async function prerenderToStream(
         serverCapturedErrors: allCapturedErrors,
         basePath,
         tracingMetadata: tracingMetadata,
+        collectedInlineCss,
       })
       return {
         digestErrorsMap: reactServerErrorsByDigest,
@@ -5501,6 +5525,7 @@ async function prerenderToStream(
             serverCapturedErrors: [],
             basePath,
             tracingMetadata: tracingMetadata,
+            collectedInlineCss,
           }),
           getServerInsertedMetadata,
           validateRootLayout: dev,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2535,6 +2535,7 @@ async function renderToStream(
   // and RSC payload (serialized in <script> tags).
   const collectedInlineCss: CollectedInlineCss = {
     styles: [],
+    rootLayoutCSSPaths: new Set(),
     inlineCssMode: experimental.inlineCss,
   }
 
@@ -4152,6 +4153,7 @@ async function prerenderToStream(
   // and RSC payload (serialized in <script> tags).
   const collectedInlineCss: CollectedInlineCss = {
     styles: [],
+    rootLayoutCSSPaths: new Set(),
     inlineCssMode: experimental.inlineCss,
   }
 

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -4,6 +4,7 @@ import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 import { renderCssResource } from './render-css-resource'
+import type { CollectedInlineCss } from './types'
 
 export async function createComponentStylesAndScripts({
   filePath,
@@ -11,12 +12,14 @@ export async function createComponentStylesAndScripts({
   injectedCSS,
   injectedJS,
   ctx,
+  collectedInlineCss,
 }: {
   filePath: string
   getComponent: () => any
   injectedCSS: Set<string>
   injectedJS: Set<string>
   ctx: AppRenderContext
+  collectedInlineCss?: CollectedInlineCss
 }): Promise<[React.ComponentType<any>, React.ReactNode, React.ReactNode]> {
   const {
     componentMod: { createElement },
@@ -27,7 +30,12 @@ export async function createComponentStylesAndScripts({
     injectedJS
   )
 
-  const styles = renderCssResource(entryCssFiles, ctx)
+  const styles = renderCssResource(
+    entryCssFiles,
+    ctx,
+    undefined,
+    collectedInlineCss
+  )
 
   const scripts = jsHrefs
     ? jsHrefs.map((href, index) =>

--- a/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
+++ b/packages/next/src/server/app-render/create-component-styles-and-scripts.tsx
@@ -4,7 +4,6 @@ import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 import { renderCssResource } from './render-css-resource'
-import type { CollectedInlineCss } from './types'
 
 export async function createComponentStylesAndScripts({
   filePath,
@@ -12,14 +11,12 @@ export async function createComponentStylesAndScripts({
   injectedCSS,
   injectedJS,
   ctx,
-  collectedInlineCss,
 }: {
   filePath: string
   getComponent: () => any
   injectedCSS: Set<string>
   injectedJS: Set<string>
   ctx: AppRenderContext
-  collectedInlineCss?: CollectedInlineCss
 }): Promise<[React.ComponentType<any>, React.ReactNode, React.ReactNode]> {
   const {
     componentMod: { createElement },
@@ -30,12 +27,7 @@ export async function createComponentStylesAndScripts({
     injectedJS
   )
 
-  const styles = renderCssResource(
-    entryCssFiles,
-    ctx,
-    undefined,
-    collectedInlineCss
-  )
+  const styles = renderCssResource(entryCssFiles, ctx)
 
   const scripts = jsHrefs
     ? jsHrefs.map((href, index) =>

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -143,6 +143,12 @@ async function createComponentTreeInternal(
     unauthorized,
   } = modules
 
+  const isLayout = typeof layout !== 'undefined'
+  /**
+   * Checks if the current segment is a root layout.
+   */
+  const rootLayoutAtThisLevel = isLayout && !rootLayoutIncluded
+
   const injectedCSSWithCurrentLayout = new Set(injectedCSS)
   const injectedJSWithCurrentLayout = new Set(injectedJS)
   const injectedFontPreloadTagsWithCurrentLayout = new Set(
@@ -157,6 +163,7 @@ async function createComponentTreeInternal(
     injectedJS: injectedJSWithCurrentLayout,
     injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
     collectedInlineCss,
+    isRootLayout: rootLayoutAtThisLevel,
   })
 
   const [Template, templateStyles, templateScripts] = template
@@ -192,7 +199,6 @@ async function createComponentTreeInternal(
       })
     : []
 
-  const isLayout = typeof layout !== 'undefined'
   const isPage = typeof page !== 'undefined'
   const { mod: layoutOrPageMod, modType } = await getTracer().trace(
     NextNodeServerSpan.getLayoutOrPageModule,
@@ -206,10 +212,6 @@ async function createComponentTreeInternal(
     () => getLayoutOrPageModule(tree)
   )
 
-  /**
-   * Checks if the current segment is a root layout.
-   */
-  const rootLayoutAtThisLevel = isLayout && !rootLayoutIncluded
   /**
    * Checks if the current segment or any level above it has a root layout.
    */

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -3,7 +3,7 @@ import type {
   CacheNodeSeedData,
   LoadingModuleData,
 } from '../../shared/lib/app-router-types'
-import type { PreloadCallbacks } from './types'
+import type { PreloadCallbacks, CollectedInlineCss } from './types'
 import {
   isClientReference,
   isUseCacheFunction,
@@ -52,6 +52,7 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   MetadataOutlet: ComponentType
+  collectedInlineCss?: CollectedInlineCss
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -87,6 +88,7 @@ async function createComponentTreeInternal(
     preloadCallbacks,
     authInterrupts,
     MetadataOutlet,
+    collectedInlineCss,
   }: {
     loaderTree: LoaderTree
     parentParams: Params
@@ -99,6 +101,7 @@ async function createComponentTreeInternal(
     preloadCallbacks: PreloadCallbacks
     authInterrupts: boolean
     MetadataOutlet: ComponentType | null
+    collectedInlineCss?: CollectedInlineCss
   },
   isRoot: boolean
 ): Promise<CacheNodeSeedData> {
@@ -153,6 +156,7 @@ async function createComponentTreeInternal(
     injectedCSS: injectedCSSWithCurrentLayout,
     injectedJS: injectedJSWithCurrentLayout,
     injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
+    collectedInlineCss,
   })
 
   const [Template, templateStyles, templateScripts] = template
@@ -162,6 +166,7 @@ async function createComponentTreeInternal(
         getComponent: template[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
+        collectedInlineCss,
       })
     : [Fragment]
 
@@ -172,6 +177,7 @@ async function createComponentTreeInternal(
         getComponent: error[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
+        collectedInlineCss,
       })
     : []
 
@@ -182,6 +188,7 @@ async function createComponentTreeInternal(
         getComponent: loading[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
+        collectedInlineCss,
       })
     : []
 
@@ -216,6 +223,7 @@ async function createComponentTreeInternal(
         getComponent: notFound[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
+        collectedInlineCss,
       })
     : []
 
@@ -233,6 +241,7 @@ async function createComponentTreeInternal(
           getComponent: forbidden[0],
           injectedCSS: injectedCSSWithCurrentLayout,
           injectedJS: injectedJSWithCurrentLayout,
+          collectedInlineCss,
         })
       : []
 
@@ -244,6 +253,7 @@ async function createComponentTreeInternal(
           getComponent: unauthorized[0],
           injectedCSS: injectedCSSWithCurrentLayout,
           injectedJS: injectedJSWithCurrentLayout,
+          collectedInlineCss,
         })
       : []
 
@@ -537,6 +547,7 @@ async function createComponentTreeInternal(
               // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
               // but we only want to throw on the first one.
               MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
+              collectedInlineCss,
             },
             false
           )

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -3,7 +3,7 @@ import type {
   CacheNodeSeedData,
   LoadingModuleData,
 } from '../../shared/lib/app-router-types'
-import type { PreloadCallbacks, CollectedInlineCss } from './types'
+import type { PreloadCallbacks } from './types'
 import {
   isClientReference,
   isUseCacheFunction,
@@ -52,7 +52,6 @@ export function createComponentTree(props: {
   preloadCallbacks: PreloadCallbacks
   authInterrupts: boolean
   MetadataOutlet: ComponentType
-  collectedInlineCss?: CollectedInlineCss
 }): Promise<CacheNodeSeedData> {
   return getTracer().trace(
     NextNodeServerSpan.createComponentTree,
@@ -88,7 +87,6 @@ async function createComponentTreeInternal(
     preloadCallbacks,
     authInterrupts,
     MetadataOutlet,
-    collectedInlineCss,
   }: {
     loaderTree: LoaderTree
     parentParams: Params
@@ -101,7 +99,6 @@ async function createComponentTreeInternal(
     preloadCallbacks: PreloadCallbacks
     authInterrupts: boolean
     MetadataOutlet: ComponentType | null
-    collectedInlineCss?: CollectedInlineCss
   },
   isRoot: boolean
 ): Promise<CacheNodeSeedData> {
@@ -162,7 +159,6 @@ async function createComponentTreeInternal(
     injectedCSS: injectedCSSWithCurrentLayout,
     injectedJS: injectedJSWithCurrentLayout,
     injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
-    collectedInlineCss,
     isRootLayout: rootLayoutAtThisLevel,
   })
 
@@ -173,7 +169,6 @@ async function createComponentTreeInternal(
         getComponent: template[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
-        collectedInlineCss,
       })
     : [Fragment]
 
@@ -184,7 +179,6 @@ async function createComponentTreeInternal(
         getComponent: error[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
-        collectedInlineCss,
       })
     : []
 
@@ -195,7 +189,6 @@ async function createComponentTreeInternal(
         getComponent: loading[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
-        collectedInlineCss,
       })
     : []
 
@@ -225,7 +218,6 @@ async function createComponentTreeInternal(
         getComponent: notFound[0],
         injectedCSS: injectedCSSWithCurrentLayout,
         injectedJS: injectedJSWithCurrentLayout,
-        collectedInlineCss,
       })
     : []
 
@@ -243,7 +235,6 @@ async function createComponentTreeInternal(
           getComponent: forbidden[0],
           injectedCSS: injectedCSSWithCurrentLayout,
           injectedJS: injectedJSWithCurrentLayout,
-          collectedInlineCss,
         })
       : []
 
@@ -255,7 +246,6 @@ async function createComponentTreeInternal(
           getComponent: unauthorized[0],
           injectedCSS: injectedCSSWithCurrentLayout,
           injectedJS: injectedJSWithCurrentLayout,
-          collectedInlineCss,
         })
       : []
 
@@ -549,7 +539,6 @@ async function createComponentTreeInternal(
               // `StreamingMetadataOutlet` is used to conditionally throw. In the case of parallel routes we will have more than one page
               // but we only want to throw on the first one.
               MetadataOutlet: isChildrenRouteKey ? MetadataOutlet : null,
-              collectedInlineCss,
             },
             false
           )

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -40,9 +40,6 @@ export function getLayerAssets({
   // Track root layout CSS paths for inlineCss: 'shared' mode
   // Root layout CSS is guaranteed to be shared across all pages
   if (isRootLayout && collectedInlineCss && styleTags.length > 0) {
-    if (!collectedInlineCss.rootLayoutCSSPaths) {
-      collectedInlineCss.rootLayoutCSSPaths = new Set()
-    }
     for (const css of styleTags) {
       collectedInlineCss.rootLayoutCSSPaths.add(css.path)
     }

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -3,7 +3,7 @@ import { getPreloadableFonts } from './get-preloadable-fonts'
 import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
-import type { PreloadCallbacks } from './types'
+import type { PreloadCallbacks, CollectedInlineCss } from './types'
 import { renderCssResource } from './render-css-resource'
 
 export function getLayerAssets({
@@ -13,6 +13,7 @@ export function getLayerAssets({
   injectedJS: injectedJSWithCurrentLayout,
   injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
   preloadCallbacks,
+  collectedInlineCss,
 }: {
   layoutOrPagePath: string | undefined
   injectedCSS: Set<string>
@@ -20,6 +21,7 @@ export function getLayerAssets({
   injectedFontPreloadTags: Set<string>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
+  collectedInlineCss?: CollectedInlineCss
 }): React.ReactNode {
   const {
     componentMod: { createElement },
@@ -74,7 +76,12 @@ export function getLayerAssets({
     }
   }
 
-  const styles = renderCssResource(styleTags, ctx, preloadCallbacks)
+  const styles = renderCssResource(
+    styleTags,
+    ctx,
+    preloadCallbacks,
+    collectedInlineCss
+  )
 
   const scripts = scriptTags
     ? scriptTags.map((href, index) => {

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -3,7 +3,7 @@ import { getPreloadableFonts } from './get-preloadable-fonts'
 import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
-import type { PreloadCallbacks, CollectedInlineCss } from './types'
+import type { PreloadCallbacks } from './types'
 import { renderCssResource } from './render-css-resource'
 
 export function getLayerAssets({
@@ -13,7 +13,6 @@ export function getLayerAssets({
   injectedJS: injectedJSWithCurrentLayout,
   injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
   preloadCallbacks,
-  collectedInlineCss,
   isRootLayout,
 }: {
   layoutOrPagePath: string | undefined
@@ -22,7 +21,6 @@ export function getLayerAssets({
   injectedFontPreloadTags: Set<string>
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
-  collectedInlineCss?: CollectedInlineCss
   isRootLayout?: boolean
 }): React.ReactNode {
   const {
@@ -39,9 +37,9 @@ export function getLayerAssets({
 
   // Track root layout CSS paths for inlineCss: 'shared' mode
   // Root layout CSS is guaranteed to be shared across all pages
-  if (isRootLayout && collectedInlineCss && styleTags.length > 0) {
+  if (isRootLayout && styleTags.length > 0) {
     for (const css of styleTags) {
-      collectedInlineCss.rootLayoutCSSPaths.add(css.path)
+      ctx.collectedInlineCss.rootLayoutCSSPaths.add(css.path)
     }
   }
 
@@ -86,12 +84,7 @@ export function getLayerAssets({
     }
   }
 
-  const styles = renderCssResource(
-    styleTags,
-    ctx,
-    preloadCallbacks,
-    collectedInlineCss
-  )
+  const styles = renderCssResource(styleTags, ctx, preloadCallbacks)
 
   const scripts = scriptTags
     ? scriptTags.map((href, index) => {

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -14,6 +14,7 @@ export function getLayerAssets({
   injectedFontPreloadTags: injectedFontPreloadTagsWithCurrentLayout,
   preloadCallbacks,
   collectedInlineCss,
+  isRootLayout,
 }: {
   layoutOrPagePath: string | undefined
   injectedCSS: Set<string>
@@ -22,6 +23,7 @@ export function getLayerAssets({
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
   collectedInlineCss?: CollectedInlineCss
+  isRootLayout?: boolean
 }): React.ReactNode {
   const {
     componentMod: { createElement },
@@ -34,6 +36,17 @@ export function getLayerAssets({
         true
       )
     : { styles: [], scripts: [] }
+
+  // Track root layout CSS paths for inlineCss: 'shared' mode
+  // Root layout CSS is guaranteed to be shared across all pages
+  if (isRootLayout && collectedInlineCss && styleTags.length > 0) {
+    if (!collectedInlineCss.rootLayoutCSSPaths) {
+      collectedInlineCss.rootLayoutCSSPaths = new Set()
+    }
+    for (const css of styleTags) {
+      collectedInlineCss.rootLayoutCSSPaths.add(css.path)
+    }
+  }
 
   const preloadedFontFiles = layoutOrPagePath
     ? getPreloadableFonts(

--- a/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
+++ b/packages/next/src/server/app-render/make-get-server-inserted-html.tsx
@@ -11,6 +11,7 @@ import { streamToString } from '../stream-utils/node-web-streams-helper'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { addPathPrefix } from '../../shared/lib/router/utils/add-path-prefix'
 import type { ClientTraceDataEntry } from '../lib/trace/tracer'
+import type { CollectedInlineCss } from './types'
 
 export function makeGetServerInsertedHTML({
   polyfills,
@@ -18,12 +19,14 @@ export function makeGetServerInsertedHTML({
   serverCapturedErrors,
   tracingMetadata,
   basePath,
+  collectedInlineCss,
 }: {
   polyfills: JSX.IntrinsicElements['script'][]
   renderServerInsertedHTML: () => React.ReactNode
   tracingMetadata: ClientTraceDataEntry[] | undefined
   serverCapturedErrors: Array<unknown>
   basePath: string
+  collectedInlineCss?: CollectedInlineCss
 }) {
   let flushedErrorMetaTagsUntilIndex = 0
 
@@ -33,6 +36,18 @@ export function makeGetServerInsertedHTML({
   })
   let traceMetaTags = (tracingMetadata || []).map(({ key, value }, index) => (
     <meta key={`next-trace-data-${index}`} name={key} content={value} />
+  ))
+
+  // Collected inline CSS styles - only need to be rendered once
+  let inlineCssStyles = (collectedInlineCss?.styles || []).map((css, index) => (
+    <style
+      key={`inline-css-${index}`}
+      href={css.href}
+      precedence={css.precedence}
+      nonce={css.nonce}
+    >
+      {css.content}
+    </style>
   ))
 
   return async function getServerInsertedHTML() {
@@ -78,6 +93,7 @@ export function makeGetServerInsertedHTML({
       polyfillTags.length === 0 &&
       traceMetaTags.length === 0 &&
       errorMetaTags.length === 0 &&
+      inlineCssStyles.length === 0 &&
       Array.isArray(serverInsertedHTML) &&
       serverInsertedHTML.length === 0
     ) {
@@ -86,6 +102,7 @@ export function makeGetServerInsertedHTML({
 
     const stream = await renderToReadableStream(
       <>
+        {inlineCssStyles}
         {polyfillTags}
         {serverInsertedHTML}
         {traceMetaTags}
@@ -98,9 +115,10 @@ export function makeGetServerInsertedHTML({
       }
     )
 
-    // The polyfills and trace metadata have been flushed, so they don't need to be rendered again
+    // The polyfills, trace metadata, and inline CSS have been flushed, so they don't need to be rendered again
     polyfillTags = []
     traceMetaTags = []
+    inlineCssStyles = []
 
     // There's no need to wait for the stream to be ready
     // e.g. calling `await stream.allReady` because `streamToString` will

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -12,6 +12,11 @@ import type { PreloadCallbacks, CollectedInlineCss } from './types'
  * When collectedInlineCss is provided, inline CSS is collected for injection
  * via ServerInsertedHTML instead of being rendered in the component tree.
  * This avoids duplicating CSS in both HTML and RSC payload.
+ *
+ * The inlineCssMode determines the inlining behavior:
+ * - `false` or `undefined`: No CSS inlining (render as <link> tags)
+ * - `true`: Inline ALL CSS
+ * - `'shared'`: Only inline root layout CSS (safer for client navigations)
  */
 export function renderCssResource(
   entryCssFiles: CssResource[],
@@ -22,6 +27,10 @@ export function renderCssResource(
   const {
     componentMod: { createElement },
   } = ctx
+
+  const inlineCssMode = collectedInlineCss?.inlineCssMode
+  const rootLayoutCSSPaths = collectedInlineCss?.rootLayoutCSSPaths
+
   return entryCssFiles
     .map((entryCssFile, index) => {
       // `Precedence` is an opt-in signal for React to handle resource
@@ -45,7 +54,49 @@ export function renderCssResource(
         entryCssFile.path
       )}${getAssetQueryString(ctx, true)}`
 
-      if (entryCssFile.inlined && !ctx.parsedRequestHeaders.isRSCRequest) {
+      // Check if this CSS is from the root layout (shared across all pages)
+      const isRootLayoutCSS = rootLayoutCSSPaths?.has(entryCssFile.path)
+
+      // In 'shared' mode, handle root layout CSS specially:
+      // - For RSC requests: skip root layout CSS entirely (client already has it from initial HTML)
+      // - For non-RSC requests: inline only root layout CSS
+      if (inlineCssMode === 'shared') {
+        if (ctx.parsedRequestHeaders.isRSCRequest) {
+          // For RSC/navigation requests, skip root layout CSS
+          // (client already has it from the initial HTML load)
+          if (isRootLayoutCSS) {
+            return null
+          }
+          // Page-specific CSS should still be included in RSC payload
+          // Fall through to render as <link> tag
+        } else if (isRootLayoutCSS && entryCssFile.inlined) {
+          // For initial HTML requests, inline only root layout CSS
+          if (collectedInlineCss) {
+            collectedInlineCss.styles.push({
+              href: fullHref,
+              content: entryCssFile.content!,
+              precedence: precedence,
+              nonce: ctx.nonce,
+            })
+            return null
+          }
+          return createElement(
+            'style',
+            {
+              key: index,
+              nonce: ctx.nonce,
+              precedence: precedence,
+              href: fullHref,
+            },
+            entryCssFile.content
+          )
+        }
+        // For page-specific CSS in 'shared' mode, fall through to render as <link> tag
+      } else if (
+        entryCssFile.inlined &&
+        !ctx.parsedRequestHeaders.isRSCRequest
+      ) {
+        // inlineCss: true mode - inline ALL CSS for non-RSC requests
         // When collectedInlineCss is provided, collect CSS for ServerInsertedHTML
         // injection instead of rendering in the component tree. This prevents
         // CSS from being duplicated in both HTML and RSC payload.

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -9,14 +9,12 @@ import type { PreloadCallbacks, CollectedInlineCss } from './types'
  * For inlined CSS, renders a <style> tag with the CSS content directly embedded.
  * For external CSS files, renders a <link> tag pointing to the CSS file.
  *
- * When collectedInlineCss is provided, inline CSS is collected for injection
- * via ServerInsertedHTML instead of being rendered in the component tree.
- * This avoids duplicating CSS in both HTML and RSC payload.
- *
  * The inlineCssMode determines the inlining behavior:
  * - `false` or `undefined`: No CSS inlining (render as <link> tags)
- * - `true`: Inline ALL CSS
- * - `'shared'`: Only inline root layout CSS (safer for client navigations)
+ * - `true`: Inline ALL CSS (note: CSS will be duplicated in HTML and RSC payload)
+ * - `'shared'`: Only inline root layout CSS (safer for client navigations).
+ *   In this mode, collectedInlineCss is used to inject CSS via ServerInsertedHTML
+ *   to avoid duplicating CSS in both HTML and RSC payload.
  */
 export function renderCssResource(
   entryCssFiles: CssResource[],
@@ -97,18 +95,6 @@ export function renderCssResource(
         !ctx.parsedRequestHeaders.isRSCRequest
       ) {
         // inlineCss: true mode - inline ALL CSS for non-RSC requests
-        // When collectedInlineCss is provided, collect CSS for ServerInsertedHTML
-        // injection instead of rendering in the component tree. This prevents
-        // CSS from being duplicated in both HTML and RSC payload.
-        if (collectedInlineCss) {
-          collectedInlineCss.styles.push({
-            href: fullHref,
-            content: entryCssFile.content!,
-            precedence: precedence,
-            nonce: ctx.nonce,
-          })
-          return null
-        }
         return createElement(
           'style',
           {

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -2,7 +2,7 @@ import type { CssResource } from '../../build/webpack/plugins/flight-manifest-pl
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
-import type { PreloadCallbacks, CollectedInlineCss } from './types'
+import type { PreloadCallbacks } from './types'
 
 /**
  * Abstracts the rendering of CSS files based on whether they are inlined or not.
@@ -21,15 +21,15 @@ import type { PreloadCallbacks, CollectedInlineCss } from './types'
 export function renderCssResource(
   entryCssFiles: CssResource[],
   ctx: AppRenderContext,
-  preloadCallbacks?: PreloadCallbacks,
-  collectedInlineCss?: CollectedInlineCss
+  preloadCallbacks?: PreloadCallbacks
 ) {
   const {
     componentMod: { createElement },
+    collectedInlineCss,
   } = ctx
 
-  const inlineCssMode = collectedInlineCss?.inlineCssMode
-  const rootLayoutCSSPaths = collectedInlineCss?.rootLayoutCSSPaths
+  const inlineCssMode = collectedInlineCss.inlineCssMode
+  const rootLayoutCSSPaths = collectedInlineCss.rootLayoutCSSPaths
 
   return entryCssFiles
     .map((entryCssFile, index) => {
@@ -55,7 +55,7 @@ export function renderCssResource(
       )}${getAssetQueryString(ctx, true)}`
 
       // Check if this CSS is from the root layout (shared across all pages)
-      const isRootLayoutCSS = rootLayoutCSSPaths?.has(entryCssFile.path)
+      const isRootLayoutCSS = rootLayoutCSSPaths.has(entryCssFile.path)
       const isRSCRequest = ctx.parsedRequestHeaders.isRSCRequest
 
       // Handle inlineCss: 'shared' mode
@@ -66,7 +66,7 @@ export function renderCssResource(
         }
         // Initial HTML: collect for ServerInsertedHTML injection
         if (entryCssFile.inlined) {
-          collectedInlineCss!.styles.push({
+          collectedInlineCss.styles.push({
             href: fullHref,
             content: entryCssFile.content!,
             precedence: precedence,

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -2,71 +2,90 @@ import type { CssResource } from '../../build/webpack/plugins/flight-manifest-pl
 import { encodeURIPath } from '../../shared/lib/encode-uri-path'
 import type { AppRenderContext } from './app-render'
 import { getAssetQueryString } from './get-asset-query-string'
-import type { PreloadCallbacks } from './types'
+import type { PreloadCallbacks, CollectedInlineCss } from './types'
 
 /**
  * Abstracts the rendering of CSS files based on whether they are inlined or not.
  * For inlined CSS, renders a <style> tag with the CSS content directly embedded.
  * For external CSS files, renders a <link> tag pointing to the CSS file.
+ *
+ * When collectedInlineCss is provided, inline CSS is collected for injection
+ * via ServerInsertedHTML instead of being rendered in the component tree.
+ * This avoids duplicating CSS in both HTML and RSC payload.
  */
 export function renderCssResource(
   entryCssFiles: CssResource[],
   ctx: AppRenderContext,
-  preloadCallbacks?: PreloadCallbacks
+  preloadCallbacks?: PreloadCallbacks,
+  collectedInlineCss?: CollectedInlineCss
 ) {
   const {
     componentMod: { createElement },
   } = ctx
-  return entryCssFiles.map((entryCssFile, index) => {
-    // `Precedence` is an opt-in signal for React to handle resource
-    // loading and deduplication, etc. It's also used as the key to sort
-    // resources so they will be injected in the correct order.
-    // During HMR, it's critical to use different `precedence` values
-    // for different stylesheets, so their order will be kept.
-    // https://github.com/facebook/react/pull/25060
-    const precedence =
-      process.env.NODE_ENV === 'development'
-        ? 'next_' + entryCssFile.path
-        : 'next'
+  return entryCssFiles
+    .map((entryCssFile, index) => {
+      // `Precedence` is an opt-in signal for React to handle resource
+      // loading and deduplication, etc. It's also used as the key to sort
+      // resources so they will be injected in the correct order.
+      // During HMR, it's critical to use different `precedence` values
+      // for different stylesheets, so their order will be kept.
+      // https://github.com/facebook/react/pull/25060
+      const precedence =
+        process.env.NODE_ENV === 'development'
+          ? 'next_' + entryCssFile.path
+          : 'next'
 
-    // In dev, Safari and Firefox will cache the resource during HMR:
-    // - https://github.com/vercel/next.js/issues/5860
-    // - https://bugs.webkit.org/show_bug.cgi?id=187726
-    // Because of this, we add a `?v=` query to bypass the cache during
-    // development. We need to also make sure that the number is always
-    // increasing.
-    const fullHref = `${ctx.assetPrefix}/_next/${encodeURIPath(
-      entryCssFile.path
-    )}${getAssetQueryString(ctx, true)}`
+      // In dev, Safari and Firefox will cache the resource during HMR:
+      // - https://github.com/vercel/next.js/issues/5860
+      // - https://bugs.webkit.org/show_bug.cgi?id=187726
+      // Because of this, we add a `?v=` query to bypass the cache during
+      // development. We need to also make sure that the number is always
+      // increasing.
+      const fullHref = `${ctx.assetPrefix}/_next/${encodeURIPath(
+        entryCssFile.path
+      )}${getAssetQueryString(ctx, true)}`
 
-    if (entryCssFile.inlined && !ctx.parsedRequestHeaders.isRSCRequest) {
-      return createElement(
-        'style',
-        {
-          key: index,
-          nonce: ctx.nonce,
-          precedence: precedence,
-          href: fullHref,
-        },
-        entryCssFile.content
-      )
-    }
+      if (entryCssFile.inlined && !ctx.parsedRequestHeaders.isRSCRequest) {
+        // When collectedInlineCss is provided, collect CSS for ServerInsertedHTML
+        // injection instead of rendering in the component tree. This prevents
+        // CSS from being duplicated in both HTML and RSC payload.
+        if (collectedInlineCss) {
+          collectedInlineCss.styles.push({
+            href: fullHref,
+            content: entryCssFile.content!,
+            precedence: precedence,
+            nonce: ctx.nonce,
+          })
+          return null
+        }
+        return createElement(
+          'style',
+          {
+            key: index,
+            nonce: ctx.nonce,
+            precedence: precedence,
+            href: fullHref,
+          },
+          entryCssFile.content
+        )
+      }
 
-    preloadCallbacks?.push(() => {
-      ctx.componentMod.preloadStyle(
-        fullHref,
-        ctx.renderOpts.crossOrigin,
-        ctx.nonce
-      )
+      preloadCallbacks?.push(() => {
+        ctx.componentMod.preloadStyle(
+          fullHref,
+          ctx.renderOpts.crossOrigin,
+          ctx.nonce
+        )
+      })
+
+      return createElement('link', {
+        key: index,
+        rel: 'stylesheet',
+        href: fullHref,
+        precedence: precedence,
+        crossOrigin: ctx.renderOpts.crossOrigin,
+        nonce: ctx.nonce,
+      })
     })
-
-    return createElement('link', {
-      key: index,
-      rel: 'stylesheet',
-      href: fullHref,
-      precedence: precedence,
-      crossOrigin: ctx.renderOpts.crossOrigin,
-      nonce: ctx.nonce,
-    })
-  })
+    .filter(Boolean)
 }

--- a/packages/next/src/server/app-render/render-css-resource.tsx
+++ b/packages/next/src/server/app-render/render-css-resource.tsx
@@ -11,7 +11,9 @@ import type { PreloadCallbacks, CollectedInlineCss } from './types'
  *
  * The inlineCssMode determines the inlining behavior:
  * - `false` or `undefined`: No CSS inlining (render as <link> tags)
- * - `true`: Inline ALL CSS (note: CSS will be duplicated in HTML and RSC payload)
+ * - `true`: Inline ALL CSS. Note: This causes CSS duplication because styles
+ *   appear both in initial HTML <style> tags AND in the RSC payload's serialized
+ *   <script> content. The client then re-injects them, causing double styles.
  * - `'shared'`: Only inline root layout CSS (safer for client navigations).
  *   In this mode, collectedInlineCss is used to inject CSS via ServerInsertedHTML
  *   to avoid duplicating CSS in both HTML and RSC payload.
@@ -54,47 +56,28 @@ export function renderCssResource(
 
       // Check if this CSS is from the root layout (shared across all pages)
       const isRootLayoutCSS = rootLayoutCSSPaths?.has(entryCssFile.path)
+      const isRSCRequest = ctx.parsedRequestHeaders.isRSCRequest
 
-      // In 'shared' mode, handle root layout CSS specially:
-      // - For RSC requests: skip root layout CSS entirely (client already has it from initial HTML)
-      // - For non-RSC requests: inline only root layout CSS
-      if (inlineCssMode === 'shared') {
-        if (ctx.parsedRequestHeaders.isRSCRequest) {
-          // For RSC/navigation requests, skip root layout CSS
-          // (client already has it from the initial HTML load)
-          if (isRootLayoutCSS) {
-            return null
-          }
-          // Page-specific CSS should still be included in RSC payload
-          // Fall through to render as <link> tag
-        } else if (isRootLayoutCSS && entryCssFile.inlined) {
-          // For initial HTML requests, inline only root layout CSS
-          if (collectedInlineCss) {
-            collectedInlineCss.styles.push({
-              href: fullHref,
-              content: entryCssFile.content!,
-              precedence: precedence,
-              nonce: ctx.nonce,
-            })
-            return null
-          }
-          return createElement(
-            'style',
-            {
-              key: index,
-              nonce: ctx.nonce,
-              precedence: precedence,
-              href: fullHref,
-            },
-            entryCssFile.content
-          )
+      // Handle inlineCss: 'shared' mode
+      if (inlineCssMode === 'shared' && isRootLayoutCSS) {
+        // RSC requests: skip root layout CSS (client already has it from initial HTML)
+        if (isRSCRequest) {
+          return null
         }
-        // For page-specific CSS in 'shared' mode, fall through to render as <link> tag
-      } else if (
-        entryCssFile.inlined &&
-        !ctx.parsedRequestHeaders.isRSCRequest
-      ) {
-        // inlineCss: true mode - inline ALL CSS for non-RSC requests
+        // Initial HTML: collect for ServerInsertedHTML injection
+        if (entryCssFile.inlined) {
+          collectedInlineCss!.styles.push({
+            href: fullHref,
+            content: entryCssFile.content!,
+            precedence: precedence,
+            nonce: ctx.nonce,
+          })
+          return null
+        }
+      }
+
+      // Handle inlineCss: true mode - inline ALL CSS for non-RSC requests
+      if (inlineCssMode === true && entryCssFile.inlined && !isRSCRequest) {
         return createElement(
           'style',
           {
@@ -106,6 +89,8 @@ export function renderCssResource(
           entryCssFile.content
         )
       }
+
+      // Default: render as <link> tag
 
       preloadCallbacks?.push(() => {
         ctx.componentMod.preloadStyle(

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -238,7 +238,7 @@ export interface CollectedInlineCss {
    * Used when `inlineCss: 'shared'` to only inline root layout CSS
    * (which is guaranteed to be shared across all pages).
    */
-  rootLayoutCSSPaths?: Set<string>
+  rootLayoutCSSPaths: Set<string>
   /**
    * The inlineCss mode from config.
    * - `false` or `undefined`: No CSS inlining

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -220,3 +220,17 @@ export type RenderOpts = LoadComponentsReturnType<AppPageModule> &
   RequestLifecycleOpts
 
 export type PreloadCallbacks = (() => void)[]
+
+/**
+ * Collected inline CSS to be injected via ServerInsertedHTML.
+ * This avoids duplicating CSS in both the HTML (as <style> tags) and
+ * the RSC payload (serialized in <script> tags).
+ */
+export interface CollectedInlineCss {
+  styles: Array<{
+    href: string
+    content: string
+    precedence: string
+    nonce?: string
+  }>
+}

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -159,7 +159,7 @@ export interface RenderOptsPartial {
     clientParamParsingOrigins: string[] | undefined
     dynamicOnHover: boolean
     optimisticRouting: boolean
-    inlineCss: boolean
+    inlineCss: boolean | 'shared'
     authInterrupts: boolean
 
     /**
@@ -233,4 +233,17 @@ export interface CollectedInlineCss {
     precedence: string
     nonce?: string
   }>
+  /**
+   * CSS file paths that belong to the root layout.
+   * Used when `inlineCss: 'shared'` to only inline root layout CSS
+   * (which is guaranteed to be shared across all pages).
+   */
+  rootLayoutCSSPaths?: Set<string>
+  /**
+   * The inlineCss mode from config.
+   * - `false` or `undefined`: No CSS inlining
+   * - `true`: Inline ALL CSS
+   * - `'shared'`: Only inline root layout CSS
+   */
+  inlineCssMode?: boolean | 'shared'
 }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -199,7 +199,7 @@ export const experimentalSchema = {
   disableOptimizedLoading: z.boolean().optional(),
   disablePostcssPresetEnv: z.boolean().optional(),
   cacheComponents: z.boolean().optional(),
-  inlineCss: z.boolean().optional(),
+  inlineCss: z.union([z.boolean(), z.literal('shared')]).optional(),
   esmExternals: z.union([z.boolean(), z.literal('loose')]).optional(),
   serverActions: z
     .object({

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -741,8 +741,12 @@ export interface ExperimentalConfig {
   /**
    * Render <style> tags inline in the HTML for imported CSS assets.
    * Supports app-router in production mode only.
+   *
+   * - `false`: No CSS inlining (default)
+   * - `true`: Inline ALL CSS
+   * - `'shared'`: Only inline root layout CSS (safer for client navigations)
    */
-  inlineCss?: boolean
+  inlineCss?: boolean | 'shared'
 
   // TODO: Remove this config when the API is stable.
   /**

--- a/test/e2e/app-dir/app-inline-css-shared/app/a/page.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/a/page.tsx
@@ -1,0 +1,11 @@
+import './styles.css'
+
+export default function PageA() {
+  return (
+    <main className="page-a" id="page-a">
+      <p>Page A</p>
+    </main>
+  )
+}
+
+export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/app-inline-css-shared/app/a/page.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/a/page.tsx
@@ -4,8 +4,9 @@ import './styles.css'
 export default async function PageA() {
   await connection()
   return (
-    <main className="page-a" id="page-a">
-      <p>Page A</p>
+    <main id="page-a" className="p-4">
+      <h1 className="text-2xl font-bold text-blue-500">Page A</h1>
+      <p className="page-a-custom">This has page-specific CSS</p>
     </main>
   )
 }

--- a/test/e2e/app-dir/app-inline-css-shared/app/a/page.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/a/page.tsx
@@ -1,11 +1,11 @@
+import { connection } from 'next/server'
 import './styles.css'
 
-export default function PageA() {
+export default async function PageA() {
+  await connection()
   return (
     <main className="page-a" id="page-a">
       <p>Page A</p>
     </main>
   )
 }
-
-export const dynamic = 'force-dynamic'

--- a/test/e2e/app-dir/app-inline-css-shared/app/a/styles.css
+++ b/test/e2e/app-dir/app-inline-css-shared/app/a/styles.css
@@ -1,0 +1,4 @@
+/* Page A specific CSS - should NOT be inlined, loaded via <link> */
+.page-a {
+  font-size: 32px;
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/a/styles.css
+++ b/test/e2e/app-dir/app-inline-css-shared/app/a/styles.css
@@ -1,4 +1,5 @@
 /* Page A specific CSS - should NOT be inlined, loaded via <link> */
-.page-a {
+.page-a-custom {
   font-size: 32px;
+  color: green;
 }

--- a/test/e2e/app-dir/app-inline-css-shared/app/b/page.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/b/page.tsx
@@ -1,0 +1,12 @@
+import { connection } from 'next/server'
+import './styles.css'
+
+export default async function PageB() {
+  await connection()
+  return (
+    <main id="page-b" className="p-4">
+      <h1 className="text-2xl font-bold text-blue-500">Page B</h1>
+      <p className="page-b-custom">This has page B specific CSS</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/b/styles.css
+++ b/test/e2e/app-dir/app-inline-css-shared/app/b/styles.css
@@ -1,0 +1,5 @@
+/* Page B specific CSS - should NOT be inlined, loaded via <link> */
+.page-b-custom {
+  font-weight: bold;
+  color: purple;
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/global.css
+++ b/test/e2e/app-dir/app-inline-css-shared/app/global.css
@@ -1,0 +1,8 @@
+/* Root layout CSS - should be inlined and shared across all pages */
+p {
+  color: blue;
+}
+
+body {
+  background-color: white;
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/global.css
+++ b/test/e2e/app-dir/app-inline-css-shared/app/global.css
@@ -1,8 +1,3 @@
-/* Root layout CSS - should be inlined and shared across all pages */
-p {
-  color: blue;
-}
-
-body {
-  background-color: white;
-}
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/test/e2e/app-dir/app-inline-css-shared/app/layout.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/layout.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import './global.css'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        <nav>
+          <Link href="/" prefetch={false}>
+            Home
+          </Link>
+          {' | '}
+          <Link href="/a" id="link-a" prefetch={false}>
+            Page A
+          </Link>
+        </nav>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/layout.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/layout.tsx
@@ -4,13 +4,21 @@ import './global.css'
 export default function RootLayout({ children }) {
   return (
     <html>
-      <body>
-        <nav>
-          <Link href="/" prefetch={false}>
+      <body className="bg-white">
+        <nav className="flex gap-4 p-4">
+          <Link
+            href="/"
+            prefetch={false}
+            className="text-blue-500 hover:underline"
+          >
             Home
           </Link>
-          {' | '}
-          <Link href="/a" id="link-a" prefetch={false}>
+          <Link
+            href="/a"
+            id="link-a"
+            prefetch={false}
+            className="text-blue-500 hover:underline"
+          >
             Page A
           </Link>
         </nav>

--- a/test/e2e/app-dir/app-inline-css-shared/app/layout.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/layout.tsx
@@ -8,6 +8,7 @@ export default function RootLayout({ children }) {
         <nav className="flex gap-4 p-4">
           <Link
             href="/"
+            id="link-home"
             prefetch={false}
             className="text-blue-500 hover:underline"
           >
@@ -20,6 +21,22 @@ export default function RootLayout({ children }) {
             className="text-blue-500 hover:underline"
           >
             Page A
+          </Link>
+          <Link
+            href="/b"
+            id="link-b"
+            prefetch={false}
+            className="text-blue-500 hover:underline"
+          >
+            Page B
+          </Link>
+          <Link
+            href="/nested"
+            id="link-nested"
+            prefetch={false}
+            className="text-blue-500 hover:underline"
+          >
+            Nested
           </Link>
         </nav>
         {children}

--- a/test/e2e/app-dir/app-inline-css-shared/app/nested/layout.css
+++ b/test/e2e/app-dir/app-inline-css-shared/app/nested/layout.css
@@ -1,0 +1,12 @@
+/* Nested layout CSS - should NOT be inlined (only root layout is inlined) */
+.nested-layout-wrapper {
+  border: 2px solid orange;
+  padding: 16px;
+}
+
+.nested-header {
+  background-color: orange;
+  color: white;
+  padding: 8px;
+  margin-bottom: 16px;
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/nested/layout.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/nested/layout.tsx
@@ -1,0 +1,14 @@
+import './layout.css'
+
+export default function NestedLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="nested-layout-wrapper">
+      <header className="nested-header">Nested Layout Header</header>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/nested/page.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/nested/page.tsx
@@ -1,0 +1,11 @@
+import { connection } from 'next/server'
+
+export default async function NestedPage() {
+  await connection()
+  return (
+    <main id="page-nested" className="p-4">
+      <h1 className="text-2xl font-bold text-blue-500">Nested Page</h1>
+      <p>This page is inside a nested layout</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/app-inline-css-shared/app/page.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/page.tsx
@@ -1,7 +1,7 @@
 export default function Page() {
   return (
-    <main id="page-home">
-      <p>Home Page</p>
+    <main id="page-home" className="p-4">
+      <h1 className="text-2xl font-bold text-blue-500">Home Page</h1>
     </main>
   )
 }

--- a/test/e2e/app-dir/app-inline-css-shared/app/page.tsx
+++ b/test/e2e/app-dir/app-inline-css-shared/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <main id="page-home">
+      <p>Home Page</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/app-inline-css-shared/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css-shared/index.test.ts
@@ -1,0 +1,125 @@
+import { nextTestSetup } from 'e2e-utils'
+import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
+
+describe('app dir - css - experimental inline css shared mode', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  ;(isNextDev ? describe.skip : describe)('Production only', () => {
+    it('should inline root layout CSS in the initial HTML', async () => {
+      const $ = await next.render$('/')
+
+      // Root layout CSS should be inlined in <style> tags
+      // Note: Turbopack minifies 'blue' to '#00f'
+      const styleContent = $('style').text()
+      expect(styleContent).toMatch(/color.*#00f|color.*blue/i)
+    })
+
+    it('should apply root layout styles correctly', async () => {
+      const browser = await next.browser('/')
+
+      const p = await browser.elementByCss('p')
+      expect(await p.getComputedCss('color')).toBe('rgb(0, 0, 255)') // blue
+    })
+
+    it('should NOT include root layout CSS in RSC payload on navigation', async () => {
+      // Fetch the RSC payload for page /a (navigation request)
+      const rscPayload = await (
+        await next.fetch(`/a?${NEXT_RSC_UNION_QUERY}`, {
+          method: 'GET',
+          headers: {
+            rsc: '1',
+          },
+        })
+      ).text()
+
+      // Root layout CSS content should NOT be in the RSC payload
+      // because it was already inlined in the initial HTML
+      // Note: 404 error styling has 'color:#000' but that's not the root layout CSS
+      expect(rscPayload).toContain('__PAGE__') // sanity check
+      // The specific root layout CSS pattern (color:#00f or color:blue) should NOT be present
+      // as inline content (but may be referenced as a <link>)
+      expect(rscPayload).not.toMatch(/p\s*\{\s*color\s*:\s*(#00f|blue)/i)
+    })
+
+    it('should include page-specific CSS in RSC payload for navigations', async () => {
+      // Fetch the RSC payload for page /a (navigation request)
+      const rscPayload = await (
+        await next.fetch(`/a?${NEXT_RSC_UNION_QUERY}`, {
+          method: 'GET',
+          headers: {
+            rsc: '1',
+          },
+        })
+      ).text()
+
+      // Page A specific CSS should be in the RSC payload as a <link> reference
+      // (not inlined, but referenced)
+      expect(rscPayload).toContain('__PAGE__') // sanity check
+      // The page-specific CSS should be referenced (as link or stylesheet)
+      expect(rscPayload).toMatch(/stylesheet|\.css/)
+    })
+
+    it('should render page-specific CSS as <link> tag on initial load', async () => {
+      const $ = await next.render$('/a')
+
+      // Root layout CSS should still be inlined
+      // Note: Turbopack minifies 'blue' to '#00f'
+      const styleContent = $('style').text()
+      expect(styleContent).toMatch(/color.*#00f|color.*blue/i)
+
+      // Page-specific CSS (font-size:32px) should NOT be in the inline styles
+      // It should be loaded via <link> tag instead
+      expect(styleContent).not.toMatch(/font-size.*32px/i)
+
+      // Page-specific CSS should be loaded via <link> tag
+      const linkTags = $('link[rel="stylesheet"]')
+      expect(linkTags.length).toBeGreaterThan(0)
+    })
+
+    it('should not include root layout CSS content in RSC inline payload on initial HTML', async () => {
+      const $ = await next.render$('/')
+
+      // Get the RSC inline payload from script tags
+      const rscScripts = $('script')
+        .filter(function () {
+          const content = $(this).html()
+          return content && content.includes('self.__next_f.push')
+        })
+        .toArray()
+
+      // Combine all RSC payload content
+      const rscPayload = rscScripts.map((script) => $(script).html()).join('\n')
+
+      // CSS content should be in the HTML <style> tags
+      // Note: Turbopack minifies 'blue' to '#00f'
+      const styleContent = $('style').text()
+      expect(styleContent).toMatch(/color.*#00f|color.*blue/i)
+
+      // Root layout CSS content should NOT be in the RSC payload
+      // (The CSS is injected via ServerInsertedHTML, not the RSC tree)
+      expect(rscPayload).not.toMatch(/p\s*\{\s*color\s*:\s*(#00f|blue)/i)
+    })
+
+    it('should work correctly with client-side navigation', async () => {
+      const browser = await next.browser('/')
+
+      // Verify initial page has root layout styles
+      const p = await browser.elementByCss('p')
+      expect(await p.getComputedCss('color')).toBe('rgb(0, 0, 255)') // blue
+
+      // Navigate to page A
+      await browser.elementByCss('#link-a').click()
+      await browser.waitForElementByCss('#page-a')
+
+      // Root layout styles should still work after navigation
+      const pAfterNav = await browser.elementByCss('p')
+      expect(await pAfterNav.getComputedCss('color')).toBe('rgb(0, 0, 255)') // blue
+
+      // Page A specific styles should also work
+      const pageA = await browser.elementByCss('#page-a')
+      expect(await pageA.getComputedCss('fontSize')).toBe('32px')
+    })
+  })
+})

--- a/test/e2e/app-dir/app-inline-css-shared/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css-shared/index.test.ts
@@ -118,5 +118,72 @@ describe('app dir - css - experimental inline css shared mode', () => {
       expect(await customElement.getComputedCss('fontSize')).toBe('32px')
       expect(await customElement.getComputedCss('color')).toBe('rgb(0, 128, 0)') // green
     })
+
+    it('should maintain styles after multiple navigations', async () => {
+      const browser = await next.browser('/')
+
+      // Verify initial page
+      expect(await browser.elementByCss('h1').getComputedCss('color')).toBe(
+        'rgb(59, 130, 246)'
+      )
+
+      // Navigate: Home → A
+      await browser.elementByCss('#link-a').click()
+      await browser.waitForElementByCss('#page-a')
+      expect(await browser.elementByCss('h1').getComputedCss('color')).toBe(
+        'rgb(59, 130, 246)'
+      )
+
+      // Navigate: A → B
+      await browser.elementByCss('#link-b').click()
+      await browser.waitForElementByCss('#page-b')
+      expect(await browser.elementByCss('h1').getComputedCss('color')).toBe(
+        'rgb(59, 130, 246)'
+      )
+      // Page B specific styles
+      expect(
+        await browser.elementByCss('.page-b-custom').getComputedCss('color')
+      ).toBe('rgb(128, 0, 128)') // purple
+
+      // Navigate: B → Home
+      await browser.elementByCss('#link-home').click()
+      await browser.waitForElementByCss('#page-home')
+      expect(await browser.elementByCss('h1').getComputedCss('color')).toBe(
+        'rgb(59, 130, 246)'
+      )
+    })
+
+    it('should only inline root layout CSS, not nested layout CSS', async () => {
+      const $ = await next.render$('/nested')
+
+      // Tailwind (root layout) CSS should be inlined
+      const styleContent = $('style').text()
+      expect(styleContent).toMatch(/\.text-blue-500|--tw-|\.bg-white/)
+
+      // Nested layout CSS should NOT be in the inline styles
+      expect(styleContent).not.toContain('.nested-layout-wrapper')
+      expect(styleContent).not.toContain('.nested-header')
+
+      // Nested layout CSS should be loaded via <link> tag
+      const linkTags = $('link[rel="stylesheet"]')
+      expect(linkTags.length).toBeGreaterThan(0)
+    })
+
+    it('should include nested layout CSS in RSC payload for navigations', async () => {
+      // Fetch the RSC payload for /nested (navigation request)
+      const rscPayload = await (
+        await next.fetch(`/nested?${NEXT_RSC_UNION_QUERY}`, {
+          method: 'GET',
+          headers: {
+            rsc: '1',
+          },
+        })
+      ).text()
+
+      // Nested layout CSS should be referenced in the RSC payload
+      expect(rscPayload).toContain('__PAGE__') // sanity check
+      // The nested layout CSS should be referenced (as link or stylesheet)
+      expect(rscPayload).toMatch(/stylesheet|\.css/)
+    })
   })
 })

--- a/test/e2e/app-dir/app-inline-css-shared/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css-shared/index.test.ts
@@ -7,23 +7,25 @@ describe('app dir - css - experimental inline css shared mode', () => {
   })
 
   ;(isNextDev ? describe.skip : describe)('Production only', () => {
-    it('should inline root layout CSS in the initial HTML', async () => {
+    it('should inline Tailwind CSS from root layout in the initial HTML', async () => {
       const $ = await next.render$('/')
 
-      // Root layout CSS should be inlined in <style> tags
-      // Note: Turbopack minifies 'blue' to '#00f'
+      // Tailwind CSS should be inlined in <style> tags
+      // Check for Tailwind's characteristic patterns like utility classes
       const styleContent = $('style').text()
-      expect(styleContent).toMatch(/color.*#00f|color.*blue/i)
+      // Tailwind generates CSS like .text-blue-500 { color: rgb(...) } or .bg-white { ... }
+      expect(styleContent).toMatch(/\.text-blue-500|--tw-|\.bg-white/)
     })
 
-    it('should apply root layout styles correctly', async () => {
+    it('should apply Tailwind styles correctly', async () => {
       const browser = await next.browser('/')
 
-      const p = await browser.elementByCss('p')
-      expect(await p.getComputedCss('color')).toBe('rgb(0, 0, 255)') // blue
+      const h1 = await browser.elementByCss('h1')
+      // text-blue-500 in Tailwind v3 is rgb(59, 130, 246)
+      expect(await h1.getComputedCss('color')).toBe('rgb(59, 130, 246)')
     })
 
-    it('should NOT include root layout CSS in RSC payload on navigation', async () => {
+    it('should NOT include Tailwind CSS in RSC payload on navigation', async () => {
       // Fetch the RSC payload for page /a (navigation request)
       const rscPayload = await (
         await next.fetch(`/a?${NEXT_RSC_UNION_QUERY}`, {
@@ -34,13 +36,11 @@ describe('app dir - css - experimental inline css shared mode', () => {
         })
       ).text()
 
-      // Root layout CSS content should NOT be in the RSC payload
+      // Root layout (Tailwind) CSS content should NOT be in the RSC payload
       // because it was already inlined in the initial HTML
-      // Note: 404 error styling has 'color:#000' but that's not the root layout CSS
       expect(rscPayload).toContain('__PAGE__') // sanity check
-      // The specific root layout CSS pattern (color:#00f or color:blue) should NOT be present
-      // as inline content (but may be referenced as a <link>)
-      expect(rscPayload).not.toMatch(/p\s*\{\s*color\s*:\s*(#00f|blue)/i)
+      // Tailwind's characteristic patterns should NOT be present as inline content
+      expect(rscPayload).not.toMatch(/--tw-text-opacity|\.text-blue-500\s*\{/)
     })
 
     it('should include page-specific CSS in RSC payload for navigations', async () => {
@@ -55,7 +55,6 @@ describe('app dir - css - experimental inline css shared mode', () => {
       ).text()
 
       // Page A specific CSS should be in the RSC payload as a <link> reference
-      // (not inlined, but referenced)
       expect(rscPayload).toContain('__PAGE__') // sanity check
       // The page-specific CSS should be referenced (as link or stylesheet)
       expect(rscPayload).toMatch(/stylesheet|\.css/)
@@ -64,21 +63,19 @@ describe('app dir - css - experimental inline css shared mode', () => {
     it('should render page-specific CSS as <link> tag on initial load', async () => {
       const $ = await next.render$('/a')
 
-      // Root layout CSS should still be inlined
-      // Note: Turbopack minifies 'blue' to '#00f'
+      // Tailwind CSS should still be inlined
       const styleContent = $('style').text()
-      expect(styleContent).toMatch(/color.*#00f|color.*blue/i)
+      expect(styleContent).toMatch(/\.text-blue-500|--tw-|\.bg-white/)
 
       // Page-specific CSS (font-size:32px) should NOT be in the inline styles
-      // It should be loaded via <link> tag instead
-      expect(styleContent).not.toMatch(/font-size.*32px/i)
+      expect(styleContent).not.toMatch(/\.page-a-custom/)
 
       // Page-specific CSS should be loaded via <link> tag
       const linkTags = $('link[rel="stylesheet"]')
       expect(linkTags.length).toBeGreaterThan(0)
     })
 
-    it('should not include root layout CSS content in RSC inline payload on initial HTML', async () => {
+    it('should not include Tailwind CSS content in RSC inline payload on initial HTML', async () => {
       const $ = await next.render$('/')
 
       // Get the RSC inline payload from script tags
@@ -92,34 +89,34 @@ describe('app dir - css - experimental inline css shared mode', () => {
       // Combine all RSC payload content
       const rscPayload = rscScripts.map((script) => $(script).html()).join('\n')
 
-      // CSS content should be in the HTML <style> tags
-      // Note: Turbopack minifies 'blue' to '#00f'
+      // Tailwind CSS content should be in the HTML <style> tags
       const styleContent = $('style').text()
-      expect(styleContent).toMatch(/color.*#00f|color.*blue/i)
+      expect(styleContent).toMatch(/\.text-blue-500|--tw-|\.bg-white/)
 
-      // Root layout CSS content should NOT be in the RSC payload
+      // Tailwind CSS content should NOT be in the RSC payload
       // (The CSS is injected via ServerInsertedHTML, not the RSC tree)
-      expect(rscPayload).not.toMatch(/p\s*\{\s*color\s*:\s*(#00f|blue)/i)
+      expect(rscPayload).not.toMatch(/--tw-text-opacity|\.text-blue-500\s*\{/)
     })
 
     it('should work correctly with client-side navigation', async () => {
       const browser = await next.browser('/')
 
-      // Verify initial page has root layout styles
-      const p = await browser.elementByCss('p')
-      expect(await p.getComputedCss('color')).toBe('rgb(0, 0, 255)') // blue
+      // Verify initial page has Tailwind styles
+      const h1 = await browser.elementByCss('h1')
+      expect(await h1.getComputedCss('color')).toBe('rgb(59, 130, 246)') // text-blue-500
 
       // Navigate to page A
       await browser.elementByCss('#link-a').click()
       await browser.waitForElementByCss('#page-a')
 
-      // Root layout styles should still work after navigation
-      const pAfterNav = await browser.elementByCss('p')
-      expect(await pAfterNav.getComputedCss('color')).toBe('rgb(0, 0, 255)') // blue
+      // Tailwind styles should still work after navigation
+      const h1AfterNav = await browser.elementByCss('h1')
+      expect(await h1AfterNav.getComputedCss('color')).toBe('rgb(59, 130, 246)') // text-blue-500
 
       // Page A specific styles should also work
-      const pageA = await browser.elementByCss('#page-a')
-      expect(await pageA.getComputedCss('fontSize')).toBe('32px')
+      const customElement = await browser.elementByCss('.page-a-custom')
+      expect(await customElement.getComputedCss('fontSize')).toBe('32px')
+      expect(await customElement.getComputedCss('color')).toBe('rgb(0, 128, 0)') // green
     })
   })
 })

--- a/test/e2e/app-dir/app-inline-css-shared/next.config.js
+++ b/test/e2e/app-dir/app-inline-css-shared/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  experimental: {
+    inlineCss: 'shared',
+  },
+}

--- a/test/e2e/app-dir/app-inline-css-shared/postcss.config.js
+++ b/test/e2e/app-dir/app-inline-css-shared/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/test/e2e/app-dir/app-inline-css-shared/tailwind.config.js
+++ b/test/e2e/app-dir/app-inline-css-shared/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{js,ts,jsx,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -93,5 +93,28 @@ describe('app dir - css - experimental inline css', () => {
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toContain('font')
     })
+
+    it('should not include CSS content in RSC inline payload on initial HTML', async () => {
+      const $ = await next.render$('/')
+
+      // Get the RSC inline payload from script tags
+      const rscScripts = $('script')
+        .filter(function () {
+          const content = $(this).html()
+          return content && content.includes('self.__next_f.push')
+        })
+        .toArray()
+
+      // Combine all RSC payload content
+      const rscPayload = rscScripts.map((script) => $(script).html()).join('\n')
+
+      // CSS content should be in the HTML <style> tags
+      const styleContent = $('style').text()
+      expect(styleContent).toContain('color')
+
+      // CSS content "color:yellow" should NOT be in the RSC payload
+      // (The CSS is injected via ServerInsertedHTML, not the RSC tree)
+      expect(rscPayload).not.toContain('color:yellow')
+    })
   })
 })

--- a/test/e2e/app-dir/app-inline-css/index.test.ts
+++ b/test/e2e/app-dir/app-inline-css/index.test.ts
@@ -93,28 +93,5 @@ describe('app dir - css - experimental inline css', () => {
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toContain('font')
     })
-
-    it('should not include CSS content in RSC inline payload on initial HTML', async () => {
-      const $ = await next.render$('/')
-
-      // Get the RSC inline payload from script tags
-      const rscScripts = $('script')
-        .filter(function () {
-          const content = $(this).html()
-          return content && content.includes('self.__next_f.push')
-        })
-        .toArray()
-
-      // Combine all RSC payload content
-      const rscPayload = rscScripts.map((script) => $(script).html()).join('\n')
-
-      // CSS content should be in the HTML <style> tags
-      const styleContent = $('style').text()
-      expect(styleContent).toContain('color')
-
-      // CSS content "color:yellow" should NOT be in the RSC payload
-      // (The CSS is injected via ServerInsertedHTML, not the RSC tree)
-      expect(rscPayload).not.toContain('color:yellow')
-    })
   })
 })


### PR DESCRIPTION
## Summary

Adds a new `'shared'` option for `experimental.inlineCss` that only inlines root layout CSS while keeping page-specific CSS as `<link>` tags. This is ideal for utility-first CSS frameworks like Tailwind CSS, where:

- Tailwind CSS is typically imported once in the root layout
- The styles are shared across all pages
- The CSS bundle doesn't grow significantly per page (O(1) complexity)

### How `'shared'` mode works

- **Initial HTML requests**: Root layout CSS is inlined in `<style>` tags, page-specific CSS loads via `<link>` tags
- **RSC navigation requests**: Root layout CSS is excluded from the payload (client already has it), page-specific CSS is referenced as `<link>` tags
- Result: Fast initial paint with inlined shared CSS, reduced payload size on navigations

## Config Options

| Value | Behavior |
|-------|----------|
| `false` | No CSS inlining (default) |
| `true` | Inline ALL CSS (note: CSS is duplicated in HTML and RSC payload) |
| `'shared'` | Only inline root layout CSS (recommended for Tailwind) |

## Key Changes

- **config-shared.ts, config-schema.ts**: Updated `inlineCss` type to `boolean | 'shared'`
- **next_config.rs**: Added `InlineCssConfig` enum for Turbopack support
- **types.ts**: Added `rootLayoutCSSPaths` and `inlineCssMode` to `CollectedInlineCss`
- **render-css-resource.tsx**: Implemented 'shared' mode logic
- **get-layer-assets.tsx**: Track root layout CSS paths
- **app-page.ts, edge-ssr-app.ts**: Preserve 'shared' value (was converting to boolean)
- **inlineCss.mdx**: Updated docs with new `'shared'` option and limitations

## Test plan

- [x] Existing inline CSS tests pass (Turbopack + Webpack)
- [x] New test suite for `inlineCss: 'shared'` mode (10 tests)
- [x] Tests use Tailwind CSS in root layout (the main use case for 'shared' mode)
- [x] Tests verify root layout CSS is inlined, page CSS is `<link>` tags
- [x] Tests verify RSC payload behavior on navigation
- [x] Tests verify nested layout CSS behavior
- [x] Tests verify multiple client-side navigations work correctly