### PR TITLE
Allowed origins environment variable

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/allowedDevOrigins.mdx
@@ -9,6 +9,8 @@ Next.js does not automatically block cross-origin requests during development, b
 
 To configure a Next.js application to allow requests from origins other than the hostname the server was initialized with (`localhost` by default) you can use the `allowedDevOrigins` config option.
 
+## Configuration File
+
 `allowedDevOrigins` allows you to set additional origins that can be used in development mode. For example, to use `local-origin.dev` instead of only `localhost`, open `next.config.js` and add the `allowedDevOrigins` config:
 
 ```js filename="next.config.js"
@@ -16,3 +18,13 @@ module.exports = {
   allowedDevOrigins: ['local-origin.dev', '*.local-origin.dev'],
 }
 ```
+
+## Environment Variable
+
+You can also configure allowed dev origins using the `NEXT_ALLOWED_DEV_ORIGINS` environment variable. This is useful for sandboxed or containerized environments where you don't want to modify the user's configuration file:
+
+```bash
+NEXT_ALLOWED_DEV_ORIGINS="example.com,*.v0.dev" npm run dev
+```
+
+The environment variable accepts a comma-separated list of origins. Values from the environment variable are merged with any values specified in `next.config.js`, allowing both sources to work together.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -9,8 +9,6 @@ Options for configuring Server Actions behavior in your Next.js application.
 
 A list of extra safe origin domains from which Server Actions can be invoked. Next.js compares the origin of a Server Action request with the host domain, ensuring they match to prevent CSRF attacks. If not provided, only the same origin is allowed.
 
-### Configuration File
-
 ```js filename="next.config.js"
 /** @type {import('next').NextConfig} */
 
@@ -22,16 +20,6 @@ module.exports = {
   },
 }
 ```
-
-### Environment Variable
-
-You can also configure allowed origins using the `NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS` environment variable. This is useful for sandboxed or containerized environments where you don't want to modify the user's configuration file:
-
-```bash
-NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS="my-proxy.com,*.my-proxy.com" npm run dev
-```
-
-The environment variable accepts a comma-separated list of origins. Values from the environment variable are merged with any values specified in `next.config.js`, allowing both sources to work together.
 
 ## `bodySizeLimit`
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/serverActions.mdx
@@ -9,6 +9,8 @@ Options for configuring Server Actions behavior in your Next.js application.
 
 A list of extra safe origin domains from which Server Actions can be invoked. Next.js compares the origin of a Server Action request with the host domain, ensuring they match to prevent CSRF attacks. If not provided, only the same origin is allowed.
 
+### Configuration File
+
 ```js filename="next.config.js"
 /** @type {import('next').NextConfig} */
 
@@ -20,6 +22,16 @@ module.exports = {
   },
 }
 ```
+
+### Environment Variable
+
+You can also configure allowed origins using the `NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS` environment variable. This is useful for sandboxed or containerized environments where you don't want to modify the user's configuration file:
+
+```bash
+NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS="my-proxy.com,*.my-proxy.com" npm run dev
+```
+
+The environment variable accepts a comma-separated list of origins. Values from the environment variable are merged with any values specified in `next.config.js`, allowing both sources to work together.
 
 ## `bodySizeLimit`
 

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -379,6 +379,39 @@ function assignDefaultsAndValidate(
     },
   }
 
+  // Parse and merge environment variables for allowed origins
+  if (process.env.NEXT_ALLOWED_DEV_ORIGINS) {
+    const envOrigins = process.env.NEXT_ALLOWED_DEV_ORIGINS.split(',')
+      .map((origin) => origin.trim())
+      .filter(Boolean)
+
+    if (envOrigins.length > 0) {
+      result.allowedDevOrigins = [
+        ...(result.allowedDevOrigins || []),
+        ...envOrigins,
+      ]
+    }
+  }
+
+  // Parse and merge environment variables for server actions allowed origins
+  if (process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS) {
+    const envOrigins = process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS.split(
+      ','
+    )
+      .map((origin) => origin.trim())
+      .filter(Boolean)
+
+    if (envOrigins.length > 0) {
+      if (!result.experimental.serverActions) {
+        result.experimental.serverActions = {}
+      }
+      result.experimental.serverActions.allowedOrigins = [
+        ...(result.experimental.serverActions.allowedOrigins || []),
+        ...envOrigins,
+      ]
+    }
+  }
+
   // ensure correct default is set for api-resolver revalidate handling
   if (!result.experimental.trustHostHeader && ciEnvironment.hasNextSupport) {
     result.experimental.trustHostHeader = true

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -379,7 +379,7 @@ function assignDefaultsAndValidate(
     },
   }
 
-  // Parse and merge environment variables for allowed origins
+  // Parse and merge environment variables for allowed dev origins
   if (process.env.NEXT_ALLOWED_DEV_ORIGINS) {
     const envOrigins = process.env.NEXT_ALLOWED_DEV_ORIGINS.split(',')
       .map((origin) => origin.trim())
@@ -388,25 +388,6 @@ function assignDefaultsAndValidate(
     if (envOrigins.length > 0) {
       result.allowedDevOrigins = [
         ...(result.allowedDevOrigins || []),
-        ...envOrigins,
-      ]
-    }
-  }
-
-  // Parse and merge environment variables for server actions allowed origins
-  if (process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS) {
-    const envOrigins = process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS.split(
-      ','
-    )
-      .map((origin) => origin.trim())
-      .filter(Boolean)
-
-    if (envOrigins.length > 0) {
-      if (!result.experimental.serverActions) {
-        result.experimental.serverActions = {}
-      }
-      result.experimental.serverActions.allowedOrigins = [
-        ...(result.experimental.serverActions.allowedOrigins || []),
         ...envOrigins,
       ]
     }

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -224,7 +224,7 @@ describe('config', () => {
     })
   })
 
-  describe('Environment variable support for allowed origins', () => {
+  describe('Environment variable support for allowedDevOrigins', () => {
     it('Should merge NEXT_ALLOWED_DEV_ORIGINS with config allowedDevOrigins', async () => {
       const originalEnv = process.env.NEXT_ALLOWED_DEV_ORIGINS
       process.env.NEXT_ALLOWED_DEV_ORIGINS = 'example.com,*.test.com'
@@ -282,55 +282,6 @@ describe('config', () => {
           delete process.env.NEXT_ALLOWED_DEV_ORIGINS
         } else {
           process.env.NEXT_ALLOWED_DEV_ORIGINS = originalEnv
-        }
-      }
-    })
-
-    it('Should merge NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS with config', async () => {
-      const originalEnv = process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
-      process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = 'api.example.com'
-
-      try {
-        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
-          customConfig: {
-            experimental: {
-              serverActions: {
-                allowedOrigins: ['localhost'],
-              },
-            },
-          },
-        })
-        expect(config.experimental.serverActions?.allowedOrigins).toContain(
-          'localhost'
-        )
-        expect(config.experimental.serverActions?.allowedOrigins).toContain(
-          'api.example.com'
-        )
-      } finally {
-        if (originalEnv === undefined) {
-          delete process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
-        } else {
-          process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = originalEnv
-        }
-      }
-    })
-
-    it('Should create serverActions config from NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS when not set', async () => {
-      const originalEnv = process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
-      process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = 'api.example.com'
-
-      try {
-        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
-          customConfig: {},
-        })
-        expect(config.experimental.serverActions?.allowedOrigins).toContain(
-          'api.example.com'
-        )
-      } finally {
-        if (originalEnv === undefined) {
-          delete process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
-        } else {
-          process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = originalEnv
         }
       }
     })

--- a/test/unit/isolated/config.test.ts
+++ b/test/unit/isolated/config.test.ts
@@ -223,4 +223,136 @@ describe('config', () => {
       expect(config.turbopack.root).toBe(config.outputFileTracingRoot)
     })
   })
+
+  describe('Environment variable support for allowed origins', () => {
+    it('Should merge NEXT_ALLOWED_DEV_ORIGINS with config allowedDevOrigins', async () => {
+      const originalEnv = process.env.NEXT_ALLOWED_DEV_ORIGINS
+      process.env.NEXT_ALLOWED_DEV_ORIGINS = 'example.com,*.test.com'
+
+      try {
+        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {
+            allowedDevOrigins: ['localhost'],
+          },
+        })
+        expect(config.allowedDevOrigins).toContain('localhost')
+        expect(config.allowedDevOrigins).toContain('example.com')
+        expect(config.allowedDevOrigins).toContain('*.test.com')
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_ALLOWED_DEV_ORIGINS
+        } else {
+          process.env.NEXT_ALLOWED_DEV_ORIGINS = originalEnv
+        }
+      }
+    })
+
+    it('Should parse NEXT_ALLOWED_DEV_ORIGINS when no config value exists', async () => {
+      const originalEnv = process.env.NEXT_ALLOWED_DEV_ORIGINS
+      process.env.NEXT_ALLOWED_DEV_ORIGINS = 'example.com,another.com'
+
+      try {
+        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {},
+        })
+        expect(config.allowedDevOrigins).toContain('example.com')
+        expect(config.allowedDevOrigins).toContain('another.com')
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_ALLOWED_DEV_ORIGINS
+        } else {
+          process.env.NEXT_ALLOWED_DEV_ORIGINS = originalEnv
+        }
+      }
+    })
+
+    it('Should trim whitespace from NEXT_ALLOWED_DEV_ORIGINS values', async () => {
+      const originalEnv = process.env.NEXT_ALLOWED_DEV_ORIGINS
+      process.env.NEXT_ALLOWED_DEV_ORIGINS = '  example.com  ,  another.com  '
+
+      try {
+        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {},
+        })
+        expect(config.allowedDevOrigins).toContain('example.com')
+        expect(config.allowedDevOrigins).toContain('another.com')
+        expect(config.allowedDevOrigins).not.toContain('  example.com  ')
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_ALLOWED_DEV_ORIGINS
+        } else {
+          process.env.NEXT_ALLOWED_DEV_ORIGINS = originalEnv
+        }
+      }
+    })
+
+    it('Should merge NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS with config', async () => {
+      const originalEnv = process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
+      process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = 'api.example.com'
+
+      try {
+        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {
+            experimental: {
+              serverActions: {
+                allowedOrigins: ['localhost'],
+              },
+            },
+          },
+        })
+        expect(config.experimental.serverActions?.allowedOrigins).toContain(
+          'localhost'
+        )
+        expect(config.experimental.serverActions?.allowedOrigins).toContain(
+          'api.example.com'
+        )
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
+        } else {
+          process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = originalEnv
+        }
+      }
+    })
+
+    it('Should create serverActions config from NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS when not set', async () => {
+      const originalEnv = process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
+      process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = 'api.example.com'
+
+      try {
+        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {},
+        })
+        expect(config.experimental.serverActions?.allowedOrigins).toContain(
+          'api.example.com'
+        )
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS
+        } else {
+          process.env.NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS = originalEnv
+        }
+      }
+    })
+
+    it('Should handle empty NEXT_ALLOWED_DEV_ORIGINS', async () => {
+      const originalEnv = process.env.NEXT_ALLOWED_DEV_ORIGINS
+      process.env.NEXT_ALLOWED_DEV_ORIGINS = ''
+
+      try {
+        const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, '<rootDir>', {
+          customConfig: {
+            allowedDevOrigins: ['localhost'],
+          },
+        })
+        expect(config.allowedDevOrigins).toEqual(['localhost'])
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_ALLOWED_DEV_ORIGINS
+        } else {
+          process.env.NEXT_ALLOWED_DEV_ORIGINS = originalEnv
+        }
+      }
+    })
+  })
 })


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Introduces two new environment variables:
- `NEXT_ALLOWED_DEV_ORIGINS`: Allows injecting additional origins into `allowedDevOrigins` for development.
- `NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS`: Allows injecting additional origins into `experimental.serverActions.allowedOrigins`.
Both accept comma-separated values, which are merged with any existing configuration.

### Why?
To enable sandboxed environments (e.g., v0) to dynamically inject allowed origins without requiring modifications to the user's `next.config.js` file. This provides flexibility for scenarios where the allowed origins might not be known at build time or need to be controlled externally.

### How?
- Modified `packages/next/src/server/config.ts` to read and parse `NEXT_ALLOWED_DEV_ORIGINS` and `NEXT_SERVER_ACTIONS_ALLOWED_ORIGINS`.
- The values are split by comma, trimmed, filtered, and then merged into the respective configuration arrays.
- Added comprehensive unit tests in `test/unit/isolated/config.test.ts` to cover merging, parsing, whitespace handling, and empty values.

Closes NEXT-
Fixes #

-->

---
[Slack Thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1770674845924869?thread_ts=1770674845.924869&cid=C03KAR5DCKC)

<p><a href="https://cursor.com/background-agent?bcId=bc-e8233529-370d-53d9-9fd1-49c685a02b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8233529-370d-53d9-9fd1-49c685a02b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

