### PR TITLE
[turbopack] mark persistent_task_type as inline

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -255,8 +255,8 @@ struct TaskStorageSchema {
     #[field(storage = "auto_map", category = "transient")]
     in_progress_cells: AutoMap<CellId, InProgressCellState>,
 
-    #[field(storage = "direct", category = "data")]
-    pub persistent_task_type: Arc<CachedTaskType>,
+    #[field(storage = "direct", category = "data", inline)]
+    pub persistent_task_type: Option<Arc<CachedTaskType>>,
 
     #[field(storage = "direct", category = "transient")]
     pub transient_task_type: Arc<TransientTask>,
@@ -944,8 +944,13 @@ mod tests {
     fn test_schema_size() {
         assert_eq!(
             size_of::<TaskStorage>(),
-            136,
+            144,
             "TaskStorage size changed! If this is intentional, update this test."
+        );
+        assert_eq!(
+            size_of::<LazyField>(),
+            56,
+            "LazyField size changed! If this is intentional, update this test."
         );
     }
 }


### PR DESCRIPTION
Nearly all tasks are 'persistent' and we need to set this field as part of task execution (and read it as part of task invalidation)

By keeping it `inline` we can avoid an entry in the lazy vec which should accelerate other accesses and save memory (it would be 56 bytes in the vec, but it is 8 bytes when stored inline)


Saves quite a bit of memory

![image.png](https://app.graphite.com/user-attachments/assets/cce81efe-e36f-4fab-9227-019617724acd.png)

