### PR TITLE
fix(pages): ensure ISR cache-control takes precedence over _app headers

### DIFF
--- a/packages/next/src/server/send-payload.ts
+++ b/packages/next/src/server/send-payload.ts
@@ -55,9 +55,11 @@ export async function sendRenderResult({
     res.setHeader('X-Powered-By', 'Next.js')
   }
 
-  // If cache control is already set on the response we don't
-  // override it to allow users to customize it via next.config
-  if (cacheControl && !res.getHeader('Cache-Control')) {
+  // When cacheControl is provided (ISR/ISG pages), always set the
+  // Cache-Control header. This ensures ISR cache-control takes precedence
+  // over any headers that may have been set during rendering (e.g., in
+  // _app.getInitialProps). See: https://github.com/vercel/next.js/issues/14244
+  if (cacheControl) {
     res.setHeader('Cache-Control', getCacheControlHeader(cacheControl))
   }
 

--- a/test/production/isr-app-getinitialprops-cache-control/isr-app-getinitialprops-cache-control.test.ts
+++ b/test/production/isr-app-getinitialprops-cache-control/isr-app-getinitialprops-cache-control.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('isr-app-getinitialprops-cache-control', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // https://github.com/vercel/next.js/issues/14244
+  // ISR cache-control should take precedence over headers set in _app.getInitialProps
+  it('should use ISR cache-control instead of _app header for pre-rendered pages', async () => {
+    const res = await next.fetch('/')
+    const cacheControl = res.headers.get('cache-control')
+
+    // ISR page with revalidate: 10 should have s-maxage=10
+    // _app sets 'max-age=0, must-revalidate' which should NOT override this
+    expect(cacheControl).toMatch(/s-maxage=10/)
+  })
+
+  // Test with dynamic route that requires server-side rendering (fallback: blocking)
+  // This is the key test case - when _app.getInitialProps runs during SSR,
+  // the ISR cache-control should still take precedence
+  it('should use ISR cache-control on dynamic routes with fallback blocking', async () => {
+    const res = await next.fetch('/test-slug')
+    const cacheControl = res.headers.get('cache-control')
+
+    // Even on first render (fallback blocking), ISR cache-control should win
+    expect(cacheControl).toMatch(/s-maxage=10/)
+  })
+
+  it('should render pages correctly', async () => {
+    const $ = await next.render$('/')
+    expect($('p').text()).toBe('hello world')
+
+    const $dynamic = await next.render$('/test-slug')
+    expect($dynamic('p').text()).toBe('slug: test-slug')
+  })
+})

--- a/test/production/isr-app-getinitialprops-cache-control/pages/[slug].tsx
+++ b/test/production/isr-app-getinitialprops-cache-control/pages/[slug].tsx
@@ -1,0 +1,23 @@
+import type { GetStaticProps, GetStaticPaths } from 'next'
+
+interface Props {
+  slug: string
+}
+
+export default function Page({ slug }: Props) {
+  return <p>slug: {slug}</p>
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: 'blocking',
+  }
+}
+
+export const getStaticProps: GetStaticProps<Props> = async ({ params }) => {
+  return {
+    props: { slug: String(params?.slug) },
+    revalidate: 10,
+  }
+}

--- a/test/production/isr-app-getinitialprops-cache-control/pages/_app.tsx
+++ b/test/production/isr-app-getinitialprops-cache-control/pages/_app.tsx
@@ -1,0 +1,19 @@
+import App, { AppContext, AppProps } from 'next/app'
+
+function MyApp({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}
+
+MyApp.getInitialProps = async (appContext: AppContext) => {
+  const appProps = await App.getInitialProps(appContext)
+
+  // This should NOT override ISR cache-control headers
+  if (appContext.ctx.res) {
+    appContext.ctx.res.setHeader('Cache-Control', 'max-age=0, must-revalidate')
+    appContext.ctx.res.setHeader('x-from-app', 'true')
+  }
+
+  return { ...appProps }
+}
+
+export default MyApp

--- a/test/production/isr-app-getinitialprops-cache-control/pages/index.tsx
+++ b/test/production/isr-app-getinitialprops-cache-control/pages/index.tsx
@@ -1,0 +1,16 @@
+import type { GetStaticProps } from 'next'
+
+interface Props {
+  message: string
+}
+
+export default function Page({ message }: Props) {
+  return <p>{message}</p>
+}
+
+export const getStaticProps: GetStaticProps<Props> = async () => {
+  return {
+    props: { message: 'hello world' },
+    revalidate: 10,
+  }
+}


### PR DESCRIPTION
## What?

Ensures that ISR (Incremental Static Regeneration) cache-control headers always take precedence over headers set in `_app.getInitialProps`.

## Why?

When an ISR page with `getStaticProps` uses `revalidate`, the cache-control header should reflect the ISR configuration (e.g., `s-maxage=10`). However, if `_app.getInitialProps` sets a `Cache-Control` header during server-side rendering, it was overriding the ISR cache-control.

This affects dynamic routes with `fallback: 'blocking'` where pages are server-rendered on first request - in these cases, `_app.getInitialProps` runs and any headers it sets would persist, breaking ISR caching.

## How?

In `send-payload.ts`, removed the check `!res.getHeader('Cache-Control')` so that when `cacheControl` is provided (indicating an ISR/ISG page), the header is always set, overriding any previously set value.

### Fixing a bug

- Related issues linked using `fixes #14244`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs

Fixes #14244