### PR TITLE
Turbopack: Remove old `Vc::try_resolve_*` methods in favor of the `ResolvedVc` alternatives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9392,7 +9392,6 @@ dependencies = [
  "serde_json",
  "shrink-to-fit",
  "smallvec",
- "thiserror 1.0.69",
  "tokio",
  "tokio-util",
  "tracing",

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -661,11 +661,11 @@ impl PageEndpoint {
         if matches!(
             *this.pages_project.project().next_mode().await?,
             NextMode::Development
-        ) && let Some(chunkable) = Vc::try_resolve_downcast(page_loader).await?
+        ) && let Some(chunkable) = ResolvedVc::try_downcast(page_loader.to_resolved().await?)
         {
             return Ok(Vc::upcast(HmrEntryModule::new(
                 AssetIdent::from_path(this.page.await?.base_path.clone()),
-                chunkable,
+                *chunkable,
             )));
         }
         Ok(page_loader)
@@ -678,23 +678,23 @@ impl PageEndpoint {
         let client_module = self.client_module();
         let client_main_module = this.pages_project.client_main_module();
 
-        let Some(client_module) =
-            Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(client_module).await?
-        else {
+        let Some(client_module) = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(
+            client_module.to_resolved().await?,
+        ) else {
             bail!("expected an evaluateable asset");
         };
 
-        let Some(client_main_module) =
-            Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(client_main_module).await?
-        else {
+        let Some(client_main_module) = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(
+            client_main_module.to_resolved().await?,
+        ) else {
             bail!("expected an evaluateable asset");
         };
 
         let evaluatable_assets = this
             .pages_project
             .client_runtime_entries()
-            .with_entry(client_main_module)
-            .with_entry(client_module);
+            .with_entry(*client_main_module)
+            .with_entry(*client_module);
         Ok(evaluatable_assets)
     }
 

--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -74,11 +74,9 @@ pub(crate) async fn create_server_actions_manifest(
 ) -> Result<Vc<ServerActionsManifest>> {
     let loader =
         build_server_actions_loader(project_path, page_name.clone(), actions, rsc_asset_context);
-    let evaluable = Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(loader)
-        .await?
-        .context("loader module must be evaluatable")?
-        .to_resolved()
-        .await?;
+    let evaluable =
+        ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(loader.to_resolved().await?)
+            .context("loader module must be evaluatable")?;
 
     let chunk_item = loader.as_chunk_item(module_graph, chunking_context);
     let manifest = build_manifest(
@@ -145,12 +143,12 @@ pub(crate) async fn build_server_actions_loader(
         .module();
 
     let Some(placeable) =
-        Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
+        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module.to_resolved().await?)
     else {
         bail!("internal module must be evaluatable");
     };
 
-    Ok(placeable)
+    Ok(*placeable)
 }
 
 /// Builds a manifest containing every action's hashed id, with an internal

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -46,7 +46,7 @@ pub async fn get_middleware_module(
 
     // Validate that the module has the required exports
     if let Some(ecma_module) =
-        Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(*userland_module).await?
+        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(userland_module)
     {
         let exports = ecma_module.get_exports().await?;
 

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -5,7 +5,7 @@
 use anyhow::{Result, bail};
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
@@ -229,7 +229,7 @@ pub async fn dynamic_image_metadata_source(
 #[turbo_tasks::function]
 async fn collect_direct_exports(module: Vc<Box<dyn Module>>) -> Result<Vc<Vec<RcStr>>> {
     let Some(ecmascript_asset) =
-        Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
+        ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module.to_resolved().await?)
     else {
         return Ok(Default::default());
     };

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -171,13 +171,13 @@ impl EcmascriptClientReferenceModule {
             .process(Vc::upcast(proxy_source), ReferenceType::Undefined)
             .module();
 
-        let Some(proxy_module) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(proxy_module).await?
-        else {
+        let Some(proxy_module) = ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(
+            proxy_module.to_resolved().await?,
+        ) else {
             bail!("proxy asset is not an ecmascript module");
         };
 
-        Ok(proxy_module)
+        Ok(*proxy_module)
     }
 }
 
@@ -260,11 +260,9 @@ impl ChunkableModule for EcmascriptClientReferenceModule {
         let item = self
             .proxy_module()
             .as_chunk_item(module_graph, *chunking_context);
-        let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
-            .await?
-            .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?
-            .to_resolved()
-            .await?;
+        let ecmascript_item =
+            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(item.to_resolved().await?)
+                .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?;
 
         Ok(Vc::upcast(
             EcmascriptClientReferenceProxyChunkItem {

--- a/crates/next-core/src/next_server_utility/server_utility_transition.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_transition.rs
@@ -1,5 +1,5 @@
 use anyhow::{Result, bail};
-use turbo_tasks::Vc;
+use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::{ModuleAssetContext, transition::Transition};
 use turbopack_core::module::Module;
 use turbopack_ecmascript::chunk::EcmascriptChunkPlaceable;
@@ -32,12 +32,12 @@ impl Transition for NextServerUtilityTransition {
         module: Vc<Box<dyn Module>>,
         _context: Vc<ModuleAssetContext>,
     ) -> Result<Vc<Box<dyn Module>>> {
-        let Some(module) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
-        else {
+        let Some(module) = ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(
+            module.to_resolved().await?,
+        ) else {
             bail!("not an ecmascript module");
         };
 
-        Ok(Vc::upcast(NextServerUtilityModule::new(module)))
+        Ok(Vc::upcast(NextServerUtilityModule::new(*module)))
     }
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/all_in_one.rs
@@ -46,8 +46,7 @@ async fn all_in_one() {
         let c_erased: Vc<Box<dyn Add>> = a_erased.add(b_erased);
 
         assert_eq!(
-            *Vc::try_resolve_downcast_type::<Number>(c_erased)
-                .await?
+            *ResolvedVc::try_downcast_type::<Number>(c_erased.to_resolved().await?)
                 .unwrap()
                 .await?,
             42

--- a/turbopack/crates/turbo-tasks/Cargo.toml
+++ b/turbopack/crates/turbo-tasks/Cargo.toml
@@ -44,7 +44,6 @@ serde = { workspace = true, features = ["rc", "derive"] }
 serde_json = { workspace = true }
 shrink-to-fit = { workspace = true, features = ["indexmap", "serde_json", "smallvec", "nightly"] }
 smallvec = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -121,7 +121,7 @@ pub use crate::{
     },
     mapped_read_ref::MappedReadRef,
     output::OutputContent,
-    raw_vc::{CellId, RawVc, ReadRawVcFuture, ResolveTypeError},
+    raw_vc::{CellId, RawVc, ReadRawVcFuture},
     read_options::{ReadCellOptions, ReadOutputOptions},
     read_ref::ReadRef,
     serialization_invalidation::SerializationInvalidator,

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -1887,20 +1887,6 @@ pub(crate) async fn read_task_output(
     }
 }
 
-pub(crate) async fn read_task_cell(
-    this: &dyn TurboTasksApi,
-    id: TaskId,
-    index: CellId,
-    options: ReadCellOptions,
-) -> Result<TypedCellContent> {
-    loop {
-        match this.try_read_task_cell(id, index, options)? {
-            Ok(result) => return Ok(result),
-            Err(listener) => listener.await,
-        }
-    }
-}
-
 /// A reference to a task's cell with methods that allow updating the contents
 /// of the cell.
 ///

--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -9,33 +9,19 @@ use anyhow::Result;
 use auto_hash_map::AutoSet;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 use crate::{
     CollectiblesSource, ReadCellOptions, ReadConsistency, ReadOutputOptions, ResolvedVc, TaskId,
-    TaskPersistence, TraitTypeId, ValueType, ValueTypeId, VcValueTrait,
-    backend::{CellContent, TypedCellContent},
+    TaskPersistence, TraitTypeId, ValueTypeId, VcValueTrait,
+    backend::TypedCellContent,
     event::EventListener,
     id::{ExecutionId, LocalTaskId},
     manager::{
-        ReadCellTracking, ReadTracking, read_local_output, read_task_cell, read_task_output,
-        with_turbo_tasks,
+        ReadCellTracking, ReadTracking, read_local_output, read_task_output, with_turbo_tasks,
     },
     registry::{self, get_value_type},
     turbo_tasks,
 };
-
-#[derive(Error, Debug)]
-pub enum ResolveTypeError {
-    #[error("no content in the cell")]
-    NoContent,
-    #[error("the content in the cell has no type")]
-    UntypedContent,
-    #[error("content is not available as task execution failed")]
-    TaskError { source: anyhow::Error },
-    #[error("reading the cell content failed")]
-    ReadError { source: anyhow::Error },
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Encode, Decode)]
 pub struct CellId {
@@ -159,78 +145,6 @@ impl RawVc {
         // returns a custom future to have something concrete and sized
         // this avoids boxing in IntoFuture
         ReadRawVcFuture::new(self, None)
-    }
-
-    pub(crate) async fn resolve_trait(
-        self,
-        trait_type: TraitTypeId,
-    ) -> Result<Option<RawVc>, ResolveTypeError> {
-        self.resolve_type_inner(|value_type_id| {
-            let value_type = get_value_type(value_type_id);
-            (value_type.has_trait(&trait_type), Some(value_type))
-        })
-        .await
-    }
-
-    pub(crate) async fn resolve_value(
-        self,
-        value_type: ValueTypeId,
-    ) -> Result<Option<RawVc>, ResolveTypeError> {
-        self.resolve_type_inner(|cell_value_type| (cell_value_type == value_type, None))
-            .await
-    }
-
-    /// Helper for `resolve_trait` and `resolve_value`.
-    ///
-    /// After finding a cell, returns `Ok(Some(...))` when `conditional` returns
-    /// `true`, and `Ok(None)` when `conditional` returns `false`.
-    ///
-    /// As an optimization, `conditional` may return the `&'static ValueType` to
-    /// avoid a potential extra lookup later.
-    async fn resolve_type_inner(
-        self,
-        conditional: impl FnOnce(ValueTypeId) -> (bool, Option<&'static ValueType>),
-    ) -> Result<Option<RawVc>, ResolveTypeError> {
-        let tt = turbo_tasks();
-        let mut current = self;
-        loop {
-            match current {
-                RawVc::TaskOutput(task) => {
-                    current = read_task_output(&*tt, task, ReadOutputOptions::default())
-                        .await
-                        .map_err(|source| ResolveTypeError::TaskError { source })?;
-                }
-                RawVc::TaskCell(task, index) => {
-                    let (ok, value_type) = conditional(index.type_id);
-                    if !ok {
-                        return Ok(None);
-                    }
-                    let value_type =
-                        value_type.unwrap_or_else(|| registry::get_value_type(index.type_id));
-                    let content = read_task_cell(
-                        &*tt,
-                        task,
-                        index,
-                        ReadCellOptions {
-                            is_serializable_cell_content: value_type.bincode.is_some(),
-                            ..Default::default()
-                        },
-                    )
-                    .await
-                    .map_err(|source| ResolveTypeError::ReadError { source })?;
-                    if let TypedCellContent(_, CellContent(Some(_))) = content {
-                        return Ok(Some(RawVc::TaskCell(task, index)));
-                    } else {
-                        return Err(ResolveTypeError::NoContent);
-                    }
-                }
-                RawVc::LocalOutput(execution_id, local_task_id, ..) => {
-                    current = read_local_output(&*tt, execution_id, local_task_id)
-                        .await
-                        .map_err(|source| ResolveTypeError::TaskError { source })?;
-                }
-            }
-        }
     }
 
     /// See [`crate::Vc::resolve`].

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -32,7 +32,7 @@ pub use self::{
     traits::{Dynamic, Upcast, UpcastStrict, VcValueTrait, VcValueType},
 };
 use crate::{
-    CellId, RawVc, ResolveTypeError,
+    CellId, RawVc,
     debug::{ValueDebug, ValueDebugFormat, ValueDebugFormatString},
     keyed::{KeyedAccess, KeyedEq},
     registry,
@@ -503,70 +503,6 @@ where
             node: self.node.resolve_strongly_consistent().await?,
             _t: PhantomData,
         })
-    }
-}
-
-impl<T> Vc<T>
-where
-    T: VcValueTrait + ?Sized,
-{
-    /// Attempts to sidecast the given `Vc<Box<dyn T>>` to a `Vc<Box<dyn K>>`.
-    /// This operation also resolves the `Vc`.
-    ///
-    /// Returns `None` if the underlying value type does not implement `K`.
-    ///
-    /// **Note:** if the trait T is required to implement K, use
-    /// `Vc::upcast(vc).resolve()` instead. This provides stronger guarantees,
-    /// removing the need for a `Result` return type.
-    pub async fn try_resolve_sidecast<K>(vc: Self) -> Result<Option<Vc<K>>, ResolveTypeError>
-    where
-        K: VcValueTrait + ?Sized,
-    {
-        debug_assert!(
-            <K as VcValueTrait>::get_trait_type_id() != <T as VcValueTrait>::get_trait_type_id(),
-            "Attempted to cast a type {} to itself, which is pointless. Use the value directly \
-             instead.",
-            crate::registry::get_trait(<T as VcValueTrait>::get_trait_type_id()).global_name
-        );
-        let raw_vc: RawVc = vc.node;
-        let raw_vc = raw_vc
-            .resolve_trait(<K as VcValueTrait>::get_trait_type_id())
-            .await?;
-        Ok(raw_vc.map(|raw_vc| Vc {
-            node: raw_vc,
-            _t: PhantomData,
-        }))
-    }
-
-    /// Attempts to downcast the given `Vc<Box<dyn T>>` to a `Vc<K>`, where `K`
-    /// is of the form `Box<dyn L>`, and `L` is a value trait.
-    /// This operation also resolves the `Vc`.
-    ///
-    /// Returns `None` if the underlying value type is not a `K`.
-    pub async fn try_resolve_downcast<K>(vc: Self) -> Result<Option<Vc<K>>, ResolveTypeError>
-    where
-        K: UpcastStrict<T> + VcValueTrait + ?Sized,
-    {
-        Self::try_resolve_sidecast(vc).await
-    }
-
-    /// Attempts to downcast the given `Vc<Box<dyn T>>` to a `Vc<K>`, where `K`
-    /// is a value type.
-    /// This operation also resolves the `Vc`.
-    ///
-    /// Returns `None` if the underlying value type is not a `K`.
-    pub async fn try_resolve_downcast_type<K>(vc: Self) -> Result<Option<Vc<K>>, ResolveTypeError>
-    where
-        K: UpcastStrict<T> + VcValueType,
-    {
-        let raw_vc: RawVc = vc.node;
-        let raw_vc = raw_vc
-            .resolve_value(<K as VcValueType>::get_value_type_id())
-            .await?;
-        Ok(raw_vc.map(|raw_vc| Vc {
-            node: raw_vc,
-            _t: PhantomData,
-        }))
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/vc/resolved.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/resolved.rs
@@ -260,8 +260,6 @@ where
     ///
     /// **Note:** if the trait `T` is required to implement `K`, use [`ResolvedVc::upcast`] instead.
     /// That method provides stronger guarantees, removing the need for a [`Option`] return type.
-    ///
-    /// See also: [`Vc::try_resolve_sidecast`].
     pub fn try_sidecast<K>(this: Self) -> Option<ResolvedVc<K>>
     where
         K: VcValueTrait + ?Sized,
@@ -292,8 +290,6 @@ where
     /// is of the form `Box<dyn L>`, and `L` is a value trait.
     ///
     /// Returns `None` if the underlying value type is not a `K`.
-    ///
-    /// See also: [`Vc::try_resolve_downcast`].
     pub fn try_downcast<K>(this: Self) -> Option<ResolvedVc<K>>
     where
         K: UpcastStrict<T> + VcValueTrait + ?Sized,
@@ -305,8 +301,6 @@ where
     /// Attempts to downcast the given `Vc<Box<dyn T>>` to a `Vc<K>`, where `K` is a value type.
     ///
     /// Returns `None` if the underlying value type is not a `K`.
-    ///
-    /// See also: [`Vc::try_resolve_downcast_type`].
     pub fn try_downcast_type<K>(this: Self) -> Option<ResolvedVc<K>>
     where
         K: UpcastStrict<T> + VcValueType,

--- a/turbopack/crates/turbopack-analyze/src/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/src/split_chunk.rs
@@ -70,7 +70,7 @@ pub async fn split_output_asset_into_parts(
     let lines_vc = file_content.lines().to_resolved().await?;
 
     let Some(generate_source_map) =
-        Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(asset).await?
+        ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(asset.to_resolved().await?)
     else {
         return self_mapped(asset, content, lines_vc).await;
     };

--- a/turbopack/crates/turbopack-core/src/chunk/data.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/data.rs
@@ -71,7 +71,8 @@ impl ChunkData {
         };
         let path = path.to_string();
 
-        let Some(output_chunk) = Vc::try_resolve_sidecast::<Box<dyn OutputChunk>>(chunk).await?
+        let Some(output_chunk) =
+            ResolvedVc::try_sidecast::<Box<dyn OutputChunk>>(chunk.to_resolved().await?)
         else {
             return Ok(Vc::cell(Some(
                 ChunkData {

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -43,13 +43,15 @@ async fn to_evaluatable(
     let module = asset_context
         .process(asset, ReferenceType::Entry(EntryReferenceSubType::Runtime))
         .module();
-    let Some(entry) = Vc::try_resolve_downcast::<Box<dyn EvaluatableAsset>>(module).await? else {
+    let Some(entry) =
+        ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module.to_resolved().await?)
+    else {
         bail!(
             "{} is not a valid evaluated entry",
             module.ident().to_string().await?
         )
     };
-    Ok(entry)
+    Ok(*entry)
 }
 
 #[turbo_tasks::value(transparent)]

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -277,13 +277,10 @@ impl CssChunkItem for CssModuleChunkItem {
                         ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module)
                     {
                         let item = placeable.as_chunk_item(*self.module_graph, *chunking_context);
-                        if let Some(css_item) =
-                            Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await?
-                        {
-                            imports.push(CssImport::Internal(
-                                import_ref,
-                                css_item.to_resolved().await?,
-                            ));
+                        if let Some(css_item) = ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(
+                            item.to_resolved().await?,
+                        ) {
+                            imports.push(CssImport::Internal(import_ref, css_item));
                         }
                     }
                 }
@@ -302,10 +299,10 @@ impl CssChunkItem for CssModuleChunkItem {
                         ResolvedVc::try_downcast::<Box<dyn CssChunkPlaceable>>(module)
                     {
                         let item = placeable.as_chunk_item(*self.module_graph, *chunking_context);
-                        if let Some(css_item) =
-                            Vc::try_resolve_downcast::<Box<dyn CssChunkItem>>(item).await?
-                        {
-                            imports.push(CssImport::Composes(css_item.to_resolved().await?));
+                        if let Some(css_item) = ResolvedVc::try_downcast::<Box<dyn CssChunkItem>>(
+                            item.to_resolved().await?,
+                        ) {
+                            imports.push(CssImport::Composes(css_item));
                         }
                     }
                 }

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -178,8 +178,7 @@ impl ModuleCssAsset {
             .inner(ReferenceType::Css(CssReferenceSubType::Analyze))
             .module();
 
-        let inner = Vc::try_resolve_sidecast::<Box<dyn ProcessCss>>(inner)
-            .await?
+        let inner = ResolvedVc::try_sidecast::<Box<dyn ProcessCss>>(inner.to_resolved().await?)
             .context("inner asset should be CSS processable")?;
 
         let result = inner.get_css_with_placeholder().await?;

--- a/turbopack/crates/turbopack-dev-server/src/update/stream.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/stream.rs
@@ -187,7 +187,8 @@ async fn get_update_stream_item_operation(
             extend_issues(&mut plain_issues, peek_issues(proxy_result_op).await?);
 
             let from = from.get();
-            if let Some(from) = Vc::try_resolve_downcast_type::<ProxyResult>(from).await?
+            if let Some(from) =
+                ResolvedVc::try_downcast_type::<ProxyResult>(from.to_resolved().await?)
                 && from.await? == proxy_result_value
             {
                 return Ok(UpdateStreamItem::Found {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -301,7 +301,11 @@ async fn find_export_from_reexports(
 
         // If we apply this logic to EcmascriptModuleAsset, we will resolve everything in the
         // target module.
-        if (Vc::try_resolve_downcast_type::<EcmascriptModuleAsset>(module_part).await?).is_none() {
+        if (ResolvedVc::try_downcast_type::<EcmascriptModuleAsset>(
+            module_part.to_resolved().await?,
+        ))
+        .is_none()
+        {
             return Ok(find_export_from_reexports(module_part, export_name));
         }
     }

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -392,13 +392,13 @@ pub async fn get_evaluate_entries(
             )
             .module();
 
-        let Some(globals_module) =
-            Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(globals_module).await?
-        else {
+        let Some(globals_module) = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(
+            globals_module.to_resolved().await?,
+        ) else {
             bail!("Internal module is not evaluatable");
         };
 
-        let mut entries = vec![globals_module.to_resolved().await?];
+        let mut entries = vec![globals_module];
         if let Some(runtime_entries) = runtime_entries {
             for &entry in &*runtime_entries.await? {
                 entries.push(entry)

--- a/turbopack/crates/turbopack-node/src/transforms/postcss.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/postcss.rs
@@ -445,7 +445,7 @@ async fn find_config_in_location(
 impl GenerateSourceMap for PostCssTransformedAsset {
     #[turbo_tasks::function]
     async fn generate_source_map(&self) -> Result<Vc<FileContent>> {
-        let source = Vc::try_resolve_sidecast::<Box<dyn GenerateSourceMap>>(*self.source).await?;
+        let source = ResolvedVc::try_sidecast::<Box<dyn GenerateSourceMap>>(self.source);
         match source {
             Some(source) => Ok(source.generate_source_map()),
             None => Ok(FileContent::NotFound.cell()),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -441,11 +441,11 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .module();
 
     let (evaluatable_assets, entry_modules) = if let Some(ecmascript) =
-        Vc::try_resolve_sidecast::<Box<dyn EvaluatableAsset>>(entry_module).await?
+        ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(entry_module.to_resolved().await?)
     {
         let evaluatable_assets = runtime_entries
             .unwrap_or_else(EvaluatableAssets::empty)
-            .with_entry(ecmascript);
+            .with_entry(*ecmascript);
         (
             evaluatable_assets,
             evaluatable_assets
@@ -600,22 +600,23 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Runtime::NodeJs => {
             OutputAssetsWithReferenced {
                 assets: ResolvedVc::cell(vec![
-                    Vc::try_resolve_downcast_type::<NodeJsChunkingContext>(chunking_context)
-                        .await?
-                        .unwrap()
-                        .entry_chunk_group(
-                            // `expected` expects a completely flat output directory.
-                            chunk_root_path
-                                .join(entry_module.ident().path().await?.file_stem().unwrap())?
-                                .with_extension("entry.js"),
-                            evaluatable_assets,
-                            module_graph,
-                            OutputAssets::empty(),
-                            OutputAssets::empty(),
-                            AvailabilityInfo::root(),
-                        )
-                        .await?
-                        .asset,
+                    ResolvedVc::try_downcast_type::<NodeJsChunkingContext>(
+                        chunking_context.to_resolved().await?,
+                    )
+                    .unwrap()
+                    .entry_chunk_group(
+                        // `expected` expects a completely flat output directory.
+                        chunk_root_path
+                            .join(entry_module.ident().path().await?.file_stem().unwrap())?
+                            .with_extension("entry.js"),
+                        evaluatable_assets,
+                        module_graph,
+                        OutputAssets::empty(),
+                        OutputAssets::empty(),
+                        AvailabilityInfo::root(),
+                    )
+                    .await?
+                    .asset,
                 ]),
                 referenced_assets: ResolvedVc::cell(vec![]),
                 references: ResolvedVc::cell(vec![]),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -600,23 +600,20 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Runtime::NodeJs => {
             OutputAssetsWithReferenced {
                 assets: ResolvedVc::cell(vec![
-                    ResolvedVc::try_downcast_type::<NodeJsChunkingContext>(
-                        chunking_context.to_resolved().await?,
-                    )
-                    .unwrap()
-                    .entry_chunk_group(
-                        // `expected` expects a completely flat output directory.
-                        chunk_root_path
-                            .join(entry_module.ident().path().await?.file_stem().unwrap())?
-                            .with_extension("entry.js"),
-                        evaluatable_assets,
-                        module_graph,
-                        OutputAssets::empty(),
-                        OutputAssets::empty(),
-                        AvailabilityInfo::root(),
-                    )
-                    .await?
-                    .asset,
+                    chunking_context
+                        .entry_chunk_group(
+                            // `expected` expects a completely flat output directory.
+                            chunk_root_path
+                                .join(entry_module.ident().path().await?.file_stem().unwrap())?
+                                .with_extension("entry.js"),
+                            evaluatable_assets,
+                            module_graph,
+                            OutputAssets::empty(),
+                            OutputAssets::empty(),
+                            AvailabilityInfo::root(),
+                        )
+                        .await?
+                        .asset,
                 ]),
                 referenced_assets: ResolvedVc::cell(vec![]),
                 references: ResolvedVc::cell(vec![]),

--- a/turbopack/crates/turbopack-wasm/src/module_asset.rs
+++ b/turbopack/crates/turbopack-wasm/src/module_asset.rs
@@ -82,25 +82,26 @@ impl WebAssemblyModuleAsset {
     async fn loader_as_resolve_origin(self: Vc<Self>) -> Result<Vc<Box<dyn ResolveOrigin>>> {
         let module = self.loader_as_module();
 
-        let Some(esm_asset) = Vc::try_resolve_sidecast::<Box<dyn ResolveOrigin>>(module).await?
+        let Some(esm_asset) =
+            ResolvedVc::try_sidecast::<Box<dyn ResolveOrigin>>(module.to_resolved().await?)
         else {
             bail!("WASM loader was not processed into an EcmascriptModuleAsset");
         };
 
-        Ok(esm_asset)
+        Ok(*esm_asset)
     }
 
     #[turbo_tasks::function]
     async fn loader(self: Vc<Self>) -> Result<Vc<Box<dyn EcmascriptChunkPlaceable>>> {
         let module = self.loader_as_module();
 
-        let Some(esm_asset) =
-            Vc::try_resolve_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(module).await?
-        else {
+        let Some(esm_asset) = ResolvedVc::try_sidecast::<Box<dyn EcmascriptChunkPlaceable>>(
+            module.to_resolved().await?,
+        ) else {
             bail!("WASM loader was not processed into an EcmascriptModuleAsset");
         };
 
-        Ok(esm_asset)
+        Ok(*esm_asset)
     }
 
     #[turbo_tasks::function]
@@ -259,9 +260,9 @@ impl EcmascriptChunkItem for ModuleChunkItem {
         let loader_asset = self.module.loader();
         let item = loader_asset.as_chunk_item(*self.module_graph, *self.chunking_context);
 
-        let ecmascript_item = Vc::try_resolve_downcast::<Box<dyn EcmascriptChunkItem>>(item)
-            .await?
-            .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?;
+        let ecmascript_item =
+            ResolvedVc::try_downcast::<Box<dyn EcmascriptChunkItem>>(item.to_resolved().await?)
+                .context("EcmascriptModuleAsset must implement EcmascriptChunkItem")?;
 
         let chunk_item_content = ecmascript_item
             .content_with_async_module_info(async_module_info, false)


### PR DESCRIPTION
These `try_resolve_*` methods predate the introduction of the `ResolvedVc` type.

`ResolvedVc` has efficient synchronous `try_downcast`/`try_sidecast` functions, and there are only a few callsites that need to do this, so it makes more sense to split the resolution and the casting into to separate calls.