### PR TITLE
Update metadata assertions

### DIFF
--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -22,7 +22,7 @@ describe('app dir - metadata dynamic routes', () => {
       const res = await next.fetch('/robots.txt')
       const text = await res.text()
 
-      expect(res.headers.get('content-type')).toBe('text/plain')
+      expect(res.headers.get('content-type')).toContain('text/plain')
       expect(res.headers.get('cache-control')).toBe(CACHE_HEADERS.REVALIDATE)
 
       expect(text).toMatchInlineSnapshot(`
@@ -187,7 +187,9 @@ describe('app dir - metadata dynamic routes', () => {
       const res = await next.fetch('/manifest.webmanifest')
       const json = await res.json()
 
-      expect(res.headers.get('content-type')).toBe('application/manifest+json')
+      expect(res.headers.get('content-type')).toContain(
+        'application/manifest+json'
+      )
       expect(res.headers.get('cache-control')).toBe(CACHE_HEADERS.REVALIDATE)
 
       expect(json).toMatchObject({

--- a/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
+++ b/test/e2e/app-dir/use-cache-metadata-route-handler/use-cache-metadata-route-handler.test.ts
@@ -97,7 +97,7 @@ describe('use-cache-metadata-route-handler', () => {
   it('should generate robots.txt with a metadata route handler that uses "use cache"', async () => {
     const res = await next.fetch('/robots.txt')
     expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toBe('text/plain')
+    expect(res.headers.get('content-type')).toContain('text/plain')
 
     const body = await res.text()
 
@@ -121,7 +121,9 @@ describe('use-cache-metadata-route-handler', () => {
   it('should generate manifest.json with a metadata route handler that uses "use cache"', async () => {
     const res = await next.fetch('/manifest.webmanifest')
     expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toBe('application/manifest+json')
+    expect(res.headers.get('content-type')).toContain(
+      'application/manifest+json'
+    )
 
     const body = await res.json()
 


### PR DESCRIPTION
These are too specific as `charset` is valid to be included in the `content-type` as well so this loosens the assertion. 

x-ref: https://github.com/vercel/next.js/actions/runs/21767409431/job/62826336346#step:34:339
x-ref: https://github.com/vercel/next.js/actions/runs/21767409431/job/62826336379#step:34:294