### PR TITLE
[turbopack] Encode task storage directly during persistence (skip clone)

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -63,7 +63,7 @@ use crate::{
         storage::Storage,
         storage_schema::{TaskStorage, TaskStorageAccessors},
     },
-    backing_storage::BackingStorage,
+    backing_storage::{BackingStorage, SnapshotItem},
     data::{
         ActivenessState, CellRef, CollectibleRef, CollectiblesRef, Dirtyness, InProgressCellState,
         InProgressState, InProgressStateInner, OutputValue, TransientTask,
@@ -1110,121 +1110,111 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let task_cache_stats: Mutex<FxHashMap<_, TaskCacheStats>> =
             Mutex::new(FxHashMap::default());
 
-        let preprocess = |task_id: TaskId, inner: &TaskStorage| {
-            if task_id.is_transient() {
-                return (None, None);
-            }
-
-            let meta_restored = inner.flags.meta_restored();
-            let data_restored = inner.flags.data_restored();
-
-            // Encode meta/data directly from TaskStorage
-            let meta = meta_restored.then(|| inner.clone_meta_snapshot());
-            let data = data_restored.then(|| inner.clone_data_snapshot());
-
-            (meta, data)
-        };
-        let process = |task_id: TaskId,
-                       (meta, data): (Option<TaskStorage>, Option<TaskStorage>),
-                       buffer: &mut TurboBincodeBuffer| {
-            #[cfg(feature = "print_cache_item_size")]
-            if let Some(ref m) = meta {
-                task_cache_stats
-                    .lock()
-                    .entry(self.get_task_name(task_id, turbo_tasks))
-                    .or_default()
-                    .add_counts(m);
-            }
-            (
-                task_id,
-                meta.map(|d| encode_task_data(task_id, &d, SpecificTaskDataCategory::Meta, buffer)),
-                data.map(|d| encode_task_data(task_id, &d, SpecificTaskDataCategory::Data, buffer)),
-            )
-        };
-        let process_snapshot =
-            |task_id: TaskId, inner: Box<TaskStorage>, buffer: &mut TurboBincodeBuffer| {
+        // Helper to encode a TaskStorage into a SnapshotItem
+        // encode_meta/encode_data control whether to encode each category
+        let encode_snapshot_item =
+            |task_id: TaskId,
+             inner: &TaskStorage,
+             encode_meta: bool,
+             encode_data: bool,
+             buffer: &mut TurboBincodeBuffer| {
+                let encode_category = |task_id: TaskId,
+                                       data: &TaskStorage,
+                                       category: SpecificTaskDataCategory,
+                                       buffer: &mut TurboBincodeBuffer|
+                 -> Option<TurboBincodeBuffer> {
+                    match encode_task_data(task_id, data, category, buffer) {
+                        Ok(encoded) => {
+                            #[cfg(feature = "print_cache_item_size")]
+                            {
+                                let mut stats = task_cache_stats.lock();
+                                let entry = stats
+                                    .entry(self.get_task_name(task_id, turbo_tasks))
+                                    .or_default();
+                                match category {
+                                    SpecificTaskDataCategory::Meta => entry.add_meta(&encoded),
+                                    SpecificTaskDataCategory::Data => entry.add_data(&encoded),
+                                }
+                            }
+                            Some(encoded)
+                        }
+                        Err(err) => {
+                            eprintln!(
+                                "Serializing task {} failed ({:?}): {:?}",
+                                self.debug_get_task_description(task_id),
+                                category,
+                                err
+                            );
+                            None
+                        }
+                    }
+                };
                 if task_id.is_transient() {
-                    return (task_id, None, None);
+                    return SnapshotItem {
+                        task_id,
+                        data: None,
+                        meta: None,
+                    };
                 }
 
                 #[cfg(feature = "print_cache_item_size")]
-                if inner.flags.meta_modified() {
+                if encode_meta {
                     task_cache_stats
                         .lock()
                         .entry(self.get_task_name(task_id, turbo_tasks))
                         .or_default()
-                        .add_counts(&inner);
+                        .add_counts(inner);
                 }
 
-                // Encode meta/data directly from TaskStorage snapshot
-                (
+                let meta = if encode_meta {
+                    encode_category(task_id, inner, SpecificTaskDataCategory::Meta, buffer)
+                } else {
+                    None
+                };
+
+                let data = if encode_data {
+                    encode_category(task_id, inner, SpecificTaskDataCategory::Data, buffer)
+                } else {
+                    None
+                };
+
+                SnapshotItem {
                     task_id,
-                    inner.flags.meta_modified().then(|| {
-                        encode_task_data(task_id, &inner, SpecificTaskDataCategory::Meta, buffer)
-                    }),
-                    inner.flags.data_modified().then(|| {
-                        encode_task_data(task_id, &inner, SpecificTaskDataCategory::Data, buffer)
-                    }),
+                    meta,
+                    data,
+                }
+            };
+
+        // Process tasks from the main storage map (uses restored flags)
+        let process = |task_id: TaskId, inner: &TaskStorage, buffer: &mut TurboBincodeBuffer| {
+            encode_snapshot_item(
+                task_id,
+                inner,
+                inner.flags.meta_restored(),
+                inner.flags.data_restored(),
+                buffer,
+            )
+        };
+
+        // Process tasks that were accessed during snapshot mode (uses modified flags)
+        let process_snapshot =
+            |task_id: TaskId, inner: Box<TaskStorage>, buffer: &mut TurboBincodeBuffer| {
+                encode_snapshot_item(
+                    task_id,
+                    &inner,
+                    inner.flags.meta_modified(),
+                    inner.flags.data_modified(),
+                    buffer,
                 )
             };
 
-        let snapshot = self
-            .storage
-            .take_snapshot(&preprocess, &process, &process_snapshot);
+        let snapshot = self.storage.take_snapshot(&process, &process_snapshot);
 
         let task_snapshots = snapshot
             .into_iter()
             .filter_map(|iter| {
                 let mut iter = iter
-                    .filter_map(
-                        |(task_id, meta, data): (
-                            _,
-                            Option<Result<SmallVec<_>>>,
-                            Option<Result<SmallVec<_>>>,
-                        )| {
-                            let meta = match meta {
-                                Some(Ok(meta)) => {
-                                    #[cfg(feature = "print_cache_item_size")]
-                                    task_cache_stats
-                                        .lock()
-                                        .entry(self.get_task_name(task_id, turbo_tasks))
-                                        .or_default()
-                                        .add_meta(&meta);
-                                    Some(meta)
-                                }
-                                None => None,
-                                Some(Err(err)) => {
-                                    println!(
-                                        "Serializing task {} failed (meta): {:?}",
-                                        self.debug_get_task_description(task_id),
-                                        err
-                                    );
-                                    None
-                                }
-                            };
-                            let data = match data {
-                                Some(Ok(data)) => {
-                                    #[cfg(feature = "print_cache_item_size")]
-                                    task_cache_stats
-                                        .lock()
-                                        .entry(self.get_task_name(task_id, turbo_tasks))
-                                        .or_default()
-                                        .add_data(&data);
-                                    Some(data)
-                                }
-                                None => None,
-                                Some(Err(err)) => {
-                                    println!(
-                                        "Serializing task {} failed (data): {:?}",
-                                        self.debug_get_task_description(task_id),
-                                        err
-                                    );
-                                    None
-                                }
-                            };
-                            (meta.is_some() || data.is_some()).then_some((task_id, meta, data))
-                        },
-                    )
+                    .filter_map(|item: SnapshotItem| (!item.is_empty()).then_some(item))
                     .peekable();
                 iter.peek().is_some().then_some(iter)
             })

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -105,23 +105,22 @@ impl Storage {
 
     /// Processes every modified item (resp. a snapshot of it) with the given functions and returns
     /// the results. Ends snapshot mode afterwards.
-    /// preprocess is potentially called within a lock, so it should be fast.
-    /// process is called outside of locks, so it could do more expensive operations.
-    /// Both process and process_snapshot receive a mutable scratch buffer that can be reused
-    /// across iterations to avoid repeated allocations.
+    /// process is called while holding a read lock on the task storage, so it can access
+    /// the TaskStorage directly without cloning.
+    /// process_snapshot is called for tasks that were accessed during snapshot mode and
+    /// receives an owned Box<TaskStorage> snapshot.
+    /// Both callbacks receive a mutable scratch buffer that can be reused across iterations
+    /// to avoid repeated allocations.
     pub fn take_snapshot<
         'l,
-        T,
         R,
-        PP: for<'a> Fn(TaskId, &'a TaskStorage) -> T + Sync,
-        P: Fn(TaskId, T, &mut TurboBincodeBuffer) -> R + Sync,
+        P: for<'a> Fn(TaskId, &'a TaskStorage, &mut TurboBincodeBuffer) -> R + Sync,
         PS: Fn(TaskId, Box<TaskStorage>, &mut TurboBincodeBuffer) -> R + Sync,
     >(
         &'l self,
-        preprocess: &'l PP,
         process: &'l P,
         process_snapshot: &'l PS,
-    ) -> Vec<SnapshotShard<'l, PP, P, PS>> {
+    ) -> Vec<SnapshotShard<'l, P, PS>> {
         if !self.snapshot_mode() {
             self.start_snapshot();
         }
@@ -165,7 +164,6 @@ impl Storage {
                 storage: self,
                 guard: Some(guard.clone()),
                 process,
-                preprocess,
                 process_snapshot,
                 scratch_buffer: TurboBincodeBuffer::with_capacity(SCRATCH_BUFFER_SIZE),
             }
@@ -379,22 +377,20 @@ impl Drop for SnapshotGuard<'_> {
     }
 }
 
-pub struct SnapshotShard<'l, PP, P, PS> {
+pub struct SnapshotShard<'l, P, PS> {
     direct_snapshots: Vec<(TaskId, Box<TaskStorage>)>,
     modified: SmallVec<[TaskId; 4]>,
     storage: &'l Storage,
     guard: Option<Arc<SnapshotGuard<'l>>>,
     process: &'l P,
-    preprocess: &'l PP,
     process_snapshot: &'l PS,
     /// Scratch buffer for encoding task data, reused across iterations to avoid allocations
     scratch_buffer: TurboBincodeBuffer,
 }
 
-impl<'l, T, R, PP, P, PS> Iterator for SnapshotShard<'l, PP, P, PS>
+impl<'l, R, P, PS> Iterator for SnapshotShard<'l, P, PS>
 where
-    PP: for<'a> Fn(TaskId, &'a TaskStorage) -> T + Sync,
-    P: Fn(TaskId, T, &mut TurboBincodeBuffer) -> R + Sync,
+    P: for<'a> Fn(TaskId, &'a TaskStorage, &mut TurboBincodeBuffer) -> R + Sync,
     PS: Fn(TaskId, Box<TaskStorage>, &mut TurboBincodeBuffer) -> R + Sync,
 {
     type Item = R;
@@ -410,13 +406,7 @@ where
         while let Some(task_id) = self.modified.pop() {
             let inner = self.storage.map.get(&task_id).unwrap();
             if !inner.flags.any_snapshot() {
-                let preprocessed = (self.preprocess)(task_id, &inner);
-                drop(inner);
-                return Some((self.process)(
-                    task_id,
-                    preprocessed,
-                    &mut self.scratch_buffer,
-                ));
+                return Some((self.process)(task_id, &inner, &mut self.scratch_buffer));
             } else {
                 drop(inner);
                 let maybe_snapshot = {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -524,14 +524,6 @@ impl TaskStorage {
         }
     }
 
-    /// Clone only the fields for the specified category
-    pub fn clone_category_snapshot(&self, category: SpecificTaskDataCategory) -> TaskStorage {
-        match category {
-            SpecificTaskDataCategory::Meta => self.clone_meta_snapshot(),
-            SpecificTaskDataCategory::Data => self.clone_data_snapshot(),
-        }
-    }
-
     /// Initialize a transient task with the given root type and activeness tracking.
     ///
     /// This sets up the activeness state for root/once tasks.

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -2,13 +2,25 @@ use std::{any::type_name, sync::Arc};
 
 use anyhow::Result;
 use either::Either;
-use smallvec::SmallVec;
+use turbo_bincode::TurboBincodeBuffer;
 use turbo_tasks::{TaskId, backend::CachedTaskType};
 
 use crate::{
     backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
     utils::chunked_vec::ChunkedVec,
 };
+
+pub struct SnapshotItem {
+    pub task_id: TaskId,
+    pub data: Option<TurboBincodeBuffer>,
+    pub meta: Option<TurboBincodeBuffer>,
+}
+
+impl SnapshotItem {
+    pub fn is_empty(&self) -> bool {
+        self.meta.is_none() && self.data.is_none()
+    }
+}
 
 /// Represents types accepted by [`TurboTasksBackend::new`]. Typically this is the value returned by
 /// [`default_backing_storage`] or [`noop_backing_storage`].
@@ -51,14 +63,7 @@ pub trait BackingStorageSealed: 'static + Send + Sync {
         snapshots: Vec<I>,
     ) -> Result<()>
     where
-        I: Iterator<
-                Item = (
-                    TaskId,
-                    Option<SmallVec<[u8; 16]>>,
-                    Option<SmallVec<[u8; 16]>>,
-                ),
-            > + Send
-            + Sync;
+        I: Iterator<Item = SnapshotItem> + Send + Sync;
     fn start_read_transaction(&self) -> Option<Self::ReadTransaction<'_>>;
     /// Returns all task IDs that match the given task type (hash collision candidates).
     ///
@@ -134,14 +139,7 @@ where
         snapshots: Vec<I>,
     ) -> Result<()>
     where
-        I: Iterator<
-                Item = (
-                    TaskId,
-                    Option<SmallVec<[u8; 16]>>,
-                    Option<SmallVec<[u8; 16]>>,
-                ),
-            > + Send
-            + Sync,
+        I: Iterator<Item = SnapshotItem> + Send + Sync,
     {
         either::for_both!(self, this => this.save_snapshot(
             operations,

--- a/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backing_storage.rs
@@ -2,6 +2,7 @@ use std::{any::type_name, sync::Arc};
 
 use anyhow::Result;
 use either::Either;
+use smallvec::SmallVec;
 use turbo_bincode::TurboBincodeBuffer;
 use turbo_tasks::{TaskId, backend::CachedTaskType};
 

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -7,9 +7,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use smallvec::SmallVec;
-use turbo_bincode::{
-    TurboBincodeBuffer, new_turbo_bincode_decoder, turbo_bincode_decode, turbo_bincode_encode,
-};
+use turbo_bincode::{new_turbo_bincode_decoder, turbo_bincode_decode, turbo_bincode_encode};
 use turbo_tasks::{
     TaskId,
     backend::CachedTaskType,

--- a/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/kv_backing_storage.rs
@@ -21,7 +21,7 @@ use turbo_tasks_hash::Xxh3Hash64Hasher;
 use crate::{
     GitVersionInfo,
     backend::{AnyOperation, SpecificTaskDataCategory, storage_schema::TaskStorage},
-    backing_storage::{BackingStorage, BackingStorageSealed},
+    backing_storage::{BackingStorage, BackingStorageSealed, SnapshotItem},
     database::{
         db_invalidation::{StartupCacheState, check_db_invalidation_and_cleanup, invalidate_db},
         db_versioning::handle_db_versioning,
@@ -258,14 +258,7 @@ impl<T: KeyValueDatabase + Send + Sync + 'static> BackingStorageSealed
         snapshots: Vec<I>,
     ) -> Result<()>
     where
-        I: Iterator<
-                Item = (
-                    TaskId,
-                    Option<TurboBincodeBuffer>,
-                    Option<TurboBincodeBuffer>,
-                ),
-            > + Send
-            + Sync,
+        I: Iterator<Item = SnapshotItem> + Send + Sync,
     {
         let _span = tracing::info_span!("save snapshot", operations = operations.len()).entered();
         let mut batch = self.inner.database.write_batch()?;
@@ -607,18 +600,16 @@ fn process_task_data<'a, B: ConcurrentWriteBatch<'a> + Send + Sync, I>(
     batch: Option<&B>,
 ) -> Result<SerializedTasks>
 where
-    I: Iterator<
-            Item = (
-                TaskId,
-                Option<TurboBincodeBuffer>,
-                Option<TurboBincodeBuffer>,
-            ),
-        > + Send
-        + Sync,
+    I: Iterator<Item = SnapshotItem> + Send + Sync,
 {
     parallel::map_collect_owned::<_, _, Result<Vec<_>>>(tasks, |tasks| {
         let mut result = Vec::new();
-        for (task_id, meta, data) in tasks {
+        for SnapshotItem {
+            task_id,
+            meta,
+            data,
+        } in tasks
+        {
             if let Some(batch) = batch {
                 let key = IntKey::new(*task_id);
                 let key = key.as_ref();

--- a/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/task_storage_macro.rs
@@ -3111,25 +3111,6 @@ fn generate_snapshot_restore_methods(grouped_fields: &GroupedFields) -> TokenStr
     let restore_meta_inline = gen_restore_inline_for_category(grouped_fields, Category::Meta);
     let restore_data_inline = gen_restore_inline_for_category(grouped_fields, Category::Data);
 
-    // Generate flags handling for clone - per category
-    let clone_meta_flags = if has_meta_flags {
-        quote! {
-            // Clone persisted meta flags
-            snapshot.flags.set_persisted_meta_bits(self.flags.persisted_meta_bits());
-        }
-    } else {
-        quote! {}
-    };
-
-    let clone_data_flags = if has_data_flags {
-        quote! {
-            // Clone persisted data flags
-            snapshot.flags.set_persisted_data_bits(self.flags.persisted_data_bits());
-        }
-    } else {
-        quote! {}
-    };
-
     let clone_all_flags = if has_any_flags {
         quote! {
             // Clone all persisted flags
@@ -3170,11 +3151,7 @@ fn generate_snapshot_restore_methods(grouped_fields: &GroupedFields) -> TokenStr
     quote! {
         #[automatically_derived]
         impl TaskStorage {
-            /// Create a snapshot containing all persistent fields (both meta and data).
-            ///
-            /// This clones all persistent fields into a new TaskStorage, skipping
-            /// transient fields that may not be cloneable. Use this for the `Both`
-            /// snapshot case where both meta and data are dirty.
+            /// Create a snapshot containing all persistent fields
             pub fn clone_snapshot(&self) -> TaskStorage {
                 let mut snapshot = TaskStorage::new();
 
@@ -3186,60 +3163,15 @@ fn generate_snapshot_restore_methods(grouped_fields: &GroupedFields) -> TokenStr
 
                 #clone_all_flags
 
+                // Pre-allocate lazy vec (upper bound - some may be transient and skipped)
+                snapshot.lazy.reserve(self.lazy.len());
+
                 // Clone all persistent lazy fields (both meta and data)
                 for field in &self.lazy {
                     match field {
                         #(#clone_data_lazy_arms)*
                         #(#clone_meta_lazy_arms)*
                         // Skip transient fields
-                        _ => {}
-                    }
-                }
-
-                snapshot
-            }
-
-            /// Create a snapshot containing only meta category fields for serialization.
-            ///
-            /// This clones only the persistent meta fields into a new TaskStorage,
-            /// which can then be serialized outside the lock.
-            pub fn clone_meta_snapshot(&self) -> TaskStorage {
-                let mut snapshot = TaskStorage::new();
-
-                // Clone inline meta fields
-                #(#clone_meta_inline)*
-
-                #clone_meta_flags
-
-                // Clone lazy meta fields (only persistent ones)
-                for field in &self.lazy {
-                    match field {
-                        #(#clone_meta_lazy_arms)*
-                        // Skip transient and data fields
-                        _ => {}
-                    }
-                }
-
-                snapshot
-            }
-
-            /// Create a snapshot containing only data category fields for serialization.
-            ///
-            /// This clones only the persistent data fields into a new TaskStorage,
-            /// which can then be serialized outside the lock.
-            pub fn clone_data_snapshot(&self) -> TaskStorage {
-                let mut snapshot = TaskStorage::new();
-
-                // Clone inline data fields
-                #(#clone_data_inline)*
-
-                #clone_data_flags
-
-                // Clone lazy data fields (only persistent ones)
-                for field in &self.lazy {
-                    match field {
-                        #(#clone_data_lazy_arms)*
-                        // Skip transient and meta fields
                         _ => {}
                     }
                 }


### PR DESCRIPTION
# Don't clone TaskStorage objects when snapshotting the database

## What

Instead of cloning `TaskStorage` objects when preparing to snapshot, we directly encode from a reference to the `TaskStorage` in the backend storage map.

## Why

From a performance profile of `save_snapshot`, I observed that ~22% of the time was spent in `clone_meta_snapshot` or `clone_data_snapshot`, while ~28% of the time was spent in `encode_task_data`. The whole reason we are cloning is so we can drop the lock on the dashmap shard while encoding. In principle this makes sense, however:

* We are only holding *read* locks on the dashmap, so we don't block other encoding threads
* Holding the read locks for slightly longer will just slow down racing writing threads, but those are rare and already incur a high cost due to the extra cloning in `track_modification`. So slowing them down isn't too risky.

## Perf

On a vercel-site cold build i don't actually see a real change in persistence time


Before: 6.6s 7.8s 7.1s
After: 6.9s 6.6s 7.2s

So we are saving cpu time and allocations from this change but the overall task is bound on IO, so we should really only expect a win on more CPU constrained systems.