### PR TITLE
Turbopack: Add --experimental-server-fast-refresh CLI flag

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -310,6 +310,10 @@ program
     'Path to a HTTPS certificate authority file.'
   )
   .option(
+    '--experimental-server-fast-refresh',
+    'Enable experimental server-side Fast Refresh.'
+  )
+  .option(
     '--experimental-upload-trace, <traceUrl>',
     'Reports a subset of the debugging trace to a remote HTTP URL. Includes sensitive data.'
   )

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -55,6 +55,7 @@ export type NextDevOptions = {
   experimentalUploadTrace?: string
   experimentalNextConfigStripTypes?: boolean
   experimentalCpuProf?: boolean
+  experimentalServerFastRefresh?: boolean
 }
 
 type PortSource = 'cli' | 'default' | 'env'
@@ -253,6 +254,7 @@ const nextDev = async (
     allowRetry,
     isDev: true,
     hostname: host,
+    experimentalServerFastRefresh: options.experimentalServerFastRefresh,
   }
 
   const startServerPath = require.resolve('../server/lib/start-server')

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -123,6 +123,7 @@ export interface StartServerOptions {
   keepAliveTimeout?: number
   // this is dev-server only
   selfSignedCertificate?: SelfSignedCertificate
+  experimentalServerFastRefresh?: boolean
 }
 
 export async function getRequestHandlers({


### PR DESCRIPTION
This adds `--experimental-server-fast-refresh` CLI flag to enable experimental server-side Fast Refresh (HMR) during development. It's disabled by default.

We call HMR "fast refresh" in public docs so let's keep the flag consistent with that. We use the HMR naming past this outer layer in the codebase.

Test Plan:

```bash
next dev --experimental-server-fast-refresh
```