### PR TITLE
[ci] Exclude tests by filename when merging manifests

### DIFF
--- a/test/get-test-filter.js
+++ b/test/get-test-filter.js
@@ -80,7 +80,13 @@ function getTestFilter() {
       tests
         .filter((test) => {
           // Check to see if this was included as-is in the manifest.
-          if (test.file in manifest.suites) return true
+          if (test.file in manifest.suites) {
+            // When merging multiple manifests, a test file may be included in
+            // the suites by one manifest, but excluded in the rules by another.
+            // If it's excluded by filename (and not by pattern), the exclusion
+            // takes precedence over the inclusion.
+            return !manifest.rules.exclude?.includes(test.file)
+          }
 
           // If this file doesn't match any of the include patterns, then it
           // should be excluded.


### PR DESCRIPTION
Follow-up to #88824.

When merging multiple test manifests, a test file may be included in `suites` by one manifest, but excluded in `rules` by another. This change ensures that if a test file is excluded by filename (and not by pattern), the exclusion takes precedence over the inclusion.

Specifically, this allows us to skip Cache Components deploy tests via the `exclude` rules in `cache-components-tests-manifest.json`, even though those may be included in the `suites` of `deploy-tests-manifest.json`.

Alternatively, we could maintain separate deploy tests manifests for Cache Components and non-Cache Components deploy tests.