### PR TITLE
fix(build): format runAfterProductionCompile duration as human-readable time

### DIFF
--- a/packages/next/src/build/after-production-compile.ts
+++ b/packages/next/src/build/after-production-compile.ts
@@ -6,6 +6,7 @@ import createSpinner from './spinner'
 import isError from '../lib/is-error'
 import type { Telemetry } from '../telemetry/storage'
 import { EVENT_BUILD_FEATURE_USAGE } from '../telemetry/events/build'
+import { hrtimeBigIntDurationToString } from './duration-to-string'
 
 // TODO: refactor this to account for more compiler lifecycle events
 // such as beforeProductionBuild, but for now this is the only one that is needed
@@ -41,14 +42,14 @@ export async function runAfterProductionCompile({
   )
 
   try {
-    const startTime = performance.now()
+    const startTime = process.hrtime.bigint()
     await buildSpan
       .traceChild('after-production-compile')
       .traceAsyncFn(async () => {
         await run(metadata)
       })
-    const duration = performance.now() - startTime
-    const formattedDuration = `${Math.round(duration)}ms`
+    const duration = process.hrtime.bigint() - startTime
+    const formattedDuration = hrtimeBigIntDurationToString(duration)
     Log.event(`Completed runAfterProductionCompile in ${formattedDuration}`)
   } catch (err) {
     // Handle specific known errors differently if needed


### PR DESCRIPTION
This change should unifiy the runAfterProductionCompile output to follow the same style as other times printed in the build logs. 

Currently build logs look like
```
✓ Compiled successfully in 89s
  Running next.config.js provided runAfterProductionCompile ...
✓ Finished writing to filesystem cache in 18.5s
✓ Completed runAfterProductionCompile in 36134ms
  Skipping validation of types
```

I hope they will now look like
```
✓ Compiled successfully in 89s
  Running next.config.js provided runAfterProductionCompile ...
✓ Finished writing to filesystem cache in 18.5s
✓ Completed runAfterProductionCompile in 36.1s
  Skipping validation of types
```

(and yes i know 36s is shameful thats my next problem but this irked me enough to want the build output looking nicer ahhaha)

It feels like adding a test for this would be semi counter productive without basically ending up adding sleeps and then in reality its testing more the logic of `durationToStringWithNanoseconds`.