### PR TITLE
[Instant] Validate blocking head

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1069,5 +1069,6 @@
   "1068": "Expected workStore to be initialized",
   "1069": "Invariant: cache entry \"%s\" not found in dir \"%s\"",
   "1070": "image of size %s could not be tracked by lru cache",
-  "1071": "toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase"
+  "1071": "toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase",
+  "1072": "Missing segment data: <head>"
 }

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -976,6 +976,9 @@ export function trackDynamicHoleInRuntimeShell(
     dynamicValidation.dynamicMetadata = error
     return
   } else if (hasViewportRegex.test(componentStack)) {
+    // TODO(instant-validation): If the page only has holes caused by runtime data,
+    // we won't find out if there's a suspense-above-body and error for dynamic viewport
+    // even if there is in fact a suspense-above-body
     const message = `Route "${workStore.route}": Uncached data or \`connection()\` was accessed inside \`generateViewport\`. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport`
     const error = createErrorWithComponentOrOwnerStack(
       message,

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -278,7 +278,6 @@ function traverseRootSeedDataSegments(
     seedData: CacheNodeSeedData
   ) => void
 ) {
-  // TODO: handle head as well
   const { flightRouterState, seedData } =
     getRootDataFromPayload(initialRSCPayload)
 
@@ -437,6 +436,8 @@ export async function collectStagedSegmentData(
   // We have to preserve the stage information for each of them,
   // so that we can later render each segment in any stage we need.
 
+  const { head } = getRootDataFromPayload(payload)
+
   const segments = new Map<SegmentPath, SegmentData>()
   traverseRootSeedDataSegments(payload, (segmentPath, seedData) => {
     segments.set(segmentPath, createSegmentData(seedData))
@@ -451,75 +452,73 @@ export async function collectStagedSegmentData(
     [RenderStage.Runtime]: -1,
   }
 
+  const renderIntoCacheItem = async (
+    data: HeadData | SegmentData,
+    cacheEntry: SegmentCacheItem
+  ): Promise<void> => {
+    const segmentDebugChannel = cacheEntry.debugChunks
+      ? createDebugChannel()
+      : undefined
+
+    const itemStream = renderToReadableStream(
+      data,
+      clientReferenceManifest.clientModules,
+      {
+        filterStackFrame,
+        debugChannel: segmentDebugChannel?.serverSide,
+        environmentName,
+        startTime,
+        onError(error: unknown) {
+          const digest = getDigestForWellKnownError(error)
+          if (digest) {
+            return digest
+          }
+          // We don't need to log the errors because we would have already done that
+          // when generating the original Flight stream for the whole page.
+          if (
+            process.env.NEXT_DEBUG_BUILD ||
+            process.env.__NEXT_VERBOSE_LOGGING
+          ) {
+            const workStore = workAsyncStorage.getStore()
+            printDebugThrownValueForProspectiveRender(
+              error,
+              workStore?.route ?? 'unknown route',
+              Phase.InstantValidation
+            )
+          }
+        },
+      }
+    )
+
+    await Promise.all([
+      // accumulate Flight chunks
+      (async () => {
+        for await (const chunk of itemStream.values()) {
+          writeChunk(cacheEntry.chunks, controller.currentStage, chunk)
+        }
+      })(),
+      // accumulate Debug chunks
+      segmentDebugChannel &&
+        (async () => {
+          for await (const chunk of segmentDebugChannel.clientSide.readable.values()) {
+            cacheEntry.debugChunks!.push(chunk)
+          }
+        })(),
+    ])
+  }
+
   await runInSequentialTasks(
     () => {
+      {
+        const headCacheItem = createSegmentCacheItem(!!fullPageDebugChunks)
+        cache.head = headCacheItem
+        pendingTasks.push(renderIntoCacheItem(head, headCacheItem))
+      }
+
       for (const [segmentPath, segmentData] of segments) {
-        const segmentCacheItem: SegmentCacheItem = {
-          chunks: {
-            [RenderStage.Static]: [],
-            [RenderStage.Runtime]: [],
-            [RenderStage.Dynamic]: [],
-          },
-          debugChunks: fullPageDebugChunks ? [] : null,
-        }
-        cache.set(segmentPath, segmentCacheItem)
-
-        const segmentTask = async () => {
-          const segmentDebugChannel = fullPageDebugChunks
-            ? createDebugChannel()
-            : undefined
-
-          const segmentStream = renderToReadableStream(
-            segmentData,
-            clientReferenceManifest.clientModules,
-            {
-              filterStackFrame,
-              debugChannel: segmentDebugChannel?.serverSide,
-              environmentName,
-              startTime,
-              onError(error: unknown) {
-                const digest = getDigestForWellKnownError(error)
-                if (digest) {
-                  return digest
-                }
-                // We don't need to log the errors because we would have already done that
-                // when generating the original Flight stream for the whole page.
-                if (
-                  process.env.NEXT_DEBUG_BUILD ||
-                  process.env.__NEXT_VERBOSE_LOGGING
-                ) {
-                  const workStore = workAsyncStorage.getStore()
-                  printDebugThrownValueForProspectiveRender(
-                    error,
-                    workStore?.route ?? 'unknown route',
-                    Phase.InstantValidation
-                  )
-                }
-              },
-            }
-          )
-
-          await Promise.all([
-            // accumulate Flight chunks
-            (async () => {
-              for await (const chunk of segmentStream.values()) {
-                writeChunk(
-                  segmentCacheItem.chunks,
-                  controller.currentStage,
-                  chunk
-                )
-              }
-            })(),
-            // accumulate Debug chunks
-            segmentDebugChannel &&
-              (async () => {
-                for await (const chunk of segmentDebugChannel.clientSide.readable.values()) {
-                  segmentCacheItem.debugChunks!.push(chunk)
-                }
-              })(),
-          ])
-        }
-        pendingTasks.push(segmentTask())
+        const segmentCacheItem = createSegmentCacheItem(!!fullPageDebugChunks)
+        cache.segments.set(segmentPath, segmentCacheItem)
+        pendingTasks.push(renderIntoCacheItem(segmentData, segmentCacheItem))
       }
     },
     () => {
@@ -803,7 +802,7 @@ export async function createCombinedPayload(
   /** mutable out-param - Which stages are actually used in the resulting payload */
   usedSegmentKinds: Set<SegmentStage>
 ): Promise<InitialRSCPayload> {
-  const { head, flightRouterState } = getRootDataFromPayload(initialRSCPayload)
+  const { flightRouterState } = getRootDataFromPayload(initialRSCPayload)
   const combinedSeedData = await createValidationSeedData(
     cache,
     validationRouteTree,
@@ -815,6 +814,23 @@ export async function createCombinedPayload(
     useRuntimeStageForPartialSegments,
     usedSegmentKinds
   )
+
+  // If we did a runtime prefetch for this navigation, then we'd get a runtime-stage head.
+  // Otherwise, we'd only have the `/_head` segment prefetch which is static.
+  // TODO(instant-validation): not sure about this as a way of detecting runtime prefetches
+  // (in the presence of `useRuntimeStageForPartialSegments`), but maybe it's actually correct?
+  const headStage = usedSegmentKinds.has(RenderStage.Runtime)
+    ? RenderStage.Runtime
+    : RenderStage.Static
+  debug?.(`    <head> - ${RenderStage[headStage]}`)
+  const head = await createValidationHead(
+    cache,
+    releaseSignal,
+    clientReferenceManifest,
+    stageEndTimes,
+    headStage
+  )
+
   const combinedRSCPayload: InitialRSCPayload = {
     ...initialRSCPayload,
     f: [
@@ -822,7 +838,7 @@ export async function createCombinedPayload(
       [
         flightRouterState satisfies FlightRouterState,
         combinedSeedData satisfies CacheNodeSeedData,
-        head satisfies HeadData, // TODO: handle head better
+        head satisfies HeadData,
       ],
     ],
   }
@@ -926,7 +942,7 @@ function createValidationSeedData(
     }
 
     debug?.(`    ${path || '/'} - ${RenderStage[stage]}`)
-    const segmentCacheItem = cache.get(path)
+    const segmentCacheItem = cache.segments.get(path)
     if (!segmentCacheItem) {
       throw new InvariantError(`Missing segment data: ${path}`)
     }
@@ -994,6 +1010,27 @@ function createValidationSeedData(
     // Root layouts are always shared. Navigating to a new root layout is an MPA navigation.
     { kind: 'shared-tree' },
     null
+  )
+}
+
+async function createValidationHead(
+  cache: SegmentCache,
+  releaseSignal: AbortSignal,
+  clientReferenceManifest: ClientReferenceManifest,
+  stageEndTimes: StageEndTimes,
+  stage: RenderStage.Static | RenderStage.Runtime
+): Promise<HeadData> {
+  const segmentCacheItem = cache.head
+  if (!segmentCacheItem) {
+    throw new InvariantError(`Missing segment data: <head>`)
+  }
+  return await deserializeFromChunks<HeadData>(
+    segmentCacheItem.chunks[stage],
+    segmentCacheItem.chunks[RenderStage.Dynamic],
+    segmentCacheItem.debugChunks,
+    releaseSignal,
+    clientReferenceManifest,
+    { startTime: undefined, endTime: stageEndTimes[stage] }
   )
 }
 
@@ -1086,10 +1123,24 @@ function getCacheNodeSeedDataFromSegment(
 }
 
 function createSegmentCache(): SegmentCache {
-  return new Map()
+  return { head: null, segments: new Map() }
 }
 
-export type SegmentCache = Map<SegmentPath, SegmentCacheItem>
+function createSegmentCacheItem(withDebugChunks: boolean): SegmentCacheItem {
+  return {
+    chunks: {
+      [RenderStage.Static]: [],
+      [RenderStage.Runtime]: [],
+      [RenderStage.Dynamic]: [],
+    },
+    debugChunks: withDebugChunks ? [] : null,
+  }
+}
+
+export type SegmentCache = {
+  head: SegmentCacheItem | null
+  segments: Map<SegmentPath, SegmentCacheItem>
+}
 
 type SegmentCacheItem = {
   chunks: StageChunks

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx
@@ -1,0 +1,16 @@
+import { ReactNode, Suspense } from 'react'
+
+export const unstable_instant = { prefetch: 'static' }
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <p>
+        This layout should have static instant UI. However, despite having a
+        suspense around children, it's not instant because of a dynamic
+        generateViewport in a child (which the Suspense doesn't catch.)
+      </p>
+      <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/page.tsx
@@ -1,0 +1,29 @@
+import type { Viewport } from 'next'
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+export async function generateViewport(): Promise<Viewport> {
+  await connection()
+  return {
+    themeColor: 'aliceblue',
+  }
+}
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>
+        This page has a dynamic generateViewport. That's not prefetchable, but
+        it has <code>instant = false</code>, so blocking is valid. However, this
+        violates a static assertion in a parent layout, so ultimately it still
+        fails validation.
+      </p>
+      <p>
+        We also access runtime data in the page itself, because a static page
+        with a dynamic vieport is not allowed.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx
@@ -1,0 +1,38 @@
+import type { Viewport } from 'next'
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{}],
+}
+
+// Note that we're inside a root layout with suspense, so we skip the static shell
+export async function generateViewport(): Promise<Viewport> {
+  await connection()
+  return {
+    themeColor: 'aliceblue',
+  }
+}
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>This page has a dynamic generateViewport</p>
+      <p>
+        We also access dynamic data in the page itself, because a static page
+        with a dynamic viewport is not allowed.
+      </p>
+      <Suspense>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return null
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/layout.tsx
@@ -1,0 +1,8 @@
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export default async function Layout({ children }) {
+  return <>{children}</>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx
@@ -1,0 +1,35 @@
+import type { Viewport } from 'next'
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// This would be valid if it used a runtime prefetch (because then it wouldn't block navigation),
+// but it's static, so it's invalid. As an extra sanity check, we put a runtime prefetch on the
+// layout above, and that should not make this error go away.
+export const unstable_instant = { prefetch: 'static' }
+
+export async function generateViewport(): Promise<Viewport> {
+  await cookies()
+  return {
+    themeColor: 'aliceblue',
+  }
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p>This page has a runtime generateViewport</p>
+      <p>
+        We also access runtime data in the page itself, because a fully static
+        page with a runtime vieport is not allowed.
+      </p>
+      <Suspense>
+        <Runtime />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Runtime() {
+  await cookies()
+  return null
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-metadata-in-runtime/page.tsx
@@ -1,0 +1,40 @@
+import { Metadata } from 'next'
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  await connection()
+  return {
+    title: 'Blocked by connection',
+  }
+}
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>
+        This page has a generateMetadata that accesses connection. It's
+        runtime-prefetchable, but metadata doesn't block, so it's fine.
+      </p>
+      <p>
+        We also access connection in the page itself, because a runtime page
+        with dynamic metadata is not allowed.
+      </p>
+      <Suspense>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Dynamic() {
+  await connection()
+  return null
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-viewport-in-blocking/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-dynamic-viewport-in-blocking/page.tsx
@@ -1,0 +1,27 @@
+import type { Viewport } from 'next'
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+export async function generateViewport(): Promise<Viewport> {
+  await connection()
+  return {
+    themeColor: 'aliceblue',
+  }
+}
+
+export default async function Page() {
+  await connection()
+  return (
+    <main>
+      <p>
+        This page has a dynamic generateViewport. That's not prefetchable, but
+        it has <code>instant = false</code>, so blocking is valid.
+      </p>
+      <p>
+        We also access runtime data in the page itself, because a static page
+        with a dynamic vieport is not allowed.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-metadata-in-static/page.tsx
@@ -1,0 +1,34 @@
+import { Metadata } from 'next'
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+export const unstable_instant = {
+  prefetch: 'static',
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  await cookies()
+  return {
+    title: 'Blocked by cookies',
+  }
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p>This page has a generateMetadata that accesses cookies.</p>
+      <p>
+        We also access cookies in the page itself, because a static page with
+        non-static metadata is not allowed.
+      </p>
+      <Suspense>
+        <Runtime />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Runtime() {
+  await cookies()
+  return null
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/head/valid-runtime-viewport-in-runtime/page.tsx
@@ -1,0 +1,27 @@
+import type { Viewport } from 'next'
+import { cookies } from 'next/headers'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{}],
+}
+
+export async function generateViewport(): Promise<Viewport> {
+  await cookies()
+  return {
+    themeColor: 'aliceblue',
+  }
+}
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>This page has a runtime generateViewport</p>
+      <p>
+        We also access runtime data in the page itself, because a static page
+        with a runtime vieport is not allowed.
+      </p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -128,6 +128,31 @@ export default async function Page() {
         </li>
       </ul>
 
+      <h2>Head</h2>
+      <ul>
+        <li>
+          <DebugLinks href="/suspense-in-root/head/valid-dynamic-metadata-in-runtime" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/head/valid-runtime-metadata-in-static" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/head/valid-runtime-viewport-in-runtime" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/head/valid-dynamic-viewport-in-blocking" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/head/invalid-dynamic-viewport-in-runtime" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/head/invalid-runtime-viewport-in-static" />
+        </li>
+      </ul>
+
       <h2>Disable Validation</h2>
       <ul>
         <li>

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -10,6 +10,7 @@ import {
   ErrorSnapshot,
   RedboxSnapshot,
 } from '../../../lib/add-redbox-matchers'
+import { Playwright } from '../../../lib/next-webdriver'
 
 describe('instant validation', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
@@ -90,7 +91,7 @@ describe('instant validation', () => {
   }
 
   async function expectNoValidationErrors(
-    browser: Awaited<ReturnType<typeof next.browser>>,
+    browser: Playwright,
     url: string
   ): Promise<void> {
     await waitForValidation(url)
@@ -1312,6 +1313,183 @@ describe('instant validation', () => {
            }
           `)
         }
+      })
+    })
+
+    describe('head', () => {
+      it('valid - runtime prefetch - dynamic generateMetadata does not block navigation', async () => {
+        // Metadata streams and does not block navigation, so it can access
+        // dynamic data without failing validation.
+        const browser = await navigateTo(
+          '/suspense-in-root/head/valid-dynamic-metadata-in-runtime'
+        )
+        await expectNoValidationErrors(browser, await browser.url())
+      })
+
+      it('valid - static prefetch - runtime generateMetadata does not block navigation', async () => {
+        // Metadata streams and does not block navigation, so it can access
+        // runtime data without failing validation.
+        const browser = await navigateTo(
+          '/suspense-in-root/head/valid-runtime-metadata-in-static'
+        )
+        await expectNoValidationErrors(browser, await browser.url())
+      })
+
+      it('invalid - static prefetch - runtime generateViewport blocks navigation', async () => {
+        // if generateViewport uses runtime data and we use a static prefetch,
+        // we won't have it available when navigating, so we'll block and should fail validation.
+        const browser = await navigateTo(
+          '/suspense-in-root/head/invalid-runtime-viewport-in-static'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33) @ unstable_instant
+         >  8 | export const unstable_instant = { prefetch: 'static' }
+              |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (8:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "description": "Runtime data was accessed inside generateViewport()
+
+         Viewport metadata needs to be available on page load so accessing data that comes from a user Request while producing it prevents Next.js from prerendering an initial UI.cookies(), headers(), and searchParams, are examples of Runtime data that can only come from a user request.
+
+         To fix this:
+
+         Remove the Runtime data requirement from generateViewport. This allows Next.js to statically prerender generateViewport() as part of the HTML document, so it's instantly visible to the user.
+
+         or
+
+         Put a <Suspense> around your document <body>.This indicate to Next.js that you are opting into allowing blocking navigations for any page.
+
+         params are usually considered Runtime data but if all params are provided a value using generateStaticParams they can be statically prerendered.
+
+         Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (11:16) @ Module.generateViewport
+         > 11 |   await cookies()
+              |                ^",
+           "stack": [
+             "Module.generateViewport app/suspense-in-root/head/invalid-runtime-viewport-in-static/page.tsx (11:16)",
+           ],
+         }
+        `)
+      })
+
+      it('invalid - runtime prefetch - dynamic viewport blocks navigation', async () => {
+        // if generateViewport uses dynamic data and we use a runtime prefetch,
+        // we won't have it available when navigating, so we'll block and should fail validation.
+        const browser = await navigateTo(
+          '/suspense-in-root/head/invalid-dynamic-viewport-in-runtime'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33) @ unstable_instant
+         > 6 | export const unstable_instant = {
+             |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (6:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "description": "Data that blocks navigation was accessed inside generateViewport()
+
+         Viewport metadata needs to be available on page load so accessing data that waits for a user navigation while producing it prevents Next.js from prerendering an initial UI. Uncached data such as fetch(...), cached data with a low expire time, or connection() are all examples of data that only resolve on navigation.
+
+         To fix this:
+
+         Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender generateViewport() as part of the HTML document, so it's instantly visible to the user.
+
+         or
+
+         Put a <Suspense> around your document <body>.This indicate to Next.js that you are opting into allowing blocking navigations for any page.
+
+         Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (13:19) @ Module.generateViewport
+         > 13 |   await connection()
+              |                   ^",
+           "stack": [
+             "Module.generateViewport app/suspense-in-root/head/invalid-dynamic-viewport-in-runtime/page.tsx (13:19)",
+           ],
+         }
+        `)
+      })
+
+      it('valid - runtime prefetch - runtime generateViewport does not block navigation', async () => {
+        // if generateViewport uses runtime data and we use a runtime prefetch,
+        // we'll have it available when navigating, so we won't block and validation should succeed.
+        const browser = await navigateTo(
+          '/suspense-in-root/head/valid-runtime-viewport-in-runtime'
+        )
+        await expectNoValidationErrors(browser, await browser.url())
+      })
+
+      it('valid - blocking page - dynamic viewport is allowed to block', async () => {
+        // if generateViewport uses dynamic data, it'll always block regardless of prefetching.
+        // however, this is valid if the page opts into blocking via `instant = false`.
+        const browser = await navigateTo(
+          '/suspense-in-root/head/valid-dynamic-viewport-in-blocking'
+        )
+        await expectNoValidationErrors(browser, await browser.url())
+      })
+
+      it('invalid - blocking page inside static - dynamic viewport is not allowed to block', async () => {
+        // if generateViewport uses dynamic data, it'll always block regardless of prefetching.
+        // this can be allowed if a page opts into blocking. but if it violates a static
+        // assertion on a parent layout, it should still fail.
+        const browser = await navigateTo(
+          '/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static'
+        )
+        // TODO(instant-validation): why aren't we pointing to `await connection()` here?
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33) @ unstable_instant
+         > 3 | export const unstable_instant = { prefetch: 'static' }
+             |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/layout.tsx (3:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "description": "Data that blocks navigation was accessed inside generateViewport()
+
+         Viewport metadata needs to be available on page load so accessing data that waits for a user navigation while producing it prevents Next.js from prerendering an initial UI. Uncached data such as fetch(...), cached data with a low expire time, or connection() are all examples of data that only resolve on navigation.
+
+         To fix this:
+
+         Move the asynchronous await into a Cache Component ("use cache"). This allows Next.js to statically prerender generateViewport() as part of the HTML document, so it's instantly visible to the user.
+
+         or
+
+         Put a <Suspense> around your document <body>.This indicate to Next.js that you are opting into allowing blocking navigations for any page.
+
+         Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/page.tsx (6:23) @ Module.generateViewport
+         > 6 | export async function generateViewport(): Promise<Viewport> {
+             |                       ^",
+           "stack": [
+             "Module.generateViewport app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/page.tsx (6:23)",
+           ],
+         }
+        `)
       })
     })
 


### PR DESCRIPTION
Previously, instant validation would always use the dynamic stage for the head, which means that we wouldn't catch errors related to a blocking `generateViewport`. This is fixed here. We treat head as a separate segment and use the appropriate stage (Static or Runtime) depending on prefetch config.
 
Closes NAR-780