### PR TITLE
refactor: Improve templates layout flexibility

### DIFF
--- a/packages/create-next-app/templates/app-tw/js/app/layout.js
+++ b/packages/create-next-app/templates/app-tw/js/app/layout.js
@@ -18,9 +18,9 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" className="h-full">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-full flex flex-col`}
       >
         {children}
       </body>

--- a/packages/create-next-app/templates/app-tw/js/app/page.js
+++ b/packages/create-next-app/templates/app-tw/js/app/page.js
@@ -2,8 +2,8 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
+      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/packages/create-next-app/templates/app-tw/ts/app/layout.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/layout.tsx
@@ -23,9 +23,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className="h-full">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-full flex flex-col`}
       >
         {children}
       </body>

--- a/packages/create-next-app/templates/app-tw/ts/app/page.tsx
+++ b/packages/create-next-app/templates/app-tw/ts/app/page.tsx
@@ -2,8 +2,8 @@ import Image from "next/image";
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black">
-      <main className="flex min-h-screen w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
+    <div className="flex flex-col flex-1 items-center justify-center bg-zinc-50 font-sans dark:bg-black">
+      <main className="flex flex-1 w-full max-w-3xl flex-col items-center justify-between py-32 px-16 bg-white dark:bg-black sm:items-start">
         <Image
           className="dark:invert"
           src="/next.svg"

--- a/packages/create-next-app/templates/app/js/app/globals.css
+++ b/packages/create-next-app/templates/app/js/app/globals.css
@@ -10,6 +10,10 @@
   }
 }
 
+html {
+  height: 100%;
+}
+
 html,
 body {
   max-width: 100vw;
@@ -17,6 +21,9 @@ body {
 }
 
 body {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
   color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;

--- a/packages/create-next-app/templates/app/js/app/page.module.css
+++ b/packages/create-next-app/templates/app/js/app/page.module.css
@@ -10,7 +10,7 @@
   --button-secondary-border: #ebebeb;
 
   display: flex;
-  min-height: 100vh;
+  flex: 1;
   align-items: center;
   justify-content: center;
   font-family: var(--font-geist-sans);
@@ -19,7 +19,7 @@
 
 .main {
   display: flex;
-  min-height: 100vh;
+  flex: 1;
   width: 100%;
   max-width: 800px;
   flex-direction: column;

--- a/packages/create-next-app/templates/app/js/app/page.module.css
+++ b/packages/create-next-app/templates/app/js/app/page.module.css
@@ -11,6 +11,7 @@
 
   display: flex;
   flex: 1;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   font-family: var(--font-geist-sans);

--- a/packages/create-next-app/templates/app/ts/app/globals.css
+++ b/packages/create-next-app/templates/app/ts/app/globals.css
@@ -10,6 +10,10 @@
   }
 }
 
+html {
+  height: 100%;
+}
+
 html,
 body {
   max-width: 100vw;
@@ -17,6 +21,9 @@ body {
 }
 
 body {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
   color: var(--foreground);
   background: var(--background);
   font-family: Arial, Helvetica, sans-serif;

--- a/packages/create-next-app/templates/app/ts/app/page.module.css
+++ b/packages/create-next-app/templates/app/ts/app/page.module.css
@@ -10,7 +10,7 @@
   --button-secondary-border: #ebebeb;
 
   display: flex;
-  min-height: 100vh;
+  flex: 1;
   align-items: center;
   justify-content: center;
   font-family: var(--font-geist-sans);
@@ -19,7 +19,7 @@
 
 .main {
   display: flex;
-  min-height: 100vh;
+  flex: 1;
   width: 100%;
   max-width: 800px;
   flex-direction: column;

--- a/packages/create-next-app/templates/app/ts/app/page.module.css
+++ b/packages/create-next-app/templates/app/ts/app/page.module.css
@@ -11,6 +11,7 @@
 
   display: flex;
   flex: 1;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   font-family: var(--font-geist-sans);


### PR DESCRIPTION
### What

Switches the `create-next-app` templates (`app-tw`, `app`) to flex-based layouts instead of `min-height: 100vh`.

### Why

At Clerk, we ship a template on top of `create-next-app` that adds a header with sign-in/sign-up links to the root layout. The current `min-height: 100vh` approach causes overflow as soon as you add anything to the layout.

Here's a [minimal repo showing the overflow issue](https://github.com/alexcarpenter/nextjs-layout-template-repo).

Using flexbox lets the page fill remaining space naturally, so headers/footers don't force an overflow and avoids us having to modify the `page.tsx` template.

### Changes

**Tailwind (`app-tw`):**
- Layout: `h-full` on `<html>`, `min-h-full flex flex-col` on `<body>`
- Page: `min-h-screen` → `flex flex-col flex-1`

**CSS Modules (`app`):**
- `globals.css`: `height: 100%` on html, `min-height: 100%; display: flex; flex-direction: column` on body
- `page.module.css`: `min-height: 100vh` → `flex: 1`

The empty templates (`app-empty`, `app-tw-empty`) don't have height styling so they're unchanged.

| BEFORE | AFTER |
|--------|--------|
| <img width="1392" height="1522" alt="Screenshot 2026-01-29 at 9 41 58 AM" src="https://github.com/user-attachments/assets/6642de41-253b-42c0-af2d-d55c4e651541" /> | <img width="1392" height="1522" alt="Screenshot 2026-01-29 at 9 42 31 AM" src="https://github.com/user-attachments/assets/633f3d46-ed8c-4d05-8173-77f2cf166703" /> | 

Closes NEXT-
Fixes #
