### PR TITLE
Fix cascading LRU eviction during prefetch batches

### DIFF
--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -7,6 +7,7 @@ import type { UnknownMapEntry } from './cache-map'
 let head: UnknownMapEntry | null = null
 let didScheduleCleanup: boolean = false
 let lruSize: number = 0
+let cleanupHoldCount: number = 0
 
 // TODO: I chose the max size somewhat arbitrarily. Consider setting this based
 // on navigator.deviceMemory, or some other heuristic. We should make this
@@ -95,8 +96,17 @@ export function deleteFromLru(deleted: UnknownMapEntry) {
   }
 }
 
+export function holdCleanup() {
+  cleanupHoldCount++
+}
+
+export function releaseCleanup() {
+  cleanupHoldCount--
+  ensureCleanupIsScheduled()
+}
+
 function ensureCleanupIsScheduled() {
-  if (didScheduleCleanup || lruSize <= maxLruSize) {
+  if (didScheduleCleanup || lruSize <= maxLruSize || cleanupHoldCount > 0) {
     return
   }
   didScheduleCleanup = true
@@ -105,6 +115,13 @@ function ensureCleanupIsScheduled() {
 
 function cleanup() {
   didScheduleCleanup = false
+
+  if (cleanupHoldCount > 0) {
+    // Cleanup is deferred because there are active prefetch tasks that haven't
+    // finished reading from the cache yet. Once all holds are released,
+    // releaseCleanup will re-schedule cleanup if still needed.
+    return
+  }
 
   // Evict entries until we're at 90% capacity. We can assume this won't
   // infinite loop because even if `maxLruSize` were 0, eventually

--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -1,11 +1,11 @@
 import { deleteMapEntry } from './cache-map'
 import type { UnknownMapEntry } from './cache-map'
+import { pingPrefetchScheduler } from './scheduler'
 
 // We use an LRU for memory management. We must update this whenever we add or
 // remove a new cache entry, or when an entry changes size.
 
 let head: UnknownMapEntry | null = null
-let scheduleCleanup: () => void = cleanup
 let lruSize: number = 0
 
 // TODO: I chose the max size somewhat arbitrarily. Consider setting this based
@@ -99,11 +99,7 @@ function ensureCleanupIsScheduled() {
   if (lruSize <= maxLruSize) {
     return
   }
-  scheduleCleanup()
-}
-
-export function registerScheduleCleanup(cb: () => void) {
-  scheduleCleanup = cb
+  pingPrefetchScheduler()
 }
 
 export function cleanup() {

--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -99,6 +99,10 @@ function ensureCleanupIsScheduled() {
   if (lruSize <= maxLruSize) {
     return
   }
+
+  // To schedule cleanup, ping the prefetch scheduler. At the end of its work
+  // loop, once there are no queued tasks and no in-progress requests, it will
+  // call cleanup().
   pingPrefetchScheduler()
 }
 

--- a/packages/next/src/client/components/segment-cache/lru.ts
+++ b/packages/next/src/client/components/segment-cache/lru.ts
@@ -5,9 +5,8 @@ import type { UnknownMapEntry } from './cache-map'
 // remove a new cache entry, or when an entry changes size.
 
 let head: UnknownMapEntry | null = null
-let didScheduleCleanup: boolean = false
+let scheduleCleanup: () => void = cleanup
 let lruSize: number = 0
-let cleanupHoldCount: number = 0
 
 // TODO: I chose the max size somewhat arbitrarily. Consider setting this based
 // on navigator.deviceMemory, or some other heuristic. We should make this
@@ -96,30 +95,19 @@ export function deleteFromLru(deleted: UnknownMapEntry) {
   }
 }
 
-export function holdCleanup() {
-  cleanupHoldCount++
-}
-
-export function releaseCleanup() {
-  cleanupHoldCount--
-  ensureCleanupIsScheduled()
-}
-
 function ensureCleanupIsScheduled() {
-  if (didScheduleCleanup || lruSize <= maxLruSize || cleanupHoldCount > 0) {
+  if (lruSize <= maxLruSize) {
     return
   }
-  didScheduleCleanup = true
-  requestCleanupCallback(cleanup)
+  scheduleCleanup()
 }
 
-function cleanup() {
-  didScheduleCleanup = false
+export function registerScheduleCleanup(cb: () => void) {
+  scheduleCleanup = cb
+}
 
-  if (cleanupHoldCount > 0) {
-    // Cleanup is deferred because there are active prefetch tasks that haven't
-    // finished reading from the cache yet. Once all holds are released,
-    // releaseCleanup will re-schedule cleanup if still needed.
+export function cleanup() {
+  if (lruSize <= maxLruSize) {
     return
   }
 
@@ -137,8 +125,3 @@ function cleanup() {
     }
   }
 }
-
-const requestCleanupCallback =
-  typeof requestIdleCallback === 'function'
-    ? requestIdleCallback
-    : (cb: () => void) => setTimeout(cb, 0)

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -44,7 +44,7 @@ import {
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import type { SegmentRequestKey } from '../../../shared/lib/segment-cache/segment-value-encoding'
-import { registerScheduleCleanup, cleanup } from './lru'
+import { cleanup } from './lru'
 
 const scheduleMicrotask =
   typeof queueMicrotask === 'function'
@@ -238,7 +238,7 @@ export function startRevalidationCooldown(): void {
   revalidationCooldownTimeoutHandle = setTimeout(() => {
     revalidationCooldownTimeoutHandle = null
     // Retry the prefetch queue now that the cooldown has expired.
-    ensureWorkIsScheduled()
+    pingPrefetchScheduler()
   }, REVALIDATION_COOLDOWN_MS)
 }
 
@@ -296,7 +296,7 @@ export function schedulePrefetchTask(
   // By deferring to a microtask, we only process the queue once per JS task.
   // If they have different priorities, it also ensures they are processed in
   // the optimal order.
-  ensureWorkIsScheduled()
+  pingPrefetchScheduler()
 
   return task
 }
@@ -359,7 +359,7 @@ export function reschedulePrefetchTask(
   } else {
     heapPush(taskHeap, task)
   }
-  ensureWorkIsScheduled()
+  pingPrefetchScheduler()
 }
 
 export function isPrefetchTaskDirty(
@@ -398,7 +398,7 @@ function trackMostRecentlyHoveredLink(task: PrefetchTask) {
   }
 }
 
-function ensureWorkIsScheduled() {
+export function pingPrefetchScheduler() {
   if (didScheduleMicrotask) {
     // Already scheduled a task to process the queue
     return
@@ -406,8 +406,6 @@ function ensureWorkIsScheduled() {
   didScheduleMicrotask = true
   scheduleMicrotask(processQueueInMicrotask)
 }
-
-registerScheduleCleanup(ensureWorkIsScheduled)
 
 /**
  * Checks if we've exceeded the maximum number of concurrent prefetch requests,
@@ -481,7 +479,7 @@ function onPrefetchConnectionClosed(): void {
 
   // Notify the scheduler that we have more bandwidth, and can continue
   // processing tasks.
-  ensureWorkIsScheduled()
+  pingPrefetchScheduler()
 }
 
 /**
@@ -501,7 +499,7 @@ export function pingPrefetchTask(task: PrefetchTask) {
   }
   // Add the task back to the queue.
   heapPush(taskHeap, task)
-  ensureWorkIsScheduled()
+  pingPrefetchScheduler()
 }
 
 function processQueueInMicrotask() {

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -571,7 +571,7 @@ function processQueueInMicrotask() {
   // no open network connections. At that point, all active prefetch tasks have
   // finished reading from the cache (moving live entries to the LRU head), so
   // eviction targets genuinely stale data.
-  if (heapPeek(taskHeap) === null && inProgressRequests === 0) {
+  if (task === null && inProgressRequests === 0) {
     cleanup()
   }
 }

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -44,6 +44,7 @@ import {
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import type { SegmentRequestKey } from '../../../shared/lib/segment-cache/segment-value-encoding'
+import { holdCleanup, releaseCleanup } from './lru'
 
 const scheduleMicrotask =
   typeof queueMicrotask === 'function'
@@ -150,6 +151,12 @@ export type PrefetchTask = {
    * We also use this field to check whether a task is currently in the queue.
    */
   _heapIndex: number
+
+  /**
+   * True while this task is holding LRU cleanup. Set on task creation,
+   * cleared on task completion or cancellation.
+   */
+  _holdingCleanup: boolean
 
   /**
    * Called when the prefetch task finishes (either completed or canceled).
@@ -264,7 +271,13 @@ export function schedulePrefetchTask(
   onInvalidate: null | (() => void),
   _onComplete?: () => void
 ): PrefetchTask {
-  // Spawn a new prefetch task
+  // Spawn a new prefetch task. Hold LRU cleanup until the task completes so
+  // that, when links remount, existing cache entries have a chance to be read
+  // (and moved to the LRU head) before eviction runs. Without this, cleanup
+  // can fire between scheduler batches and evict entries that haven't been
+  // touched yet, causing a cascade of unnecessary re-fetches.
+  holdCleanup()
+
   const task: PrefetchTask = {
     key,
     treeAtTimeOfPrefetch,
@@ -279,6 +292,7 @@ export function schedulePrefetchTask(
     isCanceled: false,
     onInvalidate,
     _heapIndex: -1,
+    _holdingCleanup: true,
   }
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     task._onComplete = _onComplete
@@ -308,6 +322,10 @@ export function cancelPrefetchTask(task: PrefetchTask): void {
   // does not get added back to the queue when it's pinged by the network.
   task.isCanceled = true
   heapDelete(taskHeap, task)
+  if (task._holdingCleanup) {
+    task._holdingCleanup = false
+    releaseCleanup()
+  }
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     // Call completion callback. In practice this shouldn't be reached for
     // test-initiated prefetches since cancellation is only used by the Link
@@ -338,6 +356,10 @@ export function reschedulePrefetchTask(
   // Un-cancel the task, in case it was previously canceled.
   task.isCanceled = false
   task.phase = PrefetchPhase.RouteTree
+  if (!task._holdingCleanup) {
+    task._holdingCleanup = true
+    holdCleanup()
+  }
 
   // Assign a new sort ID to move it ahead of all other tasks at the same
   // priority level. (Higher sort IDs are processed first.)
@@ -548,6 +570,10 @@ function processQueueInMicrotask() {
           heapResift(taskHeap, task)
         } else {
           // The prefetch is complete. Continue to the next task.
+          if (task._holdingCleanup) {
+            task._holdingCleanup = false
+            releaseCleanup()
+          }
           if (process.env.__NEXT_EXPOSE_TESTING_API) {
             // Notify the Instant Navigation Testing API that the prefetch has
             // completed, so it can proceed with navigation.

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -44,7 +44,7 @@ import {
   PAGE_SEGMENT_KEY,
 } from '../../../shared/lib/segment'
 import type { SegmentRequestKey } from '../../../shared/lib/segment-cache/segment-value-encoding'
-import { holdCleanup, releaseCleanup } from './lru'
+import { registerScheduleCleanup, cleanup } from './lru'
 
 const scheduleMicrotask =
   typeof queueMicrotask === 'function'
@@ -151,12 +151,6 @@ export type PrefetchTask = {
    * We also use this field to check whether a task is currently in the queue.
    */
   _heapIndex: number
-
-  /**
-   * True while this task is holding LRU cleanup. Set on task creation,
-   * cleared on task completion or cancellation.
-   */
-  _holdingCleanup: boolean
 
   /**
    * Called when the prefetch task finishes (either completed or canceled).
@@ -271,13 +265,7 @@ export function schedulePrefetchTask(
   onInvalidate: null | (() => void),
   _onComplete?: () => void
 ): PrefetchTask {
-  // Spawn a new prefetch task. Hold LRU cleanup until the task completes so
-  // that, when links remount, existing cache entries have a chance to be read
-  // (and moved to the LRU head) before eviction runs. Without this, cleanup
-  // can fire between scheduler batches and evict entries that haven't been
-  // touched yet, causing a cascade of unnecessary re-fetches.
-  holdCleanup()
-
+  // Spawn a new prefetch task
   const task: PrefetchTask = {
     key,
     treeAtTimeOfPrefetch,
@@ -292,7 +280,6 @@ export function schedulePrefetchTask(
     isCanceled: false,
     onInvalidate,
     _heapIndex: -1,
-    _holdingCleanup: true,
   }
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     task._onComplete = _onComplete
@@ -322,10 +309,6 @@ export function cancelPrefetchTask(task: PrefetchTask): void {
   // does not get added back to the queue when it's pinged by the network.
   task.isCanceled = true
   heapDelete(taskHeap, task)
-  if (task._holdingCleanup) {
-    task._holdingCleanup = false
-    releaseCleanup()
-  }
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     // Call completion callback. In practice this shouldn't be reached for
     // test-initiated prefetches since cancellation is only used by the Link
@@ -356,10 +339,6 @@ export function reschedulePrefetchTask(
   // Un-cancel the task, in case it was previously canceled.
   task.isCanceled = false
   task.phase = PrefetchPhase.RouteTree
-  if (!task._holdingCleanup) {
-    task._holdingCleanup = true
-    holdCleanup()
-  }
 
   // Assign a new sort ID to move it ahead of all other tasks at the same
   // priority level. (Higher sort IDs are processed first.)
@@ -427,6 +406,8 @@ function ensureWorkIsScheduled() {
   didScheduleMicrotask = true
   scheduleMicrotask(processQueueInMicrotask)
 }
+
+registerScheduleCleanup(ensureWorkIsScheduled)
 
 /**
  * Checks if we've exceeded the maximum number of concurrent prefetch requests,
@@ -570,10 +551,6 @@ function processQueueInMicrotask() {
           heapResift(taskHeap, task)
         } else {
           // The prefetch is complete. Continue to the next task.
-          if (task._holdingCleanup) {
-            task._holdingCleanup = false
-            releaseCleanup()
-          }
           if (process.env.__NEXT_EXPOSE_TESTING_API) {
             // Notify the Instant Navigation Testing API that the prefetch has
             // completed, so it can proceed with navigation.
@@ -588,6 +565,14 @@ function processQueueInMicrotask() {
       default:
         exitStatus satisfies never
     }
+  }
+
+  // Run LRU cleanup only when the scheduler is fully idle: no queued tasks and
+  // no open network connections. At that point, all active prefetch tasks have
+  // finished reading from the cache (moving live entries to the LRU head), so
+  // eviction targets genuinely stale data.
+  if (heapPeek(taskHeap) === null && inProgressRequests === 0) {
+    cleanup()
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -566,9 +566,9 @@ function processQueueInMicrotask() {
   }
 
   // Run LRU cleanup only when the scheduler is fully idle: no queued tasks and
-  // no open network connections. At that point, all active prefetch tasks have
-  // finished reading from the cache (moving live entries to the LRU head), so
-  // eviction targets genuinely stale data.
+  // no in-progress requests. At that point, all active prefetch tasks have
+  // finished reading from the cache (moving recently used entries to the front
+  // of the list), so only genuinely stale data gets evicted.
   if (task === null && inProgressRequests === 0) {
     cleanup()
   }

--- a/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
@@ -13,11 +13,9 @@ describe('segment cache memory pressure', () => {
 
   it('evicts least recently used prefetch data once cache size exceeds limit', async () => {
     let act: ReturnType<typeof createRouterAct>
-    let page: Page
     const browser = await next.browser('/memory-pressure', {
-      beforePageLoad(p) {
-        page = p
-        act = createRouterAct(p)
+      beforePageLoad(page) {
+        act = createRouterAct(page)
       },
     })
 
@@ -37,15 +35,13 @@ describe('segment cache memory pressure', () => {
     )
 
     // Switching to tab 2 causes the cache to overflow, evicting the prefetch
-    // for the Page 0 link. Count the prefetch requests during this first visit.
-    const firstVisitCounter = countPrefetchRequests(page)
+    // for the Page 0 link.
     await act(
       async () => {
         await switchToTab2.click()
       },
       { includes: 'Page 1.' }
     )
-    const firstVisitCount = firstVisitCounter.stop()
 
     // Switching back to tab 1 initiates a new prefetch for Page 0. If
     // there are no requests, that means the prefetch was not evicted correctly.
@@ -58,25 +54,14 @@ describe('segment cache memory pressure', () => {
       }
     )
 
-    // Switch back to tab 2 again. Most prefetch data should still be in the
-    // cache from the first visit — only the entries evicted by LRU cleanup
-    // should need to be re-fetched.
-    const secondVisitCounter = countPrefetchRequests(page)
+    // Switching back to tab 2 should not evict and re-fetch the prefetches for
+    // Page 0 and Page 1, since they were recently accessed.
     await act(async () => {
       await switchToTab2.click()
-    }, null)
-    const secondVisitCount = secondVisitCounter.stop()
-
-    try {
-      expect(secondVisitCount).toBeLessThan(firstVisitCount * 0.5)
-    } catch {
-      throw new Error(
-        `Expected second visit to reuse cached prefetch data, but it made ` +
-          `almost as many requests as the first visit.\n` +
-          `  First visit:  ${firstVisitCount} prefetch requests\n` +
-          `  Second visit: ${secondVisitCount} prefetch requests`
-      )
-    }
+    }, [
+      { includes: 'Page 0.', block: 'reject' },
+      { includes: 'Page 1.', block: 'reject' },
+    ])
   })
 
   it('does not leak memory when repeatedly triggering prefetches', async () => {
@@ -201,20 +186,4 @@ function waitForPrefetchesToSettle(page: Page, quietMs = 200): Promise<void> {
   page.on('requestfailed', onRequestDone)
 
   return promise
-}
-
-function countPrefetchRequests(page: Page): { stop: () => number } {
-  let count = 0
-  function onRequest(req: PlaywrightRequest) {
-    if (req.headers()['next-router-segment-prefetch']) {
-      count++
-    }
-  }
-  page.on('request', onRequest)
-  return {
-    stop() {
-      page.off('request', onRequest)
-      return count
-    },
-  }
 }

--- a/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
+++ b/test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts
@@ -13,9 +13,11 @@ describe('segment cache memory pressure', () => {
 
   it('evicts least recently used prefetch data once cache size exceeds limit', async () => {
     let act: ReturnType<typeof createRouterAct>
+    let page: Page
     const browser = await next.browser('/memory-pressure', {
-      beforePageLoad(page) {
-        act = createRouterAct(page)
+      beforePageLoad(p) {
+        page = p
+        act = createRouterAct(p)
       },
     })
 
@@ -35,13 +37,15 @@ describe('segment cache memory pressure', () => {
     )
 
     // Switching to tab 2 causes the cache to overflow, evicting the prefetch
-    // for the Page 0 link.
+    // for the Page 0 link. Count the prefetch requests during this first visit.
+    const firstVisitCounter = countPrefetchRequests(page)
     await act(
       async () => {
         await switchToTab2.click()
       },
       { includes: 'Page 1.' }
     )
+    const firstVisitCount = firstVisitCounter.stop()
 
     // Switching back to tab 1 initiates a new prefetch for Page 0. If
     // there are no requests, that means the prefetch was not evicted correctly.
@@ -53,6 +57,26 @@ describe('segment cache memory pressure', () => {
         includes: 'Page 0.',
       }
     )
+
+    // Switch back to tab 2 again. Most prefetch data should still be in the
+    // cache from the first visit — only the entries evicted by LRU cleanup
+    // should need to be re-fetched.
+    const secondVisitCounter = countPrefetchRequests(page)
+    await act(async () => {
+      await switchToTab2.click()
+    }, null)
+    const secondVisitCount = secondVisitCounter.stop()
+
+    try {
+      expect(secondVisitCount).toBeLessThan(firstVisitCount * 0.5)
+    } catch {
+      throw new Error(
+        `Expected second visit to reuse cached prefetch data, but it made ` +
+          `almost as many requests as the first visit.\n` +
+          `  First visit:  ${firstVisitCount} prefetch requests\n` +
+          `  Second visit: ${secondVisitCount} prefetch requests`
+      )
+    }
   })
 
   it('does not leak memory when repeatedly triggering prefetches', async () => {
@@ -177,4 +201,20 @@ function waitForPrefetchesToSettle(page: Page, quietMs = 200): Promise<void> {
   page.on('requestfailed', onRequestDone)
 
   return promise
+}
+
+function countPrefetchRequests(page: Page): { stop: () => number } {
+  let count = 0
+  function onRequest(req: PlaywrightRequest) {
+    if (req.headers()['next-router-segment-prefetch']) {
+      count++
+    }
+  }
+  page.on('request', onRequest)
+  return {
+    stop() {
+      page.off('request', onRequest)
+      return count
+    },
+  }
 }


### PR DESCRIPTION
When links remount (e.g. toggling between tabs), the prefetch scheduler processes tasks across multiple async batches due to network bandwidth limits. Between batches, LRU cleanup could fire and evict cache entries for tasks that hadn't been processed yet. Those tasks would then see cache misses, fetch fresh data, push the LRU over the limit again, and trigger more cleanup, cascading through nearly all entries.

We fix this by moving LRU cleanup into the prefetch scheduler loop. Instead of scheduling cleanup independently via `requestIdleCallback`/`setTimeout`, the LRU module pings the scheduler when the cache exceeds its size limit, and the scheduler runs cleanup only when it's fully idle (no queued tasks, no in-flight requests). At that point, all active prefetch tasks have finished reading from the cache, so eviction targets genuinely stale data.

The tradeoff is that the cache can temporarily exceed its size limit while prefetch tasks are in flight. This was already the case since cleanup was always async, but it's now more explicit since cleanup is tied to the scheduler settling rather than the next idle callback.