### PR TITLE
Turbopack: remove ChunkableModuleReference trait

### DIFF
--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -7,7 +7,7 @@ use turbo_tasks_fs::{FileSystem, VirtualFileSystem, rope::RopeBuilder};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
-        ChunkItem, ChunkType, ChunkableModule, ChunkableModuleReference, ChunkingContext,
+        ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ChunkingType, ChunkingTypeOption,
         EvaluatableAsset,
     },
     ident::AssetIdent,
@@ -147,10 +147,15 @@ impl ModuleReference for HmrEntryModuleReference {
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::module(self.module)
     }
-}
 
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for HmrEntryModuleReference {}
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
+}
 
 /// The chunk item for [`HmrEntryModule`].
 #[turbo_tasks::value]

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -4,7 +4,7 @@ use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{
     asset::{Asset, AssetContent},
-    chunk::{ChunkGroupType, ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    chunk::{ChunkGroupType, ChunkingType, ChunkingTypeOption},
     ident::AssetIdent,
     module::{Module, ModuleSideEffects},
     reference::{ModuleReference, ModuleReferences},
@@ -91,21 +91,18 @@ impl CssClientReference {
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkableModuleReference for CssClientReference {
+impl ModuleReference for CssClientReference {
+    #[turbo_tasks::function]
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        *ModuleResolveResult::module(self.module)
+    }
+
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Isolated {
             _ty: ChunkGroupType::Evaluated,
             merge_tag: Some(rcstr!("client")),
         }))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for CssClientReference {
-    #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -8,8 +8,8 @@ use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::AssetContent,
     chunk::{
-        AsyncModuleInfo, ChunkGroupType, ChunkItem, ChunkType, ChunkableModule,
-        ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption,
+        AsyncModuleInfo, ChunkGroupType, ChunkItem, ChunkType, ChunkableModule, ChunkingContext,
+        ChunkingType, ChunkingTypeOption,
     },
     code_builder::CodeBuilder,
     context::AssetContext,
@@ -365,21 +365,18 @@ impl EcmascriptClientReference {
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkableModuleReference for EcmascriptClientReference {
+impl ModuleReference for EcmascriptClientReference {
+    #[turbo_tasks::function]
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        *ModuleResolveResult::module(self.module)
+    }
+
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Isolated {
             _ty: self.ty,
             merge_tag: self.merge_tag.clone(),
         }))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for EcmascriptClientReference {
-    #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        *ModuleResolveResult::module(self.module)
     }
 }
 

--- a/crates/next-core/src/next_server_component/server_component_reference.rs
+++ b/crates/next-core/src/next_server_component/server_component_reference.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    chunk::{ChunkingType, ChunkingTypeOption},
     module::Module,
     reference::ModuleReference,
     resolve::ModuleResolveResult,
@@ -41,10 +41,6 @@ impl ModuleReference for NextServerComponentModuleReference {
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::module(self.asset)
     }
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for NextServerComponentModuleReference {
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Shared {

--- a/crates/next-core/src/next_server_utility/server_utility_reference.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_reference.rs
@@ -3,7 +3,7 @@ use once_cell::sync::Lazy;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    chunk::{ChunkingType, ChunkingTypeOption},
     module::Module,
     reference::ModuleReference,
     resolve::ModuleResolveResult,
@@ -36,18 +36,15 @@ impl ValueToString for NextServerUtilityModuleReference {
     }
 }
 
+pub static NEXT_SERVER_UTILITY_MERGE_TAG: Lazy<RcStr> = Lazy::new(|| rcstr!("next-server-utility"));
+
 #[turbo_tasks::value_impl]
 impl ModuleReference for NextServerUtilityModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::module(self.asset)
     }
-}
 
-pub static NEXT_SERVER_UTILITY_MERGE_TAG: Lazy<RcStr> = Lazy::new(|| rcstr!("next-server-utility"));
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for NextServerUtilityModuleReference {
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Shared {

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -44,8 +44,6 @@ use crate::{
         module_batch::{ChunkableModuleOrBatch, ModuleBatchGroup},
     },
     output::{OutputAssets, OutputAssetsReference},
-    reference::ModuleReference,
-    resolve::BindingUsage,
 };
 
 /// A module id, which can be a number or string
@@ -389,28 +387,6 @@ impl ChunkingType {
 
 #[turbo_tasks::value(transparent)]
 pub struct ChunkingTypeOption(Option<ChunkingType>);
-
-/// A [ModuleReference] implementing this trait and returning Some(_) for
-/// [ChunkableModuleReference::chunking_type] are considered as potentially
-/// chunkable references. When all [Module]s of such a reference implement
-/// [ChunkableModule] they are placed in [Chunk]s during chunking.
-/// They are even potentially placed in the same [Chunk] when a chunk type
-/// specific interface is implemented.
-#[turbo_tasks::value_trait]
-pub trait ChunkableModuleReference: ModuleReference + ValueToString {
-    #[turbo_tasks::function]
-    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::Parallel {
-            inherit_async: false,
-            hoisted: false,
-        }))
-    }
-
-    #[turbo_tasks::function]
-    fn binding_usage(self: Vc<Self>) -> Vc<BindingUsage> {
-        BindingUsage::all()
-    }
-}
 
 pub struct ChunkGroupContent {
     pub chunkable_items: Vec<ChunkableModuleOrBatch>,

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexSet, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexSet, Vc};
 use turbo_tasks_fs::FileContent;
 
 use super::{
@@ -8,7 +8,7 @@ use super::{
 };
 use crate::{
     asset::AssetContent,
-    chunk::{ChunkableModuleReference, ChunkingType},
+    chunk::ChunkingType,
     output::OutputAssetsWithReferenced,
     reference::{ModuleReference, ModuleReferences},
 };
@@ -68,25 +68,19 @@ pub async fn children_from_module_references(
     let mut children = FxIndexSet::default();
     let references = references.await?;
     for &reference in &*references {
-        let key = if let Some(chunkable) =
-            ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(reference)
-        {
-            match &*chunkable.chunking_type().await? {
-                None => key.clone(),
-                Some(ChunkingType::Parallel { inherit_async, .. }) => {
-                    if *inherit_async {
-                        parallel_inherit_async_reference_ty()
-                    } else {
-                        parallel_reference_ty()
-                    }
+        let key = match &*reference.chunking_type().await? {
+            None => key.clone(),
+            Some(ChunkingType::Parallel { inherit_async, .. }) => {
+                if *inherit_async {
+                    parallel_inherit_async_reference_ty()
+                } else {
+                    parallel_reference_ty()
                 }
-                Some(ChunkingType::Async) => async_reference_ty(),
-                Some(ChunkingType::Isolated { .. }) => isolated_reference_ty(),
-                Some(ChunkingType::Shared { .. }) => shared_reference_ty(),
-                Some(ChunkingType::Traced) => traced_reference_ty(),
             }
-        } else {
-            key.clone()
+            Some(ChunkingType::Async) => async_reference_ty(),
+            Some(ChunkingType::Isolated { .. }) => isolated_reference_ty(),
+            Some(ChunkingType::Shared { .. }) => shared_reference_ty(),
+            Some(ChunkingType::Traced) => traced_reference_ty(),
         };
 
         for &module in reference

--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -675,7 +675,7 @@ impl ModuleGraph {
     /// Analyze the module graph and remove unused references (by determining the used exports and
     /// removing unused imports).
     ///
-    /// In particular, this removes ChunkableModuleReference-s that list only unused exports in the
+    /// In particular, this removes ModuleReference-s that list only unused exports in the
     /// `import_usage()`
     #[turbo_tasks::function(operation)]
     pub async fn from_single_graph_without_unused_references(
@@ -691,7 +691,7 @@ impl ModuleGraph {
     /// Analyze the module graph and remove unused references (by determining the used exports and
     /// removing unused imports).
     ///
-    /// In particular, this removes ChunkableModuleReference-s that list only unused exports in the
+    /// In particular, this removes ModuleReference-s that list only unused exports in the
     /// `import_usage()`
     #[turbo_tasks::function(operation)]
     pub async fn from_graphs_without_unused_references(
@@ -1562,7 +1562,7 @@ struct SingleModuleGraphBuilder<'a> {
     /// Whether to walk ChunkingType::Traced references
     include_traced: bool,
 
-    /// Whether to read ChunkableModuleReference::binding_usage()
+    /// Whether to read ModuleReference::binding_usage()
     include_binding_usage: bool,
 }
 impl Visit<SingleModuleGraphBuilderNode, RefData> for SingleModuleGraphBuilder<'_> {

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -9,7 +9,7 @@ use turbo_tasks::{
 };
 
 use crate::{
-    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    chunk::{ChunkingType, ChunkingTypeOption},
     module::{Module, Modules},
     output::{
         ExpandOutputAssetsInput, ExpandedOutputAssets, OutputAsset, OutputAssets,
@@ -23,18 +23,26 @@ pub mod source_map;
 pub use source_map::SourceMapReference;
 
 /// A reference to one or multiple [Module]s, [OutputAsset]s or other special
-/// things. There are a bunch of optional traits that can influence how these
-/// references are handled. e. g. [ChunkableModuleReference]
+/// things.
 ///
 /// [Module]: crate::module::Module
 /// [OutputAsset]: crate::output::OutputAsset
-/// [ChunkableModuleReference]: crate::chunk::ChunkableModuleReference
 #[turbo_tasks::value_trait]
 pub trait ModuleReference: ValueToString {
     #[turbo_tasks::function]
     fn resolve_reference(self: Vc<Self>) -> Vc<ModuleResolveResult>;
     // TODO think about different types
     // fn kind(&self) -> Vc<AssetReferenceType>;
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(None)
+    }
+
+    #[turbo_tasks::function]
+    fn binding_usage(self: Vc<Self>) -> Vc<BindingUsage> {
+        BindingUsage::all()
+    }
 }
 
 /// Multiple [ModuleReference]s
@@ -113,7 +121,12 @@ impl SingleChunkableModuleReference {
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkableModuleReference for SingleChunkableModuleReference {
+impl ModuleReference for SingleChunkableModuleReference {
+    #[turbo_tasks::function]
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        *ModuleResolveResult::module(self.asset)
+    }
+
     #[turbo_tasks::function]
     fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Parallel {
@@ -129,14 +142,6 @@ impl ChunkableModuleReference for SingleChunkableModuleReference {
             export: self.export.owned().await?,
         }
         .cell())
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for SingleChunkableModuleReference {
-    #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        *ModuleResolveResult::module(self.asset)
     }
 }
 
@@ -235,6 +240,11 @@ impl ModuleReference for TracedModuleReference {
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::module(self.module)
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Traced))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -244,14 +254,6 @@ impl ValueToString for TracedModuleReference {
         Ok(Vc::cell(
             format!("traced {}", self.module.ident().to_string().await?).into(),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for TracedModuleReference {
-    #[turbo_tasks::function]
-    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::Traced))
     }
 }
 
@@ -303,9 +305,9 @@ pub struct ResolvedReference {
 #[turbo_tasks::value(transparent)]
 pub struct ModulesWithRefData(Vec<(ResolvedVc<Box<dyn ModuleReference>>, ResolvedReference)>);
 
-/// Aggregates all primary [Module]s referenced by an [Module] via [ChunkableModuleReference]s.
-/// This does not include transitively referenced [Module]s, only includes
-/// primary [Module]s referenced.
+/// Aggregates all primary [Module]s referenced by an [Module] via [ModuleReference]s with a
+/// non-empty chunking_type. This does not include transitively referenced [Module]s, only primary
+/// [Module]s referenced.
 ///
 /// [Module]: crate::module::Module
 #[turbo_tasks::function]
@@ -319,10 +321,7 @@ pub async fn primary_chunkable_referenced_modules(
         .await?
         .iter()
         .map(|reference| async {
-            if let Some(reference) =
-                ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(*reference)
-                && let Some(chunking_type) = &*reference.chunking_type().await?
-            {
+            if let Some(chunking_type) = &*reference.chunking_type().await? {
                 if !include_traced && matches!(chunking_type, ChunkingType::Traced) {
                     return Ok(None);
                 }
@@ -339,7 +338,7 @@ pub async fn primary_chunkable_referenced_modules(
                 };
 
                 return Ok(Some((
-                    ResolvedVc::upcast(reference),
+                    *reference,
                     ResolvedReference {
                         chunking_type: chunking_type.clone(),
                         binding_usage,

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -2,7 +2,6 @@ use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    chunk::ChunkableModuleReference,
     reference::ModuleReference,
     reference_type::CssReferenceSubType,
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
@@ -53,6 +52,3 @@ impl ValueToString for CssModuleComposeReference {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for CssModuleComposeReference {}

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
+    chunk::{ChunkingType, ChunkingTypeOption},
     reference::ModuleReference,
     reference_type::CssReferenceSubType,
     resolve::{ModuleResolveResult, origin::ResolveOrigin, parse::Request},
@@ -40,6 +41,14 @@ impl ModuleReference for CssModuleComposeReference {
             // TODO: add real issue source, currently impossible
             None,
         )
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -9,7 +9,7 @@ use lightningcss::{
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingContext},
+    chunk::ChunkingContext,
     issue::IssueSource,
     reference::ModuleReference,
     reference_type::{CssReferenceSubType, ImportContext},
@@ -205,6 +205,3 @@ impl CodeGenerateable for ImportAssetReference {
         Ok(CodeGeneration { imports }.cell())
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for ImportAssetReference {}

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -9,7 +9,7 @@ use lightningcss::{
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    chunk::ChunkingContext,
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption},
     issue::IssueSource,
     reference::ModuleReference,
     reference_type::{CssReferenceSubType, ImportContext},
@@ -140,6 +140,14 @@ impl ModuleReference for ImportAssetReference {
             CssReferenceSubType::AtImport(import_context),
             Some(self.issue_source),
         ))
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/internal.rs
+++ b/turbopack/crates/turbopack-css/src/references/internal.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbopack_core::{
-    chunk::ChunkableModuleReference, module::Module, reference::ModuleReference,
-    resolve::ModuleResolveResult,
-};
+use turbopack_core::{module::Module, reference::ModuleReference, resolve::ModuleResolveResult};
 
 /// A reference to an internal CSS asset.
 #[turbo_tasks::value]
@@ -39,6 +36,3 @@ impl ValueToString for InternalCssAssetReference {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for InternalCssAssetReference {}

--- a/turbopack/crates/turbopack-css/src/references/internal.rs
+++ b/turbopack/crates/turbopack-css/src/references/internal.rs
@@ -1,7 +1,12 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
-use turbopack_core::{module::Module, reference::ModuleReference, resolve::ModuleResolveResult};
+use turbopack_core::{
+    chunk::{ChunkingType, ChunkingTypeOption},
+    module::Module,
+    reference::ModuleReference,
+    resolve::ModuleResolveResult,
+};
 
 /// A reference to an internal CSS asset.
 #[turbo_tasks::value]
@@ -24,6 +29,14 @@ impl ModuleReference for InternalCssAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::module(self.module)
+    }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingContext},
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption},
     issue::IssueSource,
     output::OutputAsset,
     reference::ModuleReference,
@@ -84,10 +84,15 @@ impl ModuleReference for UrlAssetReference {
             ResolveErrorMode::Error,
         )
     }
-}
 
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for UrlAssetReference {}
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
+}
 
 #[turbo_tasks::value_impl]
 impl ValueToString for UrlAssetReference {

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -16,7 +16,7 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingContext},
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption},
     issue::IssueSource,
     reference::ModuleReference,
     reference_type::CommonJsReferenceSubType,
@@ -73,6 +73,14 @@ impl ModuleReference for AmdDefineAssetReference {
             self.error_mode,
         )
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -84,9 +92,6 @@ impl ValueToString for AmdDefineAssetReference {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for AmdDefineAssetReference {}
 
 #[derive(
     ValueDebugFormat, Debug, PartialEq, Eq, TraceRawVcs, Clone, NonLocalValue, Hash, Encode, Decode,

--- a/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/async_module.rs
@@ -11,7 +11,7 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbopack_core::{
-    chunk::{AsyncModuleInfo, ChunkableModuleReference, ChunkingContext, ChunkingType},
+    chunk::{AsyncModuleInfo, ChunkingContext, ChunkingType},
     reference::{ModuleReference, ModuleReferences},
     resolve::ExternalType,
 };
@@ -88,9 +88,6 @@ struct AsyncModuleIdents(
 async fn get_inherit_async_referenced_asset(
     r: ResolvedVc<Box<dyn ModuleReference>>,
 ) -> Result<Option<ReadRef<ReferencedAsset>>> {
-    let Some(r) = ResolvedVc::try_downcast::<Box<dyn ChunkableModuleReference>>(r) else {
-        return Ok(None);
-    };
     let Some(ty) = &*r.chunking_type().await? else {
         return Ok(None);
     };

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingContext},
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption},
     issue::IssueSource,
     reference::ModuleReference,
     reference_type::CommonJsReferenceSubType,
@@ -67,6 +67,14 @@ impl ModuleReference for CjsAssetReference {
             self.error_mode,
         )
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -78,9 +86,6 @@ impl ValueToString for CjsAssetReference {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for CjsAssetReference {}
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug)]
@@ -119,6 +124,14 @@ impl ModuleReference for CjsRequireAssetReference {
             self.error_mode,
         )
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -130,9 +143,6 @@ impl ValueToString for CjsRequireAssetReference {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for CjsRequireAssetReference {}
 
 impl IntoCodeGenReference for CjsRequireAssetReference {
     fn into_code_gen_reference(
@@ -246,6 +256,14 @@ impl ModuleReference for CjsRequireResolveAssetReference {
             self.error_mode,
         )
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -257,9 +275,6 @@ impl ValueToString for CjsRequireResolveAssetReference {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for CjsRequireResolveAssetReference {}
 
 impl IntoCodeGenReference for CjsRequireResolveAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -13,10 +13,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{
-        ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption,
-        ModuleChunkItemIdExt,
-    },
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption, ModuleChunkItemIdExt},
     issue::{
         Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
         OptionStyledString, StyledString,
@@ -474,18 +471,7 @@ impl ModuleReference for EsmAssetReference {
 
         Ok(result)
     }
-}
 
-#[turbo_tasks::value_impl]
-impl ValueToString for EsmAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(format!("import {} with {}", self.request, self.annotations).into())
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for EsmAssetReference {
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Result<Vc<ChunkingTypeOption>> {
         Ok(Vc::cell(
@@ -523,6 +509,14 @@ impl ChunkableModuleReference for EsmAssetReference {
             },
         }
         .cell()
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl ValueToString for EsmAssetReference {
+    #[turbo_tasks::function]
+    fn to_string(&self) -> Vc<RcStr> {
+        Vc::cell(format!("import {} with {}", self.request, self.annotations).into())
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -10,7 +10,7 @@ use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption},
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption},
     environment::ChunkLoading,
     issue::IssueSource,
     reference::ModuleReference,
@@ -87,6 +87,11 @@ impl ModuleReference for EsmAsyncAssetReference {
         )
         .await
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Async))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -96,14 +101,6 @@ impl ValueToString for EsmAsyncAssetReference {
         Ok(Vc::cell(
             format!("dynamic import {}", self.request.to_string().await?,).into(),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for EsmAsyncAssetReference {
-    #[turbo_tasks::function]
-    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::Async))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -6,7 +6,7 @@ use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingContext, ChunkingTypeOption, ModuleChunkItemIdExt},
+    chunk::{ChunkingContext, ChunkingTypeOption, ModuleChunkItemIdExt},
     reference::ModuleReference,
     resolve::ModuleResolveResult,
 };
@@ -39,6 +39,11 @@ impl ModuleReference for EsmModuleIdAssetReference {
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         self.inner.resolve_reference()
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
+        self.inner.chunking_type()
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -48,14 +53,6 @@ impl ValueToString for EsmModuleIdAssetReference {
         Ok(Vc::cell(
             format!("module id of {}", self.inner.to_string().await?,).into(),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for EsmModuleIdAssetReference {
-    #[turbo_tasks::function]
-    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
-        self.inner.chunking_type()
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -10,10 +10,7 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbopack_core::{
-    chunk::{
-        ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption,
-        ModuleChunkItemIdExt,
-    },
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption, ModuleChunkItemIdExt},
     environment::Rendering,
     issue::IssueSource,
     reference::ModuleReference,
@@ -100,6 +97,14 @@ impl ModuleReference for UrlAssetReference {
             self.error_mode,
         )
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -109,17 +114,6 @@ impl ValueToString for UrlAssetReference {
         Ok(Vc::cell(
             format!("new URL({})", self.request.to_string().await?,).into(),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for UrlAssetReference {
-    #[turbo_tasks::function]
-    fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
-        Vc::cell(Some(ChunkingType::Parallel {
-            inherit_async: false,
-            hoisted: false,
-        }))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -4,7 +4,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{ChunkableModuleReference, ChunkingType, ChunkingTypeOption},
+    chunk::{ChunkingType, ChunkingTypeOption},
     file_source::FileSource,
     issue::IssueSource,
     raw_module::RawModule,
@@ -76,9 +76,7 @@ impl ModuleReference for FileSourceReference {
         .instrument(span)
         .await
     }
-}
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for FileSourceReference {
+
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Traced))
@@ -216,10 +214,7 @@ impl ModuleReference for DirAssetReference {
         .instrument(span)
         .await
     }
-}
 
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for DirAssetReference {
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Traced))

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -22,7 +22,7 @@ use turbo_tasks::{
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemPath};
 use turbopack_core::{
     chunk::{
-        ChunkItem, ChunkType, ChunkableModule, ChunkableModuleReference, ChunkingContext,
+        ChunkItem, ChunkType, ChunkableModule, ChunkingContext, ChunkingType, ChunkingTypeOption,
         MinifyType, ModuleChunkItemIdExt,
     },
     ident::AssetIdent,
@@ -286,6 +286,14 @@ impl ModuleReference for RequireContextAssetReference {
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::module(ResolvedVc::upcast(self.inner))
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -302,9 +310,6 @@ impl ValueToString for RequireContextAssetReference {
         )
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for RequireContextAssetReference {}
 
 impl IntoCodeGenReference for RequireContextAssetReference {
     fn into_code_gen_reference(
@@ -372,6 +377,14 @@ impl ModuleReference for ResolvedModuleReference {
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *self.0
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 #[turbo_tasks::value_impl]
@@ -381,9 +394,6 @@ impl ValueToString for ResolvedModuleReference {
         Vc::cell(rcstr!("resolved reference"))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for ResolvedModuleReference {}
 
 #[turbo_tasks::value]
 pub struct RequireContextAsset {

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -11,7 +11,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
-    chunk::{ChunkableModule, ChunkableModuleReference, ChunkingContext, EvaluatableAsset},
+    chunk::{ChunkableModule, ChunkingContext, ChunkingType, ChunkingTypeOption, EvaluatableAsset},
     context::AssetContext,
     issue::{IssueExt, IssueSeverity, IssueSource, StyledString, code_gen::CodeGenerationIssue},
     module::Module,
@@ -255,6 +255,14 @@ impl ModuleReference for WorkerAssetReference {
         }
         .cell())
     }
+
+    #[turbo_tasks::function]
+    fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
+        Vc::cell(Some(ChunkingType::Parallel {
+            inherit_async: false,
+            hoisted: false,
+        }))
+    }
 }
 
 impl WorkerAssetReference {
@@ -293,9 +301,6 @@ impl ValueToString for WorkerAssetReference {
         ))
     }
 }
-
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for WorkerAssetReference {}
 
 impl IntoCodeGenReference for WorkerAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -8,10 +8,7 @@ use swc_core::{
 use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, ValueToString, Vc, trace::TraceRawVcs};
 use turbopack_core::{
-    chunk::{
-        ChunkableModuleReference, ChunkingContext, ChunkingType, ChunkingTypeOption,
-        ModuleChunkItemIdExt,
-    },
+    chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption, ModuleChunkItemIdExt},
     module::Module,
     reference::ModuleReference,
     resolve::{BindingUsage, ExportUsage, ImportUsage, ModulePart, ModuleResolveResult},
@@ -131,10 +128,7 @@ impl ModuleReference for EcmascriptModulePartReference {
 
         Ok(*ModuleResolveResult::module(module))
     }
-}
 
-#[turbo_tasks::value_impl]
-impl ChunkableModuleReference for EcmascriptModulePartReference {
     #[turbo_tasks::function]
     fn chunking_type(self: Vc<Self>) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Parallel {

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -2,10 +2,7 @@ use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
-    chunk::{
-        ChunkGroupType, ChunkableModule, ChunkableModuleReference, ChunkingContext, ChunkingType,
-        ChunkingTypeOption,
-    },
+    chunk::{ChunkGroupType, ChunkableModule, ChunkingContext, ChunkingType, ChunkingTypeOption},
     context::AssetContext,
     ident::AssetIdent,
     module::{Module, ModuleSideEffects},
@@ -112,7 +109,12 @@ impl WorkerModuleReference {
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkableModuleReference for WorkerModuleReference {
+impl ModuleReference for WorkerModuleReference {
+    #[turbo_tasks::function]
+    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
+        *ModuleResolveResult::module(self.module)
+    }
+
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Isolated {
@@ -122,14 +124,6 @@ impl ChunkableModuleReference for WorkerModuleReference {
             },
             merge_tag: None,
         }))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ModuleReference for WorkerModuleReference {
-    #[turbo_tasks::function]
-    fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
-        *ModuleResolveResult::module(self.module)
     }
 }
 


### PR DESCRIPTION
Previously, we checked "has to implement `ChunkableModuleReference` and `.chunking_type()` has to be Some"

Now, it's just "`.chunking_type()` has to be Some"

So not many logic changes were necessary.

99% of references are chunkable anyway, so the free `try_downcast().is_some()` to guard `chunking_type()` wasn't helping anyway.