### PR TITLE
Add experimental.varyParams feature flag

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -359,6 +359,7 @@ export function getDefineEnv({
       config.experimental.gestureTransition ?? false,
     'process.env.__NEXT_OPTIMISTIC_ROUTING':
       config.experimental.optimisticRouting ?? false,
+    'process.env.__NEXT_VARY_PARAMS': config.experimental.varyParams ?? false,
     'process.env.__NEXT_CACHE_LIFE': config.cacheLife,
     'process.env.__NEXT_CLIENT_PARAM_PARSING_ORIGINS':
       config.experimental.clientParamParsingOrigins || [],

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1924,7 +1924,7 @@ export async function fetchSegmentOnCacheMiss(
     // across different param values for params that the segment doesn't
     // actually depend on.
     const varyParams = serverData.varyParams
-    if (varyParams !== null) {
+    if (process.env.__NEXT_VARY_PARAMS && varyParams !== null) {
       // Re-key the entry by storing it at a more generic vary path where
       // unused params are replaced with Fallback.
       const fulfilledVaryPath = getFulfilledSegmentVaryPath(
@@ -2407,7 +2407,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       isPartial
     )
     // Re-key the entry based on which params the segment actually depends on.
-    if (segmentVaryParams !== null) {
+    if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
       const fulfilledVaryPath = getFulfilledSegmentVaryPath(
         tree.varyPath,
         segmentVaryParams
@@ -2437,7 +2437,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
         isPartial
       )
       // Re-key the entry based on which params the segment actually depends on.
-      if (segmentVaryParams !== null) {
+      if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
         const fulfilledVaryPath = getFulfilledSegmentVaryPath(
           tree.varyPath,
           segmentVaryParams
@@ -2465,7 +2465,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       // Use the fulfilled vary path if available, otherwise fall back to
       // the request vary path.
       const varyPath =
-        segmentVaryParams !== null
+        process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null
           ? getFulfilledSegmentVaryPath(tree.varyPath, segmentVaryParams)
           : getSegmentVaryPathForRequest(fetchStrategy, tree)
       upsertSegmentEntry(now, varyPath, newEntry)

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -197,6 +197,7 @@ export const experimentalSchema = {
   clientParamParsingOrigins: z.array(z.string()).optional(),
   dynamicOnHover: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
+  varyParams: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),
   disablePostcssPresetEnv: z.boolean().optional(),
   cacheComponents: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -298,6 +298,7 @@ export interface ExperimentalConfig {
   clientParamParsingOrigins?: string[]
   dynamicOnHover?: boolean
   optimisticRouting?: boolean
+  varyParams?: boolean
   preloadEntriesOnStart?: boolean
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
@@ -1533,6 +1534,7 @@ export const defaultConfig = Object.freeze({
     caseSensitiveRoutes: false,
     clientParamParsingOrigins: undefined,
     dynamicOnHover: false,
+    varyParams: false,
     preloadEntriesOnStart: true,
     clientRouterFilter: true,
     clientRouterFilterRedirects: false,

--- a/test/e2e/app-dir/optimistic-routing/next.config.js
+++ b/test/e2e/app-dir/optimistic-routing/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     optimisticRouting: true,
+    varyParams: true,
   },
   productionBrowserSourceMaps: true,
 }

--- a/test/e2e/app-dir/segment-cache/vary-params/next.config.js
+++ b/test/e2e/app-dir/segment-cache/vary-params/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   cacheComponents: true,
   experimental: {
     optimisticRouting: true,
+    varyParams: true,
   },
 }
 


### PR DESCRIPTION
## Summary

- Adds `experimental.varyParams` feature flag (defaults to `false`)
- When disabled, the client skips vary params rekeying and treats params as unknown
- Allows internal rollout with easy revert if regressions occur during dogfooding

The flag only gates the client-side rekeying logic in `cache.ts`. Server-side param tracking continues regardless.

## Test plan

- Enabled the flag in the vary-params and optimistic-routing test fixtures