### PR TITLE
Omit unused arguments for server actions

### DIFF
--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -103,13 +103,7 @@ async function fetchServerAction(
 ): Promise<FetchServerActionResult> {
   const temporaryReferences = createTemporaryReferenceSet()
   const info = extractInfoFromServerReferenceId(actionId)
-
-  // TODO: Currently, we're only omitting unused args for the experimental "use
-  // cache" functions. Once the server reference info byte feature is stable, we
-  // should apply this to server actions as well.
-  const usedArgs =
-    info.type === 'use-cache' ? omitUnusedArgs(actionArgs, info) : actionArgs
-
+  const usedArgs = omitUnusedArgs(actionArgs, info)
   const body = await encodeReply(usedArgs, { temporaryReferences })
 
   const headers: Record<string, string> = {

--- a/packages/next/src/shared/lib/server-reference-info.test.ts
+++ b/packages/next/src/shared/lib/server-reference-info.test.ts
@@ -103,7 +103,6 @@ describe('omitUnusedArgs', () => {
       'arg3',
       undefined,
       'arg5',
-      undefined,
     ])
   })
 
@@ -162,8 +161,6 @@ describe('omitUnusedArgs', () => {
       'arg4',
       'arg5',
       'arg6',
-      undefined,
-      undefined,
     ])
   })
 

--- a/packages/next/src/shared/lib/server-reference-info.ts
+++ b/packages/next/src/shared/lib/server-reference-info.ts
@@ -62,6 +62,7 @@ export function omitUnusedArgs(
   info: ServerReferenceInfo
 ): unknown[] {
   const filteredArgs = new Array(args.length)
+  let length = 0
 
   for (let index = 0; index < args.length; index++) {
     if (
@@ -71,8 +72,12 @@ export function omitUnusedArgs(
       (index >= 6 && info.hasRestArgs)
     ) {
       filteredArgs[index] = args[index]
+      length = index + 1
     }
   }
+
+  // Trim trailing unused args from the array.
+  filteredArgs.length = length
 
   return filteredArgs
 }

--- a/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
+++ b/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from '../../../lib/next-test-utils'
+
+describe('actions-unused-args', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should not call server actions with unused arguments', async () => {
+    const browser = await next.browser('/')
+    const cliOutputLength = next.cliOutput.length
+    await browser.elementById('action-button').click()
+
+    await retry(async () => {
+      const actionLog = next.cliOutput
+        .slice(cliOutputLength)
+        .split('\n')
+        .find((line) => line.includes('Action called'))
+
+      // We expect only 1 argument because the click event from the onClick
+      // handler should be omitted as an unused argument.
+      expect(actionLog).toBe('Action called with value: 42 (total args: 1)')
+    })
+  })
+})

--- a/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
+++ b/test/e2e/app-dir/actions-unused-args/actions-unused-args.test.ts
@@ -2,9 +2,15 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from '../../../lib/next-test-utils'
 
 describe('actions-unused-args', () => {
-  const { next } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
+    // No access to runtime logs when deployed.
+    skipDeployment: true,
   })
+
+  if (skipped) {
+    return
+  }
 
   it('should not call server actions with unused arguments', async () => {
     const browser = await next.browser('/')

--- a/test/e2e/app-dir/actions-unused-args/app/button.tsx
+++ b/test/e2e/app-dir/actions-unused-args/app/button.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+export function Button({
+  action,
+  children,
+}: {
+  action: any
+  children: React.ReactNode
+}) {
+  return (
+    <button id="action-button" onClick={action.bind(null, 42)}>
+      {children}
+    </button>
+  )
+}

--- a/test/e2e/app-dir/actions-unused-args/app/layout.tsx
+++ b/test/e2e/app-dir/actions-unused-args/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/actions-unused-args/app/page.tsx
+++ b/test/e2e/app-dir/actions-unused-args/app/page.tsx
@@ -1,0 +1,18 @@
+import { Button } from './button'
+
+export default function Page() {
+  return (
+    <Button
+      action={async (value: number) => {
+        'use server'
+
+        console.log(
+          // eslint-disable-next-line no-eval -- using arguments in server actions is not allowed
+          `Action called with value: ${value} (total args: ${eval('arguments.length')})`
+        )
+      }}
+    >
+      Schaltfläche drücken
+    </Button>
+  )
+}


### PR DESCRIPTION
Previously, unused argument omission was only applied to `"use cache"` functions called from the client (#72506). This enables it for server actions as well, and optimizes `omitUnusedArgs` to trim trailing unused arguments from the sparse array, so that nothing is sent to the server for those instead of `undefined`.