### PR TITLE
Remove Vercel specific assertions from E2E deploy

### DIFF
--- a/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/generate-static-params.test.ts
@@ -1,9 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
+import { getCacheHeader } from 'next-test-utils'
 
 describe('app-root-param-getters - generateStaticParams', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: join(__dirname, 'fixtures', 'generate-static-params'),
   })
 
@@ -11,11 +12,7 @@ describe('app-root-param-getters - generateStaticParams', () => {
     const params = { lang: 'en', locale: 'us' }
     const response = await next.fetch(`/${params.lang}/${params.locale}`)
     expect(response.status).toBe(200)
-    if (isNextDeploy) {
-      expect(response.headers.get('x-vercel-cache')).toBe('PRERENDER')
-    } else {
-      expect(response.headers.get('x-nextjs-cache')).toBe('HIT')
-    }
+    expect(getCacheHeader(response)).toBeOneOf(['HIT', 'PRERENDER'])
     const $ = cheerio.load(await response.text())
     expect($('p').text()).toBe(`hello world ${JSON.stringify(params)}`)
   })

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -6,6 +6,7 @@ import { nextTestSetup } from 'e2e-utils'
 import {
   check,
   fetchViaHTTP,
+  getCacheHeader,
   normalizeRegEx,
   retry,
   waitFor,
@@ -69,9 +70,7 @@ describe('app-dir static/dynamic handling', () => {
     if (isNextDev) {
       expect(data).not.toBe(data2)
     } else {
-      const pageCache = (
-        res.headers.get('x-vercel-cache') || res.headers.get('x-nextjs-cache')
-      ).toLowerCase()
+      const pageCache = getCacheHeader(res)
 
       expect(pageCache).toBeTruthy()
       expect(pageCache).not.toBe('MISS')
@@ -98,9 +97,7 @@ describe('app-dir static/dynamic handling', () => {
     } else {
       // "default" cache does not impact ISR handling on a page, similar to the above test
       // case for no fetch config
-      const pageCache = (
-        res.headers.get('x-vercel-cache') || res.headers.get('x-nextjs-cache')
-      ).toLowerCase()
+      const pageCache = getCacheHeader(res)
 
       expect(pageCache).toBeTruthy()
       expect(pageCache).not.toBe('MISS')

--- a/test/e2e/app-dir/app-static/app-static.test.ts
+++ b/test/e2e/app-dir/app-static/app-static.test.ts
@@ -69,7 +69,8 @@ describe('app-dir static/dynamic handling', () => {
 
     if (isNextDev) {
       expect(data).not.toBe(data2)
-    } else {
+      // custom cache handler is in memory only
+    } else if (!process.env.CUSTOM_CACHE_HANDLER) {
       const pageCache = getCacheHeader(res)
 
       expect(pageCache).toBeTruthy()
@@ -94,7 +95,7 @@ describe('app-dir static/dynamic handling', () => {
 
     if (isNextDev) {
       expect(data).not.toBe(data2)
-    } else {
+    } else if (!process.env.CUSTOM_CACHE_HANDLER) {
       // "default" cache does not impact ISR handling on a page, similar to the above test
       // case for no fetch config
       const pageCache = getCacheHeader(res)

--- a/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
+++ b/test/e2e/app-dir/fallback-shells/fallback-shells.test.ts
@@ -14,10 +14,6 @@ describe('fallback-shells', () => {
       expect(await browser.elementById('slug').text()).toBe('Hello /world')
       const headers = response.headers()
 
-      if (isNextDeploy) {
-        expect(headers['x-matched-path']).toBe('/without-io/[slug]')
-      }
-
       // If we didn't use the fallback shell, then we didn't postpone the
       // response, and therefore shouldn't have sent the postponed header.
       expect(headers['x-nextjs-postponed']).not.toBe('1')
@@ -44,11 +40,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/with-suspense/params-in-page/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).toBe('1')
             }
           })
@@ -167,11 +159,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/with-suspense/params-not-in-page/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).toBe('1')
             }
           })
@@ -194,11 +182,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/with-suspense/params-then-in-page/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).toBe('1')
             }
           })
@@ -221,11 +205,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/with-suspense/params-transformed/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).toBe('1')
             }
           })
@@ -250,11 +230,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/without-suspense/params-in-page/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).not.toBe('1')
             }
           })
@@ -300,11 +276,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/without-suspense/params-not-in-page/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).not.toBe('1')
             }
           })
@@ -327,11 +299,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/without-suspense/params-then-in-page/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).not.toBe('1')
             }
           })
@@ -354,11 +322,7 @@ describe('fallback-shells', () => {
 
             const headers = response.headers()
 
-            if (isNextDeploy) {
-              expect(headers['x-matched-path']).toBe(
-                '/with-cached-io/with-static-params/without-suspense/params-transformed/[slug]'
-              )
-            } else if (isNextStart) {
+            if (isNextStart) {
               expect(headers['x-nextjs-postponed']).not.toBe('1')
             }
           })
@@ -382,11 +346,7 @@ describe('fallback-shells', () => {
 
           const headers = response.headers()
 
-          if (isNextDeploy) {
-            expect(headers['x-matched-path']).toBe(
-              '/with-cached-io/without-static-params/params-in-page/[slug]'
-            )
-          } else if (isNextStart) {
+          if (isNextStart) {
             expect(headers['x-nextjs-postponed']).toBe('1')
           }
         })
@@ -433,11 +393,7 @@ describe('fallback-shells', () => {
 
           const headers = response.headers()
 
-          if (isNextDeploy) {
-            expect(headers['x-matched-path']).toBe(
-              '/with-cached-io/without-static-params/params-not-in-page/[slug]'
-            )
-          } else if (isNextStart) {
+          if (isNextStart) {
             expect(headers['x-nextjs-postponed']).toBe('1')
           }
         })
@@ -458,11 +414,7 @@ describe('fallback-shells', () => {
 
           const headers = response.headers()
 
-          if (isNextDeploy) {
-            expect(headers['x-matched-path']).toBe(
-              '/with-cached-io/without-static-params/params-then-in-page/[slug]'
-            )
-          } else if (isNextStart) {
+          if (isNextStart) {
             expect(headers['x-nextjs-postponed']).toBe('1')
           }
         })

--- a/test/e2e/app-dir/ppr-full/ppr-full.test.ts
+++ b/test/e2e/app-dir/ppr-full/ppr-full.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup, isNextStart } from 'e2e-utils'
 import { splitResponseWithPPRSentinel } from 'e2e-utils/ppr'
 import { links } from './components/links'
 import cheerio from 'cheerio'
-import { retry } from 'next-test-utils'
+import { getCacheHeader, retry } from 'next-test-utils'
 import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 type Page = {
@@ -608,11 +608,7 @@ describe.skip('ppr-full', () => {
               )
             }
 
-            if (!isNextDeploy) {
-              expect(res.headers.get('x-nextjs-cache')).toBe('HIT')
-            } else {
-              expect(res.headers.get('x-vercel-cache')).toBe('HIT')
-            }
+            expect(getCacheHeader(res)).toBe('HIT')
           })
         })
 
@@ -662,9 +658,7 @@ describe.skip('ppr-full', () => {
           ])
 
           if (isNextDeploy) {
-            expect(res.headers.get('x-vercel-cache')).toMatch(
-              /MISS|HIT|PRERENDER/
-            )
+            expect(getCacheHeader(res)).toMatch(/MISS|HIT|PRERENDER/)
           } else {
             expect(res.headers.get('x-nextjs-cache')).toEqual(null)
           }

--- a/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/sub-shell-generation-middleware.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 import * as cheerio from 'cheerio'
-import { retry } from 'next-test-utils'
+import { getCacheHeader, retry } from 'next-test-utils'
 import { computeCacheBustingSearchParam } from 'next/dist/shared/lib/router/utils/cache-busting-search-param'
 
 describe('middleware-static-rewrite', () => {
@@ -85,7 +85,7 @@ describe('middleware-static-rewrite', () => {
       expect(res.status).toBe(200)
 
       if (isNextDeploy) {
-        expect(res.headers.get('x-vercel-cache')).toMatch(/MISS|HIT|PRERENDER/)
+        expect(getCacheHeader(res)).toMatch(/MISS|HIT|PRERENDER/)
       } else {
         expect(res.headers.get('x-nextjs-cache')).toBe(null)
       }
@@ -104,7 +104,7 @@ describe('middleware-static-rewrite', () => {
 
         expect(res.status).toBe(200)
         if (isNextDeploy) {
-          expect(res.headers.get('x-vercel-cache')).toBe('HIT')
+          expect(getCacheHeader(res)).toBe('HIT')
         } else {
           expect(res.headers.get('x-nextjs-cache')).toBe(null)
         }
@@ -213,9 +213,7 @@ describe('middleware-static-rewrite', () => {
       let res = await next.fetch('/not-broken')
 
       expect(res.status).toBe(200)
-      expect(
-        res.headers.get(isNextDeploy ? 'x-vercel-cache' : 'x-nextjs-cache')
-      ).toMatch(/MISS|HIT|PRERENDER/)
+      expect(getCacheHeader(res)).toMatch(/MISS|HIT|PRERENDER/)
 
       let html = await res.text()
       let $ = cheerio.load(html)
@@ -230,9 +228,7 @@ describe('middleware-static-rewrite', () => {
         res = await next.fetch('/not-broken')
 
         expect(res.status).toBe(200)
-        expect(
-          res.headers.get(isNextDeploy ? 'x-vercel-cache' : 'x-nextjs-cache')
-        ).toBe('HIT')
+        expect(getCacheHeader(res)).toBe('HIT')
       })
 
       html = await res.text()

--- a/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
+++ b/test/e2e/app-dir/sub-shell-generation/sub-shell-generation.test.ts
@@ -58,9 +58,7 @@ describe('sub-shell-generation', () => {
         const res = await next.fetch(path)
         expect(res.status).toBe(200)
 
-        if (isNextDeploy) {
-          expect(res.headers.get('x-matched-path')).toBe(shell)
-        } else {
+        if (!isNextDeploy) {
           expect(res.headers.get('x-nextjs-postponed')).toBe(
             isPostponed ? '1' : null
           )

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -15,6 +15,7 @@ import {
   renderViaHTTP,
   retry,
   waitFor,
+  getCacheHeader,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import stripAnsi from 'strip-ansi'
@@ -2299,9 +2300,8 @@ describe('Prerender', () => {
         const html = await res.text()
         const $ = cheerio.load(html)
         const initialTime = $('#time').text()
-        const cacheHeader = isDeploy ? 'x-vercel-cache' : 'x-nextjs-cache'
 
-        expect(res.headers.get(cacheHeader)).toMatch(/MISS/)
+        expect(getCacheHeader(res)).toMatch(/MISS/)
         expect($('p').text()).toMatch(/Post:.*?test-manual-1/)
 
         // we use retry here as the cache might still be
@@ -2314,7 +2314,7 @@ describe('Prerender', () => {
           const html2 = await res2.text()
           const $2 = cheerio.load(html2)
 
-          expect(res2.headers.get(cacheHeader)).toMatch(/(HIT|STALE)/)
+          expect(getCacheHeader(res2)).toMatch(/(HIT|STALE)/)
           expect(initialTime).toBe($2('#time').text())
         })
 
@@ -2340,7 +2340,7 @@ describe('Prerender', () => {
           const $4 = cheerio.load(html4)
 
           expect($4('#time').text()).not.toBe(initialTime)
-          expect(res4.headers.get(cacheHeader)).toMatch(/(HIT|STALE)/)
+          expect(getCacheHeader(res4)).toMatch(/(HIT|STALE)/)
         })
       })
     }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1993,3 +1993,7 @@ export function getClientReferenceManifest(
 
   return manifest
 }
+
+export const getCacheHeader = (curRes: Response) =>
+  // favor generic header
+  curRes.headers.get('x-nextjs-cache') || curRes.headers.get('x-vercel-cache')


### PR DESCRIPTION
This aims to remove assertions that were specific to Vercel so that other platforms can re-use our E2E deploy workflow. 