### PR TITLE
refactor: parallelize app-dir type checking with subsequent build phases

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1773,12 +1773,16 @@ export default async function build(
       // #endregion
 
       // For app directory, we run type checking after build.
+      // Type checking has no data dependencies with subsequent phases, so we
+      // kick it off in the background and await it before the build finishes.
+      let typeCheckingPromise: Promise<void> | undefined
       if (appDir && !isCompileMode && !isGenerateMode) {
-        await updateBuildDiagnostics({
-          buildStage: 'type-checking',
-        })
-        await startTypeChecking(typeCheckingOptions)
-        traceMemoryUsage('Finished type checking', nextBuildSpan)
+        await updateBuildDiagnostics({ buildStage: 'type-checking' })
+        typeCheckingPromise = startTypeChecking(typeCheckingOptions).then(
+          () => {
+            traceMemoryUsage('Finished type checking', nextBuildSpan)
+          }
+        )
       }
 
       // #region required-server-files
@@ -3870,6 +3874,11 @@ export default async function build(
         await nextBuildSpan
           .traceChild('write-routes-manifest')
           .traceAsyncFn(() => writeManifest(routesManifestPath, routesManifest))
+      }
+
+      // Ensure type checking has completed before we finalize the build.
+      if (typeCheckingPromise) {
+        await typeCheckingPromise
       }
 
       const finalizingPageOptimizationStart = process.hrtime()


### PR DESCRIPTION
## Summary

- Run app-directory type checking concurrently with subsequent build phases (required server files generation, page data collection, build traces, and static generation) instead of blocking sequentially
- Type checking has zero data dependencies with these phases — it reads only source files and `tsconfig.json`, and produces only telemetry/console output
- The type checking promise is awaited before "Finalizing page optimization" to ensure the build doesn't exit successfully with pending type errors
- On type check failure, `process.exit(1)` is called internally, so no special error propagation is needed

## Test plan

- [ ] `pnpm build` in an app-dir project — verify type checking spinner appears concurrently with "Collecting page data" and build succeeds
- [ ] Introduce a type error in an app-dir project — verify the build still fails with the type error
- [ ] Run existing type-check-related tests: `pnpm test-start-turbo test/production/typescript`