### PR TITLE
Ensure _middleware is consistent in adapter for name/id

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -747,7 +747,7 @@ export async function handleBuildComplete({
               }
             })
           output.pathname = '/_middleware'
-          output.id = page.name
+          output.id = '/_middleware'
           outputs.middleware = output
         } else {
           currentOutputs.push(output)


### PR DESCRIPTION
Makes sure we don't use both `_middleware` and `middleware` naming for the output. 

Found in https://github.com/vercel/next.js/pull/89522 we were using both.