### PR TITLE
[test] consolidate the browser log test

### DIFF
--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -303,8 +303,10 @@ describe(`Terminal Logging (${bundlerName})`, () => {
       await retry(() => {
         const logOutput = logs.join('\n')
         // Find the hydration error log entry
+        // Stop at: another [browser] log, status indicators (○ ⨯),
+        // or timestamp-prefixed logs (e.g. "[12:34:56.789Z] Browser Log: ...")
         const hydrationMatch = logOutput.match(
-          /\[browser\].*Hydration[\s\S]*?(?=\n\[browser\]|\n *○|\n *⨯|$)/
+          /\[browser\].*Hydration[\s\S]*?(?=\n\[browser\]|\n *○|\n *⨯|\n *\[\d|$)/
         )
         expect(hydrationMatch).not.toBeNull()
         hydrationErrorLog = hydrationMatch![0]


### PR DESCRIPTION
Filter out the extra logging from test env so we only assert on the snapshot of forwarded logs
```
Snapshot name: `Terminal Logging (Webpack) App Router - Hydration Errors should show hydration errors with owner stack trace 1`

- Snapshot  - 1
+ Received  + 9

@@ -39,7 +39,15 @@
     6 |     <div>
  >  7 |       <p>{isClient ? 'client' : 'server'}</p>
       |       ^
     8 |     </div>
     9 |   )
-   10 | }
+   10 | }
+
+
+ [12:36:48.104Z] Browser Log: received ws message {"type":"isrManifest","data":{"/hydration-error":true}}
+
+ [12:36:48.104Z] Browser Log: Next.js page already hydrated
+
+ [12:36:48.109Z] Hydration complete for http://localhost:46145/hydration-error
  "
    at Object.toMatchInlineSnapshot (/root/actions-runner/_work/next.js/next.js/test/development/browser-logs/browser-logs.test.ts:317:33)
    at runNextTicks (node:internal/process/task_queues:60:5)
    at processImmediate (node:internal/timers:449:9)
    at process.callbackTrampoline (node:internal/async_hooks:130:17)
```