### PR TITLE
fix(codemod): ensure agent instruction is executable

### DIFF
--- a/packages/next-codemod/bin/agents-md.ts
+++ b/packages/next-codemod/bin/agents-md.ts
@@ -14,6 +14,7 @@ import {
   collectDocFiles,
   buildDocTree,
   generateClaudeMdIndex,
+  derivePackageTag,
   injectIntoClaudeMd,
   ensureGitignoreEntry,
 } from '../lib/agents-md'
@@ -104,10 +105,17 @@ export async function runAgentsMd(options: AgentsMdOptions): Promise<void> {
   const docFiles = collectDocFiles(docsPath)
   const sections = buildDocTree(docFiles)
 
+  // Derive the npm dist-tag from our own package version so the
+  // regeneration instruction in the output preserves it
+  // (e.g. "npx @next/codemod@canary agents-md …")
+  const codemodPackageJson = require('../package.json')
+  const packageTag = derivePackageTag(codemodPackageJson.version)
+
   const indexContent = generateClaudeMdIndex({
     docsPath: docsLinkPath,
     sections,
     outputFile: targetFile,
+    packageTag,
   })
 
   const newContent = injectIntoClaudeMd(existingContent, indexContent)

--- a/packages/next-codemod/lib/__tests__/agents-md-unit.test.js
+++ b/packages/next-codemod/lib/__tests__/agents-md-unit.test.js
@@ -1,0 +1,270 @@
+/* global jest */
+jest.autoMockOff()
+
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const {
+  getNextjsVersion,
+  derivePackageTag,
+  generateClaudeMdIndex,
+  buildDocTree,
+} = require('../../lib/agents-md')
+
+/**
+ * Unit tests for agents-md helpers.
+ * These test pure functions without any network/git access.
+ */
+
+describe('derivePackageTag', () => {
+  it('returns @canary for canary versions', () => {
+    expect(derivePackageTag('15.2.0-canary.47')).toBe('@canary')
+    expect(derivePackageTag('16.0.0-canary.1')).toBe('@canary')
+  })
+
+  it('returns @rc for release candidate versions', () => {
+    expect(derivePackageTag('15.2.0-rc.1')).toBe('@rc')
+    expect(derivePackageTag('16.0.0-rc.12')).toBe('@rc')
+  })
+
+  it('returns @alpha for alpha versions', () => {
+    expect(derivePackageTag('1.0.0-alpha.3')).toBe('@alpha')
+  })
+
+  it('returns @beta for beta versions', () => {
+    expect(derivePackageTag('2.0.0-beta.5')).toBe('@beta')
+  })
+
+  it('returns empty string for stable versions', () => {
+    expect(derivePackageTag('15.2.0')).toBe('')
+    expect(derivePackageTag('14.1.3')).toBe('')
+    expect(derivePackageTag('1.0.0')).toBe('')
+  })
+
+  it('returns empty string for versions with non-matching prerelease tags', () => {
+    expect(derivePackageTag('15.2.0-dev.1')).toBe('')
+    expect(derivePackageTag('15.2.0-nightly.1')).toBe('')
+  })
+})
+
+describe('generateClaudeMdIndex with packageTag', () => {
+  const fakeSections = buildDocTree([
+    { relativePath: 'getting-started/installation.mdx' },
+  ])
+
+  it('includes @canary tag in regeneration instruction', () => {
+    const result = generateClaudeMdIndex({
+      docsPath: './.next-docs',
+      sections: fakeSections,
+      outputFile: 'AGENTS.md',
+      packageTag: '@canary',
+    })
+    expect(result).toContain(
+      'npx @next/codemod@canary agents-md --output AGENTS.md'
+    )
+  })
+
+  it('includes @rc tag in regeneration instruction', () => {
+    const result = generateClaudeMdIndex({
+      docsPath: './.next-docs',
+      sections: fakeSections,
+      outputFile: 'CLAUDE.md',
+      packageTag: '@rc',
+    })
+    expect(result).toContain(
+      'npx @next/codemod@rc agents-md --output CLAUDE.md'
+    )
+  })
+
+  it('omits tag suffix for stable versions', () => {
+    const result = generateClaudeMdIndex({
+      docsPath: './.next-docs',
+      sections: fakeSections,
+      outputFile: 'CLAUDE.md',
+      packageTag: '',
+    })
+    expect(result).toContain(
+      'npx @next/codemod agents-md --output CLAUDE.md'
+    )
+    expect(result).not.toContain('@next/codemod@')
+  })
+
+  it('omits tag suffix when packageTag is undefined (backwards compat)', () => {
+    const result = generateClaudeMdIndex({
+      docsPath: './.next-docs',
+      sections: fakeSections,
+      outputFile: 'AGENTS.md',
+    })
+    expect(result).toContain(
+      'npx @next/codemod agents-md --output AGENTS.md'
+    )
+    expect(result).not.toContain('@next/codemod@')
+  })
+})
+
+describe('getNextjsVersion with package-lock.json', () => {
+  let testDir
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'agents-md-version-test-'))
+  })
+
+  afterEach(() => {
+    if (testDir && fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true })
+    }
+  })
+
+  it('prefers package-lock.json version over package.json range (lockfileVersion 3)', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { next: '^14.0.0' },
+      })
+    )
+    fs.writeFileSync(
+      path.join(testDir, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          'node_modules/next': { version: '14.2.3' },
+        },
+      })
+    )
+
+    const result = getNextjsVersion(testDir)
+    expect(result.version).toBe('14.2.3')
+  })
+
+  it('prefers package-lock.json version over package.json range (lockfileVersion 1)', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { next: '~13.5.0' },
+      })
+    )
+    fs.writeFileSync(
+      path.join(testDir, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 1,
+        dependencies: {
+          next: { version: '13.5.6' },
+        },
+      })
+    )
+
+    const result = getNextjsVersion(testDir)
+    expect(result.version).toBe('13.5.6')
+  })
+
+  it('falls back to package.json when no package-lock.json exists', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { next: '^15.1.0' },
+      })
+    )
+
+    const result = getNextjsVersion(testDir)
+    // Should strip the ^ prefix and return the base version
+    expect(result.version).toBe('15.1.0')
+  })
+
+  it('falls back to package.json when package-lock.json has no next entry', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { next: '^14.0.0' },
+      })
+    )
+    fs.writeFileSync(
+      path.join(testDir, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          'node_modules/react': { version: '18.2.0' },
+        },
+      })
+    )
+
+    const result = getNextjsVersion(testDir)
+    expect(result.version).toBe('14.0.0')
+  })
+
+  it('handles exact version in package.json with matching lock', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { next: '15.0.0' },
+      })
+    )
+    fs.writeFileSync(
+      path.join(testDir, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          'node_modules/next': { version: '15.0.0' },
+        },
+      })
+    )
+
+    const result = getNextjsVersion(testDir)
+    expect(result.version).toBe('15.0.0')
+  })
+
+  it('handles canary version in package-lock.json', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { next: '^15.2.0-canary.0' },
+      })
+    )
+    fs.writeFileSync(
+      path.join(testDir, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          'node_modules/next': { version: '15.2.0-canary.47' },
+        },
+      })
+    )
+
+    const result = getNextjsVersion(testDir)
+    expect(result.version).toBe('15.2.0-canary.47')
+  })
+
+  it('handles corrupt package-lock.json gracefully', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        dependencies: { next: '^14.0.0' },
+      })
+    )
+    fs.writeFileSync(path.join(testDir, 'package-lock.json'), '{invalid json')
+
+    const result = getNextjsVersion(testDir)
+    // Should fall back to package.json
+    expect(result.version).toBe('14.0.0')
+  })
+
+  it('handles devDependencies with package-lock.json', () => {
+    fs.writeFileSync(
+      path.join(testDir, 'package.json'),
+      JSON.stringify({
+        devDependencies: { next: '^14.0.0' },
+      })
+    )
+    fs.writeFileSync(
+      path.join(testDir, 'package-lock.json'),
+      JSON.stringify({
+        lockfileVersion: 3,
+        packages: {
+          'node_modules/next': { version: '14.2.5' },
+        },
+      })
+    )
+
+    const result = getNextjsVersion(testDir)
+    expect(result.version).toBe('14.2.5')
+  })
+})

--- a/packages/next-codemod/lib/agents-md.ts
+++ b/packages/next-codemod/lib/agents-md.ts
@@ -33,6 +33,12 @@ export function getNextjsVersion(cwd: string): NextjsVersionResult {
     const nextVersion = dependencies.next || devDependencies.next
 
     if (nextVersion) {
+      // Prefer package-lock.json version (exact) over package.json (may be a range)
+      const lockVersion = getVersionFromPackageLock(cwd)
+      if (lockVersion) {
+        return { version: lockVersion }
+      }
+
       const cleanVersion = nextVersion.replace(/^[\^~>=<]+/, '')
       return { version: cleanVersion }
     }
@@ -61,6 +67,30 @@ export function getNextjsVersion(cwd: string): NextjsVersionResult {
       version: null,
       error: `Failed to parse package.json: ${err instanceof Error ? err.message : String(err)}`,
     }
+  }
+}
+
+function getVersionFromPackageLock(cwd: string): string | null {
+  const lockPath = path.join(cwd, 'package-lock.json')
+  if (!fs.existsSync(lockPath)) return null
+
+  try {
+    const lockfile = JSON.parse(fs.readFileSync(lockPath, 'utf-8'))
+
+    // lockfileVersion 2/3: packages field
+    if (lockfile.packages) {
+      const nextPkg = lockfile.packages['node_modules/next']
+      if (nextPkg?.version) return nextPkg.version
+    }
+
+    // lockfileVersion 1: dependencies field
+    if (lockfile.dependencies?.next?.version) {
+      return lockfile.dependencies.next.version
+    }
+
+    return null
+  } catch {
+    return null
   }
 }
 
@@ -266,10 +296,23 @@ interface ClaudeMdIndexData {
   docsPath: string
   sections: DocSection[]
   outputFile?: string
+  packageTag?: string
+}
+
+/**
+ * Derive an npm dist-tag suffix from a package version string.
+ * e.g. "15.2.0-canary.47" → "@canary", "15.2.0-rc.1" → "@rc", "15.2.0" → ""
+ */
+export function derivePackageTag(packageVersion: string): string {
+  const match = packageVersion.match(/-(canary|rc|alpha|beta)\./)
+  if (match) {
+    return `@${match[1]}`
+  }
+  return ''
 }
 
 export function generateClaudeMdIndex(data: ClaudeMdIndexData): string {
-  const { docsPath, sections, outputFile } = data
+  const { docsPath, sections, outputFile, packageTag } = data
 
   const parts: string[] = []
 
@@ -279,8 +322,9 @@ export function generateClaudeMdIndex(data: ClaudeMdIndexData): string {
     'STOP. What you remember about Next.js is WRONG for this project. Always search docs and read before any task.'
   )
   const targetFile = outputFile || 'CLAUDE.md'
+  const tagSuffix = packageTag ?? ''
   parts.push(
-    `If docs missing, run this command first: npx @next/codemod agents-md --output ${targetFile}`
+    `If docs missing, run this command first: npx @next/codemod${tagSuffix} agents-md --output ${targetFile}`
   )
 
   const allFiles = collectAllFilesFromSections(sections)


### PR DESCRIPTION
In the current form, the agents-md command writes an instruction that doesn't actually execute, since the command is only on @canary. 

### What?

In the current form, the agents-md command writes an instruction that doesn't actually execute. There are two issues. One is that it writes the instruction without @canary and it only exists in canary right now. The second is that, without embedding a version in the instruction, it does version inference logic and in the case of a version range, the command fails.

### Why?

I work with agents running in their own sandboxes, not on my laptop where I have done out of band setup work. So the agent needs to be able to clone the repo and do necessary steps from AGENTS.md for things to work.

### How?

Fixes #89772
Fixes #89773

Capture the invocation details when it is run and write the instructions to AGENTS.md so that the original command will be re-run.

For the version issue, look for a version in package-lock.json which should always have the correct and precise version.