### PR TITLE
Make Server Function logging opt-in via `logging.serverFunctions`

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/logging.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/logging.mdx
@@ -33,6 +33,25 @@ module.exports = {
 }
 ```
 
+### Server Functions
+
+You can enable logging of [Server Function](https://react.dev/reference/rsc/server-functions) invocations during development by setting `logging.serverFunctions` to `true`.
+
+```js filename="next.config.js"
+module.exports = {
+  logging: {
+    serverFunctions: true,
+  },
+}
+```
+
+When enabled, the terminal will display each Server Function call with its function name, arguments, and duration:
+
+```bash filename="Terminal"
+POST /
+  └─ ƒ myAction(arg1, arg2) in 5ms app/actions.ts
+```
+
 ### Incoming Requests
 
 By default all the incoming requests will be logged in the console during development. You can use the `incomingRequests` option to decide which requests to ignore.

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -684,6 +684,9 @@ export async function handler(
           cacheLifeProfiles: nextConfig.cacheLife,
           basePath: nextConfig.basePath,
           serverActions: nextConfig.experimental.serverActions,
+          logServerFunctions:
+            typeof nextConfig.logging === 'object' &&
+            Boolean(nextConfig.logging.serverFunctions),
 
           ...(isDebugStaticShell ||
           isDebugDynamicAccesses ||

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -150,6 +150,9 @@ async function requestHandler(
       cacheLifeProfiles: nextConfig.cacheLife,
       basePath: nextConfig.basePath,
       serverActions: nextConfig.experimental.serverActions,
+      logServerFunctions:
+        typeof nextConfig.logging === 'object' &&
+        Boolean(nextConfig.logging.serverFunctions),
       cacheComponents: Boolean(nextConfig.cacheComponents),
       experimental: {
         isRoutePPREnabled: false,

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -1084,9 +1084,12 @@ export async function handleAction({
             actionId!
           ]
 
-        // Log server action call in development
+        // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
-        if (process.env.NODE_ENV === 'development') {
+        if (
+          process.env.NODE_ENV === 'development' &&
+          ctx.renderOpts.logServerFunctions
+        ) {
           const serverActionsManifest = getServerActionsManifest()
           const runtime = process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'
           const actionInfo = serverActionsManifest[runtime]?.[actionId!]

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -138,6 +138,7 @@ export interface RenderOptsPartial {
     bodySizeLimit?: SizeLimit
     allowedOrigins?: string[]
   }
+  logServerFunctions?: boolean
   params?: ParsedUrlQuery
   isPrefetch?: boolean
   htmlLimitedBots: string | undefined

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -576,6 +576,9 @@ export default abstract class Server<
       onInstrumentationRequestError:
         this.instrumentationOnRequestError.bind(this),
       reactMaxHeadersLength: this.nextConfig.reactMaxHeadersLength,
+      logServerFunctions:
+        typeof this.nextConfig.logging === 'object' &&
+        Boolean(this.nextConfig.logging.serverFunctions),
     }
 
     this.pagesManifest = this.getPagesManifest()

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -640,6 +640,7 @@ export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
               }),
             ])
             .optional(),
+          serverFunctions: z.boolean().optional(),
           browserToTerminal: z
             .union([z.boolean(), z.enum(['error', 'warn'])])
             .optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -306,6 +306,11 @@ export interface LoggingConfig {
   incomingRequests?: boolean | IncomingRequestLoggingConfig
 
   /**
+   * If true, Server Function invocations will be logged.
+   */
+  serverFunctions?: boolean
+
+  /**
    * Forward browser console logs to terminal.
    * - `false`: Disable browser log forwarding
    * - `true`: Forward all browser console output to terminal
@@ -1703,6 +1708,7 @@ export interface NextConfigRuntime {
   skipProxyUrlNormalize: NextConfigComplete['skipProxyUrlNormalize']
   pageExtensions: NextConfigComplete['pageExtensions']
   useFileSystemPublicRoutes: NextConfigComplete['useFileSystemPublicRoutes']
+  logging?: NextConfigComplete['logging']
 
   experimental: Pick<
     NextConfigComplete['experimental'],
@@ -1843,6 +1849,7 @@ export function getNextConfigRuntime(
     skipProxyUrlNormalize: config.skipProxyUrlNormalize,
     pageExtensions: config.pageExtensions,
     useFileSystemPublicRoutes: config.useFileSystemPublicRoutes,
+    logging: config.logging,
 
     experimental,
   }

--- a/test/e2e/app-dir/server-action-logging/next.config.js
+++ b/test/e2e/app-dir/server-action-logging/next.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-  logging: {
-    serverFunctions: true,
-  },
+  logging:
+    process.env.NEXT_TEST_SERVER_FUNCTION_LOGGING === 'true'
+      ? { serverFunctions: true }
+      : undefined,
 }

--- a/test/e2e/app-dir/server-action-logging/next.config.js
+++ b/test/e2e/app-dir/server-action-logging/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  logging: {
+    serverFunctions: true,
+  },
+}

--- a/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
+++ b/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
@@ -6,6 +6,9 @@ describe('server-action-logging', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     skipDeployment: true,
     files: __dirname,
+    env: {
+      NEXT_TEST_SERVER_FUNCTION_LOGGING: 'true',
+    },
   })
 
   if (skipped) return
@@ -186,32 +189,29 @@ describe('server-action-logging', () => {
       expect(logs).not.toContain('test/e2e/app-dir/server-action-logging/')
     })
   })
+})
 
-  describe('when logging.serverFunctions is not enabled', () => {
-    beforeAll(async () => {
-      await next.patchFile('next.config.js', (content) =>
-        content.replace('serverFunctions: true', '// serverFunctions: true')
-      )
-    })
+describe('server-action-logging when logging.serverFunctions is not enabled', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    skipDeployment: true,
+    files: __dirname,
+  })
 
-    afterAll(async () => {
-      await next.patchFile('next.config.js', (content) =>
-        content.replace('// serverFunctions: true', 'serverFunctions: true')
-      )
-    })
+  if (skipped) return
 
-    it('should not log server actions', async () => {
-      const browser = await next.browser('/')
-      const outputIndex = next.cliOutput.length
+  it('should not log server actions', async () => {
+    const browser = await next.browser('/')
+    const outputIndex = next.cliOutput.length
 
-      await browser.elementByCss('#success-action').click()
-      await browser.waitForElementByCss('#result')
+    await browser.elementByCss('#success-action').click()
+    await browser.waitForElementByCss('#result')
 
-      await retry(() => {
-        const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+    await retry(() => {
+      const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+      if (isNextDev) {
         expect(logs).toContain('POST /')
-        expect(logs).not.toContain('└─ ƒ successAction')
-      })
+      }
+      expect(logs).not.toContain('└─ ƒ successAction')
     })
   })
 })

--- a/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
+++ b/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
@@ -186,4 +186,32 @@ describe('server-action-logging', () => {
       expect(logs).not.toContain('test/e2e/app-dir/server-action-logging/')
     })
   })
+
+  describe('when logging.serverFunctions is not enabled', () => {
+    beforeAll(async () => {
+      await next.patchFile('next.config.js', (content) =>
+        content.replace('serverFunctions: true', '// serverFunctions: true')
+      )
+    })
+
+    afterAll(async () => {
+      await next.patchFile('next.config.js', (content) =>
+        content.replace('// serverFunctions: true', 'serverFunctions: true')
+      )
+    })
+
+    it('should not log server actions', async () => {
+      const browser = await next.browser('/')
+      const outputIndex = next.cliOutput.length
+
+      await browser.elementByCss('#success-action').click()
+      await browser.waitForElementByCss('#result')
+
+      await retry(() => {
+        const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+        expect(logs).toContain('POST /')
+        expect(logs).not.toContain('└─ ƒ successAction')
+      })
+    })
+  })
 })


### PR DESCRIPTION
Server Function logging (#88277) is now opt-in, consistent with how fetch logging works. This reduces noise in development logs by default.

Additionally, for `'use cache'` Server Functions called from the client, the logging needs more work to be useful. Keeping it opt-in avoids exposing incomplete functionality by default.

Server Function logging can be enabled in `next.config.js`:

```js
module.exports = {
  logging: {
    serverFunctions: true,
  },
}
```