### PR TITLE
fix: suppress baseline-browser-mapping stale-data warning

### DIFF
--- a/packages/next/src/server/require-hook.ts
+++ b/packages/next/src/server/require-hook.ts
@@ -2,6 +2,10 @@
 // This is needed for userland plugins to attach to the same webpack instance as Next.js'.
 // Individually compiled modules are as defined for the compilation in bundles/webpack/packages/*.
 
+if (process.env.BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA === undefined) {
+  process.env.BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA = '1'
+}
+
 // This module will only be loaded once per process.
 const path = require('path') as typeof import('path')
 const mod = require('module') as typeof import('module')


### PR DESCRIPTION
- What?

Stops the [baseline-browser-mapping] The data in this module is over two months old warning from showing for next dev, next build, and next info.

- Why?
browserslist (used by Next) can load baseline-browser-mapping, which prints that warning when its data is old. It’s noisy and not useful for most users.

- How?
Set BASELINE_BROWSER_MAPPING_IGNORE_OLD_DATA=1 in require-hook.ts at startup when the env var isn’t already set.

Fixes #89190