### PR TITLE
[test] Deflake `browser-log-forwarding verbose level` test suite

### DIFF
--- a/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
+++ b/test/development/app-dir/browser-log-forwarding/fixtures/verbose-level/verbose-level.test.ts
@@ -12,10 +12,10 @@ describe('browser-log-forwarding verbose level', () => {
 
     await retry(() => {
       const output = next.cliOutput.slice(outputIndex)
-      expect(output).toContain('browser error:')
-      expect(output).toContain('browser warn:')
-      expect(output).toContain('browser log:')
-      expect(output).toContain('browser debug:')
+      expect(output).toContain('[browser] browser error:')
+      expect(output).toContain('[browser] browser warn:')
+      expect(output).toContain('[browser] browser log:')
+      expect(output).toContain('[browser] browser debug:')
     })
 
     // Get final output after logs are forwarded


### PR DESCRIPTION
[flakiness metric](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22browser-log-forwarding%20verbose%20level%20should%20forward%20all%20logs%20to%20terminal%22%20%40test.type%3A%22nextjs%22%20%40test.status%3Afail&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1769207121512&end=1769811921512&paused=false)

The test frequently failed because it snapshot-asserted on the forwarded browser logs before the final debug message was forwarded. This is because the initial assertion inside the `retry` block would pass because it falsely matched the debug message inside the error code frame (line 11):

```
[browser] browser error: this is an error message
    at Page.useEffect (app/page.tsx:10:13)
   8 |     console.info('browser info: this is an info message')
   9 |     console.warn('browser warn: this is a warning message')
> 10 |     console.error('browser error: this is an error message')
     |             ^
  11 |     console.debug('browser debug: this is a debug message')
  12 |   }, [])
  13 | (app/page.tsx:10:13)
```

By adding the `[browser] ` prefix to all expected log messages, we ensure that the test only passes when the actual log messages are forwarded, and not when they appear inside code frames.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
