### PR TITLE
Turbpopack: fix is_persistent_caching_enabled

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -275,6 +275,9 @@ pub struct ProjectOptions {
     /// Debug build paths for selective builds.
     /// When set, only routes matching these paths will be included in the build.
     pub debug_build_paths: Option<DebugBuildPaths>,
+
+    /// Whether to enable persistent caching
+    pub is_persistent_caching_enabled: bool,
 }
 
 pub struct PartialProjectOptions {
@@ -324,6 +327,9 @@ pub struct PartialProjectOptions {
     /// Debug build paths for selective builds.
     /// When set, only routes matching these paths will be included in the build.
     pub debug_build_paths: Option<DebugBuildPaths>,
+
+    /// Whether to enable persistent caching
+    pub is_persistent_caching_enabled: Option<bool>,
 }
 
 #[derive(
@@ -557,6 +563,7 @@ impl ProjectContainer {
             no_mangling,
             write_routes_hashes_manifest,
             debug_build_paths,
+            is_persistent_caching_enabled,
         } = options;
 
         let resolved_self = self.to_resolved().await?;
@@ -609,6 +616,9 @@ impl ProjectContainer {
         }
         if let Some(debug_build_paths) = debug_build_paths {
             new_options.debug_build_paths = Some(debug_build_paths);
+        }
+        if let Some(is_persistent_caching_enabled) = is_persistent_caching_enabled {
+            new_options.is_persistent_caching_enabled = is_persistent_caching_enabled;
         }
 
         // TODO: Handle mode switch, should prevent mode being switched.
@@ -677,6 +687,7 @@ impl ProjectContainer {
         let write_routes_hashes_manifest;
         let current_node_js_version;
         let debug_build_paths;
+        let is_persistent_caching_enabled;
         {
             let options = self.options_state.get();
             let options = options
@@ -702,6 +713,7 @@ impl ProjectContainer {
             write_routes_hashes_manifest = options.write_routes_hashes_manifest;
             current_node_js_version = options.current_node_js_version.clone();
             debug_build_paths = options.debug_build_paths.clone();
+            is_persistent_caching_enabled = options.is_persistent_caching_enabled;
         }
 
         let dist_dir = next_config.dist_dir().owned().await?;
@@ -729,6 +741,7 @@ impl ProjectContainer {
             write_routes_hashes_manifest,
             current_node_js_version,
             debug_build_paths,
+            is_persistent_caching_enabled,
         }
         .cell())
     }
@@ -823,6 +836,9 @@ pub struct Project {
     /// Debug build paths for selective builds.
     /// When set, only routes matching these paths will be included in the build.
     debug_build_paths: Option<DebugBuildPaths>,
+
+    /// Whether to enable persistent caching
+    is_persistent_caching_enabled: bool,
 }
 
 #[turbo_tasks::value]
@@ -1030,6 +1046,11 @@ impl Project {
     #[turbo_tasks::function]
     pub fn next_config(&self) -> Vc<NextConfig> {
         *self.next_config
+    }
+
+    #[turbo_tasks::function]
+    pub(super) fn is_persistent_caching_enabled(&self) -> Vc<bool> {
+        Vc::cell(self.is_persistent_caching_enabled)
     }
 
     #[turbo_tasks::function]
@@ -1499,7 +1520,7 @@ impl Project {
         );
         emit_event(
             "persistentCaching",
-            *config.persistent_caching_enabled().await?,
+            *self.is_persistent_caching_enabled().await?,
         );
 
         emit_event(

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -327,9 +327,6 @@ pub struct PartialProjectOptions {
     /// Debug build paths for selective builds.
     /// When set, only routes matching these paths will be included in the build.
     pub debug_build_paths: Option<DebugBuildPaths>,
-
-    /// Whether to enable persistent caching
-    pub is_persistent_caching_enabled: Option<bool>,
 }
 
 #[derive(
@@ -563,7 +560,6 @@ impl ProjectContainer {
             no_mangling,
             write_routes_hashes_manifest,
             debug_build_paths,
-            is_persistent_caching_enabled,
         } = options;
 
         let resolved_self = self.to_resolved().await?;
@@ -616,9 +612,6 @@ impl ProjectContainer {
         }
         if let Some(debug_build_paths) = debug_build_paths {
             new_options.debug_build_paths = Some(debug_build_paths);
-        }
-        if let Some(is_persistent_caching_enabled) = is_persistent_caching_enabled {
-            new_options.is_persistent_caching_enabled = is_persistent_caching_enabled;
         }
 
         // TODO: Handle mode switch, should prevent mode being switched.

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -185,6 +185,7 @@ fn main() {
                 write_routes_hashes_manifest: false,
                 current_node_js_version: rcstr!("18.0.0"),
                 debug_build_paths: None,
+                is_persistent_caching_enabled: false,
             };
 
             let json = serde_json::to_string_pretty(&options).unwrap();

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -1072,7 +1072,6 @@ pub struct ExperimentalConfig {
 
     turbopack_minify: Option<bool>,
     turbopack_module_ids: Option<ModuleIds>,
-    turbopack_persistent_caching: Option<bool>,
     turbopack_source_maps: Option<bool>,
     turbopack_input_source_maps: Option<bool>,
     turbopack_tree_shaking: Option<bool>,
@@ -1099,6 +1098,9 @@ pub struct ExperimentalConfig {
     devtool_segment_explorer: Option<bool>,
     /// Whether to report inlined system environment variables as warnings or errors.
     report_system_env_inlining: Option<String>,
+    // Use project.is_persistent_caching() instead
+    // turbopack_file_system_cache_for_dev: Option<bool>,
+    // turbopack_file_system_cache_for_build: Option<bool>,
 }
 
 #[derive(
@@ -1633,15 +1635,6 @@ impl NextConfig {
             }
         }
         Ok(Vc::cell(rules))
-    }
-
-    #[turbo_tasks::function]
-    pub fn persistent_caching_enabled(&self) -> Result<Vc<bool>> {
-        Ok(Vc::cell(
-            self.experimental
-                .turbopack_persistent_caching
-                .unwrap_or_default(),
-        ))
     }
 
     #[turbo_tasks::function]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -243,9 +243,6 @@ pub struct NapiPartialProjectOptions {
     /// local names for variables, functions etc., which can be useful for
     /// debugging/profiling purposes.
     pub no_mangling: Option<bool>,
-
-    // Whether persistent caching is enabled
-    pub is_persistent_caching_enabled: Option<bool>,
 }
 
 #[napi(object)]
@@ -342,7 +339,6 @@ impl From<NapiPartialProjectOptions> for PartialProjectOptions {
             browserslist_query,
             no_mangling,
             write_routes_hashes_manifest,
-            is_persistent_caching_enabled,
         } = val;
         PartialProjectOptions {
             root_path,
@@ -359,7 +355,6 @@ impl From<NapiPartialProjectOptions> for PartialProjectOptions {
             no_mangling,
             write_routes_hashes_manifest,
             debug_build_paths: None,
-            is_persistent_caching_enabled,
         }
     }
 }

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -190,6 +190,9 @@ pub struct NapiProjectOptions {
     /// Debug build paths for selective builds.
     /// When set, only routes matching these paths will be included in the build.
     pub debug_build_paths: Option<NapiDebugBuildPaths>,
+
+    // Whether persistent caching is enabled
+    pub is_persistent_caching_enabled: bool,
 }
 
 /// [NapiProjectOptions] with all fields optional.
@@ -240,6 +243,9 @@ pub struct NapiPartialProjectOptions {
     /// local names for variables, functions etc., which can be useful for
     /// debugging/profiling purposes.
     pub no_mangling: Option<bool>,
+
+    // Whether persistent caching is enabled
+    pub is_persistent_caching_enabled: Option<bool>,
 }
 
 #[napi(object)]
@@ -252,8 +258,6 @@ pub struct NapiDefineEnv {
 
 #[napi(object)]
 pub struct NapiTurboEngineOptions {
-    /// Use the new backend with filesystem cache enabled.
-    pub persistent_caching: Option<bool>,
     /// An upper bound of memory that turbopack will attempt to stay under.
     pub memory_limit: Option<f64>,
     /// Track dependencies between tasks. If false, any change during build will error.
@@ -296,6 +300,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
             write_routes_hashes_manifest,
             current_node_js_version,
             debug_build_paths,
+            is_persistent_caching_enabled,
         } = val;
         ProjectOptions {
             root_path,
@@ -316,6 +321,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
                 app: p.app,
                 pages: p.pages,
             }),
+            is_persistent_caching_enabled,
         }
     }
 }
@@ -336,6 +342,7 @@ impl From<NapiPartialProjectOptions> for PartialProjectOptions {
             browserslist_query,
             no_mangling,
             write_routes_hashes_manifest,
+            is_persistent_caching_enabled,
         } = val;
         PartialProjectOptions {
             root_path,
@@ -352,6 +359,7 @@ impl From<NapiPartialProjectOptions> for PartialProjectOptions {
             no_mangling,
             write_routes_hashes_manifest,
             debug_build_paths: None,
+            is_persistent_caching_enabled,
         }
     }
 }
@@ -506,13 +514,12 @@ pub fn project_new(
                 .memory_limit
                 .map(|m| m as usize)
                 .unwrap_or(usize::MAX);
-            let persistent_caching = turbo_engine_options.persistent_caching.unwrap_or_default();
             let dependency_tracking = turbo_engine_options.dependency_tracking.unwrap_or(true);
             let is_ci = turbo_engine_options.is_ci.unwrap_or(false);
             let is_short_session = turbo_engine_options.is_short_session.unwrap_or(false);
             let turbo_tasks = create_turbo_tasks(
                 PathBuf::from(&options.dist_dir),
-                persistent_caching,
+                options.is_persistent_caching_enabled,
                 memory_limit,
                 dependency_tracking,
                 is_ci,

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -211,7 +211,6 @@ export interface NapiPartialProjectOptions {
    * debugging/profiling purposes.
    */
   noMangling?: boolean
-  isPersistentCachingEnabled?: boolean
 }
 export interface NapiDefineEnv {
   client: Array<NapiOptionEnvVar>

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -166,6 +166,7 @@ export interface NapiProjectOptions {
    * When set, only routes matching these paths will be included in the build.
    */
   debugBuildPaths?: NapiDebugBuildPaths
+  isPersistentCachingEnabled: boolean
 }
 /** [NapiProjectOptions] with all fields optional. */
 export interface NapiPartialProjectOptions {
@@ -210,6 +211,7 @@ export interface NapiPartialProjectOptions {
    * debugging/profiling purposes.
    */
   noMangling?: boolean
+  isPersistentCachingEnabled?: boolean
 }
 export interface NapiDefineEnv {
   client: Array<NapiOptionEnvVar>
@@ -217,8 +219,6 @@ export interface NapiDefineEnv {
   nodejs: Array<NapiOptionEnvVar>
 }
 export interface NapiTurboEngineOptions {
-  /** Use the new backend with filesystem cache enabled. */
-  persistentCaching?: boolean
   /** An upper bound of memory that turbopack will attempt to stay under. */
   memoryLimit?: number
   /** Track dependencies between tasks. If false, any change during build will error. */

--- a/packages/next/src/build/turbopack-analyze/index.ts
+++ b/packages/next/src/build/turbopack-analyze/index.ts
@@ -79,9 +79,9 @@ export async function turbopackAnalyze(
       noMangling,
       writeRoutesHashesManifest: false,
       currentNodeJsVersion,
+      isPersistentCachingEnabled: persistentCaching,
     },
     {
-      persistentCaching,
       memoryLimit: config.experimental?.turbopackMemoryLimit,
       dependencyTracking: persistentCaching,
       isCi: isCI,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -216,10 +216,10 @@ export async function turbopackBuild(): Promise<{
     writeRoutesHashesManifest:
       !!process.env.NEXT_TURBOPACK_WRITE_ROUTES_HASHES_MANIFEST,
     currentNodeJsVersion,
+    isPersistentCachingEnabled: persistentCaching,
   }
 
   const sharedTurboOptions = {
-    persistentCaching,
     memoryLimit: config.experimental?.turbopackMemoryLimit,
     dependencyTracking: persistentCaching,
     isCi: isCI,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -282,9 +282,11 @@ export async function createHotReloaderTurbopack(
       noMangling: false,
       writeRoutesHashesManifest: false,
       currentNodeJsVersion,
+      isPersistentCachingEnabled: isFileSystemCacheEnabledForDev(
+        opts.nextConfig
+      ),
     },
     {
-      persistentCaching: isFileSystemCacheEnabledForDev(opts.nextConfig),
       memoryLimit: opts.nextConfig.experimental?.turbopackMemoryLimit,
       isShortSession: false,
     }

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -389,6 +389,7 @@ describe('next.rs api', () => {
       noMangling: false,
       writeRoutesHashesManifest: false,
       currentNodeJsVersion: '18.0.0',
+      isPersistentCachingEnabled: false,
     })
     projectUpdateSubscription = filterMapAsyncIterator(
       project.updateInfoSubscribe(1000),

--- a/test/development/basic/next-rs-api.test.ts
+++ b/test/development/basic/next-rs-api.test.ts
@@ -231,6 +231,7 @@ async function main() {
     noMangling: false,
     writeRoutesHashesManifest: false,
     currentNodeJsVersion: '18.0.0',
+    isPersistentCachingEnabled: false,
   });
 
   const entrypointsSubscription = project.entrypointsSubscribe();


### PR DESCRIPTION
The next config setting was renamed, so this was always false.

So far, this was only used for telemetry.