### PR TITLE
fix(build): improve error message for non-string params in getStaticPaths

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -987,6 +987,7 @@
   "986": "Server Action arguments list is too long (%s). Maximum allowed is %s.",
   "987": "Invalid \\`deploymentId\\` configuration: must be a string. See https://nextjs.org/docs/messages/deploymentid-not-a-string",
   "988": "Invalid \\`deploymentId\\` configuration: contains invalid characters. Only alphanumeric characters, hyphens, and underscores are allowed. See https://nextjs.org/docs/messages/deploymentid-invalid-characters",
+<<<<<<< HEAD
   "989": "Loaded static props were from an outdated deployment, forcing a hard reload",
   "990": "Page \"%s\" cannot use \\`export const unstable_instant = ...\\` without enabling \\`cacheComponents\\`.",
   "991": "A page must have a root layout",
@@ -1085,5 +1086,7 @@
   "1084": "Route \"%s\": Uncached data or \\`connection()\\` was accessed outside of \\`<Suspense>\\`. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route",
   "1085": "Route \"%s\": Runtime data such as \\`cookies()\\`, \\`headers()\\`, \\`params\\`, or \\`searchParams\\` was accessed inside \\`generateMetadata\\` or you have file-based metadata such as icons that depend on dynamic params segments. Except for this instance, the page would have been entirely prerenderable which may have been the intended behavior. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata",
   "1086": "Route \"%s\": %s This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
-  "1087": "Failed to parse \"%s\":\\n%s%s"
+  "1087": "Failed to parse \"%s\":\\n%s%s",
+  "1088": "A required parameter (%s) was not provided as %s in getStaticPaths for %s.\\nReceived: %s%s\\n\\nMake sure to provide the parameter as %s. For example:\\n  { params: { %s: %s } }\\n\\nSee: https://nextjs.org/docs/messages/invalid-getstaticpaths-value",
+  "1089": "Expected a string for path segment, but received %s. Ensure all path parameters are strings."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -987,7 +987,6 @@
   "986": "Server Action arguments list is too long (%s). Maximum allowed is %s.",
   "987": "Invalid \\`deploymentId\\` configuration: must be a string. See https://nextjs.org/docs/messages/deploymentid-not-a-string",
   "988": "Invalid \\`deploymentId\\` configuration: contains invalid characters. Only alphanumeric characters, hyphens, and underscores are allowed. See https://nextjs.org/docs/messages/deploymentid-invalid-characters",
-<<<<<<< HEAD
   "989": "Loaded static props were from an outdated deployment, forcing a hard reload",
   "990": "Page \"%s\" cannot use \\`export const unstable_instant = ...\\` without enabling \\`cacheComponents\\`.",
   "991": "A page must have a root layout",

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -70,7 +70,7 @@ export async function buildPagesStaticPaths({
   ) {
     throw new Error(
       `The \`fallback\` key must be returned from getStaticPaths in ${page}.\n` +
-        expectedReturnVal
+      expectedReturnVal
     )
   }
 
@@ -79,7 +79,7 @@ export async function buildPagesStaticPaths({
   if (!Array.isArray(toPrerender)) {
     throw new Error(
       `Invalid \`paths\` value returned from getStaticPaths in ${page}.\n` +
-        `\`paths\` must be an array of strings or objects of shape { params: [key: string]: string }`
+      `\`paths\` must be an array of strings or objects of shape { params: [key: string]: string }`
     )
   }
 
@@ -137,11 +137,11 @@ export async function buildPagesStaticPaths({
       if (invalidKeys.length) {
         throw new Error(
           `Additional keys were returned from \`getStaticPaths\` in page "${page}". ` +
-            `URL Parameters intended for this dynamic route must be nested under the \`params\` key, i.e.:` +
-            `\n\n\treturn { params: { ${routeParameterKeys
-              .map((k) => `${k}: ...`)
-              .join(', ')} } }` +
-            `\n\nKeys that need to be moved: ${invalidKeys.join(', ')}.\n`
+          `URL Parameters intended for this dynamic route must be nested under the \`params\` key, i.e.:` +
+          `\n\n\treturn { params: { ${routeParameterKeys
+            .map((k) => `${k}: ...`)
+            .join(', ')} } }` +
+          `\n\nKeys that need to be moved: ${invalidKeys.join(', ')}.\n`
         )
       }
 
@@ -174,12 +174,22 @@ export async function buildPagesStaticPaths({
               : Array.isArray(paramValue)
                 ? 'an array'
                 : typeof paramValue
+
+          let receivedValueDisplay = ''
+          if (typeof paramValue !== 'undefined' && paramValue !== null) {
+            try {
+              receivedValueDisplay = ` (${JSON.stringify(paramValue)})`
+            } catch {
+              receivedValueDisplay = ` (${String(paramValue)})`
+            }
+          }
+
           throw new TypeError(
             `A required parameter (${validParamKey}) was not provided as ${expectedType} in getStaticPaths for ${page}.\n` +
-              `Received: ${receivedType}${typeof paramValue !== 'undefined' && paramValue !== null ? ` (${JSON.stringify(paramValue)})` : ''}\n` +
-              `\nMake sure to provide the parameter as ${expectedType}. For example:\n` +
-              `  { params: { ${validParamKey}: ${repeat ? '["value1", "value2"]' : '"value"'} } }\n` +
-              `\nSee: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
+            `Received: ${receivedType}${receivedValueDisplay}\n` +
+            `\nMake sure to provide the parameter as ${expectedType}. For example:\n` +
+            `  { params: { ${validParamKey}: ${repeat ? '["value1", "value2"]' : '"value"'} } }\n` +
+            `\nSee: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
           )
         }
 
@@ -219,8 +229,7 @@ export async function buildPagesStaticPaths({
           params,
           pathname,
           encodedPathname: normalizePathname(
-            `${curLocale ? `/${curLocale}` : ''}${
-              curLocale && encodedBuiltPage === '/' ? '' : encodedBuiltPage
+            `${curLocale ? `/${curLocale}` : ''}${curLocale && encodedBuiltPage === '/' ? '' : encodedBuiltPage
             }`
           ),
           fallbackRouteParams: undefined,

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -70,7 +70,7 @@ export async function buildPagesStaticPaths({
   ) {
     throw new Error(
       `The \`fallback\` key must be returned from getStaticPaths in ${page}.\n` +
-      expectedReturnVal
+        expectedReturnVal
     )
   }
 
@@ -79,7 +79,7 @@ export async function buildPagesStaticPaths({
   if (!Array.isArray(toPrerender)) {
     throw new Error(
       `Invalid \`paths\` value returned from getStaticPaths in ${page}.\n` +
-      `\`paths\` must be an array of strings or objects of shape { params: [key: string]: string }`
+        `\`paths\` must be an array of strings or objects of shape { params: [key: string]: string }`
     )
   }
 
@@ -137,11 +137,11 @@ export async function buildPagesStaticPaths({
       if (invalidKeys.length) {
         throw new Error(
           `Additional keys were returned from \`getStaticPaths\` in page "${page}". ` +
-          `URL Parameters intended for this dynamic route must be nested under the \`params\` key, i.e.:` +
-          `\n\n\treturn { params: { ${routeParameterKeys
-            .map((k) => `${k}: ...`)
-            .join(', ')} } }` +
-          `\n\nKeys that need to be moved: ${invalidKeys.join(', ')}.\n`
+            `URL Parameters intended for this dynamic route must be nested under the \`params\` key, i.e.:` +
+            `\n\n\treturn { params: { ${routeParameterKeys
+              .map((k) => `${k}: ...`)
+              .join(', ')} } }` +
+            `\n\nKeys that need to be moved: ${invalidKeys.join(', ')}.\n`
         )
       }
 
@@ -162,8 +162,12 @@ export async function buildPagesStaticPaths({
           paramValue = []
         }
 
+        const hasValidRepeatParam =
+          Array.isArray(paramValue) &&
+          paramValue.every((value) => typeof value === 'string')
+
         if (
-          (repeat && !Array.isArray(paramValue)) ||
+          (repeat && !hasValidRepeatParam) ||
           (!repeat && typeof paramValue !== 'string') ||
           typeof paramValue === 'undefined'
         ) {
@@ -186,10 +190,10 @@ export async function buildPagesStaticPaths({
 
           throw new TypeError(
             `A required parameter (${validParamKey}) was not provided as ${expectedType} in getStaticPaths for ${page}.\n` +
-            `Received: ${receivedType}${receivedValueDisplay}\n` +
-            `\nMake sure to provide the parameter as ${expectedType}. For example:\n` +
-            `  { params: { ${validParamKey}: ${repeat ? '["value1", "value2"]' : '"value"'} } }\n` +
-            `\nSee: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
+              `Received: ${receivedType}${receivedValueDisplay}\n` +
+              `\nMake sure to provide the parameter as ${expectedType}. For example:\n` +
+              `  { params: { ${validParamKey}: ${repeat ? '["value1", "value2"]' : '"value"'} } }\n` +
+              `\nSee: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
           )
         }
 
@@ -229,7 +233,8 @@ export async function buildPagesStaticPaths({
           params,
           pathname,
           encodedPathname: normalizePathname(
-            `${curLocale ? `/${curLocale}` : ''}${curLocale && encodedBuiltPage === '/' ? '' : encodedBuiltPage
+            `${curLocale ? `/${curLocale}` : ''}${
+              curLocale && encodedBuiltPage === '/' ? '' : encodedBuiltPage
             }`
           ),
           fallbackRouteParams: undefined,

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -167,10 +167,19 @@ export async function buildPagesStaticPaths({
           (!repeat && typeof paramValue !== 'string') ||
           typeof paramValue === 'undefined'
         ) {
-          throw new Error(
-            `A required parameter (${validParamKey}) was not provided as ${
-              repeat ? 'an array' : 'a string'
-            } received ${typeof paramValue} in getStaticPaths for ${page}`
+          const expectedType = repeat ? 'an array of strings' : 'a string'
+          const receivedType =
+            paramValue === null
+              ? 'null'
+              : Array.isArray(paramValue)
+                ? 'an array'
+                : typeof paramValue
+          throw new TypeError(
+            `A required parameter (${validParamKey}) was not provided as ${expectedType} in getStaticPaths for ${page}.\n` +
+              `Received: ${receivedType}${typeof paramValue !== 'undefined' && paramValue !== null ? ` (${JSON.stringify(paramValue)})` : ''}\n` +
+              `\nMake sure to provide the parameter as ${expectedType}. For example:\n` +
+              `  { params: { ${validParamKey}: ${repeat ? '["value1", "value2"]' : '"value"'} } }\n` +
+              `\nSee: https://nextjs.org/docs/messages/invalid-getstaticpaths-value`
           )
         }
 

--- a/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+++ b/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
@@ -5,10 +5,9 @@ export default function escapePathDelimiters(
 ): string {
   if (typeof segment !== 'string') {
     throw new TypeError(
-      `Expected a string for path segment, but received ${
-        segment === null ? 'null' : typeof segment
+      `Expected a string for path segment, but received ${segment === null ? 'null' : typeof segment
       }. ` +
-        `Ensure all path parameters in getStaticPaths are strings.`
+      `Ensure all path parameters are strings.`
     )
   }
   return segment.replace(

--- a/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+++ b/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
@@ -3,6 +3,14 @@ export default function escapePathDelimiters(
   segment: string,
   escapeEncoded?: boolean
 ): string {
+  if (typeof segment !== 'string') {
+    throw new TypeError(
+      `Expected a string for path segment, but received ${
+        segment === null ? 'null' : typeof segment
+      }. ` +
+        `Ensure all path parameters in getStaticPaths are strings.`
+    )
+  }
   return segment.replace(
     new RegExp(`([/#?]${escapeEncoded ? '|%(2f|23|3f|5c)' : ''})`, 'gi'),
     (char: string) => encodeURIComponent(char)

--- a/test/integration/dynamic-optional-routing/test/index.test.ts
+++ b/test/integration/dynamic-optional-routing/test/index.test.ts
@@ -237,7 +237,7 @@ function runInvalidPagesTests(buildFn) {
 }
 
 describe('Dynamic Optional Routing', () => {
-  ; (process.env.TURBOPACK_BUILD ? describe.skip : describe)(
+  ;(process.env.TURBOPACK_BUILD ? describe.skip : describe)(
     'development mode',
     () => {
       describe('rendering', () => {
@@ -263,34 +263,34 @@ describe('Dynamic Optional Routing', () => {
       })
     }
   )
-    ; (process.env.TURBOPACK_DEV ? describe.skip : describe)(
-      'production mode',
-      () => {
-        beforeAll(async () => {
-          const curConfig = await fs.readFile(nextConfig, 'utf8')
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+    'production mode',
+    () => {
+      beforeAll(async () => {
+        const curConfig = await fs.readFile(nextConfig, 'utf8')
 
-          if (curConfig.includes('target')) {
-            await fs.writeFile(nextConfig, `module.exports = {}`)
-          }
-          await nextBuild(appDir)
+        if (curConfig.includes('target')) {
+          await fs.writeFile(nextConfig, `module.exports = {}`)
+        }
+        await nextBuild(appDir)
 
-          appPort = await findPort()
-          app = await nextStart(appDir, appPort)
-        })
-        afterAll(() => killApp(app))
+        appPort = await findPort()
+        app = await nextStart(appDir, appPort)
+      })
+      afterAll(() => killApp(app))
 
-        runTests()
+      runTests()
 
-        runInvalidPagesTests(async (appDir) => {
-          ; ({ stderr } = await nextBuild(appDir, [], { stderr: true }))
-        })
+      runInvalidPagesTests(async (appDir) => {
+        ;({ stderr } = await nextBuild(appDir, [], { stderr: true }))
+      })
 
-        it('should fail to build when param is not explicitly defined', async () => {
-          const invalidRoute = appDir + 'pages/invalid/[[...slug]].js'
-          try {
-            await fs.outputFile(
-              invalidRoute,
-              `
+      it('should fail to build when param is not explicitly defined', async () => {
+        const invalidRoute = appDir + 'pages/invalid/[[...slug]].js'
+        try {
+          await fs.outputFile(
+            invalidRoute,
+            `
             export async function getStaticPaths() {
               return {
                 paths: [
@@ -310,16 +310,54 @@ describe('Dynamic Optional Routing', () => {
               )
             }
           `,
-              'utf-8'
-            )
-            const { stderr } = await nextBuild(appDir, [], { stderr: true })
-            await expect(stderr).toMatch(
-              'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /invalid/[[...slug]]'
-            )
-          } finally {
-            await fs.unlink(invalidRoute)
-          }
-        })
-      }
-    )
+            'utf-8'
+          )
+          const { stderr } = await nextBuild(appDir, [], { stderr: true })
+          expect(stderr).toContain(
+            'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /invalid/[[...slug]].'
+          )
+          expect(stderr).toContain('Received: undefined')
+        } finally {
+          await fs.unlink(invalidRoute)
+        }
+      })
+
+      it('should fail to build when catch-all param array contains non-string values', async () => {
+        const invalidRoute = appDir + 'pages/invalid/[[...slug]].js'
+        try {
+          await fs.outputFile(
+            invalidRoute,
+            `
+            export async function getStaticPaths() {
+              return {
+                paths: [
+                  { params: { slug: [123] } },
+                ],
+                fallback: false,
+              }
+            }
+
+            export async function getStaticProps({ params }) {
+              return { props: { params } }
+            }
+
+            export default function Index(props) {
+              return (
+                <div>Invalid</div>
+              )
+            }
+          `,
+            'utf-8'
+          )
+          const { stderr } = await nextBuild(appDir, [], { stderr: true })
+          expect(stderr).toContain(
+            'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /invalid/[[...slug]].'
+          )
+          expect(stderr).toContain('Received: an array ([123])')
+        } finally {
+          await fs.unlink(invalidRoute)
+        }
+      })
+    }
+  )
 })

--- a/test/integration/dynamic-optional-routing/test/index.test.ts
+++ b/test/integration/dynamic-optional-routing/test/index.test.ts
@@ -237,7 +237,7 @@ function runInvalidPagesTests(buildFn) {
 }
 
 describe('Dynamic Optional Routing', () => {
-  ;(process.env.TURBOPACK_BUILD ? describe.skip : describe)(
+  ; (process.env.TURBOPACK_BUILD ? describe.skip : describe)(
     'development mode',
     () => {
       describe('rendering', () => {
@@ -263,34 +263,34 @@ describe('Dynamic Optional Routing', () => {
       })
     }
   )
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-    'production mode',
-    () => {
-      beforeAll(async () => {
-        const curConfig = await fs.readFile(nextConfig, 'utf8')
+    ; (process.env.TURBOPACK_DEV ? describe.skip : describe)(
+      'production mode',
+      () => {
+        beforeAll(async () => {
+          const curConfig = await fs.readFile(nextConfig, 'utf8')
 
-        if (curConfig.includes('target')) {
-          await fs.writeFile(nextConfig, `module.exports = {}`)
-        }
-        await nextBuild(appDir)
+          if (curConfig.includes('target')) {
+            await fs.writeFile(nextConfig, `module.exports = {}`)
+          }
+          await nextBuild(appDir)
 
-        appPort = await findPort()
-        app = await nextStart(appDir, appPort)
-      })
-      afterAll(() => killApp(app))
+          appPort = await findPort()
+          app = await nextStart(appDir, appPort)
+        })
+        afterAll(() => killApp(app))
 
-      runTests()
+        runTests()
 
-      runInvalidPagesTests(async (appDir) => {
-        ;({ stderr } = await nextBuild(appDir, [], { stderr: true }))
-      })
+        runInvalidPagesTests(async (appDir) => {
+          ; ({ stderr } = await nextBuild(appDir, [], { stderr: true }))
+        })
 
-      it('should fail to build when param is not explicitly defined', async () => {
-        const invalidRoute = appDir + 'pages/invalid/[[...slug]].js'
-        try {
-          await fs.outputFile(
-            invalidRoute,
-            `
+        it('should fail to build when param is not explicitly defined', async () => {
+          const invalidRoute = appDir + 'pages/invalid/[[...slug]].js'
+          try {
+            await fs.outputFile(
+              invalidRoute,
+              `
             export async function getStaticPaths() {
               return {
                 paths: [
@@ -310,16 +310,16 @@ describe('Dynamic Optional Routing', () => {
               )
             }
           `,
-            'utf-8'
-          )
-          const { stderr } = await nextBuild(appDir, [], { stderr: true })
-          await expect(stderr).toMatch(
-            'A required parameter (slug) was not provided as an array received undefined in getStaticPaths for /invalid/[[...slug]]'
-          )
-        } finally {
-          await fs.unlink(invalidRoute)
-        }
-      })
-    }
-  )
+              'utf-8'
+            )
+            const { stderr } = await nextBuild(appDir, [], { stderr: true })
+            await expect(stderr).toMatch(
+              'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /invalid/[[...slug]]'
+            )
+          } finally {
+            await fs.unlink(invalidRoute)
+          }
+        })
+      }
+    )
 })

--- a/test/integration/prerender-invalid-catchall-params/test/index.test.ts
+++ b/test/integration/prerender-invalid-catchall-params/test/index.test.ts
@@ -6,14 +6,14 @@ import { nextBuild } from 'next-test-utils'
 const appDir = join(__dirname, '..')
 
 describe('Invalid Prerender Catchall Params', () => {
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+  ; (process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
       it('should fail the build', async () => {
         const out = await nextBuild(appDir, [], { stderr: true })
         expect(out.stderr).toMatch(`Build error occurred`)
         expect(out.stderr).toMatch(
-          'A required parameter (slug) was not provided as an array received string in getStaticPaths for /[...slug]'
+          'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /[...slug]'
         )
       })
     }

--- a/test/integration/prerender-invalid-catchall-params/test/index.test.ts
+++ b/test/integration/prerender-invalid-catchall-params/test/index.test.ts
@@ -6,15 +6,16 @@ import { nextBuild } from 'next-test-utils'
 const appDir = join(__dirname, '..')
 
 describe('Invalid Prerender Catchall Params', () => {
-  ; (process.env.TURBOPACK_DEV ? describe.skip : describe)(
+  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
     'production mode',
     () => {
       it('should fail the build', async () => {
         const out = await nextBuild(appDir, [], { stderr: true })
         expect(out.stderr).toMatch(`Build error occurred`)
-        expect(out.stderr).toMatch(
-          'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /[...slug]'
+        expect(out.stderr).toContain(
+          'A required parameter (slug) was not provided as an array of strings in getStaticPaths for /[...slug].'
         )
+        expect(out.stderr).toContain('Received: string ("hello")')
       })
     }
   )


### PR DESCRIPTION
Fixes #41281

## Problem
When `getStaticPaths` receives a non-string parameter, the error message was not helpful:
```
A required parameter (id) was not provided as a string received number
```

## Solution
1. **Enhanced error message** in `static-paths/pages.ts`:
   - Changed from `Error` to `TypeError` for type-related issues
   - Shows the actual value received (when applicable)
   - Provides clear example of correct usage
   - Links to documentation

2. **Added type check** in `escapePathDelimiters`:
   - Validates that segment is a string before calling `.replace()`
   - Provides clear error message pointing to getStaticPaths

## After this fix
```
A required parameter (id) was not provided as a string in getStaticPaths for /posts/[id].
Received: number (123)

Make sure to provide the parameter as a string. For example:
  { params: { id: "value" } }

See: https://nextjs.org/docs/messages/invalid-getstaticpaths-value
```

Made with [Cursor](https://cursor.com)