### PR TITLE
Optimize dev route diffing and slot dedupe

### DIFF
--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -261,8 +261,42 @@ export const getInvalidator = (dir: string) => {
 }
 
 const doneCallbacks: EventEmitter = new EventEmitter()
-const lastClientAccessPages = ['']
-const lastServerAccessPagesForAppDir = ['']
+type RecentEntriesTracker = {
+  list: string[]
+  set: Set<string>
+}
+
+const createRecentEntriesTracker = (initialEntries: string[]) => ({
+  list: initialEntries,
+  set: new Set(initialEntries),
+})
+
+const lastClientAccessPages = createRecentEntriesTracker([''])
+const lastServerAccessPagesForAppDir = createRecentEntriesTracker([''])
+
+function hasRecentEntry(tracker: RecentEntriesTracker, key: string) {
+  return tracker.set.has(key)
+}
+
+function addRecentEntry(
+  tracker: RecentEntriesTracker,
+  key: string,
+  maxLength: number
+) {
+  if (tracker.set.has(key)) {
+    return
+  }
+
+  tracker.list.unshift(key)
+  tracker.set.add(key)
+
+  if (tracker.list.length > maxLength) {
+    const removed = tracker.list.pop()
+    if (removed !== undefined) {
+      tracker.set.delete(removed)
+    }
+  }
+}
 
 type BuildingTracker = Set<CompilerNameValues>
 type RebuildTracker = Set<CompilerNameValues>
@@ -359,8 +393,8 @@ function disposeInactiveEntries(
     // Sometimes, it's possible our XHR ping to wait before completing other requests.
     // In that case, we should not dispose the current viewing page
     if (
-      lastClientAccessPages.includes(entryKey) ||
-      lastServerAccessPagesForAppDir.includes(entryKey)
+      hasRecentEntry(lastClientAccessPages, entryKey) ||
+      hasRecentEntry(lastServerAccessPagesForAppDir, entryKey)
     )
       return
 
@@ -758,15 +792,13 @@ export function onDemandEntryHandler({
         if (entryInfo.status !== BUILT) continue
 
         // If there's an entryInfo
-        if (!lastServerAccessPagesForAppDir.includes(entryKey)) {
-          lastServerAccessPagesForAppDir.unshift(entryKey)
-
-          // Maintain the buffer max length
-          // TODO: verify that the current pageKey is not at the end of the array as multiple entrypoints can exist
-          if (lastServerAccessPagesForAppDir.length > pagesBufferLength) {
-            lastServerAccessPagesForAppDir.pop()
-          }
-        }
+        // Maintain the buffer max length
+        // TODO: verify that the current pageKey is not at the end of the array as multiple entrypoints can exist
+        addRecentEntry(
+          lastServerAccessPagesForAppDir,
+          entryKey,
+          pagesBufferLength
+        )
         entryInfo.lastActiveTime = Date.now()
         entryInfo.dispose = false
       }
@@ -796,14 +828,7 @@ export function onDemandEntryHandler({
       if (entryInfo.status !== BUILT) continue
 
       // If there's an entryInfo
-      if (!lastClientAccessPages.includes(entryKey)) {
-        lastClientAccessPages.unshift(entryKey)
-
-        // Maintain the buffer max length
-        if (lastClientAccessPages.length > pagesBufferLength) {
-          lastClientAccessPages.pop()
-        }
-      }
+      addRecentEntry(lastClientAccessPages, entryKey, pagesBufferLength)
       entryInfo.lastActiveTime = Date.now()
       entryInfo.dispose = false
     }

--- a/packages/next/src/server/lib/find-page-file.ts
+++ b/packages/next/src/server/lib/find-page-file.ts
@@ -8,12 +8,38 @@ import { cyan } from '../../lib/picocolors'
 import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
 import type { PageExtensions } from '../../build/page-extensions-type'
 
+const directoryEntriesCache = new Map<string, Set<string>>()
+let isDirectoryEntriesCacheCleanupScheduled = false
+
+function scheduleDirectoryEntriesCacheCleanup() {
+  if (isDirectoryEntriesCacheCleanupScheduled) {
+    return
+  }
+  isDirectoryEntriesCacheCleanupScheduled = true
+  setImmediate(() => {
+    directoryEntriesCache.clear()
+    isDirectoryEntriesCacheCleanupScheduled = false
+  })
+}
+
+async function getDirectoryEntries(dir: string) {
+  const cached = directoryEntriesCache.get(dir)
+  if (cached) {
+    return cached
+  }
+
+  const entries = new Set(await fsPromises.readdir(dir))
+  directoryEntriesCache.set(dir, entries)
+  scheduleDirectoryEntriesCacheCleanup()
+  return entries
+}
+
 async function isTrueCasePagePath(pagePath: string, pagesDir: string) {
   const pageSegments = normalize(pagePath).split(sep).filter(Boolean)
   const segmentExistsPromises = pageSegments.map(async (segment, i) => {
     const segmentParentDir = join(pagesDir, ...pageSegments.slice(0, i))
-    const parentDirEntries = await fsPromises.readdir(segmentParentDir)
-    return parentDirEntries.includes(segment)
+    const parentDirEntries = await getDirectoryEntries(segmentParentDir)
+    return parentDirEntries.has(segment)
   })
 
   return (await Promise.all(segmentExistsPromises)).every(Boolean)

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -1126,19 +1126,12 @@ async function startWatcher(
             const prevSortedRoutesSet = new Set(prevSortedRoutes)
             const sortedRoutesSet = new Set(sortedRoutes)
 
-            const addedRoutes: string[] = []
-            for (const route of sortedRoutes) {
-              if (!prevSortedRoutesSet.has(route)) {
-                addedRoutes.push(route)
-              }
-            }
-
-            const removedRoutes: string[] = []
-            for (const route of prevSortedRoutes) {
-              if (!sortedRoutesSet.has(route)) {
-                removedRoutes.push(route)
-              }
-            }
+            const addedRoutes = sortedRoutes.filter(
+              (route) => !prevSortedRoutesSet.has(route)
+            )
+            const removedRoutes = prevSortedRoutes.filter(
+              (route) => !sortedRoutesSet.has(route)
+            )
 
             // emit the change so clients fetch the update
             hotReloader.send({

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -429,6 +429,7 @@ async function startWatcher(
       const appRoutes: Array<{ route: string; filePath: string }> = []
       const layoutRoutes: Array<{ route: string; filePath: string }> = []
       const slots: Array<{ name: string; parent: string }> = []
+      const slotKeys = new Set<string>()
 
       let envChange = false
       let tsconfigChange = false
@@ -663,14 +664,10 @@ async function startWatcher(
               )
 
               const slotName = segment.slice(1)
-              // check if the slot already exists
-              if (
-                slots.some(
-                  (s) => s.name === slotName && s.parent === parentPath
-                )
-              )
-                continue
+              const slotKey = `${parentPath}:${slotName}`
+              if (slotKeys.has(slotKey)) continue
 
+              slotKeys.add(slotKey)
               slots.push({
                 name: slotName,
                 parent: parentPath,
@@ -1126,12 +1123,22 @@ async function startWatcher(
           if (
             !prevSortedRoutes?.every((val, idx) => val === sortedRoutes[idx])
           ) {
-            const addedRoutes = sortedRoutes.filter(
-              (route) => !prevSortedRoutes.includes(route)
-            )
-            const removedRoutes = prevSortedRoutes.filter(
-              (route) => !sortedRoutes.includes(route)
-            )
+            const prevSortedRoutesSet = new Set(prevSortedRoutes)
+            const sortedRoutesSet = new Set(sortedRoutes)
+
+            const addedRoutes: string[] = []
+            for (const route of sortedRoutes) {
+              if (!prevSortedRoutesSet.has(route)) {
+                addedRoutes.push(route)
+              }
+            }
+
+            const removedRoutes: string[] = []
+            for (const route of prevSortedRoutes) {
+              if (!sortedRoutesSet.has(route)) {
+                removedRoutes.push(route)
+              }
+            }
 
             // emit the change so clients fetch the update
             hotReloader.send({


### PR DESCRIPTION
## Summary
- Keeps the dev-only route diff optimization in `setup-dev-bundler` by using `Set` membership checks instead of `includes` scans.
- Keeps parallel-route slot de-duplication in the same watcher pass via a `Set`, replacing repeated `slots.some(...)` checks.
- Refactors the route diff to a smaller/clearer form (`Set` + `filter`) so the code stays closer to the previous structure.
- Adds a short-lived directory-entry cache in `find-page-file` to reduce repeated `readdir` calls during true-case path checks.
- Uses set-backed recent-entry tracking in `on-demand-entry-handler` to avoid repeated array `includes` scans in ping/disposal paths.

## Early perf notes (tentative)
I ran a local ad-hoc benchmark that edits files and polls `/_next/static/development/_devPagesManifest.json` to time route add/remove propagation.

On a generated pages-dir app with ~5000 routes (`next dev --webpack`):
- Add route latency avg: `~277ms -> ~243ms` (`~12%` lower)
- Remove route latency avg: `~282ms -> ~244ms` (`~14%` lower)

On a smaller app (~700 routes), the effect was much smaller (~0-1%).

These numbers are early and environment-dependent, and primarily reflect the route diff/slot dedupe changes.

## Validation
- Existing pre-commit hooks ran (`prettier` + `eslint --fix`) on touched files.