### PR TITLE
Update image.mdx with note on 'sizes' property

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -5,7 +5,8 @@ description: Optimize Images in your Next.js Application using the built-in `nex
 
 {/* The content of this doc is shared between the app and pages router. You can use the `<PagesOnly>Content</PagesOnly>` component to add content that is specific to the Pages Router. Any shared content should not be wrapped in a component. */}
 
-The Next.js Image component extends the HTML `<img>` element for automatic image optimization.
+The Next.js Image component extends the HTML `<img>` element for automatic image optimization. 
+Note: the [`sizes` property](#sizes) is required for responsive resizing.
 
 ```jsx filename="app/page.js"
 import Image from 'next/image'


### PR DESCRIPTION
Added note about the required `sizes` property for responsive resizing.

I was extremely surprised to discover responsive resizing doesn't happen without this property given the way the docs start.

The docs currently describe the component with this:
> automatic image optimization

Followed by a code example that doesn't use `sizes` property and therefore doesn't get _automatically optimized_ (other than 2x version). 

I could also get behind including a `sizes` prop in the code example to at least invite people to read that detail buried in the docs. I might even argue that the default should be `100vw` with responsive resizing, but that's probably a major breaking change for folks who expect the existing behavior.

---

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
