### PR TITLE
[ci] Silence `baseline-browser-mapping` warnings

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -118,6 +118,10 @@ env:
   # defaults to 256, but we run a lot of tests in parallel, so the limit should be lower
   NEXT_TURBOPACK_IO_CONCURRENCY: 64
 
+  # Disable warnings from baseline-browser-mapping
+  # https://github.com/web-platform-dx/baseline-browser-mapping/blob/ec8136ae9e034b332fab991d63a340d2e13b8afc/README.md?plain=1#L34
+  BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA: 1
+
 jobs:
   build:
     timeout-minutes: ${{ inputs.timeout_minutes }}

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -99,7 +99,7 @@
   "dependencies": {
     "@next/env": "16.2.0-canary.14",
     "@swc/helpers": "0.5.15",
-    "baseline-browser-mapping": "^2.8.3",
+    "baseline-browser-mapping": "^2.9.19",
     "caniuse-lite": "^1.0.30001579",
     "postcss": "8.4.31",
     "styled-jsx": "5.1.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1091,8 +1091,8 @@ importers:
         specifier: 0.5.15
         version: 0.5.15
       baseline-browser-mapping:
-        specifier: ^2.8.3
-        version: 2.8.32
+        specifier: ^2.9.19
+        version: 2.9.19
       caniuse-lite:
         specifier: 1.0.30001746
         version: 1.0.30001746
@@ -7811,8 +7811,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.8.32:
-    resolution: {integrity: sha512-OPz5aBThlyLFgxyhdwf/s2+8ab3OvT7AdTNvKHBwpXomIYeXqpUUuT8LrdtxZSsWJ4R4CU1un4XGh5Ez3nlTpw==}
+  baseline-browser-mapping@2.9.19:
+    resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
   batch@0.6.1:
@@ -25413,7 +25413,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.8.32: {}
+  baseline-browser-mapping@2.9.19: {}
 
   batch@0.6.1: {}
 
@@ -25607,7 +25607,7 @@ snapshots:
 
   browserslist@4.28.0:
     dependencies:
-      baseline-browser-mapping: 2.8.32
+      baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001746
       electron-to-chromium: 1.5.262
       node-releases: 2.0.27


### PR DESCRIPTION
The warnings from `baseline-browser-mapping` about outdated data fail some tests that don't expect the CLI output. By updating the dependency we avoid showing the warning for now, and by setting the environment variable `BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA` we should silence any future warnings as well.

related:
- #86625
- #86653