### PR TITLE
docs: add Docker standalone output guidance to deploying and self-hosting guides

### DIFF
--- a/docs/01-app/01-getting-started/17-deploying.mdx
+++ b/docs/01-app/01-getting-started/17-deploying.mdx
@@ -42,6 +42,35 @@ Next.js can be deployed to any provider that supports [Docker](https://www.docke
 
 Docker deployments support all Next.js features. Learn how to [configure them](/docs/app/guides/self-hosting) for your infrastructure.
 
+### Using `output: "standalone"`
+
+For Docker deployments, we recommend using [`output: "standalone"`](/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files) in your `next.config.js`. This uses [Output File Tracing](/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files) to include only the files necessary to run your application, significantly reducing the Docker image size.
+
+```js filename="next.config.js"
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  output: 'standalone',
+}
+
+module.exports = nextConfig
+```
+
+The standalone output generates a minimal `server.js` file that can be used instead of `next start`. This avoids copying all of `node_modules` into your Docker image since the standalone output traces the required files automatically.
+
+In your `Dockerfile`, instead of running `next start`, you can run the generated `server.js`:
+
+```dockerfile
+# Copy the standalone output
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
+ENV HOSTNAME="0.0.0.0"
+CMD ["node", "server.js"]
+```
+
+> **Good to know:** If your application needs specific native `node_modules` binaries that are not included in the standalone trace, or you prefer a simpler setup, you can use `next start` directly with a full `node_modules` install in your Docker image instead.
+
 > **Note for development:** While Docker is excellent for production deployments, consider using local development (`npm run dev`) instead of Docker during development on Mac and Windows for better performance. [Learn more about optimizing local development](/docs/app/guides/local-development).
 
 ### Templates

--- a/docs/01-app/02-guides/self-hosting.mdx
+++ b/docs/01-app/02-guides/self-hosting.mdx
@@ -34,6 +34,22 @@ Proxy uses the [Edge runtime](/docs/app/api-reference/edge), a subset of all ava
 
 If you are looking to add logic (or use an external package) that requires all Node.js APIs, you might be able to move this logic to a [layout](/docs/app/api-reference/file-conventions/layout) as a [Server Component](/docs/app/getting-started/server-and-client-components). For example, checking [headers](/docs/app/api-reference/functions/headers) and [redirecting](/docs/app/api-reference/functions/redirect). You can also use headers, cookies, or query parameters to [redirect](/docs/app/api-reference/config/next-config-js/redirects#header-cookie-and-query-matching) or [rewrite](/docs/app/api-reference/config/next-config-js/rewrites#header-cookie-and-query-matching) through `next.config.js`. If that does not work, you can also use a [custom server](/docs/pages/guides/custom-server).
 
+## Docker
+
+When deploying Next.js in a Docker container, you may want to use [`output: "standalone"`](/docs/app/api-reference/config/next-config-js/output#automatically-copying-traced-files) to create a self-contained build. This traces the required files for your application and produces a minimal `server.js` that can be run without installing `node_modules`.
+
+This can significantly reduce the Docker image size. For example, the [official Docker example](https://github.com/vercel/next.js/tree/canary/examples/with-docker) uses a multistage build with standalone output to produce an image of approximately 110 MB, compared to around 1 GB with a full `node_modules` install.
+
+When using standalone mode, set the `HOSTNAME` environment variable to `0.0.0.0` to ensure the server is accessible outside the container:
+
+```dockerfile
+ENV HOSTNAME="0.0.0.0"
+ENV PORT=3000
+CMD ["node", "server.js"]
+```
+
+> **Good to know:** If your application relies on specific native binaries from `node_modules` that are not included in the standalone trace, you can use `next start` with a full `node_modules` install instead.
+
 ## Environment Variables
 
 Next.js can support both build time and runtime environment variables.


### PR DESCRIPTION
## What?

Add standalone output mode explanation and inline examples to the deploying and self-hosting documentation.

## Why?

The `with-docker` example already uses `output: "standalone"`, but the deploying and self-hosting docs did not explain this configuration or why it's recommended for Docker deployments. This caused confusion for users trying to containerize their Next.js applications (see #88885).

## How?

**`docs/01-app/01-getting-started/17-deploying.mdx`**
- Added "Using `output: "standalone"`" subsection under Docker
- Included `next.config.js` configuration example
- Added minimal Dockerfile snippet showing standalone usage
- Added notes about alternatives (native binaries, simpler setup)
- Added development tip about local development vs Docker

**`docs/01-app/02-guides/self-hosting.mdx`**
- Added dedicated "Docker" section before "Environment Variables"
- Explained standalone mode benefits (image size: ~110 MB vs ~1 GB)
- Included `HOSTNAME` and `PORT` environment variable configuration
- Added note about falling back to `next start` when needed

fixes #88885