### PR TITLE
Avoid onBeforeDeferredEntries callback being called un-necessarily

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -393,6 +393,21 @@ export async function createHotReloaderTurbopack(
   // Track whether HMR is pending - used to call callback once after HMR settles
   let hmrPendingDeferredCallback = false
 
+  function markDeferredCallbackPendingForEntry(entryKey: string) {
+    if (!hasDeferredEntriesConfig) return
+
+    try {
+      const { page } = splitEntryKey(entryKey as EntryKey)
+      if (isDeferredEntry(page, deferredEntriesConfig)) {
+        return
+      }
+    } catch {
+      // If this isn't an entry key (e.g. middleware), still allow callback.
+    }
+
+    hmrPendingDeferredCallback = true
+  }
+
   // Debounced function to call onBeforeDeferredEntries after HMR
   // This prevents rapid-fire calls when turbopack fires many update events
   // Use 500ms debounce to ensure all rapid updates are batched together
@@ -584,6 +599,7 @@ export async function createHotReloaderTurbopack(
       clientStates.get(client)?.messages.set(id, message)
     }
 
+    markDeferredCallbackPendingForEntry(id)
     hmrEventHappened = true
     sendEnqueuedMessagesDebounce()
   }
@@ -1341,6 +1357,10 @@ export async function createHotReloaderTurbopack(
       // .env files or tsconfig/jsconfig change
       reloadAfterInvalidation,
     }) {
+      if (hasDeferredEntriesConfig) {
+        hmrPendingDeferredCallback = true
+      }
+
       if (reloadAfterInvalidation) {
         for (const [key, entrypoint] of currentWrittenEntrypoints) {
           clearRequireCache(key, entrypoint, { force: true })
@@ -1567,13 +1587,6 @@ export async function createHotReloaderTurbopack(
       switch (updateMessage.updateType) {
         case 'start': {
           hotReloader.send({ type: HMR_MESSAGE_SENT_TO_BROWSER.BUILDING })
-          // Mark that HMR has started and we need to call the callback after it settles
-          // This ensures onBeforeDeferredEntries will be called again during HMR
-          if (hasDeferredEntriesConfig) {
-            hmrPendingDeferredCallback = true
-            onBeforeDeferredEntriesCalled = false
-            onBeforeDeferredEntriesPromise = null
-          }
           break
         }
         case 'end': {
@@ -1631,7 +1644,8 @@ export async function createHotReloaderTurbopack(
             })
           }
 
-          if (hmrEventHappened) {
+          const hadHmrEvent = hmrEventHappened
+          if (hadHmrEvent) {
             const time = updateMessage.value.duration
             const timeMessage =
               time > 2000 ? `${Math.round(time / 100) / 10}s` : `${time}ms`
@@ -1642,7 +1656,7 @@ export async function createHotReloaderTurbopack(
           // Call onBeforeDeferredEntries after compilation completes during HMR
           // This ensures the callback is invoked even when non-deferred entries change
           // Use debounced function to prevent rapid-fire calls from turbopack updates
-          if (hasDeferredEntriesConfig) {
+          if (hasDeferredEntriesConfig && hmrPendingDeferredCallback) {
             callOnBeforeDeferredEntriesAfterHMR()
           }
           break

--- a/packages/next/src/server/dev/on-demand-entry-handler.ts
+++ b/packages/next/src/server/dev/on-demand-entry-handler.ts
@@ -574,6 +574,9 @@ export function onDemandEntryHandler({
     deferredEntriesConfig && deferredEntriesConfig.length > 0
   let onBeforeDeferredEntriesCalled = false
   let onBeforeDeferredEntriesPromise: Promise<void> | null = null
+  // Track whether a real file change invalidation happened, so we can
+  // re-run the callback for HMR updates without triggering on request compiles.
+  let hmrPendingDeferredCallback = false
 
   // Function to wait for all non-deferred entries to be built
   async function waitForNonDeferredEntries(): Promise<void> {
@@ -640,11 +643,20 @@ export function onDemandEntryHandler({
 
   const startBuilding = (compilation: webpack.Compilation) => {
     const compilationName = compilation.name as any as CompilerNameValues
+    const compilerWithFileChanges = compilation.compiler as webpack.Compiler & {
+      modifiedFiles?: ReadonlySet<string>
+      removedFiles?: ReadonlySet<string>
+    }
+
+    if (
+      hasDeferredEntriesConfig &&
+      ((compilerWithFileChanges.modifiedFiles?.size ?? 0) > 0 ||
+        (compilerWithFileChanges.removedFiles?.size ?? 0) > 0)
+    ) {
+      hmrPendingDeferredCallback = true
+    }
+
     curInvalidator.startBuilding(compilationName)
-    // Reset deferred entries state for this compilation cycle
-    // This ensures onBeforeDeferredEntries will be called again during HMR
-    onBeforeDeferredEntriesCalled = false
-    onBeforeDeferredEntriesPromise = null
   }
   for (const compiler of multiCompiler.compilers) {
     compiler.hooks.make.tap('NextJsOnDemandEntries', startBuilding)
@@ -720,7 +732,8 @@ export function onDemandEntryHandler({
 
     // Call onBeforeDeferredEntries after compilation completes during HMR
     // This ensures the callback is invoked even when non-deferred entries change
-    if (hasDeferredEntriesConfig && !onBeforeDeferredEntriesCalled) {
+    if (hasDeferredEntriesConfig && hmrPendingDeferredCallback) {
+      hmrPendingDeferredCallback = false
       onBeforeDeferredEntriesCalled = true
       if (nextConfig.experimental.onBeforeDeferredEntries) {
         debug('calling onBeforeDeferredEntries callback after HMR')

--- a/test/e2e/deferred-entries/deferred-entries.test.ts
+++ b/test/e2e/deferred-entries/deferred-entries.test.ts
@@ -300,6 +300,42 @@ describe('deferred-entries webpack', () => {
   })
 
   if (!isNextStart) {
+    it('should not call onBeforeDeferredEntries on repeated requests without source updates, including non-deferred routes', async () => {
+      const callbackLogPath = path.join(next.testDir, '.callback-log')
+
+      await retry(async () => {
+        const deferredRes = await next.fetch('/deferred')
+        expect(deferredRes.status).toBe(200)
+      })
+
+      const stabilizedTimestamp =
+        await waitForCallbackTimestampToStabilize(callbackLogPath)
+
+      for (const request of [1, 2, 3]) {
+        await retry(async () => {
+          const deferredRes = await next.fetch(`/deferred?request=${request}`)
+          expect(deferredRes.status).toBe(200)
+        })
+      }
+
+      for (const nonDeferredPath of [
+        '/?request=1',
+        '/legacy?request=1',
+        '/no-data?request=1',
+        '/api/hello?request=1',
+      ]) {
+        await retry(async () => {
+          const res = await next.fetch(nonDeferredPath)
+          expect(res.status).toBe(200)
+        })
+      }
+
+      await sleep(600)
+
+      const latestTimestamp = parseCallbackLog(callbackLogPath)
+      expect(latestTimestamp).toBe(stabilizedTimestamp)
+    })
+
     it('should call onBeforeDeferredEntries during HMR even when non-deferred entry changes', async () => {
       const callbackLogPath = path.join(next.testDir, '.callback-log')
 

--- a/test/e2e/deferred-entries/next.config.js
+++ b/test/e2e/deferred-entries/next.config.js
@@ -48,7 +48,9 @@ module.exports = {
       await new Promise((resolve) => setTimeout(resolve, 100))
 
       // Append to entry log to mark callback position in the build sequence
-      fs.appendFileSync(logFile, `${timestamp}:CALLBACK_EXECUTED\n`)
+      if (process.env.NEXT_TEST_MODE === 'start') {
+        fs.appendFileSync(logFile, `${timestamp}:CALLBACK_EXECUTED\n`)
+      }
     },
   },
   // Turbopack loader configuration


### PR DESCRIPTION
- Tightened `onBeforeDeferredEntries` triggering in dev so it does not re-run on repeated route requests without source changes.
- Webpack dev: only schedules the deferred callback re-run on real file-change rebuild signals, instead of generic compilation cycles.
- Turbopack dev: schedules callback re-run from non-deferred HMR/invalidation signals, avoiding request-only deferred route churn.
