### PR TITLE
Turbopack: fix a css order violation

### DIFF
--- a/test/e2e/app-dir/css-order-shared-chunks/app/a/page.tsx
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/a/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+import shared1 from '../styles/shared1.module.css'
+import uniqueA from '../styles/unique-a.module.css'
+import shared2 from '../styles/shared2.module.css'
+import uniqueAFinal from '../styles/unique-a-final.module.css'
+
+export default function PageA() {
+  return (
+    <>
+      <div
+        id="target"
+        className={`${shared1.target} ${uniqueA.target} ${shared2.target} ${uniqueAFinal.target}`}
+      >
+        Page A
+      </div>
+      <Link href="/b">Go to B</Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/b/page.tsx
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/b/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+import shared1 from '../styles/shared1.module.css'
+import uniqueB from '../styles/unique-b.module.css'
+import shared2 from '../styles/shared2.module.css'
+import uniqueBFinal from '../styles/unique-b-final.module.css'
+
+export default function PageB() {
+  return (
+    <>
+      <div
+        id="target"
+        className={`${shared1.target} ${uniqueB.target} ${shared2.target} ${uniqueBFinal.target}`}
+      >
+        Page B
+      </div>
+      <Link href="/a">Go to A</Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/layout.tsx
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/page.tsx
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <div>Home</div>
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/styles/shared1.module.css
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/styles/shared1.module.css
@@ -1,0 +1,3 @@
+.target {
+  color: rgb(255, 0, 0);
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/styles/shared2.module.css
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/styles/shared2.module.css
@@ -1,0 +1,3 @@
+.target {
+  color: rgb(0, 0, 255);
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-a-final.module.css
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-a-final.module.css
@@ -1,0 +1,3 @@
+.target {
+  color: rgb(0, 128, 0);
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-a.module.css
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-a.module.css
@@ -1,0 +1,3 @@
+.target {
+  color: rgb(0, 255, 0);
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-b-final.module.css
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-b-final.module.css
@@ -1,0 +1,3 @@
+.target {
+  color: rgb(128, 0, 128);
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-b.module.css
+++ b/test/e2e/app-dir/css-order-shared-chunks/app/styles/unique-b.module.css
@@ -1,0 +1,3 @@
+.target {
+  color: rgb(255, 255, 0);
+}

--- a/test/e2e/app-dir/css-order-shared-chunks/css-order-shared-chunks.test.ts
+++ b/test/e2e/app-dir/css-order-shared-chunks/css-order-shared-chunks.test.ts
@@ -1,78 +1,84 @@
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-describe('css-order-shared-chunks', () => {
-  const { next } = nextTestSetup({
-    files: __dirname,
-  })
-
-  it('should preserve CSS cascade order on route A with shared chunks', async () => {
-    const browser = await next.browser('/a')
-    // unique-a-final.module.css is imported last, so its color should win
-    await retry(async () => {
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.getElementById('target')).color`
-        )
-      ).toBe('rgb(0, 128, 0)')
-    })
-  })
-
-  it('should preserve CSS cascade order on route B with shared chunks', async () => {
-    const browser = await next.browser('/b')
-    // unique-b-final.module.css is imported last, so its color should win
-    await retry(async () => {
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.getElementById('target')).color`
-        )
-      ).toBe('rgb(128, 0, 128)')
-    })
-  })
-
-  it('should preserve order when navigating from A to B', async () => {
-    const browser = await next.browser('/a')
-    // Verify A first
-    await retry(async () => {
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.getElementById('target')).color`
-        )
-      ).toBe('rgb(0, 128, 0)')
+// This test verifies Turbopack's CSS chunk ordering fix. Webpack has its own
+// CSS ordering behavior and this specific interleaved-shared-chunks scenario
+// is not yet fixed there.
+;(process.env.IS_TURBOPACK_TEST ? describe : describe.skip)(
+  'css-order-shared-chunks',
+  () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
     })
 
-    // Navigate to B
-    await browser.elementByCss('a[href="/b"]').click()
-    await browser.waitForElementByCss('#target')
-    await retry(async () => {
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.getElementById('target')).color`
-        )
-      ).toBe('rgb(128, 0, 128)')
-    })
-  })
-
-  it('should preserve order when navigating from B to A', async () => {
-    const browser = await next.browser('/b')
-    // Verify B first
-    await retry(async () => {
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.getElementById('target')).color`
-        )
-      ).toBe('rgb(128, 0, 128)')
+    it('should preserve CSS cascade order on route A with shared chunks', async () => {
+      const browser = await next.browser('/a')
+      // unique-a-final.module.css is imported last, so its color should win
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.getElementById('target')).color`
+          )
+        ).toBe('rgb(0, 128, 0)')
+      })
     })
 
-    // Navigate to A
-    await browser.elementByCss('a[href="/a"]').click()
-    await browser.waitForElementByCss('#target')
-    await retry(async () => {
-      expect(
-        await browser.eval(
-          `window.getComputedStyle(document.getElementById('target')).color`
-        )
-      ).toBe('rgb(0, 128, 0)')
+    it('should preserve CSS cascade order on route B with shared chunks', async () => {
+      const browser = await next.browser('/b')
+      // unique-b-final.module.css is imported last, so its color should win
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.getElementById('target')).color`
+          )
+        ).toBe('rgb(128, 0, 128)')
+      })
     })
-  })
-})
+
+    it('should preserve order when navigating from A to B', async () => {
+      const browser = await next.browser('/a')
+      // Verify A first
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.getElementById('target')).color`
+          )
+        ).toBe('rgb(0, 128, 0)')
+      })
+
+      // Navigate to B
+      await browser.elementByCss('a[href="/b"]').click()
+      await browser.waitForElementByCss('#target')
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.getElementById('target')).color`
+          )
+        ).toBe('rgb(128, 0, 128)')
+      })
+    })
+
+    it('should preserve order when navigating from B to A', async () => {
+      const browser = await next.browser('/b')
+      // Verify B first
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.getElementById('target')).color`
+          )
+        ).toBe('rgb(128, 0, 128)')
+      })
+
+      // Navigate to A
+      await browser.elementByCss('a[href="/a"]').click()
+      await browser.waitForElementByCss('#target')
+      await retry(async () => {
+        expect(
+          await browser.eval(
+            `window.getComputedStyle(document.getElementById('target')).color`
+          )
+        ).toBe('rgb(0, 128, 0)')
+      })
+    })
+  }
+)

--- a/test/e2e/app-dir/css-order-shared-chunks/css-order-shared-chunks.test.ts
+++ b/test/e2e/app-dir/css-order-shared-chunks/css-order-shared-chunks.test.ts
@@ -1,0 +1,78 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('css-order-shared-chunks', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should preserve CSS cascade order on route A with shared chunks', async () => {
+    const browser = await next.browser('/a')
+    // unique-a-final.module.css is imported last, so its color should win
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.getElementById('target')).color`
+        )
+      ).toBe('rgb(0, 128, 0)')
+    })
+  })
+
+  it('should preserve CSS cascade order on route B with shared chunks', async () => {
+    const browser = await next.browser('/b')
+    // unique-b-final.module.css is imported last, so its color should win
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.getElementById('target')).color`
+        )
+      ).toBe('rgb(128, 0, 128)')
+    })
+  })
+
+  it('should preserve order when navigating from A to B', async () => {
+    const browser = await next.browser('/a')
+    // Verify A first
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.getElementById('target')).color`
+        )
+      ).toBe('rgb(0, 128, 0)')
+    })
+
+    // Navigate to B
+    await browser.elementByCss('a[href="/b"]').click()
+    await browser.waitForElementByCss('#target')
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.getElementById('target')).color`
+        )
+      ).toBe('rgb(128, 0, 128)')
+    })
+  })
+
+  it('should preserve order when navigating from B to A', async () => {
+    const browser = await next.browser('/b')
+    // Verify B first
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.getElementById('target')).color`
+        )
+      ).toBe('rgb(128, 0, 128)')
+    })
+
+    // Navigate to A
+    await browser.elementByCss('a[href="/a"]').click()
+    await browser.waitForElementByCss('#target')
+    await retry(async () => {
+      expect(
+        await browser.eval(
+          `window.getComputedStyle(document.getElementById('target')).color`
+        )
+      ).toBe('rgb(0, 128, 0)')
+    })
+  })
+})

--- a/test/e2e/app-dir/css-order-shared-chunks/next.config.js
+++ b/test/e2e/app-dir/css-order-shared-chunks/next.config.js
@@ -1,0 +1,3 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+module.exports = nextConfig

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -1,4 +1,4 @@
-use std::collections::BinaryHeap;
+use std::{cmp::Reverse, collections::BinaryHeap};
 
 use anyhow::Result;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -148,16 +148,16 @@ pub async fn make_style_production_chunks(
         // --- Step 4: Kahn's algorithm, using a min-heap on `unit_min_pos` as tiebreaker ---
         // The heap stores (min_pos, unit_index) so that among units with in-degree 0,
         // we always pick the one that appeared earliest in the DFS post-order.
-        let mut heap: BinaryHeap<std::cmp::Reverse<(usize, usize)>> = BinaryHeap::new();
+        let mut heap: BinaryHeap<Reverse<(usize, usize)>> = BinaryHeap::new();
         for (i, unit) in units.iter().enumerate() {
             if in_degree[i] == 0 {
                 let pos = unit_min_pos.get(unit).copied().unwrap_or(usize::MAX);
-                heap.push(std::cmp::Reverse((pos, i)));
+                heap.push(Reverse((pos, i)));
             }
         }
 
         let mut sorted: Vec<usize> = Vec::with_capacity(n);
-        while let Some(std::cmp::Reverse((_, idx))) = heap.pop() {
+        while let Some(Reverse((_, idx))) = heap.pop() {
             sorted.push(idx);
             for &neighbor in &adj[idx] {
                 in_degree[neighbor] -= 1;
@@ -166,7 +166,7 @@ pub async fn make_style_production_chunks(
                         .get(&units[neighbor])
                         .copied()
                         .unwrap_or(usize::MAX);
-                    heap.push(std::cmp::Reverse((pos, neighbor)));
+                    heap.push(Reverse((pos, neighbor)));
                 }
             }
         }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -1,27 +1,16 @@
-use std::{cmp::Reverse, collections::BinaryHeap};
-
 use anyhow::Result;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashSet;
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{
     chunk::{
-        ChunkItemBatchGroup, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo,
-        ChunkableModule, ChunkingConfig, ChunkingContext,
+        ChunkItemBatchGroup, ChunkItemWithAsyncModuleInfo, ChunkingConfig, ChunkingContext,
         chunking::{ChunkItemOrBatchWithInfo, SplitContext, make_chunk},
     },
     module_graph::{ModuleGraph, style_groups::StyleGroupsConfig},
 };
-
-/// An emission unit is either a shared style batch or a single non-shared chunk item.
-/// The topological sort in `make_style_production_chunks` operates over these units.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
-enum EmissionUnit {
-    Batch(ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>),
-    Item(ChunkItemWithAsyncModuleInfo),
-}
 
 pub async fn make_style_production_chunks(
     chunk_items: Vec<&ChunkItemOrBatchWithInfo>,
@@ -44,168 +33,44 @@ pub async fn make_style_production_chunks(
                 },
             )
             .await?;
-
-        // `style_groups` has computed shared batches from the CSS chunk items across all
-        // endpoints. We need to emit chunks for this endpoint in an order that respects the
-        // CSS cascade: if module X must precede module Y, then X's emission unit (batch or
-        // individual chunk) must be emitted before Y's.
-        //
-        // We cannot simply follow the DFS post-order of `chunk_items`, because a shared batch
-        // groups members whose DFS positions may interleave with non-shared items. For example,
-        // if DFS order is [A, B, C], {A, C} form a shared batch, and B is non-shared, emitting
-        // at the last member gives [B, {A,C}] — wrong, because A must precede B.
-        //
-        // Instead, we:
-        // 1. Build a module → EmissionUnit map for all CSS items in this endpoint.
-        // 2. Translate the module-level dependency edges from `style_groups.module_dependents` into
-        //    emission-unit edges.
-        // 3. Topologically sort the emission units (Kahn's algorithm, DFS post-order as tiebreaker
-        //    for determinism).
-        // 4. Emit chunks in the sorted order.
-
-        // --- Step 1: collect all ChunkItemWithAsyncModuleInfo for this endpoint ---
-        // We also record each item's DFS position (index) so we can use it as a tiebreaker.
-        let mut all_items: Vec<ChunkItemWithAsyncModuleInfo> = Vec::new();
-        for chunk_item in &chunk_items {
+        let mut handled = FxHashSet::default();
+        let mut handle_chunk_item = async |chunk_item: &ChunkItemWithAsyncModuleInfo| {
+            if let Some(&batch) = style_groups.shared_chunk_items.get(chunk_item) {
+                if handled.insert(batch) {
+                    make_chunk(
+                        vec![&ChunkItemOrBatchWithInfo::Batch { batch, size: 0 }],
+                        vec![],
+                        &mut String::new(),
+                        &mut split_context,
+                    )
+                    .await?;
+                }
+            } else {
+                make_chunk(
+                    vec![&ChunkItemOrBatchWithInfo::ChunkItem {
+                        chunk_item: chunk_item.clone(),
+                        size: 0,
+                        asset_ident: rcstr!(""),
+                    }],
+                    vec![],
+                    &mut String::new(),
+                    &mut split_context,
+                )
+                .await?;
+            }
+            anyhow::Ok(())
+        };
+        for chunk_item in chunk_items {
             match chunk_item {
                 ChunkItemOrBatchWithInfo::ChunkItem { chunk_item, .. } => {
-                    all_items.push(chunk_item.clone());
+                    handle_chunk_item(chunk_item).await?;
                 }
                 ChunkItemOrBatchWithInfo::Batch { batch, .. } => {
-                    for item in &batch.await?.chunk_items {
-                        all_items.push(item.clone());
+                    for chunk_item in &batch.await?.chunk_items {
+                        handle_chunk_item(chunk_item).await?;
                     }
                 }
-            }
-        }
-
-        // --- Step 2: build module → EmissionUnit and module → DFS position maps ---
-        // The DFS position is the index in `all_items` (already in DFS post-order).
-        let mut module_to_unit: FxHashMap<ResolvedVc<Box<dyn ChunkableModule>>, EmissionUnit> =
-            FxHashMap::default();
-        // Track the earliest DFS position for each emission unit (for tiebreaking).
-        let mut unit_min_pos: FxHashMap<EmissionUnit, usize> = FxHashMap::default();
-
-        for (pos, item) in all_items.iter().enumerate() {
-            let Some(module) = item.module else { continue };
-            let unit = if let Some(&batch) = style_groups.shared_chunk_items.get(item) {
-                EmissionUnit::Batch(batch)
-            } else {
-                EmissionUnit::Item(item.clone())
             };
-            module_to_unit.insert(module, unit.clone());
-            unit_min_pos
-                .entry(unit)
-                .and_modify(|p| *p = (*p).min(pos))
-                .or_insert(pos);
-        }
-
-        // Collect the full set of emission units in this endpoint (in stable order for indexing).
-        let units: Vec<EmissionUnit> = {
-            let mut seen = FxHashSet::default();
-            let mut ordered = Vec::new();
-            for item in &all_items {
-                let Some(module) = item.module else { continue };
-                if let Some(unit) = module_to_unit.get(&module)
-                    && seen.insert(unit.clone())
-                {
-                    ordered.push(unit.clone());
-                }
-            }
-            ordered
-        };
-        let unit_index: FxHashMap<EmissionUnit, usize> = units
-            .iter()
-            .enumerate()
-            .map(|(i, u)| (u.clone(), i))
-            .collect::<FxHashMap<_, _>>();
-        let n = units.len();
-
-        // --- Step 3: build the emission-unit dependency graph ---
-        // edge: src → dst means src must be emitted before dst.
-        let mut adj: Vec<FxHashSet<usize>> = vec![FxHashSet::default(); n];
-        let mut in_degree: Vec<usize> = vec![0; n];
-
-        for (module, dependents) in &style_groups.module_dependents {
-            let Some(src_unit) = module_to_unit.get(module) else {
-                continue;
-            };
-            let src_idx = unit_index[src_unit];
-            for dep_module in dependents {
-                let Some(dst_unit) = module_to_unit.get(dep_module) else {
-                    continue;
-                };
-                if src_unit == dst_unit {
-                    continue; // same unit, no edge needed
-                }
-                let dst_idx = unit_index[dst_unit];
-                if adj[src_idx].insert(dst_idx) {
-                    in_degree[dst_idx] += 1;
-                }
-            }
-        }
-
-        // --- Step 4: Kahn's algorithm, using a min-heap on `unit_min_pos` as tiebreaker ---
-        // The heap stores (min_pos, unit_index) so that among units with in-degree 0,
-        // we always pick the one that appeared earliest in the DFS post-order.
-        let mut heap: BinaryHeap<Reverse<(usize, usize)>> = BinaryHeap::new();
-        for (i, unit) in units.iter().enumerate() {
-            if in_degree[i] == 0 {
-                let pos = unit_min_pos.get(unit).copied().unwrap_or(usize::MAX);
-                heap.push(Reverse((pos, i)));
-            }
-        }
-
-        let mut sorted: Vec<usize> = Vec::with_capacity(n);
-        while let Some(Reverse((_, idx))) = heap.pop() {
-            sorted.push(idx);
-            for &neighbor in &adj[idx] {
-                in_degree[neighbor] -= 1;
-                if in_degree[neighbor] == 0 {
-                    let pos = unit_min_pos
-                        .get(&units[neighbor])
-                        .copied()
-                        .unwrap_or(usize::MAX);
-                    heap.push(Reverse((pos, neighbor)));
-                }
-            }
-        }
-
-        debug_assert_eq!(
-            sorted.len(),
-            n,
-            "Topological sort did not visit all emission units; cycle in CSS dependency graph?"
-        );
-
-        // --- Step 5: emit chunks in topological order ---
-        for idx in sorted {
-            match &units[idx] {
-                EmissionUnit::Batch(batch) => {
-                    make_chunk(
-                        vec![&ChunkItemOrBatchWithInfo::Batch {
-                            batch: *batch,
-                            size: 0,
-                        }],
-                        vec![],
-                        &mut String::new(),
-                        &mut split_context,
-                    )
-                    .await?;
-                }
-                EmissionUnit::Item(chunk_item) => {
-                    make_chunk(
-                        vec![&ChunkItemOrBatchWithInfo::ChunkItem {
-                            chunk_item: chunk_item.clone(),
-                            size: 0,
-                            asset_ident: rcstr!(""),
-                        }],
-                        vec![],
-                        &mut String::new(),
-                        &mut split_context,
-                    )
-                    .await?;
-                }
-            }
         }
 
         Ok(())

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -1,5 +1,7 @@
+use std::collections::BinaryHeap;
+
 use anyhow::Result;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
@@ -7,11 +9,19 @@ use turbo_tasks::{ResolvedVc, Vc};
 use crate::{
     chunk::{
         ChunkItemBatchGroup, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo,
-        ChunkingConfig, ChunkingContext,
+        ChunkableModule, ChunkingConfig, ChunkingContext,
         chunking::{ChunkItemOrBatchWithInfo, SplitContext, make_chunk},
     },
     module_graph::{ModuleGraph, style_groups::StyleGroupsConfig},
 };
+
+/// An emission unit is either a shared style batch or a single non-shared chunk item.
+/// The topological sort in `make_style_production_chunks` operates over these units.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+enum EmissionUnit {
+    Batch(ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>),
+    Item(ChunkItemWithAsyncModuleInfo),
+}
 
 pub async fn make_style_production_chunks(
     chunk_items: Vec<&ChunkItemOrBatchWithInfo>,
@@ -35,84 +45,168 @@ pub async fn make_style_production_chunks(
             )
             .await?;
 
-        // `style_groups` has computed a set of shared batches from the chunk_items. We need to
-        // create chunks for those while respecting dependency ordering.
-        // The input `chunk_items` is already in dependency order based on a DFS post-order
-        // traversal of the module graph. However, this is a partial order and style_groups takes
-        // advantage of that to produce shared batches. To ensure we produce chunks in a valid
-        // order, we emit a shared batch only after we've seen all its members in the input.
-        // We track how many items remain for each batch and emit when the count reaches zero.
+        // `style_groups` has computed shared batches from the CSS chunk items across all
+        // endpoints. We need to emit chunks for this endpoint in an order that respects the
+        // CSS cascade: if module X must precede module Y, then X's emission unit (batch or
+        // individual chunk) must be emitted before Y's.
+        //
+        // We cannot simply follow the DFS post-order of `chunk_items`, because a shared batch
+        // groups members whose DFS positions may interleave with non-shared items. For example,
+        // if DFS order is [A, B, C], {A, C} form a shared batch, and B is non-shared, emitting
+        // at the last member gives [B, {A,C}] — wrong, because A must precede B.
+        //
+        // Instead, we:
+        // 1. Build a module → EmissionUnit map for all CSS items in this endpoint.
+        // 2. Translate the module-level dependency edges from `style_groups.module_dependents` into
+        //    emission-unit edges.
+        // 3. Topologically sort the emission units (Kahn's algorithm, DFS post-order as tiebreaker
+        //    for determinism).
+        // 4. Emit chunks in the sorted order.
 
-        // Count how many items from each batch appear in this endpoint's chunk_items.
-        // style_groups is computed globally, but chunk_items is per-endpoint.
-        let mut batch_remaining: FxHashMap<ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>, usize> =
-            FxHashMap::default();
+        // --- Step 1: collect all ChunkItemWithAsyncModuleInfo for this endpoint ---
+        // We also record each item's DFS position (index) so we can use it as a tiebreaker.
+        let mut all_items: Vec<ChunkItemWithAsyncModuleInfo> = Vec::new();
         for chunk_item in &chunk_items {
             match chunk_item {
                 ChunkItemOrBatchWithInfo::ChunkItem { chunk_item, .. } => {
-                    if let Some(&batch) = style_groups.shared_chunk_items.get(chunk_item) {
-                        *batch_remaining.entry(batch).or_default() += 1;
-                    }
+                    all_items.push(chunk_item.clone());
                 }
                 ChunkItemOrBatchWithInfo::Batch { batch, .. } => {
-                    for chunk_item in &batch.await?.chunk_items {
-                        if let Some(&style_batch) = style_groups.shared_chunk_items.get(chunk_item)
-                        {
-                            *batch_remaining.entry(style_batch).or_default() += 1;
-                        }
+                    for item in &batch.await?.chunk_items {
+                        all_items.push(item.clone());
                     }
                 }
             }
         }
 
-        // Process a single chunk item, emitting chunks as needed
-        let mut handle_chunk_item = async |chunk_item: &ChunkItemWithAsyncModuleInfo| {
-            if let Some(&batch) = style_groups.shared_chunk_items.get(chunk_item) {
-                let remaining = batch_remaining.get_mut(&batch).unwrap();
-                *remaining -= 1;
+        // --- Step 2: build module → EmissionUnit and module → DFS position maps ---
+        // The DFS position is the index in `all_items` (already in DFS post-order).
+        let mut module_to_unit: FxHashMap<ResolvedVc<Box<dyn ChunkableModule>>, EmissionUnit> =
+            FxHashMap::default();
+        // Track the earliest DFS position for each emission unit (for tiebreaking).
+        let mut unit_min_pos: FxHashMap<EmissionUnit, usize> = FxHashMap::default();
 
-                // Emit batch chunk when we've seen all its items in this endpoint
-                if *remaining == 0 {
+        for (pos, item) in all_items.iter().enumerate() {
+            let Some(module) = item.module else { continue };
+            let unit = if let Some(&batch) = style_groups.shared_chunk_items.get(item) {
+                EmissionUnit::Batch(batch)
+            } else {
+                EmissionUnit::Item(item.clone())
+            };
+            module_to_unit.insert(module, unit.clone());
+            unit_min_pos
+                .entry(unit)
+                .and_modify(|p| *p = (*p).min(pos))
+                .or_insert(pos);
+        }
+
+        // Collect the full set of emission units in this endpoint (in stable order for indexing).
+        let units: Vec<EmissionUnit> = {
+            let mut seen = FxHashSet::default();
+            let mut ordered = Vec::new();
+            for item in &all_items {
+                let Some(module) = item.module else { continue };
+                if let Some(unit) = module_to_unit.get(&module)
+                    && seen.insert(unit.clone())
+                {
+                    ordered.push(unit.clone());
+                }
+            }
+            ordered
+        };
+        let unit_index: FxHashMap<EmissionUnit, usize> = units
+            .iter()
+            .enumerate()
+            .map(|(i, u)| (u.clone(), i))
+            .collect::<FxHashMap<_, _>>();
+        let n = units.len();
+
+        // --- Step 3: build the emission-unit dependency graph ---
+        // edge: src → dst means src must be emitted before dst.
+        let mut adj: Vec<FxHashSet<usize>> = vec![FxHashSet::default(); n];
+        let mut in_degree: Vec<usize> = vec![0; n];
+
+        for (module, dependents) in &style_groups.module_dependents {
+            let Some(src_unit) = module_to_unit.get(module) else {
+                continue;
+            };
+            let src_idx = unit_index[src_unit];
+            for dep_module in dependents {
+                let Some(dst_unit) = module_to_unit.get(dep_module) else {
+                    continue;
+                };
+                if src_unit == dst_unit {
+                    continue; // same unit, no edge needed
+                }
+                let dst_idx = unit_index[dst_unit];
+                if adj[src_idx].insert(dst_idx) {
+                    in_degree[dst_idx] += 1;
+                }
+            }
+        }
+
+        // --- Step 4: Kahn's algorithm, using a min-heap on `unit_min_pos` as tiebreaker ---
+        // The heap stores (min_pos, unit_index) so that among units with in-degree 0,
+        // we always pick the one that appeared earliest in the DFS post-order.
+        let mut heap: BinaryHeap<std::cmp::Reverse<(usize, usize)>> = BinaryHeap::new();
+        for (i, unit) in units.iter().enumerate() {
+            if in_degree[i] == 0 {
+                let pos = unit_min_pos.get(unit).copied().unwrap_or(usize::MAX);
+                heap.push(std::cmp::Reverse((pos, i)));
+            }
+        }
+
+        let mut sorted: Vec<usize> = Vec::with_capacity(n);
+        while let Some(std::cmp::Reverse((_, idx))) = heap.pop() {
+            sorted.push(idx);
+            for &neighbor in &adj[idx] {
+                in_degree[neighbor] -= 1;
+                if in_degree[neighbor] == 0 {
+                    let pos = unit_min_pos
+                        .get(&units[neighbor])
+                        .copied()
+                        .unwrap_or(usize::MAX);
+                    heap.push(std::cmp::Reverse((pos, neighbor)));
+                }
+            }
+        }
+
+        debug_assert_eq!(
+            sorted.len(),
+            n,
+            "Topological sort did not visit all emission units; cycle in CSS dependency graph?"
+        );
+
+        // --- Step 5: emit chunks in topological order ---
+        for idx in sorted {
+            match &units[idx] {
+                EmissionUnit::Batch(batch) => {
                     make_chunk(
-                        vec![&ChunkItemOrBatchWithInfo::Batch { batch, size: 0 }],
+                        vec![&ChunkItemOrBatchWithInfo::Batch {
+                            batch: *batch,
+                            size: 0,
+                        }],
                         vec![],
                         &mut String::new(),
                         &mut split_context,
                     )
                     .await?;
                 }
-            } else {
-                make_chunk(
-                    vec![&ChunkItemOrBatchWithInfo::ChunkItem {
-                        chunk_item: chunk_item.clone(),
-                        size: 0,
-                        asset_ident: rcstr!(""),
-                    }],
-                    vec![],
-                    &mut String::new(),
-                    &mut split_context,
-                )
-                .await?;
+                EmissionUnit::Item(chunk_item) => {
+                    make_chunk(
+                        vec![&ChunkItemOrBatchWithInfo::ChunkItem {
+                            chunk_item: chunk_item.clone(),
+                            size: 0,
+                            asset_ident: rcstr!(""),
+                        }],
+                        vec![],
+                        &mut String::new(),
+                        &mut split_context,
+                    )
+                    .await?;
+                }
             }
-            anyhow::Ok(())
-        };
-        for chunk_item in chunk_items {
-            match chunk_item {
-                ChunkItemOrBatchWithInfo::ChunkItem { chunk_item, .. } => {
-                    handle_chunk_item(chunk_item).await?;
-                }
-                ChunkItemOrBatchWithInfo::Batch { batch, .. } => {
-                    for chunk_item in &batch.await?.chunk_items {
-                        handle_chunk_item(chunk_item).await?;
-                    }
-                }
-            };
         }
-
-        debug_assert!(
-            batch_remaining.values().all(|&count| count == 0),
-            "Not all batch items were seen in chunk_items"
-        );
 
         Ok(())
     }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -1,12 +1,13 @@
 use anyhow::Result;
-use rustc_hash::FxHashSet;
+use rustc_hash::FxHashMap;
 use tracing::Instrument;
 use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, Vc};
 
 use crate::{
     chunk::{
-        ChunkItemBatchGroup, ChunkItemWithAsyncModuleInfo, ChunkingConfig, ChunkingContext,
+        ChunkItemBatchGroup, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo,
+        ChunkingConfig, ChunkingContext,
         chunking::{ChunkItemOrBatchWithInfo, SplitContext, make_chunk},
     },
     module_graph::{ModuleGraph, style_groups::StyleGroupsConfig},
@@ -33,10 +34,30 @@ pub async fn make_style_production_chunks(
                 },
             )
             .await?;
-        let mut handled = FxHashSet::default();
+
+        // `style_groups` has computed a set of shared batches from the chunk_items. We need to
+        // create chunks for those while respecting dependency ordering.
+        // The input `chunk_items` is already in dependency order based on a DFS post-order
+        // traversal of the module graph. However, this is a partial order and style_groups takes
+        // advantage of that to produce shared batches. To ensure we produce chunks in a valid
+        // order, we emit a shared batch only after we've seen all its members in the input.
+        // We track how many items remain for each batch and emit when the count reaches zero.
+
+        // Track remaining items for each batch (initialized with batch sizes, decremented as we go)
+        let mut batch_remaining: FxHashMap<ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>, usize> =
+            FxHashMap::default();
+        for (_, &batch) in &style_groups.shared_chunk_items {
+            *batch_remaining.entry(batch).or_default() += 1;
+        }
+
+        // Process a single chunk item, emitting chunks as needed
         let mut handle_chunk_item = async |chunk_item: &ChunkItemWithAsyncModuleInfo| {
             if let Some(&batch) = style_groups.shared_chunk_items.get(chunk_item) {
-                if handled.insert(batch) {
+                let remaining = batch_remaining.get_mut(&batch).unwrap();
+                *remaining -= 1;
+
+                // Emit batch chunk when we've seen all its items
+                if *remaining == 0 {
                     make_chunk(
                         vec![&ChunkItemOrBatchWithInfo::Batch { batch, size: 0 }],
                         vec![],
@@ -72,6 +93,11 @@ pub async fn make_style_production_chunks(
                 }
             };
         }
+
+        debug_assert!(
+            batch_remaining.values().all(|&count| count == 0),
+            "Not all batch items were seen in chunk_items"
+        );
 
         Ok(())
     }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -43,11 +43,26 @@ pub async fn make_style_production_chunks(
         // order, we emit a shared batch only after we've seen all its members in the input.
         // We track how many items remain for each batch and emit when the count reaches zero.
 
-        // Track remaining items for each batch (initialized with batch sizes, decremented as we go)
+        // Count how many items from each batch appear in this endpoint's chunk_items.
+        // style_groups is computed globally, but chunk_items is per-endpoint.
         let mut batch_remaining: FxHashMap<ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>, usize> =
             FxHashMap::default();
-        for (_, &batch) in &style_groups.shared_chunk_items {
-            *batch_remaining.entry(batch).or_default() += 1;
+        for chunk_item in &chunk_items {
+            match chunk_item {
+                ChunkItemOrBatchWithInfo::ChunkItem { chunk_item, .. } => {
+                    if let Some(&batch) = style_groups.shared_chunk_items.get(chunk_item) {
+                        *batch_remaining.entry(batch).or_default() += 1;
+                    }
+                }
+                ChunkItemOrBatchWithInfo::Batch { batch, .. } => {
+                    for chunk_item in &batch.await?.chunk_items {
+                        if let Some(&style_batch) = style_groups.shared_chunk_items.get(chunk_item)
+                        {
+                            *batch_remaining.entry(style_batch).or_default() += 1;
+                        }
+                    }
+                }
+            }
         }
 
         // Process a single chunk item, emitting chunks as needed
@@ -56,7 +71,7 @@ pub async fn make_style_production_chunks(
                 let remaining = batch_remaining.get_mut(&batch).unwrap();
                 *remaining -= 1;
 
-                // Emit batch chunk when we've seen all its items
+                // Emit batch chunk when we've seen all its items in this endpoint
                 if *remaining == 0 {
                     make_chunk(
                         vec![&ChunkItemOrBatchWithInfo::Batch { batch, size: 0 }],

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -399,6 +399,40 @@ pub async fn compute_style_groups(
                     // Global CSS would leak into existing chunk_group
                     continue;
                 }
+                // Contiguity check: for every route that contains both the
+                // candidate and at least one existing batch member, ensure no
+                // unprocessed non-batch module sits between the watermark and
+                // the candidate. Without this, a shared chunk can break CSS
+                // cascade order when routes interleave shared and unique modules.
+                {
+                    let mut contiguous = true;
+                    'contiguity: for (&r_idx, &m_pos) in &info.chunk_group_indices {
+                        let Some(&watermark) = all_chunk_states.get(&r_idx) else {
+                            continue;
+                        };
+                        let (lo, hi) = if watermark < m_pos {
+                            (watermark + 1, m_pos)
+                        } else if m_pos < watermark {
+                            (m_pos + 1, watermark)
+                        } else {
+                            continue;
+                        };
+                        let styles = &chunk_group_state[r_idx].styles;
+                        for between in &styles[lo..hi] {
+                            if new_chunk_modules.contains(between) {
+                                continue;
+                            }
+                            if *ordered_modules_with_state.get(between).unwrap_or(&false) {
+                                continue;
+                            }
+                            contiguous = false;
+                            break 'contiguity;
+                        }
+                    }
+                    if !contiguous {
+                        continue;
+                    }
+                }
                 potential_next_modules.remove(&module);
                 current_size += info.size;
                 if is_global {

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -133,7 +133,7 @@ pub(crate) struct BatchingResult {
 /// - `max_chunk_size`: Maximum byte size for a single shared chunk.
 pub(crate) fn compute_style_batches(
     module_info: &FxIndexMap<usize, BatchingModuleInfo>,
-    chunk_group_styles: &[Vec<usize>],
+    chunk_group_styles: &[FxIndexSet<usize>],
     max_chunk_size: usize,
 ) -> BatchingResult {
     // --- Compute the dependents of each module ---
@@ -143,7 +143,7 @@ pub(crate) fn compute_style_batches(
     for (&module_key, info) in module_info {
         let mut dependents = FxHashSet::default();
         for (&cg_idx, &start_pos) in &info.chunk_group_indices {
-            let following = &chunk_group_styles[cg_idx][start_pos + 1..];
+            let following = &chunk_group_styles[cg_idx].as_slice()[start_pos + 1..];
             dependents.extend(following.iter().copied());
         }
 
@@ -188,10 +188,9 @@ pub(crate) fn compute_style_batches(
         // The current position of processing in all selected chunk groups
         let mut all_chunk_states = info.chunk_group_indices.clone();
 
-        // The list of modules that go into the new chunk, in insertion order.
+        // The set of modules that go into the new chunk, in insertion order.
         // Insertion order matters because it determines CSS cascade order within the chunk.
-        let mut new_batch_ordered: Vec<usize> = vec![module_key];
-        let mut new_batch_set: FxHashSet<usize> = [module_key].into_iter().collect();
+        let mut new_batch: FxIndexSet<usize> = [module_key].into_iter().collect();
 
         // The current size of the new chunk
         let mut current_size = info.size;
@@ -201,11 +200,11 @@ pub(crate) fn compute_style_batches(
         let mut potential_next = all_chunk_states
             .iter()
             .filter_map(|(&cg_idx, &pos)| {
-                let following = &chunk_group_styles[cg_idx][pos + 1..];
+                let following = &chunk_group_styles[cg_idx].as_slice()[pos + 1..];
                 following
                     .iter()
-                    .position(|m| !*processed.get(m).unwrap())
-                    .map(|i| following[i])
+                    .find(|&m| !*processed.get(m).unwrap())
+                    .copied()
             })
             .collect::<FxHashSet<_>>();
 
@@ -238,7 +237,7 @@ pub(crate) fn compute_style_batches(
                 }
                 // In loose mode we only check if the dependencies are not violated
                 if let Some(deps) = module_dependents.get(&m)
-                    && deps.iter().any(|d| new_batch_set.contains(d))
+                    && deps.iter().any(|d| new_batch.contains(d))
                 {
                     // A dependent of the module is already in the chunk, which would violate
                     // the order
@@ -289,8 +288,8 @@ pub(crate) fn compute_style_batches(
                         } else {
                             continue;
                         };
-                        for &between in &chunk_group_styles[r_idx][lo..hi] {
-                            if new_batch_set.contains(&between) {
+                        for &between in &chunk_group_styles[r_idx].as_slice()[lo..hi] {
+                            if new_batch.contains(&between) {
                                 continue;
                             }
                             if *processed.get(&between).unwrap_or(&false) {
@@ -314,30 +313,26 @@ pub(crate) fn compute_style_batches(
                         // This reduces the request count of the chunk group
                         chunk_group_requests[cg_idx] -= 1;
                     }
-                    let pos = chunk_group_styles[cg_idx]
-                        .iter()
-                        .position(|&x| x == m)
-                        .unwrap();
+                    let pos = chunk_group_styles[cg_idx].get_index_of(&m).unwrap();
                     all_chunk_states.insert(cg_idx, pos);
-                    let following = &chunk_group_styles[cg_idx][pos + 1..];
-                    if let Some(i) = following
+                    let following = &chunk_group_styles[cg_idx].as_slice()[pos + 1..];
+                    if let Some(&next) = following
                         .iter()
-                        .position(|x| !*processed.get(x).unwrap() && !new_batch_set.contains(x))
+                        .find(|&x| !*processed.get(x).unwrap() && !new_batch.contains(x))
                     {
-                        potential_next.insert(following[i]);
+                        potential_next.insert(next);
                     }
                 }
 
-                new_batch_ordered.push(m);
-                new_batch_set.insert(m);
+                new_batch.insert(m);
                 *processed.get_mut(&m).unwrap() = true;
                 continue 'outer;
             }
             break;
         }
 
-        if new_batch_ordered.len() > 1 {
-            batches.push(new_batch_ordered);
+        if new_batch.len() > 1 {
+            batches.push(new_batch.into_iter().collect());
         }
     }
 
@@ -509,7 +504,7 @@ pub async fn compute_style_groups(
         })
         .collect();
 
-    let batching_chunk_group_styles: Vec<Vec<usize>> = chunk_group_state
+    let batching_chunk_group_styles: Vec<FxIndexSet<usize>> = chunk_group_state
         .iter()
         .map(|cgs| cgs.styles.iter().map(|vc| vc_to_idx[vc]).collect())
         .collect();
@@ -551,7 +546,7 @@ pub async fn compute_style_groups(
 mod tests {
     use rustc_hash::FxHashSet;
     use turbo_rcstr::RcStr;
-    use turbo_tasks::FxIndexMap;
+    use turbo_tasks::{FxIndexMap, FxIndexSet};
 
     use super::{BatchingModuleInfo, compute_style_batches};
     use crate::module::StyleType;
@@ -565,7 +560,10 @@ mod tests {
     fn make_inputs(
         modules: &[(StyleType, usize)],
         routes: &[&[usize]],
-    ) -> (FxIndexMap<usize, BatchingModuleInfo>, Vec<Vec<usize>>) {
+    ) -> (
+        FxIndexMap<usize, BatchingModuleInfo>,
+        Vec<FxIndexSet<usize>>,
+    ) {
         let mut module_info: FxIndexMap<usize, BatchingModuleInfo> = FxIndexMap::default();
         // Compute index_sum per module for sorting (mirrors compute_style_groups behavior).
         let mut index_sums: Vec<usize> = vec![0; modules.len()];
@@ -593,7 +591,8 @@ mod tests {
                 .cmp(&index_sums[kb])
                 .then_with(|| a.ident.cmp(&b.ident))
         });
-        let styles: Vec<Vec<usize>> = routes.iter().map(|r| r.to_vec()).collect();
+        let styles: Vec<FxIndexSet<usize>> =
+            routes.iter().map(|r| r.iter().copied().collect()).collect();
         (module_info, styles)
     }
 
@@ -605,7 +604,7 @@ mod tests {
         })
     }
 
-    // ---- Test 1: Basic batching — contiguous shared modules batch together ----
+    // ---- Basic batching — contiguous shared modules batch together ----
 
     #[test]
     fn test_basic_shared_modules_batch_together() {
@@ -630,8 +629,7 @@ mod tests {
         );
     }
 
-    // ---- Test 2: Contiguity + size budget prevents shared modules from being batched
-    //              without the intervening modules ----
+    // ---- Contiguity + size budget prevents skipping intervening modules ----
 
     #[test]
     fn test_contiguity_with_size_budget_prevents_skipping_intervening() {
@@ -662,7 +660,7 @@ mod tests {
         );
     }
 
-    // ---- Test 2b: Contiguity check blocks shared2 until intervening unique is absorbed ----
+    // ---- Interleaved shared/unique modules: all absorbed with unlimited budget ----
 
     #[test]
     fn test_interleaved_shared_unique_all_absorbed() {
@@ -700,7 +698,7 @@ mod tests {
         );
     }
 
-    // ---- Test 2c: With size budget, shared modules can't absorb intervening unique ----
+    // ---- Interleaved shared/unique modules: size budget prevents full absorption ----
 
     #[test]
     fn test_interleaved_shared_unique_size_limited() {
@@ -733,7 +731,7 @@ mod tests {
         );
     }
 
-    // ---- Test 3a: Global CSS doesn't leak into routes that don't have it ----
+    // ---- Global CSS doesn't leak into routes that don't have it ----
 
     #[test]
     fn test_global_css_no_leak_into_new_route() {
@@ -754,7 +752,7 @@ mod tests {
         );
     }
 
-    // ---- Test 3b: Global CSS can batch with modules sharing exact same routes ----
+    // ---- Global CSS can batch with modules sharing exact same routes ----
 
     #[test]
     fn test_global_css_batches_with_same_routes() {
@@ -774,7 +772,7 @@ mod tests {
         );
     }
 
-    // ---- Test 4a: Size budget limits batch membership ----
+    // ---- Size budget limits batch membership ----
 
     #[test]
     fn test_size_budget_limits_batching() {
@@ -802,7 +800,7 @@ mod tests {
         );
     }
 
-    // ---- Test 4b: Oversized modules never batch ----
+    // ---- Oversized modules never batch ----
 
     #[test]
     fn test_oversized_modules_never_batch() {
@@ -819,7 +817,7 @@ mod tests {
         );
     }
 
-    // ---- Test 5: Contiguity allows absorbing all intervening modules ----
+    // ---- Contiguity allows absorbing all intervening modules ----
 
     #[test]
     fn test_contiguity_absorbs_intervening_modules() {
@@ -843,7 +841,7 @@ mod tests {
         );
     }
 
-    // ---- Test 7: Three routes, contiguity blocks when intervening can't be absorbed ----
+    // ---- Three routes: contiguity blocks when intervening can't be absorbed ----
 
     #[test]
     fn test_three_routes_size_limited() {
@@ -868,7 +866,7 @@ mod tests {
         );
     }
 
-    // ---- Test 8: Contiguity check handles the m_pos < watermark case ----
+    // ---- Contiguity check handles the m_pos < watermark direction ----
 
     #[test]
     fn test_contiguity_reverse_direction() {
@@ -906,7 +904,7 @@ mod tests {
         );
     }
 
-    // ---- Test 9: Contiguity with reverse direction and size limit ----
+    // ---- Reverse-direction contiguity blocked by size limit ----
 
     #[test]
     fn test_contiguity_reverse_direction_blocked() {

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -59,6 +59,7 @@ use std::cmp::Reverse;
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use indexmap::map::Entry;
+use roaring::RoaringBitmap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
@@ -127,11 +128,21 @@ struct ModuleInfo {
     /// modules are selected for batching, and non-deterministic order can cause CSS
     /// ordering bugs. See GitHub issue #89523.
     chunk_group_indices: FxIndexMap<usize, usize>,
-    /// Sum of all position indices across chunk groups, used for sorting modules.
-    /// Lower values mean the module tends to appear earlier in chunk groups.
+    /// Sum of all position indices across chunk groups, used as a heuristic for sorting modules.
+    ///
+    /// The greedy batching algorithm seeds new batches from the front of the sorted module list,
+    /// so we want modules that appear early in the cascade to be processed first. `index_sum` is
+    /// a cheap approximation of this: lower values bias toward modules near the top of their
+    /// routes' cascade order.
+    ///
+    /// This is imperfect — it conflates "early position" with "few chunk groups." A module at
+    /// position 0 in 1 route (`index_sum=0`) sorts before a module at position 1 in 30 routes
+    /// (`index_sum=30`), even though the latter is arguably more important to process early.
+    /// Ideally we'd sort by something like (average position, number of chunk groups), but
+    /// there's no obvious way to combine those into a single key.
     index_sum: usize,
     /// The byte size of this module's CSS output, used for chunk size budgeting.
-    size: usize,
+    size_bytes: usize,
     /// The chunk item representation of this module, populated after initial processing.
     chunk_item: Option<ChunkItemWithAsyncModuleInfo>,
 }
@@ -143,7 +154,7 @@ impl ModuleInfo {
             ident,
             chunk_group_indices: Default::default(),
             index_sum: 0,
-            size: 0,
+            size_bytes: 0,
             chunk_item: None,
         }
     }
@@ -151,7 +162,7 @@ impl ModuleInfo {
 
 /// State for a single chunk group during style batching.
 ///
-/// A chunk group typically corresponds to a route/page and contains all CSS modules
+/// A chunk group corresponds to a route/page and contains all CSS modules
 /// needed by that route in their correct cascade order (postorder DFS traversal).
 struct ChunkGroupState {
     /// CSS modules in this chunk group, in postorder traversal order.
@@ -166,7 +177,7 @@ struct BatchingModuleInfo {
     style_type: StyleType,
     ident: RcStr,
     chunk_group_indices: FxIndexMap<usize, usize>,
-    size: usize,
+    size_bytes: usize,
 }
 
 /// Result of the pure batching algorithm. Each batch is a `Vec<usize>` of module keys that should
@@ -192,51 +203,49 @@ fn compute_style_batches(
     chunk_group_styles: &[FxIndexSet<usize>],
     max_chunk_size: usize,
 ) -> BatchingResult {
-    // --- Compute the dependents of each module ---
-    // A module X is a dependency of module Y if X appears before Y in ALL chunk groups where both
-    // appear. We need to check all chunk groups, not just the shortest one.
-    let mut module_dependents: FxHashMap<usize, FxHashSet<usize>> = FxHashMap::default();
+    // --- Compute the dependencies of each module ---
+    // X is a dependency of Y if X appears before Y in *every* chunk group that Y belongs to.
+    // We compute this by intersecting the set of preceding modules across all chunk groups
+    // for each module. The intersection shrinks at each step, keeping the sets small in
+    // practice.
+    let mut module_dependencies: FxHashMap<usize, FxHashSet<usize>> = FxHashMap::default();
     for (&module_key, info) in module_info {
-        let mut dependents = FxHashSet::default();
-        for (&cg_idx, &start_pos) in &info.chunk_group_indices {
-            let following = &chunk_group_styles[cg_idx].as_slice()[start_pos + 1..];
-            dependents.extend(following.iter().copied());
+        let mut deps: Option<FxHashSet<usize>> = None;
+        for (&cg_idx, &pos) in &info.chunk_group_indices {
+            let preceding: FxHashSet<usize> = chunk_group_styles[cg_idx].as_slice()[..pos]
+                .iter()
+                .copied()
+                .collect();
+            match &mut deps {
+                None => {
+                    deps = Some(preceding);
+                }
+                Some(d) => {
+                    // intersect the previously collected deps and the new ones
+                    d.retain(|x| preceding.contains(x));
+                }
+            }
         }
-
-        // module is a dependency of dependent when it's included in all chunk groups of
-        // dependent with an index lower than the index of the dependent
-        dependents.retain(|&dep_key| {
-            let dep_info = &module_info[&dep_key];
-            info.chunk_group_indices.len() >= dep_info.chunk_group_indices.len()
-                && dep_info
-                    .chunk_group_indices
-                    .iter()
-                    .all(|(cg_idx, &dep_pos)| {
-                        info.chunk_group_indices
-                            .get(cg_idx)
-                            .is_some_and(|&mod_pos| mod_pos < dep_pos)
-                    })
-        });
-
-        if !dependents.is_empty() {
-            module_dependents.insert(module_key, dependents);
+        if let Some(mut deps) = deps
+            && !deps.is_empty()
+        {
+            deps.shrink_to_fit();
+            module_dependencies.insert(module_key, deps);
         }
     }
 
     // --- Greedy batching loop ---
     let mut chunk_group_requests: Vec<usize> = chunk_group_styles.iter().map(|s| s.len()).collect();
 
-    let mut processed: FxIndexMap<usize, bool> =
-        module_info.keys().copied().map(|k| (k, false)).collect();
+    let mut processed = RoaringBitmap::new();
 
     let mut batches: Vec<Vec<usize>> = Vec::new();
 
-    for i in 0..processed.len() {
-        let (&module_key, is_processed) = processed.get_index_mut(i).unwrap();
-        if *is_processed {
+    for (&module_key, _) in module_info.iter() {
+        if processed.contains(module_key as u32) {
             continue;
         }
-        *is_processed = true;
+        processed.insert(module_key as u32);
 
         let info = &module_info[&module_key];
         let mut global_mode = info.style_type == StyleType::GlobalStyle;
@@ -253,7 +262,7 @@ fn compute_style_batches(
         let mut new_batch: FxIndexSet<usize> = [module_key].into_iter().collect();
 
         // The current size of the new chunk
-        let mut current_size = info.size;
+        let mut current_size = info.size_bytes;
 
         // A pool of potential modules where the next module is selected from.
         // It's filled from the next module of the selected modules in every chunk group.
@@ -263,7 +272,7 @@ fn compute_style_batches(
                 let following = &chunk_group_styles[cg_idx].as_slice()[pos + 1..];
                 following
                     .iter()
-                    .find(|&m| !*processed.get(m).unwrap())
+                    .find(|&m| !processed.contains(*m as u32))
                     .copied()
             })
             .collect::<FxHashSet<_>>();
@@ -275,8 +284,23 @@ fn compute_style_batches(
             let mut candidates: Vec<(usize, &BatchingModuleInfo, usize)> = potential_next
                 .iter()
                 .copied()
-                .map(|m| {
+                .filter_map(|m| {
                     let mi = &module_info[&m];
+                    // Filter out modules that would exceed the size budget
+                    if current_size + mi.size_bytes > max_chunk_size {
+                        return None;
+                    }
+                    // Filter out modules that would violate dependency ordering:
+                    // if anything already in the batch depends on m, then m must
+                    // come before it, but the batch is unordered so we can't
+                    // guarantee that.
+                    if new_batch.iter().any(|&b| {
+                        module_dependencies
+                            .get(&b)
+                            .is_some_and(|deps| deps.contains(&m))
+                    }) {
+                        return None;
+                    }
                     let max_req = mi
                         .chunk_group_indices
                         .keys()
@@ -284,26 +308,13 @@ fn compute_style_batches(
                         .map(|&cg| chunk_group_requests[cg])
                         .max()
                         .unwrap();
-                    (m, mi, max_req)
+                    Some((m, mi, max_req))
                 })
                 .collect();
-            candidates.sort_by_key(|(_, mi, req)| (Reverse(*req), &mi.ident));
+            candidates.sort_unstable_by_key(|(_, mi, req)| (Reverse(*req), &mi.ident));
 
             // Try every potential module
             for (m, mi, _) in candidates {
-                if current_size + mi.size > max_chunk_size {
-                    // Chunk would be too large
-                    continue;
-                }
-                // In loose mode we only check if the dependencies are not violated
-                if let Some(deps) = module_dependents.get(&m)
-                    && deps.iter().any(|d| new_batch.contains(d))
-                {
-                    // A dependent of the module is already in the chunk, which would violate
-                    // the order
-                    continue;
-                }
-
                 // Global CSS must not leak into unrelated chunks
                 let is_global = mi.style_type == StyleType::GlobalStyle;
                 if is_global
@@ -348,11 +359,11 @@ fn compute_style_batches(
                         } else {
                             continue;
                         };
-                        for &between in &chunk_group_styles[r_idx].as_slice()[lo..hi] {
+                        for &between in chunk_group_styles[r_idx].as_slice()[lo..hi].iter().rev() {
                             if new_batch.contains(&between) {
                                 continue;
                             }
-                            if *processed.get(&between).unwrap_or(&false) {
+                            if processed.contains(between as u32) {
                                 continue;
                             }
                             contiguous = false;
@@ -364,14 +375,17 @@ fn compute_style_batches(
                     }
                 }
                 potential_next.remove(&m);
-                current_size += mi.size;
+                current_size += mi.size_bytes;
                 if is_global {
                     global_mode = true;
                 }
                 for &cg_idx in mi.chunk_group_indices.keys() {
-                    // Always decrement: the candidate is absorbed regardless of whether
-                    // this chunk group was already tracked by the batch.
-                    chunk_group_requests[cg_idx] -= 1;
+                    if all_chunk_states.contains_key(&cg_idx) {
+                        // Only decrement when this chunk group is already tracked by the
+                        // batch — absorbing into a new chunk group doesn't reduce its
+                        // request count.
+                        chunk_group_requests[cg_idx] -= 1;
+                    }
 
                     let pos = chunk_group_styles[cg_idx].get_index_of(&m).unwrap();
                     // Use max so the watermark only ever moves forward, preserving its
@@ -383,14 +397,14 @@ fn compute_style_batches(
                     let following = &chunk_group_styles[cg_idx].as_slice()[pos + 1..];
                     if let Some(&next) = following
                         .iter()
-                        .find(|&x| !*processed.get(x).unwrap() && !new_batch.contains(x))
+                        .find(|&x| !processed.contains(*x as u32) && !new_batch.contains(x))
                     {
                         potential_next.insert(next);
                     }
                 }
 
                 new_batch.insert(m);
-                *processed.get_mut(&m).unwrap() = true;
+                processed.insert(m as u32);
                 continue 'outer;
             }
             break;
@@ -506,7 +520,7 @@ pub async fn compute_style_groups(
 
     module_info_map.retain(|_, info| info.is_some());
 
-    module_info_map.sort_by(|_, a, _, b| {
+    module_info_map.sort_unstable_by(|_, a, _, b| {
         let a = a.as_ref().unwrap();
         let b = b.as_ref().unwrap();
         a.index_sum
@@ -538,7 +552,7 @@ pub async fn compute_style_groups(
         .zip(chunk_item_and_sizes)
         .for_each(|((_, info), (chunk_item, size))| {
             let info = info.as_mut().unwrap();
-            info.size = size;
+            info.size_bytes = size;
             info.chunk_item = Some(chunk_item);
         });
 
@@ -563,7 +577,7 @@ pub async fn compute_style_groups(
                     style_type: info.style_type,
                     ident: info.ident.clone(),
                     chunk_group_indices: info.chunk_group_indices.clone(),
-                    size: info.size,
+                    size_bytes: info.size_bytes,
                 },
             )
         })
@@ -609,33 +623,82 @@ pub async fn compute_style_groups(
 
 #[cfg(test)]
 mod tests {
-    use rustc_hash::FxHashSet;
+    use std::collections::HashMap;
+
     use turbo_rcstr::RcStr;
     use turbo_tasks::{FxIndexMap, FxIndexSet};
 
     use super::{BatchingModuleInfo, compute_style_batches};
     use crate::module::StyleType;
 
-    /// Helper to build test inputs concisely.
+    const ISO: StyleType = StyleType::IsolatedStyle;
+    const GLOBAL: StyleType = StyleType::GlobalStyle;
+
+    /// A named module definition for test inputs.
+    struct Module {
+        name: &'static str,
+        style_type: StyleType,
+        size_bytes: usize,
+    }
+
+    fn iso(name: &'static str, size_bytes: usize) -> Module {
+        Module {
+            name,
+            style_type: ISO,
+            size_bytes,
+        }
+    }
+
+    fn global(name: &'static str, size_bytes: usize) -> Module {
+        Module {
+            name,
+            style_type: GLOBAL,
+            size_bytes,
+        }
+    }
+
+    /// Test inputs ready for `compute_style_batches`, with name↔index mappings.
+    struct TestInputs {
+        module_info: FxIndexMap<usize, BatchingModuleInfo>,
+        chunk_group_styles: Vec<FxIndexSet<usize>>,
+        idx_to_name: HashMap<usize, &'static str>,
+    }
+
+    impl TestInputs {
+        fn batches(&self, max_chunk_size: usize) -> Vec<Vec<&'static str>> {
+            let result =
+                compute_style_batches(&self.module_info, &self.chunk_group_styles, max_chunk_size);
+            result
+                .batches
+                .iter()
+                .map(|batch| batch.iter().map(|&idx| self.idx_to_name[&idx]).collect())
+                .collect()
+        }
+    }
+
+    /// Build test inputs from named modules and named routes.
     ///
-    /// - `modules`: list of `(style_type, size)`. The index in the vec is the module key.
-    /// - `routes`: list of routes; each route is a list of module keys in CSS cascade order.
-    ///
-    /// Returns `(module_info, chunk_group_styles)` ready for `compute_style_batches`.
-    fn make_inputs(
-        modules: &[(StyleType, usize)],
-        routes: &[&[usize]],
-    ) -> (
-        FxIndexMap<usize, BatchingModuleInfo>,
-        Vec<FxIndexSet<usize>>,
-    ) {
+    /// `modules`: list of named module definitions.
+    /// `routes`: list of routes; each route is a list of module names in CSS cascade order.
+    fn make_inputs(modules: &[Module], routes: &[&[&'static str]]) -> TestInputs {
+        let name_to_idx: HashMap<&'static str, usize> = modules
+            .iter()
+            .enumerate()
+            .map(|(i, m)| (m.name, i))
+            .collect();
+        let idx_to_name: HashMap<usize, &'static str> = modules
+            .iter()
+            .enumerate()
+            .map(|(i, m)| (i, m.name))
+            .collect();
+
         let mut module_info: FxIndexMap<usize, BatchingModuleInfo> = FxIndexMap::default();
-        // Compute index_sum per module for sorting (mirrors compute_style_groups behavior).
         let mut index_sums: Vec<usize> = vec![0; modules.len()];
-        for (i, &(style_type, size)) in modules.iter().enumerate() {
+
+        for (i, m) in modules.iter().enumerate() {
             let mut cgi = FxIndexMap::default();
             for (cg_idx, route) in routes.iter().enumerate() {
-                if let Some(pos) = route.iter().position(|&m| m == i) {
+                if let Some(pos) = route.iter().position(|&n| name_to_idx[n] == i) {
                     cgi.insert(cg_idx, pos);
                     index_sums[i] += pos;
                 }
@@ -643,415 +706,225 @@ mod tests {
             module_info.insert(
                 i,
                 BatchingModuleInfo {
-                    style_type,
-                    ident: RcStr::from(format!("mod_{i}")),
+                    style_type: m.style_type,
+                    ident: RcStr::from(m.name),
                     chunk_group_indices: cgi,
-                    size,
+                    size_bytes: m.size_bytes,
                 },
             );
         }
-        // Sort by (index_sum, ident) to match what compute_style_groups does.
+
         module_info.sort_by(|&ka, a, &kb, b| {
             index_sums[ka]
                 .cmp(&index_sums[kb])
                 .then_with(|| a.ident.cmp(&b.ident))
         });
-        let styles: Vec<FxIndexSet<usize>> =
-            routes.iter().map(|r| r.iter().copied().collect()).collect();
-        (module_info, styles)
-    }
 
-    /// Helper: check if any batch contains all of the given modules.
-    fn batch_contains_all(batches: &[Vec<usize>], modules: &[usize]) -> bool {
-        batches.iter().any(|batch| {
-            let set: FxHashSet<usize> = batch.iter().copied().collect();
-            modules.iter().all(|m| set.contains(m))
-        })
-    }
-
-    // ---- Basic batching — contiguous shared modules batch together ----
-
-    #[test]
-    fn test_basic_shared_modules_batch_together() {
-        // Route 0: [common_a(0), common_b(1), only_0(2)]
-        // Route 1: [common_a(0), common_b(1), only_1(3)]
-        //
-        // common_a and common_b are contiguous and shared — they should batch.
-        // only_0 and only_1 are contiguous with common_b in their respective routes,
-        // so the greedy algorithm may absorb them too. The key assertion is that
-        // common_a and common_b are in the same batch.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100), (iso, 100)],
-            &[&[0, 1, 2], &[0, 1, 3]],
-        );
-        let result = compute_style_batches(&info, &styles, 1_000_000);
-
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1]),
-            "common_a and common_b should be batched together, got: {:?}",
-            result.batches
-        );
-    }
-
-    // ---- Contiguity + size budget prevents skipping intervening modules ----
-
-    #[test]
-    fn test_contiguity_with_size_budget_prevents_skipping_intervening() {
-        // Route 0: [A(0), B(1), C(2)]
-        // Route 1: [A(0), D(3), C(2)]
-        //
-        // A and C are shared. B and D sit between them in each route.
-        // With a size budget that allows only 2 modules, A can absorb B or D but
-        // not both plus C. The contiguity check prevents C from being added when
-        // the gap still has unprocessed modules.
-        //
-        // A(size=100) is the seed. Budget = 250 allows one more module (200 total).
-        // B gets absorbed (200 <= 250). D is unprocessed in route 1's gap.
-        // C cannot be added: route 1 gap [D] is unprocessed AND 300 > 250.
-        // Result: batch {A, B}, then D solo, then C solo.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100), (iso, 100)],
-            &[&[0, 1, 2], &[0, 3, 2]],
-        );
-        let result = compute_style_batches(&info, &styles, 250);
-
-        assert!(
-            !batch_contains_all(&result.batches, &[0, 2]),
-            "A and C must NOT be in the same batch (size budget prevents absorbing all \
-             intervening modules), got: {:?}",
-            result.batches
-        );
-    }
-
-    // ---- Interleaved shared/unique modules: all absorbed with unlimited budget ----
-
-    #[test]
-    fn test_interleaved_shared_unique_all_absorbed() {
-        // Route A: [shared1(0), unique_a(1), shared2(2), unique_a_final(3)]
-        // Route B: [shared1(0), unique_b(4), shared2(2), unique_b_final(5)]
-        //
-        // With unlimited budget, the greedy algorithm absorbs everything into one batch.
-        // This is correct because the single chunk can order items to satisfy both routes.
-        // The contiguity check ensures shared2 is NOT added until unique_b is absorbed.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-            ],
-            &[&[0, 1, 2, 3], &[0, 4, 2, 5]],
-        );
-        let result = compute_style_batches(&info, &styles, 1_000_000);
-
-        // All modules end up in one batch because they can all be absorbed.
-        assert_eq!(
-            result.batches.len(),
-            1,
-            "All modules should form a single batch, got: {:?}",
-            result.batches
-        );
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1, 2, 3, 4, 5]),
-            "Batch should contain all modules, got: {:?}",
-            result.batches
-        );
-    }
-
-    // ---- Interleaved shared/unique modules: size budget prevents full absorption ----
-
-    #[test]
-    fn test_interleaved_shared_unique_size_limited() {
-        // Route A: [shared1(0), unique_a(1), shared2(2), unique_a_final(3)]
-        // Route B: [shared1(0), unique_b(4), shared2(2), unique_b_final(5)]
-        //
-        // Budget = 350 (allows at most 3 modules of size 100).
-        // shared1 is the seed. It absorbs unique_a (or unique_b), but then shared2
-        // is blocked by contiguity (the other unique is in the gap) and by size
-        // (adding more would exceed 350). shared1 and shared2 end up in separate chunks.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-                (iso, 100),
-            ],
-            &[&[0, 1, 2, 3], &[0, 4, 2, 5]],
-        );
-        let result = compute_style_batches(&info, &styles, 350);
-
-        assert!(
-            !batch_contains_all(&result.batches, &[0, 2]),
-            "shared1 and shared2 must NOT be in the same batch (size limit prevents absorbing all \
-             intervening modules), got: {:?}",
-            result.batches
-        );
-    }
-
-    // ---- Global CSS doesn't leak into routes that don't have it ----
-
-    #[test]
-    fn test_global_css_no_leak_into_new_route() {
-        // Route 0: [mod_a(0), global(1)]
-        // Route 1: [mod_a(0)]
-        //
-        // mod_a appears in both routes; global only in route 0.
-        // They must NOT batch because global CSS would leak into route 1.
-        let iso = StyleType::IsolatedStyle;
-        let global = StyleType::GlobalStyle;
-        let (info, styles) = make_inputs(&[(iso, 100), (global, 100)], &[&[0, 1], &[0]]);
-        let result = compute_style_batches(&info, &styles, 1_000_000);
-
-        assert!(
-            !batch_contains_all(&result.batches, &[0, 1]),
-            "mod_a and global must NOT batch (global would leak into route 1), got: {:?}",
-            result.batches
-        );
-    }
-
-    // ---- Global CSS can batch with modules sharing exact same routes ----
-
-    #[test]
-    fn test_global_css_batches_with_same_routes() {
-        // Route 0: [global(0), mod_a(1)]
-        // Route 1: [global(0), mod_a(1)]
-        //
-        // Both modules appear in exactly the same routes — safe to batch.
-        let iso = StyleType::IsolatedStyle;
-        let global = StyleType::GlobalStyle;
-        let (info, styles) = make_inputs(&[(global, 100), (iso, 100)], &[&[0, 1], &[0, 1]]);
-        let result = compute_style_batches(&info, &styles, 1_000_000);
-
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1]),
-            "global and mod_a should batch (identical route sets), got: {:?}",
-            result.batches
-        );
-    }
-
-    // ---- Size budget limits batch membership ----
-
-    #[test]
-    fn test_size_budget_limits_batching() {
-        // Route 0: [A(0), B(1), C(2)]
-        // All in same route, contiguous. A+B = 600 fits in 700; A+B+C = 900 > 700.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(&[(iso, 300), (iso, 300), (iso, 300)], &[&[0, 1, 2]]);
-        let result = compute_style_batches(&info, &styles, 700);
-
-        // A+B should batch (600 <= 700)
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1]),
-            "A and B should batch (600 <= 700), got: {:?}",
-            result.batches
-        );
-        // C should NOT be in the same batch (would push to 900)
-        let ab_batch = result
-            .batches
+        let chunk_group_styles: Vec<FxIndexSet<usize>> = routes
             .iter()
-            .find(|b| b.contains(&0) && b.contains(&1))
-            .unwrap();
-        assert!(
-            !ab_batch.contains(&2),
-            "C should not be in the A+B batch (would exceed size budget)"
+            .map(|r| r.iter().map(|&n| name_to_idx[n]).collect())
+            .collect();
+
+        TestInputs {
+            module_info,
+            chunk_group_styles,
+            idx_to_name,
+        }
+    }
+
+    #[test]
+    fn basic_shared_modules() {
+        let t = make_inputs(
+            &[
+                iso("common_a", 100),
+                iso("common_b", 100),
+                iso("only_0", 100),
+                iso("only_1", 100),
+            ],
+            &[
+                &["common_a", "common_b", "only_0"],
+                &["common_a", "common_b", "only_1"],
+            ],
+        );
+
+        assert_eq!(
+            t.batches(1_000_000),
+            vec![vec!["common_a", "common_b", "only_0", "only_1"]],
+        );
+        assert_eq!(t.batches(200), vec![vec!["common_a", "common_b"]],);
+    }
+
+    #[test]
+    fn contiguity_with_intervening_modules() {
+        let t = make_inputs(
+            &[iso("A", 100), iso("B", 100), iso("C", 100), iso("D", 100)],
+            &[&["A", "B", "C"], &["A", "D", "C"]],
+        );
+
+        assert_eq!(t.batches(1_000_000), vec![vec!["A", "B", "D", "C"]],);
+        // Budget fits 2: A absorbs B. Then D+C form a second batch.
+        assert_eq!(t.batches(250), vec![vec!["A", "B"], vec!["D", "C"]],);
+    }
+
+    #[test]
+    fn interleaved_shared_and_unique() {
+        let t = make_inputs(
+            &[
+                iso("shared1", 100),
+                iso("unique_a", 100),
+                iso("shared2", 100),
+                iso("unique_a_final", 100),
+                iso("unique_b", 100),
+                iso("unique_b_final", 100),
+            ],
+            &[
+                &["shared1", "unique_a", "shared2", "unique_a_final"],
+                &["shared1", "unique_b", "shared2", "unique_b_final"],
+            ],
+        );
+
+        assert_eq!(
+            t.batches(1_000_000),
+            vec![vec![
+                "shared1",
+                "unique_a",
+                "unique_b",
+                "shared2",
+                "unique_a_final",
+                "unique_b_final"
+            ]],
+        );
+        // Budget fits 3: shared1 + 2 uniques, but shared2 is blocked by contiguity
+        assert_eq!(
+            t.batches(350),
+            vec![vec!["shared1", "unique_a", "unique_b"]],
         );
     }
 
-    // ---- Oversized modules never batch ----
-
     #[test]
-    fn test_oversized_modules_never_batch() {
-        // Route 0: [A(0), B(1)]
-        // Both are 1000 bytes, budget is 500. Seed A starts at 1000, B can't fit.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(&[(iso, 1000), (iso, 1000)], &[&[0, 1]]);
-        let result = compute_style_batches(&info, &styles, 500);
-
-        assert!(
-            result.batches.is_empty(),
-            "No batches should be formed when all modules exceed budget, got: {:?}",
-            result.batches
+    fn global_css_no_leak() {
+        let t = make_inputs(
+            &[iso("mod_a", 100), global("g", 100)],
+            &[&["mod_a", "g"], &["mod_a"]],
         );
+
+        // Global CSS must not leak into route 1 which doesn't import it
+        assert_eq!(t.batches(1_000_000), Vec::<Vec<&str>>::new());
     }
 
-    // ---- Contiguity allows absorbing all intervening modules ----
-
     #[test]
-    fn test_contiguity_absorbs_intervening_modules() {
-        // Route 0: [A(0), B(1), C(2)]
-        // Route 1: [A(0), C(2)]
-        //
-        // B is between A and C in route 0. With unlimited budget, the greedy algorithm
-        // absorbs B first (it's contiguous with A), then C becomes contiguous in both
-        // routes and is also absorbed. All three end up in one batch.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100)],
-            &[&[0, 1, 2], &[0, 2]],
+    fn global_css_batches_with_same_routes() {
+        let t = make_inputs(
+            &[global("g", 100), iso("mod_a", 100)],
+            &[&["g", "mod_a"], &["g", "mod_a"]],
         );
-        let result = compute_style_batches(&info, &styles, 1_000_000);
 
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1, 2]),
-            "All three modules should be absorbed into one batch, got: {:?}",
-            result.batches
-        );
+        assert_eq!(t.batches(1_000_000), vec![vec!["g", "mod_a"]]);
     }
 
-    // ---- Three routes: contiguity blocks when intervening can't be absorbed ----
-
     #[test]
-    fn test_three_routes_size_limited() {
-        // Route 0: [A(0), B(1), C(2)]
-        // Route 1: [A(0), C(2)]
-        // Route 2: [A(0), D(3), C(2)]
-        //
-        // With budget = 250 (allows 2 modules of size 100), A absorbs B (contiguous
-        // in route 0). D is in route 2's gap but can't be absorbed (size 300 > 250).
-        // C is blocked by contiguity (D is unprocessed in route 2 gap).
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100), (iso, 100)],
-            &[&[0, 1, 2], &[0, 2], &[0, 3, 2]],
+    fn size_budget() {
+        let t = make_inputs(
+            &[iso("A", 300), iso("B", 300), iso("C", 300)],
+            &[&["A", "B", "C"]],
         );
-        let result = compute_style_batches(&info, &styles, 250);
 
-        assert!(
-            !batch_contains_all(&result.batches, &[0, 2]),
-            "A and C must NOT be in the same batch (D blocks contiguity + size), got: {:?}",
-            result.batches
-        );
+        assert_eq!(t.batches(1_000_000), vec![vec!["A", "B", "C"]],);
+        // A+B=600 fits in 700, but A+B+C=900 doesn't
+        assert_eq!(t.batches(700), vec![vec!["A", "B"]],);
+        // Each module alone exceeds budget — no batches
+        assert_eq!(t.batches(200), Vec::<Vec<&str>>::new());
     }
 
-    // ---- Contiguity check handles the m_pos < watermark direction ----
-
     #[test]
-    fn test_contiguity_reverse_direction() {
-        // Route 0: [A(0), B(1)]
-        // Route 1: [B(1), X(2), A(0)]
-        //
-        // In route 1, A appears AFTER B and X. If B is the seed and A is a candidate,
-        // the contiguity check must verify the reverse gap (A's pos < watermark).
-        // X sits between A and B in route 1 and is unprocessed → A should not be batched
-        // with B (unless X is absorbed first).
-        //
-        // Module sort order: A(sum=0+2=2), B(sum=1+0=1), X(sum=1).
-        // B and X have same index_sum=1; B is "mod_1", X is "mod_2". So order: B, X, A.
-        //
-        // Seed: B. all_chunk_states = {0: 1, 1: 0}.
-        // Pool: route 0 after pos 1 → nothing. Route 1 after pos 0 → X(2). Pool = {2}.
-        // X contiguity: route 1, watermark=0, m_pos=1. Gap [1..1] = empty ✓. Accepted.
-        // all_chunk_states = {0: 1, 1: 1}. Pool: route 1 after pos 1 → A(0). Pool = {0}.
-        // A contiguity: route 0, watermark=1, m_pos=0. Gap [1..1] = empty ✓.
-        //               route 1, watermark=1, m_pos=2. Gap [2..2] = empty ✓.
-        // A accepted. Batch = {0, 1, 2}.
-        //
-        // With unlimited budget, all three module are absorbed.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100)],
-            &[&[0, 1], &[1, 2, 0]],
+    fn contiguity_absorbs_intervening() {
+        let t = make_inputs(
+            &[iso("A", 100), iso("B", 100), iso("C", 100)],
+            &[&["A", "B", "C"], &["A", "C"]],
         );
-        let result = compute_style_batches(&info, &styles, 1_000_000);
 
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1, 2]),
-            "All modules should batch when contiguous, got: {:?}",
-            result.batches
-        );
+        assert_eq!(t.batches(1_000_000), vec![vec!["A", "B", "C"]],);
+        // Budget fits 2: A absorbs B, but C is blocked (contiguous in route 1 but
+        // budget exhausted)
+        assert_eq!(t.batches(250), vec![vec!["A", "B"]],);
     }
 
-    // ---- Reverse-direction contiguity blocked by size limit ----
-
     #[test]
-    fn test_contiguity_reverse_direction_blocked() {
-        // Route 0: [B(1), A(0)]
-        // Route 1: [B(1), X(2), A(0)]
-        //
-        // Budget = 250 (2 modules of size 100 max).
-        // Seed: B (index_sum=0). all_chunk_states = {0: 0, 1: 0}.
-        // Pool: route 0 after pos 0 → A. Route 1 after pos 0 → X. Pool = {0, 2}.
-        // Try A: route 1 watermark=0, m_pos=2. Gap [1..2] = [X]. X unprocessed → blocked!
-        // Try X: route 0 → X not in route 0. No constraint. Accepted.
-        // all_chunk_states = {0: 0, 1: 1}. Size = 200. Pool = {0}.
-        // Try A: size 300 > 250 → blocked by size.
-        // Batch = {B, X}. A is solo.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100)],
-            &[&[1, 0], &[1, 2, 0]],
+    fn three_routes_contiguity_blocked() {
+        let t = make_inputs(
+            &[iso("A", 100), iso("B", 100), iso("C", 100), iso("D", 100)],
+            &[&["A", "B", "C"], &["A", "C"], &["A", "D", "C"]],
         );
-        let result = compute_style_batches(&info, &styles, 250);
 
-        assert!(
-            !batch_contains_all(&result.batches, &[0, 1]),
-            "B and A should NOT be in the same batch (size prevents absorbing X), got: {:?}",
-            result.batches
-        );
+        assert_eq!(t.batches(1_000_000), vec![vec!["A", "B", "D", "C"]],);
+        // Budget fits 2: A absorbs B. Then D+C form a second batch.
+        assert_eq!(t.batches(250), vec![vec!["A", "B"], vec!["D", "C"]],);
     }
 
-    // ---- Newly-introduced route: contiguity still enforced ----
-
     #[test]
-    fn test_newly_introduced_route_contiguity_enforced() {
-        // Route 0 (X): [Q(1), W(2), R(3)]
-        // Route 1 (Y): [P(0), Q(1), R(3)]
-        //
-        // Seed: P (only in Y). all_chunk_states = {Y: 0}.
-        // Q: route Y watermark=0, m_pos=1, gap empty → OK. Route X not tracked → skip.
-        //    Accepted. all_chunk_states = {Y: 1, X: 0}.
-        // W: size 10_000 exceeds budget → can't be absorbed.
-        // R: route Y watermark=1, m_pos=2, gap empty → OK.
-        //    Route X watermark=0, m_pos=2, gap [1..2] = [W]. W unprocessed → BLOCKED.
-        //
-        // R must NOT join {P, Q} because W blocks the gap in route X.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 10_000), (iso, 100)],
-            &[&[1, 2, 3], &[0, 1, 3]],
+    fn reverse_direction_contiguity() {
+        let t = make_inputs(
+            &[iso("A", 100), iso("B", 100), iso("X", 100)],
+            &[&["A", "B"], &["B", "X", "A"]],
         );
-        let result = compute_style_batches(&info, &styles, 500);
 
-        assert!(
-            !batch_contains_all(&result.batches, &[0, 1, 3]),
-            "R must not join P+Q batch: W blocks the gap in route X, got: {:?}",
-            result.batches
-        );
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1]),
-            "P and Q should batch (Q introduces route X at pos 0, no gap), got: {:?}",
-            result.batches
-        );
+        assert_eq!(t.batches(1_000_000), vec![vec!["B", "X", "A"]],);
+        // Budget fits 2: B absorbs X, but A is blocked by size
+        assert_eq!(t.batches(250), vec![vec!["B", "X"]],);
     }
 
-    // ---- Newly-introduced route: correct absorption when gap is clear ----
+    #[test]
+    fn newly_introduced_route_contiguity() {
+        let t = make_inputs(
+            &[
+                iso("P", 100),
+                iso("Q", 100),
+                iso("W", 10_000),
+                iso("R", 100),
+            ],
+            &[&["Q", "W", "R"], &["P", "Q", "R"]],
+        );
+
+        // W is too large to absorb, so R can't join {P, Q} — W blocks the gap in route 0
+        assert_eq!(t.batches(500), vec![vec!["P", "Q"]],);
+        // With unlimited budget, W gets absorbed and R becomes contiguous
+        assert_eq!(t.batches(1_000_000), vec![vec!["P", "Q", "W", "R"]],);
+    }
 
     #[test]
-    fn test_newly_introduced_route_absorbs_correctly() {
-        // Route 0 (X): [Q(1), R(2)]   — no gap modules
-        // Route 1 (Y): [P(0), Q(1), R(2)]
-        //
-        // Seed: P. Q introduces route X. R is contiguous in both routes.
-        // All three should end up in one batch.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100)],
-            &[&[1, 2], &[0, 1, 2]],
+    fn newly_introduced_route_clear_gap() {
+        let t = make_inputs(
+            &[iso("P", 100), iso("Q", 100), iso("R", 100)],
+            &[&["Q", "R"], &["P", "Q", "R"]],
         );
-        let result = compute_style_batches(&info, &styles, 1_000_000);
 
-        assert!(
-            batch_contains_all(&result.batches, &[0, 1, 2]),
-            "P, Q, and R should all batch when no gap modules block them, got: {:?}",
-            result.batches
+        assert_eq!(t.batches(1_000_000), vec![vec!["P", "Q", "R"]],);
+        assert_eq!(t.batches(250), vec![vec!["P", "Q"]],);
+    }
+
+    #[test]
+    fn dependency_ordering_prevents_batching() {
+        // Route: [A, B] — A is a dependency of B (A appears before B in all shared routes).
+        // B cannot be added to a batch that already contains A's dependent, because that
+        // would violate cascade order. Here B depends on A, so A is added first as seed,
+        // then B is a candidate. B's dependents don't include A (A depends on nothing),
+        // so B can join. But if we reverse: [B, A] in two routes where the dependency
+        // is B→A, the dependent check fires.
+        //
+        // Route 0: [X, Y]   Route 1: [X, Z, Y]
+        // X is dep of Y. Z is dep of Y. X is dep of Z.
+        // If X is seed and absorbs Z, then Y's dependents include Z which is in batch → blocked.
+        let t = make_inputs(
+            &[iso("X", 100), iso("Y", 100), iso("Z", 100)],
+            &[&["X", "Y"], &["X", "Z", "Y"]],
         );
+
+        assert_eq!(t.batches(1_000_000), vec![vec!["X", "Z", "Y"]],);
+        // Budget fits 2: X absorbs Z. Y is blocked because its dependency Z is in the batch
+        // and Y depends on Z (Y must come after Z), but the dep check blocks adding Y when
+        // Z is already present. Actually — the dep check prevents adding a module whose
+        // *dependent* is already in the batch, not whose *dependency* is. Y has no dependents
+        // in the batch. Let's verify:
+        assert_eq!(t.batches(250), vec![vec!["X", "Z"]],);
     }
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -106,17 +106,17 @@ struct ChunkGroupState {
 /// Pure-data version of [`ModuleInfo`] for the batching algorithm. Free of Vc types so it can be
 /// used in unit tests without a turbo-tasks runtime.
 #[derive(Debug)]
-pub(crate) struct BatchingModuleInfo {
-    pub style_type: StyleType,
-    pub ident: RcStr,
-    pub chunk_group_indices: FxIndexMap<usize, usize>,
-    pub size: usize,
+struct BatchingModuleInfo {
+    style_type: StyleType,
+    ident: RcStr,
+    chunk_group_indices: FxIndexMap<usize, usize>,
+    size: usize,
 }
 
 /// Result of the pure batching algorithm. Each batch is a `Vec<usize>` of module keys that should
 /// share a single CSS chunk. Only multi-module batches are included.
-pub(crate) struct BatchingResult {
-    pub batches: Vec<Vec<usize>>,
+struct BatchingResult {
+    batches: Vec<Vec<usize>>,
 }
 
 /// Pure algorithmic core of the style-groups batching algorithm.
@@ -131,7 +131,7 @@ pub(crate) struct BatchingResult {
 /// - `chunk_group_styles`: For each chunk group, the ordered list of module keys in CSS cascade
 ///   order (postorder DFS).
 /// - `max_chunk_size`: Maximum byte size for a single shared chunk.
-pub(crate) fn compute_style_batches(
+fn compute_style_batches(
     module_info: &FxIndexMap<usize, BatchingModuleInfo>,
     chunk_group_styles: &[FxIndexSet<usize>],
     max_chunk_size: usize,

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -42,13 +42,41 @@ pub struct StyleGroups {
         FxIndexMap<ChunkItemWithAsyncModuleInfo, ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>>,
 }
 
+/// Information about a CSS module and its presence across chunk groups.
+///
+/// Each CSS module can appear in multiple chunk groups (e.g., different routes/pages).
+/// This struct tracks where the module appears and its properties for the batching algorithm.
 #[derive(Debug)]
 struct ModuleInfo {
+    /// The type of style (e.g., GlobalStyle, ModuleStyle).
     style_type: StyleType,
+    /// The module identifier, used as a tiebreaker for deterministic ordering.
     ident: RcStr,
-    chunk_group_indices: FxHashMap<usize, usize>,
+    /// Maps chunk group index to the module's position within that chunk group's postorder.
+    ///
+    /// - Key: The index of a chunk group that contains this module
+    /// - Value: The position (index) of this module in that chunk group's postorder traversal
+    ///
+    /// For example, if a module appears in chunk groups 0 and 2:
+    /// - `{0: 5, 2: 3}` means it's at position 5 in chunk group 0, position 3 in chunk group 2
+    ///
+    /// This is used to:
+    /// 1. Determine which chunk groups a module belongs to (via `.keys()`)
+    /// 2. Look up a module's position in a specific chunk group (via `.get()`)
+    /// 3. Compute dependencies (module A depends on B if A appears after B in all shared groups)
+    ///
+    /// Uses FxIndexMap for deterministic iteration order (insertion order).
+    /// Since chunk groups are processed sequentially (0, 1, 2, ...), insertion order
+    /// equals sorted order. This is important because iteration order affects which
+    /// modules are selected for batching, and non-deterministic order can cause CSS
+    /// ordering bugs. See GitHub issue #89523.
+    chunk_group_indices: FxIndexMap<usize, usize>,
+    /// Sum of all position indices across chunk groups, used for sorting modules.
+    /// Lower values mean the module tends to appear earlier in chunk groups.
     index_sum: usize,
+    /// The byte size of this module's CSS output, used for chunk size budgeting.
     size: usize,
+    /// The chunk item representation of this module, populated after initial processing.
     chunk_item: Option<ChunkItemWithAsyncModuleInfo>,
 }
 
@@ -65,8 +93,16 @@ impl ModuleInfo {
     }
 }
 
+/// State for a single chunk group during style batching.
+///
+/// A chunk group typically corresponds to a route/page and contains all CSS modules
+/// needed by that route in their correct cascade order (postorder DFS traversal).
 struct ChunkGroupState {
+    /// CSS modules in this chunk group, in postorder traversal order.
+    /// The order here determines the correct CSS cascade order.
     styles: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
+    /// Number of CSS requests remaining for this chunk group.
+    /// Decremented as modules are assigned to shared chunks.
     requests: usize,
 }
 
@@ -184,37 +220,35 @@ pub async fn compute_style_groups(
     });
 
     // Compute the dependents of each module
-    let mut module_dependents: FxHashMap<_, Vec<_>> = FxHashMap::default();
+    // A module X is a dependency of module Y if X appears before Y in ALL chunk groups where both
+    // appear. We need to check all chunk groups, not just the shortest one.
+    let mut module_dependents: FxHashMap<_, FxHashSet<_>> = FxHashMap::default();
     for (&module, info) in &module_info_map {
         let info = info.as_ref().unwrap();
-        // Find the shortest chunk group as it's most efficient to iterate
-        let (&idx, &start_pos) = info
-            .chunk_group_indices
-            .iter()
-            .min_by_key(|&(&idx, _)| chunk_group_state[idx].styles.len())
-            .unwrap();
-        let potential_dependents = &chunk_group_state[idx].styles[start_pos + 1..];
 
-        let dependents = potential_dependents
-            .iter()
-            .copied()
-            .filter(|dependent| {
-                let dependent_info = module_info_map.get(dependent).unwrap();
-                let dependent_info = dependent_info.as_ref().unwrap();
+        // Collect potential dependents from ALL chunk groups this module appears in
+        let mut dependents = FxHashSet::default();
+        for (&idx, &start_pos) in &info.chunk_group_indices {
+            let following_styles = &chunk_group_state[idx].styles[start_pos + 1..];
+            dependents.extend(following_styles.iter().copied());
+        }
 
-                // module is a dependency of dependent when it's included in all chunk groups of
-                // dependent with an index lower than the index of the dependent
-                info.chunk_group_indices.len() >= dependent_info.chunk_group_indices.len()
-                    && dependent_info
-                        .chunk_group_indices
-                        .iter()
-                        .all(|(idx, &dependent_pos)| {
-                            info.chunk_group_indices
-                                .get(idx)
-                                .is_some_and(|&module_pos| module_pos < dependent_pos)
-                        })
-            })
-            .collect::<Vec<_>>();
+        // module is a dependency of dependent when it's included in all chunk groups of
+        // dependent with an index lower than the index of the dependent
+        dependents.retain(|dependent| {
+            let dependent_info = module_info_map.get(dependent).unwrap();
+            let dependent_info = dependent_info.as_ref().unwrap();
+
+            info.chunk_group_indices.len() >= dependent_info.chunk_group_indices.len()
+                && dependent_info
+                    .chunk_group_indices
+                    .iter()
+                    .all(|(idx, &dependent_pos)| {
+                        info.chunk_group_indices
+                            .get(idx)
+                            .is_some_and(|&module_pos| module_pos < dependent_pos)
+                    })
+        });
 
         if !dependents.is_empty() {
             module_dependents.insert(module, dependents);
@@ -301,7 +335,7 @@ pub async fn compute_style_groups(
                     let requests = info
                         .chunk_group_indices
                         .keys()
-                        .filter(|idx| all_chunk_states.contains_key(idx))
+                        .filter(|&idx| all_chunk_states.contains_key(idx))
                         .map(|&idx| chunk_group_state[idx].requests)
                         .max()
                         .unwrap();

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -114,9 +114,251 @@ struct ChunkGroupState {
     /// CSS modules in this chunk group, in postorder traversal order.
     /// The order here determines the correct CSS cascade order.
     styles: FxIndexSet<ResolvedVc<Box<dyn ChunkableModule>>>,
-    /// Number of CSS requests remaining for this chunk group.
-    /// Decremented as modules are assigned to shared chunks.
-    requests: usize,
+}
+
+/// Pure-data version of [`ModuleInfo`] for the batching algorithm. Free of Vc types so it can be
+/// used in unit tests without a turbo-tasks runtime.
+#[derive(Debug)]
+pub(crate) struct BatchingModuleInfo {
+    pub style_type: StyleType,
+    pub ident: RcStr,
+    pub chunk_group_indices: FxIndexMap<usize, usize>,
+    pub size: usize,
+}
+
+/// Result of the pure batching algorithm. Each batch is a `Vec<usize>` of module keys that should
+/// share a single CSS chunk. Only multi-module batches are included.
+pub(crate) struct BatchingResult {
+    pub batches: Vec<Vec<usize>>,
+    pub module_dependents: FxHashMap<usize, FxHashSet<usize>>,
+}
+
+/// Pure algorithmic core of the style-groups batching algorithm.
+///
+/// This function contains the dependency computation and greedy batching loop extracted from
+/// [`compute_style_groups`]. It operates on plain indices instead of Vc types, making it testable
+/// without a turbo-tasks runtime.
+///
+/// # Parameters
+/// - `module_info`: Ordered map from module key (usize) to module metadata. Must already be sorted
+///   by (index_sum ascending, ident tiebreak). Keys are opaque identifiers.
+/// - `chunk_group_styles`: For each chunk group, the ordered list of module keys in CSS cascade
+///   order (postorder DFS).
+/// - `max_chunk_size`: Maximum byte size for a single shared chunk.
+pub(crate) fn compute_style_batches(
+    module_info: &FxIndexMap<usize, BatchingModuleInfo>,
+    chunk_group_styles: &[Vec<usize>],
+    max_chunk_size: usize,
+) -> BatchingResult {
+    // --- Compute the dependents of each module ---
+    // A module X is a dependency of module Y if X appears before Y in ALL chunk groups where both
+    // appear. We need to check all chunk groups, not just the shortest one.
+    let mut module_dependents: FxHashMap<usize, FxHashSet<usize>> = FxHashMap::default();
+    for (&module_key, info) in module_info {
+        let mut dependents = FxHashSet::default();
+        for (&cg_idx, &start_pos) in &info.chunk_group_indices {
+            let following = &chunk_group_styles[cg_idx][start_pos + 1..];
+            dependents.extend(following.iter().copied());
+        }
+
+        // module is a dependency of dependent when it's included in all chunk groups of
+        // dependent with an index lower than the index of the dependent
+        dependents.retain(|&dep_key| {
+            let dep_info = &module_info[&dep_key];
+            info.chunk_group_indices.len() >= dep_info.chunk_group_indices.len()
+                && dep_info
+                    .chunk_group_indices
+                    .iter()
+                    .all(|(cg_idx, &dep_pos)| {
+                        info.chunk_group_indices
+                            .get(cg_idx)
+                            .is_some_and(|&mod_pos| mod_pos < dep_pos)
+                    })
+        });
+
+        if !dependents.is_empty() {
+            module_dependents.insert(module_key, dependents);
+        }
+    }
+
+    // --- Greedy batching loop ---
+    let mut chunk_group_requests: Vec<usize> = chunk_group_styles.iter().map(|s| s.len()).collect();
+
+    let mut processed: FxIndexMap<usize, bool> =
+        module_info.keys().copied().map(|k| (k, false)).collect();
+
+    let mut batches: Vec<Vec<usize>> = Vec::new();
+
+    for i in 0..processed.len() {
+        let (&module_key, is_processed) = processed.get_index_mut(i).unwrap();
+        if *is_processed {
+            continue;
+        }
+        *is_processed = true;
+
+        let info = &module_info[&module_key];
+        let mut global_mode = info.style_type == StyleType::GlobalStyle;
+
+        // The current position of processing in all selected chunk groups
+        let mut all_chunk_states = info.chunk_group_indices.clone();
+
+        // The list of modules that go into the new chunk, in insertion order.
+        // Insertion order matters because it determines CSS cascade order within the chunk.
+        let mut new_batch_ordered: Vec<usize> = vec![module_key];
+        let mut new_batch_set: FxHashSet<usize> = [module_key].into_iter().collect();
+
+        // The current size of the new chunk
+        let mut current_size = info.size;
+
+        // A pool of potential modules where the next module is selected from.
+        // It's filled from the next module of the selected modules in every chunk group.
+        let mut potential_next = all_chunk_states
+            .iter()
+            .filter_map(|(&cg_idx, &pos)| {
+                let following = &chunk_group_styles[cg_idx][pos + 1..];
+                following
+                    .iter()
+                    .position(|m| !*processed.get(m).unwrap())
+                    .map(|i| following[i])
+            })
+            .collect::<FxHashSet<_>>();
+
+        // Try to add modules to the chunk until a break condition is met
+        'outer: loop {
+            // We try to select a module that reduces request count and
+            // has the highest number of requests
+            let mut candidates: Vec<(usize, &BatchingModuleInfo, usize)> = potential_next
+                .iter()
+                .copied()
+                .map(|m| {
+                    let mi = &module_info[&m];
+                    let max_req = mi
+                        .chunk_group_indices
+                        .keys()
+                        .filter(|&cg| all_chunk_states.contains_key(cg))
+                        .map(|&cg| chunk_group_requests[cg])
+                        .max()
+                        .unwrap();
+                    (m, mi, max_req)
+                })
+                .collect();
+            candidates.sort_by_key(|(_, mi, req)| (Reverse(*req), &mi.ident));
+
+            // Try every potential module
+            for (m, mi, _) in candidates {
+                if current_size + mi.size > max_chunk_size {
+                    // Chunk would be too large
+                    continue;
+                }
+                // In loose mode we only check if the dependencies are not violated
+                if let Some(deps) = module_dependents.get(&m)
+                    && deps.iter().any(|d| new_batch_set.contains(d))
+                {
+                    // A dependent of the module is already in the chunk, which would violate
+                    // the order
+                    continue;
+                }
+
+                // Global CSS must not leak into unrelated chunks
+                let is_global = mi.style_type == StyleType::GlobalStyle;
+                if is_global
+                    && global_mode
+                    && all_chunk_states.len() != mi.chunk_group_indices.len()
+                {
+                    // Fast check: chunk groups need to be identical
+                    continue;
+                }
+                if global_mode
+                    && mi
+                        .chunk_group_indices
+                        .keys()
+                        .any(|cg| !all_chunk_states.contains_key(cg))
+                {
+                    // Global CSS in new_chunk_items would leak into new chunk_group
+                    continue;
+                }
+                if is_global
+                    && all_chunk_states
+                        .keys()
+                        .any(|cg| !mi.chunk_group_indices.contains_key(cg))
+                {
+                    // Global CSS would leak into existing chunk_group
+                    continue;
+                }
+                // Contiguity check: for every route that contains both the
+                // candidate and at least one existing batch member, ensure no
+                // unprocessed non-batch module sits between the watermark and
+                // the candidate. Without this, a shared chunk can break CSS
+                // cascade order when routes interleave shared and unique modules.
+                {
+                    let mut contiguous = true;
+                    'contiguity: for (&r_idx, &m_pos) in &mi.chunk_group_indices {
+                        let Some(&watermark) = all_chunk_states.get(&r_idx) else {
+                            continue;
+                        };
+                        let (lo, hi) = if watermark < m_pos {
+                            (watermark + 1, m_pos)
+                        } else if m_pos < watermark {
+                            (m_pos + 1, watermark)
+                        } else {
+                            continue;
+                        };
+                        for &between in &chunk_group_styles[r_idx][lo..hi] {
+                            if new_batch_set.contains(&between) {
+                                continue;
+                            }
+                            if *processed.get(&between).unwrap_or(&false) {
+                                continue;
+                            }
+                            contiguous = false;
+                            break 'contiguity;
+                        }
+                    }
+                    if !contiguous {
+                        continue;
+                    }
+                }
+                potential_next.remove(&m);
+                current_size += mi.size;
+                if is_global {
+                    global_mode = true;
+                }
+                for &cg_idx in mi.chunk_group_indices.keys() {
+                    if all_chunk_states.contains_key(&cg_idx) {
+                        // This reduces the request count of the chunk group
+                        chunk_group_requests[cg_idx] -= 1;
+                    }
+                    let pos = chunk_group_styles[cg_idx]
+                        .iter()
+                        .position(|&x| x == m)
+                        .unwrap();
+                    all_chunk_states.insert(cg_idx, pos);
+                    let following = &chunk_group_styles[cg_idx][pos + 1..];
+                    if let Some(i) = following
+                        .iter()
+                        .position(|x| !*processed.get(x).unwrap() && !new_batch_set.contains(x))
+                    {
+                        potential_next.insert(following[i]);
+                    }
+                }
+
+                new_batch_ordered.push(m);
+                new_batch_set.insert(m);
+                *processed.get_mut(&m).unwrap() = true;
+                continue 'outer;
+            }
+            break;
+        }
+
+        if new_batch_ordered.len() > 1 {
+            batches.push(new_batch_ordered);
+        }
+    }
+
+    BatchingResult {
+        batches,
+        module_dependents,
+    }
 }
 
 pub async fn compute_style_groups(
@@ -214,10 +456,7 @@ pub async fn compute_style_groups(
         }
 
         if !styles.is_empty() {
-            chunk_group_state.push(ChunkGroupState {
-                requests: styles.len(),
-                styles,
-            });
+            chunk_group_state.push(ChunkGroupState { styles });
             idx += 1;
         }
     }
@@ -231,42 +470,6 @@ pub async fn compute_style_groups(
             .cmp(&b.index_sum)
             .then_with(|| a.ident.cmp(&b.ident))
     });
-
-    // Compute the dependents of each module
-    // A module X is a dependency of module Y if X appears before Y in ALL chunk groups where both
-    // appear. We need to check all chunk groups, not just the shortest one.
-    let mut module_dependents: FxHashMap<_, FxHashSet<_>> = FxHashMap::default();
-    for (&module, info) in &module_info_map {
-        let info = info.as_ref().unwrap();
-
-        // Collect potential dependents from ALL chunk groups this module appears in
-        let mut dependents = FxHashSet::default();
-        for (&idx, &start_pos) in &info.chunk_group_indices {
-            let following_styles = &chunk_group_state[idx].styles[start_pos + 1..];
-            dependents.extend(following_styles.iter().copied());
-        }
-
-        // module is a dependency of dependent when it's included in all chunk groups of
-        // dependent with an index lower than the index of the dependent
-        dependents.retain(|dependent| {
-            let dependent_info = module_info_map.get(dependent).unwrap();
-            let dependent_info = dependent_info.as_ref().unwrap();
-
-            info.chunk_group_indices.len() >= dependent_info.chunk_group_indices.len()
-                && dependent_info
-                    .chunk_group_indices
-                    .iter()
-                    .all(|(idx, &dependent_pos)| {
-                        info.chunk_group_indices
-                            .get(idx)
-                            .is_some_and(|&module_pos| module_pos < dependent_pos)
-                    })
-        });
-
-        if !dependents.is_empty() {
-            module_dependents.insert(module, dependents);
-        }
-    }
 
     // Compute the chunk item and size of each module
     let chunk_item_and_sizes = module_info_map
@@ -296,186 +499,538 @@ pub async fn compute_style_groups(
             info.chunk_item = Some(chunk_item);
         });
 
-    let mut ordered_modules_with_state = module_info_map
-        .keys()
-        .copied()
-        .map(|m| (m, false))
-        .collect::<FxIndexMap<_, _>>();
+    // Build the pure-data inputs for the batching algorithm.
+    // Each module gets a usize key (its index in the sorted module_info_map).
+    let idx_to_vc: Vec<ResolvedVc<Box<dyn ChunkableModule>>> =
+        module_info_map.keys().copied().collect();
+    let vc_to_idx: FxHashMap<ResolvedVc<Box<dyn ChunkableModule>>, usize> = idx_to_vc
+        .iter()
+        .enumerate()
+        .map(|(i, &vc)| (vc, i))
+        .collect();
 
+    let batching_module_info: FxIndexMap<usize, BatchingModuleInfo> = module_info_map
+        .iter()
+        .enumerate()
+        .map(|(i, (_, info))| {
+            let info = info.as_ref().unwrap();
+            (
+                i,
+                BatchingModuleInfo {
+                    style_type: info.style_type,
+                    ident: info.ident.clone(),
+                    chunk_group_indices: info.chunk_group_indices.clone(),
+                    size: info.size,
+                },
+            )
+        })
+        .collect();
+
+    let batching_chunk_group_styles: Vec<Vec<usize>> = chunk_group_state
+        .iter()
+        .map(|cgs| cgs.styles.iter().map(|vc| vc_to_idx[vc]).collect())
+        .collect();
+
+    // Run the pure batching algorithm
+    let result = compute_style_batches(
+        &batching_module_info,
+        &batching_chunk_group_styles,
+        config.max_chunk_size,
+    );
+
+    // Convert batches back to ChunkItemBatchWithAsyncModuleInfo
     let mut shared_chunk_items = FxIndexMap::default();
-    for i in 0..ordered_modules_with_state.len() {
-        let (&module, processed) = ordered_modules_with_state.get_index_mut(i).unwrap();
-        if *processed {
-            continue;
-        }
-        *processed = true;
-
-        let info = module_info_map.get(&module).unwrap().as_ref().unwrap();
-        let mut global_mode = info.style_type == StyleType::GlobalStyle;
-
-        // The current position of processing in all selected chunk groups
-        let mut all_chunk_states = info.chunk_group_indices.clone();
-
-        // The list of modules and chunk items that go into the new chunk
-        let mut new_chunk_modules = [module].into_iter().collect::<FxHashSet<_>>();
-        let mut new_chunk_items = vec![info.chunk_item.as_ref().unwrap().clone()];
-
-        // The current size of the new chunk
-        let mut current_size = info.size;
-
-        // A pool of potential modules where the next module is selected from.
-        // It's filled from the next module of the selected modules in every chunk group.
-        let mut potential_next_modules = all_chunk_states
+    for batch_keys in &result.batches {
+        let chunk_items: Vec<ChunkItemWithAsyncModuleInfo> = batch_keys
             .iter()
-            .filter_map(|(&idx, pos)| {
-                let following_styles = &chunk_group_state[idx].styles[pos + 1..];
-                let i = following_styles
-                    .iter()
-                    .position(|m| !*ordered_modules_with_state.get(m).unwrap());
-                i.map(|i| following_styles[i])
+            .map(|&k| {
+                module_info_map[&idx_to_vc[k]]
+                    .as_ref()
+                    .unwrap()
+                    .chunk_item
+                    .as_ref()
+                    .unwrap()
+                    .clone()
             })
-            .collect::<FxHashSet<_>>();
-
-        // Try to add modules to the chunk until a break condition is met
-        'outer: loop {
-            // We try to select a module that reduces request count and
-            // has the highest number of requests
-            let mut ordered_potential_next_modules = potential_next_modules
-                .iter()
-                .copied()
-                .map(|module| {
-                    let info = module_info_map.get(&module).unwrap().as_ref().unwrap();
-                    let requests = info
-                        .chunk_group_indices
-                        .keys()
-                        .filter(|&idx| all_chunk_states.contains_key(idx))
-                        .map(|&idx| chunk_group_state[idx].requests)
-                        .max()
-                        .unwrap();
-                    (module, info, requests)
-                })
-                .collect::<Vec<_>>();
-            ordered_potential_next_modules
-                .sort_by_key(|(_, info, requests)| (Reverse(*requests), &info.ident));
-
-            // Try every potential module
-            for (module, info, _) in ordered_potential_next_modules {
-                if current_size + info.size > config.max_chunk_size {
-                    // Chunk would be too large
-                    continue;
-                }
-                // In loose mode we only check if the dependencies are not violated
-                if let Some(dependents) = module_dependents.get(&module)
-                    && dependents.iter().any(|m| new_chunk_modules.contains(m))
-                {
-                    // A dependent of the module is already in the chunk, which would violate
-                    // the order
-                    continue;
-                }
-
-                // Global CSS must not leak into unrelated chunks
-                let is_global = info.style_type == StyleType::GlobalStyle;
-                if is_global
-                    && global_mode
-                    && all_chunk_states.len() != info.chunk_group_indices.len()
-                {
-                    // Fast check: chunk groups need to be identical
-                    continue;
-                }
-                if global_mode
-                    && info
-                        .chunk_group_indices
-                        .keys()
-                        .any(|idx| !all_chunk_states.contains_key(idx))
-                {
-                    // Global CSS in new_chunk_items would leak into new chunk_group
-                    continue;
-                }
-                if is_global
-                    && all_chunk_states
-                        .keys()
-                        .any(|idx| !info.chunk_group_indices.contains_key(idx))
-                {
-                    // Global CSS would leak into existing chunk_group
-                    continue;
-                }
-                // Contiguity check: for every route that contains both the
-                // candidate and at least one existing batch member, ensure no
-                // unprocessed non-batch module sits between the watermark and
-                // the candidate. Without this, a shared chunk can break CSS
-                // cascade order when routes interleave shared and unique modules.
-                {
-                    let mut contiguous = true;
-                    'contiguity: for (&r_idx, &m_pos) in &info.chunk_group_indices {
-                        let Some(&watermark) = all_chunk_states.get(&r_idx) else {
-                            continue;
-                        };
-                        let (lo, hi) = if watermark < m_pos {
-                            (watermark + 1, m_pos)
-                        } else if m_pos < watermark {
-                            (m_pos + 1, watermark)
-                        } else {
-                            continue;
-                        };
-                        let styles = &chunk_group_state[r_idx].styles;
-                        for between in &styles[lo..hi] {
-                            if new_chunk_modules.contains(between) {
-                                continue;
-                            }
-                            if *ordered_modules_with_state.get(between).unwrap_or(&false) {
-                                continue;
-                            }
-                            contiguous = false;
-                            break 'contiguity;
-                        }
-                    }
-                    if !contiguous {
-                        continue;
-                    }
-                }
-                potential_next_modules.remove(&module);
-                current_size += info.size;
-                if is_global {
-                    global_mode = true;
-                }
-                for &idx in info.chunk_group_indices.keys() {
-                    if all_chunk_states.contains_key(&idx) {
-                        // This reduces the request count of the chunk group
-                        chunk_group_state[idx].requests -= 1;
-                    }
-                    let pos = chunk_group_state[idx].styles.get_index_of(&module).unwrap();
-                    all_chunk_states.insert(idx, pos);
-                    let following_styles = &chunk_group_state[idx].styles[pos + 1..];
-                    if let Some(i) = following_styles.iter().position(|m| {
-                        !*ordered_modules_with_state.get(m).unwrap()
-                            && !new_chunk_modules.contains(m)
-                    }) {
-                        let module = following_styles[i];
-                        potential_next_modules.insert(module);
-                    }
-                }
-
-                new_chunk_items.push(info.chunk_item.as_ref().unwrap().clone());
-                new_chunk_modules.insert(module);
-                *ordered_modules_with_state.get_mut(&module).unwrap() = true;
-                continue 'outer;
-            }
-            break;
-        }
-
-        if new_chunk_items.len() > 1 {
-            let style_group = ChunkItemBatchWithAsyncModuleInfo::new(new_chunk_items.clone())
-                .to_resolved()
-                .await?;
-            for chunk_item in new_chunk_items {
-                shared_chunk_items.insert(chunk_item, style_group);
-            }
+            .collect();
+        let style_group = ChunkItemBatchWithAsyncModuleInfo::new(chunk_items.clone())
+            .to_resolved()
+            .await?;
+        for chunk_item in chunk_items {
+            shared_chunk_items.insert(chunk_item, style_group);
         }
     }
+
+    // Convert module_dependents back to ResolvedVc keys
+    let module_dependents: ModuleDependents = result
+        .module_dependents
+        .into_iter()
+        .map(|(k, deps)| {
+            (
+                idx_to_vc[k],
+                deps.into_iter().map(|d| idx_to_vc[d]).collect(),
+            )
+        })
+        .collect();
 
     Ok(StyleGroups {
         shared_chunk_items,
         module_dependents,
     }
     .cell())
+}
+
+#[cfg(test)]
+mod tests {
+    use rustc_hash::FxHashSet;
+    use turbo_rcstr::RcStr;
+    use turbo_tasks::FxIndexMap;
+
+    use super::{BatchingModuleInfo, compute_style_batches};
+    use crate::module::StyleType;
+
+    /// Helper to build test inputs concisely.
+    ///
+    /// - `modules`: list of `(style_type, size)`. The index in the vec is the module key.
+    /// - `routes`: list of routes; each route is a list of module keys in CSS cascade order.
+    ///
+    /// Returns `(module_info, chunk_group_styles)` ready for `compute_style_batches`.
+    fn make_inputs(
+        modules: &[(StyleType, usize)],
+        routes: &[&[usize]],
+    ) -> (FxIndexMap<usize, BatchingModuleInfo>, Vec<Vec<usize>>) {
+        let mut module_info: FxIndexMap<usize, BatchingModuleInfo> = FxIndexMap::default();
+        // Compute index_sum per module for sorting (mirrors compute_style_groups behavior).
+        let mut index_sums: Vec<usize> = vec![0; modules.len()];
+        for (i, &(style_type, size)) in modules.iter().enumerate() {
+            let mut cgi = FxIndexMap::default();
+            for (cg_idx, route) in routes.iter().enumerate() {
+                if let Some(pos) = route.iter().position(|&m| m == i) {
+                    cgi.insert(cg_idx, pos);
+                    index_sums[i] += pos;
+                }
+            }
+            module_info.insert(
+                i,
+                BatchingModuleInfo {
+                    style_type,
+                    ident: RcStr::from(format!("mod_{i}")),
+                    chunk_group_indices: cgi,
+                    size,
+                },
+            );
+        }
+        // Sort by (index_sum, ident) to match what compute_style_groups does.
+        module_info.sort_by(|&ka, a, &kb, b| {
+            index_sums[ka]
+                .cmp(&index_sums[kb])
+                .then_with(|| a.ident.cmp(&b.ident))
+        });
+        let styles: Vec<Vec<usize>> = routes.iter().map(|r| r.to_vec()).collect();
+        (module_info, styles)
+    }
+
+    /// Helper: check if any batch contains all of the given modules.
+    fn batch_contains_all(batches: &[Vec<usize>], modules: &[usize]) -> bool {
+        batches.iter().any(|batch| {
+            let set: FxHashSet<usize> = batch.iter().copied().collect();
+            modules.iter().all(|m| set.contains(m))
+        })
+    }
+
+    // ---- Test 1: Basic batching — contiguous shared modules batch together ----
+
+    #[test]
+    fn test_basic_shared_modules_batch_together() {
+        // Route 0: [common_a(0), common_b(1), only_0(2)]
+        // Route 1: [common_a(0), common_b(1), only_1(3)]
+        //
+        // common_a and common_b are contiguous and shared — they should batch.
+        // only_0 and only_1 are contiguous with common_b in their respective routes,
+        // so the greedy algorithm may absorb them too. The key assertion is that
+        // common_a and common_b are in the same batch.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100), (iso, 100)],
+            &[&[0, 1, 2], &[0, 1, 3]],
+        );
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1]),
+            "common_a and common_b should be batched together, got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 2: Contiguity + size budget prevents shared modules from being batched
+    //              without the intervening modules ----
+
+    #[test]
+    fn test_contiguity_with_size_budget_prevents_skipping_intervening() {
+        // Route 0: [A(0), B(1), C(2)]
+        // Route 1: [A(0), D(3), C(2)]
+        //
+        // A and C are shared. B and D sit between them in each route.
+        // With a size budget that allows only 2 modules, A can absorb B or D but
+        // not both plus C. The contiguity check prevents C from being added when
+        // the gap still has unprocessed modules.
+        //
+        // A(size=100) is the seed. Budget = 250 allows one more module (200 total).
+        // B gets absorbed (200 <= 250). D is unprocessed in route 1's gap.
+        // C cannot be added: route 1 gap [D] is unprocessed AND 300 > 250.
+        // Result: batch {A, B}, then D solo, then C solo.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100), (iso, 100)],
+            &[&[0, 1, 2], &[0, 3, 2]],
+        );
+        let result = compute_style_batches(&info, &styles, 250);
+
+        assert!(
+            !batch_contains_all(&result.batches, &[0, 2]),
+            "A and C must NOT be in the same batch (size budget prevents absorbing all \
+             intervening modules), got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 2b: Contiguity check blocks shared2 until intervening unique is absorbed ----
+
+    #[test]
+    fn test_interleaved_shared_unique_all_absorbed() {
+        // Route A: [shared1(0), unique_a(1), shared2(2), unique_a_final(3)]
+        // Route B: [shared1(0), unique_b(4), shared2(2), unique_b_final(5)]
+        //
+        // With unlimited budget, the greedy algorithm absorbs everything into one batch.
+        // This is correct because the single chunk can order items to satisfy both routes.
+        // The contiguity check ensures shared2 is NOT added until unique_b is absorbed.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+            ],
+            &[&[0, 1, 2, 3], &[0, 4, 2, 5]],
+        );
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        // All modules end up in one batch because they can all be absorbed.
+        assert_eq!(
+            result.batches.len(),
+            1,
+            "All modules should form a single batch, got: {:?}",
+            result.batches
+        );
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1, 2, 3, 4, 5]),
+            "Batch should contain all modules, got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 2c: With size budget, shared modules can't absorb intervening unique ----
+
+    #[test]
+    fn test_interleaved_shared_unique_size_limited() {
+        // Route A: [shared1(0), unique_a(1), shared2(2), unique_a_final(3)]
+        // Route B: [shared1(0), unique_b(4), shared2(2), unique_b_final(5)]
+        //
+        // Budget = 350 (allows at most 3 modules of size 100).
+        // shared1 is the seed. It absorbs unique_a (or unique_b), but then shared2
+        // is blocked by contiguity (the other unique is in the gap) and by size
+        // (adding more would exceed 350). shared1 and shared2 end up in separate chunks.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+                (iso, 100),
+            ],
+            &[&[0, 1, 2, 3], &[0, 4, 2, 5]],
+        );
+        let result = compute_style_batches(&info, &styles, 350);
+
+        assert!(
+            !batch_contains_all(&result.batches, &[0, 2]),
+            "shared1 and shared2 must NOT be in the same batch (size limit prevents absorbing all \
+             intervening modules), got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 3a: Global CSS doesn't leak into routes that don't have it ----
+
+    #[test]
+    fn test_global_css_no_leak_into_new_route() {
+        // Route 0: [mod_a(0), global(1)]
+        // Route 1: [mod_a(0)]
+        //
+        // mod_a appears in both routes; global only in route 0.
+        // They must NOT batch because global CSS would leak into route 1.
+        let iso = StyleType::IsolatedStyle;
+        let global = StyleType::GlobalStyle;
+        let (info, styles) = make_inputs(&[(iso, 100), (global, 100)], &[&[0, 1], &[0]]);
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        assert!(
+            !batch_contains_all(&result.batches, &[0, 1]),
+            "mod_a and global must NOT batch (global would leak into route 1), got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 3b: Global CSS can batch with modules sharing exact same routes ----
+
+    #[test]
+    fn test_global_css_batches_with_same_routes() {
+        // Route 0: [global(0), mod_a(1)]
+        // Route 1: [global(0), mod_a(1)]
+        //
+        // Both modules appear in exactly the same routes — safe to batch.
+        let iso = StyleType::IsolatedStyle;
+        let global = StyleType::GlobalStyle;
+        let (info, styles) = make_inputs(&[(global, 100), (iso, 100)], &[&[0, 1], &[0, 1]]);
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1]),
+            "global and mod_a should batch (identical route sets), got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 4a: Size budget limits batch membership ----
+
+    #[test]
+    fn test_size_budget_limits_batching() {
+        // Route 0: [A(0), B(1), C(2)]
+        // All in same route, contiguous. A+B = 600 fits in 700; A+B+C = 900 > 700.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(&[(iso, 300), (iso, 300), (iso, 300)], &[&[0, 1, 2]]);
+        let result = compute_style_batches(&info, &styles, 700);
+
+        // A+B should batch (600 <= 700)
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1]),
+            "A and B should batch (600 <= 700), got: {:?}",
+            result.batches
+        );
+        // C should NOT be in the same batch (would push to 900)
+        let ab_batch = result
+            .batches
+            .iter()
+            .find(|b| b.contains(&0) && b.contains(&1))
+            .unwrap();
+        assert!(
+            !ab_batch.contains(&2),
+            "C should not be in the A+B batch (would exceed size budget)"
+        );
+    }
+
+    // ---- Test 4b: Oversized modules never batch ----
+
+    #[test]
+    fn test_oversized_modules_never_batch() {
+        // Route 0: [A(0), B(1)]
+        // Both are 1000 bytes, budget is 500. Seed A starts at 1000, B can't fit.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(&[(iso, 1000), (iso, 1000)], &[&[0, 1]]);
+        let result = compute_style_batches(&info, &styles, 500);
+
+        assert!(
+            result.batches.is_empty(),
+            "No batches should be formed when all modules exceed budget, got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 5a: Dependents computation — universal predecessor ----
+
+    #[test]
+    fn test_dependents_universal_predecessor() {
+        // Route 0: [A(0), B(1), C(2)]
+        // Route 1: [A(0), B(1)]
+        //
+        // A appears before B in all routes B is in → A is a dependency of B.
+        // A appears before C in all routes C is in (only route 0) → A is a dep of C.
+        // B appears before C in all routes C is in (only route 0) → B is a dep of C.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100)],
+            &[&[0, 1, 2], &[0, 1]],
+        );
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        let deps_a = result
+            .module_dependents
+            .get(&0)
+            .cloned()
+            .unwrap_or_default();
+        assert!(deps_a.contains(&1), "A should have B as dependent");
+        assert!(deps_a.contains(&2), "A should have C as dependent");
+
+        let deps_b = result
+            .module_dependents
+            .get(&1)
+            .cloned()
+            .unwrap_or_default();
+        assert!(deps_b.contains(&2), "B should have C as dependent");
+
+        let deps_c = result
+            .module_dependents
+            .get(&2)
+            .cloned()
+            .unwrap_or_default();
+        assert!(deps_c.is_empty(), "C should have no dependents");
+    }
+
+    // ---- Test 5b: Non-universal appearance blocks dependent relationship ----
+
+    #[test]
+    fn test_dependents_non_universal_blocks() {
+        // Route 0: [A(0), B(1)]
+        // Route 1: [B(1)]
+        //
+        // A is only in route 0. B is in routes 0 and 1.
+        // A is NOT a dependency of B because A doesn't appear in route 1 where B does.
+        // (info.chunk_group_indices.len() >= dep.chunk_group_indices.len() fails: 1 < 2)
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(&[(iso, 100), (iso, 100)], &[&[0, 1], &[1]]);
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        let deps_a = result
+            .module_dependents
+            .get(&0)
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            !deps_a.contains(&1),
+            "A should NOT be a dependency of B (A missing from route 1), got A deps: {:?}",
+            deps_a
+        );
+    }
+
+    // ---- Test 6: Contiguity allows absorbing all intervening modules ----
+
+    #[test]
+    fn test_contiguity_absorbs_intervening_modules() {
+        // Route 0: [A(0), B(1), C(2)]
+        // Route 1: [A(0), C(2)]
+        //
+        // B is between A and C in route 0. With unlimited budget, the greedy algorithm
+        // absorbs B first (it's contiguous with A), then C becomes contiguous in both
+        // routes and is also absorbed. All three end up in one batch.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100)],
+            &[&[0, 1, 2], &[0, 2]],
+        );
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1, 2]),
+            "All three modules should be absorbed into one batch, got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 7: Three routes, contiguity blocks when intervening can't be absorbed ----
+
+    #[test]
+    fn test_three_routes_size_limited() {
+        // Route 0: [A(0), B(1), C(2)]
+        // Route 1: [A(0), C(2)]
+        // Route 2: [A(0), D(3), C(2)]
+        //
+        // With budget = 250 (allows 2 modules of size 100), A absorbs B (contiguous
+        // in route 0). D is in route 2's gap but can't be absorbed (size 300 > 250).
+        // C is blocked by contiguity (D is unprocessed in route 2 gap).
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100), (iso, 100)],
+            &[&[0, 1, 2], &[0, 2], &[0, 3, 2]],
+        );
+        let result = compute_style_batches(&info, &styles, 250);
+
+        assert!(
+            !batch_contains_all(&result.batches, &[0, 2]),
+            "A and C must NOT be in the same batch (D blocks contiguity + size), got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 8: Contiguity check handles the m_pos < watermark case ----
+
+    #[test]
+    fn test_contiguity_reverse_direction() {
+        // Route 0: [A(0), B(1)]
+        // Route 1: [B(1), X(2), A(0)]
+        //
+        // In route 1, A appears AFTER B and X. If B is the seed and A is a candidate,
+        // the contiguity check must verify the reverse gap (A's pos < watermark).
+        // X sits between A and B in route 1 and is unprocessed → A should not be batched
+        // with B (unless X is absorbed first).
+        //
+        // Module sort order: A(sum=0+2=2), B(sum=1+0=1), X(sum=1).
+        // B and X have same index_sum=1; B is "mod_1", X is "mod_2". So order: B, X, A.
+        //
+        // Seed: B. all_chunk_states = {0: 1, 1: 0}.
+        // Pool: route 0 after pos 1 → nothing. Route 1 after pos 0 → X(2). Pool = {2}.
+        // X contiguity: route 1, watermark=0, m_pos=1. Gap [1..1] = empty ✓. Accepted.
+        // all_chunk_states = {0: 1, 1: 1}. Pool: route 1 after pos 1 → A(0). Pool = {0}.
+        // A contiguity: route 0, watermark=1, m_pos=0. Gap [1..1] = empty ✓.
+        //               route 1, watermark=1, m_pos=2. Gap [2..2] = empty ✓.
+        // A accepted. Batch = {0, 1, 2}.
+        //
+        // With unlimited budget, all three module are absorbed.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100)],
+            &[&[0, 1], &[1, 2, 0]],
+        );
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1, 2]),
+            "All modules should batch when contiguous, got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Test 9: Contiguity with reverse direction and size limit ----
+
+    #[test]
+    fn test_contiguity_reverse_direction_blocked() {
+        // Route 0: [B(1), A(0)]
+        // Route 1: [B(1), X(2), A(0)]
+        //
+        // Budget = 250 (2 modules of size 100 max).
+        // Seed: B (index_sum=0). all_chunk_states = {0: 0, 1: 0}.
+        // Pool: route 0 after pos 0 → A. Route 1 after pos 0 → X. Pool = {0, 2}.
+        // Try A: route 1 watermark=0, m_pos=2. Gap [1..2] = [X]. X unprocessed → blocked!
+        // Try X: route 0 → X not in route 0. No constraint. Accepted.
+        // all_chunk_states = {0: 0, 1: 1}. Size = 200. Pool = {0}.
+        // Try A: size 300 > 250 → blocked by size.
+        // Batch = {B, X}. A is solo.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100)],
+            &[&[1, 0], &[1, 2, 0]],
+        );
+        let result = compute_style_batches(&info, &styles, 250);
+
+        assert!(
+            !batch_contains_all(&result.batches, &[0, 1]),
+            "B and A should NOT be in the same batch (size prevents absorbing X), got: {:?}",
+            result.batches
+        );
+    }
 }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -1,3 +1,59 @@
+//! # CSS Style Groups — Shared Chunk Batching
+//!
+//! CSS modules must not be duplicated across chunks: each module is emitted exactly once, and every
+//! route that needs it references the same shared chunk. The simplest strategy — one chunk per
+//! module — is correct but causes many HTTP requests. This module groups multiple CSS modules into
+//! shared chunks to reduce request count while preserving the CSS cascade order that each route
+//! expects.
+//!
+//! ## Algorithm overview
+//!
+//! 1. **Collect per-route orderings.** For each chunk group (≈ route), DFS-postorder traverse the
+//!    module graph to get the CSS modules in cascade order.
+//!
+//! 2. **Compute dependencies.** Module X is a dependency of Y when X appears before Y in *every*
+//!    chunk group where both are present.
+//!
+//! 3. **Greedy batching.** Process modules in `(index_sum, ident)` order. For each unprocessed
+//!    "seed," start a new batch and greedily absorb neighbouring candidates, subject to:
+//!    - a per-chunk **size budget** (`max_chunk_size`),
+//!    - dependency ordering (no dependent already in the batch),
+//!    - **global-CSS leak prevention** (global styles must not appear in routes that don't import
+//!      them), and
+//!    - the **contiguity check**: for every route containing both the candidate and an existing
+//!      batch member, no unprocessed non-batch module may sit in the gap between them. This is the
+//!      key invariant that prevents shared chunks from breaking per-route cascade order.
+//!
+//! 4. **Emit.** Each batch of ≥ 2 modules becomes a single shared CSS chunk. Modules not assigned
+//!    to any batch get their own individual chunk.
+//!
+//! ## Overserving is expected
+//!
+//! The greedy algorithm can absorb a module into a batch even when that module does not appear in
+//! every route that the batch covers. For example, if route A has `[shared1, unique_a, shared2]`
+//! and route B has `[shared1, unique_b, shared2]`, the algorithm may produce a single batch
+//! `{shared1, unique_a, unique_b, shared2}`. Route A then receives `unique_b`'s CSS even though
+//! it doesn't import it, and vice versa.
+//!
+//! This is intentional. For **isolated / scoped CSS** (CSS Modules), the unused classes are never
+//! referenced in the DOM, so the extra bytes have no visual effect — they only cost bandwidth.
+//! The trade-off is worthwhile because merging reduces the number of HTTP requests, which has a
+//! larger impact on page-load performance than a modest increase in CSS payload size.
+//!
+//! **Global CSS** is handled differently: the global-CSS leak checks (see step 3) prevent a global
+//! stylesheet from being served to routes that don't import it, because global styles *would*
+//! affect rendering.
+//!
+//! ## Comparison with module merging
+//!
+//! The JS module-merging algorithm ([`super::merged_modules`]) solves a similar problem but uses a
+//! stricter bitmap-based approach: only modules with *identical* entry-point reachability are
+//! merged. This avoids overserving entirely but produces more, smaller groups. The CSS algorithm
+//! uses a greedier strategy because (a) scoped CSS overserving is benign, (b) fewer chunks
+//! meaningfully reduces request count, and (c) a longest-common-prefix reconciliation approach
+//! (like module merging uses) would fail to merge modules separated by route-unique modules —
+//! exactly the scenario this algorithm is designed to handle.
+
 use std::cmp::Reverse;
 
 use anyhow::Result;

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -22,12 +22,6 @@ use crate::{
     },
 };
 
-/// Maps each CSS module to the set of CSS modules that must be emitted after it.
-pub type ModuleDependents = FxHashMap<
-    ResolvedVc<Box<dyn ChunkableModule>>,
-    FxHashSet<ResolvedVc<Box<dyn ChunkableModule>>>,
->;
-
 #[derive(
     TaskInput, Debug, Clone, PartialEq, Eq, Hash, NonLocalValue, TraceRawVcs, Encode, Decode,
 )]
@@ -46,13 +40,6 @@ pub struct StyleGroups {
     #[bincode(with = "turbo_bincode::indexmap")]
     pub shared_chunk_items:
         FxIndexMap<ChunkItemWithAsyncModuleInfo, ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>>,
-    /// For each CSS module, the set of CSS modules that must be emitted after it (its dependents
-    /// in cascade order). A module X maps to {Y, Z, ...} meaning X must be loaded before Y and Z.
-    ///
-    /// This is used by `style_production.rs` to topologically sort emission units (shared batches
-    /// and non-shared items) into a correct CSS cascade order, taking into account that a shared
-    /// batch may group items whose DFS post-order positions interleave with non-shared items.
-    pub module_dependents: ModuleDependents,
 }
 
 /// Information about a CSS module and its presence across chunk groups.
@@ -130,7 +117,6 @@ pub(crate) struct BatchingModuleInfo {
 /// share a single CSS chunk. Only multi-module batches are included.
 pub(crate) struct BatchingResult {
     pub batches: Vec<Vec<usize>>,
-    pub module_dependents: FxHashMap<usize, FxHashSet<usize>>,
 }
 
 /// Pure algorithmic core of the style-groups batching algorithm.
@@ -355,10 +341,7 @@ pub(crate) fn compute_style_batches(
         }
     }
 
-    BatchingResult {
-        batches,
-        module_dependents,
-    }
+    BatchingResult { batches }
 }
 
 pub async fn compute_style_groups(
@@ -561,23 +544,7 @@ pub async fn compute_style_groups(
         }
     }
 
-    // Convert module_dependents back to ResolvedVc keys
-    let module_dependents: ModuleDependents = result
-        .module_dependents
-        .into_iter()
-        .map(|(k, deps)| {
-            (
-                idx_to_vc[k],
-                deps.into_iter().map(|d| idx_to_vc[d]).collect(),
-            )
-        })
-        .collect();
-
-    Ok(StyleGroups {
-        shared_chunk_items,
-        module_dependents,
-    }
-    .cell())
+    Ok(StyleGroups { shared_chunk_items }.cell())
 }
 
 #[cfg(test)]
@@ -852,73 +819,7 @@ mod tests {
         );
     }
 
-    // ---- Test 5a: Dependents computation — universal predecessor ----
-
-    #[test]
-    fn test_dependents_universal_predecessor() {
-        // Route 0: [A(0), B(1), C(2)]
-        // Route 1: [A(0), B(1)]
-        //
-        // A appears before B in all routes B is in → A is a dependency of B.
-        // A appears before C in all routes C is in (only route 0) → A is a dep of C.
-        // B appears before C in all routes C is in (only route 0) → B is a dep of C.
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(
-            &[(iso, 100), (iso, 100), (iso, 100)],
-            &[&[0, 1, 2], &[0, 1]],
-        );
-        let result = compute_style_batches(&info, &styles, 1_000_000);
-
-        let deps_a = result
-            .module_dependents
-            .get(&0)
-            .cloned()
-            .unwrap_or_default();
-        assert!(deps_a.contains(&1), "A should have B as dependent");
-        assert!(deps_a.contains(&2), "A should have C as dependent");
-
-        let deps_b = result
-            .module_dependents
-            .get(&1)
-            .cloned()
-            .unwrap_or_default();
-        assert!(deps_b.contains(&2), "B should have C as dependent");
-
-        let deps_c = result
-            .module_dependents
-            .get(&2)
-            .cloned()
-            .unwrap_or_default();
-        assert!(deps_c.is_empty(), "C should have no dependents");
-    }
-
-    // ---- Test 5b: Non-universal appearance blocks dependent relationship ----
-
-    #[test]
-    fn test_dependents_non_universal_blocks() {
-        // Route 0: [A(0), B(1)]
-        // Route 1: [B(1)]
-        //
-        // A is only in route 0. B is in routes 0 and 1.
-        // A is NOT a dependency of B because A doesn't appear in route 1 where B does.
-        // (info.chunk_group_indices.len() >= dep.chunk_group_indices.len() fails: 1 < 2)
-        let iso = StyleType::IsolatedStyle;
-        let (info, styles) = make_inputs(&[(iso, 100), (iso, 100)], &[&[0, 1], &[1]]);
-        let result = compute_style_batches(&info, &styles, 1_000_000);
-
-        let deps_a = result
-            .module_dependents
-            .get(&0)
-            .cloned()
-            .unwrap_or_default();
-        assert!(
-            !deps_a.contains(&1),
-            "A should NOT be a dependency of B (A missing from route 1), got A deps: {:?}",
-            deps_a
-        );
-    }
-
-    // ---- Test 6: Contiguity allows absorbing all intervening modules ----
+    // ---- Test 5: Contiguity allows absorbing all intervening modules ----
 
     #[test]
     fn test_contiguity_absorbs_intervening_modules() {

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -185,7 +185,11 @@ pub(crate) fn compute_style_batches(
         let info = &module_info[&module_key];
         let mut global_mode = info.style_type == StyleType::GlobalStyle;
 
-        // The current position of processing in all selected chunk groups
+        // The furthest position of any batch member seen so far in each chunk group.
+        // Only chunk groups containing at least one batch member are present.
+        // The watermark only ever moves forward (we use max on update) so that the
+        // contiguity gap check [watermark+1, m_pos) correctly reflects the full
+        // extent of the batch in each route.
         let mut all_chunk_states = info.chunk_group_indices.clone();
 
         // The set of modules that go into the new chunk, in insertion order.
@@ -309,12 +313,17 @@ pub(crate) fn compute_style_batches(
                     global_mode = true;
                 }
                 for &cg_idx in mi.chunk_group_indices.keys() {
-                    if all_chunk_states.contains_key(&cg_idx) {
-                        // This reduces the request count of the chunk group
-                        chunk_group_requests[cg_idx] -= 1;
-                    }
+                    // Always decrement: the candidate is absorbed regardless of whether
+                    // this chunk group was already tracked by the batch.
+                    chunk_group_requests[cg_idx] -= 1;
+
                     let pos = chunk_group_styles[cg_idx].get_index_of(&m).unwrap();
-                    all_chunk_states.insert(cg_idx, pos);
+                    // Use max so the watermark only ever moves forward, preserving its
+                    // semantic as "furthest extent of the batch in this route."
+                    all_chunk_states
+                        .entry(cg_idx)
+                        .and_modify(|w| *w = (*w).max(pos))
+                        .or_insert(pos);
                     let following = &chunk_group_styles[cg_idx].as_slice()[pos + 1..];
                     if let Some(&next) = following
                         .iter()
@@ -929,6 +938,63 @@ mod tests {
         assert!(
             !batch_contains_all(&result.batches, &[0, 1]),
             "B and A should NOT be in the same batch (size prevents absorbing X), got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Newly-introduced route: contiguity still enforced ----
+
+    #[test]
+    fn test_newly_introduced_route_contiguity_enforced() {
+        // Route 0 (X): [Q(1), W(2), R(3)]
+        // Route 1 (Y): [P(0), Q(1), R(3)]
+        //
+        // Seed: P (only in Y). all_chunk_states = {Y: 0}.
+        // Q: route Y watermark=0, m_pos=1, gap empty → OK. Route X not tracked → skip.
+        //    Accepted. all_chunk_states = {Y: 1, X: 0}.
+        // W: size 10_000 exceeds budget → can't be absorbed.
+        // R: route Y watermark=1, m_pos=2, gap empty → OK.
+        //    Route X watermark=0, m_pos=2, gap [1..2] = [W]. W unprocessed → BLOCKED.
+        //
+        // R must NOT join {P, Q} because W blocks the gap in route X.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 10_000), (iso, 100)],
+            &[&[1, 2, 3], &[0, 1, 3]],
+        );
+        let result = compute_style_batches(&info, &styles, 500);
+
+        assert!(
+            !batch_contains_all(&result.batches, &[0, 1, 3]),
+            "R must not join P+Q batch: W blocks the gap in route X, got: {:?}",
+            result.batches
+        );
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1]),
+            "P and Q should batch (Q introduces route X at pos 0, no gap), got: {:?}",
+            result.batches
+        );
+    }
+
+    // ---- Newly-introduced route: correct absorption when gap is clear ----
+
+    #[test]
+    fn test_newly_introduced_route_absorbs_correctly() {
+        // Route 0 (X): [Q(1), R(2)]   — no gap modules
+        // Route 1 (Y): [P(0), Q(1), R(2)]
+        //
+        // Seed: P. Q introduces route X. R is contiguous in both routes.
+        // All three should end up in one batch.
+        let iso = StyleType::IsolatedStyle;
+        let (info, styles) = make_inputs(
+            &[(iso, 100), (iso, 100), (iso, 100)],
+            &[&[1, 2], &[0, 1, 2]],
+        );
+        let result = compute_style_batches(&info, &styles, 1_000_000);
+
+        assert!(
+            batch_contains_all(&result.batches, &[0, 1, 2]),
+            "P, Q, and R should all batch when no gap modules block them, got: {:?}",
             result.batches
         );
     }

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -22,6 +22,12 @@ use crate::{
     },
 };
 
+/// Maps each CSS module to the set of CSS modules that must be emitted after it.
+pub type ModuleDependents = FxHashMap<
+    ResolvedVc<Box<dyn ChunkableModule>>,
+    FxHashSet<ResolvedVc<Box<dyn ChunkableModule>>>,
+>;
+
 #[derive(
     TaskInput, Debug, Clone, PartialEq, Eq, Hash, NonLocalValue, TraceRawVcs, Encode, Decode,
 )]
@@ -40,6 +46,13 @@ pub struct StyleGroups {
     #[bincode(with = "turbo_bincode::indexmap")]
     pub shared_chunk_items:
         FxIndexMap<ChunkItemWithAsyncModuleInfo, ResolvedVc<ChunkItemBatchWithAsyncModuleInfo>>,
+    /// For each CSS module, the set of CSS modules that must be emitted after it (its dependents
+    /// in cascade order). A module X maps to {Y, Z, ...} meaning X must be loaded before Y and Z.
+    ///
+    /// This is used by `style_production.rs` to topologically sort emission units (shared batches
+    /// and non-shared items) into a correct CSS cascade order, taking into account that a shared
+    /// batch may group items whose DFS post-order positions interleave with non-shared items.
+    pub module_dependents: ModuleDependents,
 }
 
 /// Information about a CSS module and its presence across chunk groups.
@@ -426,5 +439,9 @@ pub async fn compute_style_groups(
         }
     }
 
-    Ok(StyleGroups { shared_chunk_items }.cell())
+    Ok(StyleGroups {
+        shared_chunk_items,
+        module_dependents,
+    }
+    .cell())
 }


### PR DESCRIPTION
## What

Fix CSS cascade order violations in production builds when shared CSS chunks are emitted in the wrong position relative to non-shared chunks.

When a component imports and overrides styles from another component, the CSS cascade order could be violated in production builds. For example:

```
CardWrapper.module.css (sets background: purple)
  └── imports Card.module.css (sets background: white)
```

The expected behavior is that CardWrapper's purple background overrides Card's white background. However, in production builds, the shared chunk containing Card's CSS could be served before or after the wrong items, causing incorrect cascade order.

## Why

The style chunking algorithm (`style_groups.rs`) groups CSS modules into shared batches to reduce HTTP requests. The chunk emission code (`style_production.rs`) must then emit these batches in the correct order relative to non-shared items. 

The previous approach was incorrect, there we emitted the shared batch when the first of its members appeared in DFS post-order. This could emit the batch too early, before items that depend on later batch members.  The alternate approach of 'emit on last member' also doesn't work, since we can emit the batch too late, after non-shared items that should have come after the batch.

The core issue is that **DFS post-order is an over-specification**: it produces a single linear ordering of all CSS modules, but a shared batch groups members whose positions may interleave with unrelated non-shared items. No fixed "emit at position X" strategy works, because the correct position depends on the actual dependency relationships between emission units (batches and individual items).   Even dynamically detecting this doesn't work for the simple reason that we can batch modules in a way that will always violate a given routes order.

### Concrete example

DFS post-order for an endpoint: `[A, B, C, D, E]` where `{A, C}` form a shared batch and `B`, `D`, `E` are non-shared.

- If A must precede B in the cascade, the batch must come before B: `[{A,C}, B, D, E]`
- Emit-on-first gives: `[{A,C}, B, D, E]` — correct by accident
- Emit-on-last gives: `[B, {A,C}, D, E]` — **wrong**, B loads before A

But in a different scenario where C depends on B:
- Emit-on-first gives: `[{A,C}, B, D, E]` — **wrong**, C loads before B

Neither heuristic is generally correct. The ordering must be computed from actual dependency edges.

## How

### `style_groups.rs`

- **`FxIndexMap` for `chunk_group_indices`**: Changed from `FxHashMap` to `FxIndexMap` for deterministic iteration order. Since chunk groups are processed sequentially, insertion order equals sorted order. Non-deterministic iteration caused CSS ordering bugs (see #89523).
- **Collect dependents from all chunk groups**: The previous approach found the shortest chunk group and only looked for dependents there (as an optimization). This was incorrect — it could miss dependents that only appear in other chunk groups. Now we union potential dependents from all chunk groups.
- **Use `FxHashSet` for dependents**: Changed from `Vec` to `FxHashSet` for deduplication across multiple groups.
- **Contiguity check for batch candidates**: When considering a candidate module for a shared batch, verify that in every route containing both the candidate and existing batch members, no unprocessed non-batch module exists in the gap between them. Without this, the batching algorithm could group modules that are non-contiguous in some routes' orderings (e.g. `shared1` and `shared2` when a route-unique module sits between them), creating emission units where the intervening module can't be correctly placed.


## Test plan

- Existing `test/e2e/app-dir/css-order/` tests cover many CSS ordering scenarios across pages
- Existing `test/e2e/app-dir/initial-css-order/` tests verify correct cascade winner
- Snapshot tests in `turbopack/crates/turbopack-tests/tests/snapshot/css/split-shared/` exercise the shared batching path
- New `test/e2e/app-dir/css-order-shared-chunks/` regression test: two routes share CSS modules that interleave with route-specific modules, verifying the shared batch is emitted in the correct position relative to non-shared items so the CSS cascade order is preserved.
- Tested the repro project referenced in many of these issues 😭

Fixes #89523
Fixes #83941
Fixes #86704
Fixes #88604
Fixes #87321
Fixes #86459