### PR TITLE
Turbopack: Trace task modifications

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 workspace = true
 
 [features]
-default = ["print_cache_item_size"]
+default = []
 print_cache_item_size = ["dep:lzzzz"]
 no_fast_stale = []
 verify_serialization = []

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 workspace = true
 
 [features]
-default = []
+default = ["print_cache_item_size"]
 print_cache_item_size = ["dep:lzzzz"]
 no_fast_stale = []
 verify_serialization = []
@@ -25,6 +25,7 @@ trace_aggregation_update = ["trace_aggregation_update_queue"]
 trace_leaf_distance_update = []
 trace_find_and_schedule = ["trace_aggregation_update_queue"]
 trace_task_completion = []
+trace_task_modification = []
 trace_task_dirty = ["trace_aggregation_update_queue"]
 trace_task_output_dependencies = []
 trace_task_details = []

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -993,8 +993,10 @@ impl<B: BackingStorage> TaskGuard for TaskGuardImpl<'_, B> {
         // TODO this causes race conditions, since we never know when a value is changed. We can't
         // "snapshot" the value correctly.
         if !self.task_id.is_transient() {
-            self.task.track_modification(SpecificTaskDataCategory::Data);
-            self.task.track_modification(SpecificTaskDataCategory::Meta);
+            self.task
+                .track_modification(SpecificTaskDataCategory::Data, "invalidate_serialization");
+            self.task
+                .track_modification(SpecificTaskDataCategory::Meta, "invalidate_serialization");
         }
     }
 
@@ -1043,9 +1045,14 @@ impl<'a, B: BackingStorage> TaskStorageAccessors for TaskGuardImpl<'a, B> {
         &mut self.task
     }
 
-    fn track_modification(&mut self, category: crate::backend::storage::SpecificTaskDataCategory) {
+    #[inline(always)]
+    fn track_modification(
+        &mut self,
+        category: crate::backend::storage::SpecificTaskDataCategory,
+        name: &str,
+    ) {
         if !self.task_id.is_transient() {
-            self.task.track_modification(category);
+            self.task.track_modification(category, name);
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -288,12 +288,31 @@ pub struct StorageWriteGuard<'a> {
 
 impl StorageWriteGuard<'_> {
     /// Tracks mutation of this task
-    pub fn track_modification(&mut self, category: SpecificTaskDataCategory) {
+    #[inline(always)]
+    pub fn track_modification(
+        &mut self,
+        category: SpecificTaskDataCategory,
+        #[allow(unused_variables)] name: &str,
+    ) {
+        self.track_modification_internal(
+            category,
+            #[cfg(feature = "trace_task_modification")]
+            name,
+        );
+    }
+
+    fn track_modification_internal(
+        &mut self,
+        category: SpecificTaskDataCategory,
+        #[cfg(feature = "trace_task_modification")] name: &str,
+    ) {
         let flags = &self.inner.flags;
         if flags.is_snapshot(category) {
             return;
         }
         let modified = flags.is_modified(category);
+        #[cfg(feature = "trace_task_modification")]
+        let _span = (!modified).then(|| tracing::trace_span!("mark_modified", name).entered());
         match (self.storage.snapshot_mode(), modified) {
             (false, false) => {
                 // Not in snapshot mode and item is unmodified

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -93,12 +93,13 @@ impl FieldInfo {
 
     /// Generate the full `self.track_modification(...)` call for this field.
     fn track_modification_call(&self) -> TokenStream {
+        let field_name_str = self.field_name.to_string();
         match self.category {
             Category::Data => {
-                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Data); }
+                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Data, #field_name_str); }
             }
             Category::Meta => {
-                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Meta); }
+                quote! { self.track_modification(crate::backend::storage::SpecificTaskDataCategory::Meta, #field_name_str); }
             }
             Category::Transient => {
                 quote! {
@@ -1214,7 +1215,7 @@ fn generate_task_storage_accessors_trait(grouped_fields: &GroupedFields) -> Toke
             #[doc = "Should be called after confirming that data actually changed."]
             #[doc = "This is separate from `typed_mut()` to allow optimizations where"]
             #[doc = "we only track modifications when something actually changes."]
-            fn track_modification(&mut self, category: crate::backend::storage::SpecificTaskDataCategory);
+            fn track_modification(&mut self, category: crate::backend::storage::SpecificTaskDataCategory, name: &str);
 
             #[doc = "Verify that the task was accessed with the correct category before reading/writing."]
             #[doc = ""]


### PR DESCRIPTION
### What?

add a feature flag `trace_task_modification` which adds the reason why a task was marked as modified to the tracing