### PR TITLE
Use null-prototype objects in server actions manifests

### DIFF
--- a/packages/next/src/server/app-render/manifests-singleton.ts
+++ b/packages/next/src/server/app-render/manifests-singleton.ts
@@ -274,13 +274,21 @@ export function selectWorkerForForwarding(
 export function setManifestsSingleton({
   page,
   clientReferenceManifest,
-  serverActionsManifest,
+  serverActionsManifest: rawServerActionsManifest,
 }: {
   page: string
   clientReferenceManifest: DeepReadonly<ClientReferenceManifest>
   serverActionsManifest: DeepReadonly<ActionManifest>
 }) {
   const existingSingleton = globalThisWithManifests[MANIFESTS_SINGLETON]
+
+  const serverActionsManifest: DeepReadonly<ActionManifest> = {
+    encryptionKey: rawServerActionsManifest.encryptionKey,
+    // Use null-prototypes for the action objects to prevent prototype pollution
+    // from affecting action ID lookups.
+    node: Object.assign(Object.create(null), rawServerActionsManifest.node),
+    edge: Object.assign(Object.create(null), rawServerActionsManifest.edge),
+  }
 
   if (existingSingleton) {
     existingSingleton.clientReferenceManifestsPerRoute.set(


### PR DESCRIPTION
As a defense-in-depth mechanism, we're converting the server actions manifests to use null-prototype objects, so that property lookups cannot traverse `Object.prototype`.