### PR TITLE
feat(turbopack): Add `type` field to loader rules for setting module type

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -794,6 +794,8 @@ pub struct RuleConfigItem {
     pub loaders: Vec<LoaderItem>,
     #[serde(default, alias = "as")]
     pub rename_as: Option<RcStr>,
+    #[serde(default, alias = "type")]
+    pub module_type: Option<RcStr>,
     #[serde(default)]
     pub condition: Option<ConfigConditionItem>,
 }
@@ -1520,6 +1522,7 @@ impl NextConfig {
                             LoaderRuleItem {
                                 loaders: transform_loaders(&mut [loaders].into_iter()),
                                 rename_as: None,
+                                module_type: None,
                                 condition: None,
                             },
                         ));
@@ -1527,6 +1530,7 @@ impl NextConfig {
                     RuleConfigCollectionItem::Full(RuleConfigItem {
                         loaders,
                         rename_as,
+                        module_type,
                         condition,
                     }) => {
                         // If the extension contains a wildcard, and the rename_as does not,
@@ -1575,6 +1579,7 @@ impl NextConfig {
                             LoaderRuleItem {
                                 loaders: transform_loaders(&mut loaders.iter()),
                                 rename_as: rename_as.clone(),
+                                module_type: module_type.clone(),
                                 condition,
                             },
                         ));

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -227,6 +227,7 @@ pub async fn get_babel_loader_rules(
                 options: loader_options,
             }]),
             rename_as: Some(rcstr!("*")),
+            module_type: None,
             condition: Some(ConditionItem::All(loader_conditions.into())),
         },
     )])

--- a/crates/next-core/src/next_shared/webpack_rules/sass.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/sass.rs
@@ -118,6 +118,7 @@ pub async fn get_sass_loader_rules(
             LoaderRuleItem {
                 loaders,
                 rename_as: Some(rename),
+                module_type: None,
                 condition: None,
             },
         ));

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -137,6 +137,7 @@ const zTurbopackRuleConfigItem: zod.ZodType<TurbopackRuleConfigItem> =
   z.strictObject({
     loaders: z.array(zTurbopackLoaderItem),
     as: z.string().optional(),
+    type: z.enum(['static', 'raw', 'css']).optional(),
     condition: zTurbopackCondition.optional(),
   })
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -121,9 +121,12 @@ export type TurbopackRuleCondition =
       query?: string | RegExp
     }
 
+export type TurbopackRuleConfigItemModuleType = 'static' | 'raw' | 'css'
+
 export type TurbopackRuleConfigItem = {
   loaders: TurbopackLoaderItem[]
   as?: string
+  type?: TurbopackRuleConfigItemModuleType
   condition?: TurbopackRuleCondition
 }
 

--- a/test/development/turbopack-asset-loader/app/icon.svg
+++ b/test/development/turbopack-asset-loader/app/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="10" fill="currentColor"/>
+</svg>

--- a/test/development/turbopack-asset-loader/app/layout.tsx
+++ b/test/development/turbopack-asset-loader/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/turbopack-asset-loader/app/page.tsx
+++ b/test/development/turbopack-asset-loader/app/page.tsx
@@ -1,0 +1,13 @@
+// @ts-expect-error - SVG with ?url query returns string URL
+import svgUrl from './icon.svg?url'
+
+export default function Page() {
+  return (
+    <div>
+      <p id="svg-url" data-url={svgUrl}>
+        SVG URL: {svgUrl}
+      </p>
+      <img src={svgUrl} alt="Icon" width={24} height={24} />
+    </div>
+  )
+}

--- a/test/development/turbopack-asset-loader/next.config.js
+++ b/test/development/turbopack-asset-loader/next.config.js
@@ -1,0 +1,14 @@
+/** @type {import('next').NextConfig} */
+module.exports = {
+  turbopack: {
+    rules: {
+      '*.svg': {
+        loaders: [],
+        type: 'static',
+        condition: {
+          query: /url/,
+        },
+      },
+    },
+  },
+}

--- a/test/development/turbopack-asset-loader/turbopack-asset-loader.test.ts
+++ b/test/development/turbopack-asset-loader/turbopack-asset-loader.test.ts
@@ -1,0 +1,38 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('turbopack-asset-loader', () => {
+  const { next, isTurbopack, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  if (!isTurbopack) {
+    it('should only run the test in turbopack', () => {})
+    return
+  }
+
+  it('should return static URL for SVG with ?url query', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      const svgUrl = await browser
+        .elementByCss('#svg-url')
+        .getAttribute('data-url')
+      expect(svgUrl).toMatch(/^\/_next\/static\/media\/icon\.[a-f0-9]+\.svg$/)
+    })
+  })
+
+  it('should render the SVG as an image', async () => {
+    const browser = await next.browser('/')
+
+    await retry(async () => {
+      const imgSrc = await browser.elementByCss('img').getAttribute('src')
+      expect(imgSrc).toMatch(/^\/_next\/static\/media\/icon\.[a-f0-9]+\.svg$/)
+    })
+  })
+})

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -580,6 +580,10 @@ impl ModuleOptions {
             );
         }
 
+        // Collect user module_type rules separately to add after framework rules
+        // This ensures user rules override framework defaults (e.g., Next.js image rule)
+        let mut user_module_type_rules = Vec::new();
+
         if let Some(webpack_loaders_options) = enable_webpack_loaders {
             let webpack_loaders_options = webpack_loaders_options.await?;
             let execution_context =
@@ -628,29 +632,52 @@ impl ModuleOptions {
                 let mut all_rule_condition = RuleCondition::All(rule_conditions);
                 all_rule_condition.flatten();
                 if !matches!(all_rule_condition, RuleCondition::False) {
-                    rules.push(ModuleRule::new(
-                        all_rule_condition,
-                        vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
-                            ResolvedVc::upcast(
-                                WebpackLoaders::new(
-                                    node_evaluate_asset_context(
+                    // If module_type is specified, collect it to add after framework rules
+                    // This ensures user rules take precedence over framework defaults
+                    if let Some(module_type_str) = &rule.module_type {
+                        let module_type = match module_type_str.as_str() {
+                            "static" => ModuleType::StaticUrlJs { tag: None },
+                            "css" => ModuleType::StaticUrlCss { tag: None },
+                            "raw" => ModuleType::Raw,
+                            other => {
+                                anyhow::bail!(
+                                    "Unknown module type '{}'. Expected 'static', 'css', or 'raw'.",
+                                    other
+                                );
+                            }
+                        };
+                        user_module_type_rules.push(ModuleRule::new(
+                            all_rule_condition.clone(),
+                            vec![ModuleRuleEffect::ModuleType(module_type)],
+                        ));
+                    }
+
+                    // If loaders are specified, add a SourceTransforms effect
+                    if !rule.loaders.await?.is_empty() {
+                        rules.push(ModuleRule::new(
+                            all_rule_condition,
+                            vec![ModuleRuleEffect::SourceTransforms(ResolvedVc::cell(vec![
+                                ResolvedVc::upcast(
+                                    WebpackLoaders::new(
+                                        node_evaluate_asset_context(
+                                            *execution_context,
+                                            Some(import_map),
+                                            None,
+                                            Layer::new(rcstr!("webpack_loaders")),
+                                            false,
+                                        ),
                                         *execution_context,
-                                        Some(import_map),
-                                        None,
-                                        Layer::new(rcstr!("webpack_loaders")),
-                                        false,
-                                    ),
-                                    *execution_context,
-                                    *rule.loaders,
-                                    rule.rename_as.clone(),
-                                    resolve_options_context,
-                                    matches!(ecmascript_source_maps, SourceMapsType::Full),
-                                )
-                                .to_resolved()
-                                .await?,
-                            ),
-                        ]))],
-                    ));
+                                        *rule.loaders,
+                                        rule.rename_as.clone(),
+                                        resolve_options_context,
+                                        matches!(ecmascript_source_maps, SourceMapsType::Full),
+                                    )
+                                    .to_resolved()
+                                    .await?,
+                                ),
+                            ]))],
+                        ));
+                    }
                 }
             }
         }
@@ -831,6 +858,9 @@ impl ModuleOptions {
         }
 
         rules.extend(module_rules.iter().cloned());
+
+        // Add user module_type rules after framework rules so user config takes precedence
+        rules.extend(user_module_type_rules);
 
         Ok(ModuleOptions::cell(ModuleOptions { rules }))
     }

--- a/turbopack/crates/turbopack/src/module_options/module_options_context.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_options_context.rs
@@ -29,6 +29,7 @@ use crate::module_options::RuleCondition;
 pub struct LoaderRuleItem {
     pub loaders: ResolvedVc<WebpackLoaderItems>,
     pub rename_as: Option<RcStr>,
+    pub module_type: Option<RcStr>,
     pub condition: Option<ConditionItem>,
 }
 


### PR DESCRIPTION
Implements Turbopack equivalent of webpack's asset loader with resourceQuery.

This allows users to configure rules that override the default module type for specific file imports:

```js
// next.config.js
module.exports = {
  turbopack: {
    rules: {
      '*.svg': {
        loaders: [],
        type: 'static',  // Return URL string instead of StructuredImage
        condition: {
          query: /url/   // Only when ?url query is present
        }
      }
    }
  }
}
```

Usage:
```ts
import svgUrl from './icon.svg?url';  // Returns URL: "/_next/static/media/icon.abc123.svg"
import Icon from './icon.svg';         // Returns StructuredImage (default)
```

Supported type values:
- `static`: Returns asset URL (maps to ModuleType::StaticUrlJs)
- `css`: Returns CSS URL (maps to ModuleType::StaticUrlCss)
- `raw`: Returns raw file contents (maps to ModuleType::Raw)

Implementation:
- Added `type` field to TypeScript config (`TurbopackRuleConfigItem`)
- Added `module_type` field to Rust config (`RuleConfigItem`, `LoaderRuleItem`)
- Added config schema validation for `type` field
- User module_type rules are applied after framework rules to ensure user configuration takes precedence over defaults (e.g., Next.js image rule)

https://claude.ai/code/session_01JuHY9nLFgBnDzmr6pozRBm

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
