### PR TITLE
fix: use signal-based exit codes to prevent inspector blocking exit

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -382,7 +382,7 @@ export async function startServer(
       try {
         let cleanupStarted = false
         let closeUpgraded: (() => void) | null = null
-        const cleanup = (signal: NodeJS.Signals) => {
+        const cleanup = (signal: 'SIGINT' | 'SIGTERM') => {
           if (cleanupStarted) {
             // We can get duplicate signals, e.g. when `ctrl+c` is used in an
             // interactive shell (i.e. bash, zsh), the shell will recursively
@@ -439,16 +439,26 @@ export async function startServer(
             // Exit with signal-based exit code (128 + signal number) so that
             // Node.js treats this as a signal termination, not a normal exit.
             // This avoids waiting for the debugger to disconnect.
-            // SIGINT = 2 -> 130, SIGTERM = 15 -> 143
-            process.exit(signal === 'SIGINT' ? 130 : 143)
+            switch (signal) {
+              case 'SIGINT':
+                process.exit(130)
+                break
+              case 'SIGTERM':
+                process.exit(143)
+                break
+              default:
+                // Exhaustiveness check
+                signal satisfies never as never
+                process.exit(128)
+            }
           })()
         }
 
         // Make sure commands gracefully respect termination signals (e.g. from Docker)
         // Allow the graceful termination to be manually configurable
         if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
-          process.on('SIGINT', () => cleanup('SIGINT'))
-          process.on('SIGTERM', () => cleanup('SIGTERM'))
+          process.on('SIGINT', cleanup)
+          process.on('SIGTERM', cleanup)
         }
 
         // Now load config via getRequestHandlers (single loadConfig call)

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -15,7 +15,6 @@ import path from 'path'
 import http from 'http'
 import https from 'https'
 import os from 'os'
-import * as inspector from 'inspector'
 import { exec } from 'child_process'
 import Watchpack from 'next/dist/compiled/watchpack'
 import * as Log from '../../build/output/log'
@@ -383,7 +382,7 @@ export async function startServer(
       try {
         let cleanupStarted = false
         let closeUpgraded: (() => void) | null = null
-        const cleanup = () => {
+        const cleanup = (signal: NodeJS.Signals) => {
           if (cleanupStarted) {
             // We can get duplicate signals, e.g. when `ctrl+c` is used in an
             // interactive shell (i.e. bash, zsh), the shell will recursively
@@ -437,21 +436,19 @@ export async function startServer(
 
             debug('start-server process cleanup finished')
 
-            // Close the Node.js inspector if it's open. The inspector keeps
-            // the event loop alive which prevents the process from exiting.
-            if (inspector.url()) {
-              inspector.close()
-            }
-
-            process.exit(0)
+            // Exit with signal-based exit code (128 + signal number) so that
+            // Node.js treats this as a signal termination, not a normal exit.
+            // This avoids waiting for the debugger to disconnect.
+            // SIGINT = 2 -> 130, SIGTERM = 15 -> 143
+            process.exit(signal === 'SIGINT' ? 130 : 143)
           })()
         }
 
         // Make sure commands gracefully respect termination signals (e.g. from Docker)
         // Allow the graceful termination to be manually configurable
         if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
-          process.on('SIGINT', cleanup)
-          process.on('SIGTERM', cleanup)
+          process.on('SIGINT', () => cleanup('SIGINT'))
+          process.on('SIGTERM', () => cleanup('SIGTERM'))
         }
 
         // Now load config via getRequestHandlers (single loadConfig call)

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -15,6 +15,7 @@ import path from 'path'
 import http from 'http'
 import https from 'https'
 import os from 'os'
+import * as inspector from 'inspector'
 import { exec } from 'child_process'
 import Watchpack from 'next/dist/compiled/watchpack'
 import * as Log from '../../build/output/log'
@@ -435,6 +436,13 @@ export async function startServer(
             }
 
             debug('start-server process cleanup finished')
+
+            // Close the Node.js inspector if it's open. The inspector keeps
+            // the event loop alive which prevents the process from exiting.
+            if (inspector.url()) {
+              inspector.close()
+            }
+
             process.exit(0)
           })()
         }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -447,8 +447,9 @@ export async function startServer(
                 process.exit(143)
                 break
               default:
-                // Exhaustiveness check
-                signal satisfies never as never
+                // Make sure all handled signals have explicit exit codes.
+                // This is just a fallback to guard against unsound types.
+                signal satisfies never
                 process.exit(128)
             }
           })()

--- a/test/integration/cli/test/index.test.ts
+++ b/test/integration/cli/test/index.test.ts
@@ -105,7 +105,8 @@ describe('CLI Usage', () => {
           await testExitSignal(
             'SIGINT',
             ['start', dirBasic, '-p', port],
-            /- Local:/
+            /- Local:/,
+            130 // 128 + 2 (SIGINT)
           )
         })
         test('should exit when SIGTERM is signalled', async () => {
@@ -122,7 +123,8 @@ describe('CLI Usage', () => {
           await testExitSignal(
             'SIGTERM',
             ['start', dirBasic, '-p', port],
-            /- Local:/
+            /- Local:/,
+            143 // 128 + 15 (SIGTERM)
           )
         })
 

--- a/test/production/graceful-shutdown/index.test.ts
+++ b/test/production/graceful-shutdown/index.test.ts
@@ -208,9 +208,9 @@ function runTests(dev = false) {
         expect(res.status).toBe(200)
         expect(await res.json()).toStrictEqual({ hello: 'world' })
 
-        // App finally shuts down
-        expect(await appKilledPromise).toEqual([0, null])
-        expect(app.exitCode).toBe(0)
+        // App finally shuts down with signal-based exit code (128 + 15 for SIGTERM)
+        expect(await appKilledPromise).toEqual([143, null])
+        expect(app.exitCode).toBe(143)
       })
 
       it('should stop accepting new requests when shutting down', async () => {
@@ -225,9 +225,9 @@ function runTests(dev = false) {
           1000
         )
 
-        // App finally shuts down
-        expect(await appKilledPromise).toEqual([0, null])
-        expect(app.exitCode).toBe(0)
+        // App finally shuts down with signal-based exit code (128 + 15 for SIGTERM)
+        expect(await appKilledPromise).toEqual([143, null])
+        expect(app.exitCode).toBe(143)
       })
     })
   }


### PR DESCRIPTION
## What?

Use signal-based exit codes when shutting down the Next.js server to prevent the process from waiting for the debugger to disconnect.

## Why?

When Node.js devtools are attached (via `--inspect` flag or the Next.js DevTools "Attach debugger" feature), pressing Ctrl+C causes the dev server to hang instead of exiting immediately. This happens because calling `process.exit(0)` makes Node.js treat it as a normal exit, which waits for all debuggers to disconnect before terminating.

In contrast, plain Node.js terminates immediately on SIGINT even with a debugger attached, because signal-based termination doesn't wait for debuggers.

## How?

Instead of calling `process.exit(0)` after cleanup, use signal-based exit codes:

- SIGINT (signal 2) → `process.exit(130)` (128 + 2)
- SIGTERM (signal 15) → `process.exit(143)` (128 + 15)

This tells Node.js the process was terminated by a signal, which avoids the debugger wait behavior.

Changes:
- Modified the cleanup function to accept the signal that triggered it
- Use `process.exit(signal === 'SIGINT' ? 130 : 143)` instead of `process.exit(0)`
- Removed the previous `inspector.close()` workaround as it's no longer needed