### PR TITLE
Next.js docs broken links

### DIFF
--- a/BROKEN_LINKS_ANALYSIS.md
+++ b/BROKEN_LINKS_ANALYSIS.md
@@ -1,0 +1,84 @@
+# Broken Links Analysis - nextjs.org
+
+**Date:** 2026-01-27  
+**Context:** Slack report from #feedback-docs showing 28 broken links on nextjs.org
+
+These broken links appear on nextjs.org (served by vercel/front) but reference docs content from vercel/next.js.
+
+## Broken Links and Their Correct Redirects
+
+### 1. `/docs/advanced-features/customizing-postcss-config`
+
+**Referenced from:** `nextjs.org/learn/pages-router/assets-metadata-css-styling-tips`  
+**Should redirect to:** `/docs/pages/guides/post-css`  
+**File exists at:** `docs/02-pages/02-guides/post-css.mdx`
+
+### 2. `/docs/advanced-features/measuring-performance`
+
+**Referenced from:** `nextjs.org/learn/seo/custom-reporting`  
+**Should redirect to:** `/docs/app/api-reference/functions/use-report-web-vitals`  
+**Alternative:** `/docs/app/guides/analytics`  
+**File exists at:** `docs/01-app/03-api-reference/04-functions/use-report-web-vitals.mdx`
+
+### 3. `/docs/advanced-features/preview-mode`
+
+**Referenced from:** `nextjs.org/learn/pages-router/api-routes-api-routes-details`  
+**Should redirect to:** `/docs/pages/guides/preview-mode`  
+**File exists at:** `docs/02-pages/02-guides/preview-mode.mdx`
+
+### 4. `/docs/api-routes/dynamic-api-routes`
+
+**Referenced from:** `nextjs.org/learn/pages-router/api-routes-api-routes-details`  
+**Should redirect to:** `/docs/pages/building-your-application/routing/api-routes`  
+**File exists at:** `docs/02-pages/03-building-your-application/01-routing/07-api-routes.mdx`  
+**Note:** The file covers dynamic API routes in its content
+
+### 5. `/docs/app/api-reference/config/next-config-js/turbopackPersistentCaching`
+
+**Referenced from:** `nextjs.org/blog/next-15-5`  
+**Should redirect to:** `/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache`  
+**File exists at:** `docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackFileSystemCache.mdx`  
+**Note:** The feature was likely renamed from "PersistentCaching" to "FileSystemCache"
+
+### 6. `/docs/app/api-reference/functions/not-found`
+
+**Referenced from:** Multiple pages including:
+
+- `nextjs.org/docs/app/api-reference/components/image`
+- `nextjs.org/docs`
+- `nextjs.org/docs/app/api-reference`
+- `nextjs.org/docs/app/api-reference/cli`
+- `nextjs.org/docs/app/api-reference/config/next-config-js/compress`
+
+**Current path is CORRECT:** `/docs/app/api-reference/functions/not-found`  
+**File exists at:** `docs/01-app/03-api-reference/04-functions/not-found.mdx`  
+**Issue:** This file EXISTS and should work. The problem may be:
+
+- A build/deployment issue in vercel/front
+- The file not being properly indexed
+- A routing issue in the front repo
+
+## Summary
+
+**Action Required:**
+
+1. Add redirects in `vercel/front` for old paths (#1-5)
+2. Investigate why #6 is broken when the file exists
+
+**Redirect Rules Needed (for vercel/front):**
+
+```
+/docs/advanced-features/customizing-postcss-config → /docs/pages/guides/post-css
+/docs/advanced-features/measuring-performance → /docs/app/api-reference/functions/use-report-web-vitals
+/docs/advanced-features/preview-mode → /docs/pages/guides/preview-mode
+/docs/api-routes/dynamic-api-routes → /docs/pages/building-your-application/routing/api-routes
+/docs/app/api-reference/config/next-config-js/turbopackPersistentCaching → /docs/app/api-reference/config/next-config-js/turbopackFileSystemCache
+```
+
+## Notes
+
+- The `/docs` folder in `vercel/next.js` contains the source markdown files
+- These files are served by the `vercel/front` repository at nextjs.org
+- All referenced source files exist and are correctly structured in this repo
+- The broken links are from external references (learn pages, blog) that point to old/renamed paths
+- No changes needed in `vercel/next.js` docs content itself


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md
-->

## For Maintainers

### What?
Created `BROKEN_LINKS_ANALYSIS.md` to document an investigation into reported broken links on nextjs.org. This file details:
- A list of 5 broken `/docs` links reported on nextjs.org.
- Their correct target paths in the current `vercel/next.js` documentation.
- The corresponding redirect rules to be implemented in `vercel/front`.
- An investigation into a 6th reported broken link (`/docs/app/api-reference/functions/not-found`), concluding the source file exists and the issue is likely deployment-related in `vercel/front`.

### Why?
To address and resolve reported broken links on `nextjs.org` by providing a clear action plan for the `vercel/front` repository. The investigation confirmed that the issues stem from external references (e.g., from `/learn` or `/blog` pages on `nextjs.org`) pointing to old or renamed documentation paths, rather than broken links within the `vercel/next.js` docs source itself.

### How?
- Performed a comprehensive search and validation of reported broken links within the `vercel/next.js` `/docs` folder.
- Identified that the broken links are external references pointing to old or renamed documentation paths.
- Mapped the old paths to their current, correct counterparts in the `vercel/next.js` documentation.
- Documented the findings and proposed redirect rules in `BROKEN_LINKS_ANALYSIS.md`.

Closes NEXT-
Fixes #

---
[Slack Thread](https://vercel.slack.com/archives/C02F56A54LU/p1769504411412189?thread_ts=1769504411.412189&cid=C02F56A54LU)

<a href="https://cursor.com/background-agent?bcId=bc-4ac1203d-799d-4b8a-a0aa-e243b8fc7f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4ac1203d-799d-4b8a-a0aa-e243b8fc7f2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

