### PR TITLE
feat(next/server): add getSourcemappedStack API

### DIFF
--- a/packages/next/server.d.ts
+++ b/packages/next/server.d.ts
@@ -20,3 +20,5 @@ export { ImageResponse } from 'next/dist/server/web/spec-extension/image-respons
 export type { ImageResponseOptions } from 'next/dist/compiled/@vercel/og/types'
 export { after } from 'next/dist/server/after'
 export { connection } from 'next/dist/server/request/connection'
+export { getSourcemappedStack } from 'next/dist/server/get-sourcemapped-stack'
+export type { GetSourcemappedStackOptions } from 'next/dist/server/get-sourcemapped-stack'

--- a/packages/next/server.js
+++ b/packages/next/server.js
@@ -13,6 +13,8 @@ const serverExports = {
     .URLPattern,
   after: require('next/dist/server/after').after,
   connection: require('next/dist/server/request/connection').connection,
+  getSourcemappedStack: require('next/dist/server/get-sourcemapped-stack')
+    .getSourcemappedStack,
 }
 
 // https://nodejs.org/api/esm.html#commonjs-namespaces
@@ -28,3 +30,4 @@ exports.userAgent = serverExports.userAgent
 exports.URLPattern = serverExports.URLPattern
 exports.after = serverExports.after
 exports.connection = serverExports.connection
+exports.getSourcemappedStack = serverExports.getSourcemappedStack

--- a/packages/next/src/server/get-sourcemapped-stack.ts
+++ b/packages/next/src/server/get-sourcemapped-stack.ts
@@ -1,0 +1,42 @@
+import type * as util from 'util'
+
+import { parseAndSourceMap } from './patch-error-inspect'
+
+export interface GetSourcemappedStackOptions {
+  /**
+   * Whether to include ANSI color codes in the output.
+   * Defaults to false for compatibility with log aggregators.
+   */
+  colors?: boolean
+}
+
+/**
+ * Returns a sourcemapped stack trace for the given error.
+ *
+ * Use this when you need programmatic access to sourcemapped stacks,
+ * for example when using custom loggers like pino or error reporting
+ * tools like Datadog or Sentry.
+ *
+ * @example
+ * ```ts
+ * import { getSourcemappedStack } from 'next/server'
+ *
+ * try {
+ *   await riskyOperation()
+ * } catch (error) {
+ *   logger.error({
+ *     message: error.message,
+ *     stack: getSourcemappedStack(error as Error)
+ *   })
+ * }
+ * ```
+ */
+export function getSourcemappedStack(
+  error: Error,
+  options?: GetSourcemappedStackOptions
+): string {
+  const inspectOptions: util.InspectOptions = {
+    colors: options?.colors ?? false,
+  }
+  return parseAndSourceMap(error, inspectOptions)
+}

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -327,7 +327,7 @@ function getSourcemappedFrameIfPossible(
   )
 }
 
-function parseAndSourceMap(
+export function parseAndSourceMap(
   error: Error,
   inspectOptions: util.InspectOptions
 ): string {

--- a/test/e2e/app-dir/server-source-maps/fixtures/default/app/get-sourcemapped-stack-api/page.js
+++ b/test/e2e/app-dir/server-source-maps/fixtures/default/app/get-sourcemapped-stack-api/page.js
@@ -1,0 +1,12 @@
+import { getSourcemappedStack } from 'next/server'
+
+function createError() {
+  return new Error('get-sourcemapped-stack-api-test')
+}
+
+export default function Page() {
+  const error = createError()
+  const stack = getSourcemappedStack(error)
+  console.log('SOURCEMAPPED_STACK_OUTPUT:', stack)
+  return <p>Test page</p>
+}

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -774,4 +774,22 @@ describe('app-dir - server source maps', () => {
       // TODO(veil): assert on 2nd error once that's bug free
     }
   })
+
+  it('getSourcemappedStack returns sourcemapped stack programmatically', async () => {
+    const outputIndex = next.cliOutput.length
+    await next.render('/get-sourcemapped-stack-api')
+
+    await retry(() => {
+      expect(next.cliOutput.slice(outputIndex)).toContain(
+        'SOURCEMAPPED_STACK_OUTPUT:'
+      )
+    })
+
+    const output = stripAnsi(next.cliOutput.slice(outputIndex))
+
+    // Should contain sourcemapped location, not minified
+    expect(output).toContain('get-sourcemapped-stack-api-test')
+    expect(output).toContain('at createError')
+    expect(output).toContain('app/get-sourcemapped-stack-api/page.js')
+  })
 })


### PR DESCRIPTION
### What?

Add a new public API `getSourcemappedStack(error)` to `next/server` that allows users to programmatically obtain sourcemapped stack traces.

### Why?

Custom loggers (pino, Datadog, OpenTelemetry) cannot access sourcemapped stacks because `error.stack` returns minified output. This is due to Next.js overriding `Error.prepareStackTrace` to return unsourcemapped stacks (for debugger compatibility).

Currently, sourcemapping only happens when errors are inspected via `console.log(error)`, but custom loggers access `error.stack` directly.

### How?

- Export the existing internal `parseAndSourceMap()` function from `patch-error-inspect.ts`
- Create a thin public wrapper `getSourcemappedStack()` with a clean API
- Default `colors: false` for compatibility with log aggregators

#### Usage

```ts
import { getSourcemappedStack } from 'next/server'

try {
  await riskyOperation()
} catch (error) {
  logger.error({
    message: error.message,
    stack: getSourcemappedStack(error as Error)
  })
}
```

#### Changes

- **New:** `packages/next/src/server/get-sourcemapped-stack.ts`
- **Modified:** `packages/next/src/server/patch-error-inspect.ts` - export `parseAndSourceMap`
- **Modified:** `packages/next/server.js` and `server.d.ts` - add exports

#### Test plan

- [x] E2E test added in `test/e2e/app-dir/server-source-maps/`
- [x] Test verifies sourcemapped output contains original file paths and function names

Ref #74646