### PR TITLE
fix(router): support BigInt in query parameters

### DIFF
--- a/packages/next/src/shared/lib/router/utils/querystring.ts
+++ b/packages/next/src/shared/lib/router/utils/querystring.ts
@@ -24,7 +24,8 @@ function stringifyUrlQueryParam(param: unknown): string {
 
   if (
     (typeof param === 'number' && !isNaN(param)) ||
-    typeof param === 'boolean'
+    typeof param === 'boolean' ||
+    typeof param === 'bigint'
   ) {
     return String(param)
   } else {


### PR DESCRIPTION
**What changed?**
`stringifyUrlQueryParam` now handles `bigint` type properly.

**Why?**
BigInt is a valid JavaScript primitive but was being converted to empty string:

Before:
```js
stringifyUrlQueryParam(123n) // '' ❌
```

After:
```js
stringifyUrlQueryParam(123n) // '123' ✓
```

**Use case:**
Query parameters with large integers (IDs, timestamps) often use BigInt to avoid precision loss.

**Testing**
Manual testing with BigInt values.