### PR TITLE
Fix memory leak in createPrefetchResponseStream by releasing reader lock

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2554,6 +2554,7 @@ function createPrefetchResponseStream(
         }
         // The server stream has closed. Exit, but intentionally do not close
         // the target stream. We do notify the caller, though.
+        reader.releaseLock()
         onStreamClose()
         return
       }

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2534,10 +2534,11 @@ function createPrefetchResponseStream(
   // While processing the original stream, we also incrementally update the size
   // of the cache entry in the LRU.
   let totalByteLength = 0
+  let closed = false
   const reader = originalFlightStream.getReader()
   return new ReadableStream({
     async pull(controller) {
-      while (true) {
+      while (!closed) {
         const { done, value } = await reader.read()
         if (!done) {
           // Pass to the target stream and keep consuming the Flight response
@@ -2554,6 +2555,7 @@ function createPrefetchResponseStream(
         }
         // The server stream has closed. Exit, but intentionally do not close
         // the target stream. We do notify the caller, though.
+        closed = true
         reader.releaseLock()
         onStreamClose()
         return


### PR DESCRIPTION
## What?

Fix memory leak in `createPrefetchResponseStream` where the `ReadableStreamDefaultReader` is never released after consuming the original stream.

## Why?

The unreleased reader maintains a strong reference chain: `originalFlightStream.[[reader]] → reader → closures`, preventing garbage collection and causing ~32MB memory growth per 10 navigation cycles on the test app.

## How?

Add `reader.releaseLock()` when the stream completes. This breaks the reference chain while preserving the intentional behavior of keeping the target stream open (for Flight's hanging promise handling in PPR).

## Test Results

| Scenario | Cycle 10 | Cycle 20 | Growth (10→20) |
|----------|----------|----------|----------------|
| No fix | 59.9 MB | 91.8 MB | **31.91 MB** |
| controller.close() | 5.5 MB | 5.5 MB | 0.03 MB |
| reader.releaseLock() | 5.4 MB | 5.5 MB | 0.04 MB |