### PR TITLE
Turbopack:  make JavaScript runtimes moduleCache a Map

### DIFF
--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/build-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/build-base.ts
@@ -1,7 +1,7 @@
 /// <reference path="./runtime-base.ts" />
 /// <reference path="./dummy.ts" />
 
-const moduleCache: ModuleCache<Module> = {}
+const moduleCache: ModuleCache<Module> = new Map()
 contextPrototype.c = moduleCache
 
 /**
@@ -13,7 +13,7 @@ function getOrInstantiateRuntimeModule(
   chunkPath: ChunkPath,
   moduleId: ModuleId
 ): Module {
-  const module = moduleCache[moduleId]
+  const module = moduleCache.get(moduleId)
   if (module) {
     if (module.error) {
       throw module.error
@@ -33,7 +33,7 @@ function getOrInstantiateRuntimeModule(
 const getOrInstantiateModuleFromParent: GetOrInstantiateModuleFromParent<
   Module
 > = (id, sourceModule) => {
-  const module = moduleCache[id]
+  const module = moduleCache.get(id)
 
   if (module) {
     if (module.error) {
@@ -61,7 +61,7 @@ function instantiateModule(
   const module: Module = createModuleObject(id)
   const exports = module.exports
 
-  moduleCache[id] = module
+  moduleCache.set(id, module)
 
   // NOTE(alexkirsz) This can fail when the module encounters a runtime error.
   const context = new (Context as any as ContextConstructor<Module>)(

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/dev-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/browser/runtime/base/dev-base.ts
@@ -17,7 +17,7 @@ const devContextPrototype = Context.prototype as TurbopackDevContext
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 // Assign browser's module cache and runtime modules to shared HMR state
-devModuleCache = Object.create(null)
+devModuleCache = new Map()
 devContextPrototype.c = devModuleCache
 runtimeModules = new Set()
 
@@ -86,7 +86,7 @@ function getOrInstantiateRuntimeModule(
   chunkPath: ChunkPath,
   moduleId: ModuleId
 ): Module {
-  const module = devModuleCache[moduleId]
+  const module = devModuleCache.get(moduleId)
   if (module) {
     if (module.error) {
       throw module.error
@@ -111,7 +111,7 @@ const getOrInstantiateModuleFromParent: GetOrInstantiateModuleFromParent<
     )
   }
 
-  const module = devModuleCache[id]
+  const module = devModuleCache.get(id)
 
   if (sourceModule.children.indexOf(id) === -1) {
     sourceModule.children.push(id)

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/build-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/build-base.ts
@@ -58,7 +58,7 @@ function instantiateModule(
 
   const module: ModuleWithDirection = createModuleWithDirection(id)
   const exports = module.exports
-  moduleCache[id] = module
+  moduleCache.set(id, module)
 
   const context =
     new (Context as any as ContextConstructor<ModuleWithDirection>)(
@@ -90,7 +90,7 @@ function getOrInstantiateModuleFromParent(
   id: ModuleId,
   sourceModule: ModuleWithDirection
 ): ModuleWithDirection {
-  const module = moduleCache[id]
+  const module = moduleCache.get(id)
 
   if (module) {
     if (module.error) {
@@ -121,7 +121,7 @@ function getOrInstantiateRuntimeModule(
   chunkPath: ChunkPath,
   moduleId: ModuleId
 ): ModuleWithDirection {
-  const module = moduleCache[moduleId]
+  const module = moduleCache.get(moduleId)
 
   if (module) {
     if (module.error) {

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/dev-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/dev-base.ts
@@ -103,7 +103,7 @@ function getOrInstantiateRuntimeModule(
   chunkPath: ChunkPath,
   moduleId: ModuleId
 ): HotModule {
-  const module = devModuleCache[moduleId]
+  const module = devModuleCache.get(moduleId)
 
   if (module) {
     if (module.error) {
@@ -125,9 +125,9 @@ function getOrInstantiateModuleFromParent(
   sourceModule: HotModule
 ): HotModule {
   // Track parent-child relationship
-  trackModuleImport(sourceModule, id, devModuleCache[id])
+  trackModuleImport(sourceModule, id, devModuleCache.get(id))
 
-  const module = devModuleCache[id]
+  const module = devModuleCache.get(id)
 
   if (module) {
     if (module.error) {

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/nodejs-globals.d.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/nodejs-globals.d.ts
@@ -7,7 +7,7 @@
 
 declare global {
   var __turbopack_module_factories__: ModuleFactories
-  var __turbopack_module_cache__: Record<ModuleId, any>
+  var __turbopack_module_cache__: ModuleCache<ModuleId>
   var __turbopack_runtime_modules__: Set<ModuleId>
 }
 

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/runtime-base.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/nodejs/runtime/runtime-base.ts
@@ -22,7 +22,7 @@ if (!globalThis.__turbopack_module_factories__) {
   globalThis.__turbopack_module_factories__ = new Map()
 }
 if (!globalThis.__turbopack_module_cache__) {
-  globalThis.__turbopack_module_cache__ = Object.create(null)
+  globalThis.__turbopack_module_cache__ = new Map()
 }
 
 const moduleFactories: ModuleFactories =
@@ -82,9 +82,7 @@ function clearChunkCache() {
   chunkCache.clear()
   loadedChunks.clear()
   moduleFactories.clear()
-  for (const key in moduleCache) {
-    delete moduleCache[key]
-  }
+  moduleCache.clear()
 }
 
 function loadRuntimeChunkPath(

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/hmr-runtime.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/hmr-runtime.ts
@@ -21,7 +21,7 @@ type HotModuleFactoryFunction = ModuleFactoryFunction<
  * Browser runtime declares this directly.
  * Node.js runtime assigns globalThis.__turbopack_module_cache__ to this.
  */
-let devModuleCache: Record<ModuleId, any>
+let devModuleCache: ModuleCache<HotModule>
 
 /**
  * Module IDs that are instantiated as part of the runtime of a chunk.
@@ -157,7 +157,7 @@ function getAffectedModuleEffects(
       }
     }
 
-    const module = devModuleCache[moduleId]
+    const module = devModuleCache.get(moduleId)
     const hotState = moduleHotState.get(module)!
 
     if (
@@ -190,7 +190,7 @@ function getAffectedModuleEffects(
     }
 
     for (const parentId of module.parents) {
-      const parent = devModuleCache[parentId]
+      const parent = devModuleCache.get(parentId)
 
       if (!parent) {
         // TODO(alexkirsz) Is this even possible?
@@ -385,7 +385,7 @@ function computeOutdatedSelfAcceptedModules(
     errorHandler: true | Function
   }[] = []
   for (const moduleId of outdatedModules) {
-    const module = devModuleCache[moduleId]
+    const module = devModuleCache.get(moduleId)
     const hotState = moduleHotState.get(module)
     if (module && hotState?.selfAccepted && !hotState.selfInvalidated) {
       outdatedSelfAcceptedModules.push({
@@ -405,7 +405,7 @@ function computeOutdatedSelfAcceptedModules(
  * This must be done in a separate step afterwards.
  */
 function disposeModule(moduleId: ModuleId, mode: 'clear' | 'replace') {
-  const module = devModuleCache[moduleId]
+  const module = devModuleCache.get(moduleId)
   if (!module) {
     return
   }
@@ -437,7 +437,7 @@ function disposeModule(moduleId: ModuleId, mode: 'clear' | 'replace') {
   // It will be added back once the module re-instantiates and imports its
   // children again.
   for (const childId of module.children) {
-    const child = devModuleCache[childId]
+    const child = devModuleCache.get(childId)
     if (!child) {
       continue
     }
@@ -450,7 +450,7 @@ function disposeModule(moduleId: ModuleId, mode: 'clear' | 'replace') {
 
   switch (mode) {
     case 'clear':
-      delete devModuleCache[module.id]
+      devModuleCache.delete(module.id)
       moduleHotData.delete(module.id)
       break
     case 'replace':
@@ -482,9 +482,9 @@ function disposePhase(
   // We also want to keep track of previous parents of the outdated modules.
   const outdatedModuleParents = new Map<ModuleId, Array<ModuleId>>()
   for (const moduleId of outdatedModules) {
-    const oldModule = devModuleCache[moduleId]
+    const oldModule = devModuleCache.get(moduleId)
     outdatedModuleParents.set(moduleId, oldModule?.parents)
-    delete devModuleCache[moduleId]
+    devModuleCache.delete(moduleId)
   }
 
   // TODO(alexkirsz) Dependencies: remove outdated dependency from module
@@ -551,7 +551,7 @@ function instantiateModuleShared(
   module.children = []
   module.hot = hot
 
-  devModuleCache[id] = module
+  devModuleCache.set(id, module)
   moduleHotState.set(module, hotState)
 
   // 5. Module execution (React Refresh hooks are platform-specific)
@@ -741,7 +741,7 @@ function applyPhase(
     } catch (err) {
       if (typeof errorHandler === 'function') {
         try {
-          errorHandler(err, { moduleId, module: devModuleCache[moduleId] })
+          errorHandler(err, { moduleId, module: devModuleCache.get(moduleId) })
         } catch (err2) {
           reportError(err2)
           reportError(err)

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-types.d.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-types.d.ts
@@ -73,7 +73,7 @@ type LoadWebAssemblyModule = (
   edgeModule: () => WebAssembly.Module
 ) => WebAssembly.Module
 
-type ModuleCache<M> = Record<ModuleId, M>
+type ModuleCache<M> = Map<ModuleId, M>
 // TODO properly type values here
 type ModuleFactories = Map<ModuleId, Function>
 /**

--- a/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-utils.ts
+++ b/turbopack/crates/turbopack-ecmascript-runtime/js/src/shared/runtime/runtime-utils.ts
@@ -109,12 +109,12 @@ function getOverwrittenModule(
   moduleCache: ModuleCache<Module>,
   id: ModuleId
 ): Module {
-  let module = moduleCache[id]
+  let module = moduleCache.get(id)
   if (!module) {
     // This is invoked when a module is merged into another module, thus it wasn't invoked via
     // instantiateModule and the cache entry wasn't created yet.
     module = createModuleObject(id)
-    moduleCache[id] = module
+    moduleCache.set(id, module)
   }
   return module
 }


### PR DESCRIPTION
This makes `moduleCache` across the various runtimes a `Map`, better matching the semantics of it, and allowing us to simply `.clear()` it in the Node.js hmr runtime.

Test Plan: CI