### PR TITLE
[ci] Run Cache Component tests with React's default Transition Indicator enabled

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -722,6 +722,7 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
+        export __NEXT_EXPERIMENTAL_TRANSITION_INDICATOR=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json,test/cache-components-tests-manifest.json"
         export NEXT_E2E_TEST_TIMEOUT=240000
         export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }}
@@ -962,6 +963,7 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
+        export __NEXT_EXPERIMENTAL_TRANSITION_INDICATOR=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export IS_WEBPACK_TEST=1
 
@@ -985,6 +987,7 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
+        export __NEXT_EXPERIMENTAL_TRANSITION_INDICATOR=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=dev
         export IS_WEBPACK_TEST=1
@@ -1010,6 +1013,7 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
+        export __NEXT_EXPERIMENTAL_TRANSITION_INDICATOR=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=start
         export IS_WEBPACK_TEST=1


### PR DESCRIPTION
[Fix for the blocking Chrome bug has been released](https://chromiumdash.appspot.com/commit/b887d6f518c2e5f12df3ec038086d89052cb64f7). 

This should still fail since it has only landed in Chrome Beta.

Part of https://linear.app/vercel/issue/NAR-499/