### PR TITLE
Skip Server Function logging for `'use cache'` functions

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -58,6 +58,7 @@ import {
 } from './manifests-singleton'
 import { isNodeNextRequest, isWebNextRequest } from '../base-http/helpers'
 import { normalizeFilePath } from './segment-explorer-path'
+import { extractInfoFromServerReferenceId } from '../../shared/lib/server-reference-info'
 import type { ServerActionLogInfo } from '../dev/server-action-logger'
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { synchronizeMutableCookies } from '../async-storage/request-store'
@@ -1086,9 +1087,13 @@ export async function handleAction({
 
         // Log server action call in development when enabled
         let logInfo: ServerActionLogInfo | null = null
+        const { type: actionType } = extractInfoFromServerReferenceId(actionId!)
         if (
           process.env.NODE_ENV === 'development' &&
-          ctx.renderOpts.logServerFunctions
+          ctx.renderOpts.logServerFunctions &&
+          // TODO: For now, skip logging for 'use cache' Server Functions as the
+          // output needs more work, or a different approach entirely.
+          actionType !== 'use-cache'
         ) {
           const serverActionsManifest = getServerActionsManifest()
           const runtime = process.env.NEXT_RUNTIME === 'edge' ? 'edge' : 'node'

--- a/test/e2e/app-dir/use-cache/use-cache.test.ts
+++ b/test/e2e/app-dir/use-cache/use-cache.test.ts
@@ -1419,6 +1419,22 @@ describe('use-cache', () => {
     const numbers = await browser.elementById('numbers').text()
     expect(numbers).toBe(initialNumbers)
   })
+
+  if (isNextDev) {
+    it('should not log "use cache" functions called from client', async () => {
+      const browser = await next.browser('/passed-to-client')
+      const outputIndex = next.cliOutput.length
+
+      await browser.elementByCss('#submit-button').click()
+
+      await retry(() => {
+        const logs = stripAnsi(next.cliOutput.slice(outputIndex))
+        // Should have the POST request but not the function log
+        expect(logs).toContain('POST /passed-to-client')
+        expect(logs).not.toContain('└─ ƒ')
+      })
+    })
+  }
 })
 
 async function getSanitizedLogs(browser: Playwright): Promise<string[]> {


### PR DESCRIPTION
Follow-up to #89407.

Disables Server Function logging for `'use cache'` functions called from the client.

The logging output for these Server Functions needs more work to be useful. Currently it shows internal details like `$$RSC_SERVER_CACHE_0` instead of the actual function name, as well as the encoded bound args promise.