### PR TITLE
fix(segment-cache): bypass cache for middleware redirect responses #88937

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1030,7 +1030,8 @@ export function fulfillRouteCacheEntry(
   metadataVaryPath: PageVaryPath,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
-  isPPREnabled: boolean
+  isPPREnabled: boolean,
+  isRedirect: boolean = false
 ): FulfilledRouteCacheEntry {
   // Get the rendered search from the vary path
   const renderedSearch =
@@ -1042,8 +1043,9 @@ export function fulfillRouteCacheEntry(
   // Route structure is essentially static — it only changes on deploy.
   // Always use the static stale time.
   // NOTE: An exception is rewrites/redirects in middleware or proxy, which can
-  // change routes dynamically. We have other strategies for handling those.
-  fulfilledEntry.staleAt = now + STATIC_STALETIME_MS
+  // change routes dynamically. For redirects, we set staleAt to now so the
+  // cache entry is immediately stale and middleware will be re-evaluated.
+  fulfilledEntry.staleAt = isRedirect ? now : now + STATIC_STALETIME_MS
   fulfilledEntry.couldBeIntercepted = couldBeIntercepted
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
@@ -1060,7 +1062,8 @@ export function writeRouteIntoCache(
   metadataVaryPath: PageVaryPath,
   couldBeIntercepted: boolean,
   canonicalUrl: string,
-  isPPREnabled: boolean
+  isPPREnabled: boolean,
+  isRedirect: boolean = false
 ): FulfilledRouteCacheEntry {
   const pendingEntry = createDetachedRouteCacheEntry()
   const fulfilledEntry = fulfillRouteCacheEntry(
@@ -1070,7 +1073,8 @@ export function writeRouteIntoCache(
     metadataVaryPath,
     couldBeIntercepted,
     canonicalUrl,
-    isPPREnabled
+    isPPREnabled,
+    isRedirect
   )
   // nextUrl is always null here because we only write to the route cache for
   // non-intercepted routes. Intercepted routes are deopted in attemptOptimisticRouting.
@@ -1735,7 +1739,8 @@ export async function fetchRouteOnCacheMiss(
         couldBeIntercepted,
         canonicalUrl,
         routeIsPPREnabled,
-        false // hasDynamicRewrite
+        false, // hasDynamicRewrite
+        response.redirected // isRedirect - bypass cache for middleware redirects
       )
     } else {
       // PPR is not enabled for this route. The server responds with a
@@ -2173,7 +2178,8 @@ function writeDynamicTreeResponseIntoCache(
     couldBeIntercepted,
     canonicalUrl,
     routeIsPPREnabled,
-    false // hasDynamicRewrite
+    false, // hasDynamicRewrite
+    response.redirected // isRedirect - bypass cache for middleware redirects
   )
 
   // If the server sent segment data as part of the response, we should write

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -173,7 +173,8 @@ export function discoverKnownRoute(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   isPPREnabled: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  isRedirect: boolean = false
 ): FulfilledRouteCacheEntry {
   const tree = routeTree
 
@@ -190,7 +191,8 @@ export function discoverKnownRoute(
       metadataVaryPath,
       couldBeIntercepted,
       canonicalUrl,
-      isPPREnabled
+      isPPREnabled,
+      isRedirect
     )
     if (hasDynamicRewrite) {
       fulfilledEntry.hasDynamicRewrite = true
@@ -211,7 +213,8 @@ export function discoverKnownRoute(
       couldBeIntercepted,
       canonicalUrl,
       isPPREnabled,
-      hasDynamicRewrite
+      hasDynamicRewrite,
+      isRedirect
     )
     return fulfilledEntry
   }
@@ -231,7 +234,8 @@ export function discoverKnownRoute(
     couldBeIntercepted,
     canonicalUrl,
     isPPREnabled,
-    hasDynamicRewrite
+    hasDynamicRewrite,
+    isRedirect
   )
 }
 
@@ -286,7 +290,8 @@ function discoverKnownRoutePart(
   couldBeIntercepted: boolean,
   canonicalUrl: string,
   isPPREnabled: boolean,
-  hasDynamicRewrite: boolean
+  hasDynamicRewrite: boolean,
+  isRedirect: boolean = false
 ): FulfilledRouteCacheEntry {
   const segment = routeTree.segment
 
@@ -325,7 +330,8 @@ function discoverKnownRoutePart(
         metadataVaryPath,
         couldBeIntercepted,
         canonicalUrl,
-        isPPREnabled
+        isPPREnabled,
+        isRedirect
       )
     }
 
@@ -404,7 +410,8 @@ function discoverKnownRoutePart(
         couldBeIntercepted,
         canonicalUrl,
         isPPREnabled,
-        hasDynamicRewrite
+        hasDynamicRewrite,
+        isRedirect
       )
       // All parallel route branches share the same URL, so they should all
       // reach compatible leaf nodes. We capture any result.
@@ -425,7 +432,8 @@ function discoverKnownRoutePart(
       metadataVaryPath,
       couldBeIntercepted,
       canonicalUrl,
-      isPPREnabled
+      isPPREnabled,
+      isRedirect
     )
   }
 
@@ -454,7 +462,8 @@ function discoverKnownRoutePart(
       metadataVaryPath,
       couldBeIntercepted,
       canonicalUrl,
-      isPPREnabled
+      isPPREnabled,
+      isRedirect
     )
   }
 


### PR DESCRIPTION
### What?

This PR makes middleware redirect responses immediately stale in the segment cache, ensuring middleware is re-evaluated on subsequent navigations.

### Why?

When a middleware redirect is prefetched, the route cache entry is stored with a 5-minute stale time (STATIC_STALETIME_MS). This causes a bug where:

 1.User visits / → middleware redirects to /process (prefetch cached)
 2.User completes processing, cookie is set
 3.User clicks link to / → cached redirect is reused, middleware NOT re-evaluated
 4.User stuck in redirect loop despite state change

Users expect middleware to evaluate fresh on each navigation. The current caching behavior violates this expectation for redirects.

### How?
Added an `isRedirect` parameter that flows through the caching chain:
`
fetchRouteOnCacheMiss (response.redirected available)
  → discoverKnownRoute(isRedirect)
    → discoverKnownRoutePart(isRedirect)
      → writeRouteIntoCache(isRedirect)
        → fulfillRouteCacheEntry(isRedirect)
          → staleAt = isRedirect ? now : now + STATIC_STALETIME_MS`

**Key change:**
```typescript
// cache.ts line 1047
fulfilledEntry.staleAt = isRedirect ? now : now + STATIC_STALETIME_MS

Non-redirect responses are unaffected (default isRedirect=false).
```
Closes NEXT-
Fixes #88937


