### PR TITLE
Fix react-loadable-manifest chunk hash mismatch by preserving async loader mapping again

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1566,8 +1566,6 @@ impl AppEndpoint {
 
                 if emit_manifests == EmitManifests::Full {
                     let dynamic_import_entries = collect_next_dynamic_chunks(
-                        *module_graphs.full,
-                        *client_chunking_context,
                         next_dynamic_imports,
                         NextDynamicChunkAvailability::ClientReferences(
                             &*(client_references_chunks.await?),
@@ -1682,8 +1680,6 @@ impl AppEndpoint {
                 let loadable_manifest_output = if emit_manifests == EmitManifests::Full {
                     // create react-loadable-manifest for next/dynamic
                     let dynamic_import_entries = collect_next_dynamic_chunks(
-                        *module_graphs.full,
-                        *client_chunking_context,
                         next_dynamic_imports,
                         NextDynamicChunkAvailability::ClientReferences(
                             &*(client_references_chunks.await?),

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -30,24 +30,29 @@ use turbo_tasks::{
     debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
-    chunk::{ChunkableModule, ChunkingContext, availability_info::AvailabilityInfo},
+    chunk::{ChunkGroupResult, ChunkableModule},
     module::Module,
-    module_graph::{ModuleGraph, ModuleGraphLayer},
+    module_graph::ModuleGraphLayer,
     output::{OutputAssetsReference, OutputAssetsWithReferenced},
 };
 
 use crate::module_graph::DynamicImportEntriesWithImporter;
 
 pub(crate) enum NextDynamicChunkAvailability<'a> {
-    /// In App Router, the client references
+    /// In App Router, the client references chunks contain the async loaders
     ClientReferences(&'a ClientReferencesChunks),
-    /// In Pages Router, the base page chunk group
-    AvailabilityInfo(AvailabilityInfo),
+    /// In Pages Router, the base page chunk group result
+    PageChunkGroup(&'a ChunkGroupResult),
 }
 
+/// Collects the chunk outputs for next/dynamic imports by looking up pre-computed
+/// async loaders from the chunk group results.
+///
+/// This function no longer recomputes chunks - instead it looks up the async loader
+/// outputs that were already computed by `make_chunk_group` when the parent chunk
+/// groups were created. This ensures consistency between the manifest and the actual
+/// chunks served at runtime.
 pub(crate) async fn collect_next_dynamic_chunks(
-    module_graph: Vc<ModuleGraph>,
-    chunking_context: Vc<Box<dyn ChunkingContext>>,
     dynamic_import_entries: ReadRef<DynamicImportEntriesWithImporter>,
     chunking_availability: NextDynamicChunkAvailability<'_>,
 ) -> Result<ResolvedVc<DynamicImportedChunks>> {
@@ -57,28 +62,36 @@ pub(crate) async fn collect_next_dynamic_chunks(
         .map(|(dynamic_entry, parent_client_reference)| async move {
             let module = ResolvedVc::upcast::<Box<dyn ChunkableModule>>(*dynamic_entry);
 
-            // This is the availability info for the parent chunk group, i.e. the client reference
-            // containing the next/dynamic imports
-            let availability_info = match chunking_availability {
+            // Look up the pre-computed async loader from the parent chunk group
+            let async_loader = match chunking_availability {
                 NextDynamicChunkAvailability::ClientReferences(client_reference_chunks) => {
-                    client_reference_chunks
+                    // For App Router: look up the chunk group for the parent client reference,
+                    // then find the async loader for this dynamic entry
+                    let parent_ref = parent_client_reference
+                        .context("Parent client reference not found for next/dynamic import")?;
+                    let chunk_group = client_reference_chunks
                         .client_component_client_chunks
-                        .get(
-                            &parent_client_reference.context(
-                                "Parent client reference not found for next/dynamic import",
-                            )?,
-                        )
+                        .get(&parent_ref)
                         .context("Client reference chunk group not found for next/dynamic import")?
-                        .await?
-                        .availability_info
+                        .await?;
+                    // Copy the ResolvedVc out of the map to avoid lifetime issues
+                    *chunk_group.async_loaders_by_module.get(&module).context(
+                        "Dynamic entry not found in async loaders - this may indicate the dynamic \
+                         import is not reachable from the client reference",
+                    )?
                 }
-                NextDynamicChunkAvailability::AvailabilityInfo(availability_info) => {
-                    *availability_info
+                NextDynamicChunkAvailability::PageChunkGroup(chunk_group) => {
+                    // For Pages Router: look up directly in the page's chunk group
+                    // Copy the ResolvedVc out of the map to avoid lifetime issues
+                    *chunk_group.async_loaders_by_module.get(&module).context(
+                        "Dynamic entry not found in async loaders - this may indicate the dynamic \
+                         import is not reachable from the page entry",
+                    )?
                 }
             };
 
-            let async_loader =
-                chunking_context.async_loader_chunk_item(*module, module_graph, availability_info);
+            // Get the output assets from the async loader reference
+            // Upcast to OutputAssetsReference to call references()
             let async_chunk_group = async_loader.references().to_resolved().await?;
 
             Ok((*dynamic_entry, (*dynamic_entry, async_chunk_group)))

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -19,15 +19,16 @@
 //!      to wait until all the dynamic components are being loaded, this ensures hydration mismatch
 //!      won't occur
 
-use anyhow::{Context, Result};
+use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
 use next_core::{
-    next_app::ClientReferencesChunks, next_client_reference::EcmascriptClientReferenceModule,
+    next_app::ClientReferencesChunks,
+    next_client_reference::{ClientReferenceType, EcmascriptClientReferenceModule},
     next_dynamic::NextDynamicEntryModule,
 };
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
-    debug::ValueDebugFormat, trace::TraceRawVcs,
+    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt,
+    ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
     chunk::{ChunkGroupResult, ChunkableModule},
@@ -37,6 +38,19 @@ use turbopack_core::{
 };
 
 use crate::module_graph::DynamicImportEntriesWithImporter;
+
+/// Helper to get a descriptive string for a ClientReferenceType
+async fn client_reference_type_to_string(ty: &ClientReferenceType) -> Result<String> {
+    match ty {
+        ClientReferenceType::EcmascriptClientReference(ecma_ref) => {
+            let module = ecma_ref.await?;
+            Ok(module.server_ident.to_string().await?.to_string())
+        }
+        ClientReferenceType::CssClientReference(css_ref) => {
+            Ok(css_ref.ident().to_string().await?.to_string())
+        }
+    }
+}
 
 pub(crate) enum NextDynamicChunkAvailability<'a> {
     /// In App Router, the client references chunks contain the async loaders
@@ -67,26 +81,55 @@ pub(crate) async fn collect_next_dynamic_chunks(
                 NextDynamicChunkAvailability::ClientReferences(client_reference_chunks) => {
                     // For App Router: look up the chunk group for the parent client reference,
                     // then find the async loader for this dynamic entry
-                    let parent_ref = parent_client_reference
-                        .context("Parent client reference not found for next/dynamic import")?;
-                    let chunk_group = client_reference_chunks
+                    let Some(parent_ref) = parent_client_reference else {
+                        let dynamic_ident = dynamic_entry.ident().to_string().await?;
+                        bail!(
+                            "Parent client reference not found for next/dynamic import.\nDynamic \
+                             entry: {dynamic_ident}"
+                        );
+                    };
+                    let Some(chunk_group_vc) = client_reference_chunks
                         .client_component_client_chunks
-                        .get(&parent_ref)
-                        .context("Client reference chunk group not found for next/dynamic import")?
-                        .await?;
+                        .get(parent_ref)
+                    else {
+                        let dynamic_ident = dynamic_entry.ident().to_string().await?;
+                        let parent_ident = client_reference_type_to_string(parent_ref).await?;
+                        bail!(
+                            "Client reference chunk group not found for next/dynamic \
+                             import.\nDynamic entry: {dynamic_ident}\nParent client reference: \
+                             {parent_ident}"
+                        );
+                    };
+                    let chunk_group = chunk_group_vc.await?;
                     // Copy the ResolvedVc out of the map to avoid lifetime issues
-                    *chunk_group.async_loaders_by_module.get(&module).context(
-                        "Dynamic entry not found in async loaders - this may indicate the dynamic \
-                         import is not reachable from the client reference",
-                    )?
+                    let Some(loader) = chunk_group.async_loaders_by_module.get(&module) else {
+                        let dynamic_ident = dynamic_entry.ident().to_string().await?;
+                        let parent_ident = client_reference_type_to_string(parent_ref).await?;
+                        let available_count = chunk_group.async_loaders_by_module.len();
+                        bail!(
+                            "Dynamic entry not found in async loaders - this may indicate the \
+                             dynamic import is not reachable from the client reference.\nDynamic \
+                             entry: {dynamic_ident}\nParent client reference: \
+                             {parent_ident}\nAvailable async loaders in chunk group: \
+                             {available_count}"
+                        );
+                    };
+                    *loader
                 }
                 NextDynamicChunkAvailability::PageChunkGroup(chunk_group) => {
                     // For Pages Router: look up directly in the page's chunk group
                     // Copy the ResolvedVc out of the map to avoid lifetime issues
-                    *chunk_group.async_loaders_by_module.get(&module).context(
-                        "Dynamic entry not found in async loaders - this may indicate the dynamic \
-                         import is not reachable from the page entry",
-                    )?
+                    let Some(loader) = chunk_group.async_loaders_by_module.get(&module) else {
+                        let dynamic_ident = dynamic_entry.ident().to_string().await?;
+                        let available_count = chunk_group.async_loaders_by_module.len();
+                        bail!(
+                            "Dynamic entry not found in async loaders - this may indicate the \
+                             dynamic import is not reachable from the page entry.\nDynamic entry: \
+                             {dynamic_ident}\nAvailable async loaders in chunk group: \
+                             {available_count}"
+                        );
+                    };
+                    *loader
                 }
             };
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -927,7 +927,7 @@ impl PageEndpoint {
             let ssr_module_graph = self.ssr_module_graph();
 
             let next_dynamic_imports = if let PageEndpointType::Html = this.ty {
-                let client_availability_info = self.client_chunk_group().await?.availability_info;
+                let client_chunk_group = self.client_chunk_group().await?;
 
                 let client_module_graph = self.client_module_graph();
                 let per_page_module_graph = *project.per_page_module_graph().await?;
@@ -966,26 +966,21 @@ impl PageEndpoint {
                     NextDynamicGraphs::new(client_module_graph, per_page_module_graph)
                         .get_next_dynamic_imports_for_endpoint(self.client_module())
                         .await?;
-                Some((next_dynamic_imports, client_availability_info))
+                Some((next_dynamic_imports, client_chunk_group))
             } else {
                 None
             };
 
-            let dynamic_import_entries = if let Some((
-                next_dynamic_imports,
-                client_availability_info,
-            )) = next_dynamic_imports
-            {
-                collect_next_dynamic_chunks(
-                    self.client_module_graph(),
-                    project.client_chunking_context(),
-                    next_dynamic_imports,
-                    NextDynamicChunkAvailability::AvailabilityInfo(client_availability_info),
-                )
-                .await?
-            } else {
-                DynamicImportedChunks::default().resolved_cell()
-            };
+            let dynamic_import_entries =
+                if let Some((next_dynamic_imports, client_chunk_group)) = next_dynamic_imports {
+                    collect_next_dynamic_chunks(
+                        next_dynamic_imports,
+                        NextDynamicChunkAvailability::PageChunkGroup(&client_chunk_group),
+                    )
+                    .await?
+                } else {
+                    DynamicImportedChunks::default().resolved_cell()
+                };
 
             let chunking_context: Vc<Box<dyn ChunkingContext>> = match runtime {
                 NextRuntime::NodeJs => Vc::upcast(node_chunking_context),

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -164,8 +164,8 @@ pub async fn get_app_client_references_chunks(
             let mut current_client_chunk_group = ChunkGroupResult {
                 assets: ResolvedVc::cell(vec![]),
                 referenced_assets: ResolvedVc::cell(vec![]),
-                references: ResolvedVc::cell(vec![]),
                 availability_info: client_availability_info,
+                async_loaders_by_module: FxIndexMap::default(),
             }
             .resolved_cell();
             let mut current_ssr_chunk_group = ChunkGroupResult::empty_resolved();

--- a/test/development/nested-dynamic-components/components/FeatureCard.tsx
+++ b/test/development/nested-dynamic-components/components/FeatureCard.tsx
@@ -1,0 +1,23 @@
+import dynamic from 'next/dynamic'
+
+const NestedIcon = dynamic(() => import('./nested/NestedIcon'))
+const NestedBadge = dynamic(() => import('./nested/NestedBadge'))
+
+export default function FeatureCard({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div className="feature-card">
+      <div>
+        <NestedIcon icon="star" />
+        <h2>{title}</h2>
+        <NestedBadge text="NEW" />
+      </div>
+      <p>{description}</p>
+    </div>
+  )
+}

--- a/test/development/nested-dynamic-components/components/UserProfile.tsx
+++ b/test/development/nested-dynamic-components/components/UserProfile.tsx
@@ -1,0 +1,20 @@
+import dynamic from 'next/dynamic'
+
+const NestedIcon = dynamic(() => import('./nested/NestedIcon'))
+const NestedStats = dynamic(() => import('./nested/NestedStats'))
+
+export default function UserProfile({
+  name,
+  count,
+}: {
+  name: string
+  count: number
+}) {
+  return (
+    <div className="user-profile">
+      <NestedIcon icon="user" />
+      <h2>{name}</h2>
+      <NestedStats value={count} />
+    </div>
+  )
+}

--- a/test/development/nested-dynamic-components/components/nested/NestedBadge.tsx
+++ b/test/development/nested-dynamic-components/components/nested/NestedBadge.tsx
@@ -1,0 +1,3 @@
+export default function NestedBadge({ text }: { text: string }) {
+  return <span className="nested-badge">{text}</span>
+}

--- a/test/development/nested-dynamic-components/components/nested/NestedIcon.tsx
+++ b/test/development/nested-dynamic-components/components/nested/NestedIcon.tsx
@@ -1,0 +1,3 @@
+export default function NestedIcon({ icon }: { icon: string }) {
+  return <span className="nested-icon">🎯 {icon}</span>
+}

--- a/test/development/nested-dynamic-components/components/nested/NestedStats.tsx
+++ b/test/development/nested-dynamic-components/components/nested/NestedStats.tsx
@@ -1,0 +1,3 @@
+export default function NestedStats({ value }: { value: number }) {
+  return <span className="nested-stats">Stats: {value}</span>
+}

--- a/test/development/nested-dynamic-components/nested-dynamic-components.test.ts
+++ b/test/development/nested-dynamic-components/nested-dynamic-components.test.ts
@@ -1,0 +1,58 @@
+import { nextTestSetup } from 'e2e-utils'
+import fs from 'fs'
+import path from 'path'
+
+describe('nested-dynamic-components', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render the page with nested dynamic components', async () => {
+    const $ = await next.render$('/')
+    expect($('h1').text()).toBe('Nested Dynamic Components Test')
+    expect($('.dynamic-component').length).toBe(2)
+  })
+
+  it('should generate react-loadable-manifest with valid chunk references', async () => {
+    // Trigger the page to ensure manifest is generated
+    await next.render('/')
+
+    // The manifest path differs between Turbopack and Webpack
+    // For Turbopack, each page has its own manifest in .next/dev/server/pages/<path>/
+    const manifestPath = isTurbopack
+      ? '.next/dev/server/pages/index/react-loadable-manifest.json'
+      : '.next/react-loadable-manifest.json'
+
+    const manifestExists = await next
+      .readFile(manifestPath)
+      .then(() => true)
+      .catch(() => false)
+
+    if (!manifestExists) {
+      // Skip if manifest doesn't exist (e.g., no dynamic imports detected)
+      console.log('Manifest not found, skipping chunk validation')
+      return
+    }
+
+    const manifest = await next.readJSON(manifestPath)
+
+    // Verify the manifest is not empty - we expect entries for our dynamic imports
+    const values = Object.values(manifest)
+    expect(values.length).toBeGreaterThan(0)
+
+    // Verify each chunk file referenced in the manifest actually exists
+    // This catches the bug where manifest references chunks with wrong hashes
+    for (const entry of values) {
+      const { files } = entry as { id: string; files: string[] }
+      for (const file of files) {
+        // The file paths in manifest are relative (e.g., "static/chunks/...")
+        // We need to check in .next/dev for Turbopack
+        const chunkPath = isTurbopack
+          ? path.join(next.testDir, '.next/dev', file)
+          : path.join(next.testDir, '.next', file)
+
+        expect(fs.existsSync(chunkPath)).toBe(true)
+      }
+    }
+  })
+})

--- a/test/development/nested-dynamic-components/pages/index.tsx
+++ b/test/development/nested-dynamic-components/pages/index.tsx
@@ -1,0 +1,22 @@
+import dynamic from 'next/dynamic'
+
+// Multiple dynamic components that themselves have nested dynamic imports
+const FeatureCard = dynamic(() => import('../components/FeatureCard'))
+const UserProfile = dynamic(() => import('../components/UserProfile'))
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Nested Dynamic Components Test</h1>
+      <div className="dynamic-component">
+        <FeatureCard
+          title="Feature 1"
+          description="Description for feature 1"
+        />
+      </div>
+      <div className="dynamic-component">
+        <UserProfile name="Test User" count={42} />
+      </div>
+    </div>
+  )
+}

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -14,9 +14,7 @@ use turbopack_core::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
         ChunkingConfig, ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAsset,
         EvaluatableAssets, MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences,
-        UrlBehavior,
-        availability_info::AvailabilityInfo,
-        chunk_group::{MakeChunkGroupResult, make_chunk_group},
+        UrlBehavior, availability_info::AvailabilityInfo, chunk_group::make_chunk_group,
         chunk_id_strategy::ModuleIdStrategy,
     },
     context::AssetContext,
@@ -713,12 +711,7 @@ impl ChunkingContext for BrowserChunkingContext {
             let this = self.await?;
             let entries = chunk_group.entries();
             let input_availability_info = availability_info;
-            let MakeChunkGroupResult {
-                chunks,
-                referenced_output_assets,
-                references,
-                availability_info,
-            } = make_chunk_group(
+            let result = make_chunk_group(
                 entries,
                 module_graph,
                 ResolvedVc::upcast(self),
@@ -726,7 +719,7 @@ impl ChunkingContext for BrowserChunkingContext {
             )
             .await?;
 
-            let chunks = chunks.await?;
+            let chunks = result.chunks.await?;
 
             let mut assets = chunks
                 .iter()
@@ -755,9 +748,9 @@ impl ChunkingContext for BrowserChunkingContext {
 
             Ok(ChunkGroupResult {
                 assets: ResolvedVc::cell(assets),
-                referenced_assets: ResolvedVc::cell(referenced_output_assets),
-                references: ResolvedVc::cell(references),
-                availability_info,
+                referenced_assets: ResolvedVc::cell(result.referenced_output_assets),
+                availability_info: result.availability_info,
+                async_loaders_by_module: result.async_loaders_by_module,
             }
             .cell())
         }
@@ -781,12 +774,7 @@ impl ChunkingContext for BrowserChunkingContext {
         async move {
             let this = self.await?;
             let entries = chunk_group.entries();
-            let MakeChunkGroupResult {
-                chunks,
-                referenced_output_assets,
-                references,
-                availability_info,
-            } = make_chunk_group(
+            let result = make_chunk_group(
                 entries,
                 module_graph,
                 ResolvedVc::upcast(self),
@@ -794,7 +782,7 @@ impl ChunkingContext for BrowserChunkingContext {
             )
             .await?;
 
-            let chunks = chunks.await?;
+            let chunks = result.chunks.await?;
 
             let mut assets: Vec<ResolvedVc<Box<dyn OutputAsset>>> = chunks
                 .iter()
@@ -840,9 +828,9 @@ impl ChunkingContext for BrowserChunkingContext {
 
             Ok(ChunkGroupResult {
                 assets: ResolvedVc::cell(assets),
-                referenced_assets: ResolvedVc::cell(referenced_output_assets),
-                references: ResolvedVc::cell(references),
-                availability_info,
+                referenced_assets: ResolvedVc::cell(result.referenced_output_assets),
+                availability_info: result.availability_info,
+                async_loaders_by_module: result.async_loaders_by_module,
             }
             .cell())
         }

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, sync::atomic::AtomicBool};
 use anyhow::{Context, Result};
 use rustc_hash::FxHashMap;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc};
+use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc};
 
 use super::{
     ChunkGroupContent, ChunkItemWithAsyncModuleInfo, ChunkingContext,
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::{
     chunk::{
-        ChunkableModule, ChunkingType, Chunks,
+        ChunkItem, ChunkableModule, ChunkingType, Chunks,
         available_modules::AvailableModuleItem,
         chunk_item_batch::{ChunkItemBatchGroup, ChunkItemOrBatchWithAsyncModuleInfo},
     },
@@ -37,8 +37,24 @@ use crate::{
 pub struct MakeChunkGroupResult {
     pub chunks: ResolvedVc<Chunks>,
     pub referenced_output_assets: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
-    pub references: Vec<ResolvedVc<Box<dyn OutputAssetsReference>>>,
     pub availability_info: AvailabilityInfo,
+    /// Map from async module to its async loader chunk item.
+    /// This preserves the module→loader relationship for async loaders,
+    /// allowing downstream code to look up pre-computed chunk outputs
+    /// instead of recomputing them.
+    #[allow(clippy::type_complexity)]
+    pub async_loaders_by_module:
+        FxIndexMap<ResolvedVc<Box<dyn ChunkableModule>>, ResolvedVc<Box<dyn ChunkItem>>>,
+}
+
+impl MakeChunkGroupResult {
+    // Returns all the assets referenced by this chunk group.
+    pub fn references(&self) -> Vec<ResolvedVc<Box<dyn OutputAssetsReference>>> {
+        self.async_loaders_by_module
+            .values()
+            .map(|loader| ResolvedVc::upcast(*loader))
+            .collect()
+    }
 }
 
 /// Creates a chunk group from a set of entries.
@@ -121,19 +137,28 @@ pub async fn make_chunk_group(
         } else {
             availability_info
         };
-    let async_loaders = async_modules
+    // Build async loaders while preserving the module→loader mapping
+    let async_loaders_with_modules: Vec<_> = async_modules
         .into_iter()
         .map(async |module| {
-            chunking_context
+            let loader = chunking_context
                 .async_loader_chunk_item(*module, module_graph, async_availability_info)
                 .to_resolved()
-                .await
+                .await?;
+            Ok((module, loader))
         })
         .try_join()
         .await?;
-    let async_loader_chunk_items = async_loaders.iter().map(|&chunk_item| {
+
+    // Build the module→loader mapping
+    let async_loaders_by_module: FxIndexMap<_, _> = async_loaders_with_modules
+        .iter()
+        .map(|(module, loader)| (*module, *loader))
+        .collect();
+
+    let async_loader_chunk_items = async_loaders_with_modules.iter().map(|(_, chunk_item)| {
         ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(ChunkItemWithAsyncModuleInfo {
-            chunk_item,
+            chunk_item: *chunk_item,
             module: None,
             async_info: None,
         })
@@ -165,8 +190,8 @@ pub async fn make_chunk_group(
     Ok(MakeChunkGroupResult {
         chunks,
         referenced_output_assets,
-        references: ResolvedVc::upcast_vec(async_loaders),
         availability_info: new_availability_info,
+        async_loaders_by_module,
     })
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -3,7 +3,9 @@ use bincode::{Decode, Encode};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Upcast, Vc, trace::TraceRawVcs};
+use turbo_tasks::{
+    FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, Upcast, Vc, trace::TraceRawVcs,
+};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
@@ -22,8 +24,8 @@ use crate::{
         module_batches::BatchingConfig,
     },
     output::{
-        ExpandOutputAssetsInput, OutputAsset, OutputAssets, OutputAssetsReferences,
-        OutputAssetsWithReferenced, expand_output_assets,
+        ExpandOutputAssetsInput, OutputAsset, OutputAssets, OutputAssetsWithReferenced,
+        expand_output_assets,
     },
     reference::ModuleReference,
 };
@@ -127,8 +129,15 @@ pub enum ChunkGroupType {
 pub struct ChunkGroupResult {
     pub assets: ResolvedVc<OutputAssets>,
     pub referenced_assets: ResolvedVc<OutputAssets>,
-    pub references: ResolvedVc<OutputAssetsReferences>,
     pub availability_info: AvailabilityInfo,
+    /// Map from async module to its async loader chunk item.
+    /// This preserves the module→loader relationship for async loaders,
+    /// allowing downstream code to look up pre-computed chunk outputs
+    /// instead of recomputing them.
+    #[bincode(with = "turbo_bincode::indexmap")]
+    #[allow(clippy::type_complexity)]
+    pub async_loaders_by_module:
+        FxIndexMap<ResolvedVc<Box<dyn ChunkableModule>>, ResolvedVc<Box<dyn ChunkItem>>>,
 }
 
 impl ChunkGroupResult {
@@ -136,8 +145,8 @@ impl ChunkGroupResult {
         ChunkGroupResult {
             assets: ResolvedVc::cell(vec![]),
             referenced_assets: ResolvedVc::cell(vec![]),
-            references: ResolvedVc::cell(vec![]),
             availability_info: AvailabilityInfo::root(),
+            async_loaders_by_module: FxIndexMap::default(),
         }
         .cell()
     }
@@ -146,8 +155,8 @@ impl ChunkGroupResult {
         ChunkGroupResult {
             assets: ResolvedVc::cell(vec![]),
             referenced_assets: ResolvedVc::cell(vec![]),
-            references: ResolvedVc::cell(vec![]),
             availability_info: AvailabilityInfo::root(),
+            async_loaders_by_module: FxIndexMap::default(),
         }
         .resolved_cell()
     }
@@ -157,10 +166,16 @@ impl ChunkGroupResult {
 impl ChunkGroupResult {
     #[turbo_tasks::function]
     pub async fn output_assets_with_referenced(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
+        let references: Vec<_> = self
+            .async_loaders_by_module
+            .values()
+            .map(|loader| ResolvedVc::upcast(*loader))
+            .collect();
+
         Ok(OutputAssetsWithReferenced {
             assets: self.assets,
             referenced_assets: self.referenced_assets,
-            references: self.references,
+            references: ResolvedVc::cell(references),
         }
         .cell())
     }
@@ -168,6 +183,11 @@ impl ChunkGroupResult {
     #[turbo_tasks::function]
     pub async fn concatenate(&self, next: Vc<Self>) -> Result<Vc<Self>> {
         let next = next.await?;
+
+        // Merge async_loaders_by_module maps
+        let mut merged_async_loaders = self.async_loaders_by_module.clone();
+        merged_async_loaders.extend(next.async_loaders_by_module.iter().map(|(k, v)| (*k, *v)));
+
         Ok(ChunkGroupResult {
             assets: self.assets.concatenate(*next.assets).to_resolved().await?,
             referenced_assets: self
@@ -175,12 +195,8 @@ impl ChunkGroupResult {
                 .concatenate(*next.referenced_assets)
                 .to_resolved()
                 .await?,
-            references: self
-                .references
-                .concatenate(*next.references)
-                .to_resolved()
-                .await?,
             availability_info: next.availability_info,
+            async_loaders_by_module: merged_async_loaders,
         }
         .cell())
     }
@@ -196,11 +212,9 @@ impl ChunkGroupResult {
                     .copied()
                     .map(ExpandOutputAssetsInput::Asset)
                     .chain(
-                        self.references
-                            .await?
-                            .into_iter()
-                            .copied()
-                            .map(ExpandOutputAssetsInput::Reference),
+                        self.async_loaders_by_module
+                            .values()
+                            .map(|v| ExpandOutputAssetsInput::Reference(ResolvedVc::upcast(*v))),
                     ),
                 false,
             )
@@ -217,6 +231,13 @@ impl ChunkGroupResult {
 
     #[turbo_tasks::function]
     pub async fn referenced_assets(&self) -> Result<Vc<OutputAssets>> {
+        // Derive references from async_loaders_by_module
+        let references = self
+            .async_loaders_by_module
+            .values()
+            .copied()
+            .map(ResolvedVc::upcast);
+
         Ok(Vc::cell(
             expand_output_assets(
                 self.referenced_assets
@@ -224,13 +245,7 @@ impl ChunkGroupResult {
                     .into_iter()
                     .copied()
                     .map(ExpandOutputAssetsInput::Asset)
-                    .chain(
-                        self.references
-                            .await?
-                            .into_iter()
-                            .copied()
-                            .map(ExpandOutputAssetsInput::Reference),
-                    ),
+                    .chain(references.map(ExpandOutputAssetsInput::Reference)),
                 false,
             )
             .await?,

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -12,7 +12,8 @@ use swc_core::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Vc, debug::ValueDebugFormat,
+    FxIndexMap, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, Vc,
+    debug::{ValueDebug, ValueDebugFormat},
     trace::TraceRawVcs,
 };
 use turbopack_core::{
@@ -372,9 +373,13 @@ async fn to_single_pattern_mapping(
     CodeGenerationIssue {
         severity: IssueSeverity::Bug,
         title: StyledString::Text(rcstr!("non-ecmascript placeable asset")).resolved_cell(),
-        message: StyledString::Text(rcstr!(
-            "asset is not placeable in ESM chunks, so it doesn't have a module id"
-        ))
+        message: StyledString::Text(
+            format!(
+                "asset is not placeable in ESM chunks, so it doesn't have a module id: {}",
+                module.dbg_depth(2).await?
+            )
+            .into(),
+        )
         .resolved_cell(),
         path: origin.origin_path().owned().await?,
         source: None,

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -9,8 +9,7 @@ use turbopack_core::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
         ChunkingConfig, ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAssets,
         MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
-        availability_info::AvailabilityInfo,
-        chunk_group::{MakeChunkGroupResult, make_chunk_group},
+        availability_info::AvailabilityInfo, chunk_group::make_chunk_group,
         chunk_id_strategy::ModuleIdStrategy,
     },
     environment::Environment,
@@ -493,12 +492,7 @@ impl ChunkingContext for NodeJsChunkingContext {
         let span = tracing::info_span!("chunking", name = display(ident.to_string().await?));
         async move {
             let modules = chunk_group.entries();
-            let MakeChunkGroupResult {
-                chunks,
-                referenced_output_assets,
-                references,
-                availability_info,
-            } = make_chunk_group(
+            let result = make_chunk_group(
                 modules,
                 module_graph,
                 ResolvedVc::upcast(self),
@@ -506,7 +500,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             )
             .await?;
 
-            let chunks = chunks.await?;
+            let chunks = result.chunks.await?;
 
             let assets = chunks
                 .iter()
@@ -516,9 +510,9 @@ impl ChunkingContext for NodeJsChunkingContext {
 
             Ok(ChunkGroupResult {
                 assets: ResolvedVc::cell(assets),
-                referenced_assets: ResolvedVc::cell(referenced_output_assets),
-                references: ResolvedVc::cell(references),
-                availability_info,
+                referenced_assets: ResolvedVc::cell(result.referenced_output_assets),
+                availability_info: result.availability_info,
+                async_loaders_by_module: result.async_loaders_by_module,
             }
             .cell())
         }
@@ -547,12 +541,7 @@ impl ChunkingContext for NodeJsChunkingContext {
                 .iter()
                 .map(|&asset| ResolvedVc::upcast::<Box<dyn Module>>(asset));
 
-            let MakeChunkGroupResult {
-                chunks,
-                mut referenced_output_assets,
-                references,
-                availability_info,
-            } = make_chunk_group(
+            let result = make_chunk_group(
                 entries,
                 module_graph,
                 ResolvedVc::upcast(self),
@@ -560,7 +549,9 @@ impl ChunkingContext for NodeJsChunkingContext {
             )
             .await?;
 
-            let chunks = chunks.await?;
+            let chunks = result.chunks.await?;
+            let references = result.references();
+            let mut referenced_output_assets = result.referenced_output_assets;
 
             let extra_chunks = extra_chunks.await?;
             let mut other_chunks = chunks
@@ -594,7 +585,7 @@ impl ChunkingContext for NodeJsChunkingContext {
 
             Ok(EntryChunkGroupResult {
                 asset,
-                availability_info,
+                availability_info: result.availability_info,
             }
             .cell())
         }


### PR DESCRIPTION
Revert #89073 to reapply https://github.com/vercel/next.js/pull/88775