### PR TITLE
fix(types): correct AppType generic parameter to match runtime behavior

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType & P
 >
 
 export type AppTreeType = ComponentType<

--- a/test/integration/typescript/pages/_app.tsx
+++ b/test/integration/typescript/pages/_app.tsx
@@ -1,9 +1,12 @@
 import type { AppType } from 'next/app'
 
-const MyApp: AppType<{ foo: string }> = ({ Component, pageProps }) => {
+const MyApp: AppType<{ foo: string }> = ({ Component, pageProps, foo }) => {
+  // foo should be available directly on props (from getInitialProps)
+  // This tests the fix for https://github.com/vercel/next.js/issues/42846
+  console.log('foo from getInitialProps:', foo)
   return <Component {...pageProps} />
 }
 
-MyApp.getInitialProps = () => ({ foo: 'bar' })
+MyApp.getInitialProps = () => ({ foo: 'bar', pageProps: {} })
 
 export default MyApp


### PR DESCRIPTION
## Summary

- Fixes `AppType<P>` generic parameter to correctly type props from `getInitialProps`
- The generic parameter `P` now correctly represents additional props spread onto the App component
- Previously, `P` was incorrectly passed as `PageProps` to `AppPropsType`, causing TypeScript to expect custom props under `pageProps` instead of at the top level

## Problem

When defining a custom `_app.tsx` with `AppType<{ foo: string }>` and returning `{ foo: 'bar' }` from `getInitialProps`, TypeScript incorrectly expects `props.pageProps.foo` instead of `props.foo`, even though at runtime `foo` is available directly on props.

## Solution

Changed the `AppType` definition from:
```typescript
export type AppType<P = {}> = NextComponentType<
  AppContextType,
  P,
  AppPropsType<any, P>  // P incorrectly used as PageProps
>
```

To:
```typescript
export type AppType<P = {}> = NextComponentType<
  AppContextType,
  P,
  AppPropsType & P  // P correctly intersected with AppPropsType
>
```

## Test plan

- [ ] Updated existing TypeScript integration test to verify the fix
- [ ] The test now correctly destructures `foo` from props (not `pageProps`)

## Related Issues

Fixes #42846

---

This PR was generated with AI assistance (Claude claude-opus-4-5). All code changes have been reviewed for correctness.