### PR TITLE
 turbopack: ignore CSS data: URLs in url() reference resolution

### DIFF
--- a/turbopack/crates/turbopack-css/src/references/mod.rs
+++ b/turbopack/crates/turbopack-css/src/references/mod.rs
@@ -36,6 +36,21 @@ pub type AnalyzedRefs = (
     Vec<(String, ResolvedVc<UrlAssetReference>)>,
 );
 
+fn should_resolve_css_url(src: &str) -> bool {
+    if matches!(src.bytes().next(), Some(b'#') | Some(b'/')) {
+        return false;
+    }
+
+    if src
+        .get(..5)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:"))
+    {
+        return false;
+    }
+
+    true
+}
+
 /// Returns `(all_references, urls)`.
 pub async fn analyze_references(
     stylesheet: &mut StyleSheet<'static, 'static>,
@@ -134,7 +149,7 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
 
         // ignore internal urls like `url(#noiseFilter)`
         // ignore server-relative urls like `url(/foo)`
-        if !matches!(src.bytes().next(), Some(b'#') | Some(b'/')) {
+        if should_resolve_css_url(src) {
             let issue_span = u.loc;
 
             let vc = UrlAssetReference::new(
@@ -170,6 +185,30 @@ impl Visitor<'_> for ModuleReferencesVisitor<'_> {
         _: &mut lightningcss::rules::supports::SupportsCondition<'_>,
     ) -> Result<(), Self::Error> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_resolve_css_url;
+
+    #[test]
+    fn should_ignore_internal_and_server_relative_urls() {
+        assert!(!should_resolve_css_url("#noiseFilter"));
+        assert!(!should_resolve_css_url("/foo.woff2"));
+    }
+
+    #[test]
+    fn should_ignore_data_urls() {
+        assert!(!should_resolve_css_url(
+            "data:font/woff2;charset=utf-8;base64,AAAA"
+        ));
+    }
+
+    #[test]
+    fn should_resolve_relative_urls() {
+        assert!(should_resolve_css_url("./foo.woff2"));
+        assert!(should_resolve_css_url("../foo.woff2"));
     }
 }
 


### PR DESCRIPTION
## What?

Fixes a Turbopack CSS resolver bug where `url(data:...)` values are treated as resolvable asset references, which can lead to filesystem-style resolution attempts and path watch/write failures.

Specifically, `data:` URLs are now excluded from CSS URL reference collection (same as internal `#...` and server-relative `/...` URLs), so they remain URL literals.

## Why?
CSS may contain embedded font data URLs like:

```css
url(data:font/woff2;charset=utf-8;base64,...)
```

Under Turbopack dev mode this could be interpreted as a filesystem/module request and trigger failures such as File name too long (os error 36) during endpoint write/watch flow, particularly on Windows or overlayfs filesystem with a max filename size of 255.

Webpack mode does not show this behavior; this change aligns Turbopack handling with expected CSS semantics for data: URLs.

## How?

    Added a small helper in turbopack/crates/turbopack-css/src/references/mod.rs:
        should_resolve_css_url(src: &str)
    Updated URL visitor logic to use this helper.
    The helper now returns false for:
        internal URLs (#...)
        server-relative URLs (/...)
        data: URLs (case-insensitive check)

## Tests

Added focused unit tests in turbopack/crates/turbopack-css/src/references/mod.rs:

    should_ignore_data_urls
    should_ignore_internal_and_server_relative_urls
    should_resolve_relative_urls

Regression behavior:

    New test fails without the fix.
    Tests pass with this patch.

## Backport request

This affects users currently on stable Next.js 15.x (including 15.5.x) in Turbopack dev mode.
If acceptable, please consider backporting this fix to the 15.5 release line as well.