### PR TITLE
Turbopack: Replace next.js wrapper modules with boundary markers

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -918,7 +918,16 @@ impl AppProject {
                                 merge_tag: NEXT_SERVER_UTILITY_MERGE_TAG.clone(),
                                 entries: server_utils
                                     .iter()
-                                    .map(async |m| Ok(ResolvedVc::upcast(m.await?.module)))
+                                    .map(async |m| {
+                                        let boundary = m
+                                            .boundary_info()
+                                            .await?
+                                            .as_ref()
+                                            .expect("server utility must have boundary info")
+                                            .inner_module
+                                            .expect("server utility must have inner module");
+                                        Ok(boundary)
+                                    })
                                     .try_join()
                                     .await?,
                             },
@@ -941,13 +950,13 @@ impl AppProject {
                         let graph = SingleModuleGraph::new_with_entries_visited_intern(
                             // This should really be ChunkGroupEntry::Shared(module.await?.module),
                             // but that breaks everything for some reason.
-                            vec![ChunkGroupEntry::Entry(vec![ResolvedVc::upcast(*module)])],
+                            vec![ChunkGroupEntry::Entry(vec![*module])],
                             visited_modules,
                             should_trace,
                             should_read_binding_usage,
                         );
                         graphs.push(graph);
-                        let is_layout = module.server_path().await?.file_stem() == Some("layout");
+                        let is_layout = module.ident().path().await?.file_stem() == Some("layout");
                         visited_modules = if is_layout {
                             // Only propagate the visited_modules of the parent layout(s), not
                             // across siblings such as loading.js and
@@ -1847,7 +1856,16 @@ impl AppEndpoint {
                         let server_utils = client_references
                             .server_utils
                             .iter()
-                            .map(async |m| Ok(ResolvedVc::upcast(m.await?.module)))
+                            .map(async |m| {
+                                let boundary = m
+                                    .boundary_info()
+                                    .await?
+                                    .as_ref()
+                                    .expect("server utility must have boundary info")
+                                    .inner_module
+                                    .expect("server utility must have inner module");
+                                Ok(boundary)
+                            })
                             .try_join()
                             .await?;
                         let chunk_group = chunking_context
@@ -1886,12 +1904,17 @@ impl AppEndpoint {
                             name = display(server_component.ident().to_string().await?)
                         );
                         async {
+                            let inner = server_component
+                                .boundary_info()
+                                .await?
+                                .as_ref()
+                                .expect("server component must have boundary info")
+                                .inner_module
+                                .expect("server component must have inner module");
                             let chunk_group = chunking_context.chunk_group(
                                 server_component.ident(),
                                 // TODO this should be ChunkGroup::Shared
-                                ChunkGroup::Entry(vec![ResolvedVc::upcast(
-                                    server_component.await?.module,
-                                )]),
+                                ChunkGroup::Entry(vec![inner]),
                                 module_graph,
                                 current_chunk_group.await?.availability_info,
                             );

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -1,8 +1,10 @@
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use next_core::{
+    boundary_types::{boundary_type_server_component, boundary_type_server_utility},
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
     next_server_component::server_component_module::NextServerComponentModule,
+    next_server_utility::server_utility_module::NextServerUtilityModule,
 };
 use rustc_hash::FxHashMap;
 use turbo_tasks::{
@@ -21,6 +23,7 @@ pub enum ClientManifestEntryType {
     },
     CssClientReference(ResolvedVc<Box<dyn CssChunkPlaceable>>),
     ServerComponent(ResolvedVc<NextServerComponentModule>),
+    ServerUtility(ResolvedVc<NextServerUtilityModule>),
 }
 
 /// Tracks information about all the css and js client references in the graph.
@@ -54,13 +57,18 @@ pub async fn map_client_references(
                         client_reference_module.await?.client_module,
                     ),
                 )))
-            } else if let Some(server_component) =
-                ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
-            {
-                Ok(Some((
-                    module,
-                    ClientManifestEntryType::ServerComponent(server_component),
-                )))
+            } else if let Some(boundary) = &*module.boundary_info().await? {
+                if boundary.boundary_type == boundary_type_server_component() {
+                    let sc = ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
+                        .expect("server-component boundary must be NextServerComponentModule");
+                    Ok(Some((module, ClientManifestEntryType::ServerComponent(sc))))
+                } else if boundary.boundary_type == boundary_type_server_utility() {
+                    let su = ResolvedVc::try_downcast_type::<NextServerUtilityModule>(module)
+                        .expect("server-utility boundary must be NextServerUtilityModule");
+                    Ok(Some((module, ClientManifestEntryType::ServerUtility(su))))
+                } else {
+                    Ok(None)
+                }
             } else {
                 Ok(None)
             }

--- a/crates/next-api/src/client_references.rs
+++ b/crates/next-api/src/client_references.rs
@@ -3,8 +3,6 @@ use bincode::{Decode, Encode};
 use next_core::{
     boundary_types::{boundary_type_server_component, boundary_type_server_utility},
     next_client_reference::{CssClientReferenceModule, EcmascriptClientReferenceModule},
-    next_server_component::server_component_module::NextServerComponentModule,
-    next_server_utility::server_utility_module::NextServerUtilityModule,
 };
 use rustc_hash::FxHashMap;
 use turbo_tasks::{
@@ -22,8 +20,8 @@ pub enum ClientManifestEntryType {
         ssr_module: ResolvedVc<Box<dyn Module>>,
     },
     CssClientReference(ResolvedVc<Box<dyn CssChunkPlaceable>>),
-    ServerComponent(ResolvedVc<NextServerComponentModule>),
-    ServerUtility(ResolvedVc<NextServerUtilityModule>),
+    ServerComponent(ResolvedVc<Box<dyn Module>>),
+    ServerUtility(ResolvedVc<Box<dyn Module>>),
 }
 
 /// Tracks information about all the css and js client references in the graph.
@@ -59,13 +57,15 @@ pub async fn map_client_references(
                 )))
             } else if let Some(boundary) = &*module.boundary_info().await? {
                 if boundary.boundary_type == boundary_type_server_component() {
-                    let sc = ResolvedVc::try_downcast_type::<NextServerComponentModule>(module)
-                        .expect("server-component boundary must be NextServerComponentModule");
-                    Ok(Some((module, ClientManifestEntryType::ServerComponent(sc))))
+                    Ok(Some((
+                        module,
+                        ClientManifestEntryType::ServerComponent(module),
+                    )))
                 } else if boundary.boundary_type == boundary_type_server_utility() {
-                    let su = ResolvedVc::try_downcast_type::<NextServerUtilityModule>(module)
-                        .expect("server-utility boundary must be NextServerUtilityModule");
-                    Ok(Some((module, ClientManifestEntryType::ServerUtility(su))))
+                    Ok(Some((
+                        module,
+                        ClientManifestEntryType::ServerUtility(module),
+                    )))
                 } else {
                     Ok(None)
                 }

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -23,7 +23,7 @@ use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use next_core::{
     boundary_types::boundary_type_dynamic_entry, next_app::ClientReferencesChunks,
-    next_client_reference::EcmascriptClientReferenceModule, next_dynamic::NextDynamicEntryModule,
+    next_client_reference::EcmascriptClientReferenceModule,
 };
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
@@ -55,7 +55,8 @@ pub(crate) async fn collect_next_dynamic_chunks(
     let dynamic_import_chunks = dynamic_import_entries
         .iter()
         .map(|(dynamic_entry, parent_client_reference)| async move {
-            let module = ResolvedVc::upcast::<Box<dyn ChunkableModule>>(*dynamic_entry);
+            let module = ResolvedVc::try_sidecast::<Box<dyn ChunkableModule>>(*dynamic_entry)
+                .expect("dynamic entry must be ChunkableModule");
 
             // This is the availability info for the parent chunk group, i.e. the client reference
             // containing the next/dynamic imports
@@ -96,9 +97,9 @@ pub(crate) async fn collect_next_dynamic_chunks(
 pub struct DynamicImportedChunks(
     #[bincode(with = "turbo_bincode::indexmap")]
     pub  FxIndexMap<
-        ResolvedVc<NextDynamicEntryModule>,
+        ResolvedVc<Box<dyn Module>>,
         (
-            ResolvedVc<NextDynamicEntryModule>,
+            ResolvedVc<Box<dyn Module>>,
             ResolvedVc<OutputAssetsWithReferenced>,
         ),
     >,
@@ -106,7 +107,7 @@ pub struct DynamicImportedChunks(
 
 #[derive(Clone, PartialEq, Eq, ValueDebugFormat, TraceRawVcs, NonLocalValue, Encode, Decode)]
 pub enum DynamicImportEntriesMapType {
-    DynamicEntry(ResolvedVc<NextDynamicEntryModule>),
+    DynamicEntry(ResolvedVc<Box<dyn Module>>),
     ClientReference(ResolvedVc<EcmascriptClientReferenceModule>),
 }
 
@@ -133,12 +134,9 @@ pub async fn map_next_dynamic(
                 && let Some(boundary) = &*module.boundary_info().await?
                 && boundary.boundary_type == boundary_type_dynamic_entry()
             {
-                let dynamic_entry_module =
-                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module)
-                        .expect("dynamic-entry boundary must be NextDynamicEntryModule");
                 return Ok(Some((
                     module,
-                    DynamicImportEntriesMapType::DynamicEntry(dynamic_entry_module),
+                    DynamicImportEntriesMapType::DynamicEntry(module),
                 )));
             }
             // TODO add this check once these modules have the correct layer

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -94,6 +94,7 @@ pub(crate) async fn collect_next_dynamic_chunks(
 
 #[turbo_tasks::value(transparent)]
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 pub struct DynamicImportedChunks(
     #[bincode(with = "turbo_bincode::indexmap")]
     pub  FxIndexMap<

--- a/crates/next-api/src/dynamic_imports.rs
+++ b/crates/next-api/src/dynamic_imports.rs
@@ -22,8 +22,8 @@
 use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use next_core::{
-    next_app::ClientReferencesChunks, next_client_reference::EcmascriptClientReferenceModule,
-    next_dynamic::NextDynamicEntryModule,
+    boundary_types::boundary_type_dynamic_entry, next_app::ClientReferencesChunks,
+    next_client_reference::EcmascriptClientReferenceModule, next_dynamic::NextDynamicEntryModule,
 };
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, Vc,
@@ -130,9 +130,12 @@ pub async fn map_next_dynamic(
                 .layer
                 .as_ref()
                 .is_some_and(|layer| layer.name() == "app-client" || layer.name() == "client")
-                && let Some(dynamic_entry_module) =
-                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module)
+                && let Some(boundary) = &*module.boundary_info().await?
+                && boundary.boundary_type == boundary_type_dynamic_entry()
             {
+                let dynamic_entry_module =
+                    ResolvedVc::try_downcast_type::<NextDynamicEntryModule>(module)
+                        .expect("dynamic-entry boundary must be NextDynamicEntryModule");
                 return Ok(Some((
                     module,
                     DynamicImportEntriesMapType::DynamicEntry(dynamic_entry_module),

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -10,7 +10,6 @@ use next_core::{
     },
     next_dynamic::NextDynamicEntryModule,
     next_manifests::ActionLayer,
-    next_server_utility::server_utility_module::NextServerUtilityModule,
 };
 use rustc_hash::FxHashMap;
 use tracing::Instrument;
@@ -578,18 +577,13 @@ impl ClientReferencesGraph {
                             | ClientManifestEntryType::CssClientReference { .. }
                             | ClientManifestEntryType::ServerComponent { .. },
                         ) => GraphTraversalAction::Skip,
-                        None => GraphTraversalAction::Continue,
+                        // ServerUtility is NOT a traversal boundary — continue into its children
+                        Some(ClientManifestEntryType::ServerUtility { .. }) | None => {
+                            GraphTraversalAction::Continue
+                        }
                     })
                 },
                 |node, _| {
-                    if let Some(server_util_module) =
-                        ResolvedVc::try_downcast_type::<NextServerUtilityModule>(node)
-                    {
-                        // Server utility used by the template, not a server component
-                        server_utils.insert(server_util_module);
-                        return Ok(());
-                    }
-
                     let module_type = data.get(&node);
 
                     let ty = match module_type {
@@ -602,6 +596,10 @@ impl ClientReferencesGraph {
                         }
                         Some(ClientManifestEntryType::ServerComponent(sc)) => {
                             server_components.insert(*sc);
+                            return Ok(());
+                        }
+                        Some(ClientManifestEntryType::ServerUtility(su)) => {
+                            server_utils.insert(*su);
                             return Ok(());
                         }
                         None => {
@@ -640,11 +638,6 @@ impl ClientReferencesGraph {
                     },
                     |node, _| {
                         let module = node;
-                        if let Some(server_util_module) =
-                            ResolvedVc::try_downcast_type::<NextServerUtilityModule>(module)
-                        {
-                            server_utils.insert(server_util_module);
-                        }
 
                         let Some(module_type) = data.get(&module) else {
                             return Ok(());
@@ -659,6 +652,10 @@ impl ClientReferencesGraph {
                                 ClientReferenceType::CssClientReference(*module)
                             }
                             ClientManifestEntryType::ServerComponent(_) => {
+                                return Ok(());
+                            }
+                            ClientManifestEntryType::ServerUtility(su) => {
+                                server_utils.insert(*su);
                                 return Ok(());
                             }
                         };

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -120,6 +120,7 @@ impl NextDynamicGraphs {
 }
 
 #[turbo_tasks::value(transparent)]
+#[allow(clippy::type_complexity)]
 pub struct DynamicImportEntriesWithImporter(
     pub Vec<(ResolvedVc<Box<dyn Module>>, Option<ClientReferenceType>)>,
 );

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -8,7 +8,6 @@ use next_core::{
         ClientReference, ClientReferenceGraphResult, ClientReferenceType, ServerEntries,
         find_server_entries,
     },
-    next_dynamic::NextDynamicEntryModule,
     next_manifests::ActionLayer,
 };
 use rustc_hash::FxHashMap;
@@ -39,7 +38,7 @@ pub struct NextDynamicGraph {
     graph: ResolvedVc<ModuleGraphLayer>,
     is_single_page: bool,
 
-    /// list of NextDynamicEntryModules
+    /// list of next/dynamic entry modules
     data: ResolvedVc<DynamicImportEntries>,
 }
 
@@ -122,10 +121,7 @@ impl NextDynamicGraphs {
 
 #[turbo_tasks::value(transparent)]
 pub struct DynamicImportEntriesWithImporter(
-    pub  Vec<(
-        ResolvedVc<NextDynamicEntryModule>,
-        Option<ClientReferenceType>,
-    )>,
+    pub Vec<(ResolvedVc<Box<dyn Module>>, Option<ClientReferenceType>)>,
 );
 
 #[turbo_tasks::value_impl]
@@ -622,7 +618,7 @@ impl ClientReferencesGraph {
             // determine the order of client references individually for each server component.
             for sc in server_components.iter().copied() {
                 graph.traverse_nodes_dfs(
-                    std::iter::once(ResolvedVc::upcast(sc)),
+                    std::iter::once(sc),
                     &mut (),
                     |node, _| {
                         let module = node;

--- a/crates/next-core/src/boundary_types.rs
+++ b/crates/next-core/src/boundary_types.rs
@@ -1,0 +1,13 @@
+use turbo_rcstr::{RcStr, rcstr};
+
+pub fn boundary_type_server_component() -> RcStr {
+    rcstr!("server-component")
+}
+
+pub fn boundary_type_server_utility() -> RcStr {
+    rcstr!("server-utility")
+}
+
+pub fn boundary_type_dynamic_entry() -> RcStr {
+    rcstr!("dynamic-entry")
+}

--- a/crates/next-core/src/lib.rs
+++ b/crates/next-core/src/lib.rs
@@ -8,6 +8,7 @@ mod app_page_loader_tree;
 pub mod app_structure;
 mod base_loader_tree;
 mod bootstrap;
+pub mod boundary_types;
 mod embed_js;
 mod emit;
 pub mod hmr_entry;

--- a/crates/next-core/src/next_app/app_client_references_chunks.rs
+++ b/crates/next-core/src/next_app/app_client_references_chunks.rs
@@ -9,15 +9,12 @@ use turbopack_core::{
     output::OutputAssetsWithReferenced,
 };
 
-use crate::{
-    next_client_reference::{
-        ClientReferenceType,
-        ecmascript_client_reference::ecmascript_client_reference_module::{
-            ecmascript_client_reference_merge_tag, ecmascript_client_reference_merge_tag_ssr,
-        },
-        visit_client_reference::ClientReferenceGraphResult,
+use crate::next_client_reference::{
+    ClientReferenceType,
+    ecmascript_client_reference::ecmascript_client_reference_module::{
+        ecmascript_client_reference_merge_tag, ecmascript_client_reference_merge_tag_ssr,
     },
-    next_server_component::server_component_module::NextServerComponentModule,
+    visit_client_reference::ClientReferenceGraphResult,
 };
 
 #[turbo_tasks::value]
@@ -30,7 +27,7 @@ pub struct ClientReferencesChunks {
         FxIndexMap<ClientReferenceType, ResolvedVc<OutputAssetsWithReferenced>>,
     #[bincode(with = "turbo_bincode::indexmap")]
     pub layout_segment_client_chunks:
-        FxIndexMap<ResolvedVc<NextServerComponentModule>, ResolvedVc<OutputAssetsWithReferenced>>,
+        FxIndexMap<ResolvedVc<Box<dyn Module>>, ResolvedVc<OutputAssetsWithReferenced>>,
 }
 
 /// Computes all client references chunks.
@@ -177,15 +174,20 @@ pub async fn get_app_client_references_chunks(
             for (server_component, client_reference_types) in
                 client_references_by_server_component.into_iter()
             {
+                let boundary = server_component
+                    .boundary_info()
+                    .await?
+                    .as_ref()
+                    .expect("server component must have boundary info")
+                    .inner_module
+                    .expect("server component must have inner module");
                 let parent_chunk_group = *chunk_group_info
-                    .get_index_of(ChunkGroup::Shared(ResolvedVc::upcast(
-                        server_component.await?.module,
-                    )))
+                    .get_index_of(ChunkGroup::Shared(boundary))
                     .await?;
 
                 let base_ident = server_component.ident();
 
-                let server_path = server_component.server_path().owned().await?;
+                let server_path = server_component.ident().path().owned().await?;
                 let is_layout = server_path.file_stem() == Some("layout");
                 let server_component_path = server_path.value_to_string().await?;
 

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -21,8 +21,6 @@ use crate::{
         CssClientReferenceModule,
         ecmascript_client_reference::ecmascript_client_reference_module::EcmascriptClientReferenceModule,
     },
-    next_server_component::server_component_module::NextServerComponentModule,
-    next_server_utility::server_utility_module::NextServerUtilityModule,
 };
 
 #[derive(
@@ -39,7 +37,7 @@ use crate::{
     Decode,
 )]
 pub struct ClientReference {
-    pub server_component: Option<ResolvedVc<NextServerComponentModule>>,
+    pub server_component: Option<ResolvedVc<Box<dyn Module>>>,
     pub ty: ClientReferenceType,
 }
 
@@ -65,15 +63,15 @@ pub enum ClientReferenceType {
 #[derive(Clone, Debug, Default)]
 pub struct ClientReferenceGraphResult {
     pub client_references: Vec<ClientReference>,
-    pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
-    pub server_utils: Vec<ResolvedVc<NextServerUtilityModule>>,
+    pub server_component_entries: Vec<ResolvedVc<Box<dyn Module>>>,
+    pub server_utils: Vec<ResolvedVc<Box<dyn Module>>>,
 }
 
 #[turbo_tasks::value(shared)]
 #[derive(Clone, Debug)]
 pub struct ServerEntries {
-    pub server_component_entries: Vec<ResolvedVc<NextServerComponentModule>>,
-    pub server_utils: Vec<ResolvedVc<NextServerUtilityModule>>,
+    pub server_component_entries: Vec<ResolvedVc<Box<dyn Module>>>,
+    pub server_utils: Vec<ResolvedVc<Box<dyn Module>>>,
 }
 
 /// For a given RSC entry, finds all server components (i.e. layout segments) and server utils that
@@ -141,11 +139,8 @@ struct FindServerEntries {
 #[derive(Clone, Eq, PartialEq, Hash, Debug, ValueDebugFormat, TraceRawVcs, NonLocalValue)]
 enum FindServerEntriesNode {
     ClientReference,
-    ServerComponentEntry(
-        ResolvedVc<NextServerComponentModule>,
-        Option<ReadRef<RcStr>>,
-    ),
-    ServerUtilEntry(ResolvedVc<NextServerUtilityModule>, Option<ReadRef<RcStr>>),
+    ServerComponentEntry(ResolvedVc<Box<dyn Module>>, Option<ReadRef<RcStr>>),
+    ServerUtilEntry(ResolvedVc<Box<dyn Module>>, Option<ReadRef<RcStr>>),
     Internal(ResolvedVc<Box<dyn Module>>, Option<ReadRef<RcStr>>),
 }
 
@@ -171,9 +166,9 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
             FindServerEntriesNode::ClientReference => {
                 unreachable!("ClientReference node should not be visited")
             }
-            FindServerEntriesNode::Internal(module, _) => **module,
-            FindServerEntriesNode::ServerUtilEntry(module, _) => Vc::upcast(**module),
-            FindServerEntriesNode::ServerComponentEntry(module, _) => Vc::upcast(**module),
+            FindServerEntriesNode::Internal(module, _)
+            | FindServerEntriesNode::ServerUtilEntry(module, _)
+            | FindServerEntriesNode::ServerComponentEntry(module, _) => **module,
         };
         let emit_spans = self.emit_spans;
         async move {
@@ -205,19 +200,13 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
 
                     if let Some(boundary) = &*module.boundary_info().await? {
                         if boundary.boundary_type == boundary_type_server_component() {
-                            let sc =
-                                ResolvedVc::try_downcast_type::<NextServerComponentModule>(*module)
-                                    .expect(
-                                        "server-component boundary must be \
-                                         NextServerComponentModule",
-                                    );
                             return Ok((
                                 FindServerEntriesNode::ServerComponentEntry(
-                                    sc,
+                                    *module,
                                     if emit_spans {
                                         // INVALIDATION: we don't need to invalidate when the span
                                         // name changes
-                                        Some(sc.ident_string().untracked().await?)
+                                        Some(module.ident_string().untracked().await?)
                                     } else {
                                         None
                                     },
@@ -226,14 +215,9 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
                             ));
                         }
                         if boundary.boundary_type == boundary_type_server_utility() {
-                            let su =
-                                ResolvedVc::try_downcast_type::<NextServerUtilityModule>(*module)
-                                    .expect(
-                                        "server-utility boundary must be NextServerUtilityModule",
-                                    );
                             return Ok((
                                 FindServerEntriesNode::ServerUtilEntry(
-                                    su,
+                                    *module,
                                     if emit_spans {
                                         // INVALIDATION: we don't need to invalidate when the span
                                         // name changes

--- a/crates/next-core/src/next_client_reference/visit_client_reference.rs
+++ b/crates/next-core/src/next_client_reference/visit_client_reference.rs
@@ -16,6 +16,7 @@ use turbopack_core::{
 use turbopack_css::chunk::CssChunkPlaceable;
 
 use crate::{
+    boundary_types::{boundary_type_server_component, boundary_type_server_utility},
     next_client_reference::{
         CssClientReferenceModule,
         ecmascript_client_reference::ecmascript_client_reference_module::EcmascriptClientReferenceModule,
@@ -202,40 +203,48 @@ impl Visit<FindServerEntriesNode> for FindServerEntries {
                         return Ok((FindServerEntriesNode::ClientReference, ()));
                     }
 
-                    if let Some(server_component_asset) =
-                        ResolvedVc::try_downcast_type::<NextServerComponentModule>(*module)
-                    {
-                        return Ok((
-                            FindServerEntriesNode::ServerComponentEntry(
-                                server_component_asset,
-                                if emit_spans {
-                                    // INVALIDATION: we don't need to invalidate when the span name
-                                    // changes
-                                    Some(server_component_asset.ident_string().untracked().await?)
-                                } else {
-                                    None
-                                },
-                            ),
-                            (),
-                        ));
-                    }
-
-                    if let Some(server_util_module) =
-                        ResolvedVc::try_downcast_type::<NextServerUtilityModule>(*module)
-                    {
-                        return Ok((
-                            FindServerEntriesNode::ServerUtilEntry(
-                                server_util_module,
-                                if emit_spans {
-                                    // INVALIDATION: we don't need to invalidate when the span name
-                                    // changes
-                                    Some(module.ident_string().untracked().await?)
-                                } else {
-                                    None
-                                },
-                            ),
-                            (),
-                        ));
+                    if let Some(boundary) = &*module.boundary_info().await? {
+                        if boundary.boundary_type == boundary_type_server_component() {
+                            let sc =
+                                ResolvedVc::try_downcast_type::<NextServerComponentModule>(*module)
+                                    .expect(
+                                        "server-component boundary must be \
+                                         NextServerComponentModule",
+                                    );
+                            return Ok((
+                                FindServerEntriesNode::ServerComponentEntry(
+                                    sc,
+                                    if emit_spans {
+                                        // INVALIDATION: we don't need to invalidate when the span
+                                        // name changes
+                                        Some(sc.ident_string().untracked().await?)
+                                    } else {
+                                        None
+                                    },
+                                ),
+                                (),
+                            ));
+                        }
+                        if boundary.boundary_type == boundary_type_server_utility() {
+                            let su =
+                                ResolvedVc::try_downcast_type::<NextServerUtilityModule>(*module)
+                                    .expect(
+                                        "server-utility boundary must be NextServerUtilityModule",
+                                    );
+                            return Ok((
+                                FindServerEntriesNode::ServerUtilEntry(
+                                    su,
+                                    if emit_spans {
+                                        // INVALIDATION: we don't need to invalidate when the span
+                                        // name changes
+                                        Some(module.ident_string().untracked().await?)
+                                    } else {
+                                        None
+                                    },
+                                ),
+                                (),
+                            ));
+                        }
                     }
 
                     Ok((

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -3,6 +3,7 @@ use indoc::formatdoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack_core::{
+    boundary::{BoundaryInfo, OptionBoundaryInfo},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::{Module, ModuleSideEffects},
@@ -20,6 +21,8 @@ use turbopack_ecmascript::{
     runtime_functions::{TURBOPACK_EXPORT_NAMESPACE, TURBOPACK_IMPORT},
     utils::StringifyJs,
 };
+
+use crate::boundary_types::boundary_type_dynamic_entry;
 
 /// A [`NextDynamicEntryModule`] is a marker asset used to indicate which
 /// dynamic assets should appear in the dynamic manifest.
@@ -70,6 +73,11 @@ impl Module for NextDynamicEntryModule {
     fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
         // This just exports another import
         ModuleSideEffects::ModuleEvaluationIsSideEffectFree.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn boundary_info(self: Vc<Self>) -> Vc<OptionBoundaryInfo> {
+        Vc::cell(Some(BoundaryInfo::new(boundary_type_dynamic_entry())))
     }
 }
 

--- a/crates/next-core/src/next_dynamic/dynamic_module.rs
+++ b/crates/next-core/src/next_dynamic/dynamic_module.rs
@@ -76,8 +76,11 @@ impl Module for NextDynamicEntryModule {
     }
 
     #[turbo_tasks::function]
-    fn boundary_info(self: Vc<Self>) -> Vc<OptionBoundaryInfo> {
-        Vc::cell(Some(BoundaryInfo::new(boundary_type_dynamic_entry())))
+    fn boundary_info(&self) -> Vc<OptionBoundaryInfo> {
+        Vc::cell(Some(
+            BoundaryInfo::new(boundary_type_dynamic_entry())
+                .with_inner_module(ResolvedVc::upcast(self.module)),
+        ))
     }
 }
 

--- a/crates/next-core/src/next_manifests/client_reference_manifest.rs
+++ b/crates/next-core/src/next_manifests/client_reference_manifest.rs
@@ -13,6 +13,7 @@ use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{ChunkingContext, ModuleChunkItemIdExt, ModuleId as TurbopackModuleId},
+    module::Module,
     module_graph::async_module_info::AsyncModulesInfo,
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
 };
@@ -406,13 +407,19 @@ async fn build_manifest(
 
         // per layout segment chunks need to be emitted into the manifest too
         for (server_component, client_assets) in layout_segment_client_chunks.iter() {
-            // Use source_path() to get the original source path (e.g., page.mdx) instead of
-            // server_path() which returns the transformed path (e.g., page.mdx.tsx).
+            // Use the original source path from boundary info (e.g., page.mdx) instead of
+            // ident().path() which returns the transformed path (e.g., page.mdx.tsx).
             // This ensures the manifest key matches what the LoaderTree stores and what
             // the runtime looks up after stripping one extension.
-            let server_component_name = server_component
-                .source_path()
-                .await?
+            let boundary_opt = server_component.boundary_info().await?;
+            let boundary = boundary_opt
+                .as_ref()
+                .expect("server component must have boundary info");
+            let source_path = boundary
+                .source_path
+                .as_ref()
+                .expect("server component must have source path");
+            let server_component_name: RcStr = source_path
                 .with_extension("")
                 .value_to_string()
                 .owned()

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -4,6 +4,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    boundary::{BoundaryInfo, OptionBoundaryInfo},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::{Module, ModuleSideEffects},
@@ -22,6 +23,7 @@ use turbopack_ecmascript::{
 };
 
 use super::server_component_reference::NextServerComponentModuleReference;
+use crate::boundary_types::boundary_type_server_component;
 
 #[turbo_tasks::value(shared)]
 pub struct NextServerComponentModule {
@@ -87,6 +89,14 @@ impl Module for NextServerComponentModule {
     fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
         // This just exports another import
         ModuleSideEffects::ModuleEvaluationIsSideEffectFree.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn boundary_info(&self) -> Vc<OptionBoundaryInfo> {
+        Vc::cell(Some(BoundaryInfo::with_source_path(
+            boundary_type_server_component(),
+            self.source_path.clone(),
+        )))
     }
 }
 

--- a/crates/next-core/src/next_server_component/server_component_module.rs
+++ b/crates/next-core/src/next_server_component/server_component_module.rs
@@ -93,10 +93,13 @@ impl Module for NextServerComponentModule {
 
     #[turbo_tasks::function]
     fn boundary_info(&self) -> Vc<OptionBoundaryInfo> {
-        Vc::cell(Some(BoundaryInfo::with_source_path(
-            boundary_type_server_component(),
-            self.source_path.clone(),
-        )))
+        Vc::cell(Some(
+            BoundaryInfo::with_source_path(
+                boundary_type_server_component(),
+                self.source_path.clone(),
+            )
+            .with_inner_module(ResolvedVc::upcast(self.module)),
+        ))
     }
 }
 

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -4,6 +4,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
+    boundary::{BoundaryInfo, OptionBoundaryInfo},
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
     ident::AssetIdent,
     module::{Module, ModuleSideEffects},
@@ -22,6 +23,7 @@ use turbopack_ecmascript::{
 };
 
 use super::server_utility_reference::NextServerUtilityModuleReference;
+use crate::boundary_types::boundary_type_server_utility;
 
 #[turbo_tasks::value(shared)]
 pub struct NextServerUtilityModule {
@@ -68,6 +70,11 @@ impl Module for NextServerUtilityModule {
     fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects> {
         // This just exports another import
         ModuleSideEffects::ModuleEvaluationIsSideEffectFree.cell()
+    }
+
+    #[turbo_tasks::function]
+    fn boundary_info(self: Vc<Self>) -> Vc<OptionBoundaryInfo> {
+        Vc::cell(Some(BoundaryInfo::new(boundary_type_server_utility())))
     }
 }
 

--- a/crates/next-core/src/next_server_utility/server_utility_module.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_module.rs
@@ -73,8 +73,11 @@ impl Module for NextServerUtilityModule {
     }
 
     #[turbo_tasks::function]
-    fn boundary_info(self: Vc<Self>) -> Vc<OptionBoundaryInfo> {
-        Vc::cell(Some(BoundaryInfo::new(boundary_type_server_utility())))
+    fn boundary_info(&self) -> Vc<OptionBoundaryInfo> {
+        Vc::cell(Some(
+            BoundaryInfo::new(boundary_type_server_utility())
+                .with_inner_module(ResolvedVc::upcast(self.module)),
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/boundary.rs
+++ b/turbopack/crates/turbopack-core/src/boundary.rs
@@ -1,0 +1,34 @@
+use turbo_rcstr::RcStr;
+use turbo_tasks_fs::FileSystemPath;
+
+/// Metadata describing a module boundary (e.g., server component, server utility, dynamic entry).
+///
+/// This allows detection of boundary types without downcasting to concrete module types,
+/// decoupling the detection mechanism from the wrapper module implementation.
+#[turbo_tasks::value(shared)]
+#[derive(Clone, Debug)]
+pub struct BoundaryInfo {
+    /// The type of boundary (e.g., "server-component", "server-utility", "dynamic-entry").
+    pub boundary_type: RcStr,
+    /// Optional original source path before transformations (e.g., page.mdx before page.mdx.tsx).
+    pub source_path: Option<FileSystemPath>,
+}
+
+impl BoundaryInfo {
+    pub fn new(boundary_type: RcStr) -> Self {
+        BoundaryInfo {
+            boundary_type,
+            source_path: None,
+        }
+    }
+
+    pub fn with_source_path(boundary_type: RcStr, source_path: FileSystemPath) -> Self {
+        BoundaryInfo {
+            boundary_type,
+            source_path: Some(source_path),
+        }
+    }
+}
+
+#[turbo_tasks::value(transparent)]
+pub struct OptionBoundaryInfo(Option<BoundaryInfo>);

--- a/turbopack/crates/turbopack-core/src/boundary.rs
+++ b/turbopack/crates/turbopack-core/src/boundary.rs
@@ -1,5 +1,8 @@
 use turbo_rcstr::RcStr;
+use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
+
+use crate::module::Module;
 
 /// Metadata describing a module boundary (e.g., server component, server utility, dynamic entry).
 ///
@@ -12,6 +15,8 @@ pub struct BoundaryInfo {
     pub boundary_type: RcStr,
     /// Optional original source path before transformations (e.g., page.mdx before page.mdx.tsx).
     pub source_path: Option<FileSystemPath>,
+    /// The inner module wrapped by this boundary (e.g., the original module before wrapping).
+    pub inner_module: Option<ResolvedVc<Box<dyn Module>>>,
 }
 
 impl BoundaryInfo {
@@ -19,6 +24,7 @@ impl BoundaryInfo {
         BoundaryInfo {
             boundary_type,
             source_path: None,
+            inner_module: None,
         }
     }
 
@@ -26,7 +32,13 @@ impl BoundaryInfo {
         BoundaryInfo {
             boundary_type,
             source_path: Some(source_path),
+            inner_module: None,
         }
+    }
+
+    pub fn with_inner_module(mut self, inner_module: ResolvedVc<Box<dyn Module>>) -> Self {
+        self.inner_module = Some(inner_module);
+        self
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -8,6 +8,7 @@
 #![feature(hash_set_entry)]
 
 pub mod asset;
+pub mod boundary;
 pub mod changed;
 pub mod chunk;
 pub mod code_builder;

--- a/turbopack/crates/turbopack-core/src/module.rs
+++ b/turbopack/crates/turbopack-core/src/module.rs
@@ -1,7 +1,10 @@
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, TaskInput, ValueToString, Vc};
 
-use crate::{ident::AssetIdent, reference::ModuleReferences, source::OptionSource};
+use crate::{
+    boundary::OptionBoundaryInfo, ident::AssetIdent, reference::ModuleReferences,
+    source::OptionSource,
+};
 
 #[derive(Clone, Copy, Debug, TaskInput, Hash)]
 #[turbo_tasks::value(shared)]
@@ -67,6 +70,13 @@ pub trait Module {
     /// Returns true if the module is marked as side effect free in package.json or by other means.
     #[turbo_tasks::function]
     fn side_effects(self: Vc<Self>) -> Vc<ModuleSideEffects>;
+
+    /// Returns boundary metadata if this module represents a module boundary
+    /// (e.g., server component, server utility, dynamic entry). Returns `None` by default.
+    #[turbo_tasks::function]
+    fn boundary_info(self: Vc<Self>) -> Vc<OptionBoundaryInfo> {
+        Vc::cell(None)
+    }
 }
 
 #[turbo_tasks::value_trait]


### PR DESCRIPTION
#  What
                                                                                                                                                                                                                                                                              
Erase concrete wrapper module types (NextServerComponentModule, NextServerUtilityModule, NextDynamicEntryModule) from all data structures and consumption sites, replacing them with ResolvedVc<Box<dyn Module>>.

# Why 

The wrapper modules were thin shims, but were causing issues with the module renaming PR.

# How

  - Added inner_module: Option<ResolvedVc<Box<dyn Module>>> to BoundaryInfo so downstream code can access the wrapped module without downcasting
  - Replaced all typed ResolvedVc<NextServer*Module> / ResolvedVc<NextDynamicEntryModule> in ClientReference, ClientReferenceGraphResult, ServerEntries, ClientManifestEntryType, DynamicImportEntriesMapType, DynamicImportedChunks, and DynamicImportEntriesWithImporter
  with ResolvedVc<Box<dyn Module>>
  - Removed all validation downcasts (try_downcast_type + .expect()) at detection sites — boundary_info() is now the sole detection mechanism
  - Replaced .await?.module / .server_path() / .source_path() accessors with boundary_info().inner_module / .ident().path() / .source_path