### PR TITLE
Improve not-found-with-pages test

### DIFF
--- a/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
+++ b/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
 
-describe('not-found-with-pages', () => {
+describe('not-found-with-pages-i18n', () => {
   const { next, isNextStart } = nextTestSetup({
     files: __dirname,
   })
@@ -17,8 +17,20 @@ describe('not-found-with-pages', () => {
     })
   }
 
-  it('should prefer the app router 404 over the pages router 404 when both are present', async () => {
+  it('should prefer the app router 404 over the pages router 404 when both are present - app', async () => {
     const browser = await next.browser('/app-dir/foo')
+    expect(await browser.elementByCss('h1').text()).toBe(
+      'APP ROUTER - 404 PAGE'
+    )
+
+    await browser.loadPage(next.url)
+    expect(await browser.elementByCss('h1').text()).toBe(
+      'APP ROUTER - 404 PAGE'
+    )
+  })
+
+  it('should prefer the app router 404 over the pages router 404 when both are present - pages', async () => {
+    const browser = await next.browser('/foo')
     expect(await browser.elementByCss('h1').text()).toBe(
       'APP ROUTER - 404 PAGE'
     )

--- a/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
+++ b/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
@@ -1,7 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
 
+const isAdapterTest = Boolean(process.env.NEXT_ENABLE_ADAPTER)
+
 describe('not-found-with-pages-i18n', () => {
-  const { next, isNextStart } = nextTestSetup({
+  const { next, isNextStart, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -17,22 +19,27 @@ describe('not-found-with-pages-i18n', () => {
     })
   }
 
-  it.each(['/app-dir/foo', '/foo'])(
-    'should prefer the app router 404 over the pages router 404 when both are present - browser %s',
-    async (s) => {
-      const browser = await next.browser(s)
-      expect(await browser.elementByCss('h1').text()).toBe(
-        'APP ROUTER - 404 PAGE'
-      )
+  // When using the builder, pages router is incorrectly preferred. This is already fixed when using the adapter
+  const SKIP_TEST_FOR_BUILDER = isNextDeploy ? !isAdapterTest : false
 
-      await browser.loadPage(next.url)
-      expect(await browser.elementByCss('h1').text()).toBe(
-        'APP ROUTER - 404 PAGE'
-      )
-    }
-  )
+  if (!SKIP_TEST_FOR_BUILDER) {
+    it.each(['/app-dir/foo', '/foo'])(
+      'should prefer the app router 404 over the pages router 404 when both are present - browser %s',
+      async (s) => {
+        const browser = await next.browser(s)
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'APP ROUTER - 404 PAGE'
+        )
 
-  it.each(['/app-dir/foo', '/foo'])(
+        await browser.loadPage(next.url)
+        expect(await browser.elementByCss('h1').text()).toBe(
+          'APP ROUTER - 404 PAGE'
+        )
+      }
+    )
+  }
+
+  it.each(SKIP_TEST_FOR_BUILDER ? ['/app-dir/foo'] : ['/app-dir/foo', '/foo'])(
     'should prefer the app router 404 over the pages router 404 when both are present - SSR %s',
     async (s) => {
       const ssr = await next.fetch(s)

--- a/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
+++ b/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
@@ -27,6 +27,10 @@ describe('not-found-with-pages-i18n', () => {
     expect(await browser.elementByCss('h1').text()).toBe(
       'APP ROUTER - 404 PAGE'
     )
+
+    const ssr = await next.fetch('/app-dir/foo')
+    expect(ssr.status).toEqual(404)
+    expect(await ssr.text()).toContain('APP ROUTER - 404 PAGE')
   })
 
   it('should prefer the app router 404 over the pages router 404 when both are present - pages', async () => {
@@ -39,5 +43,9 @@ describe('not-found-with-pages-i18n', () => {
     expect(await browser.elementByCss('h1').text()).toBe(
       'APP ROUTER - 404 PAGE'
     )
+
+    const ssr = await next.fetch('/foo')
+    expect(ssr.status).toEqual(404)
+    expect(await ssr.text()).toContain('APP ROUTER - 404 PAGE')
   })
 })

--- a/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
+++ b/test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts
@@ -17,35 +17,27 @@ describe('not-found-with-pages-i18n', () => {
     })
   }
 
-  it('should prefer the app router 404 over the pages router 404 when both are present - app', async () => {
-    const browser = await next.browser('/app-dir/foo')
-    expect(await browser.elementByCss('h1').text()).toBe(
-      'APP ROUTER - 404 PAGE'
-    )
+  it.each(['/app-dir/foo', '/foo'])(
+    'should prefer the app router 404 over the pages router 404 when both are present - browser %s',
+    async (s) => {
+      const browser = await next.browser(s)
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'APP ROUTER - 404 PAGE'
+      )
 
-    await browser.loadPage(next.url)
-    expect(await browser.elementByCss('h1').text()).toBe(
-      'APP ROUTER - 404 PAGE'
-    )
+      await browser.loadPage(next.url)
+      expect(await browser.elementByCss('h1').text()).toBe(
+        'APP ROUTER - 404 PAGE'
+      )
+    }
+  )
 
-    const ssr = await next.fetch('/app-dir/foo')
-    expect(ssr.status).toEqual(404)
-    expect(await ssr.text()).toContain('APP ROUTER - 404 PAGE')
-  })
-
-  it('should prefer the app router 404 over the pages router 404 when both are present - pages', async () => {
-    const browser = await next.browser('/foo')
-    expect(await browser.elementByCss('h1').text()).toBe(
-      'APP ROUTER - 404 PAGE'
-    )
-
-    await browser.loadPage(next.url)
-    expect(await browser.elementByCss('h1').text()).toBe(
-      'APP ROUTER - 404 PAGE'
-    )
-
-    const ssr = await next.fetch('/foo')
-    expect(ssr.status).toEqual(404)
-    expect(await ssr.text()).toContain('APP ROUTER - 404 PAGE')
-  })
+  it.each(['/app-dir/foo', '/foo'])(
+    'should prefer the app router 404 over the pages router 404 when both are present - SSR %s',
+    async (s) => {
+      const ssr = await next.fetch(s)
+      expect(ssr.status).toEqual(404)
+      expect(await ssr.text()).toContain('APP ROUTER - 404 PAGE')
+    }
+  )
 })


### PR DESCRIPTION
The fixture contains both App and Pages router
But the assertions only ever tested the App endpoints

Fixed by https://github.com/vercel/vercel/pull/14878

There is still a bug in the builder:
```
FAIL webpack test/e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts (57.396 s)
  not-found-with-pages-i18n
    ✕ should prefer the app router 404 over the pages router 404 when both are present - browser /app-dir/foo (3528 ms)
    ✕ should prefer the app router 404 over the pages router 404 when both are present - browser /foo (401 ms)
    ✓ should prefer the app router 404 over the pages router 404 when both are present - SSR /app-dir/foo (141 ms)
    ✕ should prefer the app router 404 over the pages router 404 when both are present - SSR /foo (249 ms)

  ● not-found-with-pages-i18n › should prefer the app router 404 over the pages router 404 when both are present - browser /app-dir/foo

    expect(received).toBe(expected) // Object.is equality

    Expected: "APP ROUTER - 404 PAGE"
    Received: "PAGES ROUTER - 404 PAGE"

      27 |
      28 |       await browser.loadPage(next.url)
    > 29 |       expect(await browser.elementByCss('h1').text()).toBe(
         |                                                       ^
      30 |         'APP ROUTER - 404 PAGE'
      31 |       )
      32 |     }

      at toBe (e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts:29:55)

  ● not-found-with-pages-i18n › should prefer the app router 404 over the pages router 404 when both are present - browser /foo

    expect(received).toBe(expected) // Object.is equality

    Expected: "APP ROUTER - 404 PAGE"
    Received: "PAGES ROUTER - 404 PAGE"

      22 |     async (s) => {
      23 |       const browser = await next.browser(s)
    > 24 |       expect(await browser.elementByCss('h1').text()).toBe(
         |                                                       ^
      25 |         'APP ROUTER - 404 PAGE'
      26 |       )
      27 |

      at toBe (e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts:24:55)

  ● not-found-with-pages-i18n › should prefer the app router 404 over the pages router 404 when both are present - SSR /foo

    expect(received).toContain(expected) // indexOf

    Expected substring: "APP ROUTER - 404 PAGE"
    Received string:    "<!DOCTYPE html><html lang=\"en\" data-dpl-id=\"dpl_BM4HgVbmReroGBTz3augsyMX43xG\"><head><meta charSet=\"utf-8\" data-next-head=\"\"/><meta name=\"viewport\" content=\"width=device-width\" data-next-head=\"\"/><noscript data-n-css=\"\"></noscript><script defer=\"\" noModule=\"\" src=\"/_next/static/chunks/polyfills-42372ed130431b0a.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\"></script><script src=\"/_next/static/chunks/webpack-70c336f9a46f13b1.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\" defer=\"\"></script><script src=\"/_next/static/chunks/framework-8c604becf61eba86.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\" defer=\"\"></script><script src=\"/_next/static/chunks/main-16ce12b5863057b2.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\" defer=\"\"></script><script src=\"/_next/static/chunks/pages/_app-688aa0c7241baf30.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\" defer=\"\"></script><script src=\"/_next/static/chunks/pages/404-b7a49e5d00a03545.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\" defer=\"\"></script><script src=\"/_next/static/_buildManifest.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\" defer=\"\"></script><script src=\"/_next/static/_ssgManifest.js?dpl=dpl_BM4HgVbmReroGBTz3augsyMX43xG\" defer=\"\"></script></head><body><div id=\"__next\"><div><h1>PAGES ROUTER - 404 PAGE</h1><p>This page is using the PAGES ROUTER</p><p>Custom message fetched at build time</p></div></div><script id=\"__NEXT_DATA__\" type=\"application/json\">{\"props\":{\"pageProps\":{\"message\":\"Custom message fetched at build time\"},\"__N_SSG\":true},\"page\":\"/404\",\"query\":{},\"buildId\":\"build-TfctsWXpff2fKS\",\"isFallback\":false,\"isExperimentalCompile\":false,\"gsp\":true,\"locale\":\"en\",\"locales\":[\"en\",\"en-GB\"],\"defaultLocale\":\"en\",\"scriptLoader\":[]}</script></body></html>"

      38 |       const ssr = await next.fetch(s)
      39 |       expect(ssr.status).toEqual(404)
    > 40 |       expect(await ssr.text()).toContain('APP ROUTER - 404 PAGE')
         |                                ^
      41 |     }
      42 |   )
      43 | })

      at toContain (e2e/app-dir/not-found-with-pages-i18n/not-found-with-pages.test.ts:40:32)
```