### PR TITLE
Create a new compaction mechanism to ensure the TaskCache functions properly

### DIFF
--- a/turbopack/crates/turbo-persistence/src/collector.rs
+++ b/turbopack/crates/turbo-persistence/src/collector.rs
@@ -112,8 +112,12 @@ impl<K: StoreKey, const SIZE_SHIFT: usize> Collector<K, SIZE_SHIFT> {
 
     /// Sorts the entries and returns them along with the total key size. This doesn't
     /// clear the entries.
+    ///
+    /// Entries are sorted by (key, value) to ensure entries with the same key but different
+    /// values are grouped together. This is important for collision-tolerant deduplication
+    /// during compaction.
     pub fn sorted(&mut self) -> (&[CollectorEntry<K>], usize) {
-        self.entries.sort_unstable_by(|a, b| a.key.cmp(&b.key));
+        self.entries.sort_unstable();
         (&self.entries, self.total_key_size)
     }
 

--- a/turbopack/crates/turbo-persistence/src/collector_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/collector_entry.rs
@@ -11,6 +11,28 @@ pub struct CollectorEntry<K: StoreKey> {
     pub value: CollectorEntryValue,
 }
 
+impl<K: StoreKey> PartialEq for CollectorEntry<K> {
+    fn eq(&self, other: &Self) -> bool {
+        self.key == other.key && self.value == other.value
+    }
+}
+
+impl<K: StoreKey> Eq for CollectorEntry<K> {}
+
+impl<K: StoreKey> PartialOrd for CollectorEntry<K> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<K: StoreKey> Ord for CollectorEntry<K> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.key
+            .cmp(&other.key)
+            .then_with(|| self.value.cmp(&other.value))
+    }
+}
+
 /// The size threshold for inline storage in CollectorEntryValue, this is the largest value that can
 /// be stored inline without inflating the size of the enum
 pub const TINY_VALUE_THRESHOLD: usize = 22;
@@ -43,6 +65,59 @@ impl CollectorEntryValue {
             CollectorEntryValue::Medium { value } => value.len(),
             CollectorEntryValue::Large { blob: _ } => 0,
             CollectorEntryValue::Deleted => 0,
+        }
+    }
+
+    /// Returns the byte slice for byte-content values, or None for Large/Deleted.
+    fn as_bytes(&self) -> Option<&[u8]> {
+        match self {
+            CollectorEntryValue::Tiny { value, len } => Some(&value[..*len as usize]),
+            CollectorEntryValue::Small { value } => Some(value),
+            CollectorEntryValue::Medium { value } => Some(value),
+            CollectorEntryValue::Large { .. } | CollectorEntryValue::Deleted => None,
+        }
+    }
+}
+
+impl PartialEq for CollectorEntryValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for CollectorEntryValue {}
+
+impl PartialOrd for CollectorEntryValue {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CollectorEntryValue {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Order: byte-content values < Large < Deleted
+        // For byte-content values, compare by bytes
+        match (self.as_bytes(), other.as_bytes()) {
+            (Some(a), Some(b)) => a.cmp(b),
+            (Some(_), None) => Ordering::Less,
+            (None, Some(_)) => Ordering::Greater,
+            (None, None) => {
+                // Both are Large or Deleted
+                match (self, other) {
+                    (
+                        CollectorEntryValue::Large { blob: a },
+                        CollectorEntryValue::Large { blob: b },
+                    ) => a.cmp(b),
+                    (CollectorEntryValue::Large { .. }, CollectorEntryValue::Deleted) => {
+                        Ordering::Less
+                    }
+                    (CollectorEntryValue::Deleted, CollectorEntryValue::Large { .. }) => {
+                        Ordering::Greater
+                    }
+                    (CollectorEntryValue::Deleted, CollectorEntryValue::Deleted) => Ordering::Equal,
+                    _ => unreachable!("as_bytes() returned None for non-Large/Deleted variant"),
+                }
+            }
         }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -20,7 +20,7 @@ use smallvec::SmallVec;
 
 pub use crate::compaction::selector::CompactConfig;
 use crate::{
-    DbConfig, QueryKey,
+    DbConfig, DeduplicationMode, QueryKey,
     arc_slice::ArcSlice,
     compaction::selector::{Compactable, get_merge_segments},
     compression::decompress_into_arc,
@@ -1081,12 +1081,23 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 }
                                 let mut used_collector = Collector::default();
                                 let mut unused_collector = Collector::default();
+                                let family_config = &self.config.family_configs[family as usize];
+
                                 for entry in iter {
                                     let entry = entry?;
 
-                                    // Remove duplicates
+                                    // Remove duplicates based on family's deduplication mode
                                     if let Some(current) = current.take() {
-                                        if current.key != entry.key {
+                                        let is_duplicate = match family_config.deduplication_mode {
+                                            DeduplicationMode::ByKeyOnly => {
+                                                current.key == entry.key
+                                            }
+                                            DeduplicationMode::ByKeyAndValue => {
+                                                current.key == entry.key
+                                                    && current.value.eq_for_dedup(&entry.value)
+                                            }
+                                        };
+                                        if !is_duplicate {
                                             let is_used =
                                                 used_key_hashes[family as usize].iter().any(
                                                     |amqf| amqf.contains_fingerprint(current.hash),

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -29,6 +29,17 @@ pub use arc_slice::ArcSlice;
 use constants::{DATA_THRESHOLD_PER_INITIAL_FILE, MAX_ENTRIES_PER_INITIAL_FILE};
 pub use db::{CompactConfig, MetaFileEntryInfo, MetaFileInfo, TurboPersistence};
 
+/// How to deduplicate entries during compaction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeduplicationMode {
+    /// Keep only the newest entry for each key (default LSM behavior).
+    /// When multiple entries have the same key, only the last one is retained.
+    ByKeyOnly,
+    /// Keep entries that differ by key OR value (for hash-collision-tolerant keyspaces).
+    /// Only drops entries that are true duplicates (same key AND same value).
+    /// Use this when a keyspace may contain different values that hash to the same key.
+    ByKeyAndValue,
+}
 /// Configuration for a single family's file limits during writes.
 ///
 /// Controls when SST files are split during writes.
@@ -45,6 +56,9 @@ pub struct FamilyConfig {
     /// Data size threshold for initial SST files (bytes).
     /// Controls memory usage during writes.
     pub data_threshold_per_initial_file: usize,
+
+    /// How to handle duplicate keys during compaction
+    pub deduplication_mode: DeduplicationMode,
 }
 
 impl Default for FamilyConfig {
@@ -52,6 +66,7 @@ impl Default for FamilyConfig {
         Self {
             max_entries_per_initial_file: MAX_ENTRIES_PER_INITIAL_FILE,
             data_threshold_per_initial_file: DATA_THRESHOLD_PER_INITIAL_FILE,
+            deduplication_mode: DeduplicationMode::ByKeyOnly,
         }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/lookup_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/lookup_entry.rs
@@ -1,3 +1,5 @@
+use std::cmp::Ordering;
+
 use crate::{
     ArcSlice,
     constants::{MAX_INLINE_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
@@ -45,24 +47,64 @@ impl LazyLookupValue<'_> {
     /// For `Medium` values, compares the compressed block bytes directly
     /// (assumes deterministic compression).
     pub fn eq_for_dedup(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                LazyLookupValue::Eager(LookupValue::Deleted),
-                LazyLookupValue::Eager(LookupValue::Deleted),
-            ) => true,
-            (
-                LazyLookupValue::Eager(LookupValue::Slice { value: a }),
-                LazyLookupValue::Eager(LookupValue::Slice { value: b }),
-            ) => a.as_ref() == b.as_ref(),
-            (
-                LazyLookupValue::Eager(LookupValue::Blob { sequence_number: a }),
-                LazyLookupValue::Eager(LookupValue::Blob { sequence_number: b }),
-            ) => a == b,
-            (
-                LazyLookupValue::Medium { block: a, .. },
-                LazyLookupValue::Medium { block: b, .. },
-            ) => *a == *b,
-            _ => false, // Different types are not equal
+        self.cmp_for_dedup(other) == Ordering::Equal
+    }
+
+    /// Compares two values for ordering purposes during merge sort.
+    ///
+    /// Order: Deleted < byte-content values (Slice/Medium) < Blob
+    /// This ensures entries with the same key are grouped by value for deduplication.
+    pub fn cmp_for_dedup(&self, other: &Self) -> Ordering {
+        // Assign a type order: Deleted=0, Slice/Medium=1, Blob=2
+        fn type_order(v: &LazyLookupValue) -> u8 {
+            match v {
+                LazyLookupValue::Eager(LookupValue::Deleted) => 0,
+                LazyLookupValue::Eager(LookupValue::Slice { .. })
+                | LazyLookupValue::Medium { .. } => 1,
+                LazyLookupValue::Eager(LookupValue::Blob { .. }) => 2,
+            }
+        }
+
+        match type_order(self).cmp(&type_order(other)) {
+            Ordering::Equal => {
+                // Same type category, compare within type
+                match (self, other) {
+                    (
+                        LazyLookupValue::Eager(LookupValue::Deleted),
+                        LazyLookupValue::Eager(LookupValue::Deleted),
+                    ) => Ordering::Equal,
+                    (
+                        LazyLookupValue::Eager(LookupValue::Slice { value: a }),
+                        LazyLookupValue::Eager(LookupValue::Slice { value: b }),
+                    ) => a.as_ref().cmp(b.as_ref()),
+                    (
+                        LazyLookupValue::Medium { block: a, .. },
+                        LazyLookupValue::Medium { block: b, .. },
+                    ) => a.cmp(b),
+                    (
+                        LazyLookupValue::Eager(LookupValue::Slice { value }),
+                        LazyLookupValue::Medium { block, .. },
+                    ) => {
+                        // Cross-type comparison: compare slice bytes with compressed bytes
+                        // This shouldn't happen for the same semantic value, but we need a total
+                        // order
+                        value.as_ref().cmp(*block)
+                    }
+                    (
+                        LazyLookupValue::Medium { block, .. },
+                        LazyLookupValue::Eager(LookupValue::Slice { value }),
+                    ) => {
+                        // Cross-type comparison
+                        (*block).cmp(value.as_ref())
+                    }
+                    (
+                        LazyLookupValue::Eager(LookupValue::Blob { sequence_number: a }),
+                        LazyLookupValue::Eager(LookupValue::Blob { sequence_number: b }),
+                    ) => a.cmp(b),
+                    _ => unreachable!("type_order comparison should have handled this"),
+                }
+            }
+            ord => ord,
         }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/lookup_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/lookup_entry.rs
@@ -39,6 +39,32 @@ impl LazyLookupValue<'_> {
             } => *uncompressed_size as usize,
         }
     }
+
+    /// Returns true if two values are equal for deduplication purposes.
+    ///
+    /// For `Medium` values, compares the compressed block bytes directly
+    /// (assumes deterministic compression).
+    pub fn eq_for_dedup(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                LazyLookupValue::Eager(LookupValue::Deleted),
+                LazyLookupValue::Eager(LookupValue::Deleted),
+            ) => true,
+            (
+                LazyLookupValue::Eager(LookupValue::Slice { value: a }),
+                LazyLookupValue::Eager(LookupValue::Slice { value: b }),
+            ) => a.as_ref() == b.as_ref(),
+            (
+                LazyLookupValue::Eager(LookupValue::Blob { sequence_number: a }),
+                LazyLookupValue::Eager(LookupValue::Blob { sequence_number: b }),
+            ) => a == b,
+            (
+                LazyLookupValue::Medium { block: a, .. },
+                LazyLookupValue::Medium { block: b, .. },
+            ) => *a == *b,
+            _ => false, // Different types are not equal
+        }
+    }
 }
 
 /// An entry from a SST file lookup.

--- a/turbopack/crates/turbo-persistence/src/merge_iter.rs
+++ b/turbopack/crates/turbo-persistence/src/merge_iter.rs
@@ -14,7 +14,9 @@ struct ActiveIterator<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> {
 
 impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> PartialEq for ActiveIterator<'l, T> {
     fn eq(&self, other: &Self) -> bool {
-        self.entry.hash == other.entry.hash && *self.entry.key == *other.entry.key
+        self.entry.hash == other.entry.hash
+            && *self.entry.key == *other.entry.key
+            && self.entry.value.eq_for_dedup(&other.entry.value)
     }
 }
 
@@ -32,6 +34,9 @@ impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> Ord for ActiveIterator<'l,
             .hash
             .cmp(&other.entry.hash)
             .then_with(|| (*self.entry.key).cmp(&other.entry.key))
+            // Sort by value to group entries with the same (key, value) together
+            // for collision-tolerant deduplication
+            .then_with(|| self.entry.value.cmp_for_dedup(&other.entry.value))
             .then_with(|| self.order.cmp(&other.order))
             .reverse()
     }

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
-    constants::MAX_MEDIUM_VALUE_SIZE,
+    constants::{DbConfig, DeduplicationMode, FamilyConfig, MAX_MEDIUM_VALUE_SIZE},
     db::{CompactConfig, TurboPersistence},
     parallel_scheduler::ParallelScheduler,
     write_batch::WriteBatch,
@@ -1505,6 +1505,225 @@ fn get_multiple_empty_result() -> Result<()> {
             results.is_empty(),
             "Should return empty vec for different family"
         );
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn compaction_by_key_only_drops_same_key_entries() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Default behavior: ByKeyOnly deduplication drops entries with same key
+    let key = vec![42u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
+            path.to_path_buf(),
+            RayonParallelScheduler,
+        )?;
+
+        // Write same key with different values in separate batches
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![1u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![2u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![3u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        // Before compaction: all 3 values exist
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 3, "Should have 3 values before compaction");
+
+        // Compact with default ByKeyOnly mode
+        db.full_compact()?;
+
+        // After compaction: only newest value remains
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            1,
+            "ByKeyOnly should keep only 1 value after compaction"
+        );
+        assert_eq!(results[0].as_ref(), &[3u8], "Should be the newest value");
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn compaction_by_key_and_value_preserves_different_values() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Configure family 0 to use ByKeyAndValue deduplication
+    let mut config = DbConfig::<1>::default();
+    config.family_configs[0] = FamilyConfig {
+        deduplication_mode: DeduplicationMode::ByKeyAndValue,
+        ..Default::default()
+    };
+
+    let key = vec![42u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            config,
+            RayonParallelScheduler,
+        )?;
+
+        // Write same key with different values in separate batches
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![1u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![2u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![3u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        // Before compaction: all 3 values exist
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 3, "Should have 3 values before compaction");
+
+        // Compact with ByKeyAndValue mode
+        db.full_compact()?;
+
+        // After compaction: all different values should be preserved
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            3,
+            "ByKeyAndValue should preserve all different values after compaction"
+        );
+
+        let mut values: Vec<u8> = results.iter().map(|r| r[0]).collect();
+        values.sort();
+        assert_eq!(values, vec![1, 2, 3], "All values should be preserved");
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn compaction_by_key_and_value_drops_true_duplicates() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Configure family 0 to use ByKeyAndValue deduplication
+    let mut config = DbConfig::<1>::default();
+    config.family_configs[0] = FamilyConfig {
+        deduplication_mode: DeduplicationMode::ByKeyAndValue,
+        ..Default::default()
+    };
+
+    let key = vec![42u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            config,
+            RayonParallelScheduler,
+        )?;
+
+        // Write same key with SAME value multiple times (true duplicates)
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![100u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![100u8].into())?; // Same value
+        db.commit_write_batch(batch)?;
+
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![100u8].into())?; // Same value
+        db.commit_write_batch(batch)?;
+
+        // Before compaction: all 3 entries exist
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 3, "Should have 3 entries before compaction");
+
+        // Compact with ByKeyAndValue mode
+        db.full_compact()?;
+
+        // After compaction: true duplicates should be deduplicated
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            1,
+            "ByKeyAndValue should deduplicate true duplicates (same key AND value)"
+        );
+        assert_eq!(results[0].as_ref(), &[100u8]);
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn compaction_by_key_and_value_preserves_all_unique_values() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Configure family 0 to use ByKeyAndValue deduplication
+    let mut config = DbConfig::<1>::default();
+    config.family_configs[0] = FamilyConfig {
+        deduplication_mode: DeduplicationMode::ByKeyAndValue,
+        ..Default::default()
+    };
+
+    let key = vec![42u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            config,
+            RayonParallelScheduler,
+        )?;
+
+        // Write a mix of different values (simulating hash collisions)
+        // Each unique value should be preserved after compaction
+        for value in [1u8, 2, 3, 4, 5] {
+            let batch = db.write_batch()?;
+            batch.put(0, key.clone(), vec![value].into())?;
+            db.commit_write_batch(batch)?;
+        }
+
+        // Before compaction: 5 entries exist
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 5, "Should have 5 entries before compaction");
+
+        // Compact
+        db.full_compact()?;
+
+        // After compaction: all 5 unique values should be preserved
+        // (this is the key difference from ByKeyOnly which would keep only 1)
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            5,
+            "ByKeyAndValue should preserve all unique values after compaction"
+        );
+
+        let mut values: Vec<u8> = results.iter().map(|r| r[0]).collect();
+        values.sort();
+        assert_eq!(values, vec![1, 2, 3, 4, 5], "Should have all values 1-5");
 
         db.shutdown()?;
     }

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
 use crate::{
-    constants::{DbConfig, DeduplicationMode, FamilyConfig, MAX_MEDIUM_VALUE_SIZE},
+    DbConfig, DeduplicationMode, FamilyConfig,
+    constants::MAX_MEDIUM_VALUE_SIZE,
     db::{CompactConfig, TurboPersistence},
     parallel_scheduler::ParallelScheduler,
     write_batch::WriteBatch,
@@ -1724,6 +1725,223 @@ fn compaction_by_key_and_value_preserves_all_unique_values() -> Result<()> {
         let mut values: Vec<u8> = results.iter().map(|r| r[0]).collect();
         values.sort();
         assert_eq!(values, vec![1, 2, 3, 4, 5], "Should have all values 1-5");
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn compaction_by_key_and_value_interleaved_batches() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Configure family 0 to use ByKeyAndValue deduplication
+    let mut config = DbConfig::<1>::default();
+    config.family_configs[0] = FamilyConfig {
+        deduplication_mode: DeduplicationMode::ByKeyAndValue,
+        ..Default::default()
+    };
+
+    let key = vec![42u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            config,
+            RayonParallelScheduler,
+        )?;
+
+        // Write interleaved values across multiple batches:
+        // Batch 1: value=1
+        // Batch 2: value=2
+        // Batch 3: value=1 (duplicate)
+        // Batch 4: value=3
+        // Batch 5: value=2 (duplicate)
+        // This tests that the merge sort correctly groups same values together
+        // even when they come from different SST files in different orders.
+        for value in [1u8, 2, 1, 3, 2] {
+            let batch = db.write_batch()?;
+            batch.put(0, key.clone(), vec![value].into())?;
+            db.commit_write_batch(batch)?;
+        }
+
+        // Before compaction: 5 entries exist
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 5, "Should have 5 entries before compaction");
+
+        // Compact
+        db.full_compact()?;
+
+        // After compaction: should have exactly 3 unique values (1, 2, 3)
+        // The duplicates should be merged
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            3,
+            "ByKeyAndValue should deduplicate to 3 unique values after compaction"
+        );
+
+        let mut values: Vec<u8> = results.iter().map(|r| r[0]).collect();
+        values.sort();
+        assert_eq!(values, vec![1, 2, 3], "Should have values 1, 2, 3");
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn compaction_by_key_and_value_same_batch_different_values() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Configure family 0 to use ByKeyAndValue deduplication
+    let mut config = DbConfig::<1>::default();
+    config.family_configs[0] = FamilyConfig {
+        deduplication_mode: DeduplicationMode::ByKeyAndValue,
+        ..Default::default()
+    };
+
+    let key = vec![42u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            config,
+            RayonParallelScheduler,
+        )?;
+
+        // Write multiple different values in the SAME batch
+        // All entries go into a single SST file
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![3u8].into())?;
+        batch.put(0, key.clone(), vec![1u8].into())?;
+        batch.put(0, key.clone(), vec![2u8].into())?;
+        batch.put(0, key.clone(), vec![1u8].into())?; // duplicate
+        batch.put(0, key.clone(), vec![3u8].into())?; // duplicate
+        db.commit_write_batch(batch)?;
+
+        // All 5 entries are stored in the SST file
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 5, "Should have 5 entries in single SST");
+
+        // Compaction on a single file just moves it (no merge = no deduplication)
+        db.full_compact()?;
+
+        // Still 5 entries - single-file compaction doesn't deduplicate
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            5,
+            "Single-file compaction preserves all entries"
+        );
+
+        // Now write a second batch with a new value to create a second SST file
+        let batch = db.write_batch()?;
+        batch.put(0, key.clone(), vec![4u8].into())?;
+        db.commit_write_batch(batch)?;
+
+        // 6 entries total now
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 6, "Should have 6 entries across 2 SST files");
+
+        // Second compaction will merge the two files and deduplicate
+        db.full_compact()?;
+
+        // After multi-file compaction: should have exactly 4 unique values (1, 2, 3, 4)
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            4,
+            "Multi-file compaction should deduplicate to 4 unique values"
+        );
+
+        let mut values: Vec<u8> = results.iter().map(|r| r[0]).collect();
+        values.sort();
+        assert_eq!(values, vec![1, 2, 3, 4], "Should have values 1, 2, 3, 4");
+
+        db.shutdown()?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn compaction_by_key_and_value_multiple_compactions() -> Result<()> {
+    let tempdir = tempfile::tempdir()?;
+    let path = tempdir.path();
+
+    // Configure family 0 to use ByKeyAndValue deduplication
+    let mut config = DbConfig::<1>::default();
+    config.family_configs[0] = FamilyConfig {
+        deduplication_mode: DeduplicationMode::ByKeyAndValue,
+        ..Default::default()
+    };
+
+    let key = vec![42u8];
+
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            config.clone(),
+            RayonParallelScheduler,
+        )?;
+
+        // Write initial values
+        for value in [1u8, 2, 3] {
+            let batch = db.write_batch()?;
+            batch.put(0, key.clone(), vec![value].into())?;
+            db.commit_write_batch(batch)?;
+        }
+
+        db.full_compact()?;
+
+        // After first compaction: 3 unique values
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 3);
+
+        // Add more values (some duplicates)
+        for value in [2u8, 4, 1] {
+            let batch = db.write_batch()?;
+            batch.put(0, key.clone(), vec![value].into())?;
+            db.commit_write_batch(batch)?;
+        }
+
+        // Before second compaction: 6 entries total (3 old + 3 new)
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 6);
+
+        // Second compaction
+        db.full_compact()?;
+
+        // After second compaction: 4 unique values (1, 2, 3, 4)
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(
+            results.len(),
+            4,
+            "Should have 4 unique values after second compaction"
+        );
+
+        let mut values: Vec<u8> = results.iter().map(|r| r[0]).collect();
+        values.sort();
+        assert_eq!(values, vec![1, 2, 3, 4], "Should have values 1, 2, 3, 4");
+
+        db.shutdown()?;
+    }
+
+    // Reopen and verify persistence
+    {
+        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
+            path.to_path_buf(),
+            config,
+            RayonParallelScheduler,
+        )?;
+
+        let results = db.get_multiple(0, &key.as_slice())?;
+        assert_eq!(results.len(), 4, "Should still have 4 values after reopen");
 
         db.shutdown()?;
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -10,8 +10,8 @@ use anyhow::{Ok, Result};
 use parking_lot::Mutex;
 use smallvec::SmallVec;
 use turbo_persistence::{
-    ArcSlice, CompactConfig, DbConfig, FamilyConfig, KeyBase, StoreKey, TurboPersistence,
-    ValueBuffer,
+    ArcSlice, CompactConfig, DbConfig, DeduplicationMode, FamilyConfig, KeyBase, StoreKey,
+    TurboPersistence, ValueBuffer,
 };
 use turbo_tasks::{JoinHandle, message_queue::TimingEvent, spawn, turbo_tasks};
 
@@ -69,6 +69,9 @@ impl KeySpace {
                 // file size as compaction
                 max_entries_per_initial_file: 1024 * 1024,
                 data_threshold_per_initial_file: 256 * 1024 * 1024,
+                // We need to gracefully handle hash collisions, so only deduplicate if both key and
+                // value are identical
+                deduplication_mode: DeduplicationMode::ByKeyAndValue,
                 ..Default::default()
             },
         }


### PR DESCRIPTION
When compacting TaskCache data, dedup by key and value.   Ensure SSTs break sorting ties by value so that merging works correctly.


