### PR TITLE
Turbopack: refactor extend transforms

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -327,6 +327,7 @@ pub async fn get_client_module_options_context(
         ecmascript: EcmascriptOptionsContext {
             esm_url_rewrite_behavior: Some(UrlRewriteBehavior::Relative),
             enable_typeof_window_inlining: Some(TypeofWindow::Object),
+            enable_import_as_bytes: *next_config.turbopack_import_type_bytes().await?,
             source_maps,
             infer_module_side_effects: *next_config.turbopack_infer_module_side_effects().await?,
             ..Default::default()

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -9,11 +9,10 @@ use crate::{
     next_client::context::ClientContextType,
     next_config::NextConfig,
     next_shared::transforms::{
-        debug_fn_name::get_debug_fn_name_rule, get_import_type_bytes_rule,
-        get_next_dynamic_transform_rule, get_next_font_transform_rule, get_next_image_rule,
-        get_next_lint_transform_rule, get_next_modularize_imports_rule,
-        get_next_pages_transforms_rule, get_server_actions_transform_rule,
-        next_cjs_optimizer::get_next_cjs_optimizer_rule,
+        debug_fn_name::get_debug_fn_name_rule, get_next_dynamic_transform_rule,
+        get_next_font_transform_rule, get_next_image_rule, get_next_lint_transform_rule,
+        get_next_modularize_imports_rule, get_next_pages_transforms_rule,
+        get_server_actions_transform_rule, next_cjs_optimizer::get_next_cjs_optimizer_rule,
         next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
         next_pure::get_next_pure_rule, server_actions::ActionsTransform,
     },
@@ -111,10 +110,6 @@ pub async fn get_next_client_transforms_rules(
         );
 
         rules.push(get_next_image_rule().await?);
-    }
-
-    if *next_config.turbopack_import_type_bytes().await? {
-        rules.push(get_import_type_bytes_rule());
     }
 
     Ok(rules)

--- a/crates/next-core/src/next_client/transforms.rs
+++ b/crates/next-core/src/next_client/transforms.rs
@@ -10,8 +10,8 @@ use crate::{
     next_config::NextConfig,
     next_shared::transforms::{
         debug_fn_name::get_debug_fn_name_rule, get_import_type_bytes_rule,
-        get_import_type_json_rule, get_next_dynamic_transform_rule, get_next_font_transform_rule,
-        get_next_image_rule, get_next_lint_transform_rule, get_next_modularize_imports_rule,
+        get_next_dynamic_transform_rule, get_next_font_transform_rule, get_next_image_rule,
+        get_next_lint_transform_rule, get_next_modularize_imports_rule,
         get_next_pages_transforms_rule, get_server_actions_transform_rule,
         next_cjs_optimizer::get_next_cjs_optimizer_rule,
         next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
@@ -116,8 +116,6 @@ pub async fn get_next_client_transforms_rules(
     if *next_config.turbopack_import_type_bytes().await? {
         rules.push(get_import_type_bytes_rule());
     }
-
-    rules.push(get_import_type_json_rule());
 
     Ok(rules)
 }

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -553,11 +553,11 @@ pub async fn get_server_module_options_context(
 
     // A set of custom ecma transform rules being applied to server context.
     let source_transform_rules: Vec<ModuleRule> = vec![
-        get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?,
-        get_relay_transform_rule(next_config, project_path.clone()).await?,
-        get_emotion_transform_rule(next_config).await?,
-        get_react_remove_properties_transform_rule(next_config).await?,
         get_remove_console_transform_rule(next_config).await?,
+        get_react_remove_properties_transform_rule(next_config).await?,
+        get_emotion_transform_rule(next_config).await?,
+        get_relay_transform_rule(next_config, project_path.clone()).await?,
+        get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?,
     ]
     .into_iter()
     .flatten()
@@ -621,15 +621,14 @@ pub async fn get_server_module_options_context(
 
     let module_options_context = match ty {
         ServerContextType::Pages { .. } | ServerContextType::PagesApi { .. } => {
-            next_server_rules.extend(page_transform_rules);
+            next_server_rules.extend(source_transform_rules);
             if let ServerContextType::Pages { .. } = ty {
                 next_server_rules.push(
                     get_next_react_server_components_transform_rule(next_config, false, None)
                         .await?,
                 );
             }
-
-            next_server_rules.extend(source_transform_rules);
+            next_server_rules.extend(page_transform_rules);
 
             foreign_next_server_rules.extend(internal_custom_rules);
 
@@ -699,12 +698,12 @@ pub async fn get_server_module_options_context(
         ServerContextType::AppSSR { app_dir, .. } => {
             foreign_next_server_rules.extend(internal_custom_rules);
 
-            next_server_rules.extend(page_transform_rules.clone());
+            next_server_rules.extend(source_transform_rules);
             next_server_rules.push(
                 get_next_react_server_components_transform_rule(next_config, false, Some(app_dir))
                     .await?,
             );
-            next_server_rules.extend(source_transform_rules);
+            next_server_rules.extend(page_transform_rules.clone());
 
             let module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {
@@ -763,8 +762,6 @@ pub async fn get_server_module_options_context(
             ecmascript_client_reference_transition_name,
             ..
         } => {
-            next_server_rules.extend(page_transform_rules);
-
             let client_directive_transformer = ecmascript_client_reference_transition_name.map(
                 |ecmascript_client_reference_transition_name| {
                     get_ecma_transform_rule(
@@ -777,16 +774,16 @@ pub async fn get_server_module_options_context(
                 },
             );
 
-            foreign_next_server_rules.extend(client_directive_transformer.clone());
             foreign_next_server_rules.extend(internal_custom_rules);
+            foreign_next_server_rules.extend(client_directive_transformer.clone());
 
-            next_server_rules.extend(client_directive_transformer.clone());
+            next_server_rules.extend(source_transform_rules);
             next_server_rules.push(
                 get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
                     .await?,
             );
-
-            next_server_rules.extend(source_transform_rules);
+            next_server_rules.extend(client_directive_transformer.clone());
+            next_server_rules.extend(page_transform_rules);
 
             let module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {
@@ -843,8 +840,6 @@ pub async fn get_server_module_options_context(
             app_dir,
             ecmascript_client_reference_transition_name,
         } => {
-            next_server_rules.extend(source_transform_rules);
-
             let mut common_next_server_rules = vec![
                 get_next_react_server_components_transform_rule(next_config, true, Some(app_dir))
                     .await?,
@@ -864,6 +859,8 @@ pub async fn get_server_module_options_context(
 
             next_server_rules.extend(common_next_server_rules.iter().cloned());
             internal_custom_rules.extend(common_next_server_rules);
+
+            next_server_rules.extend(source_transform_rules);
 
             let module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -578,6 +578,7 @@ pub async fn get_server_module_options_context(
     let module_options_context = ModuleOptionsContext {
         ecmascript: EcmascriptOptionsContext {
             enable_typeof_window_inlining: Some(TypeofWindow::Undefined),
+            enable_import_as_bytes: *next_config.turbopack_import_type_bytes().await?,
             import_externals: *next_config.import_externals().await?,
             ignore_dynamic_requests: true,
             source_maps,

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -12,8 +12,8 @@ use crate::{
     next_config::NextConfig,
     next_server::context::ServerContextType,
     next_shared::transforms::{
-        get_import_type_bytes_rule, get_next_dynamic_transform_rule, get_next_font_transform_rule,
-        get_next_image_rule, get_next_lint_transform_rule, get_next_modularize_imports_rule,
+        get_next_dynamic_transform_rule, get_next_font_transform_rule, get_next_image_rule,
+        get_next_lint_transform_rule, get_next_modularize_imports_rule,
         get_next_pages_transforms_rule, get_next_track_dynamic_imports_transform_rule,
         get_server_actions_transform_rule, next_cjs_optimizer::get_next_cjs_optimizer_rule,
         next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
@@ -213,10 +213,6 @@ pub async fn get_next_server_transforms_rules(
                 vec![ModuleRuleEffect::Ignore],
             ));
         }
-    }
-
-    if *next_config.turbopack_import_type_bytes().await? {
-        rules.push(get_import_type_bytes_rule());
     }
 
     Ok(rules)

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -12,11 +12,10 @@ use crate::{
     next_config::NextConfig,
     next_server::context::ServerContextType,
     next_shared::transforms::{
-        get_import_type_bytes_rule, get_import_type_json_rule, get_next_dynamic_transform_rule,
-        get_next_font_transform_rule, get_next_image_rule, get_next_lint_transform_rule,
-        get_next_modularize_imports_rule, get_next_pages_transforms_rule,
-        get_next_track_dynamic_imports_transform_rule, get_server_actions_transform_rule,
-        next_cjs_optimizer::get_next_cjs_optimizer_rule,
+        get_import_type_bytes_rule, get_next_dynamic_transform_rule, get_next_font_transform_rule,
+        get_next_image_rule, get_next_lint_transform_rule, get_next_modularize_imports_rule,
+        get_next_pages_transforms_rule, get_next_track_dynamic_imports_transform_rule,
+        get_server_actions_transform_rule, next_cjs_optimizer::get_next_cjs_optimizer_rule,
         next_disallow_re_export_all_in_page::get_next_disallow_export_all_in_page_rule,
         next_edge_node_api_assert::next_edge_node_api_assert,
         next_middleware_dynamic_assert::get_middleware_dynamic_assert_rule,
@@ -219,8 +218,6 @@ pub async fn get_next_server_transforms_rules(
     if *next_config.turbopack_import_type_bytes().await? {
         rules.push(get_import_type_bytes_rule());
     }
-
-    rules.push(get_import_type_json_rule());
 
     Ok(rules)
 }

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -32,9 +32,7 @@ pub use server_actions::get_server_actions_transform_rule;
 use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
-use turbopack_core::reference_type::{
-    EcmaScriptModulesReferenceSubType, ReferenceType, UrlReferenceSubType,
-};
+use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform};
 
 use crate::next_image::{StructuredImageModuleType, module::BlurPlaceholderMode};

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -125,25 +125,6 @@ pub(crate) fn module_rule_match_pages_page_file(
     ])
 }
 
-pub(crate) fn get_import_type_bytes_rule() -> ModuleRule {
-    // Move this into turbopack once the feature is standardized
-    ModuleRule::new(
-        RuleCondition::ReferenceType(ReferenceType::EcmaScriptModules(
-            EcmaScriptModulesReferenceSubType::ImportWithType("bytes".into()),
-        )),
-        vec![ModuleRuleEffect::ModuleType(ModuleType::InlinedBytesJs)],
-    )
-}
-
-pub(crate) fn get_import_type_json_rule() -> ModuleRule {
-    ModuleRule::new(
-        RuleCondition::ReferenceType(ReferenceType::EcmaScriptModules(
-            EcmaScriptModulesReferenceSubType::ImportWithType("json".into()),
-        )),
-        vec![ModuleRuleEffect::ModuleType(ModuleType::Json)],
-    )
-}
-
 pub(crate) enum EcmascriptTransformStage {
     Preprocess,
     Main,

--- a/test/e2e/transpile-packages-typescript-foreign/index.test.ts
+++ b/test/e2e/transpile-packages-typescript-foreign/index.test.ts
@@ -28,9 +28,9 @@ This module doesn't have an associated type`)
         expect(
           next.cliOutput.match(/Unknown module type/g).length
         ).toBeLessThanOrEqual(1)
-        expect(
-          next.cliOutput.match(/Missing module type/g).length
-        ).toBeLessThanOrEqual(1)
+        expect(next.cliOutput.match(/Missing module type/g)?.length ?? 0).toBe(
+          0
+        )
       } else {
         expect(next.cliOutput).toContain(`pkg/index.ts
 Module parse failed: Unexpected token`)

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -361,7 +361,10 @@ impl SingleModuleGraph {
                     }
                 }
                 if !duplicates.is_empty() {
-                    panic!("Duplicate module idents in graph: {duplicates:#?}");
+                    panic!(
+                        "Duplicate module idents in graph: {duplicates:#?}\n{:#?}",
+                        modules
+                    );
                 }
             }
         }

--- a/turbopack/crates/turbopack-tests/tests/execution.rs
+++ b/turbopack/crates/turbopack-tests/tests/execution.rs
@@ -416,6 +416,7 @@ async fn run_test_operation(prepared_test: ResolvedVc<PreparedTest>) -> Result<V
                 enable_typescript_transform: Some(
                     TypescriptTransformOptions::default().resolved_cell(),
                 ),
+                enable_import_as_bytes: true,
                 import_externals: true,
                 enable_exports_info_inlining: true,
                 infer_module_side_effects: true,

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -361,6 +361,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                 enable_typescript_transform: Some(
                     TypescriptTransformOptions::default().resolved_cell(),
                 ),
+                enable_import_as_bytes: true,
                 enable_jsx: Some(JsxTransformOptions::resolved_cell(JsxTransformOptions {
                     development: true,
                     ..Default::default()

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -720,10 +720,9 @@ async fn process_default_internal(
                         }
                     }
                     ModuleRuleEffect::ModuleType(module) => {
-                        // Apply any collected transforms to this module type.
-                        // This clears the collected transform lists.
-                        // If another ModuleType is encountered later, it will override
-                        // with any transforms collected since this point.
+                        // Apply any collected transforms to this module type and exit rule
+                        // processing. Once a ModuleType is determined, we
+                        // stop processing further rules.
                         let mut module = module.clone();
                         apply_module_rule_transforms(
                             &mut module,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -24,7 +24,7 @@ use turbopack_core::{
     chunk::SourceMapsType,
     compile_time_info::CompileTimeInfo,
     context::{AssetContext, ProcessResult},
-    ident::Layer,
+    ident::{AssetIdent, Layer},
     issue::{IssueExt, IssueSource, module::ModuleIssue},
     module::{Module, ModuleSideEffects},
     node_addon_module::NodeAddonModule,
@@ -43,7 +43,8 @@ use turbopack_core::{
 };
 use turbopack_css::{CssModuleAsset, ModuleCssAsset};
 use turbopack_ecmascript::{
-    AnalyzeMode, EcmascriptModuleAsset, EcmascriptModuleAssetType, TreeShakingMode,
+    AnalyzeMode, EcmascriptInputTransform, EcmascriptModuleAsset, EcmascriptModuleAssetType,
+    TreeShakingMode,
     chunk::EcmascriptChunkPlaceable,
     inlined_bytes_module::InlinedBytesJsModule,
     references::{
@@ -506,6 +507,157 @@ async fn process_default(
     .await
 }
 
+/// Apply collected transforms to a module type.
+/// For Ecmascript/Typescript variants: merge collected transforms into the module type.
+/// For Custom: call extend_ecmascript_transforms() if any transforms exist.
+/// For non-ecmascript types: warn if transforms exist, return unchanged.
+async fn apply_module_rule_transforms(
+    module_type: &mut ModuleType,
+    collected_preprocess: &mut Vec<EcmascriptInputTransform>,
+    collected_main: &mut Vec<EcmascriptInputTransform>,
+    collected_postprocess: &mut Vec<EcmascriptInputTransform>,
+    ident: ResolvedVc<AssetIdent>,
+    current_source: ResolvedVc<Box<dyn Source>>,
+) -> Result<()> {
+    let has_transforms = !collected_preprocess.is_empty()
+        || !collected_main.is_empty()
+        || !collected_postprocess.is_empty();
+
+    // If no transforms were collected, return early
+    if !has_transforms {
+        return Ok(());
+    }
+
+    match module_type {
+        ModuleType::Ecmascript {
+            preprocess,
+            main,
+            postprocess,
+            ..
+        } => {
+            // Prepend collected preprocess/main, append collected postprocess
+            let mut final_preprocess = std::mem::take(collected_preprocess);
+            final_preprocess.extend(preprocess.owned().await?);
+            *preprocess = ResolvedVc::cell(final_preprocess);
+
+            let mut final_main = std::mem::take(collected_main);
+            final_main.extend(main.owned().await?);
+            *main = ResolvedVc::cell(final_main);
+
+            let mut final_postprocess = postprocess.owned().await?;
+            final_postprocess.extend(std::mem::take(collected_postprocess));
+            *postprocess = ResolvedVc::cell(final_postprocess);
+        }
+        ModuleType::Typescript {
+            preprocess,
+            main,
+            postprocess,
+            ..
+        } => {
+            let mut final_preprocess = std::mem::take(collected_preprocess);
+            final_preprocess.extend(preprocess.owned().await?);
+            *preprocess = ResolvedVc::cell(final_preprocess);
+
+            let mut final_main = std::mem::take(collected_main);
+            final_main.extend(main.owned().await?);
+            *main = ResolvedVc::cell(final_main);
+
+            let mut final_postprocess = postprocess.owned().await?;
+            final_postprocess.extend(std::mem::take(collected_postprocess));
+            *postprocess = ResolvedVc::cell(final_postprocess);
+        }
+        ModuleType::TypescriptDeclaration {
+            preprocess,
+            main,
+            postprocess,
+            ..
+        } => {
+            let mut final_preprocess = std::mem::take(collected_preprocess);
+            final_preprocess.extend(preprocess.owned().await?);
+            *preprocess = ResolvedVc::cell(final_preprocess);
+
+            let mut final_main = std::mem::take(collected_main);
+            final_main.extend(main.owned().await?);
+            *main = ResolvedVc::cell(final_main);
+
+            let mut final_postprocess = postprocess.owned().await?;
+            final_postprocess.extend(std::mem::take(collected_postprocess));
+            *postprocess = ResolvedVc::cell(final_postprocess);
+        }
+        ModuleType::EcmascriptExtensionless {
+            preprocess,
+            main,
+            postprocess,
+            ..
+        } => {
+            let mut final_preprocess = std::mem::take(collected_preprocess);
+            final_preprocess.extend(preprocess.owned().await?);
+            *preprocess = ResolvedVc::cell(final_preprocess);
+
+            let mut final_main = std::mem::take(collected_main);
+            final_main.extend(main.owned().await?);
+            *main = ResolvedVc::cell(final_main);
+
+            let mut final_postprocess = postprocess.owned().await?;
+            final_postprocess.extend(std::mem::take(collected_postprocess));
+            *postprocess = ResolvedVc::cell(final_postprocess);
+        }
+        ModuleType::Custom(custom_module_type) => {
+            if has_transforms {
+                match custom_module_type
+                    .extend_ecmascript_transforms(
+                        Vc::cell(std::mem::take(collected_preprocess)),
+                        Vc::cell(std::mem::take(collected_main)),
+                        Vc::cell(std::mem::take(collected_postprocess)),
+                    )
+                    .to_resolved()
+                    .await
+                {
+                    Ok(new_custom_module_type) => {
+                        *custom_module_type = new_custom_module_type;
+                    }
+                    Err(_) => {
+                        ModuleIssue::new(
+                            *ident,
+                            rcstr!("Invalid module type"),
+                            rcstr!(
+                                "The custom module type didn't accept the additional Ecmascript \
+                                 transforms"
+                            ),
+                            Some(IssueSource::from_source_only(current_source)),
+                        )
+                        .to_resolved()
+                        .await?
+                        .emit();
+                    }
+                }
+            }
+        }
+        other => {
+            if has_transforms {
+                ModuleIssue::new(
+                    *ident,
+                    rcstr!("Invalid module type"),
+                    format!(
+                        "The module type must be Ecmascript or Typescript to add Ecmascript \
+                         transforms (got {})",
+                        other
+                    )
+                    .into(),
+                    Some(IssueSource::from_source_only(current_source)),
+                )
+                .to_resolved()
+                .await?
+                .emit();
+                collected_preprocess.clear();
+                collected_main.clear();
+                collected_postprocess.clear();
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn process_default_internal(
     module_asset_context: Vc<ModuleAssetContext>,
     source: ResolvedVc<Box<dyn Source>>,
@@ -533,8 +685,14 @@ async fn process_default_internal(
     let mut current_source = source;
     let mut current_module_type = None;
 
+    // Collect transforms from ExtendEcmascriptTransforms effects.
+    // They will be applied when ModuleType is set.
+    let mut collected_preprocess: Vec<EcmascriptInputTransform> = Vec::new();
+    let mut collected_main: Vec<EcmascriptInputTransform> = Vec::new();
+    let mut collected_postprocess: Vec<EcmascriptInputTransform> = Vec::new();
+
     let options_value = options.await?;
-    for (i, rule) in options_value.rules.iter().enumerate() {
+    'outer: for (i, rule) in options_value.rules.iter().enumerate() {
         if processed_rules.contains(&i) {
             continue;
         }
@@ -575,117 +733,41 @@ async fn process_default_internal(
                         }
                     }
                     ModuleRuleEffect::ModuleType(module) => {
-                        current_module_type = Some(module.clone());
+                        // Apply any collected transforms to this module type.
+                        // This clears the collected transform lists.
+                        // If another ModuleType is encountered later, it will override
+                        // with any transforms collected since this point.
+                        let mut module = module.clone();
+                        apply_module_rule_transforms(
+                            &mut module,
+                            &mut collected_preprocess,
+                            &mut collected_main,
+                            &mut collected_postprocess,
+                            ident,
+                            current_source,
+                        )
+                        .await?;
+                        current_module_type = Some(module);
+                        break 'outer;
                     }
                     ModuleRuleEffect::ExtendEcmascriptTransforms {
                         preprocess: extend_preprocess,
                         main: extend_main,
                         postprocess: extend_postprocess,
                     } => {
-                        current_module_type = match current_module_type {
-                            Some(ModuleType::Ecmascript {
-                                preprocess,
-                                main,
-                                postprocess,
-                                options,
-                            }) => Some(ModuleType::Ecmascript {
-                                preprocess: extend_preprocess
-                                    .extend(*preprocess)
-                                    .to_resolved()
-                                    .await?,
-                                main: extend_main.extend(*main).to_resolved().await?,
-                                postprocess: postprocess
-                                    .extend(**extend_postprocess)
-                                    .to_resolved()
-                                    .await?,
-                                options,
-                            }),
-                            Some(ModuleType::Typescript {
-                                preprocess,
-                                main,
-                                postprocess,
-                                tsx,
-                                analyze_types,
-                                options,
-                            }) => Some(ModuleType::Typescript {
-                                preprocess: extend_preprocess
-                                    .extend(*preprocess)
-                                    .to_resolved()
-                                    .await?,
-                                main: extend_main.extend(*main).to_resolved().await?,
-                                postprocess: postprocess
-                                    .extend(**extend_postprocess)
-                                    .to_resolved()
-                                    .await?,
-                                tsx,
-                                analyze_types,
-                                options,
-                            }),
-                            Some(ModuleType::Custom(custom_module_type)) => {
-                                match custom_module_type
-                                    .extend_ecmascript_transforms(
-                                        **extend_preprocess,
-                                        **extend_main,
-                                        **extend_postprocess,
-                                    )
-                                    .to_resolved()
-                                    .await
-                                {
-                                    Ok(custom_module_type) => {
-                                        Some(ModuleType::Custom(custom_module_type))
-                                    }
-                                    // TODO ideally this would print the actual error message
-                                    // returned by the CustomModuleType
-                                    Err(_) => {
-                                        ModuleIssue::new(
-                                            *ident,
-                                            rcstr!("Invalid module type"),
-                                            rcstr!(
-                                                "The custom module type didn't accept the \
-                                                 additional Ecmascript transforms"
-                                            ),
-                                            Some(IssueSource::from_source_only(current_source)),
-                                        )
-                                        .to_resolved()
-                                        .await?
-                                        .emit();
-                                        Some(ModuleType::Custom(custom_module_type))
-                                    }
-                                }
-                            }
-                            Some(module_type) => {
-                                ModuleIssue::new(
-                                    *ident,
-                                    rcstr!("Invalid module type"),
-                                    format!(
-                                        "The module type must be Ecmascript or Typescript to add \
-                                         Ecmascript transforms (got {})",
-                                        module_type
-                                    )
-                                    .into(),
-                                    Some(IssueSource::from_source_only(current_source)),
-                                )
-                                .to_resolved()
-                                .await?
-                                .emit();
-                                Some(module_type)
-                            }
-                            None => {
-                                ModuleIssue::new(
-                                    *ident,
-                                    rcstr!("Missing module type"),
-                                    rcstr!(
-                                        "The module type effect must be applied before adding \
-                                         Ecmascript transforms"
-                                    ),
-                                    Some(IssueSource::from_source_only(current_source)),
-                                )
-                                .to_resolved()
-                                .await?
-                                .emit();
-                                None
-                            }
-                        };
+                        // Collect transforms. They will be applied when ModuleType is set.
+                        // Prepend preprocess (new transforms run first)
+                        let mut new_preprocess = extend_preprocess.owned().await?;
+                        new_preprocess.append(&mut collected_preprocess);
+                        collected_preprocess = new_preprocess;
+
+                        // Prepend main (new transforms run first)
+                        let mut new_main = extend_main.owned().await?;
+                        new_main.append(&mut collected_main);
+                        collected_main = new_main;
+
+                        // Append postprocess (new transforms run last)
+                        collected_postprocess.extend(extend_postprocess.owned().await?);
                     }
                 }
             }

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -43,7 +43,7 @@ use turbopack_core::{
 };
 use turbopack_css::{CssModuleAsset, ModuleCssAsset};
 use turbopack_ecmascript::{
-    AnalyzeMode, EcmascriptInputTransform, EcmascriptModuleAsset, EcmascriptModuleAssetType,
+    AnalyzeMode, EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptModuleAssetType,
     TreeShakingMode,
     chunk::EcmascriptChunkPlaceable,
     inlined_bytes_module::InlinedBytesJsModule,
@@ -513,9 +513,9 @@ async fn process_default(
 /// For non-ecmascript types: warn if transforms exist, return unchanged.
 async fn apply_module_rule_transforms(
     module_type: &mut ModuleType,
-    collected_preprocess: &mut Vec<EcmascriptInputTransform>,
-    collected_main: &mut Vec<EcmascriptInputTransform>,
-    collected_postprocess: &mut Vec<EcmascriptInputTransform>,
+    collected_preprocess: &mut Vec<ResolvedVc<EcmascriptInputTransforms>>,
+    collected_main: &mut Vec<ResolvedVc<EcmascriptInputTransforms>>,
+    collected_postprocess: &mut Vec<ResolvedVc<EcmascriptInputTransforms>>,
     ident: ResolvedVc<AssetIdent>,
     current_source: ResolvedVc<Box<dyn Source>>,
 ) -> Result<()> {
@@ -534,81 +534,68 @@ async fn apply_module_rule_transforms(
             main,
             postprocess,
             ..
-        } => {
-            // Prepend collected preprocess/main, append collected postprocess
-            let mut final_preprocess = std::mem::take(collected_preprocess);
-            final_preprocess.extend(preprocess.owned().await?);
-            *preprocess = ResolvedVc::cell(final_preprocess);
-
-            let mut final_main = std::mem::take(collected_main);
-            final_main.extend(main.owned().await?);
-            *main = ResolvedVc::cell(final_main);
-
-            let mut final_postprocess = postprocess.owned().await?;
-            final_postprocess.extend(std::mem::take(collected_postprocess));
-            *postprocess = ResolvedVc::cell(final_postprocess);
         }
-        ModuleType::Typescript {
+        | ModuleType::Typescript {
+            preprocess,
+            main,
+            postprocess,
+            ..
+        }
+        | ModuleType::TypescriptDeclaration {
+            preprocess,
+            main,
+            postprocess,
+            ..
+        }
+        | ModuleType::EcmascriptExtensionless {
             preprocess,
             main,
             postprocess,
             ..
         } => {
-            let mut final_preprocess = std::mem::take(collected_preprocess);
-            final_preprocess.extend(preprocess.owned().await?);
-            *preprocess = ResolvedVc::cell(final_preprocess);
+            // Apply collected preprocess/main in order, then module type's transforms
+            let mut final_preprocess = EcmascriptInputTransforms::empty();
+            for vc in collected_preprocess.drain(..) {
+                final_preprocess = final_preprocess.extend(*vc);
+            }
+            final_preprocess = final_preprocess.extend(**preprocess);
+            *preprocess = final_preprocess.to_resolved().await?;
 
-            let mut final_main = std::mem::take(collected_main);
-            final_main.extend(main.owned().await?);
-            *main = ResolvedVc::cell(final_main);
+            let mut final_main = EcmascriptInputTransforms::empty();
+            for vc in collected_main.drain(..) {
+                final_main = final_main.extend(*vc);
+            }
+            final_main = final_main.extend(**main);
+            *main = final_main.to_resolved().await?;
 
-            let mut final_postprocess = postprocess.owned().await?;
-            final_postprocess.extend(std::mem::take(collected_postprocess));
-            *postprocess = ResolvedVc::cell(final_postprocess);
-        }
-        ModuleType::TypescriptDeclaration {
-            preprocess,
-            main,
-            postprocess,
-            ..
-        } => {
-            let mut final_preprocess = std::mem::take(collected_preprocess);
-            final_preprocess.extend(preprocess.owned().await?);
-            *preprocess = ResolvedVc::cell(final_preprocess);
-
-            let mut final_main = std::mem::take(collected_main);
-            final_main.extend(main.owned().await?);
-            *main = ResolvedVc::cell(final_main);
-
-            let mut final_postprocess = postprocess.owned().await?;
-            final_postprocess.extend(std::mem::take(collected_postprocess));
-            *postprocess = ResolvedVc::cell(final_postprocess);
-        }
-        ModuleType::EcmascriptExtensionless {
-            preprocess,
-            main,
-            postprocess,
-            ..
-        } => {
-            let mut final_preprocess = std::mem::take(collected_preprocess);
-            final_preprocess.extend(preprocess.owned().await?);
-            *preprocess = ResolvedVc::cell(final_preprocess);
-
-            let mut final_main = std::mem::take(collected_main);
-            final_main.extend(main.owned().await?);
-            *main = ResolvedVc::cell(final_main);
-
-            let mut final_postprocess = postprocess.owned().await?;
-            final_postprocess.extend(std::mem::take(collected_postprocess));
-            *postprocess = ResolvedVc::cell(final_postprocess);
+            // Apply module type's postprocess first, then collected postprocess
+            let mut final_postprocess = **postprocess;
+            for vc in collected_postprocess.drain(..) {
+                final_postprocess = final_postprocess.extend(*vc);
+            }
+            *postprocess = final_postprocess.to_resolved().await?;
         }
         ModuleType::Custom(custom_module_type) => {
             if has_transforms {
+                // Combine collected transforms into single Vcs
+                let mut combined_preprocess = EcmascriptInputTransforms::empty();
+                for vc in collected_preprocess.drain(..) {
+                    combined_preprocess = combined_preprocess.extend(*vc);
+                }
+                let mut combined_main = EcmascriptInputTransforms::empty();
+                for vc in collected_main.drain(..) {
+                    combined_main = combined_main.extend(*vc);
+                }
+                let mut combined_postprocess = EcmascriptInputTransforms::empty();
+                for vc in collected_postprocess.drain(..) {
+                    combined_postprocess = combined_postprocess.extend(*vc);
+                }
+
                 match custom_module_type
                     .extend_ecmascript_transforms(
-                        Vc::cell(std::mem::take(collected_preprocess)),
-                        Vc::cell(std::mem::take(collected_main)),
-                        Vc::cell(std::mem::take(collected_postprocess)),
+                        combined_preprocess,
+                        combined_main,
+                        combined_postprocess,
                     )
                     .to_resolved()
                     .await
@@ -687,9 +674,9 @@ async fn process_default_internal(
 
     // Collect transforms from ExtendEcmascriptTransforms effects.
     // They will be applied when ModuleType is set.
-    let mut collected_preprocess: Vec<EcmascriptInputTransform> = Vec::new();
-    let mut collected_main: Vec<EcmascriptInputTransform> = Vec::new();
-    let mut collected_postprocess: Vec<EcmascriptInputTransform> = Vec::new();
+    let mut collected_preprocess: Vec<ResolvedVc<EcmascriptInputTransforms>> = Vec::new();
+    let mut collected_main: Vec<ResolvedVc<EcmascriptInputTransforms>> = Vec::new();
+    let mut collected_postprocess: Vec<ResolvedVc<EcmascriptInputTransforms>> = Vec::new();
 
     let options_value = options.await?;
     'outer: for (i, rule) in options_value.rules.iter().enumerate() {
@@ -756,18 +743,9 @@ async fn process_default_internal(
                         postprocess: extend_postprocess,
                     } => {
                         // Collect transforms. They will be applied when ModuleType is set.
-                        // Prepend preprocess (new transforms run first)
-                        let mut new_preprocess = extend_preprocess.owned().await?;
-                        new_preprocess.append(&mut collected_preprocess);
-                        collected_preprocess = new_preprocess;
-
-                        // Prepend main (new transforms run first)
-                        let mut new_main = extend_main.owned().await?;
-                        new_main.append(&mut collected_main);
-                        collected_main = new_main;
-
-                        // Append postprocess (new transforms run last)
-                        collected_postprocess.extend(extend_postprocess.owned().await?);
+                        collected_preprocess.push(*extend_preprocess);
+                        collected_main.push(*extend_main);
+                        collected_postprocess.push(*extend_postprocess);
                     }
                 }
             }

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -424,6 +424,48 @@ impl ModuleOptions {
 
         rules.extend(module_rules.iter().cloned());
 
+        if enable_mdx || enable_mdx_rs.is_some() {
+            let (jsx_runtime, jsx_import_source, development) = if let Some(enable_jsx) = enable_jsx
+            {
+                let jsx = enable_jsx.await?;
+                (
+                    jsx.runtime.clone(),
+                    jsx.import_source.clone(),
+                    jsx.development,
+                )
+            } else {
+                (None, None, false)
+            };
+
+            let mdx_options = &*enable_mdx_rs
+                .unwrap_or_else(|| MdxTransformOptions::default().resolved_cell())
+                .await?;
+
+            let mdx_transform_options = (MdxTransformOptions {
+                development: Some(development),
+                jsx: Some(false),
+                jsx_runtime,
+                jsx_import_source,
+                ..(mdx_options.clone())
+            })
+            .cell();
+
+            rules.push(ModuleRule::new(
+                RuleCondition::any(vec![
+                    RuleCondition::ResourcePathEndsWith(".md".to_string()),
+                    RuleCondition::ResourcePathEndsWith(".mdx".to_string()),
+                    RuleCondition::ContentTypeStartsWith("text/markdown".to_string()),
+                ]),
+                vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
+                    ResolvedVc::upcast(
+                        MdxTransform::new(mdx_transform_options)
+                            .to_resolved()
+                            .await?,
+                    ),
+                ]))],
+            ));
+        }
+
         // Rules that apply for certains references
         rules.extend([
             ModuleRule::new(
@@ -801,48 +843,6 @@ impl ModuleOptions {
                     })],
                 ),
             ]);
-        }
-
-        if enable_mdx || enable_mdx_rs.is_some() {
-            let (jsx_runtime, jsx_import_source, development) = if let Some(enable_jsx) = enable_jsx
-            {
-                let jsx = enable_jsx.await?;
-                (
-                    jsx.runtime.clone(),
-                    jsx.import_source.clone(),
-                    jsx.development,
-                )
-            } else {
-                (None, None, false)
-            };
-
-            let mdx_options = &*enable_mdx_rs
-                .unwrap_or_else(|| MdxTransformOptions::default().resolved_cell())
-                .await?;
-
-            let mdx_transform_options = (MdxTransformOptions {
-                development: Some(development),
-                jsx: Some(false),
-                jsx_runtime,
-                jsx_import_source,
-                ..(mdx_options.clone())
-            })
-            .cell();
-
-            rules.push(ModuleRule::new(
-                RuleCondition::any(vec![
-                    RuleCondition::ResourcePathEndsWith(".md".to_string()),
-                    RuleCondition::ResourcePathEndsWith(".mdx".to_string()),
-                    RuleCondition::ContentTypeStartsWith("text/markdown".to_string()),
-                ]),
-                vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
-                    ResolvedVc::upcast(
-                        MdxTransform::new(mdx_transform_options)
-                            .to_resolved()
-                            .await?,
-                    ),
-                ]))],
-            ));
         }
 
         Ok(ModuleOptions::cell(ModuleOptions { rules }))

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -19,7 +19,9 @@ use turbo_tasks_fs::{
 use turbopack_core::{
     chunk::SourceMapsType,
     ident::Layer,
-    reference_type::{CssReferenceSubType, ReferenceType, UrlReferenceSubType},
+    reference_type::{
+        CssReferenceSubType, EcmaScriptModulesReferenceSubType, ReferenceType, UrlReferenceSubType,
+    },
     resolve::options::{ImportMap, ImportMapping},
 };
 use turbopack_css::CssModuleAssetType;
@@ -222,6 +224,7 @@ impl ModuleOptions {
                     esm_url_rewrite_behavior,
                     enable_typeof_window_inlining,
                     enable_exports_info_inlining,
+                    enable_import_as_bytes,
                     source_maps: ecmascript_source_maps,
                     inline_helpers,
                     infer_module_side_effects,
@@ -342,7 +345,126 @@ impl ModuleOptions {
         let postprocess = ResolvedVc::cell(postprocess);
         let empty = ResolvedVc::<EcmascriptInputTransforms>::cell(vec![]);
 
-        let mut rules = vec![
+        let mut rules = vec![];
+
+        if let Some(webpack_loaders_options) = enable_webpack_loaders {
+            let webpack_loaders_options = webpack_loaders_options.await?;
+            let execution_context =
+                execution_context.context("execution_context is required for webpack_loaders")?;
+            let import_map = if let Some(loader_runner_package) =
+                webpack_loaders_options.loader_runner_package
+            {
+                package_import_map_from_import_mapping(
+                    rcstr!("loader-runner"),
+                    *loader_runner_package,
+                )
+            } else {
+                package_import_map_from_context(
+                    rcstr!("loader-runner"),
+                    path.clone()
+                        .context("need_path in ModuleOptions::new is incorrect")?,
+                )
+            };
+            let builtin_conditions = webpack_loaders_options
+                .builtin_conditions
+                .into_trait_ref()
+                .await?;
+            for (key, rule) in webpack_loaders_options.rules.await?.iter() {
+                let mut rule_conditions = Vec::new();
+
+                // prefer to add the glob condition ahead of the user-defined `condition` field,
+                // because we know it's cheap to check
+                rule_conditions.push(
+                    rule_condition_from_webpack_condition_glob(execution_context, key).await?,
+                );
+
+                if let Some(condition) = &rule.condition {
+                    rule_conditions.push(
+                        rule_condition_from_webpack_condition(
+                            execution_context,
+                            &*builtin_conditions,
+                            condition,
+                        )
+                        .await?,
+                    )
+                }
+
+                rule_conditions.push(RuleCondition::not(RuleCondition::ResourceIsVirtualSource));
+                rule_conditions.push(module_css_external_transform_conditions.clone());
+
+                let mut all_rule_condition = RuleCondition::All(rule_conditions);
+                all_rule_condition.flatten();
+                if !matches!(all_rule_condition, RuleCondition::False) {
+                    rules.push(ModuleRule::new(
+                        all_rule_condition,
+                        vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
+                            ResolvedVc::upcast(
+                                WebpackLoaders::new(
+                                    node_evaluate_asset_context(
+                                        *execution_context,
+                                        Some(import_map),
+                                        None,
+                                        Layer::new(rcstr!("webpack_loaders")),
+                                        false,
+                                    ),
+                                    *execution_context,
+                                    *rule.loaders,
+                                    rule.rename_as.clone(),
+                                    resolve_options_context,
+                                    matches!(ecmascript_source_maps, SourceMapsType::Full),
+                                )
+                                .to_resolved()
+                                .await?,
+                            ),
+                        ]))],
+                    ));
+                }
+            }
+        }
+
+        rules.extend(module_rules.iter().cloned());
+
+        // Rules that apply for certains references
+        rules.extend([
+            ModuleRule::new(
+                RuleCondition::ReferenceType(ReferenceType::Url(UrlReferenceSubType::CssUrl)),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlCss {
+                    tag: static_url_tag.clone(),
+                })],
+            ),
+            ModuleRule::new(
+                RuleCondition::ReferenceType(ReferenceType::Url(UrlReferenceSubType::Undefined)),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlJs {
+                    tag: static_url_tag.clone(),
+                })],
+            ),
+            ModuleRule::new(
+                RuleCondition::ReferenceType(ReferenceType::Url(
+                    UrlReferenceSubType::EcmaScriptNewUrl,
+                )),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlJs {
+                    tag: static_url_tag.clone(),
+                })],
+            ),
+            ModuleRule::new(
+                RuleCondition::ReferenceType(ReferenceType::EcmaScriptModules(
+                    EcmaScriptModulesReferenceSubType::ImportWithType("json".into()),
+                )),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::Json)],
+            ),
+        ]);
+
+        if enable_import_as_bytes {
+            rules.push(ModuleRule::new(
+                RuleCondition::ReferenceType(ReferenceType::EcmaScriptModules(
+                    EcmaScriptModulesReferenceSubType::ImportWithType("bytes".into()),
+                )),
+                vec![ModuleRuleEffect::ModuleType(ModuleType::InlinedBytesJs)],
+            ));
+        }
+
+        // Rules that apply based on file extension or content type
+        rules.extend([
             ModuleRule::new_all(
                 RuleCondition::any(vec![
                     RuleCondition::ResourcePathEndsWith(".json".to_string()),
@@ -425,22 +547,6 @@ impl ModuleOptions {
                     source_ty: WebAssemblySourceType::Text,
                 })],
             ),
-            // Fallback to ecmascript without extension (this is node.js behavior)
-            ModuleRule::new(
-                RuleCondition::all(vec![
-                    RuleCondition::ResourcePathHasNoExtension,
-                    RuleCondition::ContentTypeEmpty,
-                ]),
-                vec![ModuleRuleEffect::ModuleType(
-                    ModuleType::EcmascriptExtensionless {
-                        preprocess: empty,
-                        main: empty,
-                        postprocess: empty,
-                        options: ecmascript_options_vc,
-                    },
-                )],
-            ),
-            // Static assets
             ModuleRule::new(
                 RuleCondition::any(vec![
                     RuleCondition::ResourcePathEndsWith(".apng".to_string()),
@@ -459,26 +565,21 @@ impl ModuleOptions {
                 })],
             ),
             ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::Url(UrlReferenceSubType::Undefined)),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlJs {
-                    tag: static_url_tag.clone(),
-                })],
+                RuleCondition::all(vec![
+                    // Fallback to ecmascript without extension (this is node.js behavior)
+                    RuleCondition::ResourcePathHasNoExtension,
+                    RuleCondition::ContentTypeEmpty,
+                ]),
+                vec![ModuleRuleEffect::ModuleType(
+                    ModuleType::EcmascriptExtensionless {
+                        preprocess: empty,
+                        main: empty,
+                        postprocess: empty,
+                        options: ecmascript_options_vc,
+                    },
+                )],
             ),
-            ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::Url(
-                    UrlReferenceSubType::EcmaScriptNewUrl,
-                )),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlJs {
-                    tag: static_url_tag.clone(),
-                })],
-            ),
-            ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::Url(UrlReferenceSubType::CssUrl)),
-                vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlCss {
-                    tag: static_url_tag.clone(),
-                })],
-            ),
-        ];
+        ]);
 
         if let Some(options) = enable_typescript_transform {
             let ts_preprocess = ResolvedVc::cell(
@@ -491,172 +592,101 @@ impl ModuleOptions {
                     .collect(),
             );
 
-            rules.splice(
-                0..0,
-                [
-                    ModuleRule::new_all(
-                        RuleCondition::ResourcePathEndsWith(".ts".to_string()),
-                        vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                            preprocess: ts_preprocess,
-                            main,
-                            postprocess,
-                            tsx: false,
-                            analyze_types: enable_types,
-                            options: ecmascript_options_vc,
-                        })],
-                    ),
-                    ModuleRule::new_all(
-                        RuleCondition::ResourcePathEndsWith(".tsx".to_string()),
-                        vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                            preprocess: ts_preprocess,
-                            main,
-                            postprocess,
-                            tsx: true,
-                            analyze_types: enable_types,
-                            options: ecmascript_options_vc,
-                        })],
-                    ),
-                    ModuleRule::new_all(
-                        RuleCondition::ResourcePathEndsWith(".mts".to_string()),
-                        vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                            preprocess: ts_preprocess,
-                            main,
-                            postprocess,
-                            tsx: false,
-                            analyze_types: enable_types,
-                            options: EcmascriptOptions {
-                                specified_module_type: SpecifiedModuleType::EcmaScript,
-                                ..ecmascript_options
-                            }
-                            .resolved_cell(),
-                        })],
-                    ),
-                    ModuleRule::new_all(
-                        RuleCondition::ResourcePathEndsWith(".mtsx".to_string()),
-                        vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                            preprocess: ts_preprocess,
-                            main,
-                            postprocess,
-                            tsx: true,
-                            analyze_types: enable_types,
-                            options: EcmascriptOptions {
-                                specified_module_type: SpecifiedModuleType::EcmaScript,
-                                ..ecmascript_options
-                            }
-                            .resolved_cell(),
-                        })],
-                    ),
-                    ModuleRule::new_all(
-                        RuleCondition::ResourcePathEndsWith(".cts".to_string()),
-                        vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                            preprocess: ts_preprocess,
-                            main,
-                            postprocess,
-                            tsx: false,
-                            analyze_types: enable_types,
-                            options: EcmascriptOptions {
-                                specified_module_type: SpecifiedModuleType::CommonJs,
-                                ..ecmascript_options
-                            }
-                            .resolved_cell(),
-                        })],
-                    ),
-                    ModuleRule::new_all(
-                        RuleCondition::ResourcePathEndsWith(".ctsx".to_string()),
-                        vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
-                            preprocess: ts_preprocess,
-                            main,
-                            postprocess,
-                            tsx: true,
-                            analyze_types: enable_types,
-                            options: EcmascriptOptions {
-                                specified_module_type: SpecifiedModuleType::CommonJs,
-                                ..ecmascript_options
-                            }
-                            .resolved_cell(),
-                        })],
-                    ),
-                ],
-            );
-        }
-
-        if let Some(webpack_loaders_options) = enable_webpack_loaders {
-            let webpack_loaders_options = webpack_loaders_options.await?;
-            let execution_context =
-                execution_context.context("execution_context is required for webpack_loaders")?;
-            let import_map = if let Some(loader_runner_package) =
-                webpack_loaders_options.loader_runner_package
-            {
-                package_import_map_from_import_mapping(
-                    rcstr!("loader-runner"),
-                    *loader_runner_package,
-                )
-            } else {
-                package_import_map_from_context(
-                    rcstr!("loader-runner"),
-                    path.clone()
-                        .context("need_path in ModuleOptions::new is incorrect")?,
-                )
-            };
-            let builtin_conditions = webpack_loaders_options
-                .builtin_conditions
-                .into_trait_ref()
-                .await?;
-            for (key, rule) in webpack_loaders_options.rules.await?.iter() {
-                let mut rule_conditions = Vec::new();
-
-                // prefer to add the glob condition ahead of the user-defined `condition` field,
-                // because we know it's cheap to check
-                rule_conditions.push(
-                    rule_condition_from_webpack_condition_glob(execution_context, key).await?,
-                );
-
-                if let Some(condition) = &rule.condition {
-                    rule_conditions.push(
-                        rule_condition_from_webpack_condition(
-                            execution_context,
-                            &*builtin_conditions,
-                            condition,
-                        )
-                        .await?,
-                    )
-                }
-
-                rule_conditions.push(RuleCondition::not(RuleCondition::ResourceIsVirtualSource));
-                rule_conditions.push(module_css_external_transform_conditions.clone());
-
-                let mut all_rule_condition = RuleCondition::All(rule_conditions);
-                all_rule_condition.flatten();
-                if !matches!(all_rule_condition, RuleCondition::False) {
-                    rules.push(ModuleRule::new(
-                        all_rule_condition,
-                        vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
-                            ResolvedVc::upcast(
-                                WebpackLoaders::new(
-                                    node_evaluate_asset_context(
-                                        *execution_context,
-                                        Some(import_map),
-                                        None,
-                                        Layer::new(rcstr!("webpack_loaders")),
-                                        false,
-                                    ),
-                                    *execution_context,
-                                    *rule.loaders,
-                                    rule.rename_as.clone(),
-                                    resolve_options_context,
-                                    matches!(ecmascript_source_maps, SourceMapsType::Full),
-                                )
-                                .to_resolved()
-                                .await?,
-                            ),
-                        ]))],
-                    ));
-                }
-            }
+            rules.extend([
+                ModuleRule::new_all(
+                    RuleCondition::ResourcePathEndsWith(".ts".to_string()),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                        preprocess: ts_preprocess,
+                        main,
+                        postprocess,
+                        tsx: false,
+                        analyze_types: enable_types,
+                        options: ecmascript_options_vc,
+                    })],
+                ),
+                ModuleRule::new_all(
+                    RuleCondition::ResourcePathEndsWith(".tsx".to_string()),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                        preprocess: ts_preprocess,
+                        main,
+                        postprocess,
+                        tsx: true,
+                        analyze_types: enable_types,
+                        options: ecmascript_options_vc,
+                    })],
+                ),
+                ModuleRule::new_all(
+                    RuleCondition::ResourcePathEndsWith(".mts".to_string()),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                        preprocess: ts_preprocess,
+                        main,
+                        postprocess,
+                        tsx: false,
+                        analyze_types: enable_types,
+                        options: EcmascriptOptions {
+                            specified_module_type: SpecifiedModuleType::EcmaScript,
+                            ..ecmascript_options
+                        }
+                        .resolved_cell(),
+                    })],
+                ),
+                ModuleRule::new_all(
+                    RuleCondition::ResourcePathEndsWith(".mtsx".to_string()),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                        preprocess: ts_preprocess,
+                        main,
+                        postprocess,
+                        tsx: true,
+                        analyze_types: enable_types,
+                        options: EcmascriptOptions {
+                            specified_module_type: SpecifiedModuleType::EcmaScript,
+                            ..ecmascript_options
+                        }
+                        .resolved_cell(),
+                    })],
+                ),
+                ModuleRule::new_all(
+                    RuleCondition::ResourcePathEndsWith(".cts".to_string()),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                        preprocess: ts_preprocess,
+                        main,
+                        postprocess,
+                        tsx: false,
+                        analyze_types: enable_types,
+                        options: EcmascriptOptions {
+                            specified_module_type: SpecifiedModuleType::CommonJs,
+                            ..ecmascript_options
+                        }
+                        .resolved_cell(),
+                    })],
+                ),
+                ModuleRule::new_all(
+                    RuleCondition::ResourcePathEndsWith(".ctsx".to_string()),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Typescript {
+                        preprocess: ts_preprocess,
+                        main,
+                        postprocess,
+                        tsx: true,
+                        analyze_types: enable_types,
+                        options: EcmascriptOptions {
+                            specified_module_type: SpecifiedModuleType::CommonJs,
+                            ..ecmascript_options
+                        }
+                        .resolved_cell(),
+                    })],
+                ),
+            ]);
         }
 
         if enable_raw_css {
             rules.extend([
+                ModuleRule::new(
+                    module_css_condition.clone(),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
+                        ty: CssModuleAssetType::Module,
+                        environment,
+                    })],
+                ),
                 ModuleRule::new(
                     RuleCondition::any(vec![
                         RuleCondition::ResourcePathEndsWith(".css".to_string()),
@@ -664,13 +694,6 @@ impl ModuleOptions {
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleAssetType::Default,
-                        environment,
-                    })],
-                ),
-                ModuleRule::new(
-                    module_css_condition.clone(),
-                    vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Module,
                         environment,
                     })],
                 ),
@@ -724,28 +747,6 @@ impl ModuleOptions {
             }
 
             rules.extend([
-                ModuleRule::new_all(
-                    RuleCondition::Any(vec![
-                        RuleCondition::ResourcePathEndsWith(".css".to_string()),
-                        RuleCondition::ContentTypeStartsWith("text/css".to_string()),
-                    ]),
-                    vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Default,
-                        environment,
-                    })],
-                ),
-                ModuleRule::new(
-                    RuleCondition::all(vec![
-                        module_css_condition.clone(),
-                        // Only create a module CSS asset if not `@import`ed from CSS already.
-                        // NOTE: `composes` references should not be treated as `@import`s and
-                        // should also create a module CSS asset.
-                        RuleCondition::not(RuleCondition::ReferenceType(ReferenceType::Css(
-                            CssReferenceSubType::AtImport(None),
-                        ))),
-                    ]),
-                    vec![ModuleRuleEffect::ModuleType(ModuleType::CssModule)],
-                ),
                 ModuleRule::new(
                     RuleCondition::all(vec![
                         module_css_condition.clone(),
@@ -762,10 +763,10 @@ impl ModuleOptions {
                 // Ecmascript CSS Modules referencing the actual CSS module to include it
                 ModuleRule::new(
                     RuleCondition::all(vec![
+                        module_css_condition.clone(),
                         RuleCondition::ReferenceType(ReferenceType::Css(
                             CssReferenceSubType::Inner,
                         )),
-                        module_css_condition.clone(),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleAssetType::Module,
@@ -775,13 +776,27 @@ impl ModuleOptions {
                 // Ecmascript CSS Modules referencing the actual CSS module to list the classes
                 ModuleRule::new(
                     RuleCondition::all(vec![
+                        module_css_condition.clone(),
                         RuleCondition::ReferenceType(ReferenceType::Css(
                             CssReferenceSubType::Analyze,
                         )),
-                        module_css_condition.clone(),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleAssetType::Module,
+                        environment,
+                    })],
+                ),
+                ModuleRule::new(
+                    RuleCondition::all(vec![module_css_condition.clone()]),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::CssModule)],
+                ),
+                ModuleRule::new_all(
+                    RuleCondition::Any(vec![
+                        RuleCondition::ResourcePathEndsWith(".css".to_string()),
+                        RuleCondition::ContentTypeStartsWith("text/css".to_string()),
+                    ]),
+                    vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
+                        ty: CssModuleAssetType::Default,
                         environment,
                     })],
                 ),
@@ -829,8 +844,6 @@ impl ModuleOptions {
                 ]))],
             ));
         }
-
-        rules.extend(module_rules.iter().cloned());
 
         Ok(ModuleOptions::cell(ModuleOptions { rules }))
     }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -253,6 +253,9 @@ pub struct EcmascriptOptionsContext {
     /// Whether to allow accessing exports info via `__webpack_exports_info__`.
     pub enable_exports_info_inlining: bool,
 
+    /// Whether to enable `import bytes from 'module' as { type: "bytes }` syntax.
+    pub enable_import_as_bytes: bool,
+
     // TODO should this be a part of Environment instead?
     pub inline_helpers: bool,
 


### PR DESCRIPTION
### What?

Stop rules when module type is set.
Apply ecmascript transforms before module type is set. (no more errors when trying to apply a transform on non-ecmascript type)
Fix ordering of transform apply.
Reorder module rules to match previous order. They are applied in order now. 
