### PR TITLE
Dynamic routing tests structure

### DIFF
--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -26,7 +26,13 @@ let buildId
 const appDir = join(__dirname, '../')
 const buildIdPath = join(appDir, '.next/BUILD_ID')
 
-function runTests({ dev, withMiddleware }: { dev: boolean; withMiddleware: boolean }) {
+function runTests({
+  dev,
+  withMiddleware,
+}: {
+  dev: boolean
+  withMiddleware: boolean
+}) {
   if (!dev) {
     it('should have correct cache entries on prefetch', async () => {
       const browser = await webdriver(appPort, '/')
@@ -1607,7 +1613,6 @@ describe.each([{ withMiddleware: false }, { withMiddleware: true }])(
         await fs.remove(middlewarePath)
       }
     })
-
     ;(process.env.TURBOPACK_BUILD ? describe.skip : describe)(
       'development mode',
       () => {

--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -26,7 +26,7 @@ let buildId
 const appDir = join(__dirname, '../')
 const buildIdPath = join(appDir, '.next/BUILD_ID')
 
-function runTests({ dev }) {
+function runTests({ dev, withMiddleware }: { dev: boolean; withMiddleware: boolean }) {
   if (!dev) {
     it('should have correct cache entries on prefetch', async () => {
       const browser = await webdriver(appPort, '/')
@@ -46,7 +46,7 @@ function runTests({ dev }) {
 
       const cacheKeys = await getCacheKeys()
       expect(cacheKeys).toEqual(
-        process.env.__MIDDLEWARE_TEST
+        withMiddleware
           ? [
               '/_next/data/BUILD_ID/[name].json?another=value&name=%5Bname%5D',
               '/_next/data/BUILD_ID/added-later/first.json?name=added-later&comment=first',
@@ -117,7 +117,7 @@ function runTests({ dev }) {
       const newCacheKeys = await getCacheKeys()
       expect(newCacheKeys).toEqual(
         [
-          ...(process.env.__MIDDLEWARE_TEST
+          ...(withMiddleware
             ? // data route is fetched with middleware due to query hydration
               // since middleware matches the index route
               ['/_next/data/BUILD_ID/index.json']
@@ -1205,7 +1205,7 @@ function runTests({ dev }) {
       expect(text).toBe('slug: first')
     })
 
-    if (!process.env.__MIDDLEWARE_TEST) {
+    if (!withMiddleware) {
       it('should show error when interpolating fails for href', async () => {
         const browser = await webdriver(appPort, '/')
         await browser
@@ -1583,54 +1583,62 @@ function runTests({ dev }) {
 
 const nextConfig = join(appDir, 'next.config.js')
 
-describe('Dynamic Routing', () => {
-  if (process.env.__MIDDLEWARE_TEST) {
+describe.each([{ withMiddleware: false }, { withMiddleware: true }])(
+  'Dynamic Routing (withMiddleware: $withMiddleware)',
+  ({ withMiddleware }) => {
     const middlewarePath = join(__dirname, '../middleware.js')
 
     beforeAll(async () => {
-      await fs.writeFile(
-        middlewarePath,
-        `
+      if (withMiddleware) {
+        await fs.writeFile(
+          middlewarePath,
+          `
         import { NextResponse } from 'next/server'
         export default function middleware() {
           return NextResponse.next()
         }
       `
-      )
+        )
+      }
     })
-    afterAll(() => fs.remove(middlewarePath))
+
+    afterAll(async () => {
+      if (withMiddleware) {
+        await fs.remove(middlewarePath)
+      }
+    })
+
+    ;(process.env.TURBOPACK_BUILD ? describe.skip : describe)(
+      'development mode',
+      () => {
+        beforeAll(async () => {
+          await fs.remove(nextConfig)
+
+          appPort = await findPort()
+          app = await launchApp(appDir, appPort)
+          buildId = 'development'
+        })
+        afterAll(() => killApp(app))
+
+        runTests({ dev: true, withMiddleware })
+      }
+    )
+    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
+      'production mode',
+      () => {
+        beforeAll(async () => {
+          await fs.remove(nextConfig)
+
+          await nextBuild(appDir)
+          buildId = await fs.readFile(buildIdPath, 'utf8')
+
+          appPort = await findPort()
+          app = await nextStart(appDir, appPort)
+        })
+        afterAll(() => killApp(app))
+
+        runTests({ dev: false, withMiddleware })
+      }
+    )
   }
-
-  ;(process.env.TURBOPACK_BUILD ? describe.skip : describe)(
-    'development mode',
-    () => {
-      beforeAll(async () => {
-        await fs.remove(nextConfig)
-
-        appPort = await findPort()
-        app = await launchApp(appDir, appPort)
-        buildId = 'development'
-      })
-      afterAll(() => killApp(app))
-
-      runTests({ dev: true })
-    }
-  )
-  ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-    'production mode',
-    () => {
-      beforeAll(async () => {
-        await fs.remove(nextConfig)
-
-        await nextBuild(appDir)
-        buildId = await fs.readFile(buildIdPath, 'utf8')
-
-        appPort = await findPort()
-        app = await nextStart(appDir, appPort)
-      })
-      afterAll(() => killApp(app))
-
-      runTests({ dev: false })
-    }
-  )
-})
+)

--- a/test/integration/dynamic-routing/test/middleware.test.ts
+++ b/test/integration/dynamic-routing/test/middleware.test.ts
@@ -1,7 +1,0 @@
-/* eslint-env jest */
-
-process.env.__MIDDLEWARE_TEST = '1'
-
-// run all existing tests from ./index.test.js with middleware
-// setup enabled via the above env variable
-require('./index.test')


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Fixing a bug

- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs

## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Combined `test/integration/dynamic-routing/test/index.test.ts` and `test/integration/dynamic-routing/test/middleware.test.ts` into a single test file.

### Why?
The previous setup with `middleware.test.ts` requiring `index.test.ts` caused confusion in CI, making tests appear to run twice. This change simplifies the test structure and consolidates related logic.

### How?
- Refactored the dynamic routing tests to use `describe.each([{ withMiddleware: false }, { withMiddleware: true }])`.
- Replaced `process.env.__MIDDLEWARE_TEST` checks with a `withMiddleware` parameter passed to the `runTests` function.
- The `middleware.js` file is now conditionally created and removed within the `beforeAll`/`afterAll` hooks based on the `withMiddleware` flag.

Closes NEXT-
Fixes #

---
[Slack Thread](https://vercel.slack.com/archives/C04KC8A53T7/p1770391144723359?thread_ts=1770391144.723359&cid=C04KC8A53T7)

<p><a href="https://cursor.com/background-agent?bcId=bc-15ea1f21-766a-584b-a136-caf020d1e4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-15ea1f21-766a-584b-a136-caf020d1e4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

