### PR TITLE
Revert "Fix/zlib mem node"

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -262,12 +262,6 @@ export async function initialize(opts: {
     if (compress) {
       // @ts-expect-error not express req/res
       compress(req, res, () => {})
-
-      // Only on client abort: destroy response so compression streams are cleaned up
-      req.once('aborted', () => {
-        if (res.destroyed || res.writableFinished) return
-        res.destroy()
-      })
     }
     req.on('error', (_err) => {
       // TODO: log socket errors?


### PR DESCRIPTION
Reverts vercel/next.js#89099

Apparently this did not solve the other user's memory leak issue: https://github.com/vercel/next.js/issues/89091#issuecomment-3826050800