### PR TITLE
Document Buddy.Works caching for Next.js

### DIFF
--- a/docs/01-app/02-guides/ci-build-caching.mdx
+++ b/docs/01-app/02-guides/ci-build-caching.mdx
@@ -88,6 +88,11 @@ with:
     ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
 ```
 
+## Buddy
+
+Buddy.Works requires no additional configuration for Next.js build caching. The entire project directory is automatically [cached](https://buddy.works/docs/pipelines/cache) between pipeline runs, including  `.next/cache`
+
+
 ## Bitbucket Pipelines
 
 Add or merge the following into your `bitbucket-pipelines.yml` at the top level (same level as `pipelines`):


### PR DESCRIPTION
### What
Adds information about Buddy CI caching behavior

### Why
Buddy automatically caches the project directory between pipeline runs, so `.next/cache` does not need manual configuration

### How
Adds a new "Buddy" section in the CI caching guide with a link to the cache documentation