### PR TITLE
Restore default-enabled Server Function logging

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/logging.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/logging.mdx
@@ -35,17 +35,17 @@ module.exports = {
 
 ### Server Functions
 
-You can enable logging of [Server Function](https://react.dev/reference/rsc/server-functions) invocations during development by setting `logging.serverFunctions` to `true`.
+[Server Function](https://react.dev/reference/rsc/server-functions) invocations are logged by default during development. You can disable this by setting `logging.serverFunctions` to `false`.
 
 ```js filename="next.config.js"
 module.exports = {
   logging: {
-    serverFunctions: true,
+    serverFunctions: false,
   },
 }
 ```
 
-When enabled, the terminal will display each Server Function call with its function name, arguments, and duration:
+When enabled, the terminal displays each Server Function call with its function name, arguments, and duration:
 
 ```bash filename="Terminal"
 POST /

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -306,7 +306,8 @@ export interface LoggingConfig {
   incomingRequests?: boolean | IncomingRequestLoggingConfig
 
   /**
-   * If true, Server Function invocations will be logged.
+   * If false, Server Function invocation logging is disabled.
+   * @default true
    */
   serverFunctions?: boolean
 
@@ -1507,7 +1508,9 @@ export const defaultConfig = Object.freeze({
   httpAgentOptions: {
     keepAlive: true,
   },
-  logging: {},
+  logging: {
+    serverFunctions: true,
+  } satisfies LoggingConfig,
   compiler: {},
   expireTime: process.env.NEXT_PRIVATE_CDN_CONSUMED_SWR_CACHE_CONTROL
     ? undefined

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -393,10 +393,12 @@ function assignDefaultsAndValidate(
     if (!('browserToTerminal' in loggingConfig)) {
       const expConfig = result.experimental.browserDebugInfoInTerminal
       // Convert object config to simple format (level or true)
-      const normalizedValue =
+      const level =
         typeof expConfig === 'object' && expConfig !== null
           ? (expConfig.level ?? true)
           : expConfig
+      // Map 'verbose' to true since browserToTerminal doesn't support 'verbose'
+      const normalizedValue = level === 'verbose' ? true : level
 
       result.logging = {
         ...loggingConfig,

--- a/test/e2e/app-dir/server-action-logging/next.config.js
+++ b/test/e2e/app-dir/server-action-logging/next.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   logging:
-    process.env.NEXT_TEST_SERVER_FUNCTION_LOGGING === 'true'
-      ? { serverFunctions: true }
+    process.env.NEXT_TEST_SERVER_FUNCTION_LOGGING === 'false'
+      ? { serverFunctions: false }
       : undefined,
 }

--- a/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
+++ b/test/e2e/app-dir/server-action-logging/server-action-logging.test.ts
@@ -6,9 +6,6 @@ describe('server-action-logging', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     skipDeployment: true,
     files: __dirname,
-    env: {
-      NEXT_TEST_SERVER_FUNCTION_LOGGING: 'true',
-    },
   })
 
   if (skipped) return
@@ -191,10 +188,13 @@ describe('server-action-logging', () => {
   })
 })
 
-describe('server-action-logging when logging.serverFunctions is not enabled', () => {
+describe('server-action-logging when logging.serverFunctions is disabled', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
     skipDeployment: true,
     files: __dirname,
+    env: {
+      NEXT_TEST_SERVER_FUNCTION_LOGGING: 'false',
+    },
   })
 
   if (skipped) return


### PR DESCRIPTION
Restores Server Function logging to be enabled by default during development, as originally implemented in #88277. The change to opt-in in #89321 was overly conservative. The implicit default in #88277 was an intentional design decision.

Users can still opt out via `next.config.js`:

```js
module.exports = {
  logging: {
    serverFunctions: false,
  },
}
```

For `'use cache'` Server Functions called from the client, the logging still needs more work. We'll disable it for those in a follow-up PR rather than gating the entire feature.

Also fixes a pre-existing error where `'verbose'` from the deprecated `experimental.browserDebugInfoInTerminal` config wasn't properly normalized to `logging.browserToTerminal`. This was now surfaced because the default `logging` value object was not typed as `LoggingConfig`.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
