### PR TITLE
Revert "fix(router): support BigInt in query parameters"

### DIFF
--- a/packages/next/src/shared/lib/router/utils/querystring.ts
+++ b/packages/next/src/shared/lib/router/utils/querystring.ts
@@ -24,8 +24,7 @@ function stringifyUrlQueryParam(param: unknown): string {
 
   if (
     (typeof param === 'number' && !isNaN(param)) ||
-    typeof param === 'boolean' ||
-    typeof param === 'bigint'
+    typeof param === 'boolean'
   ) {
     return String(param)
   } else {


### PR DESCRIPTION
Reverts vercel/next.js#89213

vercel/next.js#89213 is missing the deserialization part which has security (DoS) implications: Deserializing BigInts needs to be limited since unreasonably large numbers (500+ digits) take a lot of blocking CPU time (upwards of 50ms).

If people really want to put BigInt into their search params, they can call .toString themselves and deserialize it. But since this makes a DDoS pretty trivial, we don't want to encourage BigInt for search params unless Next.js can make deserialization safe.