### PR TITLE
fix: run Node instrumentation when using standalone server

### DIFF
--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -60,6 +60,7 @@ import {
   isChromeDevtoolsWorkspaceUrl,
 } from './chrome-devtools-workspace'
 import { getNextConfigRuntime, type NextConfigComplete } from '../config-shared'
+import { ensureInstrumentationRegistered } from './router-utils/instrumentation-globals.external'
 
 const debug = setupDebug('next:router-server:main')
 const isNextFont = (pathname: string | null) =>
@@ -116,6 +117,10 @@ export async function initialize(opts: {
 
   if (config?.compress !== false) {
     compress = setupCompression()
+  }
+
+  if (!opts.dev && config) {
+    await ensureInstrumentationRegistered(opts.dir, config.distDir)
   }
 
   const fsChecker = await setupFsCheck({


### PR DESCRIPTION
### What?

- Fixes Node.js instrumentation not running in standalone mode.

### Why?
- Standalone server bypasses NextNodeServer.prepareImpl() where instrumentation is registered.

### How?
- Register instrumentation in router-server.ts initialize() for production mode.

Closes NEXT-
fixes: #89377
