### PR TITLE
Revert "Ensure _middleware is consistent in adapter for name/id"

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -749,7 +749,7 @@ export async function handleBuildComplete({
               }
             })
           output.pathname = '/_middleware'
-          output.id = '/_middleware'
+          output.id = page.name
           outputs.middleware = output
         } else {
           currentOutputs.push(output)


### PR DESCRIPTION
This is causing conflicts as the name value is relied on too much since it can differ heavily e.g. for `src` dir and if not. 

x-ref: https://github.com/vercel/next.js/actions/runs/21767409431/job/62826336354#step:34:240

Reverts vercel/next.js#89559