### PR TITLE
Turbopack: skip static/media writing for metadata files in dev mode

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1112,6 +1112,7 @@ impl AppEndpoint {
             self.page.clone(),
             self.app_project.project().project_path().owned().await?,
             self.app_project.project().next_config(),
+            *self.app_project.project().next_mode().await?,
         ))
     }
 

--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -17,6 +17,7 @@ use crate::{
         MetadataWithAltItem, get_metadata_route_name,
     },
     base_loader_tree::{AppDirModuleType, BaseLoaderTreeBuilder},
+    mode::NextMode,
     next_app::{
         AppPage,
         metadata::{get_content_type, image::dynamic_image_metadata_source},
@@ -29,6 +30,8 @@ pub struct AppPageLoaderTreeBuilder {
     loader_tree_code: String,
     /// next.config.js' basePath option to construct og metadata.
     base_path: Option<RcStr>,
+    /// The mode in which Next.js is running (development or build).
+    mode: NextMode,
 }
 
 impl AppPageLoaderTreeBuilder {
@@ -36,11 +39,13 @@ impl AppPageLoaderTreeBuilder {
         module_asset_context: ResolvedVc<ModuleAssetContext>,
         server_component_transition: ResolvedVc<Box<dyn Transition>>,
         base_path: Option<RcStr>,
+        mode: NextMode,
     ) -> Self {
         AppPageLoaderTreeBuilder {
             base: BaseLoaderTreeBuilder::new(module_asset_context, server_component_transition),
             loader_tree_code: String::new(),
             base_path,
+            mode,
         }
     }
 
@@ -237,11 +242,22 @@ impl AppPageLoaderTreeBuilder {
         self.base
             .imports
             .push(format!("const {identifier} = require(\"{inner_module_id}\");").into());
-        let module = StructuredImageModuleType::create_module(
-            Vc::upcast(FileSource::new(path.clone())),
-            BlurPlaceholderMode::None,
-            *self.base.module_asset_context,
-        );
+
+        // In development mode, use a lightweight module that doesn't write to static/media.
+        // The image is served directly from the app/ directory via the route handler.
+        // In production, use the full module that creates a StaticOutputAsset.
+        let module = if self.mode.is_development() {
+            StructuredImageModuleType::create_metadata_module(
+                Vc::upcast(FileSource::new(path.clone())),
+                *self.base.module_asset_context,
+            )
+        } else {
+            StructuredImageModuleType::create_module(
+                Vc::upcast(FileSource::new(path.clone())),
+                BlurPlaceholderMode::None,
+                *self.base.module_asset_context,
+            )
+        };
         let module = self.base.process_module(module).to_resolved().await?;
         self.base
             .inner_assets
@@ -452,10 +468,16 @@ impl AppPageLoaderTreeModule {
         module_asset_context: ResolvedVc<ModuleAssetContext>,
         server_component_transition: ResolvedVc<Box<dyn Transition>>,
         base_path: Option<RcStr>,
+        mode: NextMode,
     ) -> Result<Self> {
-        AppPageLoaderTreeBuilder::new(module_asset_context, server_component_transition, base_path)
-            .build(loader_tree)
-            .await
+        AppPageLoaderTreeBuilder::new(
+            module_asset_context,
+            server_component_transition,
+            base_path,
+            mode,
+        )
+        .build(loader_tree)
+        .await
     }
 }
 

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -18,6 +18,7 @@ use turbopack_ecmascript::runtime_functions::{TURBOPACK_LOAD, TURBOPACK_REQUIRE}
 use crate::{
     app_page_loader_tree::AppPageLoaderTreeModule,
     app_structure::AppPageLoaderTree,
+    mode::NextMode,
     next_app::{AppPage, AppPath, app_entry::AppEntry},
     next_config::NextConfig,
     next_edge::entry::wrap_edge_entry,
@@ -35,6 +36,7 @@ pub async fn get_app_page_entry(
     page: AppPage,
     project_root: FileSystemPath,
     next_config: Vc<NextConfig>,
+    mode: NextMode,
 ) -> Result<Vc<AppEntry>> {
     let config = parse_segment_config_from_loader_tree(loader_tree);
     let is_edge = matches!(config.await?.runtime, Some(NextRuntime::Edge));
@@ -53,6 +55,7 @@ pub async fn get_app_page_entry(
         module_asset_context,
         server_component_transition,
         base_path,
+        mode,
     )
     .await?;
 

--- a/crates/next-core/src/next_image/metadata_source.rs
+++ b/crates/next-core/src/next_image/metadata_source.rs
@@ -1,0 +1,79 @@
+use std::io::Write;
+
+use anyhow::{Result, bail};
+use turbo_rcstr::rcstr;
+use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks_fs::{FileContent, rope::RopeBuilder};
+use turbopack_core::{
+    asset::{Asset, AssetContent},
+    ident::AssetIdent,
+    source::Source,
+};
+use turbopack_ecmascript::utils::StringifyJs;
+use turbopack_image::process::get_meta_data;
+
+/// A source that generates JS exporting `{ src: "hash.ext", width, height }` for static metadata
+/// images in development mode. Unlike `StructuredImageFileSource`, this does NOT import the image
+/// file (which would create a `StaticUrlJsModule` and write to `/_next/static/media/`).
+///
+/// The `src` field contains only a content hash + extension, used for cache-busting query params.
+/// The actual image is served directly from the app/ directory via the route handler.
+#[turbo_tasks::value(shared)]
+pub struct MetadataStaticImageSource {
+    pub image: ResolvedVc<Box<dyn Source>>,
+}
+
+#[turbo_tasks::value_impl]
+impl Source for MetadataStaticImageSource {
+    #[turbo_tasks::function]
+    fn ident(&self) -> Vc<AssetIdent> {
+        self.image
+            .ident()
+            .with_modifier(rcstr!("metadata static image"))
+            .rename_as(rcstr!("*.mjs"))
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl Asset for MetadataStaticImageSource {
+    #[turbo_tasks::function]
+    async fn content(&self) -> Result<Vc<AssetContent>> {
+        let content = self.image.content().await?;
+        let AssetContent::File(file_content) = *content else {
+            bail!("Input source is not a file and can't be transformed into image information");
+        };
+
+        let file = file_content.await?;
+        let FileContent::Content(file) = &*file else {
+            bail!("Input source is not a file and can't be transformed into image information");
+        };
+
+        // Compute content hash for cache-busting
+        let content_hash = turbo_tasks_hash::hash_xxh3_hash64(file.content());
+        let content_hash_b16 = turbo_tasks_hash::encode_hex(content_hash);
+
+        // Get image extension
+        let ident = self.image.ident().await?;
+        let ext = ident.path.extension_ref().unwrap_or("");
+
+        // Get image metadata (width, height)
+        let info = get_meta_data(*self.image, *file_content, None).await?;
+
+        let mut result = RopeBuilder::from("");
+
+        // Generate: export default { src: "hash.ext", width, height }
+        // The src is just for cache-busting, not an actual URL
+        writeln!(
+            result,
+            "export default {{ src: {src}, width: {width}, height: {height} }};",
+            src = StringifyJs(&format!("{content_hash_b16}.{ext}")),
+            width = StringifyJs(&info.width),
+            height = StringifyJs(&info.height),
+        )?;
+
+        Ok(AssetContent::File(
+            turbo_tasks_fs::FileContent::Content(result.build().into()).resolved_cell(),
+        )
+        .cell())
+    }
+}

--- a/crates/next-core/src/next_image/mod.rs
+++ b/crates/next-core/src/next_image/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod metadata_source;
 pub(crate) mod module;
 pub(crate) mod source_asset;
 

--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -10,7 +10,7 @@ use turbopack_core::{
 use turbopack_ecmascript::EcmascriptInputTransforms;
 use turbopack_static::ecma::StaticUrlJsModule;
 
-use super::source_asset::StructuredImageFileSource;
+use super::{metadata_source::MetadataStaticImageSource, source_asset::StructuredImageFileSource};
 
 #[derive(
     Eq,
@@ -80,6 +80,27 @@ impl StructuredImageModuleType {
         StructuredImageModuleType::cell(StructuredImageModuleType {
             blur_placeholder_mode,
         })
+    }
+
+    /// Creates a module for metadata images without StaticOutputAsset (dev mode only).
+    ///
+    /// Unlike `create_module`, this does not create a `StaticUrlJsModule` which would
+    /// write the image to `/_next/static/media/`. Instead, it generates a module that
+    /// exports `{ src: "hash.ext", width, height }` where `src` is just a content hash
+    /// used for cache-busting query params.
+    ///
+    /// The actual image is served directly from the app/ directory via the route handler.
+    #[turbo_tasks::function]
+    pub(crate) fn create_metadata_module(
+        source: ResolvedVc<Box<dyn Source>>,
+        module_asset_context: ResolvedVc<ModuleAssetContext>,
+    ) -> Vc<Box<dyn Module>> {
+        module_asset_context
+            .process(
+                Vc::upcast(MetadataStaticImageSource { image: source }.cell()),
+                ReferenceType::Internal(ResolvedVc::cell(Default::default())),
+            )
+            .module()
     }
 }
 


### PR DESCRIPTION
## Summary

In development mode, static metadata files (favicon.ico, opengraph-image.png, etc.) are now served directly from the app/ directory via the route handler, instead of being written to `/_next/static/media/`.

This change introduces:
- A new `MetadataStaticImageSource` that extracts image metadata (width, height) and computes a content hash for cache-busting, without creating a `StaticOutputAsset`
- A new `create_metadata_module()` method on `StructuredImageModuleType` for dev-mode metadata handling
- Pass `NextMode` through `AppPageLoaderTreeBuilder` to conditionally use the lightweight module in development

Production builds continue to work as before, writing files to `/_next/static/media/`.

## Test plan

- [x] `pnpm test-dev-turbo test/e2e/app-dir/metadata/metadata.test.ts -t "should render icon"` - passes
- [x] `pnpm test-dev-turbo test/e2e/app-dir/metadata/metadata.test.ts -t "should have icons as route"` - passes
- [x] `pnpm test-dev-turbo test/e2e/app-dir/metadata/metadata.test.ts -t "should pick up opengraph-image"` - passes
- [x] `pnpm test-start-turbo test/e2e/app-dir/metadata/metadata.test.ts -t "should render icon"` - passes (production mode still works)