### PR TITLE
docs: add documentation for no-typos ESLint rule

### DIFF
--- a/errors/no-typos.mdx
+++ b/errors/no-typos.mdx
@@ -1,0 +1,54 @@
+---
+title: No typos in Next.js data fetching functions
+---
+
+> Prevent common typos in Next.js data fetching functions.
+
+## Why This Error Occurred
+
+A possible typo was detected in a Next.js data fetching function name. This rule checks for typos in:
+
+- `getStaticProps`
+- `getStaticPaths`
+- `getServerSideProps`
+
+Typos in these function names will cause them to not be recognized by Next.js, resulting in unexpected behavior where your data fetching logic won't execute.
+
+## Possible Ways to Fix It
+
+Check the spelling of your exported function and make sure it matches one of the Next.js data fetching functions exactly.
+
+**Before:**
+
+```jsx filename="pages/index.js"
+// Typo: "getStaticProp" instead of "getStaticProps"
+export async function getStaticProp() {
+  return {
+    props: {},
+  }
+}
+```
+
+**After:**
+
+```jsx filename="pages/index.js"
+// Correct spelling
+export async function getStaticProps() {
+  return {
+    props: {},
+  }
+}
+```
+
+### Common Typos
+
+- `getStaticProp` → `getStaticProps`
+- `getStaticPath` → `getStaticPaths`
+- `getServerSideProp` → `getServerSideProps`
+- `getServerSideProps` with incorrect casing
+
+## Useful Links
+
+- [getStaticProps Documentation](/docs/pages/building-your-application/data-fetching/get-static-props)
+- [getStaticPaths Documentation](/docs/pages/building-your-application/data-fetching/get-static-paths)
+- [getServerSideProps Documentation](/docs/pages/building-your-application/data-fetching/get-server-side-props)


### PR DESCRIPTION
## Summary
Added missing documentation for the `@next/next/no-typos` ESLint rule.

## Problem
The `no-typos` rule exists in `@next/eslint-plugin-next` but has no documentation page in the errors directory, causing broken links when users click on the rule in ESLint config inspectors.

## Solution
Created `errors/no-typos.mdx` documenting:
- What the rule does (detects typos in data fetching functions)
- Which functions it checks (`getStaticProps`, `getStaticPaths`, `getServerSideProps`)
- Common typo examples
- Links to relevant documentation

Fixes #67342