### PR TITLE
url is considered as new if only a hash was changed from previous url

### DIFF
--- a/packages/next/src/shared/lib/router/router.ts
+++ b/packages/next/src/shared/lib/router/router.ts
@@ -2332,6 +2332,7 @@ export default class Router implements BaseRouter {
   }
 
   urlIsNew(asPath: string): boolean {
+    if (this.onlyAHashChange(asPath)) return true
     return this.asPath !== asPath
   }
 

--- a/test/e2e/app-dir/hash-navigation/app/page.tsx
+++ b/test/e2e/app-dir/hash-navigation/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div style={{ paddingTop: '100px' }}>
+      <Link href="#section" id="link">
+        Go to section
+      </Link>
+
+      <div style={{ marginTop: '15000px' }} id="section">
+        <h1 style={{ color: 'black' }}>Section</h1>
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/hash-navigation/hash-navigation.test.ts
+++ b/test/e2e/app-dir/hash-navigation/hash-navigation.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('hash navigation', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (skipped) return
+
+  it('should scroll again when navigating to the same hash', async () => {
+    const browser = await next.browser('/')
+
+    // First click
+    await browser.elementByCss('#section').click()
+    const firstScroll = await browser.eval(() => window.scrollY)
+    expect(firstScroll).toBeGreaterThan(0)
+
+    // Scroll back to top
+    await browser.eval(() => window.scrollTo(0, 0))
+    const resetScroll = await browser.eval(() => window.scrollY)
+    expect(resetScroll).toBe(0)
+
+    // Second click
+    await browser.elementByCss('#section').click()
+    const secondScroll = await browser.eval(() => window.scrollY)
+    expect(secondScroll).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making: -->

## For Contributors

### Fixing a bug

- Related issues linked using `fixes #88986`
- Tests added: `test/e2e/app-dir/hash-navigation`
- Errors have a helpful link attached

## For Maintainers

### What?

Fixes hash navigation when using `next/link` so that clicking a link to the same hash (e.g. `#section`) triggers scrolling again.

Previously, if the current URL already contained the same hash, Next.js treated it as a no-op and did not scroll.

---

### Why?

This breaks expected browser behavior and real user flows:

- Users scroll away from a section
- Click the same in-page link again
- Nothing happens

Native anchors scroll again, but Next’s router skipped navigation due to the `onlyAHashChange` logic.

This affects common patterns such as:
- Table of contents links
- In-page navigation menus
- Documentation pages

---

### How?

The router logic was updated so that same-hash navigations are no longer ignored.

Instead of treating identical hash changes as a no-op, the router now explicitly allows the navigation, ensuring scroll behavior is applied again.

---

Closes NEXT-
Fixes #88986
