### PR TITLE
[docs] Always include `unsafe-eval` in dev `Content-Security-Policy`

### DIFF
--- a/docs/01-app/02-guides/content-security-policy.mdx
+++ b/docs/01-app/02-guides/content-security-policy.mdx
@@ -44,9 +44,10 @@ import { NextRequest, NextResponse } from 'next/server'
 
 export function proxy(request: NextRequest) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  const isDev = process.env.NODE_ENV === 'development'
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'nonce-${nonce}' 'strict-dynamic';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ''};
     style-src 'self' 'nonce-${nonce}';
     img-src 'self' blob: data:;
     font-src 'self';
@@ -88,9 +89,10 @@ import { NextResponse } from 'next/server'
 
 export function proxy(request) {
   const nonce = Buffer.from(crypto.randomUUID()).toString('base64')
+  const isDev = process.env.NODE_ENV === 'development'
   const cspHeader = `
     default-src 'self';
-    script-src 'self' 'nonce-${nonce}' 'strict-dynamic';
+    script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ''};
     style-src 'self' 'nonce-${nonce}';
     img-src 'self' blob: data:;
     font-src 'self';
@@ -483,9 +485,11 @@ When SRI is enabled, you can continue using your existing CSP policies. SRI work
 > **Good to know**: For dynamic rendering scenarios, you can still generate nonces with proxy if needed, combining both SRI integrity attributes and nonce-based CSP approaches.
 
 ```js filename="next.config.js"
+const isDev = process.env.NODE_ENV === 'development'
+
 const cspHeader = `
     default-src 'self';
-    script-src 'self';
+    script-src 'self'${isDev ? " 'unsafe-eval'" : ''};
     style-src 'self';
     img-src 'self' blob: data:;
     font-src 'self';

--- a/docs/01-app/02-guides/content-security-policy.mdx
+++ b/docs/01-app/02-guides/content-security-policy.mdx
@@ -39,6 +39,8 @@ Every time a page is viewed, a fresh nonce should be generated. This means that 
 
 For example:
 
+> **Good to know**: In development, `'unsafe-eval'` is required because React uses `eval` to provide enhanced debugging information, such as reconstructing server-side error stacks in the browser. This should only be enabled in development mode.
+
 ```ts filename="proxy.ts" switcher
 import { NextRequest, NextResponse } from 'next/server'
 
@@ -544,7 +546,7 @@ CSP implementation differs between development and production environments:
 
 ### Development Environment
 
-In development, you will need to enable `'unsafe-eval'` to support APIs that provide additional debugging information:
+In development, you will need to enable `'unsafe-eval'` because React uses `eval` to provide enhanced debugging information, such as reconstructing server-side error stacks in the browser to show you where errors originated on the server:
 
 ```ts filename="proxy.ts" switcher
 export function proxy(request: NextRequest) {

--- a/docs/01-app/02-guides/content-security-policy.mdx
+++ b/docs/01-app/02-guides/content-security-policy.mdx
@@ -39,7 +39,7 @@ Every time a page is viewed, a fresh nonce should be generated. This means that 
 
 For example:
 
-> **Good to know**: In development, `'unsafe-eval'` is required because React uses `eval` to provide enhanced debugging information, such as reconstructing server-side error stacks in the browser. This should only be enabled in development mode.
+> **Good to know**: In development, `'unsafe-eval'` is required because React uses `eval` to provide enhanced debugging information, such as reconstructing server-side error stacks in the browser. `unsafe-eval` is not required for production. Neither React nor Next.js use `eval` in production by default.
 
 ```ts filename="proxy.ts" switcher
 import { NextRequest, NextResponse } from 'next/server'


### PR DESCRIPTION
`eval` is critical for React's Server error/console replaying to work.
We included `unsafe-eval` in the CSP in some examples but not all. Now we include `unsafe-eval` everywhere.

Part of https://linear.app/vercel/issue/NAR-754/

---
[Slack Thread](https://vercel.slack.com/archives/C02CDC2ALJH/p1768204811843809?thread_ts=1768204811.843809&cid=C02CDC2ALJH)

<a href="https://cursor.com/background-agent?bcId=bc-a99ec062-6eb3-4131-ac1c-2e218e7e6af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a99ec062-6eb3-4131-ac1c-2e218e7e6af0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

