### PR TITLE
Turbopack: warn when tracing the whole project

### DIFF
--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -147,10 +147,16 @@ impl Asset for NftJsonAsset {
         );
         async move {
             let mut result: BTreeSet<RcStr> = BTreeSet::new();
+            let project_path = this.project.project_path().owned().await?;
 
             let output_root_ref = this.project.output_fs().root().await?;
             let project_root_ref = this.project.project_fs().root().await?;
             let next_config = this.project.next_config();
+            let next_config_path = this
+                .project
+                .next_config()
+                .config_file_path(project_path.clone())
+                .await?;
 
             let output_file_tracing_includes = &*next_config.output_file_tracing_includes().await?;
             let output_file_tracing_excludes = &*next_config.output_file_tracing_excludes().await?;
@@ -173,7 +179,6 @@ impl Asset for NftJsonAsset {
                 .chain(std::iter::once(chunk))
                 .collect();
 
-            let project_path = this.project.project_path().owned().await?;
             let exclude_glob = if let Some(route) = &this.page_name {
                 if let Some(excludes_config) = output_file_tracing_excludes {
                     let mut combined_excludes = BTreeSet::new();
@@ -230,13 +235,11 @@ impl Asset for NftJsonAsset {
                 None
             };
 
+            let entries = Vc::cell(entries);
             // Collect base assets first
-            let all_assets = all_assets_from_entries_filtered(
-                Vc::cell(entries),
-                Some(client_root),
-                exclude_glob,
-            )
-            .await?;
+            let all_assets =
+                all_assets_from_entries_filtered(entries, Some(client_root.clone()), exclude_glob)
+                    .await?;
 
             for referenced_chunk in all_assets.iter().copied() {
                 if chunk.eq(&referenced_chunk) {
@@ -244,6 +247,19 @@ impl Asset for NftJsonAsset {
                 }
 
                 let referenced_chunk_path = referenced_chunk.path().await?;
+
+                if referenced_chunk_path == next_config_path {
+                    // If next.config.js was traced, assume that the whole project was traced
+                    // (unintentionally). Throw a build error in this case to avoid deploying
+                    // unnecessary files.
+                    error_unexpected_file(
+                        entries,
+                        Some(client_root.clone()),
+                        exclude_glob,
+                        *referenced_chunk,
+                    )
+                    .await?;
+                }
 
                 if referenced_chunk_path.has_extension(".map") {
                     continue;
@@ -440,6 +456,80 @@ pub async fn all_assets_from_entries_filtered(
             .map(|n| n.0)
             .collect(),
     ))
+}
+
+#[turbo_tasks::function]
+pub async fn error_unexpected_file(
+    entries: Vc<OutputAssets>,
+    client_root: Option<FileSystemPath>,
+    exclude_glob: Option<Vc<Glob>>,
+    referenced_chunk: ResolvedVc<Box<dyn OutputAsset>>,
+) -> Result<()> {
+    let exclude_glob = if let Some(exclude_glob) = exclude_glob {
+        Some(exclude_glob.await?)
+    } else {
+        None
+    };
+    let emit_spans = tracing::enabled!(Level::INFO);
+    let map = AdjacencyMap::new()
+        .visit(
+            entries
+                .await?
+                .iter()
+                .map(async |asset| {
+                    Ok((
+                        *asset,
+                        if emit_spans {
+                            // INVALIDATION: we don't need to invalidate the list of assets when
+                            // the span name changes
+                            Some(asset.path_string().untracked().await?)
+                        } else {
+                            None
+                        },
+                    ))
+                })
+                .try_join()
+                .await?,
+            OutputAssetFilteredVisit {
+                client_root,
+                exclude_glob,
+                emit_spans,
+            },
+        )
+        .await
+        .completed()?;
+
+    let reversed = map.reversed();
+
+    let mut path = vec![];
+    {
+        let mut current = (
+            referenced_chunk,
+            if emit_spans {
+                // INVALIDATION: we don't need to invalidate the list of assets when
+                // the span name changes
+                Some(referenced_chunk.path_string().untracked().await?)
+            } else {
+                None
+            },
+        );
+        while let Some((from, _)) = reversed.get(&current).and_then(|mut edges| edges.next()) {
+            current = from.clone();
+            path.push(current.0);
+        }
+    }
+
+    bail!(
+        "Encountered unexpected file in NFT list: {}\nDependency trace:\n{:#?}",
+        referenced_chunk.path_string().await?,
+        path.iter()
+            .rev()
+            .map(|a| a.path_string())
+            .try_join()
+            .await?
+    );
+
+    Ok(())
 }
 
 struct OutputAssetFilteredVisit {

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeSet, HashSet, VecDeque};
 
 use anyhow::{Result, bail};
 use serde_json::json;
@@ -503,7 +503,9 @@ pub async fn error_unexpected_file(
     let reversed = map.reversed();
 
     let mut path = vec![];
+    // Find any path from the referenced chunk back to one of the roots
     {
+        let mut visited = HashSet::new();
         let mut current = (
             referenced_chunk,
             if emit_spans {
@@ -516,6 +518,9 @@ pub async fn error_unexpected_file(
         );
         while let Some((from, _)) = reversed.get(&current).and_then(|mut edges| edges.next()) {
             current = from.clone();
+            if !visited.insert(current.0) {
+                break;
+            }
             path.push(current.0);
         }
     }

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, VecDeque};
 use anyhow::{Result, bail};
 use serde_json::json;
 use tracing::{Instrument, Level, Span};
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal, Visit},
@@ -14,6 +14,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     asset::{Asset, AssetContent},
+    issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     output::{OutputAsset, OutputAssets, OutputAssetsReference},
 };
 
@@ -250,7 +251,7 @@ impl Asset for NftJsonAsset {
 
                 if referenced_chunk_path == next_config_path {
                     // If next.config.js was traced, assume that the whole project was traced
-                    // (unintentionally). Throw a build error in this case to avoid deploying
+                    // (unintentionally). Print a message in this case to avoid deploying
                     // unnecessary files.
                     error_unexpected_file(
                         entries,
@@ -519,17 +520,105 @@ pub async fn error_unexpected_file(
         }
     }
 
-    bail!(
-        "Encountered unexpected file in NFT list: {}\nDependency trace:\n{:#?}",
-        referenced_chunk.path_string().await?,
-        path.iter()
-            .rev()
-            .map(|a| a.path_string())
-            .try_join()
-            .await?
-    );
+    ForbiddenTracedFileIssue {
+        file: referenced_chunk,
+        path,
+    }
+    .resolved_cell()
+    .emit();
 
     Ok(())
+}
+
+#[turbo_tasks::value(shared)]
+struct ForbiddenTracedFileIssue {
+    file: ResolvedVc<Box<dyn OutputAsset>>,
+    path: Vec<ResolvedVc<Box<dyn OutputAsset>>>,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for ForbiddenTracedFileIssue {
+    fn severity(&self) -> IssueSeverity {
+        // Ideally this would be an error, but for now we keep it a warning to avoid breaking
+        // existing apps
+        IssueSeverity::Warning
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Misc.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.file.path()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text(rcstr!("Encountered unexpected file in NFT list")).cell()
+    }
+
+    #[turbo_tasks::function]
+    async fn description(&self) -> Result<Vc<OptionStyledString>> {
+        let mut stack = vec![
+            StyledString::Text(rcstr!(
+                "A file was traced that indicates that the whole project was traced \
+                 unintentionally. Somewhere in the import trace below, there are:"
+            )),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("- filesystem operations (like ")),
+                StyledString::Code(rcstr!("path.join")),
+                StyledString::Text(rcstr!(", ")),
+                StyledString::Code(rcstr!("path.resolve")),
+                StyledString::Text(rcstr!(" or ")),
+                StyledString::Code(rcstr!("fs.readFile")),
+                StyledString::Text(rcstr!("), or")),
+            ]),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("- very dynamic requires (like ")),
+                StyledString::Code(rcstr!("require('./' + foo)")),
+                StyledString::Text(rcstr!(").")),
+            ]),
+            StyledString::Text(rcstr!("To resolve this, you can either")),
+            StyledString::Text(rcstr!("- remove them if possible, or")),
+            StyledString::Text(rcstr!("- only use them in development, or")),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!(
+                    "- make sure they are statically scoped to some subfolder: "
+                )),
+                StyledString::Code(rcstr!("path.join(process.cwd(), 'data', bar)")),
+                StyledString::Text(rcstr!(", or")),
+            ]),
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("- add ignore comments: ")),
+                StyledString::Code(rcstr!(
+                    "path.join(/*turbopackIgnore: true*/ process.cwd(), bar)"
+                )),
+            ]),
+        ];
+
+        if self.path.len() > 1 {
+            stack.extend([
+                StyledString::Text(rcstr!("")),
+                StyledString::Text(
+                    format!(
+                        "Output asset trace:\n{}",
+                        self.path
+                            .iter()
+                            .rev()
+                            .map(async |a| Ok(format!("  {}", a.path_string().await?)))
+                            .try_join()
+                            .await?
+                            .join("\n")
+                    )
+                    .into(),
+                ),
+            ])
+        }
+
+        Ok(Vc::cell(Some(StyledString::Stack(stack).resolved_cell())))
+    }
 }
 
 struct OutputAssetFilteredVisit {

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -585,7 +585,7 @@ impl Issue for ForbiddenTracedFileIssue {
                 StyledString::Code(rcstr!("require('./' + foo)")),
                 StyledString::Text(rcstr!(").")),
             ]),
-            StyledString::Text(rcstr!("To resolve this, you can either")),
+            StyledString::Text(rcstr!("To resolve this, you can")),
             StyledString::Text(rcstr!("- remove them if possible, or")),
             StyledString::Text(rcstr!("- only use them in development, or")),
             StyledString::Line(vec![

--- a/test/production/build-tracing-message/app/join-cwd.js
+++ b/test/production/build-tracing-message/app/join-cwd.js
@@ -1,0 +1,5 @@
+import path from 'path'
+
+export default function (f) {
+  return path.join(process.cwd(), f)
+}

--- a/test/production/build-tracing-message/app/layout.js
+++ b/test/production/build-tracing-message/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/build-tracing-message/app/page.js
+++ b/test/production/build-tracing-message/app/page.js
@@ -1,0 +1,6 @@
+import joinCwd from './join-cwd'
+
+export default function Page() {
+  joinCwd('index.test.ts')
+  return <h1>My Page</h1>
+}

--- a/test/production/build-tracing-message/index.test.ts
+++ b/test/production/build-tracing-message/index.test.ts
@@ -1,0 +1,44 @@
+import { nextTestSetup } from 'e2e-utils'
+
+// Only Turbopack prints these warnings
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'build-tracing-message',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+    })
+
+    it('should warn when tracing all files in the project', async () => {
+      const { exitCode } = await next.build()
+      expect(exitCode).toBe(0)
+
+      let output = next.cliOutput
+        .slice(
+          next.cliOutput.indexOf('Turbopack build encountered'),
+          next.cliOutput.indexOf('✓ Compiled successfully')
+        )
+        .trim()
+
+      expect(output).toMatchInlineSnapshot(`
+       "Turbopack build encountered 1 warnings:
+       ./next.config.js
+       Encountered unexpected file in NFT list
+       A file was traced that indicates that the whole project was traced unintentionally. Somewhere in the import trace below, there are:
+       - filesystem operations (like path.join, path.resolve or fs.readFile), or
+       - very dynamic requires (like require('./' + foo)).
+       To resolve this, you can either
+       - remove them if possible, or
+       - only use them in development, or
+       - make sure they are statically scoped to some subfolder: path.join(process.cwd(), 'data', bar), or
+       - add ignore comments: path.join(/*turbopackIgnore: true*/ process.cwd(), bar)
+
+       Import trace:
+         Server Component:
+           ./next.config.js
+           ./app/join-cwd.js
+           ./app/page.js"
+      `)
+    })
+  }
+)

--- a/test/production/build-tracing-message/index.test.ts
+++ b/test/production/build-tracing-message/index.test.ts
@@ -27,7 +27,7 @@ import { nextTestSetup } from 'e2e-utils'
        A file was traced that indicates that the whole project was traced unintentionally. Somewhere in the import trace below, there are:
        - filesystem operations (like path.join, path.resolve or fs.readFile), or
        - very dynamic requires (like require('./' + foo)).
-       To resolve this, you can either
+       To resolve this, you can
        - remove them if possible, or
        - only use them in development, or
        - make sure they are statically scoped to some subfolder: path.join(process.cwd(), 'data', bar), or

--- a/test/production/build-tracing-message/next.config.js
+++ b/test/production/build-tracing-message/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
+++ b/turbopack/crates/turbo-tasks/src/graph/adjacency_map.rs
@@ -78,6 +78,26 @@ where
     pub fn is_empty(&self) -> bool {
         self.adjacency_map.is_empty()
     }
+
+    pub fn reversed(&self) -> AdjacencyMap<T, &E> {
+        let mut reversed = AdjacencyMap::new();
+
+        for root in &self.roots {
+            reversed.roots.push(root.clone());
+        }
+
+        for (from, edges) in &self.adjacency_map {
+            for (to, edge) in edges {
+                let vec = reversed
+                    .adjacency_map
+                    .entry(to.clone())
+                    .or_insert_with(|| Vec::with_capacity(1));
+                vec.push((from.clone(), edge));
+            }
+        }
+
+        reversed
+    }
 }
 
 impl<T, E> GraphStore for AdjacencyMap<T, E>


### PR DESCRIPTION
This should really be an error, but let's start with making it a warning

the only missing piece will be somehow showing the line/col information of the offending reference, this is currently very hard to figure out


<img width="1265" height="428" alt="Bildschirmfoto 2026-01-28 um 12 32 17" src="https://github.com/user-attachments/assets/80e48fa8-a021-4ca2-a966-26164c42b1dd" />
