### PR TITLE
test: add resume-data-cache failing deploy test

### DIFF
--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -86,6 +86,11 @@
     },
     "test/e2e/middleware-rewrites/test/index.test.ts": {
       "failed": ["Middleware Rewrite should handle catch-all rewrite correctly"]
+    },
+    "test/e2e/app-dir/resume-data-cache/resume-data-cache.test.ts": {
+      "failed": [
+        "resume-data-cache should have consistent data between static and dynamic renders with fetch cache"
+      ]
     }
   },
   "rules": {

--- a/test/deploy-tests-manifest.json
+++ b/test/deploy-tests-manifest.json
@@ -3,7 +3,8 @@
   "suites": {
     "test/e2e/app-dir/app-client-cache/client-cache.defaults.test.ts": {
       "failed": [
-        "app dir client cache semantics (default semantics) prefetch={true} should re-use the cache for the full page, only for 5 mins"
+        "app dir client cache semantics (default semantics) prefetch={true} should re-use the cache for the full page, only for 5 mins",
+        "app dir client cache semantics (default semantics) prefetch={undefined} - default should refetch the full page after 5 mins"
       ]
     },
     "test/e2e/app-dir/app-client-cache/client-cache.experimental.test.ts": {


### PR DESCRIPTION
This deployment test has been failing very recently. This PR adds the test case to the deployment test manifest to unblock sync. Will continue deflaking at this PR at https://github.com/vercel/next.js/pull/89187

x-ref: [Datadog](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40ci.pipeline.name%3Atest-e2e-deploy-release%20%40ci.pipeline.url%3A%2A%2Fattempts%2F2%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_q=%40test.name&agg_q_source=base&agg_t=count&currentTab=history&eventStack=&fromUser=true&index=citest&panel=%7B%22queryString%22%3A%22%40test.name%3A%5C%22resume-data-cache%20should%20have%20consistent%20data%20between%20static%20and%20dynamic%20renders%20with%20fetch%20cache%5C%22%22%2C%22filters%22%3A%5B%7B%22isClicked%22%3Atrue%2C%22source%22%3A%22log%22%2C%22path%22%3A%22test.name%22%2C%22value%22%3A%22resume-data-cache%20should%20have%20consistent%20data%20between%20static%20and%20dynamic%20renders%20with%20fetch%20cache%22%7D%5D%2C%22timeRange%22%3A%7B%22from%22%3A1769520224000%2C%22to%22%3A1769693024000%2C%22live%22%3Atrue%7D%7D&test-detail-history=log_test.status%2Ctimestamp%2Clog_git.branch%2Clog_git.commit.sha%2Clog_test.is_known_flaky&top_n=30&top_o=top&viz=query_table&x_missing=true&start=1769520224360&end=1769693024360&paused=false)

Part of https://linear.app/vercel/issue/NAR-719/fix-deploy-tests