### PR TITLE
feat(metadata): support non-standard directives in robots.ts

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/robots.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/robots.mdx
@@ -119,6 +119,52 @@ Disallow: /
 Sitemap: https://acme.com/sitemap.xml
 ```
 
+### Non-standard directives
+
+Some crawlers support additional, non-standard directives in `robots.txt`. You can include these by adding any custom key-value pair to a rule. For example:
+
+```ts filename="app/robots.ts" switcher
+import type { MetadataRoute } from 'next'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: 'SeznamBot',
+        allow: '/',
+        'Request-Rate': '10/1m',
+      },
+    ],
+    sitemap: 'https://acme.com/sitemap.xml',
+  }
+}
+```
+
+```js filename="app/robots.js" switcher
+export default function robots() {
+  return {
+    rules: [
+      {
+        userAgent: 'SeznamBot',
+        allow: '/',
+        'Request-Rate': '10/1m',
+      },
+    ],
+    sitemap: 'https://acme.com/sitemap.xml',
+  }
+}
+```
+
+Output:
+
+```txt
+User-Agent: SeznamBot
+Allow: /
+Request-Rate: 10/1m
+
+Sitemap: https://acme.com/sitemap.xml
+```
+
 ### Robots object
 
 ```tsx
@@ -129,12 +175,16 @@ type Robots = {
         allow?: string | string[]
         disallow?: string | string[]
         crawlDelay?: number
+        // Non-standard directives
+        [key: string]: string | string[] | number | boolean | undefined
       }
     | Array<{
         userAgent: string | string[]
         allow?: string | string[]
         disallow?: string | string[]
         crawlDelay?: number
+        // Non-standard directives
+        [key: string]: string | string[] | number | boolean | undefined
       }>
   sitemap?: string | string[]
   host?: string
@@ -143,6 +193,7 @@ type Robots = {
 
 ## Version History
 
-| Version   | Changes              |
-| --------- | -------------------- |
-| `v13.3.0` | `robots` introduced. |
+| Version   | Changes                                         |
+| --------- | ----------------------------------------------- |
+| `v16.2.0` | Support for non-standard directives in `robots` |
+| `v13.3.0` | `robots` introduced.                            |

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
@@ -29,6 +29,95 @@ describe('resolveRouteData', () => {
       `)
     })
 
+    it('should resolve robots.txt with non-standard directives', () => {
+      const data: MetadataRoute.Robots = {
+        rules: [
+          {
+            userAgent: 'SeznamBot',
+            allow: '/',
+            'Request-Rate': '10/1m',
+          },
+          {
+            userAgent: '*',
+            allow: '/',
+            disallow: '/admin',
+            'Visit-time': '0600-0845',
+          },
+        ],
+      }
+      const content = resolveRobots(data)
+      expect(content).toMatchInlineSnapshot(`
+        "User-Agent: SeznamBot
+        Allow: /
+        Request-Rate: 10/1m
+
+        User-Agent: *
+        Allow: /
+        Disallow: /admin
+        Visit-time: 0600-0845
+
+        "
+      `)
+    })
+
+    it('should resolve robots.txt with array values in non-standard directives', () => {
+      const data: MetadataRoute.Robots = {
+        rules: {
+          userAgent: '*',
+          allow: '/',
+          'No-Index': ['/private', '/tmp'],
+        },
+      }
+      const content = resolveRobots(data)
+      expect(content).toMatchInlineSnapshot(`
+        "User-Agent: *
+        Allow: /
+        No-Index: /private
+        No-Index: /tmp
+
+        "
+      `)
+    })
+
+    it('should resolve robots.txt with numeric and boolean non-standard directives', () => {
+      const data: MetadataRoute.Robots = {
+        rules: {
+          userAgent: '*',
+          allow: '/',
+          'Custom-Delay': 5,
+          'Some-Flag': true,
+        },
+      }
+      const content = resolveRobots(data)
+      expect(content).toMatchInlineSnapshot(`
+        "User-Agent: *
+        Allow: /
+        Custom-Delay: 5
+        Some-Flag: true
+
+        "
+      `)
+    })
+
+    it('should skip non-standard directives with null or undefined values', () => {
+      const data: MetadataRoute.Robots = {
+        rules: {
+          userAgent: '*',
+          allow: '/',
+          Included: 'yes',
+          Skipped: undefined,
+        },
+      }
+      const content = resolveRobots(data)
+      expect(content).toMatchInlineSnapshot(`
+        "User-Agent: *
+        Allow: /
+        Included: yes
+
+        "
+      `)
+    })
+
     it('should error with ts when specify both wildcard userAgent and specific userAgent', () => {
       const data1: MetadataRoute.Robots = {
         rules: [

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -1,6 +1,8 @@
 import type { MetadataRoute } from '../../../../lib/metadata/types/metadata-interface'
 import { resolveArray } from '../../../../lib/metadata/generate/utils'
 
+const knownRuleKeys = new Set(['userAgent', 'allow', 'disallow', 'crawlDelay'])
+
 // convert robots data to txt string
 export function resolveRobots(data: MetadataRoute.Robots): string {
   let content = ''
@@ -24,6 +26,16 @@ export function resolveRobots(data: MetadataRoute.Robots): string {
     }
     if (rule.crawlDelay) {
       content += `Crawl-delay: ${rule.crawlDelay}\n`
+    }
+    // Output non-standard directives (e.g. Request-Rate, Visit-time)
+    for (const [key, value] of Object.entries(rule)) {
+      if (knownRuleKeys.has(key) || value == null) {
+        continue
+      }
+      const values = Array.isArray(value) ? value : [value]
+      for (const v of values) {
+        content += `${key}: ${v}\n`
+      }
     }
     content += '\n'
   }

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -674,22 +674,22 @@ export type WithStringifiedURLs<T> = T extends URL
  */
 type ResolvedMetadata = WithStringifiedURLs<ResolvedMetadataWithURLs>
 
+type RobotsRule = {
+  userAgent?: string | string[] | undefined
+  allow?: string | string[] | undefined
+  disallow?: string | string[] | undefined
+  crawlDelay?: number | undefined
+  // Allow non-standard directives (e.g. Request-Rate, Visit-time)
+  [key: string]: string | string[] | number | boolean | undefined
+}
+
+type RobotsRuleWithUserAgent = RobotsRule & {
+  userAgent: string | string[]
+}
+
 type RobotsFile = {
   // Apply rules for all
-  rules:
-    | {
-        userAgent?: string | string[] | undefined
-        allow?: string | string[] | undefined
-        disallow?: string | string[] | undefined
-        crawlDelay?: number | undefined
-      }
-    // Apply rules for specific user agents
-    | Array<{
-        userAgent: string | string[]
-        allow?: string | string[] | undefined
-        disallow?: string | string[] | undefined
-        crawlDelay?: number | undefined
-      }>
+  rules: RobotsRule | Array<RobotsRuleWithUserAgent>
   sitemap?: string | string[] | undefined
   host?: string | undefined
 }

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/robots.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/robots.ts
@@ -6,11 +6,13 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: 'Googlebot',
         allow: ['/'],
+        'Request-Rate': '10/1m',
       },
       {
         userAgent: ['Applebot', 'Bingbot'],
         disallow: ['/'],
         crawlDelay: 2,
+        'Visit-time': '0600-0845',
       },
     ],
     sitemap: 'https://example.com/sitemap.xml',

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -28,11 +28,13 @@ describe('app dir - metadata dynamic routes', () => {
       expect(text).toMatchInlineSnapshot(`
         "User-Agent: Googlebot
         Allow: /
+        Request-Rate: 10/1m
 
         User-Agent: Applebot
         User-Agent: Bingbot
         Disallow: /
         Crawl-delay: 2
+        Visit-time: 0600-0845
 
         Host: https://example.com
         Sitemap: https://example.com/sitemap.xml

--- a/test/production/typescript-basic/typechecking/metadata/robots.ts
+++ b/test/production/typescript-basic/typechecking/metadata/robots.ts
@@ -11,4 +11,15 @@ import type { MetadataRoute } from 'next'
     sitemap: undefined,
     host: undefined,
   }) satisfies MetadataRoute.Robots
+
+  // Non-standard directives should be allowed
+  ;({
+    rules: [
+      {
+        userAgent: 'SeznamBot',
+        allow: '/',
+        'Request-Rate': '10/1m',
+      },
+    ],
+  }) satisfies MetadataRoute.Robots
 }


### PR DESCRIPTION
## What?

Add support for non-standard directives in `robots.ts` metadata route.

## Why?

Many crawlers support additional, non-standard directives in `robots.txt` (e.g. `Request-Rate`, `Visit-time`, `No-Index`). Currently the `MetadataRoute.Robots` type only allows the standard directives (`userAgent`, `allow`, `disallow`, `crawlDelay`), requiring workarounds for custom properties.

This was requested in #89521.

## How?

- Extended `RobotsRule` type with an index signature (`[key: string]: string | string[] | number | boolean | undefined`) to accept arbitrary key-value pairs alongside the standard directives
- Updated `resolveRobots()` to serialize non-standard directives after the standard ones, using a `knownRuleKeys` Set to skip known keys and avoid duplication
- Supports string, string array, number, and boolean values; `null`/`undefined` values are skipped

### Example

```ts
import type { MetadataRoute } from 'next'

export default function robots(): MetadataRoute.Robots {
  return {
    rules: [
      {
        userAgent: 'SeznamBot',
        allow: '/',
        'Request-Rate': '10/1m',
      },
    ],
    sitemap: 'https://acme.com/sitemap.xml',
  }
}
```

Output:

```
User-Agent: SeznamBot
Allow: /
Request-Rate: 10/1m

Sitemap: https://acme.com/sitemap.xml
```

### Checklist

- [x] Related issues linked using `fixes #89521`
- [x] Tests added (unit tests for various value types + e2e test in `metadata-dynamic-routes`)
- [x] Documentation added (updated `robots.mdx` with usage examples, type definition, and version history)

Fixes #89521