### PR TITLE
[turbopack] Mark `all_entrypoints_write_to_disk_operation` as a turbo-tasks root

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1057,6 +1057,7 @@ pub async fn all_entrypoints_write_to_disk_operation(
     project: ResolvedVc<ProjectContainer>,
     app_dir_only: bool,
 ) -> Result<Vc<Entrypoints>> {
+    turbo_tasks::mark_root();
     let output_assets_operation = output_assets_operation(project, app_dir_only);
     project
         .project()
@@ -1064,7 +1065,7 @@ pub async fn all_entrypoints_write_to_disk_operation(
         .as_side_effect()
         .await?;
 
-    Ok(project.entrypoints())
+    Ok(project.entrypoints().resolve().await?)
 }
 
 #[turbo_tasks::function(operation)]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -955,12 +955,13 @@ async fn get_entrypoints_with_issues_operation(
 }
 
 #[turbo_tasks::function(operation)]
-fn project_container_entrypoints_operation(
+async fn project_container_entrypoints_operation(
     // the container is a long-lived object with internally mutable state, there's no risk of it
     // becoming stale
     container: ResolvedVc<ProjectContainer>,
-) -> Vc<Entrypoints> {
-    container.entrypoints()
+) -> Result<Vc<Entrypoints>> {
+    turbo_tasks::mark_root();
+    container.entrypoints().resolve().await
 }
 
 #[turbo_tasks::value(serialization = "none")]


### PR DESCRIPTION
From profiling vercel-site i saw some expensive aggregation update queue operations when reading this task.

see a cpu profile 
![image.png](https://app.graphite.com/user-attachments/assets/ba07bffa-3e13-4e51-86db-d8154022d1d8.png)

That is 5 seconds of single threaded updates as we restructure the aggregation graph around a root that we discover too late.



<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
