### PR TITLE
fix(turbopack): --debug-build-paths fails with route groups

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -10,6 +10,7 @@ use next_core::{
     instrumentation::instrumentation_files,
     middleware::middleware_files,
     mode::NextMode,
+    next_app::{AppPage, AppPath},
     next_client::{
         ClientChunkingContextOptions, get_client_chunking_context, get_client_compile_time_info,
     },
@@ -218,42 +219,13 @@ struct DebugBuildPathsRouteKeys {
 }
 
 impl DebugBuildPathsRouteKeys {
-    fn from_debug_build_paths(paths: &DebugBuildPaths) -> Self {
-        Self {
+    fn from_debug_build_paths(paths: &DebugBuildPaths) -> Result<Self> {
+        Ok(Self {
             app: paths
                 .app
                 .iter()
-                .map(|path| {
-                    // App router: "/blog/[slug]/page.tsx" -> "/blog/[slug]"
-                    // First strip the filename
-                    let path_without_file = if let Some(last_slash_idx) = path.rfind('/') {
-                        if last_slash_idx == 0 {
-                            "/" // Root: "/page.tsx" -> "/"
-                        } else {
-                            &path[..last_slash_idx]
-                        }
-                    } else {
-                        path.as_str()
-                    };
-
-                    // Strip route groups (xxx) and parallel routes @xxx to match AppPath format
-                    // This matches the behavior in next-core/src/next_app/mod.rs AppPage -> AppPath
-                    let segments: Vec<&str> = path_without_file
-                        .split('/')
-                        .filter(|s| {
-                            !s.is_empty()
-                                && !s.starts_with('(') // route groups like (dashboard)
-                                && !s.starts_with('@') // parallel routes like @modal
-                        })
-                        .collect();
-
-                    if segments.is_empty() {
-                        "/".into()
-                    } else {
-                        format!("/{}", segments.join("/")).into()
-                    }
-                })
-                .collect(),
+                .map(|path| Ok(AppPath::from(AppPage::parse(path)?).to_string().into()))
+                .collect::<Result<FxHashSet<_>>>()?,
             pages: paths
                 .pages
                 .iter()
@@ -266,10 +238,9 @@ impl DebugBuildPathsRouteKeys {
                     }
                 })
                 .collect(),
-        }
+        })
     }
 
-    /// Checks if an app router route should be included based on pre-converted route keys.
     fn should_include_app_route(&self, route_key: &RcStr) -> bool {
         // Special app router framework routes
         if matches!(route_key.as_str(), "/_not-found" | "/_global-error") {
@@ -278,7 +249,6 @@ impl DebugBuildPathsRouteKeys {
         self.app.contains(route_key)
     }
 
-    /// Checks if a pages router route should be included based on pre-converted route keys.
     fn should_include_pages_route(&self, route_key: &RcStr) -> bool {
         // Special pages router framework routes
         if matches!(route_key.as_str(), "/_error" | "/_document" | "/_app") {
@@ -1653,7 +1623,8 @@ impl Project {
         let debug_build_paths_route_keys = this
             .debug_build_paths
             .as_ref()
-            .map(DebugBuildPathsRouteKeys::from_debug_build_paths);
+            .map(DebugBuildPathsRouteKeys::from_debug_build_paths)
+            .transpose()?;
 
         if let Some(app_project) = &*app_project.await? {
             let app_routes = app_project.routes();

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -268,6 +268,24 @@ impl DebugBuildPathsRouteKeys {
                 .collect(),
         }
     }
+
+    /// Checks if an app router route should be included based on pre-converted route keys.
+    fn should_include_app_route(&self, route_key: &RcStr) -> bool {
+        // Special app router framework routes
+        if matches!(route_key.as_str(), "/_not-found" | "/_global-error") {
+            return true;
+        }
+        self.app.contains(route_key)
+    }
+
+    /// Checks if a pages router route should be included based on pre-converted route keys.
+    fn should_include_pages_route(&self, route_key: &RcStr) -> bool {
+        // Special pages router framework routes
+        if matches!(route_key.as_str(), "/_error" | "/_document" | "/_app") {
+            return true;
+        }
+        self.pages.contains(route_key)
+    }
 }
 
 #[derive(
@@ -540,24 +558,6 @@ fn define_env_diff_report(old: &DefineEnv, new: &DefineEnv) -> String {
         }
     }
     report
-}
-
-/// Checks if an app router route should be included based on pre-converted route keys.
-fn should_include_app_route(route_key: &RcStr, route_keys: &FxHashSet<RcStr>) -> bool {
-    // Special app router framework routes
-    if matches!(route_key.as_str(), "/_not-found" | "/_global-error") {
-        return true;
-    }
-    route_keys.contains(route_key)
-}
-
-/// Checks if a pages router route should be included based on pre-converted route keys.
-fn should_include_pages_route(route_key: &RcStr, route_keys: &FxHashSet<RcStr>) -> bool {
-    // Special pages router framework routes
-    if matches!(route_key.as_str(), "/_error" | "/_document" | "/_app") {
-        return true;
-    }
-    route_keys.contains(route_key)
 }
 
 impl ProjectContainer {
@@ -1664,17 +1664,20 @@ impl Project {
                     .filter(|(k, _)| {
                         debug_build_paths_route_keys
                             .as_ref()
-                            .is_none_or(|keys| should_include_app_route(k, &keys.app))
+                            .is_none_or(|keys| keys.should_include_app_route(k))
                     })
                     .map(|(k, v)| (k.clone(), v.clone())),
             );
         }
 
-        for (pathname, page_route) in pages_project.routes().await?.iter().filter(|(k, _)| {
-            debug_build_paths_route_keys
+        for (pathname, page_route) in &pages_project.routes().await? {
+            if debug_build_paths_route_keys
                 .as_ref()
-                .is_none_or(|keys| should_include_pages_route(k, &keys.pages))
-        }) {
+                .is_some_and(|keys| !keys.should_include_pages_route(pathname))
+            {
+                continue;
+            }
+
             match routes.entry(pathname.clone()) {
                 Entry::Occupied(mut entry) => {
                     ConflictIssue {

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -225,14 +225,32 @@ impl DebugBuildPathsRouteKeys {
                 .iter()
                 .map(|path| {
                     // App router: "/blog/[slug]/page.tsx" -> "/blog/[slug]"
-                    if let Some(last_slash_idx) = path.rfind('/') {
+                    // First strip the filename
+                    let path_without_file = if let Some(last_slash_idx) = path.rfind('/') {
                         if last_slash_idx == 0 {
-                            "/".into() // Root: "/page.tsx" -> "/"
+                            "/" // Root: "/page.tsx" -> "/"
                         } else {
-                            path[..last_slash_idx].into()
+                            &path[..last_slash_idx]
                         }
                     } else {
-                        path.clone()
+                        path.as_str()
+                    };
+
+                    // Strip route groups (xxx) and parallel routes @xxx to match AppPath format
+                    // This matches the behavior in next-core/src/next_app/mod.rs AppPage -> AppPath
+                    let segments: Vec<&str> = path_without_file
+                        .split('/')
+                        .filter(|s| {
+                            !s.is_empty()
+                                && !s.starts_with('(') // route groups like (dashboard)
+                                && !s.starts_with('@') // parallel routes like @modal
+                        })
+                        .collect();
+
+                    if segments.is_empty() {
+                        "/".into()
+                    } else {
+                        format!("/{}", segments.join("/")).into()
                     }
                 })
                 .collect(),

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -246,6 +246,17 @@ impl AppPage {
             app_page.push_str(segment)?;
         }
 
+        if let Some(last) = app_page.0.last_mut()
+            && let PageSegment::Static(last_name) = &*last
+        {
+            if last_name.starts_with("page.") {
+                *last = PageSegment::PageType(PageType::Page);
+            } else if last_name.starts_with("route") {
+                *last = PageSegment::PageType(PageType::Route);
+            }
+            // can also be metadata (and be neither Page nor Route)
+        }
+
         Ok(app_page)
     }
 
@@ -527,5 +538,51 @@ impl From<AppPage> for AppPath {
                 })
                 .collect(),
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::next_app::{AppPage, PageSegment, PageType};
+
+    #[test]
+    fn test_normalize_metadata_route() {
+        assert_eq!(
+            AppPage::parse("(group)/foo/@par/bar/page.tsx").unwrap(),
+            AppPage(vec![
+                PageSegment::Group("group".into()),
+                PageSegment::Static("foo".into()),
+                PageSegment::Parallel("par".into()),
+                PageSegment::Static("bar".into()),
+                PageSegment::PageType(PageType::Page),
+            ])
+        );
+
+        assert_eq!(
+            AppPage::parse("(group)/foo/@par/bar/route.tsx").unwrap(),
+            AppPage(vec![
+                PageSegment::Group("group".into()),
+                PageSegment::Static("foo".into()),
+                PageSegment::Parallel("par".into()),
+                PageSegment::Static("bar".into()),
+                PageSegment::PageType(PageType::Route),
+            ])
+        );
+
+        assert_eq!(
+            AppPage::parse("foo/sitemap").unwrap(),
+            AppPage(vec![
+                PageSegment::Static("foo".into()),
+                PageSegment::Static("sitemap".into()),
+            ])
+        );
+
+        assert_eq!(
+            AppPage::parse("foo/robots.txt").unwrap(),
+            AppPage(vec![
+                PageSegment::Static("foo".into()),
+                PageSegment::Static("robots.txt".into()),
+            ])
+        );
     }
 }

--- a/crates/next-core/src/next_app/mod.rs
+++ b/crates/next-core/src/next_app/mod.rs
@@ -249,9 +249,10 @@ impl AppPage {
         if let Some(last) = app_page.0.last_mut()
             && let PageSegment::Static(last_name) = &*last
         {
-            if last_name.starts_with("page.") {
+            // Next.js internals sometimes omit extensions when creating synthetic page entries
+            if last_name == "page" || last_name.starts_with("page.") {
                 *last = PageSegment::PageType(PageType::Page);
-            } else if last_name.starts_with("route") {
+            } else if last_name == "route" || last_name.starts_with("route.") {
                 *last = PageSegment::PageType(PageType::Route);
             }
             // can also be metadata (and be neither Page nor Route)
@@ -557,9 +558,29 @@ mod test {
                 PageSegment::PageType(PageType::Page),
             ])
         );
+        assert_eq!(
+            AppPage::parse("(group)/foo/@par/bar/page").unwrap(),
+            AppPage(vec![
+                PageSegment::Group("group".into()),
+                PageSegment::Static("foo".into()),
+                PageSegment::Parallel("par".into()),
+                PageSegment::Static("bar".into()),
+                PageSegment::PageType(PageType::Page),
+            ])
+        );
 
         assert_eq!(
             AppPage::parse("(group)/foo/@par/bar/route.tsx").unwrap(),
+            AppPage(vec![
+                PageSegment::Group("group".into()),
+                PageSegment::Static("foo".into()),
+                PageSegment::Parallel("par".into()),
+                PageSegment::Static("bar".into()),
+                PageSegment::PageType(PageType::Route),
+            ])
+        );
+        assert_eq!(
+            AppPage::parse("(group)/foo/@par/bar/route").unwrap(),
             AppPage(vec![
                 PageSegment::Group("group".into()),
                 PageSegment::Static("foo".into()),

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -238,6 +238,19 @@ describe('debug-build-paths', () => {
         expect(buildResult.cliOutput).not.toContain('○ /about')
         expect(buildResult.cliOutput).not.toContain('○ /dashboard')
       })
+
+      it('should build routes with parallel routes', async () => {
+        const buildResult = await next.build({
+          args: ['--debug-build-paths', 'app/parallel-test/**/page.tsx'],
+        })
+        expect(buildResult.exitCode).toBe(0)
+        expect(buildResult.cliOutput).toContain('Route (app)')
+        // Parallel route segments (@sidebar) are stripped from the path
+        expect(buildResult.cliOutput).toContain('/parallel-test')
+        // Should not build other routes
+        expect(buildResult.cliOutput).not.toContain('○ /about')
+        expect(buildResult.cliOutput).not.toContain('○ /dashboard')
+      })
     })
 
     describe('typechecking with debug-build-paths', () => {

--- a/test/production/debug-build-path/debug-build-paths.test.ts
+++ b/test/production/debug-build-path/debug-build-paths.test.ts
@@ -225,6 +225,19 @@ describe('debug-build-paths', () => {
         expect(buildResult.cliOutput).toContain('○ /foo')
         expect(buildResult.cliOutput).not.toContain('/with-type-error')
       })
+
+      it('should build routes inside route groups', async () => {
+        const buildResult = await next.build({
+          args: ['--debug-build-paths', 'app/(group)/**/page.tsx'],
+        })
+        expect(buildResult.exitCode).toBe(0)
+        expect(buildResult.cliOutput).toContain('Route (app)')
+        // Route groups are stripped from the path, so /nested instead of /(group)/nested
+        expect(buildResult.cliOutput).toContain('/nested')
+        // Should not build other routes
+        expect(buildResult.cliOutput).not.toContain('○ /about')
+        expect(buildResult.cliOutput).not.toContain('○ /dashboard')
+      })
     })
 
     describe('typechecking with debug-build-paths', () => {

--- a/test/production/debug-build-path/fixtures/default/app/(group)/nested/page.tsx
+++ b/test/production/debug-build-path/fixtures/default/app/(group)/nested/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Grouped nested page</div>
+}

--- a/test/production/debug-build-path/fixtures/default/app/parallel-test/@sidebar/default.tsx
+++ b/test/production/debug-build-path/fixtures/default/app/parallel-test/@sidebar/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return null
+}

--- a/test/production/debug-build-path/fixtures/default/app/parallel-test/@sidebar/page.tsx
+++ b/test/production/debug-build-path/fixtures/default/app/parallel-test/@sidebar/page.tsx
@@ -1,0 +1,3 @@
+export default function Sidebar() {
+  return <div>Sidebar parallel route</div>
+}

--- a/test/production/debug-build-path/fixtures/default/app/parallel-test/layout.tsx
+++ b/test/production/debug-build-path/fixtures/default/app/parallel-test/layout.tsx
@@ -1,14 +1,11 @@
-export default function Layout({
-  children,
-  sidebar,
-}: {
+export default function Layout(props: {
   children: React.ReactNode
   sidebar: React.ReactNode
 }) {
   return (
     <div>
-      {children}
-      {sidebar}
+      {props.children}
+      {props.sidebar}
     </div>
   )
 }

--- a/test/production/debug-build-path/fixtures/default/app/parallel-test/layout.tsx
+++ b/test/production/debug-build-path/fixtures/default/app/parallel-test/layout.tsx
@@ -1,0 +1,14 @@
+export default function Layout({
+  children,
+  sidebar,
+}: {
+  children: React.ReactNode
+  sidebar: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {sidebar}
+    </div>
+  )
+}

--- a/test/production/debug-build-path/fixtures/default/app/parallel-test/page.tsx
+++ b/test/production/debug-build-path/fixtures/default/app/parallel-test/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Parallel test main page</div>
+}


### PR DESCRIPTION
Confirmed the fix locally on the original app I faced the issue with.

### Why?

When using `--debug-build-paths`, a pattern with a route group on Turbopack, it fails with an error:

```
Error [PageNotFoundError]: Cannot find module for page: /nested
    at ignore-listed frames {
  code: 'ENOENT'
}
```

Current Behavior: https://github.com/vercel/next.js/actions/runs/21544427008/job/62083680496?pr=89336#step:35:459

The bug lives in `crates/next-api/src/project.rs`, specifically in `from_debug_build_paths()`. This function is responsible for deriving route paths from debug build inputs, but it currently preserves route groups when it shouldn’t.

With the current behavior, an input like `app/(group)/nested/page.tsx` produces the output `/(group)/nested`. In other words, the route group segment is kept in the generated path.

However, Turbopack route keys explicitly strip route groups. In `next-core/src/next_app/mod.rs`, the conversion from `AppPage` to `AppPath` removes route group segments. For the same input, Turbopack expects the route key to be `/nested`, not `/(group)/nested`.

This mismatch causes a downstream failure. `from_debug_build_paths()` produces `/(group)/nested`, while the Turbopack route key is `/nested`. Since `should_include_app_route()` relies on an exact string match, the comparison fails. As a result, the route is excluded, the module is never compiled, and the error ultimately surfaces as a `PageNotFoundError`.

### How?

Strip route group `(xxx)` and parallel route `@xxx` segments in `from_debug_build_paths()` to match how Turbopack normalizes route keys.