### PR TITLE
dx: Include path count in export error message

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1050,5 +1050,6 @@
   "1049": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\\n\\nTo use Next.js on this platform, use Webpack instead:\\n  next dev --webpack\\n\\nFor more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms",
   "1050": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\\n\\nTo build on this platform, use Webpack instead:\\n  next build --webpack\\n\\nFor more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms",
   "1051": "Turbopack trace server is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.",
-  "1052": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings. Use the --webpack flag instead."
+  "1052": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings. Use the --webpack flag instead.",
+  "1053": "Export encountered errors on following %s %s:\\n\\t%s"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1051,5 +1051,5 @@
   "1050": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\\n\\nTo build on this platform, use Webpack instead:\\n  next build --webpack\\n\\nFor more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms",
   "1051": "Turbopack trace server is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.",
   "1052": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings. Use the --webpack flag instead.",
-  "1053": "Export encountered errors on following %s %s:\\n\\t%s"
+  "1053": "Export encountered errors on %s %s:\\n\\t%s"
 }

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -997,7 +997,7 @@ async function exportAppImpl(
   if (failedExportAttemptsByPage.size > 0) {
     const failedPages = Array.from(failedExportAttemptsByPage.keys())
     throw new ExportError(
-      `Export encountered errors on following ${failedPages.length} ${failedPages.length === 1 ? 'path' : 'paths'}:\n\t${failedPages
+      `Export encountered errors on ${failedPages.length} ${failedPages.length === 1 ? 'path' : 'paths'}:\n\t${failedPages
         .sort()
         .join('\n\t')}`
     )

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -997,7 +997,7 @@ async function exportAppImpl(
   if (failedExportAttemptsByPage.size > 0) {
     const failedPages = Array.from(failedExportAttemptsByPage.keys())
     throw new ExportError(
-      `Export encountered errors on following paths:\n\t${failedPages
+      `Export encountered errors on following ${failedPages.length} ${failedPages.length === 1 ? 'path' : 'paths'}:\n\t${failedPages
         .sort()
         .join('\n\t')}`
     )

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -128,7 +128,7 @@ describe('Cache Components Errors', () => {
                "Route "/dynamic-metadata-static-route" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
                Error occurred prerendering page "/dynamic-metadata-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/dynamic-metadata-static-route/page: /dynamic-metadata-static-route"
               `)
           } else {
@@ -206,7 +206,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
               `)
             } else {
@@ -238,7 +238,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
               `)
             } else {
@@ -331,7 +331,7 @@ describe('Cache Components Errors', () => {
                "Route "/dynamic-metadata-static-with-suspense" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
                Error occurred prerendering page "/dynamic-metadata-static-with-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/dynamic-metadata-static-with-suspense/page: /dynamic-metadata-static-with-suspense"
               `)
           } else {
@@ -421,7 +421,7 @@ describe('Cache Components Errors', () => {
              "Route "/dynamic-viewport-static-route" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
              Error occurred prerendering page "/dynamic-viewport-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-             > Export encountered errors on following 1 path:
+             > Export encountered errors on 1 path:
              	/dynamic-viewport-static-route/page: /dynamic-viewport-static-route"
             `)
           } else {
@@ -486,7 +486,7 @@ describe('Cache Components Errors', () => {
              "Route "/dynamic-viewport-dynamic-route" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
              Error occurred prerendering page "/dynamic-viewport-dynamic-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-             > Export encountered errors on following 1 path:
+             > Export encountered errors on 1 path:
              	/dynamic-viewport-dynamic-route/page: /dynamic-viewport-dynamic-route"
             `)
           } else {
@@ -623,7 +623,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/dynamic-root/page: /dynamic-root"
               `)
             } else {
@@ -683,7 +683,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/dynamic-root/page: /dynamic-root"
               `)
             } else {
@@ -834,7 +834,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-random-with-fallback/page: /sync-random-with-fallback"
                 `)
               } else {
@@ -852,7 +852,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-random-with-fallback/page: /sync-random-with-fallback"
                 `)
               }
@@ -947,7 +947,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-random-without-fallback/page: /sync-random-without-fallback"
                 `)
               } else {
@@ -966,7 +966,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-random-without-fallback/page: /sync-random-without-fallback"
                 `)
               }
@@ -1206,7 +1206,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-cookies/page: /sync-cookies"
                 `)
               } else {
@@ -1224,7 +1224,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-cookies/page: /sync-cookies"
                 `)
               }
@@ -1540,7 +1540,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-headers/page: /sync-headers"
                 `)
               } else {
@@ -1558,7 +1558,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-headers/page: /sync-headers"
                 `)
               }
@@ -1846,7 +1846,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync"
                 `)
               } else {
@@ -1864,7 +1864,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync"
                 `)
               }
@@ -1971,7 +1971,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
                 `)
               } else {
@@ -2005,7 +2005,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
                 `)
               } else {
@@ -2115,7 +2115,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync"
                 `)
               } else {
@@ -2133,7 +2133,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync"
                 `)
               }
@@ -2222,7 +2222,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-cookies/page: /use-cache-cookies"
                 `)
               } else {
@@ -2258,7 +2258,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-cookies/page: /use-cache-cookies"
                 `)
               } else {
@@ -2327,7 +2327,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-draft-mode/page: /use-cache-draft-mode"
                 `)
               } else {
@@ -2344,7 +2344,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-draft-mode/page: /use-cache-draft-mode"
                 `)
               }
@@ -2431,7 +2431,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-headers/page: /use-cache-headers"
                 `)
               } else {
@@ -2467,7 +2467,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-headers/page: /use-cache-headers"
                 `)
               } else {
@@ -2549,7 +2549,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-low-expire/fast/page: /use-cache-low-expire/fast"
                   `)
                 } else {
@@ -2580,7 +2580,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-low-expire/fast/page: /use-cache-low-expire/fast"
                   `)
                 } else {
@@ -2693,7 +2693,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-low-expire/slow/page: /use-cache-low-expire/slow"
                   `)
                 } else {
@@ -2724,7 +2724,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-low-expire/slow/page: /use-cache-low-expire/slow"
                   `)
                 } else {
@@ -2823,7 +2823,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on 1 path:
                    	/use-cache-low-expire/nested/page: /use-cache-low-expire/nested"
                   `)
                 } else {
@@ -2859,7 +2859,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/nested" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/nested". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on 1 path:
                    	/use-cache-low-expire/nested/page: /use-cache-low-expire/nested"
                   `)
                 } else {
@@ -2941,7 +2941,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-revalidate-0/fast/page: /use-cache-revalidate-0/fast"
                   `)
                 } else {
@@ -2972,7 +2972,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-revalidate-0/fast/page: /use-cache-revalidate-0/fast"
                   `)
                 } else {
@@ -3085,7 +3085,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-revalidate-0/slow/page: /use-cache-revalidate-0/slow"
                   `)
                 } else {
@@ -3116,7 +3116,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following 1 path:
+                   > Export encountered errors on 1 path:
                    	/use-cache-revalidate-0/slow/page: /use-cache-revalidate-0/slow"
                   `)
                 } else {
@@ -3217,7 +3217,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on 1 path:
                    	/use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested"
                   `)
                 } else {
@@ -3253,7 +3253,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/nested" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/nested". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on 1 path:
                    	/use-cache-revalidate-0/nested/page: /use-cache-revalidate-0/nested"
                   `)
                 } else {
@@ -3329,7 +3329,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-params/[slug]/page: /use-cache-params/[slug]"
                 `)
               } else {
@@ -3354,7 +3354,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-params/[slug]/page: /use-cache-params/[slug]"
                 `)
               } else {
@@ -3617,7 +3617,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache"
                 `)
               } else {
@@ -3635,7 +3635,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache"
                 `)
               }
@@ -3729,7 +3729,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
                 `)
               } else
@@ -3748,7 +3748,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
                 `)
             } else {
@@ -3873,7 +3873,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-private-without-suspense/page: /use-cache-private-without-suspense"
                 `)
               } else {
@@ -3906,7 +3906,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following 1 path:
+                 > Export encountered errors on 1 path:
                  	/use-cache-private-without-suspense/page: /use-cache-private-without-suspense"
                 `)
               } else {
@@ -4046,7 +4046,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-current-time/date/page: /sync-io-current-time/date"
               `)
             } else {
@@ -4063,7 +4063,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-current-time/date/page: /sync-io-current-time/date"
               `)
             }
@@ -4150,7 +4150,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-current-time/date-now/page: /sync-io-current-time/date-now"
               `)
             } else {
@@ -4167,7 +4167,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-current-time/date-now/page: /sync-io-current-time/date-now"
               `)
             }
@@ -4254,7 +4254,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-current-time/new-date/page: /sync-io-current-time/new-date"
               `)
             } else {
@@ -4271,7 +4271,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-current-time/new-date/page: /sync-io-current-time/new-date"
               `)
             }
@@ -4358,7 +4358,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-random/math-random/page: /sync-io-random/math-random"
               `)
             } else {
@@ -4375,7 +4375,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-random/math-random/page: /sync-io-random/math-random"
               `)
             }
@@ -4463,7 +4463,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value"
               `)
             } else {
@@ -4481,7 +4481,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value"
               `)
             }
@@ -4569,7 +4569,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid"
               `)
             } else {
@@ -4586,7 +4586,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid"
               `)
             }
@@ -4691,7 +4691,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync"
               `)
             } else {
@@ -4728,7 +4728,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync"
               `)
             } else {
@@ -4815,7 +4815,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync"
               `)
             } else {
@@ -4852,7 +4852,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync"
               `)
             } else {
@@ -4939,7 +4939,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync"
               `)
             } else {
@@ -4976,7 +4976,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync"
               `)
             } else {
@@ -5063,7 +5063,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values"
               `)
             } else {
@@ -5100,7 +5100,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values"
               `)
             } else {
@@ -5187,7 +5187,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes"
               `)
             } else {
@@ -5224,7 +5224,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes"
               `)
             } else {
@@ -5311,7 +5311,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync"
               `)
             } else {
@@ -5348,7 +5348,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync"
               `)
             } else {
@@ -5435,7 +5435,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between"
               `)
             } else {
@@ -5472,7 +5472,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between"
               `)
             } else {
@@ -5559,7 +5559,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to"
               `)
             } else {
@@ -5596,7 +5596,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to"
               `)
             } else {
@@ -5683,7 +5683,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid"
               `)
             } else {
@@ -5720,7 +5720,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid"
               `)
             } else {
@@ -5802,7 +5802,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/client-awaited-io/page: /client-awaited-io"
               `)
             } else {
@@ -5841,7 +5841,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following 1 path:
+               > Export encountered errors on 1 path:
                	/client-awaited-io/page: /client-awaited-io"
               `)
             } else {

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -128,7 +128,7 @@ describe('Cache Components Errors', () => {
                "Route "/dynamic-metadata-static-route" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
                Error occurred prerendering page "/dynamic-metadata-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/dynamic-metadata-static-route/page: /dynamic-metadata-static-route"
               `)
           } else {
@@ -206,7 +206,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
               `)
             } else {
@@ -238,7 +238,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-metadata-error-route" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-metadata-error-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/dynamic-metadata-error-route/page: /dynamic-metadata-error-route"
               `)
             } else {
@@ -331,7 +331,7 @@ describe('Cache Components Errors', () => {
                "Route "/dynamic-metadata-static-with-suspense" has a \`generateMetadata\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) when the rest of the route does not. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata
                Error occurred prerendering page "/dynamic-metadata-static-with-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/dynamic-metadata-static-with-suspense/page: /dynamic-metadata-static-with-suspense"
               `)
           } else {
@@ -421,7 +421,7 @@ describe('Cache Components Errors', () => {
              "Route "/dynamic-viewport-static-route" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
              Error occurred prerendering page "/dynamic-viewport-static-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-             > Export encountered errors on following paths:
+             > Export encountered errors on following 1 path:
              	/dynamic-viewport-static-route/page: /dynamic-viewport-static-route"
             `)
           } else {
@@ -486,7 +486,7 @@ describe('Cache Components Errors', () => {
              "Route "/dynamic-viewport-dynamic-route" has a \`generateViewport\` that depends on Request data (\`cookies()\`, etc...) or uncached external data (\`fetch(...)\`, etc...) without explicitly allowing fully dynamic rendering. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport
              Error occurred prerendering page "/dynamic-viewport-dynamic-route". Read more: https://nextjs.org/docs/messages/prerender-error
 
-             > Export encountered errors on following paths:
+             > Export encountered errors on following 1 path:
              	/dynamic-viewport-dynamic-route/page: /dynamic-viewport-dynamic-route"
             `)
           } else {
@@ -623,7 +623,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/dynamic-root/page: /dynamic-root"
               `)
             } else {
@@ -683,7 +683,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/dynamic-root" in your browser to investigate the error.
                Error occurred prerendering page "/dynamic-root". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/dynamic-root/page: /dynamic-root"
               `)
             } else {
@@ -834,7 +834,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-random-with-fallback/page: /sync-random-with-fallback"
                 `)
               } else {
@@ -852,7 +852,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-with-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-with-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-random-with-fallback/page: /sync-random-with-fallback"
                 `)
               }
@@ -947,7 +947,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-random-without-fallback/page: /sync-random-without-fallback"
                 `)
               } else {
@@ -966,7 +966,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-random-without-fallback" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-random-without-fallback". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-random-without-fallback/page: /sync-random-without-fallback"
                 `)
               }
@@ -1206,7 +1206,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-cookies/page: /sync-cookies"
                 `)
               } else {
@@ -1224,7 +1224,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-cookies/page: /sync-cookies"
                 `)
               }
@@ -1540,7 +1540,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-headers/page: /sync-headers"
                 `)
               } else {
@@ -1558,7 +1558,7 @@ describe('Cache Components Errors', () => {
                    digest: '<error-digest>'
                  }
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-headers/page: /sync-headers"
                 `)
               }
@@ -1846,7 +1846,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync"
                 `)
               } else {
@@ -1864,7 +1864,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/guarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/guarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-attribution/guarded-async-unguarded-clientsync/page: /sync-attribution/guarded-async-unguarded-clientsync"
                 `)
               }
@@ -1971,7 +1971,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
                 `)
               } else {
@@ -2005,7 +2005,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-guarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-guarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-attribution/unguarded-async-guarded-clientsync/page: /sync-attribution/unguarded-async-guarded-clientsync"
                 `)
               } else {
@@ -2115,7 +2115,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync"
                 `)
               } else {
@@ -2133,7 +2133,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-attribution/unguarded-async-unguarded-clientsync" in your browser to investigate the error.
                  Error occurred prerendering page "/sync-attribution/unguarded-async-unguarded-clientsync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/sync-attribution/unguarded-async-unguarded-clientsync/page: /sync-attribution/unguarded-async-unguarded-clientsync"
                 `)
               }
@@ -2222,7 +2222,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-cookies/page: /use-cache-cookies"
                 `)
               } else {
@@ -2258,7 +2258,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-cookies" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-cookies". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-cookies/page: /use-cache-cookies"
                 `)
               } else {
@@ -2327,7 +2327,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-draft-mode/page: /use-cache-draft-mode"
                 `)
               } else {
@@ -2344,7 +2344,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-draft-mode" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-draft-mode". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-draft-mode/page: /use-cache-draft-mode"
                 `)
               }
@@ -2431,7 +2431,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-headers/page: /use-cache-headers"
                 `)
               } else {
@@ -2467,7 +2467,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-headers" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-headers". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-headers/page: /use-cache-headers"
                 `)
               } else {
@@ -2549,7 +2549,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-low-expire/fast/page: /use-cache-low-expire/fast"
                   `)
                 } else {
@@ -2580,7 +2580,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-low-expire/fast/page: /use-cache-low-expire/fast"
                   `)
                 } else {
@@ -2693,7 +2693,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-low-expire/slow/page: /use-cache-low-expire/slow"
                   `)
                 } else {
@@ -2724,7 +2724,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-low-expire/slow/page: /use-cache-low-expire/slow"
                   `)
                 } else {
@@ -2941,7 +2941,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-revalidate-0/fast/page: /use-cache-revalidate-0/fast"
                   `)
                 } else {
@@ -2972,7 +2972,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-revalidate-0/fast/page: /use-cache-revalidate-0/fast"
                   `)
                 } else {
@@ -3085,7 +3085,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-revalidate-0/slow/page: /use-cache-revalidate-0/slow"
                   `)
                 } else {
@@ -3116,7 +3116,7 @@ describe('Cache Components Errors', () => {
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                   > Export encountered errors on following paths:
+                   > Export encountered errors on following 1 path:
                    	/use-cache-revalidate-0/slow/page: /use-cache-revalidate-0/slow"
                   `)
                 } else {
@@ -3329,7 +3329,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-params/[slug]/page: /use-cache-params/[slug]"
                 `)
               } else {
@@ -3354,7 +3354,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-params/[slug]" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-params/[slug]". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-params/[slug]/page: /use-cache-params/[slug]"
                 `)
               } else {
@@ -3617,7 +3617,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache"
                 `)
               } else {
@@ -3635,7 +3635,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-unstable-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-unstable-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-private-in-unstable-cache/page: /use-cache-private-in-unstable-cache"
                 `)
               }
@@ -3729,7 +3729,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
                 `)
               } else
@@ -3748,7 +3748,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-in-use-cache" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-in-use-cache". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-private-in-use-cache/page: /use-cache-private-in-use-cache"
                 `)
             } else {
@@ -3873,7 +3873,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-private-without-suspense/page: /use-cache-private-without-suspense"
                 `)
               } else {
@@ -3906,7 +3906,7 @@ describe('Cache Components Errors', () => {
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 
-                 > Export encountered errors on following paths:
+                 > Export encountered errors on following 1 path:
                  	/use-cache-private-without-suspense/page: /use-cache-private-without-suspense"
                 `)
               } else {
@@ -4046,7 +4046,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-current-time/date/page: /sync-io-current-time/date"
               `)
             } else {
@@ -4063,7 +4063,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-current-time/date/page: /sync-io-current-time/date"
               `)
             }
@@ -4150,7 +4150,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-current-time/date-now/page: /sync-io-current-time/date-now"
               `)
             } else {
@@ -4167,7 +4167,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/date-now" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/date-now". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-current-time/date-now/page: /sync-io-current-time/date-now"
               `)
             }
@@ -4254,7 +4254,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-current-time/new-date/page: /sync-io-current-time/new-date"
               `)
             } else {
@@ -4271,7 +4271,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-current-time/new-date" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-current-time/new-date". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-current-time/new-date/page: /sync-io-current-time/new-date"
               `)
             }
@@ -4358,7 +4358,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-random/math-random/page: /sync-io-random/math-random"
               `)
             } else {
@@ -4375,7 +4375,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-random/math-random" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-random/math-random". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-random/math-random/page: /sync-io-random/math-random"
               `)
             }
@@ -4463,7 +4463,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value"
               `)
             } else {
@@ -4481,7 +4481,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/get-random-value" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/get-random-value". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-web-crypto/get-random-value/page: /sync-io-web-crypto/get-random-value"
               `)
             }
@@ -4569,7 +4569,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid"
               `)
             } else {
@@ -4586,7 +4586,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-web-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-web-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-web-crypto/random-uuid/page: /sync-io-web-crypto/random-uuid"
               `)
             }
@@ -4691,7 +4691,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync"
               `)
             } else {
@@ -4728,7 +4728,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-pair-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-pair-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/generate-key-pair-sync/page: /sync-io-node-crypto/generate-key-pair-sync"
               `)
             } else {
@@ -4815,7 +4815,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync"
               `)
             } else {
@@ -4852,7 +4852,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-key-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-key-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/generate-key-sync/page: /sync-io-node-crypto/generate-key-sync"
               `)
             } else {
@@ -4939,7 +4939,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync"
               `)
             } else {
@@ -4976,7 +4976,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/generate-prime-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/generate-prime-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/generate-prime-sync/page: /sync-io-node-crypto/generate-prime-sync"
               `)
             } else {
@@ -5063,7 +5063,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values"
               `)
             } else {
@@ -5100,7 +5100,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/get-random-values" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/get-random-values". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/get-random-values/page: /sync-io-node-crypto/get-random-values"
               `)
             } else {
@@ -5187,7 +5187,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes"
               `)
             } else {
@@ -5224,7 +5224,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-bytes" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-bytes". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-bytes/page: /sync-io-node-crypto/random-bytes"
               `)
             } else {
@@ -5311,7 +5311,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync"
               `)
             } else {
@@ -5348,7 +5348,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-fill-sync" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-fill-sync". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-fill-sync/page: /sync-io-node-crypto/random-fill-sync"
               `)
             } else {
@@ -5435,7 +5435,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between"
               `)
             } else {
@@ -5472,7 +5472,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-between" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-between". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-int-between/page: /sync-io-node-crypto/random-int-between"
               `)
             } else {
@@ -5559,7 +5559,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to"
               `)
             } else {
@@ -5596,7 +5596,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-int-up-to" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-int-up-to". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-int-up-to/page: /sync-io-node-crypto/random-int-up-to"
               `)
             } else {
@@ -5683,7 +5683,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid"
               `)
             } else {
@@ -5720,7 +5720,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/sync-io-node-crypto/random-uuid" in your browser to investigate the error.
                Error occurred prerendering page "/sync-io-node-crypto/random-uuid". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/sync-io-node-crypto/random-uuid/page: /sync-io-node-crypto/random-uuid"
               `)
             } else {
@@ -5802,7 +5802,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/client-awaited-io/page: /client-awaited-io"
               `)
             } else {
@@ -5841,7 +5841,7 @@ describe('Cache Components Errors', () => {
                To debug the issue, start the app in development mode by running \`next dev\`, then open "/client-awaited-io" in your browser to investigate the error.
                Error occurred prerendering page "/client-awaited-io". Read more: https://nextjs.org/docs/messages/prerender-error
 
-               > Export encountered errors on following paths:
+               > Export encountered errors on following 1 path:
                	/client-awaited-io/page: /client-awaited-io"
               `)
             } else {

--- a/test/integration/handles-export-errors/test/index.test.ts
+++ b/test/integration/handles-export-errors/test/index.test.ts
@@ -16,7 +16,9 @@ describe('Handles Errors During Export', () => {
         })
 
         expect(stdout + stderr).not.toMatch(/ERR_IPC_CHANNEL_CLOSED/)
-        expect(stderr).toContain('Export encountered errors on following paths')
+        expect(stderr).toMatch(
+          /Export encountered errors on following \d+ paths?:/
+        )
         expect(stderr).toContain('/page')
         expect(stderr).toContain('/page-1')
         expect(stderr).toContain('/page-2')

--- a/test/integration/handles-export-errors/test/index.test.ts
+++ b/test/integration/handles-export-errors/test/index.test.ts
@@ -16,9 +16,7 @@ describe('Handles Errors During Export', () => {
         })
 
         expect(stdout + stderr).not.toMatch(/ERR_IPC_CHANNEL_CLOSED/)
-        expect(stderr).toMatch(
-          /Export encountered errors on following \d+ paths?:/
-        )
+        expect(stderr).toMatch(/Export encountered errors on \d+ paths?:/)
         expect(stderr).toContain('/page')
         expect(stderr).toContain('/page-1')
         expect(stderr).toContain('/page-2')

--- a/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
+++ b/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
@@ -20,9 +20,7 @@ describe('app-dir-hide-suppressed-error-during-next-export', () => {
     await expect(next.start()).rejects.toThrow('next build failed')
     expect(next.cliOutput).toInclude('Page build time error')
     expect(next.cliOutput).toInclude('occurred prerendering page "/"')
-    expect(next.cliOutput).toInclude(
-      'Export encountered errors on following 1 path'
-    )
+    expect(next.cliOutput).toInclude('Export encountered errors on 1 path')
     expect(next.cliOutput).not.toInclude(
       'The specific message is omitted in production builds to avoid leaking sensitive details.'
     )

--- a/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
+++ b/test/production/app-dir-hide-suppressed-error-during-next-export/index.test.ts
@@ -21,7 +21,7 @@ describe('app-dir-hide-suppressed-error-during-next-export', () => {
     expect(next.cliOutput).toInclude('Page build time error')
     expect(next.cliOutput).toInclude('occurred prerendering page "/"')
     expect(next.cliOutput).toInclude(
-      'Export encountered errors on following paths'
+      'Export encountered errors on following 1 path'
     )
     expect(next.cliOutput).not.toInclude(
       'The specific message is omitted in production builds to avoid leaking sensitive details.'

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -216,7 +216,7 @@ describe('build-output-prerender', () => {
            To debug the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error.
            Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
-           > Export encountered errors on following paths:
+           > Export encountered errors on following 2 paths:
            	/client/page: /client
            	/server/page: /server"
           `)
@@ -246,7 +246,7 @@ describe('build-output-prerender', () => {
            To debug the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error.
            Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
-           > Export encountered errors on following paths:
+           > Export encountered errors on following 2 paths:
            	/client/page: /client
            	/server/page: /server"
           `)

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -216,7 +216,7 @@ describe('build-output-prerender', () => {
            To debug the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error.
            Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
-           > Export encountered errors on following 2 paths:
+           > Export encountered errors on 2 paths:
            	/client/page: /client
            	/server/page: /server"
           `)
@@ -246,7 +246,7 @@ describe('build-output-prerender', () => {
            To debug the issue, start the app in development mode by running \`next dev\`, then open "/server" in your browser to investigate the error.
            Error occurred prerendering page "/server". Read more: https://nextjs.org/docs/messages/prerender-error
 
-           > Export encountered errors on following 2 paths:
+           > Export encountered errors on 2 paths:
            	/client/page: /client
            	/server/page: /server"
           `)


### PR DESCRIPTION
Supersedes https://github.com/vercel/next.js/pull/88910

---
<a href="https://cursor.com/background-agent?bcId=bc-a05c69b9-7049-4095-8985-761868c63e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a05c69b9-7049-4095-8985-761868c63e1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

