### PR TITLE
Tracing: trace render times as render-path

### DIFF
--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -8,6 +8,7 @@ import type { UrlWithParsedQuery } from 'url'
 import type { MiddlewareRoutingItem } from '../base-server'
 import type { RouteDefinition } from '../route-definitions/route-definition'
 import type { RouteMatcherManager } from '../route-matcher-managers/route-matcher-manager'
+
 import {
   addRequestMeta,
   getRequestMeta,
@@ -39,7 +40,12 @@ import { normalizePagePath } from '../../shared/lib/page-path/normalize-page-pat
 import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
 import { removePathPrefix } from '../../shared/lib/router/utils/remove-path-prefix'
 import { Telemetry } from '../../telemetry/storage'
-import { type Span, setGlobal, trace } from '../../trace'
+import {
+  type Span,
+  hrtimeToEpochNanoseconds,
+  setGlobal,
+  trace,
+} from '../../trace'
 import { traceGlobals } from '../../trace/shared'
 import { findPageFile } from '../lib/find-page-file'
 import { getFormattedNodeOptionsWithoutInspect } from '../lib/utils'
@@ -532,6 +538,20 @@ export default class DevServer extends Server {
               getRequestMeta(req, 'devRequestTimingInternalsEnd'),
               getRequestMeta(req, 'devGenerateStaticParamsDuration')
             )
+
+            // Create trace span for render phase
+            const devRequestTimingInternalsEnd = getRequestMeta(
+              req,
+              'devRequestTimingInternalsEnd'
+            )
+            if (devRequestTimingInternalsEnd) {
+              this.startServerSpan.manualTraceChild(
+                'render-path',
+                hrtimeToEpochNanoseconds(devRequestTimingInternalsEnd),
+                hrtimeToEpochNanoseconds(requestEnd),
+                { path: req.url || '' }
+              )
+            }
           })
         }
       }

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -414,6 +414,9 @@ export async function startServer(
               cleanupListeners?.runAll().catch(console.error),
             ])
 
+            // Flush any remaining traces to the trace file on shutdown
+            await flushAllTraces()
+
             // Flush telemetry if this is a dev server
             if (isDev) {
               try {

--- a/packages/next/src/trace/index.ts
+++ b/packages/next/src/trace/index.ts
@@ -7,6 +7,7 @@ import {
   recordTraceEvents,
   Span,
   SpanStatus,
+  hrtimeToEpochNanoseconds,
 } from './trace'
 import { setGlobal } from './shared'
 import type { SpanId, TraceEvent, TraceState } from './types'
@@ -16,6 +17,7 @@ export {
   exportTraceState,
   flushAllTraces,
   getTraceEvents,
+  hrtimeToEpochNanoseconds,
   initializeTraceState,
   recordTraceEvents,
   Span,

--- a/packages/next/src/trace/trace-uploader.ts
+++ b/packages/next/src/trace/trace-uploader.ts
@@ -15,6 +15,7 @@ const COMMON_ALLOWED_EVENTS = ['memory-usage']
 const DEV_ALLOWED_EVENTS = new Set([
   ...COMMON_ALLOWED_EVENTS,
   'client-hmr-latency',
+  'render-path',
   'hot-reloader',
   'webpack-invalid-client',
   'webpack-invalidated-server',

--- a/packages/next/src/trace/trace.ts
+++ b/packages/next/src/trace/trace.ts
@@ -3,6 +3,7 @@ import type { SpanId, TraceEvent, TraceState } from './types'
 
 const NUM_OF_MICROSEC_IN_NANOSEC = BigInt('1000')
 const NUM_OF_MILLISEC_IN_NANOSEC = BigInt('1000000')
+
 let count = 0
 const getId = () => {
   count++
@@ -188,3 +189,18 @@ export function recordTraceEvents(events: TraceEvent[]) {
 }
 
 export const clearTraceEvents = () => (savedTraceEvents = [])
+
+/**
+ * Converts hrtime (process.hrtime.bigint()) to epoch-based nanoseconds.
+ *
+ * hrtime values are relative to an arbitrary point in the past, while
+ * epoch-based times are nanoseconds since Unix epoch (Jan 1, 1970).
+ *
+ * This is useful when passing hrtime values to APIs that expect epoch-based times,
+ * such as Span.manualTraceChild().
+ */
+export function hrtimeToEpochNanoseconds(hrtimeValue: bigint): bigint {
+  const offset =
+    BigInt(Date.now()) * NUM_OF_MILLISEC_IN_NANOSEC - process.hrtime.bigint()
+  return hrtimeValue + offset
+}

--- a/test/development/app-dir/hmr-trace-timing/app/layout.tsx
+++ b/test/development/app-dir/hmr-trace-timing/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/hmr-trace-timing/app/page.tsx
+++ b/test/development/app-dir/hmr-trace-timing/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/hmr-trace-timing/hmr-trace-timing.test.ts
+++ b/test/development/app-dir/hmr-trace-timing/hmr-trace-timing.test.ts
@@ -1,0 +1,97 @@
+import { nextTestSetup } from 'e2e-utils'
+import { join } from 'path'
+import { existsSync, readFileSync } from 'fs'
+
+type SpanId = number
+
+type TraceEvent = {
+  traceId?: string
+  parentId?: SpanId
+  name: string
+  id: SpanId
+  timestamp: number
+  duration: number
+  tags?: Record<string, unknown>
+  startTime?: number
+}
+
+interface TraceStructure {
+  events: TraceEvent[]
+  eventsByName: Map<string, TraceEvent[]>
+  eventsById: Map<string, TraceEvent>
+}
+
+function parseTraceFile(tracePath: string): TraceStructure {
+  const traceContent = readFileSync(tracePath, 'utf8')
+  const traceLines = traceContent
+    .trim()
+    .split('\n')
+    .filter((line) => line.trim())
+
+  const allEvents: TraceEvent[] = []
+
+  for (const line of traceLines) {
+    const events = JSON.parse(line) as TraceEvent[]
+    allEvents.push(...events)
+  }
+
+  const eventsByName = new Map<string, TraceEvent[]>()
+  const eventsById = new Map<string, TraceEvent>()
+
+  // Index all events
+  for (const event of allEvents) {
+    if (!eventsByName.has(event.name)) {
+      eventsByName.set(event.name, [])
+    }
+    eventsByName.get(event.name)!.push(event)
+    eventsById.set(event.id.toString(), event)
+  }
+
+  return {
+    events: allEvents,
+    eventsByName,
+    eventsById,
+  }
+}
+
+describe('render-path tracing', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (!isNextDev) {
+    it('should be skipped in production', () => {})
+    return
+  }
+
+  it('should record render-path events for page requests', async () => {
+    const tracePath = join(next.testDir, '.next/dev/trace')
+
+    // Trigger page request if trace doesn't exist yet
+    if (!existsSync(tracePath)) {
+      const browser = await next.browser('/')
+      expect(await browser.elementByCss('p').text()).toBe('hello world')
+      await browser.close()
+      await next.stop('SIGTERM')
+      await new Promise((resolve) => setTimeout(resolve, 500))
+    }
+
+    const traceStructure = parseTraceFile(tracePath)
+
+    // Check for render-path events
+    const renderPathEvents = traceStructure.eventsByName.get('render-path')
+    expect(renderPathEvents).toBeDefined()
+    expect(renderPathEvents!.length).toBeGreaterThan(0)
+
+    // Verify the first render-path event has expected attributes
+    const renderEvent = renderPathEvents![0]
+    expect(renderEvent.tags).toBeDefined()
+    const renderTags = renderEvent.tags as any
+
+    expect(renderTags.path).toBeDefined()
+    expect(typeof renderTags.path).toBe('string')
+
+    // Verify render event has valid duration
+    expect(renderEvent.duration).toBeGreaterThan(0)
+  })
+})

--- a/test/development/app-dir/hmr-trace-timing/next.config.js
+++ b/test/development/app-dir/hmr-trace-timing/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
Analagous to the existing compile-path, which records compile times for each path in development, we now record path render times as `render-path`. It corresponds with the value we write to the tty when rendering routes (e.g. `GET / 200 in 228ms (compile: 129ms, render: 99ms)`).

This change also adds tests for recording hmr data in the trace file.

Test Plan:
- CI
- Made changes in a test app and verified the trace file included valid
  entries for these. Confirmed the duration matched what was shown in
the cli.
