### PR TITLE
fix(next): improve getStaticPaths error message for non-string params

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -986,5 +986,8 @@
   "985": "No response is returned from route handler '%s'. Expected a Response object but received '%s' (method: %s, url: %s). Ensure you return a \\`Response\\` or a \\`NextResponse\\` in all branches of your handler.",
   "986": "Server Action arguments list is too long (%s). Maximum allowed is %s.",
   "987": "Invalid \\`deploymentId\\` configuration: must be a string. See https://nextjs.org/docs/messages/deploymentid-not-a-string",
-  "988": "Invalid \\`deploymentId\\` configuration: contains invalid characters. Only alphanumeric characters, hyphens, and underscores are allowed. See https://nextjs.org/docs/messages/deploymentid-invalid-characters"
+  "988": "Invalid \\`deploymentId\\` configuration: contains invalid characters. Only alphanumeric characters, hyphens, and underscores are allowed. See https://nextjs.org/docs/messages/deploymentid-invalid-characters",
+  "989": "A required parameter (%s) contains a non-string value in the array. All values must be strings, received %s (%s) in getStaticPaths for %s",
+  "990": "A path segment must be a string, received %s (%s). This typically happens when a non-string value is passed to getStaticPaths. Make sure all path parameters are strings.",
+  "991": "A required parameter (%s) contains a non-string value in the array. All values must be strings, received %s (%s) in generateStaticParams for %s"
 }

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -374,6 +374,17 @@ function validateParams(
             `A required parameter (${key}) was not provided as an array received ${typeof paramValue} in generateStaticParams for ${page}`
           )
         }
+
+        // Ensure all array elements are strings
+        const invalidElement = paramValue.find(
+          (element) => typeof element !== 'string'
+        )
+        if (invalidElement !== undefined) {
+          throw new Error(
+            `A required parameter (${key}) contains a non-string value in the array. ` +
+              `All values must be strings, received ${typeof invalidElement} (${JSON.stringify(invalidElement)}) in generateStaticParams for ${page}`
+          )
+        }
       } else {
         if (typeof paramValue !== 'string') {
           throw new Error(

--- a/packages/next/src/build/static-paths/pages.ts
+++ b/packages/next/src/build/static-paths/pages.ts
@@ -174,6 +174,19 @@ export async function buildPagesStaticPaths({
           )
         }
 
+        // For catch-all routes, ensure all array elements are strings
+        if (repeat && Array.isArray(paramValue)) {
+          const invalidElement = paramValue.find(
+            (element) => typeof element !== 'string'
+          )
+          if (invalidElement !== undefined) {
+            throw new Error(
+              `A required parameter (${validParamKey}) contains a non-string value in the array. ` +
+                `All values must be strings, received ${typeof invalidElement} (${JSON.stringify(invalidElement)}) in getStaticPaths for ${page}`
+            )
+          }
+        }
+
         let replaced = `[${repeat ? '...' : ''}${validParamKey}]`
         if (optional) {
           replaced = `[${replaced}]`

--- a/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
+++ b/packages/next/src/shared/lib/router/utils/escape-path-delimiters.ts
@@ -3,6 +3,14 @@ export default function escapePathDelimiters(
   segment: string,
   escapeEncoded?: boolean
 ): string {
+  if (typeof segment !== 'string') {
+    throw new Error(
+      `A path segment must be a string, received ${typeof segment} (${JSON.stringify(segment)}). ` +
+        `This typically happens when a non-string value is passed to getStaticPaths. ` +
+        `Make sure all path parameters are strings.`
+    )
+  }
+
   return segment.replace(
     new RegExp(`([/#?]${escapeEncoded ? '|%(2f|23|3f|5c)' : ''})`, 'gi'),
     (char: string) => encodeURIComponent(char)

--- a/test/unit/escape-path-delimiters.test.ts
+++ b/test/unit/escape-path-delimiters.test.ts
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+import escapePathDelimiters from 'next/dist/shared/lib/router/utils/escape-path-delimiters'
+
+describe('escapePathDelimiters', () => {
+  describe('valid string inputs', () => {
+    it('should escape forward slashes', () => {
+      expect(escapePathDelimiters('foo/bar')).toBe('foo%2Fbar')
+    })
+
+    it('should escape hash characters', () => {
+      expect(escapePathDelimiters('foo#bar')).toBe('foo%23bar')
+    })
+
+    it('should escape question marks', () => {
+      expect(escapePathDelimiters('foo?bar')).toBe('foo%3Fbar')
+    })
+
+    it('should return unchanged string without delimiters', () => {
+      expect(escapePathDelimiters('foobar')).toBe('foobar')
+    })
+
+    it('should handle empty string', () => {
+      expect(escapePathDelimiters('')).toBe('')
+    })
+
+    it('should escape encoded characters when escapeEncoded is true', () => {
+      expect(escapePathDelimiters('%2f', true)).toBe('%252f')
+      expect(escapePathDelimiters('%23', true)).toBe('%2523')
+      expect(escapePathDelimiters('%3f', true)).toBe('%253f')
+    })
+  })
+
+  describe('invalid non-string inputs', () => {
+    it('should throw an error when passed a number', () => {
+      expect(() => {
+        // @ts-expect-error testing invalid input
+        escapePathDelimiters(123)
+      }).toThrow(/A path segment must be a string, received number \(123\)/)
+    })
+
+    it('should throw an error when passed an object', () => {
+      expect(() => {
+        // @ts-expect-error testing invalid input
+        escapePathDelimiters({ foo: 'bar' })
+      }).toThrow(/A path segment must be a string, received object/)
+    })
+
+    it('should throw an error when passed null', () => {
+      expect(() => {
+        escapePathDelimiters(null as unknown as string)
+      }).toThrow(/A path segment must be a string, received object \(null\)/)
+    })
+
+    it('should throw an error when passed undefined', () => {
+      expect(() => {
+        escapePathDelimiters(undefined as unknown as string)
+      }).toThrow(/A path segment must be a string, received undefined/)
+    })
+
+    it('should throw an error when passed an array', () => {
+      expect(() => {
+        // @ts-expect-error testing invalid input
+        escapePathDelimiters(['foo', 'bar'])
+      }).toThrow(/A path segment must be a string, received object/)
+    })
+
+    it('should include helpful message about getStaticPaths', () => {
+      expect(() => {
+        // @ts-expect-error testing invalid input
+        escapePathDelimiters(42)
+      }).toThrow(
+        /This typically happens when a non-string value is passed to getStaticPaths/
+      )
+    })
+  })
+})


### PR DESCRIPTION
## What?

Improve error messages when non-string values are passed to `getStaticPaths` or `generateStaticParams`.

## Why?

When developers accidentally pass non-string values (e.g., numbers) to path parameters, the current error message is cryptic:
```
TypeError: segment.replace is not a function
```

This makes debugging difficult, especially for beginners.

## How?

1. Added type validation in `escapePathDelimiters()` function to check if the segment is a string
2. Added array element validation in `pages.ts` for catch-all routes (`[...slug]`)
3. Added the same validation in `app.ts` for `generateStaticParams`

Now the error message is clear:
```
A path segment must be a string, received number (123).
This typically happens when a non-string value is passed to getStaticPaths.
Make sure all path parameters are strings.
```

## Testing

- [x] Added unit tests for `escapePathDelimiters` with invalid inputs
- [x] Ran existing unit tests (`pnpm test-unit`)
- [x] Ran lint and prettier checks

fixes #41281