### PR TITLE
fix: respect pageExtensions in no-html-link-for-pages ESLint rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -8,6 +8,7 @@ import {
   normalizeURL,
   execOnce,
   getUrlFromAppDirectory,
+  DEFAULT_PAGE_EXTENSIONS,
 } from '../utils/url'
 
 const pagesDirWarning = execOnce((pagesDirs) => {
@@ -74,6 +75,13 @@ export default defineRule({
 
     const rootDirs = getRootDirs(context)
 
+    const nextSettings: {
+      rootDir?: string | string[]
+      pageExtensions?: string[]
+    } = context.settings.next || {}
+    const pageExtensions: string[] =
+      nextSettings.pageExtensions || DEFAULT_PAGE_EXTENSIONS
+
     const pagesDirs = (
       customPagesDirectory
         ? [customPagesDirectory]
@@ -107,8 +115,16 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,52 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+export const DEFAULT_PAGE_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js']
+
+/**
+ * Build a regex that matches any of the given page extensions.
+ * For example, ['page.tsx', 'page.ts', 'tsx', 'ts'] will produce
+ * a regex matching `.page.tsx`, `.page.ts`, `.tsx`, `.ts`.
+ */
+function buildPageExtRegex(pageExtensions: string[]): RegExp {
+  const escaped = pageExtensions.map((ext) =>
+    ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  )
+  return new RegExp(`(\\.(${escaped.join('|')}))$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extRegex = buildPageExtRegex(pageExtensions)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extRegex.test(dirent.name)) {
+      const indexRegex = new RegExp(
+        `^index(\\.(${pageExtensions.map((e) => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')}))$`
+      )
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -36,24 +60,39 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[]
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extRegex = buildPageExtRegex(pageExtensions)
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      const pageRegex = new RegExp(
+        `^page(\\.(${pageExtensions.map((e) => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')}))$`
+      )
+      const layoutRegex = new RegExp(
+        `^layout(\\.(${pageExtensions.map((e) => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')}))$`
+      )
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensions
+          )
+        )
       }
     }
   })
@@ -136,13 +175,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +198,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,7 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withPageExtensionsDir = path.join(__dirname, 'with-page-extensions')
 
 const linters = {
   withoutPages: new Linter({
@@ -26,6 +27,10 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withPageExtensions: new Linter({
+    cwd: withPageExtensionsDir,
     configType: 'eslintrc',
   }),
 }
@@ -69,6 +74,14 @@ const linterConfigWithNestedContentRootDirDirectory = {
   settings: {
     next: {
       rootDir: path.join(withNestedPagesDir, 'demos/with-nextjs'),
+    },
+  },
+}
+const linterConfigWithPageExtensions: any = {
+  ...linterConfig,
+  settings: {
+    next: {
+      pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
     },
   },
 }
@@ -494,5 +507,58 @@ describe('no-html-link-for-pages', function () {
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
+  })
+  it('invalid static route with pageExtensions', function () {
+    const [report] = linters.withPageExtensions.verify(
+      invalidStaticCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid route to /about with pageExtensions', function () {
+    const invalidAboutCode = `
+import Link from 'next/link';
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/about'>About</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+    const [report] = linters.withPageExtensions.verify(
+      invalidAboutCode,
+      linterConfigWithPageExtensions,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/about/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('does not report when pageExtensions do not match files', function () {
+    const linterConfigWithMdxOnly: any = {
+      ...linterConfig,
+      settings: {
+        next: {
+          pageExtensions: ['mdx'],
+        },
+      },
+    }
+    const report = linters.withPageExtensions.verify(
+      invalidStaticCode,
+      linterConfigWithMdxOnly,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
   })
 })

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/about/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/about/index.page.tsx
@@ -1,0 +1,3 @@
+export default function About() {
+  return <div>About</div>
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <div>Home</div>
+}


### PR DESCRIPTION
## Summary

Fixes #53473

The `@next/next/no-html-link-for-pages` ESLint rule did not respect the `pageExtensions` configuration. It only matched files with hardcoded extensions (`.js`, `.jsx`, `.ts`, `.tsx`), which meant projects using custom `pageExtensions` (e.g., `['page.tsx', 'page.ts', 'page.jsx', 'page.js']`) would not receive lint warnings when using `<a>` elements instead of `<Link>` for internal navigation.

## Changes

- **`packages/eslint-plugin-next/src/utils/url.ts`**: Replaced hardcoded `/(\.(j|t)sx?)$/` regex with a dynamic `buildPageExtRegex()` function that builds the extension-matching regex from the provided `pageExtensions` array. Updated `parseUrlForPages`, `parseUrlForAppDir`, `getUrlFromPagesDirectories`, and `getUrlFromAppDirectory` to accept and pass through the `pageExtensions` parameter. Added `DEFAULT_PAGE_EXTENSIONS` constant (`['tsx', 'ts', 'jsx', 'js']`) for backward compatibility.

- **`packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts`**: Reads `pageExtensions` from `context.settings.next.pageExtensions` (following the existing pattern used by `rootDir`) and passes it to the URL resolution functions.

- **`test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts`**: Added three test cases:
  - Verifies the rule detects `<a>` links to `/` when pages use custom `.page.tsx` extensions
  - Verifies the rule detects `<a>` links to `/about` with nested custom-extension pages
  - Verifies the rule does not report errors when `pageExtensions` don't match any files in the directory

## Usage

Users can configure `pageExtensions` in their ESLint settings:

```json
{
  "settings": {
    "next": {
      "pageExtensions": ["page.tsx", "page.ts", "page.jsx", "page.js"]
    }
  }
}
```

When not configured, the rule uses the default extensions (`tsx`, `ts`, `jsx`, `js`), preserving full backward compatibility.

## Test Plan

- [x] All 26 existing + new unit tests pass
- [x] All 21 eslint-plugin-next test suites pass (182 tests)
- [x] Lint-staged checks (prettier + eslint) pass
- [x] No changes to existing behavior when `pageExtensions` is not configured

Closes #53473