### PR TITLE
Update vercel CLI version in flakey deployment-id test

### DIFF
--- a/test/production/deterministic-build/deployment-id.test.ts
+++ b/test/production/deterministic-build/deployment-id.test.ts
@@ -222,7 +222,7 @@ const FILES = {
           ...FILES,
         },
         dependencies: {
-          vercel: '>=50.12.1',
+          vercel: '>=50.13.2',
         },
         packageJson: {
           scripts: {


### PR DESCRIPTION
If an old version of the CLI is cached on a CI runner but still in the old range it can cause this test to fail. 

x-ref: [slack thread](https://vercel.slack.com/archives/C07UCHRBWGK/p1770501780921239?thread_ts=1770499294.893139&cid=C07UCHRBWGK)