### PR TITLE
re-introduce partial fallback -> route upgrading

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -935,8 +935,8 @@ export async function handler(
               : normalizedSrcPage
 
           const fallbackRouteParams =
-            // If we're in production and we have fallback route params, then we
-            // can use the manifest fallback route params.
+            // If we're in production and we have fallback route params, always
+            // use them for the fallback shell.
             isProduction && prerenderInfo?.fallbackRouteParams
               ? createOpaqueFallbackRouteParams(
                   prerenderInfo.fallbackRouteParams
@@ -976,6 +976,50 @@ export async function handler(
 
           // Otherwise, if we did get a fallback response, we should return it.
           if (fallbackResponse) {
+            if (
+              !isMinimalMode &&
+              isRoutePPREnabled &&
+              ssgCacheKey &&
+              incrementalCache &&
+              !isOnDemandRevalidate &&
+              !isDebugFallbackShell &&
+              // Avoid background revalidate during prefetches; this can trigger
+              // static prerender errors that surface as 500s for the prefetch
+              // request itself.
+              !isPrefetchRSCRequest
+            ) {
+              scheduleOnNextTick(async () => {
+                const responseCache = routeModule.getResponseCache(req)
+
+                try {
+                  await responseCache.revalidate(
+                    ssgCacheKey,
+                    incrementalCache,
+                    isRoutePPREnabled,
+                    false,
+                    (c) => {
+                      return doRender({
+                        span: c.span,
+                        // Route shell render should not use the fallback params.
+                        postponed: undefined,
+                        fallbackRouteParams: null,
+                        forceStaticRender: true,
+                      })
+                    },
+                    // We don't have a prior entry for this param-specific shell.
+                    null,
+                    hasResolved,
+                    ctx.waitUntil
+                  )
+                } catch (err) {
+                  console.error(
+                    'Error revalidating the page in the background',
+                    err
+                  )
+                }
+              })
+            }
+
             // Remove the cache control from the response to prevent it from being
             // used in the surrounding cache.
             delete fallbackResponse.cacheControl

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -983,6 +983,13 @@ export async function handler(
               incrementalCache &&
               !isOnDemandRevalidate &&
               !isDebugFallbackShell &&
+              // The testing API relies on deterministic shell behavior, so
+              // don't upgrade fallback shells in the background when it's
+              // exposed.
+              !exposeTestingApi &&
+              // Instant Navigation Testing API requests intentionally keep
+              // the route in shell mode; don't upgrade these in background.
+              !isInstantNavigationTest &&
               // Avoid background revalidate during prefetches; this can trigger
               // static prerender errors that surface as 500s for the prefetch
               // request itself.

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -570,6 +570,7 @@ export class IncrementalCache implements IncrementalCacheType {
     }
 
     let entry: IncrementalResponseCacheEntry | null = null
+    const { isFallback } = ctx
     const cacheControl = this.cacheControls.get(toRoute(cacheKey))
 
     let isStale: boolean | -1 | undefined
@@ -621,6 +622,7 @@ export class IncrementalCache implements IncrementalCacheType {
         cacheControl,
         revalidateAfter,
         value: cacheData.value,
+        isFallback,
       }
     }
 
@@ -638,6 +640,7 @@ export class IncrementalCache implements IncrementalCacheType {
         value: null,
         cacheControl,
         revalidateAfter,
+        isFallback,
       }
       this.set(cacheKey, entry.value, { ...ctx, cacheControl })
     }

--- a/packages/next/src/server/response-cache/types.ts
+++ b/packages/next/src/server/response-cache/types.ts
@@ -143,6 +143,7 @@ export interface IncrementalResponseCacheEntry {
    */
   isStale?: boolean | -1
   isMiss?: boolean
+  isFallback?: boolean
   value: Exclude<IncrementalCacheValue, CachedFetchValue> | null
 }
 
@@ -178,6 +179,7 @@ export type ResponseCacheEntry = {
   value: ResponseCacheValue | null
   isStale?: boolean | -1
   isMiss?: boolean
+  isFallback?: boolean
 }
 
 /**

--- a/packages/next/src/server/response-cache/utils.ts
+++ b/packages/next/src/server/response-cache/utils.ts
@@ -48,6 +48,7 @@ export async function toResponseCacheEntry(
     isMiss: response.isMiss,
     isStale: response.isStale,
     cacheControl: response.cacheControl,
+    isFallback: response.isFallback,
     value:
       response.value?.kind === CachedRouteKind.PAGES
         ? ({

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -87,10 +87,10 @@ describe('fallback-shells', () => {
                 isNextDev ? 'runtime' : 'buildtime'
               )
 
-              // `/bar` was not prerendered, and thus resumes the fallback shell.
               await browser.loadPage(
                 new URL(
-                  '/with-cached-io/with-static-params/with-suspense/params-in-page/bar',
+                  // Use a unique slug so earlier tests don't upgrade this route.
+                  `/with-cached-io/with-static-params/with-suspense/params-in-page/baz`,
                   next.url
                 ).href
               )

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/app/[slug]/loading.tsx
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/app/[slug]/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div id="fallback" data-fallback>
+      loading...
+    </div>
+  )
+}

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/app/[slug]/page.tsx
@@ -1,0 +1,29 @@
+import { Suspense } from 'react'
+
+async function Dynamic() {
+  await new Promise((resolve) => setTimeout(resolve, 1000))
+  return <div id="agent">Custom Data</div>
+}
+
+export async function generateStaticParams() {
+  return [{ slug: 'one' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  return (
+    <div>
+      <div id="slug" data-slug={slug}>
+        {slug}
+      </div>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Dynamic />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/app/layout.tsx
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/app/layout.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from 'react'
+
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/next.config.js
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/partial-fallback-shell-upgrade.test.ts
@@ -1,0 +1,26 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('partial-fallback-shell-upgrade', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('skipped in dev', () => {})
+    return
+  }
+
+  it('should upgrade the fallback shell to a route shell', async () => {
+    const pathname = '/two'
+    let $ = await next.render$(pathname)
+    expect($('#fallback').text()).toBe('loading...')
+    expect($('#slug').closest('[hidden]').length).toBe(1)
+
+    await retry(async () => {
+      $ = await next.render$(pathname)
+      expect($('#slug').closest('[hidden]').length).toBe(0)
+      expect($('#fallback').length).toBe(0)
+    })
+  })
+})

--- a/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
@@ -85,7 +85,8 @@ describe('middleware-static-rewrite', () => {
       expect(res.status).toBe(200)
 
       if (isNextDeploy) {
-        expect(getCacheHeader(res)).toMatch(/MISS|HIT|PRERENDER/)
+        // We produced a partial fallback shell for rewrite/[slug], so we shouldn't see a cache HIT.
+        expect(getCacheHeader(res)).toMatch(/MISS|PRERENDER/)
       } else {
         expect(res.headers.get('x-nextjs-cache')).toBe(null)
       }
@@ -106,20 +107,25 @@ describe('middleware-static-rewrite', () => {
         if (isNextDeploy) {
           expect(getCacheHeader(res)).toBe('HIT')
         } else {
-          expect(res.headers.get('x-nextjs-cache')).toBe(null)
+          expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
         }
+
+        html = await res.text()
+        $ = cheerio.load(html)
+
+        expect($('[data-rewrite-slug]').data('rewrite-slug')).toBe('not-broken')
+
+        // With partial fallback upgrading, the cached entry upgrades from a
+        // fallback shell to a full route render.
+        // These assertions are part of the outer retry block because the fallback->route shell upgrade
+        // happens in the background. It's possible to see a cache HIT for the fallback shell before it
+        // switches to the full route shell.
+        expect($('[data-layout="/"]').data('sentinel')).toBe('runtime')
+        expect($('[data-layout="/rewrite"]').data('sentinel')).toBe('runtime')
+        expect($('[data-layout="/rewrite/[slug]"]').data('sentinel')).toBe(
+          'runtime'
+        )
       })
-
-      html = await res.text()
-      $ = cheerio.load(html)
-
-      expect($('[data-rewrite-slug]').data('rewrite-slug')).toBe('not-broken')
-
-      expect($('[data-layout="/"]').data('sentinel')).toBe('buildtime')
-      expect($('[data-layout="/rewrite"]').data('sentinel')).toBe('buildtime')
-      expect($('[data-layout="/rewrite/[slug]"]').data('sentinel')).toBe(
-        'runtime'
-      )
     })
 
     it('should revalidate the overview page without replacing it with a 404', async () => {


### PR DESCRIPTION
In https://github.com/vercel/next.js/pull/69282, we landed support for Partial Fallback Prerendering. The intention behind this feature was to be able to upgrade from a partial fallback (essentially the UI produced when `await params` is dynamic, ie the param was not part of `generateStaticParams` at build time) to a route shell (when the param values are filled in, and thus we can prerender more of the page).

It was reverted in https://github.com/vercel/next.js/pull/79258 because we didn't add first-class support to this in the build output API and the necessary infrastructure changes to perform similar behavior that this PR does to trigger a background revalidation with params filled in.

This re-lands the feature in Next.js now that upstream support landed in our public adapter/CLI (https://github.com/vercel/vercel/pull/14703, https://github.com/vercel/vercel/pull/15338, https://github.com/nextjs/adapter-vercel/pull/39, and Vercel infra changes which are rolling out)