### PR TITLE
tweak LRU sentinel cache key

### DIFF
--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -63,10 +63,9 @@ const KEY_SEPARATOR = '\0'
 
 /**
  * Sentinel value used for TTL-based cache entries (when invocationID is undefined).
- * Uses KEY_SEPARATOR prefix to guarantee uniqueness since null bytes cannot appear
- * in HTTP headers (RFC 7230), making collision with real invocation IDs impossible.
+ * Chosen to be a clearly reserved marker for internal cache keys.
  */
-const TTL_SENTINEL = `${KEY_SEPARATOR}ttl`
+const TTL_SENTINEL = '__ttl_sentinel__'
 
 /**
  * Entry stored in the LRU cache.


### PR DESCRIPTION
We originally prefixed the TTL sentinel with the null-byte separator to avoid collisions with real invocation IDs, but that makes `extractInvocationID` return "ttl" instead of undefined for TTL-mode keys.

This switches to a reserved magic string sentinel so TTL-mode entries are correctly treated as “no invocation ID”.