### PR TITLE
fix: return 405 for POST requests to auto-exported pages in dev

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2252,6 +2252,18 @@ export default abstract class Server<
       res.statusCode = parseInt(pathname.slice(1), 10)
     }
 
+    const defaultAppGetInitialProps =
+      components.App.getInitialProps ===
+      (components.App as any).origGetInitialProps
+    const hasPageGetInitialProps = !!(components.Component as any)
+      ?.getInitialProps
+    const isAutoExport =
+      !isAppPath &&
+      !hasPageGetInitialProps &&
+      defaultAppGetInitialProps &&
+      !isSSG &&
+      !hasServerProps
+
     if (
       // Server actions can use non-GET/HEAD methods.
       !isPossibleServerAction &&
@@ -2262,7 +2274,7 @@ export default abstract class Server<
       pathname !== '/_error' &&
       req.method !== 'HEAD' &&
       req.method !== 'GET' &&
-      (typeof components.Component === 'string' || isSSG)
+      (typeof components.Component === 'string' || isSSG || isAutoExport)
     ) {
       res.statusCode = 405
       res.setHeader('Allow', ['GET', 'HEAD'])

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -572,6 +572,17 @@ describe('Prerender', () => {
       }
     })
 
+    it('should respond with 405 for POST to auto-exported page', async () => {
+      const res = await fetchViaHTTP(next.url, '/normal', undefined, {
+        method: 'POST',
+      })
+      expect(res.status).toBe(405)
+
+      if (!isDeploy) {
+        expect(await res.text()).toContain('Method Not Allowed')
+      }
+    })
+
     it('should SSR normal page correctly', async () => {
       const html = await renderViaHTTP(next.url, '/')
       expect(html).toMatch(/hello.*?world/)


### PR DESCRIPTION
Fixes #38863

## Summary
- treat auto-exported pages in the pages router as read-only request targets in `next dev`, matching production behavior
- reuse existing auto-export detection signals (`App.getInitialProps`, page `getInitialProps`, `isSSG`, and `hasServerProps`) before the method guard in `base-server`
- add an e2e regression test that verifies `POST /normal` responds with `405 Method Not Allowed` in the prerender suite

## Testing
- `pnpm --filter=next build`
- `pnpm test-dev-turbo test/e2e/prerender.test.ts -t "auto-exported page"` (fails on current published canary before this change with `Received: 200`)