### PR TITLE
Fix actions/checkout clean failure

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -194,12 +194,15 @@ jobs:
       - run: corepack enable
       - run: pwd
 
-      # clean up any previous artifacts to avoid hitting disk space limits
-      - run: rm -rf ./* && rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 25
+          # we clean manually in next step since actions/checkout cleaning
+          # can be buggy with rmdir
+          clean: false
+
+      # clean up any previous artifacts to avoid hitting disk space limits
+      - run: git clean -xdf; git reset --hard HEAD; rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
 
       # local action -> needs to run after checkout
       - name: Install Rust

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -198,27 +198,51 @@ jobs:
       # This prevents the checkout action from failing when trying to clean up locked files
       - name: Pre-checkout cleanup
         run: |
-          # Kill any processes that might be holding locks on files in the workspace
-          # This includes node, pnpm, turbo, or any other processes running from this directory
+          # Kill any processes that might be holding locks on files in subdirectories
+          # Only target node_modules and .git to avoid killing the current workflow
           WORKSPACE_DIR="${GITHUB_WORKSPACE:-$PWD}"
           echo "Killing processes using files in: $WORKSPACE_DIR"
 
-          # Find and kill processes using files in the workspace
-          # Use lsof to find processes, then kill them
+          # Get current script's PID and parent PIDs to avoid killing ourselves
+          CURRENT_PID=$$
+          PARENT_PIDS=$(ps -o ppid= -p $CURRENT_PID | tr -d ' ')
+          echo "Current process: $CURRENT_PID, Parent: $PARENT_PIDS"
+
+          # Find and kill processes using files specifically in node_modules or .git
+          # This avoids killing processes using the workflow script itself
           if command -v lsof &> /dev/null; then
-            lsof +D "$WORKSPACE_DIR" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u | while read pid; do
-              if [ -n "$pid" ] && [ "$pid" != "$$" ]; then
-                echo "Killing process: $pid"
-                kill -9 "$pid" 2>/dev/null || true
+            for dir in "node_modules" ".git"; do
+              if [ -d "$WORKSPACE_DIR/$dir" ]; then
+                echo "Checking for processes using $dir..."
+                lsof +D "$WORKSPACE_DIR/$dir" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u | while read pid; do
+                  if [ -n "$pid" ] && [ "$pid" != "$CURRENT_PID" ] && [ "$pid" != "$PARENT_PIDS" ]; then
+                    # Double-check this isn't a bash/shell process from the workflow
+                    if ! ps -p "$pid" -o comm= 2>/dev/null | grep -qE '^(bash|sh|runner)$'; then
+                      echo "Killing process $pid using $dir"
+                      kill -9 "$pid" 2>/dev/null || true
+                    else
+                      echo "Skipping workflow-related process: $pid"
+                    fi
+                  fi
+                done
               fi
             done
           fi
 
-          # Also kill any node/pnpm/turbo processes that might be lingering
-          pkill -9 -f "node.*next" 2>/dev/null || true
-          pkill -9 node 2>/dev/null || true
-          pkill -9 pnpm 2>/dev/null || true
-          pkill -9 turbo 2>/dev/null || true
+          # Kill any lingering node/pnpm/turbo processes, but exclude current bash session
+          # Only kill processes that are children of the workspace, not the workflow itself
+          for proc in "node" "pnpm" "turbo"; do
+            pgrep "$proc" 2>/dev/null | while read pid; do
+              # Skip if it's us or our parent
+              if [ "$pid" != "$CURRENT_PID" ] && [ "$pid" != "$PARENT_PIDS" ]; then
+                # Check if process is actually using workspace files
+                if lsof -p "$pid" 2>/dev/null | grep -q "$WORKSPACE_DIR"; then
+                  echo "Killing $proc process: $pid"
+                  kill -9 "$pid" 2>/dev/null || true
+                fi
+              fi
+            done
+          done
 
           # Give the system a moment to release file handles
           sleep 2

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -194,12 +194,22 @@ jobs:
       - run: corepack enable
       - run: pwd
 
+      # Pre-checkout cleanup: remove any lingering files that might cause ENOTEMPTY errors
+      # This prevents the checkout action from failing when trying to clean up locked files
+      - name: Pre-checkout cleanup
+        run: |
+          if [ -d node_modules ]; then
+            rm -rf node_modules || true
+          fi
+          if [ -d .git ]; then
+            rm -rf .git || true
+          fi
+        shell: bash
+        continue-on-error: true
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 25
-          # we clean manually in next step since actions/checkout cleaning
-          # can be buggy with rmdir
-          clean: false
 
       # clean up any previous artifacts to avoid hitting disk space limits
       - run: git clean -xdf; git reset --hard HEAD; rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -197,6 +197,7 @@ jobs:
       # Pre-checkout cleanup: remove any lingering files that might cause ENOTEMPTY errors
       # This prevents the checkout action from failing when trying to clean up locked files
       - name: Pre-checkout cleanup
+        if: ${{ contains(fromJson(inputs.runs_on_labels), 'linux') }}
         run: |
           # Kill any processes that might be holding locks on files in subdirectories
           # Only target node_modules and .git to avoid killing the current workflow

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -198,12 +198,42 @@ jobs:
       # This prevents the checkout action from failing when trying to clean up locked files
       - name: Pre-checkout cleanup
         run: |
+          # Kill any processes that might be holding locks on files in the workspace
+          # This includes node, pnpm, turbo, or any other processes running from this directory
+          WORKSPACE_DIR="${GITHUB_WORKSPACE:-$PWD}"
+          echo "Killing processes using files in: $WORKSPACE_DIR"
+
+          # Find and kill processes using files in the workspace
+          # Use lsof to find processes, then kill them
+          if command -v lsof &> /dev/null; then
+            lsof +D "$WORKSPACE_DIR" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u | while read pid; do
+              if [ -n "$pid" ] && [ "$pid" != "$$" ]; then
+                echo "Killing process: $pid"
+                kill -9 "$pid" 2>/dev/null || true
+              fi
+            done
+          fi
+
+          # Also kill any node/pnpm/turbo processes that might be lingering
+          pkill -9 -f "node.*next" 2>/dev/null || true
+          pkill -9 node 2>/dev/null || true
+          pkill -9 pnpm 2>/dev/null || true
+          pkill -9 turbo 2>/dev/null || true
+
+          # Give the system a moment to release file handles
+          sleep 2
+
+          # Now remove the directories
           if [ -d node_modules ]; then
+            echo "Removing node_modules..."
             rm -rf node_modules || true
           fi
           if [ -d .git ]; then
+            echo "Removing .git..."
             rm -rf .git || true
           fi
+
+          echo "Pre-checkout cleanup complete"
         shell: bash
         continue-on-error: true
 

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -214,17 +214,21 @@ jobs:
             for dir in "node_modules" ".git"; do
               if [ -d "$WORKSPACE_DIR/$dir" ]; then
                 echo "Checking for processes using $dir..."
-                lsof +D "$WORKSPACE_DIR/$dir" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u | while read pid; do
-                  if [ -n "$pid" ] && [ "$pid" != "$CURRENT_PID" ] && [ "$pid" != "$PARENT_PIDS" ]; then
-                    # Double-check this isn't a bash/shell process from the workflow
-                    if ! ps -p "$pid" -o comm= 2>/dev/null | grep -qE '^(bash|sh|runner)$'; then
-                      echo "Killing process $pid using $dir"
-                      kill -9 "$pid" 2>/dev/null || true
-                    else
-                      echo "Skipping workflow-related process: $pid"
+                # Wrap in subshell with set +e to prevent exit on lsof errors
+                (
+                  set +e
+                  lsof +D "$WORKSPACE_DIR/$dir" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u | while read pid; do
+                    if [ -n "$pid" ] && [ "$pid" != "$CURRENT_PID" ] && [ "$pid" != "$PARENT_PIDS" ]; then
+                      # Double-check this isn't a bash/shell process from the workflow
+                      if ! ps -p "$pid" -o comm= 2>/dev/null | grep -qE '^(bash|sh|runner)$'; then
+                        echo "Killing process $pid using $dir"
+                        kill -9 "$pid" 2>/dev/null || true
+                      else
+                        echo "Skipping workflow-related process: $pid"
+                      fi
                     fi
-                  fi
-                done
+                  done
+                ) || true
               fi
             done
           fi
@@ -232,16 +236,19 @@ jobs:
           # Kill any lingering node/pnpm/turbo processes, but exclude current bash session
           # Only kill processes that are children of the workspace, not the workflow itself
           for proc in "node" "pnpm" "turbo"; do
-            pgrep "$proc" 2>/dev/null | while read pid; do
-              # Skip if it's us or our parent
-              if [ "$pid" != "$CURRENT_PID" ] && [ "$pid" != "$PARENT_PIDS" ]; then
-                # Check if process is actually using workspace files
-                if lsof -p "$pid" 2>/dev/null | grep -q "$WORKSPACE_DIR"; then
-                  echo "Killing $proc process: $pid"
-                  kill -9 "$pid" 2>/dev/null || true
+            (
+              set +e
+              pgrep "$proc" 2>/dev/null | while read pid; do
+                # Skip if it's us or our parent
+                if [ "$pid" != "$CURRENT_PID" ] && [ "$pid" != "$PARENT_PIDS" ]; then
+                  # Check if process is actually using workspace files
+                  if lsof -p "$pid" 2>/dev/null | grep -q "$WORKSPACE_DIR"; then
+                    echo "Killing $proc process: $pid"
+                    kill -9 "$pid" 2>/dev/null || true
+                  fi
                 fi
-              fi
-            done
+              done
+            ) || true
           done
 
           # Give the system a moment to release file handles

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -235,7 +235,6 @@ jobs:
 
           echo "Pre-checkout cleanup complete"
         shell: bash
-        continue-on-error: true
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -287,7 +287,7 @@ jobs:
           fetch-depth: 25
 
       # clean up any previous artifacts to avoid hitting disk space limits
-      - run: rm -rf /tmp/old-node_modules-*; rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
+      - run: (rm -rf /tmp/old-node_modules-* || true); rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
 
       # local action -> needs to run after checkout
       - name: Install Rust

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -287,7 +287,7 @@ jobs:
           fetch-depth: 25
 
       # clean up any previous artifacts to avoid hitting disk space limits
-      - run: /tmp/old-node_modules-*; rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
+      - run: rm -rf /tmp/old-node_modules-*; rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
 
       # local action -> needs to run after checkout
       - name: Install Rust

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -254,14 +254,28 @@ jobs:
           # Give the system a moment to release file handles
           sleep 2
 
-          # Now remove the directories
+          # Now remove the directories with multiple strategies
           if [ -d node_modules ]; then
             echo "Removing node_modules..."
-            rm -rf node_modules || true
+            # Try multiple removal strategies in order of preference
+            # 1. Standard rm -rf
+            rm -rf node_modules 2>/dev/null || \
+            # 2. Use find to delete files first, then directories (more thorough)
+            (find node_modules -type f -delete 2>/dev/null && find node_modules -depth -type d -delete 2>/dev/null) || \
+            # 3. Force remove with chmod (in case of permission issues)
+            (chmod -R 777 node_modules 2>/dev/null && rm -rf node_modules 2>/dev/null) || \
+            # 4. Final fallback - move to temp for OS to clean up later
+            (mv node_modules "/tmp/old-node_modules-$$" 2>/dev/null) || \
+            echo "Warning: Could not fully remove node_modules"
           fi
+
           if [ -d .git ]; then
             echo "Removing .git..."
-            rm -rf .git || true
+            rm -rf .git 2>/dev/null || \
+            (find .git -type f -delete 2>/dev/null && find .git -depth -type d -delete 2>/dev/null) || \
+            (chmod -R 777 .git 2>/dev/null && rm -rf .git 2>/dev/null) || \
+            (mv .git "/tmp/old-git-$$" 2>/dev/null) || \
+            echo "Warning: Could not fully remove .git"
           fi
 
           echo "Pre-checkout cleanup complete"

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -235,7 +235,7 @@ jobs:
 
           # Kill any lingering node/pnpm/turbo processes, but exclude current bash session
           # Only kill processes that are children of the workspace, not the workflow itself
-          for proc in "node" "pnpm" "turbo"; do
+          for proc in "pnpm" "turbo"; do
             (
               set +e
               pgrep "$proc" 2>/dev/null | while read pid; do
@@ -286,7 +286,7 @@ jobs:
           fetch-depth: 25
 
       # clean up any previous artifacts to avoid hitting disk space limits
-      - run: git clean -xdf; git reset --hard HEAD; rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
+      - run: /tmp/old-node_modules-*; rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
 
       # local action -> needs to run after checkout
       - name: Install Rust

--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -194,7 +194,8 @@ jobs:
       - run: corepack enable
       - run: pwd
 
-      - run: rm -rf .git
+      # clean up any previous artifacts to avoid hitting disk space limits
+      - run: rm -rf ./* && rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
 
       - uses: actions/checkout@v4
         with:
@@ -228,9 +229,6 @@ jobs:
           cache-provider: 'turbo'
           save-if: ${{ github.ref_name == 'canary' }}
           shared-key: ${{ inputs.rustCacheKey }}-${{ inputs.buildNativeTarget }}-build-${{ inputs.rustBuildProfile }}-${{ hashFiles('.cargo/config.toml') }}
-
-      # clean up any previous artifacts to avoid hitting disk space limits
-      - run: git clean -xdf && rm -rf /tmp/next-repo-*; rm -rf /tmp/next-install-* /tmp/yarn-* /tmp/ncc-cache target
 
       # Configure a git user so that Create Next App can initialize git repos during integration tests.
       - name: Set CI git user


### PR DESCRIPTION
This fails from clean being finicky during actions/checkout if `.git` directory isn't present and we can just use our own cleanup before checkout attempts to instead.  

x-ref: https://github.com/vercel/next.js/actions/runs/21328167060/job/61388831410?pr=89001
x-ref: https://github.com/vercel/next.js/actions/runs/21327973676/job/61388348348?pr=88831