### PR TITLE
fix(router): prevent duplicate prefix and double slashes in addPathPrefix

### DIFF
--- a/packages/next/src/shared/lib/router/utils/add-path-prefix.ts
+++ b/packages/next/src/shared/lib/router/utils/add-path-prefix.ts
@@ -10,5 +10,12 @@ export function addPathPrefix(path: string, prefix?: string) {
   }
 
   const { pathname, query, hash } = parsePath(path)
-  return `${prefix}${pathname}${query}${hash}`
+  
+  // Avoid duplicate prefix and normalize slashes
+  const normalizedPrefix = prefix.replace(/\/+$/, '')
+  if (pathname.startsWith(normalizedPrefix)) {
+    return path
+  }
+  
+  return `${normalizedPrefix}${pathname}${query}${hash}`
 }


### PR DESCRIPTION
**What changed?**
`addPathPrefix` now:
1. Removes trailing slashes from prefix
2. Checks if path already starts with prefix (avoid duplicates)

**Why?**
Current implementation has two bugs:

**Bug 1: Duplicate prefix**
```js
addPathPrefix('/api/users', '/api') // '/api/api/users' ❌
```

**Bug 2: Double slashes**
```js
addPathPrefix('/users', '/api/') // '/api//users' ❌
```

**After fix:**
```js
addPathPrefix('/api/users', '/api') // '/api/users' ✓
addPathPrefix('/users', '/api/') // '/api/users' ✓
```

**Testing**
Manual testing with edge cases.