### PR TITLE
[backport]: fix: ensure LRU cache items have minimum size of 1 to prevent unbounded growth

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -786,5 +786,6 @@
   "785": "Request body exceeded %s",
   "786": "Server Actions are not enabled for this application. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
   "787": "Failed to find Server Action. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
-  "788": "Failed to find Server Action%s. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action"
+  "788": "Failed to find Server Action%s. This request might be from an older or newer deployment.\\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action",
+  "789": "LRUCache: calculateSize returned %s, but size must be > 0. Items with size 0 would never be evicted, causing unbounded cache growth."
 }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -175,7 +175,8 @@ export default class DevServer extends Server {
       // 5MB
       5 * 1024 * 1024,
       function length(value) {
-        return JSON.stringify(value.staticPaths)?.length ?? 0
+        // Ensure minimum size of 1 for LRU eviction to work correctly
+        return JSON.stringify(value.staticPaths)?.length || 1
       }
     )
     this.renderOpts.ampSkipValidation =

--- a/packages/next/src/server/lib/lru-cache.ts
+++ b/packages/next/src/server/lib/lru-cache.ts
@@ -119,6 +119,12 @@ export class LRUCache<T> {
    */
   public set(key: string, value: T): void {
     const size = this.calculateSize?.(value) ?? 1
+    if (size <= 0) {
+      throw new Error(
+        `LRUCache: calculateSize returned ${size}, but size must be > 0. ` +
+          `Items with size 0 would never be evicted, causing unbounded cache growth.`
+      )
+    }
     if (size > this.maxSize) {
       console.warn('Single item size exceeds maxSize')
       return

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -110,7 +110,10 @@ export async function setupFsCheck(opts: {
 }) {
   const getItemsLru = !opts.dev
     ? new LRUCache<FsOutput | null>(1024 * 1024, function length(value) {
-        if (!value) return 0
+        if (!value) {
+          // Null entries (negative cache) still need a non-zero size for LRU eviction
+          return 1
+        }
         return (
           (value.fsPath || '').length +
           value.itemPath.length +


### PR DESCRIPTION
Backports:
- #89040