### PR TITLE
Add full adapters E2E tests to workflow

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -111,6 +111,8 @@ env:
   NEXT_TEST_JOB: 1
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
+  VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
+  VERCEL_ADAPTER_TEST_TEAM: vtest314-next-adapter-e2e-tests
   NEXT_TEST_PREFER_OFFLINE: 1
   NEXT_CI_RUNNER: ${{ inputs.runs_on_labels }}
   NEXT_TEST_PROXY_ADDRESS: ${{ inputs.overrideProxyAddress || '' }}

--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -21,10 +21,12 @@ on:
         type: string
 
 env:
+  DD_ENV: 'ci'
+  DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
-  DATADOG_API_KEY: ${{ secrets.DATA_DOG_API_KEY }}
-  DD_ENV: 'ci'
+  VERCEL_ADAPTER_TEST_TEAM: vtest314-next-adapter-e2e-tests
+  VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
 
 run-name: test-e2e-deploy ${{ inputs.nextVersion || (github.event_name == 'release' && github.event.release.tag_name) || 'canary' }}
 
@@ -98,7 +100,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1/1]
+        group:
+          [
+            1/12,
+            2/12,
+            3/12,
+            4/12,
+            5/12,
+            6/12,
+            7/12,
+            8/12,
+            9/12,
+            10/12,
+            11/12,
+            12/12,
+          ]
     with:
       afterBuild: |
         npm i -g vercel@latest && \
@@ -109,10 +125,10 @@ jobs:
         NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json" \
         NEXT_TEST_VERSION="${{ github.event.inputs.nextVersion || needs.setup.outputs.next-version || 'canary' }}" \
         VERCEL_CLI_VERSION="${{ github.event.inputs.vercelCliVersion || 'vercel@latest' }}" \
-        node run-tests.js --timings -g ${{ matrix.group }} -c 2 test/e2e/app-dir/segment-cache/client-params/client-params.test.ts test/e2e/app-dir/app-static/app-static.test.ts test/e2e/app-dir/cache-components/cache-components.test.ts test/e2e/app-dir/app/index.test.ts test/e2e/app-dir/app-edge/app-edge.test.ts test/e2e/edge-pages-support/index.test.ts test/e2e/prerender.test.ts test/e2e/middleware-general/test/index.test.ts test/e2e/middleware-rewrites/test/index.test.ts test/e2e/app-dir/actions/app-action-node-middleware.test.ts
+        node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
       skipNativeBuild: 'yes'
       skipNativeInstall: 'no'
-      stepName: 'test-deploy-adapter-${{ matrix.group }}'
+      stepName: 'test-deploy-deploy-${{ matrix.group }}'
       timeout_minutes: 180
       runs_on_labels: '["ubuntu-latest"]'
       overrideProxyAddress: ${{ inputs.overrideProxyAddress || '' }}

--- a/.github/workflows/test_e2e_project_reset_cron.yml
+++ b/.github/workflows/test_e2e_project_reset_cron.yml
@@ -10,6 +10,8 @@ on:
 env:
   VERCEL_TEST_TEAM: vtest314-next-e2e-tests
   VERCEL_TEST_TOKEN: ${{ secrets.VERCEL_TEST_TOKEN }}
+  VERCEL_ADAPTER_TEST_TEAM: vtest314-next-adapter-e2e-tests
+  VERCEL_ADAPTER_TEST_TOKEN: ${{ secrets.VERCEL_ADAPTER_TEST_TOKEN }}
   NODE_LTS_VERSION: 20
   TURBO_TEAM: 'vercel'
   TURBO_CACHE: 'remote:rw'

--- a/scripts/reset-project.mjs
+++ b/scripts/reset-project.mjs
@@ -4,6 +4,9 @@ export const TEST_PROJECT_NAME = 'vtest314-e2e-tests'
 export const TEST_TEAM_NAME = process.env.VERCEL_TEST_TEAM
 export const TEST_TOKEN = process.env.VERCEL_TEST_TOKEN
 
+export const ADAPTER_TEST_TEAM_NAME = process.env.VERCEL_ADAPTER_TEST_TEAM
+export const ADAPTER_TEST_TOKEN = process.env.VERCEL_ADAPTER_TEST_TOKEN
+
 /**
  * Retry a fetch request with exponential backoff
  * @param {string} url - The URL to fetch
@@ -55,7 +58,8 @@ async function fetchWithRetry(
 export async function resetProject({
   teamId = TEST_TEAM_NAME,
   projectName = TEST_PROJECT_NAME,
-  disableDeploymentProtection,
+  token = TEST_TOKEN,
+  disableDeploymentProtection = true,
 }) {
   console.log(`Resetting project ${teamId}/${projectName}`)
   // TODO: error/bail if existing deployments are pending
@@ -66,7 +70,7 @@ export async function resetProject({
     {
       method: 'DELETE',
       headers: {
-        Authorization: `Bearer ${TEST_TOKEN}`,
+        Authorization: `Bearer ${token}`,
       },
     },
     {
@@ -82,7 +86,7 @@ export async function resetProject({
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        Authorization: `Bearer ${TEST_TOKEN}`,
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
         framework: 'nextjs',
@@ -111,11 +115,14 @@ export async function resetProject({
         method: 'PATCH',
         headers: {
           'content-type': 'application/json',
-          Authorization: `Bearer ${TEST_TOKEN}`,
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
           ssoProtection: null,
           passwordProtection: null,
+          resourceConfig: {
+            buildMachineType: 'enhanced',
+          },
         }),
       },
       {

--- a/scripts/run-e2e-test-project-reset.mjs
+++ b/scripts/run-e2e-test-project-reset.mjs
@@ -2,13 +2,40 @@ import {
   resetProject,
   TEST_PROJECT_NAME,
   TEST_TEAM_NAME,
+  ADAPTER_TEST_TEAM_NAME,
+  ADAPTER_TEST_TOKEN,
+  TEST_TOKEN,
 } from './reset-project.mjs'
 
-resetProject({
-  projectName: TEST_PROJECT_NAME,
-  teamId: TEST_TEAM_NAME,
-  disableDeploymentProtection: true,
-}).catch((err) => {
+async function main() {
+  let hadFailure = false
+
+  await resetProject({
+    projectName: TEST_PROJECT_NAME,
+    teamId: TEST_TEAM_NAME,
+    token: TEST_TOKEN,
+    disableDeploymentProtection: true,
+  }).catch((err) => {
+    console.error(err)
+    hadFailure = true
+  })
+
+  await resetProject({
+    projectName: TEST_PROJECT_NAME,
+    teamId: ADAPTER_TEST_TEAM_NAME,
+    token: ADAPTER_TEST_TOKEN,
+    disableDeploymentProtection: true,
+  }).catch((err) => {
+    console.error(err)
+    hadFailure = true
+  })
+
+  if (hadFailure) {
+    throw new Error(`resetting a project failed`)
+  }
+}
+
+main().catch((err) => {
   console.error(err)
   process.exit(1)
 })

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -3,11 +3,7 @@ import path from 'path'
 import execa from 'execa'
 import fs from 'fs-extra'
 import { NextInstance } from './base'
-import {
-  TEST_PROJECT_NAME,
-  TEST_TEAM_NAME,
-  TEST_TOKEN,
-} from '../../../scripts/reset-project.mjs'
+import * as projectEnv from '../../../scripts/reset-project.mjs'
 import { Span } from 'next/dist/trace'
 
 export class NextDeployInstance extends NextInstance {
@@ -55,6 +51,15 @@ export class NextDeployInstance extends NextInstance {
     }
 
     const vercelFlags: string[] = []
+    const NEXT_ENABLE_ADAPTER = process.env.NEXT_ENABLE_ADAPTER
+
+    const TEST_TEAM_NAME = NEXT_ENABLE_ADAPTER
+      ? projectEnv.ADAPTER_TEST_TEAM_NAME
+      : projectEnv.TEST_TEAM_NAME
+
+    const TEST_TOKEN = NEXT_ENABLE_ADAPTER
+      ? projectEnv.ADAPTER_TEST_TOKEN
+      : projectEnv.TEST_TOKEN
 
     // If the team name is available in the environment, use it as the scope.
     if (TEST_TEAM_NAME) {
@@ -101,7 +106,7 @@ export class NextDeployInstance extends NextInstance {
       // link the project
       const linkRes = await execa(
         'vercel',
-        ['link', '-p', TEST_PROJECT_NAME, '--yes', ...vercelFlags],
+        ['link', '-p', projectEnv.TEST_PROJECT_NAME, '--yes', ...vercelFlags],
         {
           cwd: this.testDir,
           env: vercelEnv,


### PR DESCRIPTION
This updates to run the entire E2E deploy tests same as we do currently but with adapters enabled to catch regressions there. These run on a separate test team to isolate from existing test team and avoid rate limits. 

Test run of the workflow done here https://github.com/vercel/next.js/actions/runs/21418745794