### PR TITLE
docs: clarify documentation link in README

### DIFF
--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -24,6 +24,7 @@ Used by some of the world's largest companies, Next.js enables you to create ful
 ## Documentation
 
 Visit [https://nextjs.org/docs](https://nextjs.org/docs) to view the full documentation.
+
 The documentation includes guides, API references, and explanations of core features such as routing, data fetching, and deployment.
 
 

--- a/packages/next/README.md
+++ b/packages/next/README.md
@@ -24,6 +24,8 @@ Used by some of the world's largest companies, Next.js enables you to create ful
 ## Documentation
 
 Visit [https://nextjs.org/docs](https://nextjs.org/docs) to view the full documentation.
+The documentation includes guides, API references, and explanations of core features such as routing, data fetching, and deployment.
+
 
 ## Community
 


### PR DESCRIPTION
What?

Add a brief description under the documentation link in the README to clarify what the official Next.js documentation includes.

Why?

The README previously linked to the documentation without explaining its contents.
Adding a short description helps new users quickly understand what they can find there (guides, API references, core features).

How?

Added two explanatory sentences below the documentation link describing the scope of the Next.js docs.
No functional changes were made.
