### PR TITLE
fix: undefined metadata fields overriding parent fallbacks

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -60,6 +60,30 @@ describe('accumulateMetadata', () => {
         description: 'child',
       })
     })
+
+    it('should fall back to parent when child description is undefined', async () => {
+      const metadataItems: MetadataItems = [
+        [{ description: 'parent' }, null],
+        [{ description: undefined }, null],
+      ]
+
+      const metadata = await accumulateMetadata(metadataItems)
+      expect(metadata).toMatchObject({
+        description: 'parent',
+      })
+    })
+
+    it('should clear parent when child description is null', async () => {
+      const metadataItems: MetadataItems = [
+        [{ description: 'parent' }, null],
+        [{ description: null }, null],
+      ]
+
+      const metadata = await accumulateMetadata(metadataItems)
+      expect(metadata).toMatchObject({
+        description: null,
+      })
+    })
   })
 
   describe('title', () => {

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -346,34 +346,54 @@ async function mergeMetadata(
       }
       // directly assign fields that fallback to null
       case 'abstract':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'applicationName':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'description':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'generator':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'creator':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'publisher':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'category':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'classification':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'referrer':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'formatDetection':
-        newResolvedMetadata[key] = metadata[key] ?? null
+        if (metadata[key] !== undefined) {
+          newResolvedMetadata[key] = metadata[key] ?? null
+        }
         break
       case 'manifest':
         newResolvedMetadata[key] = convertUrlsToStrings(metadata[key]) ?? null


### PR DESCRIPTION
Fixes #71668

## Summary
- treat explicit `undefined` values in nullable metadata fields as unset so parent metadata can continue to fall through
- keep explicit `null` behavior unchanged so child metadata can still clear inherited values
- add regression tests for `description: undefined` fallback and `description: null` clearing behavior