### PR TITLE
Draft: Turbopack: Add FsError type, return it from write/write_link effects

### DIFF
--- a/turbopack/crates/turbo-tasks-fs/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/error.rs
@@ -15,7 +15,7 @@ use crate::{FileSystemPath, LinkContent};
 pub type FsResult<T, E = FsError> = Result<T, E>;
 
 #[cfg(windows)]
-const ERROR_INVALID_FUNCTION: u32 = 1;
+const ERROR_INVALID_FUNCTION: i32 = 1;
 
 #[turbo_tasks::value]
 #[derive(Debug)]
@@ -145,9 +145,6 @@ pub enum FsErrorSource {
         #[turbo_tasks(trace_ignore)]
         io::Error,
     ),
-    /// During reads, a denied path is treated as non-existent, but during writes, we generate an
-    /// error.
-    DeniedPath,
     InvalidLinkTarget,
     /// Path segment exceeds the maximum length (typically 255 bytes on Unix)
     PathSegmentTooLong {
@@ -177,7 +174,6 @@ impl Display for FsErrorSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FsErrorSource::Io(err) => err.fmt(f),
-            FsErrorSource::DeniedPath => write!(f, "access to this path is restricted"),
             FsErrorSource::InvalidLinkTarget => write!(f, "link target is invalid"),
             FsErrorSource::PathSegmentTooLong { max_length } => {
                 write!(f, "path segment is too long (exceeds {max_length} bytes)")

--- a/turbopack/crates/turbo-tasks-fs/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/error.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use bincode::{Decode, Encode};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
 
 use crate::FileSystemPath;
@@ -26,16 +27,11 @@ pub struct FsError {
 }
 
 impl FsError {
-    fn io_error(&self) -> Option<&io::Error> {
-        match &self.source {
-            FsErrorSource::Io(err) => Some(err),
-            _ => None,
-        }
-    }
-
     // It might be possible for this to return a `StyledString`, but we'd need to move
     // `StyledString` into a standalone crate.
     pub fn hint(&self) -> Option<Cow<'static, str>> {
+        #[cfg(windows)]
+        use std::io::ErrorKind;
         match (&self.operation, &self.source) {
             #[cfg(windows)]
             (
@@ -66,7 +62,11 @@ impl FsError {
 
 impl std::error::Error for FsError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        self.io_error().map(|err| err as &dyn std::error::Error)
+        match &self.source {
+            FsErrorSource::Io(err) => Some(err as &dyn std::error::Error),
+            FsErrorSource::Anyhow(err) => err.source(),
+            _ => None,
+        }
     }
 }
 
@@ -93,7 +93,7 @@ pub enum FsErrorOperation {
     Write,
     Link {
         link_type: FsErrorLinkType,
-        target: FileSystemPath,
+        target: RcStr,
     },
 }
 
@@ -108,7 +108,7 @@ impl Display for FsErrorOperation {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+#[derive(Debug, Clone, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
 pub enum FsErrorLinkType {
     Symbolic,
     #[cfg(windows)]
@@ -136,12 +136,23 @@ pub enum FsErrorSource {
     /// error.
     DeniedPath,
     InvalidLinkTarget,
+    /// Path segment exceeds the maximum length (typically 255 bytes on Unix)
+    PathSegmentTooLong {
+        max_length: usize,
+    },
+    /// Full path exceeds the maximum length
+    PathTooLong {
+        max_length: usize,
+    },
+    /// A catch-all for other errors that don't fit into the other categories
+    Anyhow(#[bincode(with = "bincode_anyhow_error")] anyhow::Error),
 }
 
 impl PartialEq for FsErrorSource {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Io(l), Self::Io(r)) => l.to_string() == r.to_string(),
+            (Self::Anyhow(l), Self::Anyhow(r)) => l.to_string() == r.to_string(),
             _ => discriminant(self) == discriminant(other),
         }
     }
@@ -155,6 +166,13 @@ impl Display for FsErrorSource {
             FsErrorSource::Io(err) => err.fmt(f),
             FsErrorSource::DeniedPath => write!(f, "access to this path is restricted"),
             FsErrorSource::InvalidLinkTarget => write!(f, "link target is invalid"),
+            FsErrorSource::PathSegmentTooLong { max_length } => {
+                write!(f, "path segment is too long (exceeds {max_length} bytes)")
+            }
+            FsErrorSource::PathTooLong { max_length } => {
+                write!(f, "path is too long (exceeds {max_length} bytes)")
+            }
+            FsErrorSource::Anyhow(err) => err.fmt(f),
         }
     }
 }
@@ -213,5 +231,33 @@ mod bincode_io_error {
             // The kind becomes Other after roundtrip
             assert_eq!(err2.0.kind(), ErrorKind::Other);
         }
+    }
+}
+
+/// Best effort string-based serialization for `anyhow::Error`.
+mod bincode_anyhow_error {
+    use anyhow::anyhow;
+    use bincode::{
+        Decode, Encode,
+        de::{BorrowDecoder, Decoder},
+        enc::Encoder,
+        error::{DecodeError, EncodeError},
+    };
+
+    pub fn encode<E: Encoder>(err: &anyhow::Error, encoder: &mut E) -> Result<(), EncodeError> {
+        err.to_string().encode(encoder)
+    }
+
+    pub fn decode<Context, D: Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<anyhow::Error, DecodeError> {
+        let message = String::decode(decoder)?;
+        Ok(anyhow!(message))
+    }
+
+    pub fn borrow_decode<'de, Context, D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<anyhow::Error, DecodeError> {
+        decode(decoder)
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/error.rs
@@ -1,0 +1,217 @@
+use core::mem::discriminant;
+#[cfg(windows)]
+use std::io::ErrorKind;
+use std::{
+    borrow::Cow,
+    fmt::{self, Display},
+    io,
+};
+
+use bincode::{Decode, Encode};
+use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
+
+use crate::FileSystemPath;
+
+pub type FsResult<T, E = FsError> = Result<T, E>;
+
+#[cfg(windows)]
+const ERROR_INVALID_FUNCTION: u32 = 1;
+
+#[turbo_tasks::value]
+#[derive(Debug)]
+pub struct FsError {
+    pub operation: FsErrorOperation,
+    pub path: FileSystemPath,
+    pub source: FsErrorSource,
+}
+
+impl FsError {
+    fn io_error(&self) -> Option<&io::Error> {
+        match &self.source {
+            FsErrorSource::Io(err) => Some(err),
+            _ => None,
+        }
+    }
+
+    // It might be possible for this to return a `StyledString`, but we'd need to move
+    // `StyledString` into a standalone crate.
+    pub fn hint(&self) -> Option<Cow<'static, str>> {
+        match (&self.operation, &self.source) {
+            #[cfg(windows)]
+            (
+                FsErrorOperation::Link {
+                    link_type: FsErrorLinkType::Symbolic,
+                    ..
+                },
+                FsErrorSource::Io(err),
+            ) if err.kind() == ErrorKind::PermissionDenied => Some(Cow::Borrowed(
+                "Creating file symlinks on Windows require developer mode or admin permissions:\n\
+                 https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode",
+            )),
+            #[cfg(windows)]
+            (
+                FsErrorOperation::Link {
+                    link_type: FsErrorLinkType::Junction,
+                    ..
+                },
+                FsErrorSource::Io(err),
+            ) if err.raw_os_error() == Some(ERROR_INVALID_FUNCTION) => Some(Cow::Borrowed(
+                "Creating junction points on Windows requires support from the filesystem. Check \
+                 that you're using an NTFS filesystem.",
+            )),
+            _ => None,
+        }
+    }
+}
+
+impl std::error::Error for FsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        self.io_error().map(|err| err as &dyn std::error::Error)
+    }
+}
+
+/// Note: The `Display` implementation for `FsError` exists as a fallback, but is not typically used
+/// in Turbopack. Turbopack should usually transform `FsError`s into an `Issue` and use that for
+/// display purposes.
+///
+/// There is an implementation of `Issue` for `FsError` in `turbopack-core/src/issue/fs_error.rs`.
+///
+/// Some of the `Display` implementations of the fields on `FsError` are used by the `Issue`
+/// implementation.
+impl Display for FsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Failed to {} at {}: {}",
+            self.operation, self.path, self.source,
+        )
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum FsErrorOperation {
+    Write,
+    Link {
+        link_type: FsErrorLinkType,
+        target: FileSystemPath,
+    },
+}
+
+impl Display for FsErrorOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Write => write!(f, "write to file"),
+            Self::Link { link_type, target } => {
+                write!(f, "create a {link_type} pointing to {target}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum FsErrorLinkType {
+    Symbolic,
+    #[cfg(windows)]
+    Junction,
+}
+
+impl Display for FsErrorLinkType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Symbolic => write!(f, "symbolic link"),
+            #[cfg(windows)]
+            Self::Junction => write!(f, "junction point"),
+        }
+    }
+}
+
+#[derive(Debug, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum FsErrorSource {
+    Io(
+        #[bincode(with = "bincode_io_error")]
+        #[turbo_tasks(trace_ignore)]
+        io::Error,
+    ),
+    /// During reads, a denied path is treated as non-existent, but during writes, we generate an
+    /// error.
+    DeniedPath,
+    InvalidLinkTarget,
+}
+
+impl PartialEq for FsErrorSource {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Io(l), Self::Io(r)) => l.to_string() == r.to_string(),
+            _ => discriminant(self) == discriminant(other),
+        }
+    }
+}
+
+impl Eq for FsErrorSource {}
+
+impl Display for FsErrorSource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FsErrorSource::Io(err) => err.fmt(f),
+            FsErrorSource::DeniedPath => write!(f, "access to this path is restricted"),
+            FsErrorSource::InvalidLinkTarget => write!(f, "link target is invalid"),
+        }
+    }
+}
+
+/// Best effort string-based serialization for `io::Error`. Most of the functions that construct an
+/// `FsError` are either effects or are marked as session-dependent, so most io errors won't be
+/// serialized.
+mod bincode_io_error {
+
+    use std::io;
+
+    use bincode::{
+        Decode, Encode,
+        de::{BorrowDecoder, Decoder},
+        enc::Encoder,
+        error::{DecodeError, EncodeError},
+    };
+
+    pub fn encode<E: Encoder>(err: &io::Error, encoder: &mut E) -> Result<(), EncodeError> {
+        err.to_string().encode(encoder)
+    }
+
+    pub fn decode<Context, D: Decoder<Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<io::Error, DecodeError> {
+        let message = String::decode(decoder)?;
+        Ok(io::Error::other(message))
+    }
+
+    pub fn borrow_decode<'de, Context, D: BorrowDecoder<'de, Context = Context>>(
+        decoder: &mut D,
+    ) -> Result<io::Error, DecodeError> {
+        decode(decoder)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use std::io::{self, ErrorKind};
+
+        use bincode::{Decode, Encode, decode_from_slice, encode_to_vec};
+
+        #[derive(Encode, Decode)]
+        struct Wrapper(#[bincode(with = "super")] io::Error);
+
+        #[test]
+        fn test_roundtrip() {
+            let cfg = bincode::config::standard();
+
+            let err1 = Wrapper(io::Error::new(ErrorKind::NotFound, "file not found"));
+            let err2: Wrapper = decode_from_slice(&encode_to_vec(&err1, cfg).unwrap(), cfg)
+                .unwrap()
+                .0;
+
+            // The `Display` implementation is equivalent
+            assert_eq!(err1.0.to_string(), err2.0.to_string());
+            // The kind becomes Other after roundtrip
+            assert_eq!(err2.0.kind(), ErrorKind::Other);
+        }
+    }
+}

--- a/turbopack/crates/turbo-tasks-fs/src/error.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/error.rs
@@ -8,10 +8,9 @@ use std::{
 };
 
 use bincode::{Decode, Encode};
-use turbo_rcstr::RcStr;
-use turbo_tasks::{NonLocalValue, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, ReadRef, trace::TraceRawVcs};
 
-use crate::FileSystemPath;
+use crate::{FileSystemPath, LinkContent};
 
 pub type FsResult<T, E = FsError> = Result<T, E>;
 
@@ -36,7 +35,7 @@ impl FsError {
             #[cfg(windows)]
             (
                 FsErrorOperation::Link {
-                    link_type: FsErrorLinkType::Symbolic,
+                    creation_method: LinkCreationMethod::Symbolic,
                     ..
                 },
                 FsErrorSource::Io(err),
@@ -47,7 +46,7 @@ impl FsError {
             #[cfg(windows)]
             (
                 FsErrorOperation::Link {
-                    link_type: FsErrorLinkType::Junction,
+                    creation_method: LinkCreationMethod::Junction,
                     ..
                 },
                 FsErrorSource::Io(err),
@@ -92,8 +91,8 @@ impl Display for FsError {
 pub enum FsErrorOperation {
     Write,
     Link {
-        link_type: FsErrorLinkType,
-        target: RcStr,
+        creation_method: LinkCreationMethod,
+        content: ReadRef<LinkContent>,
     },
 }
 
@@ -101,26 +100,40 @@ impl Display for FsErrorOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Write => write!(f, "write to file"),
-            Self::Link { link_type, target } => {
-                write!(f, "create a {link_type} pointing to {target}")
-            }
+            Self::Link {
+                creation_method,
+                content,
+            } => match &**content {
+                LinkContent::Link { target, .. } => {
+                    write!(f, "create a {creation_method} pointing to {target}")
+                }
+                LinkContent::Invalid => {
+                    write!(f, "create a {creation_method} (invalid target)")
+                }
+                LinkContent::NotFound => {
+                    write!(f, "remove a {creation_method}")
+                }
+            },
         }
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
-pub enum FsErrorLinkType {
+#[derive(Debug, Clone, Copy, Eq, PartialEq, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub enum LinkCreationMethod {
     Symbolic,
     #[cfg(windows)]
     Junction,
+    /// The creation method could not be determined.
+    Unknown,
 }
 
-impl Display for FsErrorLinkType {
+impl Display for LinkCreationMethod {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Symbolic => write!(f, "symbolic link"),
             #[cfg(windows)]
             Self::Junction => write!(f, "junction point"),
+            Self::Unknown => write!(f, "link"),
         }
     }
 }
@@ -144,7 +157,7 @@ pub enum FsErrorSource {
     PathTooLong {
         max_length: usize,
     },
-    /// A catch-all for other errors that don't fit into the other categories
+    /// A catch-all for other errors that haven't been migrated to use structured errors yet.
     Anyhow(#[bincode(with = "bincode_anyhow_error")] anyhow::Error),
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -37,7 +37,6 @@ use std::{
     borrow::Cow,
     cmp::{Ordering, min},
     env,
-    error::Error as StdError,
     fmt::{self, Debug, Formatter},
     fs::FileType,
     future::Future,
@@ -79,6 +78,7 @@ use turbo_unix_path::{
 
 use crate::{
     attach::AttachedFileSystem,
+    error::{FsError, FsErrorLinkType, FsErrorOperation, FsErrorSource},
     glob::Glob,
     invalidation::Write,
     invalidator_map::{InvalidatorMap, WriteContent},
@@ -117,59 +117,53 @@ pub use crate::{read_glob::ReadGlobResult, virtual_fs::VirtualFileSystem};
 /// 255 characters, because it is the shortest of the three options.
 ///
 /// [PATH_MAX]: https://eklitzke.org/path-max-is-tricky
-pub fn validate_path_length(path: &Path) -> Result<Cow<'_, Path>> {
-    /// Here we check if the path is too long for windows, and if so, attempt to canonicalize it
-    /// to a UNC path.
-    fn validate_path_length_inner(path: &Path) -> Result<Cow<'_, Path>> {
-        if cfg!(windows) {
-            const MAX_PATH_LENGTH_WINDOWS: usize = 260;
-            const UNC_PREFIX: &str = "\\\\?\\";
+fn validate_path_length(path: &Path) -> Result<Cow<'_, Path>, FsErrorSource> {
+    // Here we check if the path is too long for windows, and if so, attempt to canonicalize it
+    // to a UNC path.
+    if cfg!(windows) {
+        const MAX_PATH_LENGTH_WINDOWS: usize = 260;
+        const UNC_PREFIX: &str = "\\\\?\\";
 
-            if path.starts_with(UNC_PREFIX) {
-                return Ok(path.into());
-            }
-
-            if path.as_os_str().len() > MAX_PATH_LENGTH_WINDOWS {
-                let new_path = std::fs::canonicalize(path).map_err(|err| {
-                    anyhow!(err).context("file is too long, and could not be normalized")
-                })?;
-                return Ok(new_path.into());
-            }
-
-            Ok(path.into())
-        } else {
-            /// here we are only going to check if the total length exceeds, or the last segment
-            /// exceeds. This heuristic is primarily to avoid long file names, and it makes the
-            /// operation much cheaper.
-            const MAX_FILE_NAME_LENGTH_UNIX: usize = 255;
-            // macOS reports a limit of 1024, but I (@arlyon) have had issues with paths above 1016
-            // so we subtract a bit to be safe. on most linux distros this is likely a lot larger
-            // than 1024, but macOS is *special*
-            const MAX_PATH_LENGTH: usize = 1024 - 8;
-
-            // check the last segment (file name)
-            if path
-                .file_name()
-                .map(|n| n.as_encoded_bytes().len())
-                .unwrap_or(0)
-                > MAX_FILE_NAME_LENGTH_UNIX
-            {
-                anyhow::bail!(
-                    "file name is too long (exceeds {} bytes)",
-                    MAX_FILE_NAME_LENGTH_UNIX,
-                );
-            }
-
-            if path.as_os_str().len() > MAX_PATH_LENGTH {
-                anyhow::bail!("path is too long (exceeds {MAX_PATH_LENGTH} bytes)");
-            }
-
-            Ok(path.into())
+        if path.starts_with(UNC_PREFIX) {
+            return Ok(path.into());
         }
-    }
 
-    validate_path_length_inner(path)
-        .with_context(|| format!("path length for file {path:?} exceeds max length of filesystem"))
+        if path.as_os_str().len() > MAX_PATH_LENGTH_WINDOWS {
+            let new_path = std::fs::canonicalize(path).map_err(FsErrorSource::Io)?;
+            return Ok(new_path.into());
+        }
+
+        Ok(path.into())
+    } else {
+        // Here we are only going to check if the total length exceeds, or the last segment exceeds.
+        // This heuristic is primarily to avoid long file names, and it makes the operation much
+        // cheaper.
+        const MAX_FILE_NAME_LENGTH_UNIX: usize = 255;
+        // macOS reports a limit of 1024, but I (@arlyon) have had issues with paths above 1016
+        // so we subtract a bit to be safe. on most linux distros this is likely a lot larger
+        // than 1024, but macOS is *special*
+        const MAX_PATH_LENGTH: usize = 1024 - 8;
+
+        // check the last segment (file name)
+        if path
+            .file_name()
+            .map(|n| n.as_encoded_bytes().len())
+            .unwrap_or(0)
+            > MAX_FILE_NAME_LENGTH_UNIX
+        {
+            return Err(FsErrorSource::PathSegmentTooLong {
+                max_length: MAX_FILE_NAME_LENGTH_UNIX,
+            });
+        }
+
+        if path.as_os_str().len() > MAX_PATH_LENGTH {
+            return Err(FsErrorSource::PathTooLong {
+                max_length: MAX_PATH_LENGTH,
+            });
+        }
+
+        Ok(path.into())
+    }
 }
 
 trait ConcurrencyLimitedExt {
@@ -980,16 +974,23 @@ impl FileSystem for DiskFileSystem {
         #[derive(TraceRawVcs, NonLocalValue)]
         struct WriteEffect {
             full_path: PathBuf,
+            fs_path: FileSystemPath,
             inner: Arc<DiskFileSystemInner>,
             invalidator: Option<Invalidator>,
             content: ReadRef<FileContent>,
         }
 
         impl Effect for WriteEffect {
-            type Error = AnyhowWrapper;
+            type Error = FsError;
 
             async fn apply(&self) -> Result<(), Self::Error> {
-                let full_path = validate_path_length(&self.full_path)?;
+                let make_err = |source: FsErrorSource| FsError {
+                    operation: FsErrorOperation::Write,
+                    path: self.fs_path.clone(),
+                    source,
+                };
+
+                let full_path = validate_path_length(&self.full_path).map_err(&make_err)?;
 
                 let _lock = self.inner.lock_path(&full_path).await;
 
@@ -1003,7 +1004,8 @@ impl FileSystem for DiskFileSystem {
                             WriteContent::File(self.content.clone()),
                         )
                     })
-                    .transpose()?
+                    .transpose()
+                    .map_err(|err| make_err(FsErrorSource::Anyhow(err)))?
                     .unwrap_or_default();
 
                 // We perform an untracked comparison here, so that this write is not dependent
@@ -1016,7 +1018,10 @@ impl FileSystem for DiskFileSystem {
                     .streaming_compare(&full_path)
                     .instrument(tracing::info_span!("read file before write", name = ?full_path))
                     .concurrency_limited(&self.inner.read_semaphore)
-                    .await?;
+                    .await
+                    .map_err(|err| {
+                        make_err(FsErrorSource::Io(io::Error::other(err.to_string())))
+                    })?;
                 if compare == FileComparison::Equal {
                     if !old_invalidators.is_empty() {
                         for (invalidator, write_content) in old_invalidators {
@@ -1034,11 +1039,8 @@ impl FileSystem for DiskFileSystem {
                     FileContent::Content(..) => {
                         let create_directory = compare == FileComparison::Create;
                         if create_directory && let Some(parent) = full_path.parent() {
-                            self.inner.create_directory(parent).await.with_context(|| {
-                                format!(
-                                    "failed to create directory {parent:?} for write to \
-                                     {full_path:?}",
-                                )
+                            self.inner.create_directory(parent).await.map_err(|err| {
+                                make_err(FsErrorSource::Io(io::Error::other(err.to_string())))
                             })?;
                         }
 
@@ -1078,7 +1080,7 @@ impl FileSystem for DiskFileSystem {
                         .instrument(tracing::info_span!("write file", name = ?full_path))
                         .concurrency_limited(&self.inner.write_semaphore)
                         .await
-                        .with_context(|| format!("failed to write to {full_path:?}"))?;
+                        .map_err(|err| make_err(FsErrorSource::Io(err)))?;
                     }
                     FileContent::NotFound => {
                         retry_blocking(|| std::fs::remove_file(&full_path))
@@ -1092,7 +1094,7 @@ impl FileSystem for DiskFileSystem {
                                     Err(err)
                                 }
                             })
-                            .with_context(|| format!("removing {full_path:?} failed"))?;
+                            .map_err(|err| make_err(FsErrorSource::Io(err)))?;
                     }
                 }
 
@@ -1105,6 +1107,7 @@ impl FileSystem for DiskFileSystem {
 
         emit_effect(WriteEffect {
             full_path,
+            fs_path,
             inner,
             invalidator,
             content,
@@ -1132,16 +1135,44 @@ impl FileSystem for DiskFileSystem {
         #[derive(TraceRawVcs, NonLocalValue)]
         struct WriteLinkEffect {
             full_path: PathBuf,
+            fs_path: FileSystemPath,
             inner: Arc<DiskFileSystemInner>,
             invalidator: Option<Invalidator>,
             content: ReadRef<LinkContent>,
         }
 
         impl Effect for WriteLinkEffect {
-            type Error = AnyhowWrapper;
+            type Error = FsError;
 
             async fn apply(&self) -> Result<(), Self::Error> {
-                let full_path = validate_path_length(&self.full_path)?;
+                // Helper to construct link errors. The link_type and target are determined
+                // based on the content when needed.
+                let make_link_err =
+                    |source: FsErrorSource, link_type: FsErrorLinkType, target: RcStr| -> FsError {
+                        FsError {
+                            operation: FsErrorOperation::Link { link_type, target },
+                            path: self.fs_path.clone(),
+                            source,
+                        }
+                    };
+
+                // For errors that occur before we know the link type/target, use a default
+                let make_early_err = |source: FsErrorSource| -> FsError {
+                    // Use Symbolic as default for early errors (before we know the actual type)
+                    FsError {
+                        operation: FsErrorOperation::Link {
+                            link_type: FsErrorLinkType::Symbolic,
+                            target: match &*self.content {
+                                LinkContent::Link { target, .. } => target.clone(),
+                                _ => RcStr::default(),
+                            },
+                        },
+                        path: self.fs_path.clone(),
+                        source,
+                    }
+                };
+
+                let full_path = validate_path_length(&self.full_path).map_err(&make_early_err)?;
 
                 let _lock = self.inner.lock_path(&full_path).await;
 
@@ -1154,7 +1185,8 @@ impl FileSystem for DiskFileSystem {
                             WriteContent::Link(self.content.clone()),
                         )
                     })
-                    .transpose()?
+                    .transpose()
+                    .map_err(|err| make_early_err(FsErrorSource::Anyhow(err)))?
                     .unwrap_or_default();
 
                 enum OsSpecificLinkContent {
@@ -1162,6 +1194,7 @@ impl FileSystem for DiskFileSystem {
                         #[cfg(windows)]
                         is_directory: bool,
                         target: PathBuf,
+                        target_str: RcStr,
                     },
                     NotFound,
                     Invalid,
@@ -1188,6 +1221,7 @@ impl FileSystem for DiskFileSystem {
                             #[cfg(windows)]
                             is_directory,
                             target: target_path,
+                            target_str: target.clone(),
                         }
                     }
                     LinkContent::Invalid => OsSpecificLinkContent::Invalid,
@@ -1226,18 +1260,30 @@ impl FileSystem for DiskFileSystem {
                 match os_specific_link_content {
                     OsSpecificLinkContent::Link {
                         target,
+                        target_str,
                         #[cfg(windows)]
                         is_directory,
                         ..
                     } => {
                         let full_path = full_path.into_owned();
 
+                        // Determine the link type for error reporting
+                        #[cfg(not(windows))]
+                        let link_type = FsErrorLinkType::Symbolic;
+                        #[cfg(windows)]
+                        let link_type = if is_directory {
+                            FsErrorLinkType::Junction
+                        } else {
+                            FsErrorLinkType::Symbolic
+                        };
+
                         let create_directory = old_content.is_none();
                         if create_directory && let Some(parent) = full_path.parent() {
-                            self.inner.create_directory(parent).await.with_context(|| {
-                                format!(
-                                    "failed to create directory {parent:?} for write link to \
-                                     {full_path:?}",
+                            self.inner.create_directory(parent).await.map_err(|err| {
+                                make_link_err(
+                                    FsErrorSource::Io(io::Error::other(err.to_string())),
+                                    link_type.clone(),
+                                    target_str.clone(),
                                 )
                             })?;
                         }
@@ -1288,28 +1334,6 @@ impl FileSystem for DiskFileSystem {
                         fn can_retry_link(err: &SymlinkCreationError) -> bool {
                             err.source.kind() == ErrorKind::AlreadyExists || can_retry(&err.source)
                         }
-                        let err_context = || {
-                            #[cfg(not(windows))]
-                            let message = format!(
-                                "failed to create symlink at {full_path:?} pointing to {target:?}"
-                            );
-                            #[cfg(windows)]
-                            let message = if is_directory {
-                                format!(
-                                    "failed to create junction point at {full_path:?} pointing to \
-                                     {target:?}"
-                                )
-                            } else {
-                                format!(
-                                    "failed to create symlink at {full_path:?} pointing to \
-                                     {target:?}\n\
-                                    (Note: creating file symlinks on Windows require developer \
-                                     mode or admin permissions: \
-                                     https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode)",
-                                )
-                            };
-                            message
-                        };
                         retry_blocking_custom(try_create_link, can_retry_link)
                             .instrument(tracing::info_span!(
                                 "write symlink",
@@ -1318,19 +1342,36 @@ impl FileSystem for DiskFileSystem {
                             ))
                             .concurrency_limited(&self.inner.write_semaphore)
                             .await
-                            .with_context(err_context)?;
+                            .map_err(|err| {
+                                make_link_err(FsErrorSource::Io(err.source), link_type, target_str)
+                            })?;
                     }
                     OsSpecificLinkContent::Invalid => {
-                        return Err(AnyhowWrapper(anyhow!(
-                            "invalid symlink target: {full_path:?}"
-                        )));
+                        return Err(FsError {
+                            operation: FsErrorOperation::Link {
+                                link_type: FsErrorLinkType::Symbolic,
+                                target: match &*self.content {
+                                    LinkContent::Link { target, .. } => target.clone(),
+                                    _ => RcStr::default(),
+                                },
+                            },
+                            path: self.fs_path.clone(),
+                            source: FsErrorSource::InvalidLinkTarget,
+                        });
                     }
                     OsSpecificLinkContent::NotFound => {
                         retry_blocking(|| remove_symbolic_link_dir_helper(&full_path))
                             .instrument(tracing::info_span!("remove symlink", name = ?full_path))
                             .concurrency_limited(&self.inner.write_semaphore)
                             .await
-                            .with_context(|| format!("removing {full_path:?} failed"))?;
+                            .map_err(|err| {
+                                // For NotFound removal, use Symbolic as the link type
+                                make_link_err(
+                                    FsErrorSource::Io(err),
+                                    FsErrorLinkType::Symbolic,
+                                    RcStr::default(),
+                                )
+                            })?;
                     }
                 }
 
@@ -1340,6 +1381,7 @@ impl FileSystem for DiskFileSystem {
 
         emit_effect(WriteLinkEffect {
             full_path,
+            fs_path,
             inner,
             invalidator,
             content,
@@ -2861,35 +2903,6 @@ async fn realpath_with_links(path: FileSystemPath) -> Result<Vc<RealPathResult>>
         symlinks: symlinks.into_iter().collect(),
     }
     .cell())
-}
-
-/// Wrapper to convert `anyhow::Error` to `impl std::error::Error` for use in `Effect::apply`.
-// TODO(bgw): use a structured error type instead of anyhow for write/write_link
-#[derive(TraceRawVcs, NonLocalValue)]
-struct AnyhowWrapper(anyhow::Error);
-
-impl std::fmt::Display for AnyhowWrapper {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Display::fmt(&self.0, f)
-    }
-}
-
-impl std::fmt::Debug for AnyhowWrapper {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        std::fmt::Debug::fmt(&self.0, f)
-    }
-}
-
-impl StdError for AnyhowWrapper {
-    fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        self.0.source()
-    }
-}
-
-impl From<anyhow::Error> for AnyhowWrapper {
-    fn from(err: anyhow::Error) -> Self {
-        AnyhowWrapper(err)
-    }
 }
 
 #[cfg(test)]

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod attach;
 pub mod embed;
+pub mod error;
 pub mod glob;
 mod globset;
 pub mod invalidation;
@@ -1118,7 +1119,6 @@ impl FileSystem for DiskFileSystem {
         // effect and does not need to be re-executed in the next session. All side effects are
         // re-executed in general.
 
-        // Check if path is denied - if so, return an error
         if self.inner.is_path_denied(&fs_path) {
             turbobail!("Cannot write link to denied path: {fs_path}");
         }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -88,7 +88,6 @@ use crate::{
     read_glob::{read_glob, track_glob},
     retry::{can_retry, retry_blocking, retry_blocking_custom},
     rope::{Rope, RopeReader},
-    util::extract_disk_access,
     watcher::DiskWatcher,
 };
 pub use crate::{read_glob::ReadGlobResult, virtual_fs::VirtualFileSystem};
@@ -531,7 +530,7 @@ impl DiskFileSystemInner {
         Ok(())
     }
 
-    async fn create_directory(self: &Arc<Self>, directory: &Path) -> Result<()> {
+    async fn create_directory(self: &Arc<Self>, directory: &Path) -> io::Result<()> {
         let already_created = ApplyEffectsContext::with_or_insert_with(
             DiskFileSystemApplyContext::default,
             |fs_context| fs_context.created_directories.contains(directory),
@@ -1019,9 +1018,7 @@ impl FileSystem for DiskFileSystem {
                     .instrument(tracing::info_span!("read file before write", name = ?full_path))
                     .concurrency_limited(&self.inner.read_semaphore)
                     .await
-                    .map_err(|err| {
-                        make_err(FsErrorSource::Io(io::Error::other(err.to_string())))
-                    })?;
+                    .map_err(|err| make_err(FsErrorSource::Io(err)))?;
                 if compare == FileComparison::Equal {
                     if !old_invalidators.is_empty() {
                         for (invalidator, write_content) in old_invalidators {
@@ -1039,9 +1036,10 @@ impl FileSystem for DiskFileSystem {
                     FileContent::Content(..) => {
                         let create_directory = compare == FileComparison::Create;
                         if create_directory && let Some(parent) = full_path.parent() {
-                            self.inner.create_directory(parent).await.map_err(|err| {
-                                make_err(FsErrorSource::Io(io::Error::other(err.to_string())))
-                            })?;
+                            self.inner
+                                .create_directory(parent)
+                                .await
+                                .map_err(|err| make_err(FsErrorSource::Io(err)))?;
                         }
 
                         let content = self.content.clone();
@@ -1281,7 +1279,7 @@ impl FileSystem for DiskFileSystem {
                         if create_directory && let Some(parent) = full_path.parent() {
                             self.inner.create_directory(parent).await.map_err(|err| {
                                 make_link_err(
-                                    FsErrorSource::Io(io::Error::other(err.to_string())),
+                                    FsErrorSource::Io(err),
                                     link_type.clone(),
                                     target_str.clone(),
                                 )
@@ -2036,27 +2034,33 @@ enum FileComparison {
 impl FileContent {
     /// Performs a comparison of self's data against a disk file's streamed
     /// read.
-    async fn streaming_compare(&self, path: &Path) -> Result<FileComparison> {
-        let old_file =
-            extract_disk_access(retry_blocking(|| std::fs::File::open(path)).await, path)?;
-        let Some(old_file) = old_file else {
-            return Ok(match self {
-                FileContent::NotFound => FileComparison::Equal,
-                _ => FileComparison::Create,
-            });
+    async fn streaming_compare(&self, path: &Path) -> io::Result<FileComparison> {
+        let old_file = match retry_blocking(|| std::fs::File::open(path)).await {
+            Ok(file) => file,
+            Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::InvalidFilename) => {
+                return Ok(match self {
+                    FileContent::NotFound => FileComparison::Equal,
+                    _ => FileComparison::Create,
+                });
+            }
+            Err(e) => return Err(e),
         };
+
         // We know old file exists, does the new file?
         let FileContent::Content(new_file) = self else {
             return Ok(FileComparison::NotEqual);
         };
 
-        let old_meta = extract_disk_access(retry_blocking(|| old_file.metadata()).await, path)?;
-        let Some(old_meta) = old_meta else {
-            // If we failed to get meta, then the old file has been deleted between the
-            // handle open. In which case, we just pretend the file never
-            // existed.
-            return Ok(FileComparison::Create);
+        let old_meta = match retry_blocking(|| old_file.metadata()).await {
+            Ok(meta) => meta,
+            Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::InvalidFilename) => {
+                // If we failed to get meta, then the old file has been deleted between the
+                // handle open. In which case, we just pretend the file never existed.
+                return Ok(FileComparison::Create);
+            }
+            Err(e) => return Err(e),
         };
+
         // If the meta is different, we need to rewrite the file to update it.
         if new_file.meta != old_meta.into() {
             return Ok(FileComparison::NotEqual);

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -78,7 +78,7 @@ use turbo_unix_path::{
 
 use crate::{
     attach::AttachedFileSystem,
-    error::{FsError, FsErrorLinkType, FsErrorOperation, FsErrorSource},
+    error::{FsError, FsErrorOperation, FsErrorSource, LinkCreationMethod},
     glob::Glob,
     invalidation::Write,
     invalidator_map::{InvalidatorMap, WriteContent},
@@ -1143,34 +1143,21 @@ impl FileSystem for DiskFileSystem {
             type Error = FsError;
 
             async fn apply(&self) -> Result<(), Self::Error> {
-                // Helper to construct link errors. The link_type and target are determined
-                // based on the content when needed.
+                // Helper to construct link errors
                 let make_link_err =
-                    |source: FsErrorSource, link_type: FsErrorLinkType, target: RcStr| -> FsError {
+                    |source: FsErrorSource, creation_method: LinkCreationMethod| -> FsError {
                         FsError {
-                            operation: FsErrorOperation::Link { link_type, target },
+                            operation: FsErrorOperation::Link {
+                                creation_method,
+                                content: self.content.clone(),
+                            },
                             path: self.fs_path.clone(),
                             source,
                         }
                     };
 
-                // For errors that occur before we know the link type/target, use a default
-                let make_early_err = |source: FsErrorSource| -> FsError {
-                    // Use Symbolic as default for early errors (before we know the actual type)
-                    FsError {
-                        operation: FsErrorOperation::Link {
-                            link_type: FsErrorLinkType::Symbolic,
-                            target: match &*self.content {
-                                LinkContent::Link { target, .. } => target.clone(),
-                                _ => RcStr::default(),
-                            },
-                        },
-                        path: self.fs_path.clone(),
-                        source,
-                    }
-                };
-
-                let full_path = validate_path_length(&self.full_path).map_err(&make_early_err)?;
+                let full_path = validate_path_length(&self.full_path)
+                    .map_err(|source| make_link_err(source, LinkCreationMethod::Unknown))?;
 
                 let _lock = self.inner.lock_path(&full_path).await;
 
@@ -1184,7 +1171,9 @@ impl FileSystem for DiskFileSystem {
                         )
                     })
                     .transpose()
-                    .map_err(|err| make_early_err(FsErrorSource::Anyhow(err)))?
+                    .map_err(|err| {
+                        make_link_err(FsErrorSource::Anyhow(err), LinkCreationMethod::Unknown)
+                    })?
                     .unwrap_or_default();
 
                 enum OsSpecificLinkContent {
@@ -1192,7 +1181,6 @@ impl FileSystem for DiskFileSystem {
                         #[cfg(windows)]
                         is_directory: bool,
                         target: PathBuf,
-                        target_str: RcStr,
                     },
                     NotFound,
                     Invalid,
@@ -1219,7 +1207,6 @@ impl FileSystem for DiskFileSystem {
                             #[cfg(windows)]
                             is_directory,
                             target: target_path,
-                            target_str: target.clone(),
                         }
                     }
                     LinkContent::Invalid => OsSpecificLinkContent::Invalid,
@@ -1258,31 +1245,26 @@ impl FileSystem for DiskFileSystem {
                 match os_specific_link_content {
                     OsSpecificLinkContent::Link {
                         target,
-                        target_str,
                         #[cfg(windows)]
                         is_directory,
                         ..
                     } => {
                         let full_path = full_path.into_owned();
 
-                        // Determine the link type for error reporting
+                        // Determine the creation method for error reporting
                         #[cfg(not(windows))]
-                        let link_type = FsErrorLinkType::Symbolic;
+                        let creation_method = LinkCreationMethod::Symbolic;
                         #[cfg(windows)]
-                        let link_type = if is_directory {
-                            FsErrorLinkType::Junction
+                        let creation_method = if is_directory {
+                            LinkCreationMethod::Junction
                         } else {
-                            FsErrorLinkType::Symbolic
+                            LinkCreationMethod::Symbolic
                         };
 
                         let create_directory = old_content.is_none();
                         if create_directory && let Some(parent) = full_path.parent() {
                             self.inner.create_directory(parent).await.map_err(|err| {
-                                make_link_err(
-                                    FsErrorSource::Io(err),
-                                    link_type.clone(),
-                                    target_str.clone(),
-                                )
+                                make_link_err(FsErrorSource::Io(err), creation_method)
                             })?;
                         }
 
@@ -1341,21 +1323,14 @@ impl FileSystem for DiskFileSystem {
                             .concurrency_limited(&self.inner.write_semaphore)
                             .await
                             .map_err(|err| {
-                                make_link_err(FsErrorSource::Io(err.source), link_type, target_str)
+                                make_link_err(FsErrorSource::Io(err.source), creation_method)
                             })?;
                     }
                     OsSpecificLinkContent::Invalid => {
-                        return Err(FsError {
-                            operation: FsErrorOperation::Link {
-                                link_type: FsErrorLinkType::Symbolic,
-                                target: match &*self.content {
-                                    LinkContent::Link { target, .. } => target.clone(),
-                                    _ => RcStr::default(),
-                                },
-                            },
-                            path: self.fs_path.clone(),
-                            source: FsErrorSource::InvalidLinkTarget,
-                        });
+                        return Err(make_link_err(
+                            FsErrorSource::InvalidLinkTarget,
+                            LinkCreationMethod::Unknown,
+                        ));
                     }
                     OsSpecificLinkContent::NotFound => {
                         retry_blocking(|| remove_symbolic_link_dir_helper(&full_path))
@@ -1363,12 +1338,7 @@ impl FileSystem for DiskFileSystem {
                             .concurrency_limited(&self.inner.write_semaphore)
                             .await
                             .map_err(|err| {
-                                // For NotFound removal, use Symbolic as the link type
-                                make_link_err(
-                                    FsErrorSource::Io(err),
-                                    FsErrorLinkType::Symbolic,
-                                    RcStr::default(),
-                                )
+                                make_link_err(FsErrorSource::Io(err), LinkCreationMethod::Unknown)
                             })?;
                     }
                 }

--- a/turbopack/crates/turbo-tasks-fs/src/util.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/util.rs
@@ -1,24 +1,9 @@
-use std::{
-    io::{self, ErrorKind},
-    path::{Path, PathBuf},
-};
+use std::path::PathBuf;
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use turbo_tasks::ResolvedVc;
 
 use crate::{DiskFileSystem, FileSystemPath};
-
-/// Converts a disk access `Result<T>` into a `Result<Some<T>>`, where a [`ErrorKind::NotFound`] (or
-/// [`ErrorKind::InvalidFilename`]) error results in a [`None`] value. This is purely to reduce
-/// boilerplate code comparing [`ErrorKind::NotFound`] errors against all other errors.
-pub fn extract_disk_access<T>(value: io::Result<T>, path: &Path) -> Result<Option<T>> {
-    match value {
-        Ok(v) => Ok(Some(v)),
-        Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::InvalidFilename) => Ok(None),
-        // ast-grep-ignore: no-context-format
-        Err(e) => Err(anyhow!(e).context(format!("reading file {}", path.display()))),
-    }
-}
 
 pub async fn uri_from_file(root: FileSystemPath, path: Option<&str>) -> Result<String> {
     let root_fs = root.fs;

--- a/turbopack/crates/turbopack-core/src/issue/fs_error.rs
+++ b/turbopack/crates/turbopack-core/src/issue/fs_error.rs
@@ -1,0 +1,38 @@
+use turbo_rcstr::{RcStr, rcstr};
+use turbo_tasks::Vc;
+use turbo_tasks_fs::{FileSystemPath, error::FsError};
+
+use crate::issue::{Issue, IssueStage, OptionStyledString, StyledString};
+
+#[turbo_tasks::value_impl]
+impl Issue for FsError {
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.path.clone().cell()
+    }
+
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::WriteOutput.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Text(rcstr!("File system operation failed")).cell()
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(
+            StyledString::Stack(vec![
+                StyledString::Line(vec![
+                    StyledString::Text(rcstr!("Failed to ")),
+                    StyledString::Text(RcStr::from(self.operation.to_string())),
+                    StyledString::Text(rcstr!(":")),
+                ]),
+                StyledString::Text(RcStr::from(self.source.to_string())),
+            ])
+            .resolved_cell(),
+        ))
+    }
+}

--- a/turbopack/crates/turbopack-core/src/issue/fs_error.rs
+++ b/turbopack/crates/turbopack-core/src/issue/fs_error.rs
@@ -23,16 +23,20 @@ impl Issue for FsError {
 
     #[turbo_tasks::function]
     fn description(&self) -> Vc<OptionStyledString> {
-        Vc::cell(Some(
-            StyledString::Stack(vec![
-                StyledString::Line(vec![
-                    StyledString::Text(rcstr!("Failed to ")),
-                    StyledString::Text(RcStr::from(self.operation.to_string())),
-                    StyledString::Text(rcstr!(":")),
-                ]),
-                StyledString::Text(RcStr::from(self.source.to_string())),
-            ])
-            .resolved_cell(),
-        ))
+        let mut stack = vec![
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!("Failed to ")),
+                StyledString::Text(RcStr::from(self.operation.to_string())),
+                StyledString::Text(rcstr!(":")),
+            ]),
+            StyledString::Text(RcStr::from(self.source.to_string())),
+        ];
+        if let Some(hint) = self.hint() {
+            stack.extend([
+                StyledString::Line(Vec::new()), // empty line
+                StyledString::Text(RcStr::from(hint)),
+            ]);
+        }
+        Vc::cell(Some(StyledString::Stack(stack).resolved_cell()))
     }
 }

--- a/turbopack/crates/turbopack-core/src/issue/mod.rs
+++ b/turbopack/crates/turbopack-core/src/issue/mod.rs
@@ -1,5 +1,6 @@
 pub mod analyze;
 pub mod code_gen;
+mod fs_error;
 pub mod module;
 pub mod resolve;
 
@@ -148,13 +149,11 @@ pub trait Issue {
     /// The issue title should be descriptive of the issue, but should be a
     /// single line. This is displayed to the user directly under the issue
     /// header.
-    // TODO add Vc<StyledString>
     #[turbo_tasks::function]
     fn title(self: Vc<Self>) -> Vc<StyledString>;
 
     /// A more verbose message of the issue, appropriate for providing multiline
     /// information of the issue.
-    // TODO add Vc<StyledString>
     #[turbo_tasks::function]
     fn description(self: Vc<Self>) -> Vc<OptionStyledString> {
         Vc::cell(None)
@@ -875,6 +874,7 @@ pub enum IssueStage {
     Resolve,
     Bindings,
     CodeGen,
+    WriteOutput,
     Unsupported,
     Misc,
     Other(RcStr),
@@ -895,6 +895,7 @@ impl Display for IssueStage {
             IssueStage::CodeGen => write!(f, "code gen"),
             IssueStage::Unsupported => write!(f, "unsupported"),
             IssueStage::AppStructure => write!(f, "app structure"),
+            IssueStage::WriteOutput => write!(f, "write output"),
             IssueStage::Misc => write!(f, "misc"),
             IssueStage::Other(s) => write!(f, "{s}"),
         }


### PR DESCRIPTION
We'd like to create `Issue`s when IO operations fail, so `FsError` is basically that:
- `FsError` is a structured error type, so we can track things like `FileSystemPath` (note: this type contains a `Vc`).
- There's an implementation of `Issue` on `FsError`. This implementation lives in `turbopack-core` due to crate-ordering issues.

## What's missing

- At the top-level, when we apply effects, we need to also need to attempt to downcast errors and collect them as issues to avoid surfacing the `FsError`s as an internal error.
- We also want to emit issues for failed reads and other filesystem operations.