### PR TITLE
docs: add task decomposition and verification guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,13 @@ See [Codebase structure](#codebase-structure) above for detailed explanations.
 - PR descriptions should focus on what changed and why
 - Do NOT mark PRs as "ready for review" (`gh pr ready`) - leave PRs in draft mode and let the user decide when to mark them ready
 
+## Task Decomposition and Verification
+
+- **Split work into smaller, individually verifiable tasks.** Before starting, break the overall goal into incremental steps where each step produces a result that can be checked independently.
+- **Verify each task before moving on to the next.** After completing a step, confirm it works correctly (e.g., run relevant tests, check types, build, or manually inspect output). Do not proceed to the next task until the current one is verified.
+- **Choose the right verification method for each change.** This may include running unit tests, integration tests, type checking, linting, building the project, or inspecting runtime behavior depending on what was changed.
+- **When unclear how to verify a change, ask the user.** If there is no obvious test or verification method for a particular change, ask the user how they would like it verified before moving on.
+
 ## Rebuilding Before Running Tests
 
 When running Next.js integration tests, you must rebuild if source files have changed:


### PR DESCRIPTION
## What?

Added a new section "Task Decomposition and Verification" to AGENTS.md that provides guidance on breaking down work into smaller, verifiable tasks and establishing verification practices before moving to the next step.

## Why?

This guidance helps ensure that AI agents (and developers) work systematically by:
- Breaking complex goals into incremental, independently verifiable steps
- Establishing clear verification checkpoints before proceeding
- Choosing appropriate verification methods for different types of changes
- Asking for clarification when verification approaches are unclear

This promotes more reliable and traceable development practices.

## How?

Added four bullet points under a new "Task Decomposition and Verification" section that outline:
1. How to split work into smaller, verifiable tasks upfront
2. The importance of verifying each task before moving forward
3. Guidance on selecting appropriate verification methods (tests, type checking, linting, builds, etc.)
4. When and how to ask users for clarification on verification approaches

https://claude.ai/code/session_012eJNxH5NRUHKdAaNpz4Yr6