### PR TITLE
test: add client-cache.defaults failing deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -3,7 +3,8 @@
   "suites": {
     "test/e2e/app-dir/app-client-cache/client-cache.defaults.test.ts": {
       "failed": [
-        "app dir client cache semantics (default semantics) prefetch={true} should re-use the cache for the full page, only for 5 mins"
+        "app dir client cache semantics (default semantics) prefetch={true} should re-use the cache for the full page, only for 5 mins",
+        "app dir client cache semantics (default semantics) prefetch={undefined} - default should refetch the full page after 5 mins"
       ]
     },
     "test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts": {


### PR DESCRIPTION
This deployment test has been failing very recently since the first attempt of [v16.1.5](https://github.com/vercel/next.js/actions/runs/21373599266/attempts/2). Tried deflaking at https://github.com/vercel/next.js/pull/87412, but seems to have no effect. This PR adds the test case to the deployment test manifest to unblock sync. Will continue deflaking at this PR at https://github.com/vercel/next.js/pull/89106

x-ref: [Datadog](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40ci.pipeline.name%3Atest-e2e-deploy-release%20%40ci.pipeline.url%3A%2A%2Fattempts%2F2%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=true&index=citest&panel=%7B%22queryString%22%3A%22%40test.name%3A%5C%22app%20dir%20client%20cache%20semantics%20%28default%20semantics%29%20prefetch%3D%7Bundefined%7D%20-%20default%20should%20refetch%20the%20full%20page%20after%205%20mins%5C%22%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22test.name%22%2C%22value%22%3A%22app%20dir%20client%20cache%20semantics%20%28default%20semantics%29%20prefetch%3D%7Bundefined%7D%20-%20default%20should%20refetch%20the%20full%20page%20after%205%20mins%22%7D%5D%2C%22timeRange%22%3A%7B%22from%22%3A1769209200000%2C%22to%22%3A1769514811691%2C%22live%22%3Afalse%7D%7D&test-detail-history=log_test.status%2Ctimestamp%2Clog_git.branch%2Clog_git.commit.sha%2Clog_test.is_known_flaky&top_n=30&top_o=top&viz=query_table&x_missing=true&start=1769209200000&end=1769514811691&paused=true)
x-ref: [slack thread](https://vercel.slack.com/archives/C02CDC2ALJH/p1769519877570459)

Part of https://linear.app/vercel/issue/NAR-719/fix-deploy-tests