### PR TITLE
Allow `reset()` from user's global-error

### DIFF
--- a/packages/next/src/client/components/builtin/global-error.tsx
+++ b/packages/next/src/client/components/builtin/global-error.tsx
@@ -5,6 +5,7 @@ import { errorStyles, errorThemeCss, ErrorIcon } from './error-styles'
 
 export type GlobalErrorComponent = React.ComponentType<{
   error: any
+  reset: () => void
 }>
 
 function DefaultGlobalError({ error }: { error: any }) {

--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -12,9 +12,7 @@ const isBotUserAgent =
 
 export type ErrorComponent = React.ComponentType<{
   error: Error
-  // global-error, there's no `reset` function;
-  // regular error boundary, there's a `reset` function.
-  reset?: () => void
+  reset: () => void
 }>
 
 export interface ErrorBoundaryProps {

--- a/packages/next/src/next-devtools/userspace/app/app-dev-overlay-error-boundary.tsx
+++ b/packages/next/src/next-devtools/userspace/app/app-dev-overlay-error-boundary.tsx
@@ -64,7 +64,7 @@ export class AppDevOverlayErrorBoundary extends PureComponent<
     dispatcher.openErrorOverlay()
   }
 
-  reset() {
+  reset = () => {
     this.setState({ reactError: null })
   }
 

--- a/packages/next/src/next-devtools/userspace/app/app-dev-overlay-error-boundary.tsx
+++ b/packages/next/src/next-devtools/userspace/app/app-dev-overlay-error-boundary.tsx
@@ -18,9 +18,11 @@ type AppDevOverlayErrorBoundaryState = {
 function ErroredHtml({
   globalError: [GlobalError, globalErrorStyles],
   error,
+  reset,
 }: {
   globalError: GlobalErrorState
   error: unknown
+  reset: () => void
 }) {
   if (!error) {
     return (
@@ -33,7 +35,7 @@ function ErroredHtml({
   return (
     <ErrorBoundary errorComponent={DefaultGlobalError}>
       {globalErrorStyles}
-      <GlobalError error={error} />
+      <GlobalError error={error} reset={reset} />
     </ErrorBoundary>
   )
 }
@@ -62,12 +64,20 @@ export class AppDevOverlayErrorBoundary extends PureComponent<
     dispatcher.openErrorOverlay()
   }
 
+  reset() {
+    this.setState({ reactError: null })
+  }
+
   render() {
     const { children, globalError } = this.props
     const { reactError } = this.state
 
     const fallback = (
-      <ErroredHtml globalError={globalError} error={reactError} />
+      <ErroredHtml
+        globalError={globalError}
+        error={reactError}
+        reset={this.reset}
+      />
     )
 
     return reactError !== null ? fallback : children


### PR DESCRIPTION
User's `global-error.js` is within the router. There's no reason it shouldn't have access to the options available to the `error.js` component. It was already available on prod. This PR syncs dev behavior to prod.

For the follow-up feature, `retry()` will also be available in `global-error.js`.