### PR TITLE
Turbopack: Store task error as pointer to the source error

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -37,8 +37,8 @@ use tracing_subscriber::{Registry, layer::SubscriberExt, util::SubscriberInitExt
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Effects, FxIndexSet, NonLocalValue, OperationValue, OperationVc, PrettyPrintError, ReadRef,
-    ResolvedVc, TaskInput, TransientInstance, TryJoinIterExt, TurboTasksApi, UpdateInfo, Vc,
-    get_effects,
+    ResolvedVc, TaskInput, TransientInstance, TryJoinIterExt, TurboTasksApi, TurboTasksCallApi,
+    UpdateInfo, Vc, get_effects,
     message_queue::{CompilationEvent, Severity},
     trace::TraceRawVcs,
 };

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -18,7 +18,7 @@ use owo_colors::OwoColorize;
 use serde::Serialize;
 use terminal_hyperlink::Hyperlink;
 use turbo_tasks::{
-    PrettyPrintError, TurboTasks, TurboTasksApi,
+    PrettyPrintError, TurboTasks, TurboTasksCallApi,
     backend::TurboTasksExecutionError,
     message_queue::{CompilationEvent, Severity},
 };

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 workspace = true
 
 [features]
-default = ["print_cache_item_size"]
+default = []
 print_cache_item_size = ["dep:lzzzz"]
 no_fast_stale = []
 verify_serialization = []

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 workspace = true
 
 [features]
-default = []
+default = ["print_cache_item_size"]
 print_cache_item_size = ["dep:lzzzz"]
 no_fast_stale = []
 verify_serialization = []

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -390,6 +390,10 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             .map(|stats| stats.increment_cache_miss(task_type.native_fn));
     }
 
+    /// Reconstructs a full [`TurboTasksExecutionError`] from the compact [`TaskError`] storage
+    /// representation. For [`TaskError::TaskChain`], this looks up the source error from the last
+    /// task's output and rebuilds the nested `TaskContext` wrappers with `TurboTasksCallApi`
+    /// references for lazy name resolution.
     fn task_error_to_turbo_tasks_execution_error(
         &self,
         error: &TaskError,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -417,7 +417,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 let task_id = chain.last().unwrap();
                 let error = {
                     let task = ctx.task(*task_id, TaskDataCategory::Meta);
-                    if let Some(OutputValue::Error(error)) = task.get_output().clone() {
+                    if let Some(OutputValue::Error(error)) = task.get_output() {
                         Some(error.clone())
                     } else {
                         None

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -429,6 +429,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 };
                 let error = error.map_or_else(
                     || {
+                        // Eventual consistency will cause errors to no longer be available
                         TurboTasksExecutionError::Panic(Arc::new(TurboTasksPanic {
                             message: TurboTasksExecutionErrorMessage::PIISafe(Cow::Borrowed(
                                 "Error no longer available",

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -28,10 +28,12 @@ use turbo_bincode::{TurboBincodeBuffer, new_turbo_bincode_decoder, new_turbo_bin
 use turbo_tasks::{
     CellId, FxDashMap, RawVc, ReadCellOptions, ReadCellTracking, ReadConsistency,
     ReadOutputOptions, ReadTracking, SharedReference, TRANSIENT_TASK_BIT, TaskExecutionReason,
-    TaskId, TaskPriority, TraitTypeId, TurboTasksBackendApi, ValueTypeId,
+    TaskId, TaskPriority, TraitTypeId, TurboTasksBackendApi, TurboTasksPanic, ValueTypeId,
     backend::{
         Backend, CachedTaskType, CellContent, TaskExecutionSpec, TransientTaskType,
-        TurboTasksExecutionError, TypedCellContent, VerificationMode,
+        TurboTaskContextError, TurboTaskLocalContextError, TurboTasksError,
+        TurboTasksExecutionError, TurboTasksExecutionErrorMessage, TypedCellContent,
+        VerificationMode,
     },
     event::{Event, EventDescription, EventListener},
     message_queue::TimingEvent,
@@ -39,7 +41,6 @@ use turbo_tasks::{
     scope::scope_and_block,
     task_statistics::TaskStatisticsApi,
     trace::TraceRawVcs,
-    turbo_tasks,
     util::{IdFactoryWithReuse, good_chunk_size, into_chunks},
 };
 
@@ -66,6 +67,7 @@ use crate::{
         ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
         InProgressState, InProgressStateInner, OutputValue, TransientTask,
     },
+    error::TaskError,
     utils::{
         arc_or_owned::ArcOrOwned,
         chunked_vec::ChunkedVec,
@@ -386,6 +388,64 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
     fn track_cache_miss(&self, task_type: &CachedTaskType) {
         self.task_statistics
             .map(|stats| stats.increment_cache_miss(task_type.native_fn));
+    }
+
+    fn task_error_to_turbo_tasks_execution_error(
+        &self,
+        error: &TaskError,
+        ctx: &mut impl ExecuteContext<'_>,
+    ) -> TurboTasksExecutionError {
+        match error {
+            TaskError::Panic(panic) => TurboTasksExecutionError::Panic(panic.clone()),
+            TaskError::Error(item) => TurboTasksExecutionError::Error(Arc::new(TurboTasksError {
+                message: item.message.clone(),
+                source: item
+                    .source
+                    .as_ref()
+                    .map(|e| self.task_error_to_turbo_tasks_execution_error(e, ctx)),
+            })),
+            TaskError::LocalTaskContext(local_task_context) => {
+                TurboTasksExecutionError::LocalTaskContext(Arc::new(TurboTaskLocalContextError {
+                    name: local_task_context.name.clone(),
+                    source: local_task_context
+                        .source
+                        .as_ref()
+                        .map(|e| self.task_error_to_turbo_tasks_execution_error(e, ctx)),
+                }))
+            }
+            TaskError::TaskChain(chain) => {
+                let task_id = chain.last().unwrap();
+                let error = {
+                    let task = ctx.task(*task_id, TaskDataCategory::Meta);
+                    if let Some(OutputValue::Error(error)) = task.get_output().clone() {
+                        Some(error.clone())
+                    } else {
+                        None
+                    }
+                };
+                let error = error.map_or_else(
+                    || {
+                        TurboTasksExecutionError::Panic(Arc::new(TurboTasksPanic {
+                            message: TurboTasksExecutionErrorMessage::PIISafe(Cow::Borrowed(
+                                "Error no longer available",
+                            )),
+                            location: None,
+                        }))
+                    },
+                    |e| self.task_error_to_turbo_tasks_execution_error(&e, ctx),
+                );
+                let mut current_error = error;
+                for &task_id in chain.iter().rev() {
+                    current_error =
+                        TurboTasksExecutionError::TaskContext(Arc::new(TurboTaskContextError {
+                            task_id,
+                            source: Some(current_error),
+                            turbo_tasks: ctx.turbo_tasks(),
+                        }));
+                }
+                current_error
+            }
+        }
     }
 }
 
@@ -715,11 +775,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             let result = match output {
                 OutputValue::Cell(cell) => Ok(Ok(RawVc::TaskCell(cell.task, cell.cell))),
                 OutputValue::Output(task) => Ok(Ok(RawVc::TaskOutput(*task))),
-                OutputValue::Error(error) => Err(error
-                    .with_task_context(task.get_task_type(), Some(task_id))
-                    .into()),
+                OutputValue::Error(error) => Err(error.clone()),
             };
-            if let Some(mut reader_task) = reader_task
+            if let Some(mut reader_task) = reader_task.take()
                 && options.tracking.should_track(result.is_err())
                 && (!task.immutable() || cfg!(feature = "verify_immutable"))
             {
@@ -759,9 +817,15 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 drop(reader_task);
 
                 queue.execute(&mut ctx);
+            } else {
+                drop(task);
             }
 
-            return result;
+            return result.map_err(|error| {
+                self.task_error_to_turbo_tasks_execution_error(&error, &mut ctx)
+                    .with_task_context(task_id, turbo_tasks.pin())
+                    .into()
+            });
         }
         drop(reader_task);
 
@@ -962,6 +1026,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         &self,
         parent_span: Option<tracing::Id>,
         reason: &str,
+        turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> Option<(Instant, bool)> {
         let snapshot_span =
             tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason)
@@ -1087,7 +1152,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             if let Some(ref m) = meta {
                 task_cache_stats
                     .lock()
-                    .entry(self.debug_get_task_name(task_id))
+                    .entry(self.get_task_name(task_id, turbo_tasks))
                     .or_default()
                     .add_counts(m);
             }
@@ -1107,7 +1172,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 if inner.flags.meta_modified() {
                     task_cache_stats
                         .lock()
-                        .entry(self.debug_get_task_name(task_id))
+                        .entry(self.get_task_name(task_id, turbo_tasks))
                         .or_default()
                         .add_counts(&inner);
                 }
@@ -1143,7 +1208,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                     #[cfg(feature = "print_cache_item_size")]
                                     task_cache_stats
                                         .lock()
-                                        .entry(self.debug_get_task_name(task_id))
+                                        .entry(self.get_task_name(task_id, turbo_tasks))
                                         .or_default()
                                         .add_meta(&meta);
                                     Some(meta)
@@ -1163,7 +1228,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                                     #[cfg(feature = "print_cache_item_size")]
                                     task_cache_stats
                                         .lock()
-                                        .entry(self.debug_get_task_name(task_id))
+                                        .entry(self.get_task_name(task_id, turbo_tasks))
                                         .or_default()
                                         .add_data(&data);
                                     Some(data)
@@ -1317,7 +1382,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let elapsed = start.elapsed();
         // avoid spamming the event queue with information about fast operations
         if elapsed > Duration::from_secs(10) {
-            turbo_tasks().send_compilation_event(Arc::new(TimingEvent::new(
+            turbo_tasks.send_compilation_event(Arc::new(TimingEvent::new(
                 "Finished writing to filesystem cache".to_string(),
                 elapsed,
             )));
@@ -1366,7 +1431,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             self.verify_aggregation_graph(turbo_tasks, false);
         }
         if self.should_persist() {
-            self.snapshot_and_persist(Span::current().into(), "stop");
+            self.snapshot_and_persist(Span::current().into(), "stop", turbo_tasks);
         }
         drop_contents(&self.task_cache);
         self.storage.drop_contents();
@@ -1718,15 +1783,19 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
     }
 
-    #[allow(dead_code)]
-    fn debug_get_task_name(&self, task_id: TaskId) -> String {
-        let task = self.storage.access_mut(task_id);
+    fn get_task_name(
+        &self,
+        task_id: TaskId,
+        turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
+    ) -> String {
+        let mut ctx = self.execute_context(turbo_tasks);
+        let task = ctx.task(task_id, TaskDataCategory::Data);
         if let Some(value) = task.get_persistent_task_type() {
             value.to_string()
         } else if let Some(value) = task.get_transient_task_type() {
             value.to_string()
         } else {
-            "unknown".to_string()
+            panic!("Every task must have a type\n{:#?}", task);
         }
     }
 
@@ -2180,11 +2249,11 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             }
             Err(err) => {
                 if let Some(OutputValue::Error(old_error)) = current_output
-                    && old_error == &err
+                    && **old_error == err
                 {
                     None
                 } else {
-                    Some(OutputValue::Error(err))
+                    Some(OutputValue::Error(Arc::new((&err).into())))
                 }
             }
         };
@@ -2715,7 +2784,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                         }
 
                         let this = self.clone();
-                        let snapshot = this.snapshot_and_persist(None, reason);
+                        let snapshot = this.snapshot_and_persist(None, reason, turbo_tasks);
                         if let Some((snapshot_start, new_data)) = snapshot {
                             last_snapshot = snapshot_start;
                             if !new_data {
@@ -3526,6 +3595,10 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
 
     fn is_tracking_dependencies(&self) -> bool {
         self.0.options.dependency_tracking
+    }
+
+    fn get_task_name(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>) -> String {
+        self.0.get_task_name(task, turbo_tasks)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1799,7 +1799,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         } else if let Some(value) = task.get_transient_task_type() {
             value.to_string()
         } else {
-            panic!("Every task must have a type\n{:#?}", task);
+            "unknown".to_string()
         }
     }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/mod.rs
@@ -16,7 +16,7 @@ use std::{
 use bincode::{Decode, Encode};
 use turbo_tasks::{
     CellId, FxIndexMap, TaskExecutionReason, TaskId, TaskPriority, TurboTasksBackendApi,
-    TypedSharedReference, backend::CachedTaskType,
+    TurboTasksCallApi, TypedSharedReference, backend::CachedTaskType,
 };
 
 use crate::{
@@ -93,6 +93,7 @@ pub trait ExecuteContext<'e>: Sized {
     fn suspending_requested(&self) -> bool;
     fn should_track_dependencies(&self) -> bool;
     fn should_track_activeness(&self) -> bool;
+    fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi>;
 }
 
 pub trait ChildExecuteContext<'e>: Send + Sized {
@@ -636,6 +637,10 @@ where
 
     fn should_track_activeness(&self) -> bool {
         self.backend.should_track_activeness()
+    }
+
+    fn turbo_tasks(&self) -> Arc<dyn TurboTasksCallApi> {
+        self.turbo_tasks.pin()
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -1010,7 +1010,7 @@ mod tests {
     fn test_schema_size() {
         assert_eq!(
             size_of::<TaskStorage>(),
-            144,
+            136,
             "TaskStorage size changed! If this is intentional, update this test."
         );
         assert_eq!(

--- a/turbopack/crates/turbo-tasks-backend/src/data.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/data.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{self, Debug, Display},
     pin::Pin,
+    sync::Arc,
 };
 
 use anyhow::Result;
@@ -9,9 +10,11 @@ use parking_lot::Mutex;
 use rustc_hash::FxHashSet;
 use turbo_tasks::{
     CellId, RawVc, TaskExecutionReason, TaskId, TaskPriority, TraitTypeId,
-    backend::{TransientTaskRoot, TurboTasksExecutionError},
+    backend::TransientTaskRoot,
     event::{Event, EventDescription, EventListener},
 };
+
+use crate::error::TaskError;
 
 // this traits are needed for the transient variants of `CachedDataItem`
 // transient variants are never cloned or compared
@@ -78,8 +81,9 @@ impl CollectiblesRef {
 pub enum OutputValue {
     Cell(CellRef),
     Output(TaskId),
-    Error(TurboTasksExecutionError),
+    Error(Arc<TaskError>),
 }
+
 impl OutputValue {
     /// Returns true if this output value references a transient task.
     ///

--- a/turbopack/crates/turbo-tasks-backend/src/error.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/error.rs
@@ -91,17 +91,15 @@ impl PartialEq<TurboTasksExecutionError> for TaskError {
                 }
                 let mut current_source = other.source.as_ref();
                 for &task_id in &chain[1..] {
-                    match current_source {
-                        Some(other) => match other {
-                            TurboTasksExecutionError::TaskContext(task_context) => {
-                                if task_context.task_id != task_id {
-                                    return false;
-                                }
-                                current_source = task_context.source.as_ref();
-                            }
-                            _ => return false,
-                        },
-                        None => return false,
+                    if let Some(TurboTasksExecutionError::TaskContext(task_context)) =
+                        current_source
+                    {
+                        if task_context.task_id != task_id {
+                            return false;
+                        }
+                        current_source = task_context.source.as_ref();
+                    } else {
+                        return false;
                     }
                 }
                 // TaskError will stop at the last task in the chain (this is a pointer), so we do

--- a/turbopack/crates/turbo-tasks-backend/src/error.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/error.rs
@@ -1,0 +1,114 @@
+use std::sync::Arc;
+
+use bincode::{Decode, Encode};
+use smallvec::SmallVec;
+use turbo_rcstr::RcStr;
+use turbo_tasks::{
+    TaskId, TurboTasksPanic,
+    backend::{TurboTasksExecutionError, TurboTasksExecutionErrorMessage},
+};
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+pub struct TaskErrorItem {
+    pub message: TurboTasksExecutionErrorMessage,
+    pub source: Option<TaskError>,
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+pub struct LocalTaskContext {
+    pub name: RcStr,
+    pub source: Option<TaskError>,
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+pub enum TaskError {
+    Panic(Arc<TurboTasksPanic>),
+    Error(Box<TaskErrorItem>),
+    LocalTaskContext(Box<LocalTaskContext>),
+    TaskChain(SmallVec<[TaskId; 4]>),
+}
+
+impl From<&TurboTasksExecutionError> for TaskError {
+    fn from(value: &TurboTasksExecutionError) -> Self {
+        match value {
+            TurboTasksExecutionError::Panic(panic) => TaskError::Panic(panic.clone()),
+            TurboTasksExecutionError::Error(error) => TaskError::Error(Box::new(TaskErrorItem {
+                message: error.message.clone(),
+                source: error.source.as_ref().map(|e| e.into()),
+            })),
+            TurboTasksExecutionError::LocalTaskContext(local_task_context) => {
+                TaskError::LocalTaskContext(Box::new(LocalTaskContext {
+                    name: local_task_context.name.clone(),
+                    source: local_task_context.source.as_ref().map(|e| e.into()),
+                }))
+            }
+            TurboTasksExecutionError::TaskContext(task_context) => {
+                let mut chain = SmallVec::new();
+                chain.push(task_context.task_id);
+                let mut current_error = task_context.source.as_ref();
+                while let Some(error) = current_error {
+                    match error {
+                        TurboTasksExecutionError::TaskContext(task_context) => {
+                            chain.push(task_context.task_id);
+                            current_error = task_context.source.as_ref();
+                        }
+                        _ => {
+                            return TaskError::TaskChain(chain);
+                        }
+                    }
+                }
+                TaskError::TaskChain(chain)
+            }
+        }
+    }
+}
+
+fn eq_option(this: &Option<TaskError>, other: &Option<TurboTasksExecutionError>) -> bool {
+    match (this, other) {
+        (Some(this), Some(other)) => this == other,
+        (None, None) => true,
+        _ => false,
+    }
+}
+
+impl PartialEq<TurboTasksExecutionError> for TaskError {
+    fn eq(&self, other: &TurboTasksExecutionError) -> bool {
+        match (self, other) {
+            (TaskError::Panic(this), TurboTasksExecutionError::Panic(other)) => this == other,
+            (TaskError::Error(this), TurboTasksExecutionError::Error(other)) => {
+                this.message == other.message && eq_option(&this.source, &other.source)
+            }
+            (
+                TaskError::LocalTaskContext(this),
+                TurboTasksExecutionError::LocalTaskContext(other),
+            ) => this.name == other.name && eq_option(&this.source, &other.source),
+            (TaskError::TaskChain(chain), TurboTasksExecutionError::TaskContext(other)) => {
+                if chain.is_empty() {
+                    return false;
+                }
+                if chain[0] != other.task_id {
+                    return false;
+                }
+                let mut current_source = other.source.as_ref();
+                for &task_id in &chain[1..] {
+                    match current_source {
+                        Some(other) => match other {
+                            TurboTasksExecutionError::TaskContext(task_context) => {
+                                if task_context.task_id != task_id {
+                                    return false;
+                                }
+                                current_source = task_context.source.as_ref();
+                            }
+                            _ => return false,
+                        },
+                        None => return false,
+                    }
+                }
+                // TaskError will stop at the last task in the chain (this is a pointer), so we do
+                // not compare further.
+                true
+            }
+            _ => false,
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/error.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/error.rs
@@ -1,3 +1,12 @@
+//! Compact error representation for storage in the turbo-tasks backend.
+//!
+//! [`TurboTasksExecutionError`] contains the whole chain of errors. That is expensive to store and
+//! we would duplicate error messages for many tasks. [`TaskError`] is a backend-internal
+//! representation that replaces nested [`TurboTasksExecutionError::TaskContext`] chains with a flat
+//! list of [`TaskId`]s (`TaskChain`), and omits the actual error message behind them. The actual
+//! error content is recovered at read time by looking up the task's output, and task names are
+//! resolved lazily via `TurboTasksCallApi::get_task_name`.
+
 use std::sync::Arc;
 
 use bincode::{Decode, Encode};
@@ -8,26 +17,39 @@ use turbo_tasks::{
     backend::{TurboTasksExecutionError, TurboTasksExecutionErrorMessage},
 };
 
+/// An error with a message and an optional cause.
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct TaskErrorItem {
     pub message: TurboTasksExecutionErrorMessage,
     pub source: Option<TaskError>,
 }
 
+/// Context for a local task that failed.
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct LocalTaskContext {
     pub name: RcStr,
     pub source: Option<TaskError>,
 }
 
+/// Compact, serializable representation of a task execution error.
+///
+/// `TaskContext` chains are collapsed into a flat [`TaskChain`](TaskError::TaskChain) of
+/// [`TaskId`]s. The source error is not stored in the chain; it is recovered by looking up the
+/// output of the last task in the chain.
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub enum TaskError {
     Panic(Arc<TurboTasksPanic>),
     Error(Box<TaskErrorItem>),
     LocalTaskContext(Box<LocalTaskContext>),
+    /// A chain of task IDs representing nested `TaskContext` wrappers. The last element is the
+    /// innermost task whose output holds the actual error. Earlier elements are outer tasks that
+    /// propagated the error. The source error is not stored here. The task id acts as a pointer to
+    /// the originating task's output.
     TaskChain(SmallVec<[TaskId; 4]>),
 }
 
+/// Converts a [`TurboTasksExecutionError`] into the compact [`TaskError`] representation.
+/// Nested `TaskContext` chains are flattened into a single [`TaskError::TaskChain`].
 impl From<&TurboTasksExecutionError> for TaskError {
     fn from(value: &TurboTasksExecutionError) -> Self {
         match value {
@@ -63,6 +85,7 @@ impl From<&TurboTasksExecutionError> for TaskError {
     }
 }
 
+/// Compares optional errors across the two representations.
 fn eq_option(this: &Option<TaskError>, other: &Option<TurboTasksExecutionError>) -> bool {
     match (this, other) {
         (Some(this), Some(other)) => this == other,
@@ -71,6 +94,9 @@ fn eq_option(this: &Option<TaskError>, other: &Option<TurboTasksExecutionError>)
     }
 }
 
+/// Cross-type equality used to detect whether a task's stored error has changed (to avoid
+/// unnecessary dirty-flagging). For `TaskChain`, only the task ID chain is compared — the source
+/// error content is not checked because the chain acts as a pointer to the originating task.
 impl PartialEq<TurboTasksExecutionError> for TaskError {
     fn eq(&self, other: &TurboTasksExecutionError) -> bool {
         match (self, other) {

--- a/turbopack/crates/turbo-tasks-backend/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/lib.rs
@@ -7,6 +7,7 @@ mod backend;
 mod backing_storage;
 mod data;
 mod database;
+mod error;
 mod kv_backing_storage;
 mod utils;
 

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -155,6 +155,16 @@ impl TurboTasksCallApi for VcStorage {
     ) {
         unreachable!()
     }
+
+    /// Should not be called on the testing VcStorage. These methods are only implemented for
+    /// structs with access to a `MessageQueue` like `TurboTasks`.
+    fn send_compilation_event(&self, _event: Arc<dyn CompilationEvent>) {
+        unimplemented!()
+    }
+
+    fn get_task_name(&self, task: TaskId) -> String {
+        format!("Task({})", task)
+    }
 }
 
 impl TurboTasksApi for VcStorage {
@@ -313,12 +323,6 @@ impl TurboTasksApi for VcStorage {
         &self,
         _event_types: Option<Vec<String>>,
     ) -> Receiver<Arc<dyn CompilationEvent>> {
-        unimplemented!()
-    }
-
-    /// Should not be called on the testing VcStorage. These methods are only implemented for
-    /// structs with access to a `MessageQueue` like `TurboTasks`.
-    fn send_compilation_event(&self, _event: Arc<dyn CompilationEvent>) {
         unimplemented!()
     }
 

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -296,6 +296,9 @@ pub struct TurboTasksError {
     pub source: Option<TurboTasksExecutionError>,
 }
 
+/// Error context indicating that a task's execution failed. Stores a `task_id` and a reference to
+/// the `TurboTasksCallApi` so that the task name can be resolved lazily at display time (via
+/// [`TurboTasksCallApi::get_task_name`]) rather than eagerly at error creation time.
 #[derive(Clone)]
 pub struct TurboTaskContextError {
     pub turbo_tasks: Arc<dyn TurboTasksCallApi>,
@@ -342,6 +345,8 @@ impl Debug for TurboTaskContextError {
     }
 }
 
+/// Error context for a local task that failed. Unlike [`TurboTaskContextError`],
+/// this stores the task name directly since local tasks don't have a [`TaskId`].
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub struct TurboTaskLocalContextError {
     pub name: RcStr,
@@ -357,6 +362,8 @@ pub enum TurboTasksExecutionError {
 }
 
 impl TurboTasksExecutionError {
+    /// Wraps this error in a [`TaskContext`](TurboTasksExecutionError::TaskContext) layer
+    /// identifying the normal task that encountered the error.
     pub fn with_task_context(
         self,
         task_id: TaskId,
@@ -368,6 +375,9 @@ impl TurboTasksExecutionError {
             source: Some(self),
         }))
     }
+
+    /// Wraps this error in a [`LocalTaskContext`](TurboTasksExecutionError::LocalTaskContext) layer
+    /// identifying the local task that encountered the error.
     pub fn with_local_task_context(self, name: String) -> Self {
         TurboTasksExecutionError::LocalTaskContext(Arc::new(TurboTaskLocalContextError {
             name: RcStr::from(name),
@@ -627,5 +637,7 @@ pub trait Backend: Sync + Send {
 
     fn is_tracking_dependencies(&self) -> bool;
 
+    /// Returns a human-readable name for the given task. Used by error display formatting
+    /// to lazily resolve task names instead of storing them eagerly in error objects.
     fn get_task_name(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>) -> String;
 }

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -12,6 +12,8 @@ use anyhow::{Result, anyhow};
 use auto_hash_map::AutoMap;
 use bincode::{
     Decode, Encode,
+    de::Decoder,
+    enc::Encoder,
     error::{DecodeError, EncodeError},
     impl_borrow_decode,
 };
@@ -26,10 +28,10 @@ use turbo_rcstr::RcStr;
 
 use crate::{
     RawVc, ReadCellOptions, ReadOutputOptions, ReadRef, SharedReference, TaskId, TaskIdSet,
-    TaskPriority, TraitRef, TraitTypeId, TurboTasksPanic, ValueTypeId, VcValueTrait, VcValueType,
-    event::EventListener, macro_helpers::NativeFunction, magic_any::MagicAny,
-    manager::TurboTasksBackendApi, raw_vc::CellId, registry,
-    task::shared_reference::TypedSharedReference, task_statistics::TaskStatisticsApi,
+    TaskPriority, TraitRef, TraitTypeId, TurboTasksCallApi, TurboTasksPanic, ValueTypeId,
+    VcValueTrait, VcValueType, event::EventListener, macro_helpers::NativeFunction,
+    magic_any::MagicAny, manager::TurboTasksBackendApi, raw_vc::CellId, registry,
+    task::shared_reference::TypedSharedReference, task_statistics::TaskStatisticsApi, turbo_tasks,
 };
 
 pub type TransientTaskRoot =
@@ -273,7 +275,7 @@ pub type TaskCollectiblesMap = AutoMap<RawVc, i32, BuildHasherDefault<FxHasher>,
 
 // Structurally and functionally similar to Cow<&'static, str> but explicitly notes the importance
 // of non-static strings potentially containing PII (Personal Identifiable Information).
-#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub enum TurboTasksExecutionErrorMessage {
     PIISafe(#[bincode(with = "turbo_bincode::owned_cow")] Cow<'static, str>),
     NonPIISafe(String),
@@ -294,28 +296,82 @@ pub struct TurboTasksError {
     pub source: Option<TurboTasksExecutionError>,
 }
 
-#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct TurboTaskContextError {
-    pub task: RcStr,
-    #[cfg(feature = "task_id_details")]
-    pub task_id: Option<TaskId>,
+    pub turbo_tasks: Arc<dyn TurboTasksCallApi>,
+    pub task_id: TaskId,
     pub source: Option<TurboTasksExecutionError>,
 }
 
-#[derive(Clone, Debug, Encode, Decode, PartialEq, Eq)]
+impl PartialEq for TurboTaskContextError {
+    fn eq(&self, other: &Self) -> bool {
+        self.task_id == other.task_id && self.source == other.source
+    }
+}
+impl Eq for TurboTaskContextError {}
+
+impl Encode for TurboTaskContextError {
+    fn encode<E: Encoder>(&self, encoder: &mut E) -> Result<(), EncodeError> {
+        Encode::encode(&self.task_id, encoder)?;
+        Encode::encode(&self.source, encoder)?;
+        Ok(())
+    }
+}
+
+impl<Context> Decode<Context> for TurboTaskContextError {
+    fn decode<D: Decoder<Context = Context>>(decoder: &mut D) -> Result<Self, DecodeError> {
+        let task_id = Decode::decode(decoder)?;
+        let source = Decode::decode(decoder)?;
+        let turbo_tasks = turbo_tasks();
+        Ok(Self {
+            turbo_tasks,
+            task_id,
+            source,
+        })
+    }
+}
+
+impl_borrow_decode!(TurboTaskContextError);
+
+impl Debug for TurboTaskContextError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TurboTaskContextError")
+            .field("task_id", &self.task_id)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
+pub struct TurboTaskLocalContextError {
+    pub name: RcStr,
+    pub source: Option<TurboTasksExecutionError>,
+}
+
+#[derive(Debug, Clone, Encode, Decode, PartialEq, Eq)]
 pub enum TurboTasksExecutionError {
     Panic(Arc<TurboTasksPanic>),
     Error(Arc<TurboTasksError>),
     TaskContext(Arc<TurboTaskContextError>),
+    LocalTaskContext(Arc<TurboTaskLocalContextError>),
 }
 
 impl TurboTasksExecutionError {
-    pub fn with_task_context(&self, task: impl Display, _task_id: Option<TaskId>) -> Self {
+    pub fn with_task_context(
+        self,
+        task_id: TaskId,
+        turbo_tasks: Arc<dyn TurboTasksCallApi>,
+    ) -> Self {
         TurboTasksExecutionError::TaskContext(Arc::new(TurboTaskContextError {
-            task: RcStr::from(task.to_string()),
-            #[cfg(feature = "task_id_details")]
-            task_id: _task_id,
-            source: Some(self.clone()),
+            task_id,
+            turbo_tasks,
+            source: Some(self),
+        }))
+    }
+    pub fn with_local_task_context(self, name: String) -> Self {
+        TurboTasksExecutionError::LocalTaskContext(Arc::new(TurboTaskLocalContextError {
+            name: RcStr::from(name),
+            source: Some(self),
         }))
     }
 }
@@ -330,6 +386,9 @@ impl Error for TurboTasksExecutionError {
             TurboTasksExecutionError::TaskContext(context_error) => {
                 context_error.source.as_ref().map(|s| s as &dyn Error)
             }
+            TurboTasksExecutionError::LocalTaskContext(context_error) => {
+                context_error.source.as_ref().map(|s| s as &dyn Error)
+            }
         }
     }
 }
@@ -342,15 +401,16 @@ impl Display for TurboTasksExecutionError {
                 write!(f, "{}", error.message)
             }
             TurboTasksExecutionError::TaskContext(context_error) => {
-                #[cfg(feature = "task_id_details")]
-                if let Some(task_id) = context_error.task_id {
-                    return write!(
-                        f,
-                        "Execution of {} ({}) failed",
-                        context_error.task, task_id
-                    );
+                let task_id = context_error.task_id;
+                let name = context_error.turbo_tasks.get_task_name(task_id);
+                if cfg!(feature = "task_id_details") {
+                    write!(f, "Execution of {name} ({}) failed", task_id)
+                } else {
+                    write!(f, "Execution of {name} failed")
                 }
-                write!(f, "Execution of {} failed", context_error.task)
+            }
+            TurboTasksExecutionError::LocalTaskContext(context_error) => {
+                write!(f, "Execution of {} failed", context_error.name)
             }
         }
     }
@@ -566,4 +626,6 @@ pub trait Backend: Sync + Send {
     fn task_statistics(&self) -> &TaskStatisticsApi;
 
     fn is_tracking_dependencies(&self) -> bool;
+
+    fn get_task_name(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>) -> String;
 }

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -94,6 +94,10 @@ pub trait TurboTasksCallApi: Sync + Send {
         future: Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
     fn start_once_process(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>);
+
+    fn send_compilation_event(&self, event: Arc<dyn CompilationEvent>);
+
+    fn get_task_name(&self, task: TaskId) -> String;
 }
 
 /// A type-erased subset of [`TurboTasks`] stored inside a thread local when we're in a turbo task
@@ -190,7 +194,6 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         &self,
         event_types: Option<Vec<String>>,
     ) -> Receiver<Arc<dyn CompilationEvent>>;
-    fn send_compilation_event(&self, event: Arc<dyn CompilationEvent>);
 
     // Returns true if TurboTasks is configured to track dependencies.
     fn is_tracking_dependencies(&self) -> bool;
@@ -1274,7 +1277,7 @@ impl<B: Backend> Executor<TurboTasks<B>, ScheduledTask, TaskPriority> for TurboT
                             Ok(raw_vc) => OutputContent::Link(raw_vc),
                             Err(err) => OutputContent::Error(
                                 TurboTasksExecutionError::from(err)
-                                    .with_task_context(task_type, None),
+                                    .with_local_task_context(task_type.to_string()),
                             ),
                         };
 
@@ -1373,6 +1376,16 @@ impl<B: Backend + 'static> TurboTasksCallApi for TurboTasks<B> {
     #[track_caller]
     fn start_once_process(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>) {
         self.start_once_process(future)
+    }
+
+    fn send_compilation_event(&self, event: Arc<dyn CompilationEvent>) {
+        if let Err(e) = self.compilation_events.send(event) {
+            tracing::warn!("Failed to send compilation event: {e}");
+        }
+    }
+
+    fn get_task_name(&self, task: TaskId) -> String {
+        self.backend.get_task_name(task, self)
     }
 }
 
@@ -1578,12 +1591,6 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         event_types: Option<Vec<String>>,
     ) -> Receiver<Arc<dyn CompilationEvent>> {
         self.compilation_events.subscribe(event_types)
-    }
-
-    fn send_compilation_event(&self, event: Arc<dyn CompilationEvent>) {
-        if let Err(e) = self.compilation_events.send(event) {
-            tracing::warn!("Failed to send compilation event: {e}");
-        }
     }
 
     fn is_tracking_dependencies(&self) -> bool {

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -95,8 +95,10 @@ pub trait TurboTasksCallApi: Sync + Send {
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send>>;
     fn start_once_process(&self, future: Pin<Box<dyn Future<Output = ()> + Send + 'static>>);
 
+    /// Sends a compilation event to subscribers.
     fn send_compilation_event(&self, event: Arc<dyn CompilationEvent>);
 
+    /// Returns a human-readable name for the given task.
     fn get_task_name(&self, task: TaskId) -> String;
 }
 


### PR DESCRIPTION
Store task error as pointer to the source error

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
