### PR TITLE
Rename CACHE_ONE_YEAR for clarity and fix usage

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -33,7 +33,7 @@ import type {
 } from '..'
 
 import {
-  CACHE_ONE_YEAR,
+  CACHE_ONE_YEAR_SECONDS,
   HTML_CONTENT_TYPE_HEADER,
   JSON_CONTENT_TYPE_HEADER,
   NEXT_RESUME_HEADER,
@@ -2012,7 +2012,7 @@ export async function handleBuildComplete({
               // Next.js assets contain a hash or entropy in their filenames, so they
               // are guaranteed to be unique and cacheable indefinitely.
               headers: {
-                'cache-control': `public,max-age=${CACHE_ONE_YEAR},immutable`,
+                'cache-control': `public,max-age=${CACHE_ONE_YEAR_SECONDS},immutable`,
               },
             },
           ],

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -52,7 +52,7 @@ import {
 import { FallbackMode, parseFallbackField } from '../../lib/fallback'
 import RenderResult from '../../server/render-result'
 import {
-  CACHE_ONE_YEAR,
+  CACHE_ONE_YEAR_SECONDS,
   HTML_CONTENT_TYPE_HEADER,
   NEXT_CACHE_TAGS_HEADER,
   NEXT_NAV_DEPLOYMENT_ID_HEADER,
@@ -1227,7 +1227,10 @@ export async function handler(
           // Otherwise if the revalidate value is false, then we should use the
           // cache time of one year.
           else {
-            cacheControl = { revalidate: CACHE_ONE_YEAR, expire: undefined }
+            cacheControl = {
+              revalidate: CACHE_ONE_YEAR_SECONDS,
+              expire: undefined,
+            }
           }
         }
       }

--- a/packages/next/src/lib/constants.ts
+++ b/packages/next/src/lib/constants.ts
@@ -37,7 +37,7 @@ export const NEXT_CACHE_SOFT_TAG_MAX_LENGTH = 1024
 export const NEXT_CACHE_IMPLICIT_TAG_ID = '_N_T_'
 
 // in seconds
-export const CACHE_ONE_YEAR = 31536000
+export const CACHE_ONE_YEAR_SECONDS = 31536000
 
 // in seconds, represents revalidate=false. I.e. never revaliate.
 // We use this value since it can be represented as a V8 SMI for optimal performance.

--- a/packages/next/src/server/lib/cache-control.ts
+++ b/packages/next/src/server/lib/cache-control.ts
@@ -1,4 +1,4 @@
-import { CACHE_ONE_YEAR } from '../../lib/constants'
+import { CACHE_ONE_YEAR_SECONDS } from '../../lib/constants'
 
 /**
  * The revalidate option used internally for pages. A value of `false` means
@@ -31,5 +31,5 @@ export function getCacheControlHeader({
     return `s-maxage=${revalidate}${swrHeader}`
   }
 
-  return `s-maxage=${CACHE_ONE_YEAR}${swrHeader}`
+  return `s-maxage=${CACHE_ONE_YEAR_SECONDS}${swrHeader}`
 }

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -19,7 +19,7 @@ import FileSystemCache from './file-system-cache'
 import { normalizePagePath } from '../../../shared/lib/page-path/normalize-page-path'
 
 import {
-  CACHE_ONE_YEAR,
+  CACHE_ONE_YEAR_SECONDS,
   NEXT_CACHE_TAGS_HEADER,
   PRERENDER_REVALIDATE_HEADER,
 } from '../../../lib/constants'
@@ -577,7 +577,7 @@ export class IncrementalCache implements IncrementalCacheType {
 
     if (cacheData?.lastModified === -1) {
       isStale = -1
-      revalidateAfter = -1 * CACHE_ONE_YEAR
+      revalidateAfter = -1 * CACHE_ONE_YEAR_SECONDS * 1000
     } else {
       const now = performance.timeOrigin + performance.now()
       const lastModified = cacheData?.lastModified || now

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -6,7 +6,7 @@ import type {
 import { AppRenderSpan, NextNodeServerSpan } from './trace/constants'
 import { getTracer, SpanKind } from './trace/tracer'
 import {
-  CACHE_ONE_YEAR,
+  CACHE_ONE_YEAR_SECONDS,
   INFINITE_CACHE,
   NEXT_CACHE_TAG_MAX_ITEMS,
   NEXT_CACHE_TAG_MAX_LENGTH,
@@ -846,7 +846,7 @@ export function createPatchedFetcher(
               ) {
                 const normalizedRevalidate =
                   finalRevalidate >= INFINITE_CACHE
-                    ? CACHE_ONE_YEAR
+                    ? CACHE_ONE_YEAR_SECONDS
                     : finalRevalidate
 
                 const incrementalCacheConfig:

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -28,7 +28,7 @@ import {
 import { normalizeRepeatedSlashes } from '../../../shared/lib/utils'
 import { getRedirectStatus } from '../../../lib/redirect-status'
 import {
-  CACHE_ONE_YEAR,
+  CACHE_ONE_YEAR_SECONDS,
   HTML_CONTENT_TYPE_HEADER,
   JSON_CONTENT_TYPE_HEADER,
 } from '../../../lib/constants'
@@ -607,7 +607,7 @@ export const getHandler = ({
           } else {
             // revalidate: false
             cacheControl = {
-              revalidate: CACHE_ONE_YEAR,
+              revalidate: CACHE_ONE_YEAR_SECONDS,
               expire: undefined,
             }
           }

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -1,6 +1,6 @@
 import type { IncrementalCache } from '../../lib/incremental-cache'
 
-import { CACHE_ONE_YEAR } from '../../../lib/constants'
+import { CACHE_ONE_YEAR_SECONDS } from '../../../lib/constants'
 import { validateRevalidate, validateTags } from '../../lib/patch-fetch'
 import {
   workAsyncStorage,
@@ -45,7 +45,8 @@ async function cacheNewResult<T>(
         status: 200,
         url: '',
       } satisfies CachedFetchData,
-      revalidate: typeof revalidate !== 'number' ? CACHE_ONE_YEAR : revalidate,
+      revalidate:
+        typeof revalidate !== 'number' ? CACHE_ONE_YEAR_SECONDS : revalidate,
     },
     { fetchCache: true, tags, fetchIdx, fetchUrl }
   )


### PR DESCRIPTION
This renames the variable for clarity as we've had issues with unit mismatch with this constant specifically. Also fixes usage which was working accidentally because we converted it to a negative unit which is always in the past. 

x-ref: [slack thread](https://vercel.slack.com/archives/C02K2HCH5V4/p1770137071766599?thread_ts=1769515738.350369&cid=C02K2HCH5V4)