### PR TITLE
fix: non-ASCII page names returning 404 under SSR

### DIFF
--- a/packages/next/src/server/lib/router-utils/decode-path-params.ts
+++ b/packages/next/src/server/lib/router-utils/decode-path-params.ts
@@ -9,8 +9,6 @@ import { DecodeError } from '../../../shared/lib/utils'
  * Japanese characters.
  * */
 function decodePathParams(pathname: string): string {
-  // TODO: investigate adding this handling for non-SSG
-  // pages so non-ascii names also work there.
   return pathname
     .split('/')
     .map((seg) => {

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -303,6 +303,18 @@ export function getResolveRoutes(
       }
       const localeResult = fsChecker.handleLocale(curPathname || '')
 
+      // Try decoded pathname for non-ASCII route segments
+      // (e.g. /%D0%B1%D0%BB%D0%BE%D0%B3/hello → /блог/hello)
+      let decodedLocalePathname: string | undefined
+      try {
+        const decoded = decodeURI(localeResult.pathname)
+        if (decoded !== localeResult.pathname) {
+          decodedLocalePathname = decoded
+        }
+      } catch {
+        // malformed percent-encoded sequence; leave decodedLocalePathname undefined
+      }
+
       for (const route of dynamicRoutes) {
         // when resolving fallback: false the
         // render worker may return a no-fallback response
@@ -312,7 +324,9 @@ export function getResolveRoutes(
         if (invokedOutputs?.has(route.page)) {
           continue
         }
-        const params = route.match(localeResult.pathname)
+        const params =
+          route.match(localeResult.pathname) ||
+          (decodedLocalePathname && route.match(decodedLocalePathname))
 
         if (params) {
           const pageOutput = await fsChecker.getItem(

--- a/packages/next/src/server/route-matchers/route-matcher.ts
+++ b/packages/next/src/server/route-matchers/route-matcher.ts
@@ -13,6 +13,24 @@ type RouteMatchResult = {
   params?: Params
 }
 
+/** decodeURI that returns the original string on malformed input. */
+function tryDecodeURI(value: string): string {
+  try {
+    return decodeURI(value)
+  } catch {
+    return value
+  }
+}
+
+/** decodeURIComponent that returns the original string on malformed input. */
+function tryDecodeURIComponent(value: string): string {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
 export class RouteMatcher<D extends RouteDefinition = RouteDefinition> {
   private readonly dynamic?: RouteMatchFn
 
@@ -52,12 +70,24 @@ export class RouteMatcher<D extends RouteDefinition = RouteDefinition> {
   public test(pathname: string): RouteMatchResult | null {
     if (this.dynamic) {
       const params = this.dynamic(pathname)
-      if (!params) return null
+      if (params) return { params }
 
-      return { params }
+      // Try decoding for non-ASCII pathnames (e.g. /%D1%82%D0%B5%D1%81%D1%82 → /тест).
+      const decoded = tryDecodeURI(pathname)
+      if (decoded !== pathname) {
+        const decodedParams = this.dynamic(decoded)
+        if (decodedParams) return { params: decodedParams }
+      }
+
+      return null
     }
 
     if (pathname === this.definition.pathname) {
+      return {}
+    }
+
+    // Try decoding for non-ASCII pathnames (e.g. /%D1%82%D0%B5%D1%81%D1%82 → /тест).
+    if (tryDecodeURIComponent(pathname) === this.definition.pathname) {
       return {}
     }
 

--- a/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/segment-value-encoding.ts
@@ -80,7 +80,13 @@ function encodeToFilesystemAndURLSafeString(value: string) {
   }
   // If there are any unsafe characters, base64url-encode the entire value.
   // We also add a ! prefix so it doesn't collide with the simple case.
-  const base64url = btoa(value)
+  // btoa() only supports Latin1 characters, so we need to encode non-ASCII
+  // strings to UTF-8 bytes first (e.g. Cyrillic page names like "тест").
+  const base64url = btoa(
+    typeof TextEncoder !== 'undefined'
+      ? String.fromCharCode(...new TextEncoder().encode(value))
+      : Buffer.from(value, 'utf-8').toString('binary')
+  )
     .replace(/\+/g, '-') // Replace '+' with '-'
     .replace(/\//g, '_') // Replace '/' with '_'
     .replace(/=+$/, '') // Remove trailing '='

--- a/test/e2e/app-dir/non-ascii-page-name/app/layout.tsx
+++ b/test/e2e/app-dir/non-ascii-page-name/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/non-ascii-page-name/app/page.tsx
+++ b/test/e2e/app-dir/non-ascii-page-name/app/page.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <p>home</p>
+      <Link href="/тест" id="link-to-test">
+        Go to тест
+      </Link>
+      <Link href="/блог/hello" id="link-to-blog">
+        Go to блог
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/non-ascii-page-name/app/блог/[slug]/page.tsx
+++ b/test/e2e/app-dir/non-ascii-page-name/app/блог/[slug]/page.tsx
@@ -1,0 +1,12 @@
+export function generateStaticParams() {
+  return [{ slug: 'hello' }]
+}
+
+export default async function BlogPost({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>blog post: {slug}</p>
+}

--- a/test/e2e/app-dir/non-ascii-page-name/app/тест/page.tsx
+++ b/test/e2e/app-dir/non-ascii-page-name/app/тест/page.tsx
@@ -1,0 +1,3 @@
+export default function TestPage() {
+  return <p>non-ascii static page</p>
+}

--- a/test/e2e/app-dir/non-ascii-page-name/next.config.js
+++ b/test/e2e/app-dir/non-ascii-page-name/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/non-ascii-page-name/non-ascii-page-name.test.ts
+++ b/test/e2e/app-dir/non-ascii-page-name/non-ascii-page-name.test.ts
@@ -1,0 +1,40 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('non-ascii-page-name', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render a static page with non-ASCII name via encoded URL', async () => {
+    const $ = await next.render$('/%D1%82%D0%B5%D1%81%D1%82')
+    expect($('p').text()).toBe('non-ascii static page')
+  })
+
+  it('should render a dynamic route with non-ASCII static segment', async () => {
+    const $ = await next.render$('/%D0%B1%D0%BB%D0%BE%D0%B3/hello')
+    expect($('p').text()).toBe('blog post: hello')
+  })
+
+  it('should client-side navigate to a non-ASCII page', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('home')
+
+    await browser.elementByCss('#link-to-test').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe(
+        'non-ascii static page'
+      )
+    })
+  })
+
+  it('should client-side navigate to a dynamic route with non-ASCII segment', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('home')
+
+    await browser.elementByCss('#link-to-blog').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe('blog post: hello')
+    })
+  })
+})

--- a/test/e2e/non-ascii-page-name-pages-router/non-ascii-page-name-pages-router.test.ts
+++ b/test/e2e/non-ascii-page-name-pages-router/non-ascii-page-name-pages-router.test.ts
@@ -1,0 +1,40 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('non-ascii-page-name-pages-router', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should render a static page with non-ASCII name via encoded URL', async () => {
+    const $ = await next.render$('/%D1%82%D0%B5%D1%81%D1%82')
+    expect($('p').text()).toBe('non-ascii static page')
+  })
+
+  it('should render a dynamic route with non-ASCII static segment', async () => {
+    const $ = await next.render$('/%D0%B1%D0%BB%D0%BE%D0%B3/hello')
+    expect($('p').text()).toBe('blog post: hello')
+  })
+
+  it('should client-side navigate to a non-ASCII page', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('home')
+
+    await browser.elementByCss('[data-test="link-to-test"]').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe(
+        'non-ascii static page'
+      )
+    })
+  })
+
+  it('should client-side navigate to a dynamic route with non-ASCII segment', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('home')
+
+    await browser.elementByCss('[data-test="link-to-blog"]').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('p').text()).toBe('blog post: hello')
+    })
+  })
+})

--- a/test/e2e/non-ascii-page-name-pages-router/pages/index.tsx
+++ b/test/e2e/non-ascii-page-name-pages-router/pages/index.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <p>home</p>
+      <Link href="/тест" data-test="link-to-test">
+        Go to тест
+      </Link>
+      <Link href="/блог/hello" data-test="link-to-blog">
+        Go to блог
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/non-ascii-page-name-pages-router/pages/блог/[slug].tsx
+++ b/test/e2e/non-ascii-page-name-pages-router/pages/блог/[slug].tsx
@@ -1,0 +1,21 @@
+import type { InferGetServerSidePropsType, GetServerSideProps } from 'next'
+
+type Props = {
+  slug: string
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({
+  params,
+}) => {
+  return {
+    props: {
+      slug: String(params?.slug ?? ''),
+    },
+  }
+}
+
+export default function BlogPost({
+  slug,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) {
+  return <p>blog post: {slug}</p>
+}

--- a/test/e2e/non-ascii-page-name-pages-router/pages/тест.tsx
+++ b/test/e2e/non-ascii-page-name-pages-router/pages/тест.tsx
@@ -1,0 +1,3 @@
+export default function TestPage() {
+  return <p>non-ascii static page</p>
+}


### PR DESCRIPTION
Fixes #10084

## Summary

Pages and app router routes with non-ASCII names (e.g. `/тест`, `/блог/[slug]`) return 404 because the server receives percent-encoded URLs but route definitions use decoded Unicode names.

- **`route-matcher.ts`**: Try `decodeURI`/`decodeURIComponent` when matching encoded pathnames against route definitions
- **`resolve-routes.ts`**: Decode pathname before matching dynamic routes in the router server
- **`segment-value-encoding.ts`**: Fix `btoa()` crash (`InvalidCharacterError`) on non-Latin1 characters by encoding to UTF-8 first

## Test plan

- E2E tests for both app router and pages router covering static pages, dynamic routes with non-ASCII static segments, and client-side navigation