### PR TITLE
fix(router): ensure parsePath always returns non-empty pathname

### DIFF
--- a/packages/next/src/shared/lib/router/utils/parse-path.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-path.ts
@@ -9,8 +9,9 @@ export function parsePath(path: string) {
   const hasQuery = queryIndex > -1 && (hashIndex < 0 || queryIndex < hashIndex)
 
   if (hasQuery || hashIndex > -1) {
+    const pathname = path.substring(0, hasQuery ? queryIndex : hashIndex)
     return {
-      pathname: path.substring(0, hasQuery ? queryIndex : hashIndex),
+      pathname: pathname || '/',
       query: hasQuery
         ? path.substring(queryIndex, hashIndex > -1 ? hashIndex : undefined)
         : '',
@@ -18,5 +19,5 @@ export function parsePath(path: string) {
     }
   }
 
-  return { pathname: path, query: '', hash: '' }
+  return { pathname: path || '/', query: '', hash: '' }
 }


### PR DESCRIPTION
**What changed?**
`parsePath` now returns `'/'` instead of empty string when pathname would be empty.

**Why?**
Edge cases with paths like `'?'` or `'#'` result in empty pathname:

Before:
```js
parsePath('?') // { pathname: '', query: '?', hash: '' } ❌
parsePath('#') // { pathname: '', query: '', hash: '#' } ❌
parsePath('') // { pathname: '', query: '', hash: '' } ❌
```

After:
```js
parsePath('?') // { pathname: '/', query: '?', hash: '' } ✓
parsePath('#') // { pathname: '/', query: '', hash: '#' } ✓
parsePath('') // { pathname: '/', query: '', hash: '' } ✓
```

Empty pathnames can cause routing issues. Defaulting to `'/'` (root) is safer and consistent with Next.js routing conventions.

**Testing**
Manual testing with edge cases.