### PR TITLE
Turbopack: add support for contentType condition for webpack loaders

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2193,6 +2193,7 @@ mod tests {
                                         source: rcstr!("@someQuery"),
                                         flags: rcstr!(""),
                                     })),
+                                    content_type: None,
                                 },
                             ]
                             .into(),

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -14,8 +14,8 @@ use turbo_tasks_env::EnvMap;
 use turbo_tasks_fetch::FetchClientConfig;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{
-    ConditionItem, ConditionPath, ConditionQuery, LoaderRuleItem, WebpackRules,
-    module_options_context::MdxTransformOptions,
+    ConditionContentType, ConditionItem, ConditionPath, ConditionQuery, LoaderRuleItem,
+    WebpackRules, module_options_context::MdxTransformOptions,
 };
 use turbopack_core::{
     chunk::SourceMapsType,
@@ -710,6 +710,42 @@ impl TryFrom<ConfigConditionQuery> for ConditionQuery {
 }
 
 #[derive(
+    Clone,
+    PartialEq,
+    Eq,
+    Debug,
+    Deserialize,
+    TraceRawVcs,
+    NonLocalValue,
+    OperationValue,
+    Encode,
+    Decode,
+)]
+#[serde(
+    tag = "type",
+    content = "value",
+    rename_all = "camelCase",
+    deny_unknown_fields
+)]
+pub enum ConfigConditionContentType {
+    Glob(RcStr),
+    Regex(RegexComponents),
+}
+
+impl TryFrom<ConfigConditionContentType> for ConditionContentType {
+    type Error = anyhow::Error;
+
+    fn try_from(config: ConfigConditionContentType) -> Result<ConditionContentType> {
+        Ok(match config {
+            ConfigConditionContentType::Glob(value) => ConditionContentType::Glob(value),
+            ConfigConditionContentType::Regex(regex) => {
+                ConditionContentType::Regex(EsRegex::try_from(regex)?.resolved_cell())
+            }
+        })
+    }
+}
+
+#[derive(
     Deserialize,
     Clone,
     PartialEq,
@@ -741,6 +777,8 @@ pub enum ConfigConditionItem {
         content: Option<RegexComponents>,
         #[serde(default)]
         query: Option<ConfigConditionQuery>,
+        #[serde(default, rename = "contentType")]
+        content_type: Option<ConfigConditionContentType>,
     },
 }
 
@@ -765,6 +803,7 @@ impl TryFrom<ConfigConditionItem> for ConditionItem {
                 path,
                 content,
                 query,
+                content_type,
             } => ConditionItem::Base {
                 path: path.map(ConditionPath::try_from).transpose()?,
                 content: content
@@ -772,6 +811,9 @@ impl TryFrom<ConfigConditionItem> for ConditionItem {
                     .transpose()?
                     .map(EsRegex::resolved_cell),
                 query: query.map(ConditionQuery::try_from).transpose()?,
+                content_type: content_type
+                    .map(ConditionContentType::try_from)
+                    .transpose()?,
             },
         })
     }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -199,6 +199,7 @@ pub async fn get_babel_loader_rules(
                                 .resolved_cell(),
                         ),
                         query: None,
+                        content_type: None,
                     });
                 }
                 ReactCompilerCompilationMode::Infer => {
@@ -212,6 +213,7 @@ pub async fn get_babel_loader_rules(
                                 .resolved_cell(),
                         ),
                         query: None,
+                        content_type: None,
                     });
                 }
                 ReactCompilerCompilationMode::All => {}

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -216,10 +216,11 @@ module.exports = {
 ```
 
 - Supported boolean operators are `{all: [...]}`, `{any: [...]}` and `{not: ...}`.
-- Supported customizable operators are `{path: string | RegExp}`, `{content: RegExp}`, and `{query: string | RegExp}`. If multiple operators are specified in the same object, it acts as an implicit `and`.
+- Supported customizable operators are `{path: string | RegExp}`, `{content: RegExp}`, `{query: string | RegExp}`, and `{contentType: string | RegExp}`. If multiple operators are specified in the same object, it acts as an implicit `and`.
   - `path` matches against the project-relative file path. A string is treated as a glob pattern, while a RegExp matches anywhere in the path.
   - `content` matches anywhere in the file content.
   - `query` matches the import's query string (e.g., `?foo` in `import './file?foo'`). A string must match exactly, while a RegExp can match partially.
+  - `contentType` matches the MIME content type of the resource (e.g., from data URLs like `data:text/plain,...`). A string is treated as a glob pattern (e.g., `text/*`, `image/*`), while a RegExp can match partially.
 
 In addition, a number of built-in conditions are supported:
 
@@ -312,10 +313,11 @@ The option automatically adds a polyfill for debug IDs to the JavaScript bundle 
 
 ## Version History
 
-| Version  | Changes                                         |
-| -------- | ----------------------------------------------- |
-| `16.2.0` | `turbopack.rules.*.condition.query` was added.  |
-| `16.0.0` | `turbopack.debugIds` was added.                 |
-| `16.0.0` | `turbopack.rules.*.condition` was added.        |
-| `15.3.0` | `experimental.turbo` is changed to `turbopack`. |
-| `13.0.0` | `experimental.turbo` introduced.                |
+| Version  | Changes                                              |
+| -------- | ---------------------------------------------------- |
+| `16.2.0` | `turbopack.rules.*.condition.contentType` was added. |
+| `16.2.0` | `turbopack.rules.*.condition.query` was added.       |
+| `16.0.0` | `turbopack.debugIds` was added.                      |
+| `16.0.0` | `turbopack.rules.*.condition` was added.             |
+| `15.3.0` | `experimental.turbo` is changed to `turbopack`.      |
+| `13.0.0` | `experimental.turbo` introduced.                     |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopack.mdx
@@ -217,10 +217,10 @@ module.exports = {
 
 - Supported boolean operators are `{all: [...]}`, `{any: [...]}` and `{not: ...}`.
 - Supported customizable operators are `{path: string | RegExp}`, `{content: RegExp}`, `{query: string | RegExp}`, and `{contentType: string | RegExp}`. If multiple operators are specified in the same object, it acts as an implicit `and`.
-  - `path` matches against the project-relative file path. A string is treated as a glob pattern, while a RegExp matches anywhere in the path.
+  - `path` matches against the project-relative file path. A string is treated as a glob pattern, while a RegExp can be used to match the path partially.
   - `content` matches anywhere in the file content.
-  - `query` matches the import's query string (e.g., `?foo` in `import './file?foo'`). A string must match exactly, while a RegExp can match partially.
-  - `contentType` matches the MIME content type of the resource (e.g., from data URLs like `data:text/plain,...`). A string is treated as a glob pattern (e.g., `text/*`, `image/*`), while a RegExp can match partially.
+  - `query` matches the import's query string (e.g., `?foo` in `import './file?foo'`). A string must match exactly, while a RegExp can be used to match the query string partially.
+  - `contentType` matches the MIME content type of the resource (e.g., from data URLs like `data:text/plain,...`). A string is treated as a glob pattern (e.g., `text/*`, `image/*`), while a RegExp can be used to match the content type partially.
 
 In addition, a number of built-in conditions are supported:
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -953,6 +953,9 @@ function bindingToApi(
         query?:
           | { type: 'regex'; value: { source: string; flags: string } }
           | { type: 'constant'; value: string }
+        contentType?:
+          | { type: 'regex'; value: { source: string; flags: string } }
+          | { type: 'glob'; value: string }
       }
 
   // converts regexes to a `RegexComponents` object so that it can be JSON-serialized when passed to
@@ -997,6 +1000,15 @@ function bindingToApi(
                   value: regexComponents(cond.query),
                 }
               : { type: 'constant', value: cond.query },
+        contentType:
+          cond.contentType == null
+            ? undefined
+            : cond.contentType instanceof RegExp
+              ? {
+                  type: 'regex',
+                  value: regexComponents(cond.contentType),
+                }
+              : { type: 'glob', value: cond.contentType },
       }
     }
   }

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -130,6 +130,7 @@ const zTurbopackCondition: zod.ZodType<TurbopackRuleCondition> = z.union([
     path: z.union([z.string(), z.instanceof(RegExp)]).optional(),
     content: z.instanceof(RegExp).optional(),
     query: z.union([z.string(), z.instanceof(RegExp)]).optional(),
+    contentType: z.union([z.string(), z.instanceof(RegExp)]).optional(),
   }),
 ])
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -119,6 +119,7 @@ export type TurbopackRuleCondition =
       path?: string | RegExp
       content?: RegExp
       query?: string | RegExp
+      contentType?: string | RegExp
     }
 
 export type TurbopackRuleConfigItem = {

--- a/test/e2e/app-dir/turbopack-loader-content-type/app/layout.tsx
+++ b/test/e2e/app-dir/turbopack-loader-content-type/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/turbopack-loader-content-type/app/page.tsx
+++ b/test/e2e/app-dir/turbopack-loader-content-type/app/page.tsx
@@ -1,0 +1,13 @@
+// @ts-expect-error -- data URL import
+import textData from 'data:text/plain,Hello World'
+// @ts-expect-error -- data URL import
+import imageData from 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
+
+export default function Page() {
+  return (
+    <div>
+      <p id="text">{textData}</p>
+      <p id="image">{imageData}</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/turbopack-loader-content-type/app/page.tsx
+++ b/test/e2e/app-dir/turbopack-loader-content-type/app/page.tsx
@@ -1,12 +1,15 @@
 // @ts-expect-error -- data URL import
 import textData from 'data:text/plain,Hello World'
 // @ts-expect-error -- data URL import
+import jsData from 'data:text/javascript,export default "Hello JS"'
+// @ts-expect-error -- data URL import
 import imageData from 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=='
 
 export default function Page() {
   return (
     <div>
       <p id="text">{textData}</p>
+      <p id="js">{jsData}</p>
       <p id="image">{imageData}</p>
     </div>
   )

--- a/test/e2e/app-dir/turbopack-loader-content-type/image-loader.js
+++ b/test/e2e/app-dir/turbopack-loader-content-type/image-loader.js
@@ -1,0 +1,3 @@
+module.exports = function imageLoader(source) {
+  return `export default ${JSON.stringify('IMAGE:' + source.length + ' bytes')}`
+}

--- a/test/e2e/app-dir/turbopack-loader-content-type/js-loader.js
+++ b/test/e2e/app-dir/turbopack-loader-content-type/js-loader.js
@@ -1,0 +1,3 @@
+module.exports = function jsLoader(source) {
+  return source.replace('Hello JS', 'Hello from loader')
+}

--- a/test/e2e/app-dir/turbopack-loader-content-type/next.config.js
+++ b/test/e2e/app-dir/turbopack-loader-content-type/next.config.js
@@ -1,0 +1,25 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  turbopack: {
+    rules: {
+      '*': [
+        {
+          // Glob pattern match for text content types
+          condition: { contentType: 'text/*' },
+          loaders: [require.resolve('./text-loader.js')],
+          as: '*.js',
+        },
+        {
+          // Regex match for image content types
+          condition: { contentType: /^image\// },
+          loaders: [require.resolve('./image-loader.js')],
+          as: '*.js',
+        },
+      ],
+    },
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/turbopack-loader-content-type/next.config.js
+++ b/test/e2e/app-dir/turbopack-loader-content-type/next.config.js
@@ -20,6 +20,21 @@ const nextConfig = {
       ],
     },
   },
+  webpack: (config) => {
+    config.module.rules.push(
+      {
+        mimetype: /^text\//,
+        use: [{ loader: require.resolve('./text-loader.js') }],
+        type: 'javascript/auto',
+      },
+      {
+        mimetype: /^image\//,
+        use: [{ loader: require.resolve('./image-loader.js') }],
+        type: 'javascript/auto',
+      }
+    )
+    return config
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/turbopack-loader-content-type/next.config.js
+++ b/test/e2e/app-dir/turbopack-loader-content-type/next.config.js
@@ -6,7 +6,14 @@ const nextConfig = {
     rules: {
       '*': [
         {
+          // Exact match for text/javascript content type
+          condition: { contentType: 'text/javascript' },
+          loaders: [require.resolve('./js-loader.js')],
+          as: '*.js',
+        },
+        {
           // Glob pattern match for text content types
+          // Should not be applied to text/javascript due to the order of rules
           condition: { contentType: 'text/*' },
           loaders: [require.resolve('./text-loader.js')],
           as: '*.js',
@@ -23,7 +30,12 @@ const nextConfig = {
   webpack: (config) => {
     config.module.rules.push(
       {
-        mimetype: /^text\//,
+        mimetype: 'text/javascript',
+        use: [{ loader: require.resolve('./js-loader.js') }],
+        type: 'javascript/auto',
+      },
+      {
+        mimetype: /^text\/(?!javascript$)/,
         use: [{ loader: require.resolve('./text-loader.js') }],
         type: 'javascript/auto',
       },

--- a/test/e2e/app-dir/turbopack-loader-content-type/text-loader.js
+++ b/test/e2e/app-dir/turbopack-loader-content-type/text-loader.js
@@ -1,0 +1,3 @@
+module.exports = function textLoader(source) {
+  return `export default ${JSON.stringify('TEXT:' + source)}`
+}

--- a/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
+++ b/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
@@ -1,0 +1,22 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('turbopack-loader-content-type', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  it('should apply loader based on contentType glob pattern', async () => {
+    const $ = await next.render$('/')
+    const text = $('#text').text()
+    expect(text).toBe('TEXT:Hello World')
+  })
+
+  it('should apply loader based on contentType regex', async () => {
+    const $ = await next.render$('/')
+    const text = $('#image').text()
+    expect(text).toMatch(/^IMAGE:\d+ bytes$/)
+  })
+})

--- a/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
+++ b/test/e2e/app-dir/turbopack-loader-content-type/turbopack-loader-content-type.test.ts
@@ -14,6 +14,12 @@ describe('turbopack-loader-content-type', () => {
     expect(text).toBe('TEXT:Hello World')
   })
 
+  it('should apply loader based on contentType for text/javascript', async () => {
+    const $ = await next.render$('/')
+    const text = $('#js').text()
+    expect(text).toBe('Hello from loader')
+  })
+
   it('should apply loader based on contentType regex', async () => {
     const $ = await next.render$('/')
     const text = $('#image').text()

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -100,6 +100,7 @@ impl AssetIdent {
         let root = self.path.root().await?;
         let path = self.path.clone();
         self.path = root.join(&pattern.replace('*', &path.path))?;
+        self.content_type = None;
         Ok(())
     }
 }

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -121,6 +121,7 @@ async fn rule_condition_from_webpack_condition(
             path,
             content,
             query,
+            content_type,
         } => {
             let mut rule_conditions = Vec::new();
             match &path {
@@ -138,6 +139,17 @@ async fn rule_condition_from_webpack_condition(
                 }
                 Some(ConditionQuery::Regex(regex)) => {
                     rule_conditions.push(RuleCondition::ResourceQueryEsRegex(regex.await?));
+                }
+                None => {}
+            }
+            match &content_type {
+                Some(ConditionContentType::Glob(glob)) => {
+                    rule_conditions.push(RuleCondition::ContentTypeGlob(
+                        Glob::new(glob.clone(), GlobOptions::default()).await?,
+                    ));
+                }
+                Some(ConditionContentType::Regex(regex)) => {
+                    rule_conditions.push(RuleCondition::ContentTypeEsRegex(regex.await?));
                 }
                 None => {}
             }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -53,6 +53,12 @@ pub enum ConditionQuery {
     Regex(ResolvedVc<EsRegex>),
 }
 
+#[derive(Clone, PartialEq, Eq, Debug, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum ConditionContentType {
+    Glob(RcStr),
+    Regex(ResolvedVc<EsRegex>),
+}
+
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub enum ConditionItem {
@@ -64,6 +70,7 @@ pub enum ConditionItem {
         path: Option<ConditionPath>,
         content: Option<ResolvedVc<EsRegex>>,
         query: Option<ConditionQuery>,
+        content_type: Option<ConditionContentType>,
     },
 }
 

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -47,6 +47,8 @@ pub enum RuleCondition {
     ResourceQueryContains(String),
     ResourceQueryEquals(String),
     ResourceQueryEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
+    ContentTypeGlob(#[turbo_tasks(trace_ignore)] ReadRef<Glob>),
+    ContentTypeEsRegex(#[turbo_tasks(trace_ignore)] ReadRef<EsRegex>),
 }
 
 impl RuleCondition {
@@ -292,6 +294,20 @@ impl RuleCondition {
                     RuleCondition::ResourceQueryEsRegex(regex) => {
                         let ident = source.ident().await?;
                         return Ok(regex.is_match(&ident.query));
+                    }
+                    RuleCondition::ContentTypeGlob(glob) => {
+                        let ident = source.ident().await?;
+                        return Ok(ident
+                            .content_type
+                            .as_ref()
+                            .is_some_and(|ct| glob.matches(ct)));
+                    }
+                    RuleCondition::ContentTypeEsRegex(regex) => {
+                        let ident = source.ident().await?;
+                        return Ok(ident
+                            .content_type
+                            .as_ref()
+                            .is_some_and(|ct| regex.is_match(ct)));
                     }
                 }
             }


### PR DESCRIPTION
### What?

Add `contentType` condition

This allows to apply webpack loaders to data urls

### Usage Example

```
module.exports = {
  turbopack: {
    rules: {
      '*': [
        {
          condition: { contentType: 'text/*' },  // glob match
          loaders: ['text-loader'],
          as: '*.js'
        },
        {
          condition: { contentType: /^image\// },  // regex match
          loaders: ['image-loader'],
          as: '*.js'
        },
      ],
    },
  },
}
```