### PR TITLE
fix(router): remove all trailing slashes in removeTrailingSlash

### DIFF
--- a/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts
+++ b/packages/next/src/shared/lib/router/utils/remove-trailing-slash.ts
@@ -6,5 +6,5 @@
  *   - `/` -> `/`
  */
 export function removeTrailingSlash(route: string) {
-  return route.replace(/\/$/, '') || '/'
+  return route.replace(/\/+$/, '') || '/'
 }


### PR DESCRIPTION
**What changed?**
`removeTrailingSlash` now removes ALL trailing slashes, not just one.

**Why?**
Current regex `/$/` only removes one trailing slash. Multiple trailing slashes (e.g., `///`) are only partially removed.

Before:
```js
removeTrailingSlash('/path///') // '/path//' ❌
removeTrailingSlash('///') // '//' ❌
```

After:
```js
removeTrailingSlash('/path///') // '/path' ✓
removeTrailingSlash('///') // '/' ✓
```

Changed `/$/` to `/\/+$/` to match one or more trailing slashes.

**Testing**
Manual testing with edge cases. Existing tests should pass.