### PR TITLE
Limit number of server action arguments to 1000

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -983,5 +983,6 @@
   "982": "`serializeResumeDataCache` should not be called in edge runtime.",
   "983": "Invariant: global-error module is required but not found in loader tree",
   "984": "LRUCache: calculateSize returned %s, but size must be > 0. Items with size 0 would never be evicted, causing unbounded cache growth.",
-  "985": "No response is returned from route handler '%s'. Expected a Response object but received '%s' (method: %s, url: %s). Ensure you return a \\`Response\\` or a \\`NextResponse\\` in all branches of your handler."
+  "985": "No response is returned from route handler '%s'. Expected a Response object but received '%s' (method: %s, url: %s). Ensure you return a \\`Response\\` or a \\`NextResponse\\` in all branches of your handler.",
+  "986": "Server Action arguments list is too long (%s). Maximum allowed is %s."
 }

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1267,6 +1267,12 @@ export async function handleAction({
   }
 }
 
+/**
+ * Limit on the number of arguments passed to a server action. This prevents
+ * stack overflow during `action.apply()` from malicious requests.
+ */
+const SERVER_ACTION_ARGS_LIMIT = 1000
+
 async function executeActionAndPrepareForRender<
   TFn extends (...args: any[]) => Promise<any>,
 >(
@@ -1281,6 +1287,12 @@ async function executeActionAndPrepareForRender<
 }> {
   requestStore.phase = 'action'
   let skipPageRendering = actionWasForwarded
+
+  if (args.length > SERVER_ACTION_ARGS_LIMIT) {
+    throw new Error(
+      `Server Action arguments list is too long (${args.length}). Maximum allowed is ${SERVER_ACTION_ARGS_LIMIT}.`
+    )
+  }
 
   try {
     const actionResult = await workUnitAsyncStorage.run(requestStore, () =>

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -192,6 +192,27 @@ describe('app-dir action handling', () => {
     )
   })
 
+  it('should error if server action arguments list is too long', async () => {
+    const browser = await next.browser('/too-many-args')
+    const cliOutputIndex = next.cliOutput.length
+    await browser.elementById('submit').click()
+    const expectedError =
+      'Error: Server Action arguments list is too long (1001). Maximum allowed is 1000.'
+
+    const error = await browser.waitForElementByCss('#error-text')
+    if (isNextDev) {
+      expect(await error.text()).toBe(expectedError)
+    } else {
+      expect(await error.text()).toBe(GENERIC_RSC_ERROR)
+    }
+
+    if (!isNextDeploy) {
+      const cliOutput = next.cliOutput.slice(cliOutputIndex)
+      expect(cliOutput).toInclude(expectedError)
+      expect(cliOutput).not.toInclude('Action was called')
+    }
+  })
+
   it('should support headers and cookies', async () => {
     const browser = await next.browser('/header')
 

--- a/test/e2e/app-dir/actions/app/too-many-args/actions.js
+++ b/test/e2e/app-dir/actions/app/too-many-args/actions.js
@@ -1,0 +1,5 @@
+'use server'
+
+export async function action(...args) {
+  console.log(`Action was called with ${args.length} arguments.`)
+}

--- a/test/e2e/app-dir/actions/app/too-many-args/error.js
+++ b/test/e2e/app-dir/actions/app/too-many-args/error.js
@@ -1,0 +1,11 @@
+'use client'
+
+export default function Error({ error }) {
+  return (
+    <div>
+      <h2 id="error-text">
+        {error.name}: {error.message}
+      </h2>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/actions/app/too-many-args/page.js
+++ b/test/e2e/app-dir/actions/app/too-many-args/page.js
@@ -1,0 +1,15 @@
+'use client'
+
+import { action } from './actions'
+
+// Bind the action with 1000 arguments. React will add the form data as the last
+// argument when invoked, exceeding the limit.
+const boundAction = action.bind(null, ...Array(1000).fill(0))
+
+export default function Page() {
+  return (
+    <form action={boundAction}>
+      <button id="submit">Submit</button>
+    </form>
+  )
+}


### PR DESCRIPTION
This prevents stack overflow errors when malicious payloads include a large number of arguments.