### PR TITLE
Docs: clarify using transitions when invoking server functions from event handlers

### DIFF
--- a/docs/01-app/01-getting-started/08-updating-data.mdx
+++ b/docs/01-app/01-getting-started/08-updating-data.mdx
@@ -274,56 +274,6 @@ export default function LikeButton({ initialLikes }: { initialLikes: number }) {
 > updates after the `await` are not part of the transition.
 > See the React documentation for details.
 
-```tsx filename="app/like-button.tsx" switcher
-'use client'
-
-import { incrementLike } from './actions'
-import { useState } from 'react'
-
-export default function LikeButton({ initialLikes }: { initialLikes: number }) {
-  const [likes, setLikes] = useState(initialLikes)
-
-  return (
-    <>
-      <p>Total Likes: {likes}</p>
-      <button
-        onClick={async () => {
-          const updatedLikes = await incrementLike()
-          setLikes(updatedLikes)
-        }}
-      >
-        Like
-      </button>
-    </>
-  )
-}
-```
-
-```jsx filename="app/like-button.js" switcher
-'use client'
-
-import { incrementLike } from './actions'
-import { useState } from 'react'
-
-export default function LikeButton({ initialLikes }) {
-  const [likes, setLikes] = useState(initialLikes)
-
-  return (
-    <>
-      <p>Total Likes: {likes}</p>
-      <button
-        onClick={async () => {
-          const updatedLikes = await incrementLike()
-          setLikes(updatedLikes)
-        }}
-      >
-        Like
-      </button>
-    </>
-  )
-}
-```
-
 ## Examples
 
 ### Showing a pending state

--- a/docs/01-app/01-getting-started/08-updating-data.mdx
+++ b/docs/01-app/01-getting-started/08-updating-data.mdx
@@ -236,6 +236,9 @@ export async function createPost(formData) {
 
 ### Event Handlers
 
+> **Good to know**:
+> When invoking Server Functions from Client Components outside of form actions (for example, in event handlers or effects), wrap the call in a React transition such as [`useTransition`](https://react.dev/reference/react/useTransition) to avoid blocking rendering and to ensure consistent UI updates.
+
 You can invoke a Server Function in a Client Component by using event handlers such as `onClick`.
 
 ```tsx filename="app/like-button.tsx" switcher

--- a/docs/01-app/01-getting-started/08-updating-data.mdx
+++ b/docs/01-app/01-getting-started/08-updating-data.mdx
@@ -236,10 +236,43 @@ export async function createPost(formData) {
 
 ### Event Handlers
 
-> **Good to know**:
-> When invoking Server Functions from Client Components outside of form actions (for example, in event handlers or effects), wrap the call in a React transition such as [`useTransition`](https://react.dev/reference/react/useTransition) to avoid blocking rendering and to ensure consistent UI updates.
+You can invoke a Server Function from event handlers like `onClick`. While calling a
+Server Function directly works, wrapping the call in a React transition integrates it
+with React’s rendering cycle—giving you access to pending states and ensuring consistent
+UI updates.
 
-You can invoke a Server Function in a Client Component by using event handlers such as `onClick`.
+```tsx filename="app/like-button.tsx" switcher
+'use client'
+
+import { incrementLike } from './actions'
+import { useState, useTransition } from 'react'
+
+export default function LikeButton({ initialLikes }: { initialLikes: number }) {
+  const [likes, setLikes] = useState(initialLikes)
+  const [isPending, startTransition] = useTransition()
+
+  return (
+    <>
+      <p>Total Likes: {likes}</p>
+      <button
+        onClick={() => {
+          startTransition(async () => {
+            const updatedLikes = await incrementLike()
+            setLikes(updatedLikes)
+          })
+        }}
+      >
+        {isPending ? 'Updating...' : 'Like'}
+      </button>
+    </>
+  )
+}
+```
+
+> **Note**: After an `await` inside `startTransition`, React does not preserve the
+> transition context. The `isPending` flag still reflects the async work, but state
+> updates after the `await` are not part of the transition.
+> See the React documentation for details.
 
 ```tsx filename="app/like-button.tsx" switcher
 'use client'
@@ -477,7 +510,11 @@ export async function exampleAction() {
 
 ### useEffect
 
-You can use the React [`useEffect`](https://react.dev/reference/react/useEffect) hook to invoke a Server Action when the component mounts or a dependency changes. This is useful for mutations that depend on global events or need to be triggered automatically. For example, `onKeyDown` for app shortcuts, an intersection observer hook for infinite scrolling, or when the component mounts to update a view count:
+You can use the React [`useEffect`](https://react.dev/reference/react/useEffect) hook to invoke a Server Action when the component mounts or a dependency changes. This is useful for mutations that depend on global events or need to be triggered automatically. For example, `onKeyDown` for app shortcuts, an intersection observer hook for infinite scrolling, or when the component mounts to update a view count.
+
+When invoking a Server Function from `useEffect`, wrapping the call in a React
+transition integrates the update with React’s rendering cycle and allows you to
+track pending state during the async work.
 
 ```tsx filename="app/view-count.tsx" switcher
 'use client'
@@ -500,6 +537,10 @@ export default function ViewCount({ initialViews }: { initialViews: number }) {
   return <p>Total Views: {views}</p>
 }
 ```
+
+> **Note**: After an `await` inside `startTransition`, React does not preserve the
+> transition context. The pending state still reflects the async work, but state
+> updates after the `await` are not part of the transition.
 
 ```jsx filename="app/view-count.js" switcher
 'use client'


### PR DESCRIPTION
### What?

Clarifies that Server Functions invoked from Client Components outside of form actions (for example, in event handlers) should be wrapped in a React transition.

### Why?

This behavior is implicit today and can be confusing when invoking Server Functions directly from event handlers. Adding a short note helps set expectations and avoid blocking rendering.

### How?

Added a “Good to know” note to the Event Handlers section of the Updating Data guide.

Fixes #89430
