### PR TITLE
Clarify type checking error message

### DIFF
--- a/packages/next/src/lib/verify-typescript-setup.ts
+++ b/packages/next/src/lib/verify-typescript-setup.ts
@@ -241,7 +241,7 @@ export async function verifyTypeScriptSetup({
   } catch (err) {
     // These are special errors that should not show a stack trace:
     if (err instanceof CompileError) {
-      console.error(red('Failed to compile.\n'))
+      console.error(red('Failed to type check.\n'))
       console.error(err.message)
       process.exit(1)
     }

--- a/test/integration/next-image-legacy/typescript/test/index.test.ts
+++ b/test/integration/next-image-legacy/typescript/test/index.test.ts
@@ -26,7 +26,7 @@ describe('TypeScript Image Component', () => {
     () => {
       it('should fail to build invalid usage of the Image component', async () => {
         const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
-        expect(stderr).toMatch(/Failed to compile/)
+        expect(stderr).toMatch(/Failed to type check/)
         expect(stderr).toMatch(/is not assignable to type/)
         expect(code).toBe(1)
         const envTypes = await fs.readFile(
@@ -43,7 +43,7 @@ describe('TypeScript Image Component', () => {
           content.replace('// disableStaticImages', 'disableStaticImages')
         )
         const { code, stderr } = await nextBuild(appDir, [], { stderr: true })
-        expect(stderr).toMatch(/Failed to compile/)
+        expect(stderr).toMatch(/Failed to type check/)
         expect(stderr).toMatch(/is not assignable to type/)
         expect(code).toBe(1)
         await fs.writeFile(nextConfig, content)

--- a/test/integration/next-image-new/typescript/test/index.test.ts
+++ b/test/integration/next-image-new/typescript/test/index.test.ts
@@ -26,7 +26,7 @@ describe('TypeScript Image Component', () => {
     () => {
       it('should fail to build invalid usage of the Image component', async () => {
         const { stderr, code } = await nextBuild(appDir, [], { stderr: true })
-        expect(stderr).toMatch(/Failed to compile/)
+        expect(stderr).toMatch(/Failed to type check/)
         expect(stderr).toMatch(/is not assignable to type/)
         expect(code).toBe(1)
         const envTypes = await fs.readFile(
@@ -43,7 +43,7 @@ describe('TypeScript Image Component', () => {
           content.replace('// disableStaticImages', 'disableStaticImages')
         )
         const { code, stderr } = await nextBuild(appDir, [], { stderr: true })
-        expect(stderr).toMatch(/Failed to compile/)
+        expect(stderr).toMatch(/Failed to type check/)
         expect(stderr).toMatch(/is not assignable to type/)
         expect(code).toBe(1)
         await fs.writeFile(nextConfig, content)

--- a/test/integration/typescript-filtered-files/test/index.test.ts
+++ b/test/integration/typescript-filtered-files/test/index.test.ts
@@ -15,7 +15,7 @@ describe('TypeScript filtered files', () => {
         })
         expect(output.stdout).not.toMatch(/Compiled successfully/)
         expect(output.code).toBe(1)
-        expect(output.stderr).toMatch(/Failed to compile/)
+        expect(output.stderr).toMatch(/Failed to type check/)
         expect(output.stderr).toMatch(/is not assignable to type 'boolean'/)
       })
     }

--- a/test/integration/typescript-ignore-errors/test/index.test.ts
+++ b/test/integration/typescript-ignore-errors/test/index.test.ts
@@ -58,13 +58,13 @@ describe('TypeScript with error handling options', () => {
 
                 if (ignoreBuildErrors) {
                   expect(stdout).toContain('Compiled successfully')
-                  expect(stderr).not.toContain('Failed to compile.')
+                  expect(stderr).not.toContain('Failed to type check.')
                   expect(stderr).not.toContain(
                     "not assignable to type 'boolean'"
                   )
                 } else {
                   expect(stdout).not.toContain('Compiled successfully')
-                  expect(stderr).toContain('Failed to compile.')
+                  expect(stderr).toContain('Failed to type check.')
                   expect(stderr).toContain('./pages/index.tsx:2:31')
                   expect(stderr).toContain("not assignable to type 'boolean'")
                 }


### PR DESCRIPTION
Previously:
```
pnpm next build
▲ Next.js 16.2.0-canary.28 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 5.7s
  Running TypeScript  ...
Failed to compile.

./app/page.tsx:3:5
Type error: Type 'string' is not assignable to type 'number'.

  1 | import Nav from "../components/Nav";
  2 |
> 3 | let x: number = 'abc'
    |     ^
  4 |
  5 |
  6 | const IndexPage = () => (
Next.js build worker exited with code: 1 and signal: null
```

Now:
```
pnpm next build
▲ Next.js 16.2.0-canary.28 (Turbopack)

  Creating an optimized production build ...
✓ Compiled successfully in 5.7s
  Running TypeScript  ...
Failed to type check.

./app/page.tsx:3:5
Type error: Type 'string' is not assignable to type 'number'.

  1 | import Nav from "../components/Nav";
  2 |
> 3 | let x: number = 'abc'
    |     ^
  4 |
  5 |
  6 | const IndexPage = () => (
Next.js build worker exited with code: 1 and signal: null
```