### PR TITLE
Don't include build id in runtime files if not needed

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1350,15 +1350,19 @@ impl Project {
     }
 
     #[turbo_tasks::function]
-    pub(super) fn edge_env(&self) -> Vc<EnvMap> {
-        let edge_env = fxindexmap! {
-            rcstr!("__NEXT_BUILD_ID") => self.build_id.clone(),
+    pub(super) async fn edge_env(&self) -> Result<Vc<EnvMap>> {
+        let mut edge_env = fxindexmap! {
             rcstr!("NEXT_SERVER_ACTIONS_ENCRYPTION_KEY") => self.encryption_key.clone(),
             rcstr!("__NEXT_PREVIEW_MODE_ID") => self.preview_props.preview_mode_id.clone(),
             rcstr!("__NEXT_PREVIEW_MODE_ENCRYPTION_KEY") => self.preview_props.preview_mode_encryption_key.clone(),
             rcstr!("__NEXT_PREVIEW_MODE_SIGNING_KEY") => self.preview_props.preview_mode_signing_key.clone(),
         };
-        Vc::cell(edge_env)
+        if !*self.next_config.has_deployment_id().await? {
+            // The build id is only needed at runtime when there is no deployment id.
+            edge_env.insert(rcstr!("__NEXT_BUILD_ID"), self.build_id.clone());
+        }
+
+        Ok(Vc::cell(edge_env))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1875,6 +1875,11 @@ impl NextConfig {
     }
 
     #[turbo_tasks::function]
+    pub fn has_deployment_id(&self) -> Vc<bool> {
+        Vc::cell(self.deployment_id.is_some())
+    }
+
+    #[turbo_tasks::function]
     pub fn cache_kinds(&self) -> Vc<CacheKinds> {
         let mut cache_kinds = CacheKinds::default();
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -987,5 +987,6 @@
   "986": "Server Action arguments list is too long (%s). Maximum allowed is %s.",
   "987": "Invalid \\`deploymentId\\` configuration: must be a string. See https://nextjs.org/docs/messages/deploymentid-not-a-string",
   "988": "Invalid \\`deploymentId\\` configuration: contains invalid characters. Only alphanumeric characters, hyphens, and underscores are allowed. See https://nextjs.org/docs/messages/deploymentid-invalid-characters",
-  "989": "Loaded static props were from an outdated deployment, forcing a hard reload"
+  "989": "Loaded static props were from an outdated deployment, forcing a hard reload",
+  "990": "Invariant: buildID or deploymentId is required"
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2009,7 +2009,9 @@ export default async function build(
                     path.join(SERVER_DIRECTORY, DYNAMIC_CSS_MANIFEST + '.js'),
                   ]
                 : []),
-              BUILD_ID_FILE,
+              // When deploymentId is available, headers are used for softnavs, and the build id
+              // isn't needed anymore.
+              ...(config.deploymentId ? [BUILD_ID_FILE] : []),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.js'),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.json'),
               SERVER_FILES_MANIFEST + '.json',

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2011,7 +2011,9 @@ export default async function build(
                 : []),
               // When deploymentId is available, headers are used for softnavs, and the build id
               // isn't needed anymore.
-              ...(config.deploymentId ? [BUILD_ID_FILE] : []),
+              ...(!config.deploymentId || !ciEnvironment.hasNextSupport
+                ? [BUILD_ID_FILE]
+                : []),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.js'),
               path.join(SERVER_DIRECTORY, NEXT_FONT_MANIFEST + '.json'),
               SERVER_FILES_MANIFEST + '.json',

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -124,6 +124,7 @@ export async function handler(
 
   const {
     buildId,
+    deploymentId,
     params,
     nextConfig,
     parsedUrl,
@@ -249,6 +250,7 @@ export async function handler(
     },
     sharedContext: {
       buildId,
+      deploymentId,
     },
   }
   const nodeNextReq = new NodeNextRequest(req)

--- a/packages/next/src/client/page-loader.ts
+++ b/packages/next/src/client/page-loader.ts
@@ -37,7 +37,7 @@ export type GoodPageCache = {
 }
 
 export default class PageLoader {
-  private buildId: string
+  private buildId: string | undefined
   private assetPrefix: string
   private promisedSsgManifest: Promise<Set<string>>
   private promisedDevPagesManifest?: Promise<string[]>
@@ -45,7 +45,7 @@ export default class PageLoader {
 
   public routeLoader: RouteLoader
 
-  constructor(buildId: string, assetPrefix: string) {
+  constructor(buildId: string | undefined, assetPrefix: string) {
     this.routeLoader = createRouteLoader(assetPrefix)
 
     this.buildId = buildId

--- a/packages/next/src/export/routes/app-route.ts
+++ b/packages/next/src/export/routes/app-route.ts
@@ -49,7 +49,8 @@ export async function exportAppRoute(
   fileWriter: MultiFileWriter,
   cacheComponents: boolean,
   experimental: Required<Pick<ExperimentalConfig, 'authInterrupts'>>,
-  buildId: string
+  buildId: string,
+  deploymentId: string
 ): Promise<ExportRouteResult> {
   // Ensure that the URL is absolute.
   req.url = `http://localhost:3000${req.url}`
@@ -90,6 +91,7 @@ export async function exportAppRoute(
     },
     sharedContext: {
       buildId,
+      deploymentId,
     },
   }
 

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -248,7 +248,8 @@ async function exportPageImpl(
       fileWriter,
       commonRenderOpts.cacheComponents,
       commonRenderOpts.experimental,
-      buildId
+      buildId,
+      deploymentId
     )
   }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -238,7 +238,7 @@ export type DynamicParam = {
 export type GenerateFlight = typeof generateDynamicFlightRenderResult
 
 export type AppSharedContext = {
-  buildId: string
+  buildId: string | undefined
   deploymentId: string
 }
 
@@ -2432,7 +2432,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
     renderOpts,
     // @TODO move to workUnitStore of type Request
     isPrefetchRequest,
-    buildId: sharedContext.buildId,
+    buildId: sharedContext.deploymentId,
     previouslyRevalidatedTags,
     nonce,
   })

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -239,7 +239,7 @@ export type GenerateFlight = typeof generateDynamicFlightRenderResult
 
 export type AppSharedContext = {
   buildId: string | undefined
-  deploymentId: string
+  deploymentId: string | undefined
 }
 
 export type AppRenderContext = {
@@ -2432,7 +2432,7 @@ export const renderToHTMLOrFlight: AppPageRender = (
     renderOpts,
     // @TODO move to workUnitStore of type Request
     isPrefetchRequest,
-    buildId: sharedContext.deploymentId,
+    buildId: sharedContext.buildId || sharedContext.deploymentId || '',
     previouslyRevalidatedTags,
     nonce,
   })

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -95,7 +95,8 @@ export interface WorkStore {
   isPrefetchRequest?: boolean
 
   /**
-   * Prefer `sharedContext.buildId` instead. This only exists because it's needed in use-cache-wrapper
+   * Prefer `sharedContext.buildId` instead. This can also be the deploymentId when available. This
+   * only exists because it's needed in use-cache-wrapper for cache busting between builds.
    */
   buildId: string
 

--- a/packages/next/src/server/async-storage/work-store.ts
+++ b/packages/next/src/server/async-storage/work-store.ts
@@ -65,7 +65,7 @@ export type WorkStoreContext = {
     Partial<Pick<RenderOpts, 'reactLoadableManifest'>>
 
   /**
-   * The build ID of the current build.
+   * The build or deployment ID of the current build, for cache busting of server actions.
    */
   buildId: string
 

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -161,7 +161,7 @@ export async function setupFsCheck(opts: {
     },
     headers: [],
   }
-  let buildId = 'development'
+  let buildId: string | undefined
   let prerenderManifest: PrerenderManifest
 
   if (!opts.dev) {
@@ -170,9 +170,6 @@ export async function setupFsCheck(opts: {
       buildId = await fs.readFile(buildIdPath, 'utf8')
     } catch (err: any) {
       if (err.code !== 'ENOENT') throw err
-      throw new Error(
-        `Could not find a production build in the '${opts.config.distDir}' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id`
-      )
     }
 
     try {
@@ -230,7 +227,12 @@ export async function setupFsCheck(opts: {
     const appRoutesManifestPath = path.join(distDir, APP_PATH_ROUTES_MANIFEST)
 
     const routesManifest = JSON.parse(
-      await fs.readFile(routesManifestPath, 'utf8')
+      await fs.readFile(routesManifestPath, 'utf8').catch((err) => {
+        if (err.code !== 'ENOENT') throw err
+        throw new Error(
+          `Could not find a production build in the '${opts.config.distDir}' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id`
+        )
+      })
     ) as RoutesManifest
 
     prerenderManifest = JSON.parse(
@@ -266,7 +268,7 @@ export async function setupFsCheck(opts: {
       appFiles.add(appRoutesManifest[key])
     }
 
-    const escapedBuildId = escapeStringRegexp(buildId)
+    const escapedBuildId = buildId ? escapeStringRegexp(buildId) : buildId
 
     for (const route of routesManifest.dataRoutes) {
       if (isDynamicRoute(route.page)) {
@@ -345,6 +347,8 @@ export async function setupFsCheck(opts: {
       headers: routesManifest.headers,
     }
   } else {
+    buildId = 'development'
+
     // dev handling
     customRoutes = await loadCustomRoutes(opts.config)
 

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -161,7 +161,7 @@ export async function setupFsCheck(opts: {
     },
     headers: [],
   }
-  let buildId: string | undefined
+  let buildId = 'development'
   let prerenderManifest: PrerenderManifest
 
   if (!opts.dev) {
@@ -170,6 +170,9 @@ export async function setupFsCheck(opts: {
       buildId = await fs.readFile(buildIdPath, 'utf8')
     } catch (err: any) {
       if (err.code !== 'ENOENT') throw err
+      throw new Error(
+        `Could not find a production build in the '${opts.config.distDir}' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id`
+      )
     }
 
     try {
@@ -227,12 +230,7 @@ export async function setupFsCheck(opts: {
     const appRoutesManifestPath = path.join(distDir, APP_PATH_ROUTES_MANIFEST)
 
     const routesManifest = JSON.parse(
-      await fs.readFile(routesManifestPath, 'utf8').catch((err) => {
-        if (err.code !== 'ENOENT') throw err
-        throw new Error(
-          `Could not find a production build in the '${opts.config.distDir}' directory. Try building your app with 'next build' before starting the production server. https://nextjs.org/docs/messages/production-start-no-build-id`
-        )
-      })
+      await fs.readFile(routesManifestPath, 'utf8')
     ) as RoutesManifest
 
     prerenderManifest = JSON.parse(
@@ -347,8 +345,6 @@ export async function setupFsCheck(opts: {
       headers: routesManifest.headers,
     }
   } else {
-    buildId = 'development'
-
     // dev handling
     customRoutes = await loadCustomRoutes(opts.config)
 

--- a/packages/next/src/server/load-manifest.external.ts
+++ b/packages/next/src/server/load-manifest.external.ts
@@ -148,6 +148,38 @@ export function loadManifestFromRelativePath<T extends object>({
   }
 }
 
+export function loadManifestFileFromRelativePath({
+  projectDir,
+  distDir,
+  manifest,
+  shouldCache,
+  cache,
+  handleMissing,
+}: {
+  projectDir: string
+  distDir: string
+  manifest: string
+  shouldCache?: boolean
+  cache?: Map<string, unknown>
+  handleMissing?: boolean
+}): string | undefined {
+  try {
+    const manifestPath = join(
+      /* turbopackIgnore: true */ projectDir,
+      distDir,
+      manifest
+    )
+
+    // @ts-expect-error loadManifest skipParse isn't really reflected in the type signature
+    return loadManifest(manifestPath, shouldCache, cache, true)
+  } catch (err) {
+    if (handleMissing) {
+      return undefined
+    }
+    throw err
+  }
+}
+
 export function clearManifestCache(path: string, cache = sharedCache): boolean {
   return cache.delete(path)
 }

--- a/packages/next/src/server/normalizers/request/next-data.test.ts
+++ b/packages/next/src/server/normalizers/request/next-data.test.ts
@@ -2,10 +2,12 @@ import { NextDataPathnameNormalizer } from './next-data'
 
 describe('NextDataPathnameNormalizer', () => {
   describe('constructor', () => {
-    it('should error when no buildID is provided', () => {
+    it('should error when no buildID and no deploymentId is provided', () => {
       expect(() => {
         new NextDataPathnameNormalizer('', '')
-      }).toThrowErrorMatchingInlineSnapshot(`"Invariant: buildID is required"`)
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"Invariant: buildID or deploymentId is required"`
+      )
     })
   })
 

--- a/packages/next/src/server/normalizers/request/next-data.ts
+++ b/packages/next/src/server/normalizers/request/next-data.ts
@@ -7,11 +7,10 @@ import { SuffixPathnameNormalizer } from './suffix'
 export class NextDataPathnameNormalizer implements PathnameNormalizer {
   private readonly prefix: PrefixPathnameNormalizer
   private readonly suffix = new SuffixPathnameNormalizer('.json')
-  constructor(buildID: string, deploymentId: string) {
-    if (!buildID) {
-      throw new Error('Invariant: buildID is required')
+  constructor(buildID: string | undefined, deploymentId: string) {
+    if (!buildID && !deploymentId) {
+      throw new Error('Invariant: buildID or deploymentId is required')
     }
-
     // When deploymentId is set, data URLs don't include the build ID
     this.prefix = new PrefixPathnameNormalizer(
       deploymentId ? '/_next/data' : `/_next/data/${buildID}`

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -301,7 +301,7 @@ export type PagesSharedContext = {
    * Used to facilitate caching of page bundles, we send it to the client so
    * that pageloader knows where to load bundles.
    */
-  buildId: string
+  buildId: string | undefined
 
   /**
    * The deployment ID if the user is deploying to a platform that provides one.

--- a/packages/next/src/server/render.tsx
+++ b/packages/next/src/server/render.tsx
@@ -306,7 +306,7 @@ export type PagesSharedContext = {
   /**
    * The deployment ID if the user is deploying to a platform that provides one.
    */
-  deploymentId: string
+  deploymentId: string | undefined
 
   /**
    * True if the user is using a custom server.

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -103,7 +103,8 @@ export class WrappedNextRouterError {
 export type AppRouteModule = typeof import('../../../build/templates/app-route')
 
 export type AppRouteSharedContext = {
-  buildId: string
+  deploymentId: string
+  buildId: string | undefined
 }
 
 /**
@@ -702,7 +703,7 @@ export class AppRouteRouteModule extends RouteModule<
     const staticGenerationContext: WorkStoreContext = {
       page: this.definition.page,
       renderOpts: context.renderOpts,
-      buildId: context.sharedContext.buildId,
+      buildId: context.sharedContext.deploymentId,
       previouslyRevalidatedTags: [],
     }
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -703,7 +703,10 @@ export class AppRouteRouteModule extends RouteModule<
     const staticGenerationContext: WorkStoreContext = {
       page: this.definition.page,
       renderOpts: context.renderOpts,
-      buildId: context.sharedContext.deploymentId,
+      buildId:
+        context.sharedContext.deploymentId ||
+        context.sharedContext.buildId ||
+        '',
       previouslyRevalidatedTags: [],
     }
 

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -182,7 +182,7 @@ export abstract class RouteModule<
     srcPage: string,
     projectDir?: string
   ): {
-    buildId: string
+    buildId: string | undefined
     buildManifest: BuildManifest
     fallbackBuildManifest: BuildManifest
     routesManifest: DeepReadonly<DevRoutesManifest>
@@ -205,7 +205,7 @@ export abstract class RouteModule<
         str ? JSON.parse(str) : undefined
 
       result = {
-        buildId: process.env.__NEXT_BUILD_ID || '',
+        buildId: process.env.__NEXT_BUILD_ID,
         buildManifest: self.__BUILD_MANIFEST as any,
         fallbackBuildManifest: {} as any,
         reactLoadableManifest: maybeJSONParse(self.__REACT_LOADABLE_MANIFEST),
@@ -249,7 +249,7 @@ export abstract class RouteModule<
       if (!projectDir) {
         throw new Error('Invariant: projectDir is required for node runtime')
       }
-      const { loadManifestFromRelativePath } =
+      const { loadManifestFromRelativePath, loadManifestFileFromRelativePath } =
         require('../load-manifest.external') as typeof import('../load-manifest.external')
       const normalizedPagePath = normalizePagePath(srcPage)
 
@@ -350,11 +350,11 @@ export abstract class RouteModule<
             }),
         this.isDev
           ? 'development'
-          : loadManifestFromRelativePath<any>({
+          : loadManifestFileFromRelativePath({
               projectDir,
               distDir: this.distDir,
               manifest: BUILD_ID_FILE,
-              skipParse: true,
+              handleMissing: true,
             }),
         loadManifestFromRelativePath<any>({
           projectDir,
@@ -563,7 +563,7 @@ export abstract class RouteModule<
     }
   ): Promise<
     | {
-        buildId: string
+        buildId: string | undefined
         deploymentId: string
         locale?: string
         locales?: readonly string[]

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -586,7 +586,6 @@ export abstract class RouteModule<
           | DeepReadonly<RequiredServerFilesManifest>
           | undefined
         reactLoadableManifest: DeepReadonly<ReactLoadableManifest>
-        routesManifest: DeepReadonly<DevRoutesManifest>
         prerenderManifest: DeepReadonly<PrerenderManifest>
         // we can't pull in the client reference type or it causes issues with
         // our pre-compiled types

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -142,7 +142,8 @@ export async function adapter(
   }
 
   // Ensure users only see page requests, never data requests.
-  let buildId = process.env.__NEXT_BUILD_ID || ''
+  // TODO
+  let buildId = process.env.__NEXT_BUILD_ID
   if ('buildId' in requestURL) {
     buildId = (requestURL as NextURL).buildId || ''
     requestURL.buildId = ''

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -81,7 +81,7 @@ export class EdgeRouteModuleWrapper {
       caseSensitive: false,
     })
 
-    const { nextConfig } = this.routeModule.getNextConfigEdge(
+    const { nextConfig, deploymentId } = this.routeModule.getNextConfigEdge(
       new WebNextRequest(request)
     )
 
@@ -119,6 +119,7 @@ export class EdgeRouteModuleWrapper {
       },
       sharedContext: {
         buildId: '', // TODO: Populate this properly.
+        deploymentId,
       },
     }
 

--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -89,7 +89,7 @@ export type NEXT_DATA = {
   props: Record<string, any>
   page: string
   query: ParsedUrlQuery
-  buildId: string
+  buildId: string | undefined
   assetPrefix?: string
   nextExport?: boolean
   autoExport?: boolean


### PR DESCRIPTION
After
- https://github.com/vercel/next.js/pull/88855
- https://github.com/vercel/next.js/pull/88959

we don't need the build id at runtime anymore when a deployment id is available.

Closes PACK-6756