### PR TITLE
[CC] Rename "unstable_prefetch" to "unstable_instant"

### DIFF
--- a/errors/invalid-instant-configuration.mdx
+++ b/errors/invalid-instant-configuration.mdx
@@ -12,7 +12,7 @@ You provided an invalid configuration for `export const unstable_instant` in a L
 
 ```tsx filename="app/.../layout.tsx"
 export const unstable_instant = {
-  mode: 'static',
+  prefetch: 'static',
 }
 ```
 
@@ -20,7 +20,7 @@ export const unstable_instant = {
 
 ```tsx filename="app/[slug]/page.tsx"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [
     {
       cookies: [{ name: 'experiment', value: 'A' }],

--- a/errors/invalid-instant-configuration.mdx
+++ b/errors/invalid-instant-configuration.mdx
@@ -1,17 +1,17 @@
 ---
-title: Invalid Prefetch Configuration
+title: Invalid Instant Configuration
 ---
 
 ## Why This Message Occurred
 
-You provided an invalid configuration for `export const unstable_prefetch` in a Layout or Page file.
+You provided an invalid configuration for `export const unstable_instant` in a Layout or Page file.
 
 ### Example of Correct Usage
 
 #### Static Prefetching
 
 ```tsx filename="app/.../layout.tsx"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'static',
 }
 ```
@@ -19,7 +19,7 @@ export const unstable_prefetch = {
 #### Runtime Prefetching
 
 ```tsx filename="app/[slug]/page.tsx"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [
     {

--- a/errors/next-prerender-runtime-crypto.mdx
+++ b/errors/next-prerender-runtime-crypto.mdx
@@ -20,7 +20,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -41,7 +41,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -66,7 +66,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -85,7 +85,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -108,7 +108,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -123,7 +123,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 

--- a/errors/next-prerender-runtime-crypto.mdx
+++ b/errors/next-prerender-runtime-crypto.mdx
@@ -19,7 +19,7 @@ If you are generating a token to talk to a database that itself should be cached
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -40,7 +40,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -65,7 +65,7 @@ If you require this random value to be unique per Request and an async version o
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -84,7 +84,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -107,7 +107,7 @@ If you require this random value to be unique per Request and an async version o
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -122,7 +122,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }

--- a/errors/next-prerender-runtime-current-time.mdx
+++ b/errors/next-prerender-runtime-current-time.mdx
@@ -23,7 +23,7 @@ If you are using the current time for performance tracking with elapsed time use
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -42,7 +42,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -67,7 +67,7 @@ If you want to read the time when some cache entry is created (such as when a Ne
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -96,7 +96,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -136,7 +136,7 @@ If you go with this approach you will need to ensure the Client Component which 
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -193,7 +193,7 @@ export function RelativeTime({ when }) {
 ```
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -230,7 +230,7 @@ Next.js enforces that it can always produce at least a partially static initial 
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -249,7 +249,7 @@ export default async function Page() {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }

--- a/errors/next-prerender-runtime-current-time.mdx
+++ b/errors/next-prerender-runtime-current-time.mdx
@@ -24,7 +24,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -43,7 +43,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -68,7 +68,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -97,7 +97,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -137,7 +137,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -194,7 +194,7 @@ export function RelativeTime({ when }) {
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -231,7 +231,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -250,7 +250,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 

--- a/errors/next-prerender-runtime-random.mdx
+++ b/errors/next-prerender-runtime-random.mdx
@@ -24,7 +24,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -41,7 +41,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -69,7 +69,7 @@ Before:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 
@@ -86,7 +86,7 @@ After:
 
 ```jsx filename="app/page.js"
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [...],
 }
 

--- a/errors/next-prerender-runtime-random.mdx
+++ b/errors/next-prerender-runtime-random.mdx
@@ -23,7 +23,7 @@ If your random value is cacheable, move the `Math.random()` call to a `"use cach
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -40,7 +40,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -68,7 +68,7 @@ If you want the random value to be evaluated on each Request precede it with `aw
 Before:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }
@@ -85,7 +85,7 @@ export default async function Page({ params }) {
 After:
 
 ```jsx filename="app/page.js"
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [...],
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -987,5 +987,6 @@
   "986": "Server Action arguments list is too long (%s). Maximum allowed is %s.",
   "987": "Invalid \\`deploymentId\\` configuration: must be a string. See https://nextjs.org/docs/messages/deploymentid-not-a-string",
   "988": "Invalid \\`deploymentId\\` configuration: contains invalid characters. Only alphanumeric characters, hyphens, and underscores are allowed. See https://nextjs.org/docs/messages/deploymentid-invalid-characters",
-  "989": "Loaded static props were from an outdated deployment, forcing a hard reload"
+  "989": "Loaded static props were from an outdated deployment, forcing a hard reload",
+  "990": "Page \"%s\" cannot use \\`export const unstable_instant = ...\\` without enabling \\`cacheComponents\\`."
 }

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -684,9 +684,9 @@ export async function getAppPageStaticInfo({
     )
   }
 
-  if ('unstable_prefetch' in config && !nextConfig.cacheComponents) {
+  if ('unstable_instant' in config && !nextConfig.cacheComponents) {
     throw new Error(
-      `Page "${page}" cannot use \`export const unstable_prefetch = ...\` without enabling \`cacheComponents\`.`
+      `Page "${page}" cannot use \`export const unstable_instant = ...\` without enabling \`cacheComponents\`.`
     )
   }
 

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -21,7 +21,7 @@ const RuntimeSampleSchema = z
   })
   .strict()
 
-const StaticPrefetchSchema = z
+const InstantConfigStaticSchema = z
   .object({
     mode: z.literal('static'),
     from: z.array(z.string()).optional(),
@@ -29,7 +29,7 @@ const StaticPrefetchSchema = z
   })
   .strict()
 
-const RuntimePrefetchSchema = z
+const InstantConfigRuntimeSchema = z
   .object({
     mode: z.literal('runtime'),
     samples: z.array(RuntimeSampleSchema).min(1),
@@ -38,42 +38,48 @@ const RuntimePrefetchSchema = z
   })
   .strict()
 
-const PrefetchSchema = z.discriminatedUnion('mode', [
-  StaticPrefetchSchema,
-  RuntimePrefetchSchema,
+const InstantConfigSchema = z.discriminatedUnion('mode', [
+  InstantConfigStaticSchema,
+  InstantConfigRuntimeSchema,
 ])
 
-export type Prefetch = StaticPrefetch | RuntimePrefetch
-export type PrefetchForTypeCheckInternal = __GenericPrefetch | Prefetch
+export type InstantConfig = InstantConfigStatic | InstantConfigRuntime
+export type InstantConfigForTypeCheckInternal =
+  | __GenericInstantConfig
+  | InstantConfig
 // the __GenericPrefetch type is used to avoid type widening issues with
 // our choice to make exports the medium for programming a Next.js application
 // With exports the type is controlled by the module and all we can do is assert on it
 // from a consumer. However with string literals in objects these are by default typed widely
 // and thus cannot match the discriminated union type. If we figure out a better way we should
 // delete the __GenericPrefetch member.
-interface __GenericPrefetch {
+interface __GenericInstantConfig {
   mode: string
   samples?: Array<WideRuntimeSample>
   from?: string[]
   expectUnableToVerify?: boolean
 }
-interface StaticPrefetch {
+
+interface InstantConfigStatic {
   mode: 'static'
   from?: string[]
   expectUnableToVerify?: boolean
 }
-interface RuntimePrefetch {
+
+interface InstantConfigRuntime {
   mode: 'runtime'
   samples: Array<RuntimeSample>
   from?: string[]
   expectUnableToVerify?: boolean
 }
+
 type WideRuntimeSample = {
   cookies?: RuntimeSample['cookies']
   headers?: Array<string[]>
   params?: RuntimeSample['params']
   searchParams?: RuntimeSample['searchParams']
 }
+
 type RuntimeSample = {
   cookies?: Array<{
     name: string
@@ -127,7 +133,7 @@ const AppSegmentConfigSchema = z.object({
   /**
    * How this segment should be prefetched.
    */
-  unstable_prefetch: PrefetchSchema.optional(),
+  unstable_instant: InstantConfigSchema.optional(),
 
   /**
    * The preferred region for the page.
@@ -166,10 +172,10 @@ export function parseAppSegmentConfig(
               )} on "${route}", must be a non-negative number or false`,
             }
           }
-          case 'unstable_prefetch': {
+          case 'unstable_instant': {
             return {
               // @TODO replace this link with a link to the docs when they are written
-              message: `Invalid unstable_prefetch value ${JSON.stringify(ctx.data)} on "${route}", must be an object with a mode of "static" or "runtime". Read more at https://nextjs.org/docs/messages/invalid-prefetch-configuration`,
+              message: `Invalid unstable_instant value ${JSON.stringify(ctx.data)} on "${route}", must be an object with a mode of "static" or "runtime". Read more at https://nextjs.org/docs/messages/invalid-instant-configuration`,
             }
           }
           default:
@@ -224,7 +230,7 @@ export type AppSegmentConfig = {
   /**
    * How this segment should be prefetched.
    */
-  unstable_prefetch?: Prefetch
+  unstable_instant?: InstantConfig
 
   /**
    * The preferred region for the page.

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -23,7 +23,7 @@ const RuntimeSampleSchema = z
 
 const InstantConfigStaticSchema = z
   .object({
-    mode: z.literal('static'),
+    prefetch: z.literal('static'),
     from: z.array(z.string()).optional(),
     expectUnableToVerify: z.boolean().optional(),
   })
@@ -31,14 +31,14 @@ const InstantConfigStaticSchema = z
 
 const InstantConfigRuntimeSchema = z
   .object({
-    mode: z.literal('runtime'),
+    prefetch: z.literal('runtime'),
     samples: z.array(RuntimeSampleSchema).min(1),
     from: z.array(z.string()).optional(),
     expectUnableToVerify: z.boolean().optional(),
   })
   .strict()
 
-const InstantConfigSchema = z.discriminatedUnion('mode', [
+const InstantConfigSchema = z.discriminatedUnion('prefetch', [
   InstantConfigStaticSchema,
   InstantConfigRuntimeSchema,
 ])
@@ -54,20 +54,20 @@ export type InstantConfigForTypeCheckInternal =
 // and thus cannot match the discriminated union type. If we figure out a better way we should
 // delete the __GenericPrefetch member.
 interface __GenericInstantConfig {
-  mode: string
+  prefetch: string
   samples?: Array<WideRuntimeSample>
   from?: string[]
   expectUnableToVerify?: boolean
 }
 
 interface InstantConfigStatic {
-  mode: 'static'
+  prefetch: 'static'
   from?: string[]
   expectUnableToVerify?: boolean
 }
 
 interface InstantConfigRuntime {
-  mode: 'runtime'
+  prefetch: 'runtime'
   samples: Array<RuntimeSample>
   from?: string[]
   expectUnableToVerify?: boolean
@@ -175,7 +175,7 @@ export function parseAppSegmentConfig(
           case 'unstable_instant': {
             return {
               // @TODO replace this link with a link to the docs when they are written
-              message: `Invalid unstable_instant value ${JSON.stringify(ctx.data)} on "${route}", must be an object with a mode of "static" or "runtime". Read more at https://nextjs.org/docs/messages/invalid-instant-configuration`,
+              message: `Invalid unstable_instant value ${JSON.stringify(ctx.data)} on "${route}", must be an object with \`prefetch: "static"\` or \`prefetch: "runtime"\`. Read more at https://nextjs.org/docs/messages/invalid-instant-configuration`,
             }
           }
           default:

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -54,7 +54,7 @@ ${
     : `import type { ResolvingMetadata, ResolvingViewport } from 'next/dist/lib/metadata/types/metadata-interface.js'`
 }
 
-import type { PrefetchForTypeCheckInternal } from 'next/dist/build/segment-config/app/app-segment-config.js'
+import type { InstantConfigForTypeCheckInternal } from 'next/dist/build/segment-config/app/app-segment-config.js'
 
 type TEntry = typeof import('${relativePath}.js')
 
@@ -71,7 +71,7 @@ checkFields<Diff<{
   }
   config?: {}
   generateStaticParams?: Function
-  unstable_prefetch?: PrefetchForTypeCheckInternal
+  unstable_instant?: InstantConfigForTypeCheckInternal
   revalidate?: RevalidateRange<TEntry> | false
   dynamic?: 'auto' | 'force-dynamic' | 'error' | 'force-static'
   dynamicParams?: boolean

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -229,7 +229,7 @@ async function createComponentTreeInternal(
     ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
     : undefined
   /** Whether this segment should use a runtime prefetch instead of a static prefetch. */
-  const hasRuntimePrefetch = instantConfig?.mode === 'runtime'
+  const hasRuntimePrefetch = instantConfig?.prefetch === 'runtime'
 
   const [Forbidden, forbiddenStyles] =
     authInterrupts && forbidden

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -225,11 +225,11 @@ async function createComponentTreeInternal(
       })
     : []
 
-  const prefetchConfig = layoutOrPageMod
-    ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
+  const instantConfig = layoutOrPageMod
+    ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
     : undefined
   /** Whether this segment should use a runtime prefetch instead of a static prefetch. */
-  const hasRuntimePrefetch = prefetchConfig?.mode === 'runtime'
+  const hasRuntimePrefetch = instantConfig?.mode === 'runtime'
 
   const [Forbidden, forbiddenStyles] =
     authInterrupts && forbidden

--- a/packages/next/src/server/app-render/staged-validation.tsx
+++ b/packages/next/src/server/app-render/staged-validation.tsx
@@ -9,11 +9,11 @@ export async function anySegmentHasRuntimePrefetchEnabled(
   const { mod: layoutOrPageMod } = await getLayoutOrPageModule(tree)
 
   // TODO(restart-on-cache-miss): Does this work correctly for client page/layout modules?
-  const prefetchConfig = layoutOrPageMod
-    ? (layoutOrPageMod as AppSegmentConfig).unstable_prefetch
+  const instantConfig = layoutOrPageMod
+    ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
     : undefined
   /** Whether this segment should use a runtime prefetch instead of a static prefetch. */
-  const hasRuntimePrefetch = prefetchConfig?.mode === 'runtime'
+  const hasRuntimePrefetch = instantConfig?.mode === 'runtime'
   if (hasRuntimePrefetch) {
     return true
   }

--- a/packages/next/src/server/app-render/staged-validation.tsx
+++ b/packages/next/src/server/app-render/staged-validation.tsx
@@ -13,7 +13,7 @@ export async function anySegmentHasRuntimePrefetchEnabled(
     ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
     : undefined
   /** Whether this segment should use a runtime prefetch instead of a static prefetch. */
-  const hasRuntimePrefetch = instantConfig?.mode === 'runtime'
+  const hasRuntimePrefetch = instantConfig?.prefetch === 'runtime'
   if (hasRuntimePrefetch) {
     return true
   }

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -146,7 +146,7 @@ const API_DOCS: Record<
       '`maxDuration` allows you to set max default execution time for your function. If it is not specified, the default value is dependent on your deployment platform and plan.',
     link: 'https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#maxduration',
   },
-  unstable_prefetch: {
+  unstable_instant: {
     description: `Specifies the default prefetching behavior for this segment. This configuration is currently under development and will change.`,
     link: '(docs coming soon)',
     type: 'object',
@@ -154,7 +154,7 @@ const API_DOCS: Record<
     // with the way this plugin is currently structured.
     // For now, since we don't provide an `options` here, we won't do any validation in
     // `getSemanticDiagnosticsForExportVariableStatement` below, and only provide hover a tooltip + autocomplete.
-    insertText: 'unstable_prefetch = { mode: "static" };',
+    insertText: 'unstable_instant = { mode: "static" };',
   },
 }
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
@@ -3,7 +3,7 @@ import { CachedData } from '../../data-fetching'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/apis/[param]/page.tsx
@@ -3,7 +3,7 @@ import { CachedData } from '../../data-fetching'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
 import { PrivateCachedData } from './data-fetching'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 const CACHE_KEY = '/private-cache/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/private-cache/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
 import { PrivateCachedData } from './data-fetching'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 const CACHE_KEY = '/private-cache/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
 import { ShortLivedCache } from './data-fetching'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/short-lived-cache/layout.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { UncachedFetch, CachedData } from '../data-fetching'
 import { ShortLivedCache } from './data-fetching'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { UncachedFetch, CachedFetch, CachedData } from '../data-fetching'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { UncachedFetch, CachedFetch, CachedData } from '../data-fetching'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__LAYOUT__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 export default async function Page() {
   return (

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/successive-caches/page.tsx
@@ -1,4 +1,4 @@
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 export default async function Page() {
   return (

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { CachedData, getCachedData } from '../../data-fetching'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/runtime/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { CachedData, getCachedData } from '../../data-fetching'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
@@ -1,6 +1,6 @@
 import { CachedData, getCachedData } from '../../data-fetching'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
+++ b/test/development/app-dir/cache-components-dev-warmup/fixtures/with-prefetch-config/app/sync-io/static/page.tsx
@@ -1,6 +1,6 @@
 import { CachedData, getCachedData } from '../../data-fetching'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 const CACHE_KEY = __dirname + '/__PAGE__'
 

--- a/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { Static, Runtime, Dynamic } from '../shared'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 export default function Root({ children }: { children: React.ReactNode }) {
   return (

--- a/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
+++ b/test/development/app-dir/cache-components-tasks/fixtures/with-prefetch-config/app/simple/layout.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { Static, Runtime, Dynamic } from '../shared'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 export default function Root({ children }: { children: React.ReactNode }) {
   return (

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/runtime-prefetch-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/runtime-prefetch-target/page.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from 'react'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
-  mode: 'runtime',
+export const unstable_instant = {
+  prefetch: 'runtime',
   samples: [{ searchParams: { myParam: 'testValue' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/layout.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../shared'
 
-// No `export const unstable_prefetch = ...` is needed, we default to static
+// No `export const unstable_instant = ...` is needed, we default to static
 
 export default async function SubLayout({ children }) {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-runtime/page.tsx
@@ -1,7 +1,7 @@
 import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-static/page.tsx
@@ -2,9 +2,9 @@ import { cookies } from 'next/headers'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
-// Technically, no `export const unstable_prefetch = ...` is needed, because we default to static,
+// Technically, no `export const unstable_instant = ...` is needed, because we default to static,
 // this is just to make sure that we excercise the codepaths for it
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'static',
 }
 export default function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/configured-as-static/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from 'react'
 // Technically, no `export const unstable_instant = ...` is needed, because we default to static,
 // this is just to make sure that we excercise the codepaths for it
 export const unstable_instant = {
-  mode: 'static',
+  prefetch: 'static',
 }
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/fully-static/page.tsx
@@ -1,4 +1,4 @@
-// No `export const unstable_prefetch = ...` is needed, we default to static
+// No `export const unstable_instant = ...` is needed, we default to static
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../shared'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/layout.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { DebugRenderKind } from '../../shared'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 export default async function Layout({ children }) {

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/app/segment-config/runtime-prefetchable/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { DebugLinkAccordion } from '../../../components/link-accordion'
 import { Suspense } from 'react'
 
-// No `export const unstable_prefetch = ...` is needed, we default to static
+// No `export const unstable_instant = ...` is needed, we default to static
 // (but see page description for more on the actual behavior)
 
 export default function Page() {

--- a/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-layout-sharing/prefetch-layout-sharing.test.ts
@@ -17,7 +17,7 @@ describe('layout sharing in non-static prefetches', () => {
   // - A "full prefetch" is `<Link prefetch="true">`
   //  It includes cached and uncached IO.
 
-  // - A "runtime prefetch" is the new `unstable_prefetch` segment config (only available in cacheComponents mode).
+  // - A "runtime prefetch" is the new `unstable_instant` segment config (only available in cacheComponents mode).
   //   It includes cached IO, and allows access to cookies/params/searchParams/"use cache: private", but excludes uncached IO.
 
   // TODO (runtime-prefetching): link-level opt-in has been removed. These tests need to be updated to use the segment configuration.

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-seconds/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/private-short-stale/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-seconds/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-long-stale/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/caches/public-short-expire-short-stale/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { ErrorBoundary } from '../../../../components/error-boundary'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/error-after-cookies/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { ErrorBoundary } from '../../../../components/error-boundary'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/cookies/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -3,7 +3,7 @@ import { DebugRenderKind } from '../../../../../shared'
 
 type Params = { id: string }
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/dynamic-params/[id]/page.tsx
@@ -4,7 +4,7 @@ import { DebugRenderKind } from '../../../../../shared'
 type Params = { id: string }
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/headers/page.tsx
@@ -2,7 +2,7 @@ import { headers } from 'next/headers'
 import { Suspense } from 'react'
 import { DebugRenderKind } from '../../../../shared'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../../shared'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/private-cache/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../../shared'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../../shared'
 import { cacheLife } from 'next/cache'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/quickly-expiring-public-cache/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../../shared'
 import { cacheLife } from 'next/cache'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -3,7 +3,7 @@ import { DebugRenderKind } from '../../../../shared'
 
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/errors/sync-io-after-runtime-api/search-params/page.tsx
@@ -4,7 +4,7 @@ import { DebugRenderKind } from '../../../../shared'
 type AnySearchParams = { [key: string]: string | string[] | undefined }
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
@@ -4,7 +4,7 @@
 // In the future, this test can be used to check whether we correctly
 // *skip* a runtime prefetch if a page was prerendered as static.
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/fully-static/page.tsx
@@ -3,7 +3,7 @@
 // but it's useful to exercise this codepath.
 // In the future, this test can be used to check whether we correctly
 // *skip* a runtime prefetch if a page was prerendered as static.
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies-only/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/cookies/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/dynamic-params/[id]/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/headers/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ searchParams: { key: 'value' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-page/search-params/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ searchParams: { key: 'value' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies-only/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/cookies/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/date-now/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/dynamic-params/[id]/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/headers/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ searchParams: { key: 'value' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/in-private-cache/search-params/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ searchParams: { key: 'value' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies-only/page.tsx
@@ -2,7 +2,7 @@ import { cookies } from 'next/headers'
 import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/cookies/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ cookies: [{ name: 'testCookie', value: 'testValue' }] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../../shared'
 import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/dynamic-params/[id]/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ params: { id: 'test' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
@@ -4,7 +4,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/headers/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from 'react'
 import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ headers: [['host', 'test-host']] }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind } from '../../../shared'
 import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ searchParams: { key: 'value' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/(default)/passed-to-public-cache/search-params/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ searchParams: { key: 'value' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -5,7 +5,7 @@ import { lang } from 'next/root-params'
 import { cookies } from 'next/headers'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-page/root-params/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/in-private-cache/root-params/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -3,7 +3,7 @@ import { cachedDelay, DebugRenderKind, uncachedIO } from '../../../../shared'
 import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-runtime/app/with-root-param/[lang]/passed-to-public-cache/root-params/page.tsx
@@ -4,7 +4,7 @@ import { connection } from 'next/server'
 import { lang } from 'next/root-params'
 
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ params: { lang: 'en' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-2-minutes/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
-export const unstable_prefetch = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { mode: 'runtime', samples: [{}] }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/runtime-stale-4-minutes/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react'
 import { cacheLife } from 'next/cache'
 import { cookies } from 'next/headers'
 
-export const unstable_instant = { mode: 'runtime', samples: [{}] }
+export const unstable_instant = { prefetch: 'runtime', samples: [{}] }
 
 export default function Page() {
   return (

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
@@ -12,10 +12,10 @@ import { connection } from 'next/server'
  * providing instant loading feedback when navigating.
  */
 export const unstable_instant: {
-  mode: 'runtime'
+  prefetch: 'runtime'
   samples: Array<{ params: { category: string; itemId: string } }>
 } = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [
     { params: { category: 'electronics', itemId: 'phone' } },
     { params: { category: 'clothing', itemId: 'shirt' } },

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/runtime-prefetch/[category]/[itemId]/page.tsx
@@ -11,7 +11,7 @@ import { connection } from 'next/server'
  * This allows cache reuse across different itemId values (same category),
  * providing instant loading feedback when navigating.
  */
-export const unstable_prefetch: {
+export const unstable_instant: {
   mode: 'runtime'
   samples: Array<{ params: { category: string; itemId: string } }>
 } = {

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
@@ -15,7 +15,7 @@ import { Suspense } from 'react'
  * - Prefetching /target?foo=2 fetches the segment AGAIN (no cache hit)
  */
 export const unstable_instant = {
-  mode: 'runtime',
+  prefetch: 'runtime',
   samples: [{ searchParams: { foo: '1' } }],
 }
 

--- a/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/vary-params/app/(main)/search-params/target-page/page.tsx
@@ -14,7 +14,7 @@ import { Suspense } from 'react'
  * - Prefetching /target?foo=1 fetches the segment with foo=1 content
  * - Prefetching /target?foo=2 fetches the segment AGAIN (no cache hit)
  */
-export const unstable_prefetch = {
+export const unstable_instant = {
   mode: 'runtime',
   samples: [{ searchParams: { foo: '1' } }],
 }

--- a/turbopack/crates/turbopack-ecmascript/tests/benches/app-page-turbo.runtime.prod.js
+++ b/turbopack/crates/turbopack-ecmascript/tests/benches/app-page-turbo.runtime.prod.js
@@ -24267,7 +24267,7 @@ Read more: https://nextjs.org/docs/messages/failed-to-find-server-action`),
               injectedJS: Q,
             })
           : [],
-        ev = 'unstable_runtime' === (ef ? ef.unstable_prefetch : void 0),
+        ev = 'unstable_runtime' === (ef ? ef.unstable_instant : void 0),
         [eb, e_] =
           m && J
             ? await rg({


### PR DESCRIPTION
Mostly mechanical.

Also changes the error page to `errors/invalid-instant-configuration`. I'm not really worried about dangling links here because this is a new API and we don't expect anyone to be using it yet.