### PR TITLE
Prettier-ignore changes in `next-env.d.ts` files in all top-level apps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -78,6 +78,7 @@ test/integration/typescript-app-type-declarations/next-env.strictRouteTypes.d.ts
 /turbopack/crates/turbopack-tracing/tests/node-file-trace/test/unit/tsx/lib.tsx
 
 /apps/docs/.source/*
+/apps/*/next-env.d.ts
 
 # Symlink files
 readme.md


### PR DESCRIPTION
Specifically, the `lint` job is currently failing in CI for `apps/bundle-analyzer/next-env.d.ts`, e.g.:
https://github.com/vercel/next.js/actions/runs/21444929031/job/61758061793?pr=89175