### PR TITLE
Fix reset-project script for E2E deploy tests

### DIFF
--- a/scripts/reset-project.mjs
+++ b/scripts/reset-project.mjs
@@ -97,10 +97,11 @@ export async function resetProject({
         resourceConfig: {
           buildMachineType: 'enhanced',
         },
-        env: [
+        environmentVariables: [
           {
             key: 'VERCEL_FORCE_NO_BUILD_CACHE_UPLOAD',
             value: '1',
+            type: 'plain',
             target: ['production', 'preview', 'development'],
           },
         ],


### PR DESCRIPTION
Our reset script was failing from invalid body shape: 

```sh
Error: Create project failed. Got status: 400, {"error":{"code":"bad_request","message":"Invalid request: should NOT have additional property `env`."}}
```

x-ref: https://docs.vercel.com/docs/rest-api/reference/endpoints/projects/create-a-new-project#body-environment-variables

x-ref: https://github.com/vercel/next.js/actions/runs/21793009770/job/62875798461
x-ref: https://github.com/vercel/next.js/actions/runs/21807482052/attempts/1