### PR TITLE
Apply server actions transform to `node_modules` in route handlers

### DIFF
--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -863,6 +863,7 @@ pub async fn get_server_module_options_context(
 
             next_server_rules.extend(common_next_server_rules.iter().cloned());
             internal_custom_rules.extend(common_next_server_rules);
+            foreign_next_server_rules.extend(internal_custom_rules.clone());
 
             let module_options_context = ModuleOptionsContext {
                 ecmascript: EcmascriptOptionsContext {
@@ -872,7 +873,7 @@ pub async fn get_server_module_options_context(
                 ..module_options_context
             };
             let foreign_code_module_options_context = ModuleOptionsContext {
-                module_rules: internal_custom_rules.clone(),
+                module_rules: foreign_next_server_rules.clone(),
                 enable_webpack_loaders: foreign_enable_webpack_loaders,
                 // NOTE(WEB-1016) PostCSS transforms should also apply to foreign code.
                 enable_postcss_transform: enable_foreign_postcss_transform,

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/[id]/page.tsx
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/[id]/page.tsx
@@ -1,20 +1,14 @@
-import { cacheLife } from 'next/cache'
-
-async function getCachedRandom(n: number) {
-  'use cache'
-  cacheLife('weeks')
-  return String(Math.ceil(Math.random() * n))
-}
+import { getCachedRandomWithCacheLife } from 'my-pkg'
 
 export async function generateStaticParams() {
   return [
-    { id: `a${await getCachedRandom(9)}` },
-    { id: `b${await getCachedRandom(2)}` },
+    { id: `a${await getCachedRandomWithCacheLife(9)}` },
+    { id: `b${await getCachedRandomWithCacheLife(2)}` },
   ]
 }
 
 export default async function Page() {
-  const value = getCachedRandom(1)
+  const value = getCachedRandomWithCacheLife(1)
 
   return <p>{value}</p>
 }

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/api/[id]/route.ts
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/api/[id]/route.ts
@@ -1,0 +1,15 @@
+import { getCachedRandomWithCacheLife } from 'my-pkg'
+import { NextRequest } from 'next/server'
+
+export async function generateStaticParams() {
+  return [{ id: await getCachedRandomWithCacheLife() }]
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params
+
+  return Response.json({ id })
+}

--- a/test/e2e/app-dir/use-cache/app/(partially-static)/api/route.ts
+++ b/test/e2e/app-dir/use-cache/app/(partially-static)/api/route.ts
@@ -1,15 +1,8 @@
-import { cacheTag } from 'next/cache'
-
-async function getCachedRandom() {
-  'use cache'
-  cacheTag('api')
-
-  return Math.random()
-}
+import { getCachedRandomWithTag } from 'my-pkg'
 
 export async function GET() {
-  const rand1 = await getCachedRandom()
-  const rand2 = await getCachedRandom()
+  const rand1 = await getCachedRandomWithTag('api')
+  const rand2 = await getCachedRandomWithTag('api')
 
   return Response.json({ rand1, rand2 })
 }

--- a/test/e2e/app-dir/use-cache/node_modules/my-pkg/index.js
+++ b/test/e2e/app-dir/use-cache/node_modules/my-pkg/index.js
@@ -1,6 +1,20 @@
+import { cacheLife, cacheTag } from 'next/cache'
+
 export async function getCachedRandom() {
   'use cache'
   return Math.random()
+}
+
+export async function getCachedRandomWithTag(tag) {
+  'use cache'
+  cacheTag(tag)
+  return Math.random()
+}
+
+export async function getCachedRandomWithCacheLife(n = 1) {
+  'use cache'
+  cacheLife('weeks')
+  return String(Math.ceil(Math.random() * n))
 }
 
 export async function getCachedRandomWithHandler() {

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -474,6 +474,8 @@ describe('use-cache', () => {
           // [id] route, first entry in generateStaticParams
           expect.stringMatching(/\/a\d/),
           withCacheComponents && '/api',
+          // api/[id] route handler using generateStaticParams with 'use cache' from node_modules
+          expect.stringMatching(/\/api\/\d/),
           // [id] route, second entry in generateStaticParams
           expect.stringMatching(/\/b\d/),
           '/cache-fetch',


### PR DESCRIPTION
The server actions transform, which handles the `'use cache'` directive, was not being applied to `node_modules` when imported from route handlers. This caused `'use cache'` functions from dependencies to fail with errors like `"cacheLife() can only be called inside a 'use cache' function"``.

The issue was that the `AppRoute` context used `internal_custom_rules` for its foreign code module options, which did not include the server actions transform. This is inconsistent with `AppRSC` (App Router pages), which correctly uses `foreign_next_server_rules` that includes the transform.

The fix extends `foreign_next_server_rules` with `internal_custom_rules` and uses it for the foreign code context in `AppRoute`, matching the pattern used by `AppRSC`.