### PR TITLE
ci: extract node-stream coverage workflow and manifest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1021,6 +1021,63 @@ jobs:
       stepName: 'test-cache-components-prod-${{ matrix.group }}'
     secrets: inherit
 
+  test-node-streams-dev:
+    name: test node streams dev
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1/6, 2/6, 3/6, 4/6, 5/6, 6/6]
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      # Dev tests use Turbopack (default bundler) to cover turbopack code paths.
+      # Prod tests below use IS_WEBPACK_TEST=1 to cover webpack code paths.
+      afterBuild: |
+        export __NEXT_USE_NODE_STREAMS=true
+        export __NEXT_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
+        export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json,test/use-node-streams-tests-manifest.json"
+        export NEXT_TEST_MODE=dev
+        export IS_TURBOPACK_TEST=1
+        export TURBOPACK_DEV=1
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          --type development
+      stepName: 'test-node-streams-dev-${{ matrix.group }}'
+    secrets: inherit
+
+  test-node-streams-prod:
+    name: test node streams prod
+    needs: ['optimize-ci', 'changes', 'build-native', 'build-next']
+    if: ${{ needs.optimize-ci.outputs.skip == 'false' && needs.changes.outputs.docs-only == 'false' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1/7, 2/7, 3/7, 4/7, 5/7, 6/7, 7/7]
+    uses: ./.github/workflows/build_reusable.yml
+    with:
+      # Prod tests use webpack (IS_WEBPACK_TEST=1) to cover webpack code paths.
+      # Dev tests above use Turbopack (default) to cover turbopack code paths.
+      afterBuild: |
+        export __NEXT_USE_NODE_STREAMS=true
+        export __NEXT_CACHE_COMPONENTS=true
+        export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
+        export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json,test/use-node-streams-tests-manifest.json"
+        export NEXT_TEST_MODE=start
+        export IS_WEBPACK_TEST=1
+
+        node run-tests.js \
+          --timings \
+          -g ${{ matrix.group }} \
+          --type production
+      stepName: 'test-node-streams-prod-${{ matrix.group }}'
+    secrets: inherit
+
   tests-pass:
     needs:
       [
@@ -1039,6 +1096,8 @@ jobs:
         'test-cache-components-dev',
         'test-cache-components-prod',
         'test-cache-components-integration',
+        'test-node-streams-dev',
+        'test-node-streams-prod',
         'test-cargo-unit',
         'rust-check',
         'rustdoc-check',

--- a/test/use-node-streams-tests-manifest.json
+++ b/test/use-node-streams-tests-manifest.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "suites": {},
+  "rules": {
+    "include": [
+      "test/e2e/**/*.test.{t,j}s{,x}",
+      "test/integration/app-*/**/*.test.{t,j}s{,x}",
+      "test/production/app-*/**/*.test.{t,j}s{,x}",
+      "test/development/app-*/**/*.test.{t,j}s{,x}",
+      "test/development/acceptance-app/**/*.test.{t,j}s{,x}"
+    ],
+    "exclude": []
+  }
+}


### PR DESCRIPTION
## Summary
- extracts node-stream CI coverage wiring from the runtime PR
- adds node-stream dev/prod workflow jobs and dedicated test manifest

## Why
- keep runtime behavior changes and CI matrix expansion separately reviewable

## Stack
- depends on #89690