### PR TITLE
Ensure module contexts are always included in adapter traces

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -532,50 +532,48 @@ export async function handleBuildComplete({
       sharedNodeAssets[path.relative(tracingRoot, setupNodeStubPath)] =
         require.resolve('next/dist/build/adapter/setup-node-env.external')
 
-      if (bundler !== Bundler.Turbopack) {
-        const moduleTypes = ['app-page', 'pages'] as const
+      const moduleTypes = ['app-page', 'pages'] as const
 
-        for (const type of moduleTypes) {
-          const currentDependencies: string[] = []
-          const modulePath = require.resolve(
-            `next/dist/server/route-modules/${type}/module.compiled`
-          )
-          const contextDir = path.join(
-            path.dirname(modulePath),
-            'vendored',
-            'contexts'
-          )
+      for (const type of moduleTypes) {
+        const currentDependencies: string[] = []
+        const modulePath = require.resolve(
+          `next/dist/server/route-modules/${type}/module.compiled`
+        )
+        currentDependencies.push(modulePath)
 
-          for (const item of await fs.readdir(contextDir)) {
-            if (item.match(/\.(mjs|cjs|js)$/)) {
-              currentDependencies.push(path.join(contextDir, item))
-            }
-          }
+        const contextDir = path.join(
+          path.dirname(modulePath),
+          'vendored',
+          'contexts'
+        )
 
-          const { fileList, esmFileList } = await nodeFileTrace(
-            currentDependencies,
-            {
-              base: tracingRoot,
-              ignore: sharedIgnoreFn,
-            }
-          )
-          esmFileList.forEach((item) => fileList.add(item))
-
-          for (const rootRelativeFilePath of fileList) {
-            if (type === 'pages') {
-              pagesSharedNodeAssets[rootRelativeFilePath] = path.join(
-                tracingRoot,
-                rootRelativeFilePath
-              )
-            } else {
-              appPagesSharedNodeAssets[rootRelativeFilePath] = path.join(
-                tracingRoot,
-                rootRelativeFilePath
-              )
-            }
+        for (const item of await fs.readdir(contextDir)) {
+          if (item.match(/\.(mjs|cjs|js)$/)) {
+            currentDependencies.push(path.join(contextDir, item))
           }
         }
 
+        for (const dependencyPath of currentDependencies) {
+          const rootRelativeFilePath = path.relative(
+            tracingRoot,
+            dependencyPath
+          )
+
+          if (type === 'pages') {
+            pagesSharedNodeAssets[rootRelativeFilePath] = path.join(
+              tracingRoot,
+              rootRelativeFilePath
+            )
+          } else {
+            appPagesSharedNodeAssets[rootRelativeFilePath] = path.join(
+              tracingRoot,
+              rootRelativeFilePath
+            )
+          }
+        }
+      }
+
+      if (bundler !== Bundler.Turbopack) {
         // These are modules that are necessary for bootstrapping node env
         const necessaryNodeDependencies = [
           require.resolve('next/dist/server/node-environment'),

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -173,6 +173,35 @@ describe('adapter-config', () => {
       }
     }
 
+    // Verify vendored context files are traced in assets for app-page and pages outputs
+    const appPageOutput = outputs.appPages.find(
+      (output) =>
+        output.pathname === '/docs/node-app' && output.runtime === 'nodejs'
+    )
+    const pagesOutput = outputs.pages.find(
+      (output) =>
+        output.pathname === '/docs/node-pages' && output.runtime === 'nodejs'
+    )
+
+    expect(appPageOutput).toBeDefined()
+    expect(pagesOutput).toBeDefined()
+
+    // Check that vendored context files are included in assets
+    const appPageAssets = Object.values(appPageOutput!.assets)
+    const pagesAssets = Object.values(pagesOutput!.assets)
+
+    const appPageVendoredContexts = appPageAssets.filter((asset) =>
+      asset.includes('vendored/contexts/')
+    )
+    const pagesVendoredContexts = pagesAssets.filter((asset) =>
+      asset.includes('vendored/contexts/')
+    )
+
+    // app-page should have vendored context files traced
+    expect(appPageVendoredContexts.length).toBeGreaterThan(0)
+    // pages should have vendored context files traced
+    expect(pagesVendoredContexts.length).toBeGreaterThan(0)
+
     for (const route of edgeOutputs) {
       try {
         expect(route.id).toBeString()


### PR DESCRIPTION
Currently these are only included when tracing for webpack but it's needed for turbopack too and at the moment it's a separate code path as they are explicitly added for the `next_server` trace but we don't use next-server for adapters by default so this ensures it is added as trace assets for adapters outputs. 