### PR TITLE
feat(next/error): Add retry(), componentStack, and ownerStack to error.js

### DIFF
--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -1,11 +1,16 @@
 'use client'
 
-import React, { type JSX } from 'react'
+import React, { startTransition, type JSX } from 'react'
 import { useUntrackedPathname } from './navigation-untracked'
 import { isNextRouterError } from './is-next-router-error'
 import { handleHardNavError } from './nav-failure-handler'
 import { HandleISRError } from './handle-isr-error'
 import { isBot } from '../../shared/lib/router/utils/is-bot'
+import { publicAppRouterInstance } from './app-router-instance'
+import {
+  AppRouterContext,
+  type AppRouterInstance,
+} from '../../shared/lib/app-router-context.shared-runtime'
 
 const isBotUserAgent =
   typeof window !== 'undefined' && isBot(window.navigator.userAgent)
@@ -15,6 +20,9 @@ export type ErrorComponent = React.ComponentType<{
   // global-error, there's no `reset` function;
   // regular error boundary, there's a `reset` function.
   reset?: () => void
+  retry?: () => void
+  componentStack?: string
+  ownerStack?: string
 }>
 
 export interface ErrorBoundaryProps {
@@ -32,15 +40,28 @@ interface ErrorBoundaryHandlerProps extends ErrorBoundaryProps {
 interface ErrorBoundaryHandlerState {
   error: Error | null
   previousPathname: string | null
+  componentStack?: string
+  ownerStack?: string
 }
 
 export class ErrorBoundaryHandler extends React.Component<
   ErrorBoundaryHandlerProps,
   ErrorBoundaryHandlerState
 > {
+  static contextType = AppRouterContext
+  declare context: AppRouterInstance | null
+
   constructor(props: ErrorBoundaryHandlerProps) {
     super(props)
     this.state = { error: null, previousPathname: this.props.pathname }
+  }
+
+  componentDidCatch(_error: Error, info: React.ErrorInfo) {
+    this.setState({
+      componentStack: info.componentStack || undefined,
+      // @ts-expect-error ownerStack is not yet in @types/react
+      ownerStack: info.ownerStack,
+    })
   }
 
   static getDerivedStateFromError(error: Error) {
@@ -95,6 +116,14 @@ export class ErrorBoundaryHandler extends React.Component<
     this.setState({ error: null })
   }
 
+  retry = () => {
+    startTransition(() => {
+      publicAppRouterInstance.refresh()
+      this.context?.refresh()
+      this.reset()
+    })
+  }
+
   // Explicit type is needed to avoid the generated `.d.ts` having a wide return type that could be specific to the `@types/react` version.
   render(): React.ReactNode {
     //When it's bot request, segment level error boundary will keep rendering the children,
@@ -108,6 +137,9 @@ export class ErrorBoundaryHandler extends React.Component<
           <this.props.errorComponent
             error={this.state.error}
             reset={this.reset}
+            retry={this.retry}
+            componentStack={this.state.componentStack}
+            ownerStack={this.state.ownerStack}
           />
         </>
       )

--- a/packages/next/src/client/components/error-boundary.tsx
+++ b/packages/next/src/client/components/error-boundary.tsx
@@ -6,7 +6,6 @@ import { isNextRouterError } from './is-next-router-error'
 import { handleHardNavError } from './nav-failure-handler'
 import { HandleISRError } from './handle-isr-error'
 import { isBot } from '../../shared/lib/router/utils/is-bot'
-import { publicAppRouterInstance } from './app-router-instance'
 import {
   AppRouterContext,
   type AppRouterInstance,
@@ -118,7 +117,6 @@ export class ErrorBoundaryHandler extends React.Component<
 
   retry = () => {
     startTransition(() => {
-      publicAppRouterInstance.refresh()
       this.context?.refresh()
       this.reset()
     })

--- a/test/e2e/app-dir/error-retry/app/error.js
+++ b/test/e2e/app-dir/error-retry/app/error.js
@@ -1,0 +1,23 @@
+'use client'
+
+export default function Error({
+  error,
+  reset,
+  retry,
+  componentStack,
+  ownerStack,
+}) {
+  return (
+    <div>
+      <p id="error-message">{error.message}</p>
+      <div id="component-stack">{componentStack}</div>
+      <div id="owner-stack">{ownerStack}</div>
+      <button id="btn-reset" onClick={() => reset()}>
+        Reset
+      </button>
+      <button id="btn-retry" onClick={() => (retry ? retry() : null)}>
+        Retry
+      </button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/error-retry/app/layout.js
+++ b/test/e2e/app-dir/error-retry/app/layout.js
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/error-retry/app/page.js
+++ b/test/e2e/app-dir/error-retry/app/page.js
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  const c = await cookies()
+  const shouldFail = c.get('force-error')?.value === 'true'
+
+  if (shouldFail) {
+    throw new Error('Server Error Forced')
+  }
+
+  return <div id="success">Content Loaded Successfully</div>
+}

--- a/test/e2e/app-dir/error-retry/index.test.ts
+++ b/test/e2e/app-dir/error-retry/index.test.ts
@@ -1,0 +1,35 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('error-retry', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should recover from server error using retry()', async () => {
+    const browser = await next.browser('/')
+
+    // 1. Force error
+    await browser.addCookie({ name: 'force-error', value: 'true' })
+    await browser.refresh()
+
+    const text = await browser.elementById('error-message').text()
+    expect(text).toMatch(
+      /Server Error Forced|An error occurred in the Server Components render/
+    )
+
+    // Check component stack presence
+    const stack = await browser.elementById('component-stack').text()
+    expect(stack).toBeTruthy()
+
+    // 2. Fix error condition
+    await browser.addCookie({ name: 'force-error', value: 'false' })
+
+    // 3. Try retry (should work because it refreshes data)
+    await browser.elementById('btn-retry').click()
+
+    await browser.waitForElementByCss('#success')
+    expect(await browser.elementById('success').text()).toBe(
+      'Content Loaded Successfully'
+    )
+  })
+})


### PR DESCRIPTION
This PR implements the missing `retry()`, `componentStack`, and `ownerStack` props in the App Router's `error.js` component, enabling better error recovery and debugging capabilities.

**Changes:**
- Modified `packages/next/src/client/components/error-boundary.tsx` to:
  - Expose `retry` method using `startTransition` and `router.refresh()`.
  - Capture and pass `componentStack` and `ownerStack` from `componentDidCatch`.
- Added Comprehensive E2E Test (`test/e2e/app-dir/error-retry`):
  - Verifies error recovery mechanism using `retry()`.
  - Ensures `componentStack` is accessible in the error component.
  - Validates functionality in both development and production builds.

**Verification:**
- `pnpm test-dev-turbo test/e2e/app-dir/error-retry` (Passed)
- `pnpm test-start-turbo test/e2e/app-dir/error-retry` (Passed)