### PR TITLE
[turbopack] Add #[derive(ValueToString)] and convert ~45 manual impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9580,6 +9580,7 @@ name = "turbo-tasks-macros"
 version = "0.1.0"
 dependencies = [
  "either",
+ "indexmap 2.9.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",

--- a/crates/next-core/src/hmr_entry.rs
+++ b/crates/next-core/src/hmr_entry.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{FileSystem, VirtualFileSystem, rope::RopeBuilder};
 use turbopack_core::{
@@ -143,6 +143,8 @@ impl EcmascriptChunkPlaceable for HmrEntryModule {
 impl EvaluatableAsset for HmrEntryModule {}
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("entry")]
 pub struct HmrEntryModuleReference {
     pub module: ResolvedVc<Box<dyn Module>>,
 }
@@ -152,14 +154,6 @@ impl HmrEntryModuleReference {
     #[turbo_tasks::function]
     pub fn new(module: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
         HmrEntryModuleReference { module }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for HmrEntryModuleReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("entry"))
     }
 }
 

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -107,4 +107,3 @@ impl ModuleReference for CssClientReference {
         }))
     }
 }
-

--- a/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/css_client_reference/css_client_reference_module.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileContent;
 use turbopack_core::{
@@ -78,6 +78,8 @@ impl Asset for CssClientReferenceModule {
 }
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("css client reference to client")]
 pub(crate) struct CssClientReference {
     module: ResolvedVc<Box<dyn Module>>,
 }
@@ -106,10 +108,3 @@ impl ModuleReference for CssClientReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for CssClientReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("css client reference to client"))
-    }
-}

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -392,4 +392,3 @@ impl ModuleReference for EcmascriptClientReference {
         }))
     }
 }
-

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -350,6 +350,8 @@ impl EcmascriptChunkItem for EcmascriptClientReferenceProxyChunkItem {
 }
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string(self.description)]
 pub(crate) struct EcmascriptClientReference {
     module: ResolvedVc<Box<dyn Module>>,
     ty: ChunkGroupType,
@@ -391,10 +393,3 @@ impl ModuleReference for EcmascriptClientReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptClientReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.description.clone())
-    }
-}

--- a/crates/next-core/src/next_server_component/server_component_reference.rs
+++ b/crates/next-core/src/next_server_component/server_component_reference.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkingType, ChunkingTypeOption},
@@ -9,6 +7,8 @@ use turbopack_core::{
 };
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("Next.js Server Component {}", self.asset.ident())]
 pub struct NextServerComponentModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
 }
@@ -18,20 +18,6 @@ impl NextServerComponentModuleReference {
     #[turbo_tasks::function]
     pub fn new(asset: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
         NextServerComponentModuleReference { asset }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for NextServerComponentModuleReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!(
-                "Next.js Server Component {}",
-                self.asset.ident().to_string().await?
-            )
-            .into(),
-        ))
     }
 }
 

--- a/crates/next-core/src/next_server_utility/server_utility_reference.rs
+++ b/crates/next-core/src/next_server_utility/server_utility_reference.rs
@@ -1,4 +1,3 @@
-use anyhow::Result;
 use once_cell::sync::Lazy;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
@@ -10,6 +9,8 @@ use turbopack_core::{
 };
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("Next.js server utility {}", self.asset.ident())]
 pub struct NextServerUtilityModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
 }
@@ -19,20 +20,6 @@ impl NextServerUtilityModuleReference {
     #[turbo_tasks::function]
     pub fn new(asset: ResolvedVc<Box<dyn Module>>) -> Vc<Self> {
         NextServerUtilityModuleReference { asset }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for NextServerUtilityModuleReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!(
-                "Next.js server utility {}",
-                self.asset.ident().to_string().await?
-            )
-            .into(),
-        ))
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
@@ -51,7 +51,7 @@ struct DirectExpr {
 
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
-#[value_to_string("prefix({}) suffix({})", self.name, self.count)]
+#[value_to_string("prefix({name}) suffix({count})")]
 struct FormatExprs {
     name: RcStr,
     count: u32,
@@ -59,7 +59,7 @@ struct FormatExprs {
 
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
-#[value_to_string("inner: {}", self.inner)]
+#[value_to_string("inner: {inner}")]
 struct VcExprDelegate {
     inner: ResolvedVc<NamedFields>,
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
@@ -1,0 +1,224 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use std::fmt;
+
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks_testing::{Registration, register, run_once};
+
+static REGISTRATION: Registration = register!();
+
+// --- Test types ---
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+struct SimpleDisplay(u32);
+
+impl fmt::Display for SimpleDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "simple:{}", self.0)
+    }
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("item {name} (count: {count})")]
+struct NamedFields {
+    name: RcStr,
+    count: u32,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("wrapped({0})")]
+struct TupleStruct(u32);
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("constant-value")]
+struct ConstantString;
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string(self.name)]
+struct DirectExpr {
+    name: RcStr,
+    #[allow(dead_code)]
+    other: u32,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("prefix({}) suffix({})", self.name, self.count)]
+struct FormatExprs {
+    name: RcStr,
+    count: u32,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("inner: {}", self.inner)]
+struct VcExprDelegate {
+    inner: ResolvedVc<NamedFields>,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+enum Kind {
+    #[value_to_string("module")]
+    Module,
+    #[value_to_string("asset({0})")]
+    Asset(RcStr),
+    #[value_to_string("entry {name}")]
+    Entry { name: RcStr },
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+enum DefaultNames {
+    Alpha,
+    Beta,
+}
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+enum MixedEnum {
+    #[value_to_string("literal")]
+    Literal,
+    #[value_to_string(_0)]
+    Delegate(ResolvedVc<ConstantString>),
+    #[value_to_string("wrapped({})", name)]
+    ExprNamed { name: RcStr },
+}
+
+// --- Tests ---
+
+/// No attribute: delegates to Display::to_string(self).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_display_delegation() {
+    run_once(&REGISTRATION, || async {
+        let v: Vc<SimpleDisplay> = SimpleDisplay(42).cell();
+        assert_eq!(&*v.to_string().await?, "simple:42");
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// FormatAutoFields on structs: named fields, positional fields, and constant strings.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_struct_format_strings() {
+    run_once(&REGISTRATION, || async {
+        let v1: Vc<NamedFields> = NamedFields {
+            name: "foo".into(),
+            count: 7,
+        }
+        .cell();
+        assert_eq!(&*v1.to_string().await?, "item foo (count: 7)");
+
+        let v2: Vc<TupleStruct> = TupleStruct(99).cell();
+        assert_eq!(&*v2.to_string().await?, "wrapped(99)");
+
+        let v3: Vc<ConstantString> = ConstantString.cell();
+        assert_eq!(&*v3.to_string().await?, "constant-value");
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// DirectExpr form: single expression delegation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_struct_direct_expr() {
+    run_once(&REGISTRATION, || async {
+        let v: Vc<DirectExpr> = DirectExpr {
+            name: "hello".into(),
+            other: 42,
+        }
+        .cell();
+        assert_eq!(&*v.to_string().await?, "hello");
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// FormatExprs on structs: format string with explicit expressions, including Vc delegation.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_struct_format_exprs() {
+    run_once(&REGISTRATION, || async {
+        let v1: Vc<FormatExprs> = FormatExprs {
+            name: "test".into(),
+            count: 5,
+        }
+        .cell();
+        assert_eq!(&*v1.to_string().await?, "prefix(test) suffix(5)");
+
+        let inner = NamedFields {
+            name: "bar".into(),
+            count: 3,
+        }
+        .resolved_cell();
+        let v2: Vc<VcExprDelegate> = VcExprDelegate { inner }.cell();
+        assert_eq!(&*v2.to_string().await?, "inner: item bar (count: 3)");
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Enum with per-variant auto-field format strings and default variant names.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_enum_variants() {
+    run_once(&REGISTRATION, || async {
+        // Per-variant attributes
+        assert_eq!(&*Kind::Module.cell().to_string().await?, "module");
+        assert_eq!(
+            &*Kind::Asset("main.js".into()).cell().to_string().await?,
+            "asset(main.js)"
+        );
+        assert_eq!(
+            &*(Kind::Entry {
+                name: "index".into()
+            })
+            .cell()
+            .to_string()
+            .await?,
+            "entry index"
+        );
+
+        // Default variant names (no attribute)
+        assert_eq!(&*DefaultNames::Alpha.cell().to_string().await?, "Alpha");
+        assert_eq!(&*DefaultNames::Beta.cell().to_string().await?, "Beta");
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// Enum with mixed forms: constant literal, Vc delegation, and format exprs.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_mixed_enum() {
+    run_once(&REGISTRATION, || async {
+        assert_eq!(&*MixedEnum::Literal.cell().to_string().await?, "literal");
+
+        let inner = ConstantString.resolved_cell();
+        let v2: Vc<MixedEnum> = MixedEnum::Delegate(inner).cell();
+        assert_eq!(&*v2.to_string().await?, "constant-value");
+
+        let v3: Vc<MixedEnum> = (MixedEnum::ExprNamed {
+            name: "world".into(),
+        })
+        .cell();
+        assert_eq!(&*v3.to_string().await?, "wrapped(world)");
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -143,4 +143,3 @@ impl FileSystem for AttachedFileSystem {
         Ok(self.get_inner_fs_path(path).await?.metadata())
     }
 }
-

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -8,6 +8,8 @@ use crate::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawD
 /// "subdirectory" in the given root [FileSystem].
 ///
 /// Caveat: The `child_path` itself is not visible as a directory entry.
+#[derive(ValueToString)]
+#[value_to_string("{root_fs}-with-{child_fs}")]
 #[turbo_tasks::value]
 pub struct AttachedFileSystem {
     root_fs: ResolvedVc<Box<dyn FileSystem>>,
@@ -142,14 +144,3 @@ impl FileSystem for AttachedFileSystem {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for AttachedFileSystem {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let root_fs_str = self.root_fs.to_string().await?;
-        let child_fs_str = self.child_fs.to_string().await?;
-        Ok(Vc::cell(
-            format!("{root_fs_str}-with-{child_fs_str}").into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -90,4 +90,3 @@ impl FileSystem for EmbeddedFileSystem {
         Ok(FileMeta::default().cell())
     }
 }
-

--- a/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/embed/fs.rs
@@ -9,6 +9,8 @@ use crate::{
     RawDirectoryEntry,
 };
 
+#[derive(ValueToString)]
+#[value_to_string(self.name)]
 #[turbo_tasks::value(serialization = "none", cell = "new", eq = "manual")]
 pub struct EmbeddedFileSystem {
     name: RcStr,
@@ -89,10 +91,3 @@ impl FileSystem for EmbeddedFileSystem {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for EmbeddedFileSystem {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.name.clone())
-    }
-}

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -495,6 +495,8 @@ impl DiskFileSystemInner {
     }
 }
 
+#[derive(ValueToString)]
+#[value_to_string(self.inner.name)]
 #[turbo_tasks::value(cell = "new", eq = "manual")]
 pub struct DiskFileSystem {
     inner: Arc<DiskFileSystemInner>,
@@ -1289,16 +1291,9 @@ fn remove_symbolic_link_dir_helper(path: &Path) -> io::Result<()> {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for DiskFileSystem {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.inner.name.clone())
-    }
-}
-
+#[derive(Debug, Clone, Hash, TaskInput, ValueToString)]
+#[value_to_string("[{fs}]/{path}")]
 #[turbo_tasks::value(shared)]
-#[derive(Debug, Clone, Hash, TaskInput)]
 pub struct FileSystemPath {
     pub fs: ResolvedVc<Box<dyn FileSystem>>,
     pub path: RcStr,
@@ -1761,14 +1756,6 @@ impl FileSystemPath {
 
     pub fn realpath_with_links(&self) -> Vc<RealPathResult> {
         realpath_with_links(self.clone())
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for FileSystemPath {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        self.value_to_string()
     }
 }
 
@@ -2538,6 +2525,8 @@ impl DirectoryContent {
     }
 }
 
+#[derive(ValueToString)]
+#[value_to_string("null")]
 #[turbo_tasks::value(shared)]
 pub struct NullFileSystem;
 
@@ -2571,14 +2560,6 @@ impl FileSystem for NullFileSystem {
     #[turbo_tasks::function]
     fn metadata(&self, _fs_path: FileSystemPath) -> Vc<FileMeta> {
         FileMeta::default().cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for NullFileSystem {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("null"))
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -4,6 +4,8 @@ use turbo_tasks::{ValueDefault, ValueToString, Vc};
 
 use crate::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent};
 
+#[derive(ValueToString)]
+#[value_to_string(self.name)]
 #[turbo_tasks::value]
 pub struct VirtualFileSystem {
     pub name: RcStr,
@@ -76,10 +78,3 @@ impl FileSystem for VirtualFileSystem {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for VirtualFileSystem {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.name.clone())
-    }
-}

--- a/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/virtual_fs.rs
@@ -77,4 +77,3 @@ impl FileSystem for VirtualFileSystem {
         bail!("Reading is not possible on the virtual file system")
     }
 }
-

--- a/turbopack/crates/turbo-tasks-macros/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 
 [dependencies]
 either = { workspace = true }
+indexmap = { workspace = true }
 proc-macro-error = "1.0.4"
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/turbopack/crates/turbo-tasks-macros/src/derive/mod.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/mod.rs
@@ -6,6 +6,7 @@ mod task_storage_macro;
 mod trace_raw_vcs_macro;
 mod value_debug_format_macro;
 mod value_debug_macro;
+pub(crate) mod value_to_string_macro;
 
 pub use deterministic_hash_macro::derive_deterministic_hash;
 pub use non_local_value_macro::derive_non_local_value;

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexSet;
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
@@ -14,6 +15,46 @@ enum AttrForm {
     FormatExprs(String, Vec<Expr>),
     /// `#[value_to_string(expr)]` — single expression delegation.
     DirectExpr(Expr),
+}
+
+/// A parsed field reference from a format string.
+#[derive(PartialEq, Eq, Hash)]
+struct Field {
+    /// The original field name as it appears in the format string (e.g., "0", "name").
+    name: String,
+    /// The variable name used in generated code.
+    /// Tuple fields like `{0}` are prefixed with `_` because bare numeric identifiers
+    /// are not valid Rust identifiers (e.g., "0" becomes `_0`).
+    var: syn::Ident,
+    /// Whether this field is a positional tuple field (all-digit name).
+    is_positional: bool,
+}
+
+impl Field {
+    fn new(name: String) -> Self {
+        let is_positional = name.chars().all(|c| c.is_ascii_digit());
+        let var = if is_positional {
+            format_ident!("_{}", name)
+        } else {
+            format_ident!("{}", name)
+        };
+        Field {
+            name,
+            var,
+            is_positional,
+        }
+    }
+
+    /// Token stream to access this field on `self` (e.g., `self.0` or `self.name`).
+    fn struct_access(&self) -> TokenStream2 {
+        if self.is_positional {
+            let idx = syn::Index::from(self.name.parse::<usize>().unwrap());
+            quote! { self.#idx }
+        } else {
+            let ident = &self.var;
+            quote! { self.#ident }
+        }
+    }
 }
 
 /// Derive macro for `ValueToString`.
@@ -107,8 +148,17 @@ fn parse_attr(attr: &Attribute) -> syn::Result<AttrForm> {
     {
         let fmt = s.value();
         let rest: Vec<Expr> = iter.collect();
+
+        // Detect single-field patterns early and transform to DirectExpr:
+        // - `"{x}"` with no args → `DirectExpr(self.x)`
+        // - `"{}"` with one arg  → `DirectExpr(arg)`
         if rest.is_empty() {
+            if let Some(expr) = try_single_field_self_expr(&fmt) {
+                return Ok(AttrForm::DirectExpr(expr));
+            }
             Ok(AttrForm::FormatAutoFields(fmt))
+        } else if fmt == "{}" && rest.len() == 1 {
+            Ok(AttrForm::DirectExpr(rest.into_iter().next().unwrap()))
         } else {
             Ok(AttrForm::FormatExprs(fmt, rest))
         }
@@ -128,11 +178,32 @@ fn is_pure_constant(fmt: &str) -> bool {
     !fmt.contains('{') && !fmt.contains('}')
 }
 
+/// If `fmt` is exactly `{field_name}` (single field, no format specifier, no surrounding text),
+/// returns a `self.field_name` expression. This lets us skip `format!` entirely and delegate
+/// directly to `ValueToStringify::to_stringify`.
+fn try_single_field_self_expr(fmt: &str) -> Option<Expr> {
+    if fmt.starts_with('{') && fmt.ends_with('}') && fmt.len() > 2 {
+        let inner = &fmt[1..fmt.len() - 1];
+        if !inner.contains('{') && !inner.contains('}') && !inner.contains(':') {
+            return Some(if inner.chars().all(|c| c.is_ascii_digit()) {
+                let idx = syn::Index::from(inner.parse::<usize>().unwrap());
+                syn::parse_quote!(self.#idx)
+            } else {
+                let ident = format_ident!("{}", inner);
+                syn::parse_quote!(self.#ident)
+            });
+        }
+    }
+    None
+}
+
 /// Extract `{field}` references from a format string. Returns the transformed format string
-/// (with `{0}` → `{_0}` for positional fields) and a deduplicated list of field names.
-fn parse_format_fields(fmt: &str) -> (String, Vec<String>) {
-    let mut fields = Vec::new();
-    let mut seen = std::collections::HashSet::new();
+/// (with positional `{0}` → `{_0}` for valid identifiers) and a deduplicated list of fields.
+///
+/// Format specifiers (e.g., `{field:?}`, `{field:.2}`) are preserved in the transformed string
+/// but stripped from the field name used for resolution.
+fn parse_format_fields(fmt: &str) -> (String, Vec<Field>) {
+    let mut fields: IndexSet<Field> = IndexSet::new();
     let mut transformed = String::new();
 
     let chars: Vec<char> = fmt.chars().collect();
@@ -150,22 +221,23 @@ fn parse_format_fields(fmt: &str) -> (String, Vec<String>) {
             while i < chars.len() && chars[i] != '}' {
                 i += 1;
             }
-            let field_name: String = chars[start..i].iter().collect();
+            let full_contents: String = chars[start..i].iter().collect();
             i += 1;
 
-            let var_name = if field_name.chars().all(|c| c.is_ascii_digit()) {
-                format!("_{field_name}")
-            } else {
-                field_name.clone()
+            // Split off any format specifier (e.g., "field:?" → name="field", spec=":?")
+            let (field_name, spec) = match full_contents.find(':') {
+                Some(colon) => (&full_contents[..colon], &full_contents[colon..]),
+                None => (full_contents.as_str(), ""),
             };
 
-            if seen.insert(field_name.clone()) {
-                fields.push(field_name);
-            }
+            let field = Field::new(field_name.to_owned());
 
             transformed.push('{');
-            transformed.push_str(&var_name);
+            transformed.push_str(&field.var.to_string());
+            transformed.push_str(spec);
             transformed.push('}');
+
+            fields.insert(field);
         } else if chars[i] == '}' && i + 1 < chars.len() && chars[i + 1] == '}' {
             transformed.push_str("}}");
             i += 2;
@@ -175,17 +247,7 @@ fn parse_format_fields(fmt: &str) -> (String, Vec<String>) {
         }
     }
 
-    (transformed, fields)
-}
-
-fn struct_field_access(field_name: &str) -> TokenStream2 {
-    if field_name.chars().all(|c| c.is_ascii_digit()) {
-        let idx = syn::Index::from(field_name.parse::<usize>().unwrap());
-        quote! { self.#idx }
-    } else {
-        let field_ident = format_ident!("{}", field_name);
-        quote! { self.#field_ident }
-    }
+    (transformed, fields.into_iter().collect())
 }
 
 /// Generate `let var = ValueToStringify::to_stringify([&]access).await?;`
@@ -198,14 +260,6 @@ fn generate_resolve(var_name: &syn::Ident, access: &TokenStream2, add_ref: bool)
     }
 }
 
-fn field_var_name(field_name: &str) -> syn::Ident {
-    if field_name.chars().all(|c| c.is_ascii_digit()) {
-        format_ident!("_{}", field_name)
-    } else {
-        format_ident!("{}", field_name)
-    }
-}
-
 fn generate_struct_impl(
     ident: &syn::Ident,
     _fields: &Fields,
@@ -214,7 +268,7 @@ fn generate_struct_impl(
     let (is_async, body) = match attr {
         None => (
             false,
-            quote! { turbo_tasks::Vc::cell(self.to_string().into()) },
+            quote! { turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(self.to_string())) },
         ),
         Some(AttrForm::FormatAutoFields(fmt)) => struct_format_auto_fields_body(&fmt),
         Some(AttrForm::FormatExprs(fmt, exprs)) => struct_format_exprs_body(&fmt, &exprs),
@@ -222,7 +276,7 @@ fn generate_struct_impl(
             true,
             quote! {
                 let __val = turbo_tasks::display::ValueToStringify::to_stringify(&(#expr)).await?;
-                Ok(turbo_tasks::Vc::cell(__val.into()))
+                Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(__val)))
             },
         ),
     };
@@ -236,17 +290,16 @@ fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
         let value_expr = if is_pure_constant(fmt) {
             quote! { turbo_rcstr::rcstr!(#transformed_fmt) }
         } else {
-            quote! { format!(#transformed_fmt).into() }
+            quote! { turbo_rcstr::RcStr::from(format!(#transformed_fmt)) }
         };
         return (false, quote! { turbo_tasks::Vc::cell(#value_expr) });
     }
 
     let resolves: Vec<TokenStream2> = field_refs
         .iter()
-        .map(|field_name| {
-            let access = struct_field_access(field_name);
-            let var = field_var_name(field_name);
-            generate_resolve(&var, &access, true)
+        .map(|field| {
+            let access = field.struct_access();
+            generate_resolve(&field.var, &access, true)
         })
         .collect();
 
@@ -254,30 +307,28 @@ fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
         true,
         quote! {
             #(#resolves)*
-            Ok(turbo_tasks::Vc::cell(format!(#transformed_fmt).into()))
+            Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(format!(#transformed_fmt))))
         },
     )
 }
 
 fn struct_format_exprs_body(fmt: &str, exprs: &[Expr]) -> (bool, TokenStream2) {
-    let resolve_stmts: Vec<TokenStream2> = exprs
+    let (resolve_stmts, vars): (Vec<TokenStream2>, Vec<syn::Ident>) = exprs
         .iter()
         .enumerate()
         .map(|(i, expr)| {
             let var = format_ident!("__arg{}", i);
-            quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(&(#expr)).await?; }
+            let stmt =
+                quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(&(#expr)).await?; };
+            (stmt, var)
         })
-        .collect();
-
-    let vars: Vec<syn::Ident> = (0..exprs.len())
-        .map(|i| format_ident!("__arg{}", i))
-        .collect();
+        .unzip();
 
     (
         true,
         quote! {
             #(#resolve_stmts)*
-            Ok(turbo_tasks::Vc::cell(format!(#fmt, #(#vars),*).into()))
+            Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(format!(#fmt, #(#vars),*))))
         },
     )
 }
@@ -379,7 +430,7 @@ fn generate_enum_format_auto_fields(
                 .iter()
                 .map(|f| {
                     let name = f.ident.as_ref().unwrap();
-                    if field_refs.iter().any(|r| r == &name.to_string()) {
+                    if field_refs.iter().any(|r| *name == r.name) {
                         quote! { #name }
                     } else {
                         quote! { #name: _ }
@@ -388,10 +439,9 @@ fn generate_enum_format_auto_fields(
                 .collect();
             let resolves: Vec<TokenStream2> = field_refs
                 .iter()
-                .map(|field_name| {
-                    let field_ident = format_ident!("{}", field_name);
-                    let var = field_var_name(field_name);
-                    generate_resolve(&var, &quote! { #field_ident }, false)
+                .map(|field| {
+                    let field_ident = format_ident!("{}", field.name);
+                    generate_resolve(&field.var, &quote! { #field_ident }, false)
                 })
                 .collect();
             quote! {
@@ -405,7 +455,7 @@ fn generate_enum_format_auto_fields(
             let field_patterns: Vec<TokenStream2> = (0..unnamed.unnamed.len())
                 .map(|i| {
                     let idx_str = i.to_string();
-                    if field_refs.iter().any(|r| r == &idx_str) {
+                    if field_refs.iter().any(|r| r.name == idx_str) {
                         let var = format_ident!("_{}", i);
                         quote! { #var }
                     } else {
@@ -415,9 +465,9 @@ fn generate_enum_format_auto_fields(
                 .collect();
             let resolves: Vec<TokenStream2> = field_refs
                 .iter()
-                .map(|field_name| {
-                    let var = field_var_name(field_name);
-                    generate_resolve(&var, &quote! { #var }, false)
+                .map(|field| {
+                    let var = &field.var;
+                    generate_resolve(var, &quote! { #var }, false)
                 })
                 .collect();
             quote! {
@@ -441,17 +491,16 @@ fn generate_enum_format_exprs(
     exprs: &[Expr],
 ) -> TokenStream2 {
     let pattern = enum_destructure_all(ident, variant_ident, fields);
-    let resolve_stmts: Vec<TokenStream2> = exprs
+    let (resolve_stmts, vars): (Vec<TokenStream2>, Vec<syn::Ident>) = exprs
         .iter()
         .enumerate()
         .map(|(i, expr)| {
             let var = format_ident!("__arg{}", i);
-            quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(#expr).await?; }
+            let stmt =
+                quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(#expr).await?; };
+            (stmt, var)
         })
-        .collect();
-    let vars: Vec<syn::Ident> = (0..exprs.len())
-        .map(|i| format_ident!("__arg{}", i))
-        .collect();
+        .unzip();
     quote! {
         #pattern => {
             #(#resolve_stmts)*

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
@@ -297,9 +297,9 @@ fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
 
     let resolves: Vec<TokenStream2> = field_refs
         .iter()
-        .map(|field| {
-            let access = field.struct_access();
-            generate_resolve(&field.var, &access, true)
+        .map(|f| {
+            let access = f.struct_access();
+            generate_resolve(&f.var, &access, true)
         })
         .collect();
 

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
@@ -1,0 +1,505 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{
+    Attribute, Data, DeriveInput, Expr, ExprLit, Fields, Lit, Token, Variant, parse_macro_input,
+    punctuated::Punctuated,
+};
+
+/// The parsed form of a `#[value_to_string(...)]` attribute.
+enum AttrForm {
+    /// `#[value_to_string("{field} text")]` — format string with auto-field references.
+    FormatAutoFields(String),
+    /// `#[value_to_string("fmt {}", expr1, expr2)]` — format string with explicit expressions.
+    FormatExprs(String, Vec<Expr>),
+    /// `#[value_to_string(expr)]` — single expression delegation.
+    DirectExpr(Expr),
+}
+
+/// Derive macro for `ValueToString`.
+///
+/// Supports four forms:
+/// - No attribute: delegates to `Display::to_string(self)`
+/// - `#[value_to_string("{field} text")]`: auto-field references resolved via `ValueToStringify`
+/// - `#[value_to_string("fmt {}", expr)]`: format string with explicit expression arguments
+/// - `#[value_to_string(expr)]`: direct expression delegation
+///
+/// For enums, each variant can have its own attribute. Variants without one default to their name.
+pub fn derive_value_to_string(input: TokenStream) -> TokenStream {
+    let derive_input = parse_macro_input!(input as DeriveInput);
+    let ident = &derive_input.ident;
+
+    match &derive_input.data {
+        Data::Struct(data) => {
+            let attr = find_attr(&derive_input.attrs);
+            generate_struct_impl(ident, &data.fields, attr)
+        }
+        Data::Enum(data) => {
+            let attr = find_attr(&derive_input.attrs);
+            if attr.is_some() {
+                // Top-level attribute on enum: treat like a struct (self-based expression).
+                generate_struct_impl(ident, &Fields::Unit, attr)
+            } else {
+                generate_enum_impl(ident, &data.variants)
+            }
+        }
+        Data::Union(_) => {
+            syn::Error::new_spanned(&derive_input, "ValueToString cannot be derived for unions")
+                .to_compile_error()
+                .into()
+        }
+    }
+}
+
+/// Wrap a function body in the `#[turbo_tasks::value_impl] impl ValueToString` boilerplate.
+fn wrap_impl(ident: &syn::Ident, is_async: bool, body: TokenStream2) -> TokenStream {
+    let async_kw = if is_async {
+        quote! { async }
+    } else {
+        quote! {}
+    };
+    let ret_ty = if is_async {
+        quote! { anyhow::Result<turbo_tasks::Vc<turbo_rcstr::RcStr>> }
+    } else {
+        quote! { turbo_tasks::Vc<turbo_rcstr::RcStr> }
+    };
+    quote! {
+        #[turbo_tasks::value_impl]
+        impl turbo_tasks::ValueToString for #ident {
+            #[turbo_tasks::function]
+            #async_kw fn to_string(&self) -> #ret_ty {
+                #body
+            }
+        }
+    }
+    .into()
+}
+
+fn find_attr(attrs: &[Attribute]) -> Option<AttrForm> {
+    for attr in attrs {
+        if attr.path().is_ident("value_to_string") {
+            match parse_attr(attr) {
+                Ok(form) => return Some(form),
+                Err(e) => {
+                    e.span()
+                        .unwrap()
+                        .error(format!("invalid value_to_string attribute: {e}"))
+                        .emit();
+                    return None;
+                }
+            }
+        }
+    }
+    None
+}
+
+fn parse_attr(attr: &Attribute) -> syn::Result<AttrForm> {
+    let args: Punctuated<Expr, Token![,]> = attr.parse_args_with(Punctuated::parse_terminated)?;
+    let mut iter = args.into_iter();
+
+    let first = iter
+        .next()
+        .ok_or_else(|| syn::Error::new_spanned(attr, "expected format string or expression"))?;
+
+    if let Expr::Lit(ExprLit {
+        lit: Lit::Str(s), ..
+    }) = &first
+    {
+        let fmt = s.value();
+        let rest: Vec<Expr> = iter.collect();
+        if rest.is_empty() {
+            Ok(AttrForm::FormatAutoFields(fmt))
+        } else {
+            Ok(AttrForm::FormatExprs(fmt, rest))
+        }
+    } else {
+        if let Some(extra) = iter.next() {
+            return Err(syn::Error::new_spanned(
+                extra,
+                "expected format string as first argument when providing multiple arguments",
+            ));
+        }
+        Ok(AttrForm::DirectExpr(first))
+    }
+}
+
+/// Returns true if the format string has no `{` or `}` and can use `rcstr!` directly.
+fn is_pure_constant(fmt: &str) -> bool {
+    !fmt.contains('{') && !fmt.contains('}')
+}
+
+/// Extract `{field}` references from a format string. Returns the transformed format string
+/// (with `{0}` → `{_0}` for positional fields) and a deduplicated list of field names.
+fn parse_format_fields(fmt: &str) -> (String, Vec<String>) {
+    let mut fields = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let mut transformed = String::new();
+
+    let chars: Vec<char> = fmt.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        if chars[i] == '{' {
+            if i + 1 < chars.len() && chars[i + 1] == '{' {
+                transformed.push_str("{{");
+                i += 2;
+                continue;
+            }
+            i += 1;
+            let start = i;
+            while i < chars.len() && chars[i] != '}' {
+                i += 1;
+            }
+            let field_name: String = chars[start..i].iter().collect();
+            i += 1;
+
+            let var_name = if field_name.chars().all(|c| c.is_ascii_digit()) {
+                format!("_{field_name}")
+            } else {
+                field_name.clone()
+            };
+
+            if seen.insert(field_name.clone()) {
+                fields.push(field_name);
+            }
+
+            transformed.push('{');
+            transformed.push_str(&var_name);
+            transformed.push('}');
+        } else if chars[i] == '}' && i + 1 < chars.len() && chars[i + 1] == '}' {
+            transformed.push_str("}}");
+            i += 2;
+        } else {
+            transformed.push(chars[i]);
+            i += 1;
+        }
+    }
+
+    (transformed, fields)
+}
+
+fn struct_field_access(field_name: &str) -> TokenStream2 {
+    if field_name.chars().all(|c| c.is_ascii_digit()) {
+        let idx = syn::Index::from(field_name.parse::<usize>().unwrap());
+        quote! { self.#idx }
+    } else {
+        let field_ident = format_ident!("{}", field_name);
+        quote! { self.#field_ident }
+    }
+}
+
+/// Generate `let var = ValueToStringify::to_stringify([&]access).await?;`
+/// `add_ref` adds `&` for struct context (owned values); enum context already has references.
+fn generate_resolve(var_name: &syn::Ident, access: &TokenStream2, add_ref: bool) -> TokenStream2 {
+    if add_ref {
+        quote! { let #var_name = turbo_tasks::display::ValueToStringify::to_stringify(&(#access)).await?; }
+    } else {
+        quote! { let #var_name = turbo_tasks::display::ValueToStringify::to_stringify(#access).await?; }
+    }
+}
+
+fn field_var_name(field_name: &str) -> syn::Ident {
+    if field_name.chars().all(|c| c.is_ascii_digit()) {
+        format_ident!("_{}", field_name)
+    } else {
+        format_ident!("{}", field_name)
+    }
+}
+
+fn generate_struct_impl(
+    ident: &syn::Ident,
+    _fields: &Fields,
+    attr: Option<AttrForm>,
+) -> TokenStream {
+    let (is_async, body) = match attr {
+        None => (
+            false,
+            quote! { turbo_tasks::Vc::cell(self.to_string().into()) },
+        ),
+        Some(AttrForm::FormatAutoFields(fmt)) => struct_format_auto_fields_body(&fmt),
+        Some(AttrForm::FormatExprs(fmt, exprs)) => struct_format_exprs_body(&fmt, &exprs),
+        Some(AttrForm::DirectExpr(expr)) => (
+            true,
+            quote! {
+                let __val = turbo_tasks::display::ValueToStringify::to_stringify(&(#expr)).await?;
+                Ok(turbo_tasks::Vc::cell(__val.into()))
+            },
+        ),
+    };
+    wrap_impl(ident, is_async, body)
+}
+
+fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
+    let (transformed_fmt, field_refs) = parse_format_fields(fmt);
+
+    if field_refs.is_empty() {
+        let value_expr = if is_pure_constant(fmt) {
+            quote! { turbo_rcstr::rcstr!(#transformed_fmt) }
+        } else {
+            quote! { format!(#transformed_fmt).into() }
+        };
+        return (false, quote! { turbo_tasks::Vc::cell(#value_expr) });
+    }
+
+    let resolves: Vec<TokenStream2> = field_refs
+        .iter()
+        .map(|field_name| {
+            let access = struct_field_access(field_name);
+            let var = field_var_name(field_name);
+            generate_resolve(&var, &access, true)
+        })
+        .collect();
+
+    (
+        true,
+        quote! {
+            #(#resolves)*
+            Ok(turbo_tasks::Vc::cell(format!(#transformed_fmt).into()))
+        },
+    )
+}
+
+fn struct_format_exprs_body(fmt: &str, exprs: &[Expr]) -> (bool, TokenStream2) {
+    let resolve_stmts: Vec<TokenStream2> = exprs
+        .iter()
+        .enumerate()
+        .map(|(i, expr)| {
+            let var = format_ident!("__arg{}", i);
+            quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(&(#expr)).await?; }
+        })
+        .collect();
+
+    let vars: Vec<syn::Ident> = (0..exprs.len())
+        .map(|i| format_ident!("__arg{}", i))
+        .collect();
+
+    (
+        true,
+        quote! {
+            #(#resolve_stmts)*
+            Ok(turbo_tasks::Vc::cell(format!(#fmt, #(#vars),*).into()))
+        },
+    )
+}
+
+fn generate_enum_impl(
+    ident: &syn::Ident,
+    variants: &Punctuated<Variant, syn::Token![,]>,
+) -> TokenStream {
+    let mut match_arms = Vec::new();
+    let mut needs_async = false;
+
+    for variant in variants {
+        let variant_ident = &variant.ident;
+        let attr = find_attr(&variant.attrs);
+
+        match attr {
+            Some(AttrForm::FormatExprs(fmt, exprs)) => {
+                needs_async = true;
+                match_arms.push(generate_enum_format_exprs(
+                    ident,
+                    variant_ident,
+                    &variant.fields,
+                    &fmt,
+                    &exprs,
+                ));
+            }
+            Some(AttrForm::DirectExpr(expr)) => {
+                needs_async = true;
+                match_arms.push(generate_enum_direct_expr(
+                    ident,
+                    variant_ident,
+                    &variant.fields,
+                    &expr,
+                ));
+            }
+            Some(AttrForm::FormatAutoFields(fmt)) => {
+                match_arms.push(generate_enum_format_auto_fields(
+                    ident,
+                    variant_ident,
+                    &variant.fields,
+                    &fmt,
+                    &mut needs_async,
+                ));
+            }
+            None => {
+                let name = variant_ident.to_string();
+                match_arms.push(generate_enum_format_auto_fields(
+                    ident,
+                    variant_ident,
+                    &variant.fields,
+                    &name,
+                    &mut needs_async,
+                ));
+            }
+        }
+    }
+
+    let result_expr = if needs_async {
+        quote! { Ok(turbo_tasks::Vc::cell(s.into())) }
+    } else {
+        quote! { turbo_tasks::Vc::cell(s.into()) }
+    };
+
+    wrap_impl(
+        ident,
+        needs_async,
+        quote! {
+            let s = match self {
+                #(#match_arms)*
+            };
+            #result_expr
+        },
+    )
+}
+
+fn generate_enum_format_auto_fields(
+    ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+    fields: &Fields,
+    fmt: &str,
+    needs_async: &mut bool,
+) -> TokenStream2 {
+    let (transformed_fmt, field_refs) = parse_format_fields(fmt);
+
+    if !field_refs.is_empty() {
+        *needs_async = true;
+    }
+
+    let value_expr = if field_refs.is_empty() && is_pure_constant(fmt) {
+        quote! { turbo_rcstr::rcstr!(#transformed_fmt) }
+    } else {
+        quote! { turbo_rcstr::RcStr::from(format!(#transformed_fmt)) }
+    };
+
+    match fields {
+        Fields::Named(named) => {
+            let field_patterns: Vec<TokenStream2> = named
+                .named
+                .iter()
+                .map(|f| {
+                    let name = f.ident.as_ref().unwrap();
+                    if field_refs.iter().any(|r| r == &name.to_string()) {
+                        quote! { #name }
+                    } else {
+                        quote! { #name: _ }
+                    }
+                })
+                .collect();
+            let resolves: Vec<TokenStream2> = field_refs
+                .iter()
+                .map(|field_name| {
+                    let field_ident = format_ident!("{}", field_name);
+                    let var = field_var_name(field_name);
+                    generate_resolve(&var, &quote! { #field_ident }, false)
+                })
+                .collect();
+            quote! {
+                #ident::#variant_ident { #(#field_patterns),* } => {
+                    #(#resolves)*
+                    #value_expr
+                }
+            }
+        }
+        Fields::Unnamed(unnamed) => {
+            let field_patterns: Vec<TokenStream2> = (0..unnamed.unnamed.len())
+                .map(|i| {
+                    let idx_str = i.to_string();
+                    if field_refs.iter().any(|r| r == &idx_str) {
+                        let var = format_ident!("_{}", i);
+                        quote! { #var }
+                    } else {
+                        quote! { _ }
+                    }
+                })
+                .collect();
+            let resolves: Vec<TokenStream2> = field_refs
+                .iter()
+                .map(|field_name| {
+                    let var = field_var_name(field_name);
+                    generate_resolve(&var, &quote! { #var }, false)
+                })
+                .collect();
+            quote! {
+                #ident::#variant_ident(#(#field_patterns),*) => {
+                    #(#resolves)*
+                    #value_expr
+                }
+            }
+        }
+        Fields::Unit => {
+            quote! { #ident::#variant_ident => { #value_expr } }
+        }
+    }
+}
+
+fn generate_enum_format_exprs(
+    ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+    fields: &Fields,
+    fmt: &str,
+    exprs: &[Expr],
+) -> TokenStream2 {
+    let pattern = enum_destructure_all(ident, variant_ident, fields);
+    let resolve_stmts: Vec<TokenStream2> = exprs
+        .iter()
+        .enumerate()
+        .map(|(i, expr)| {
+            let var = format_ident!("__arg{}", i);
+            quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(#expr).await?; }
+        })
+        .collect();
+    let vars: Vec<syn::Ident> = (0..exprs.len())
+        .map(|i| format_ident!("__arg{}", i))
+        .collect();
+    quote! {
+        #pattern => {
+            #(#resolve_stmts)*
+            turbo_rcstr::RcStr::from(format!(#fmt, #(#vars),*))
+        }
+    }
+}
+
+fn generate_enum_direct_expr(
+    ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+    fields: &Fields,
+    expr: &Expr,
+) -> TokenStream2 {
+    let pattern = enum_destructure_all(ident, variant_ident, fields);
+    quote! {
+        #pattern => {
+            turbo_rcstr::RcStr::from(turbo_tasks::display::ValueToStringify::to_stringify(#expr).await?)
+        }
+    }
+}
+
+fn enum_destructure_all(
+    ident: &syn::Ident,
+    variant_ident: &syn::Ident,
+    fields: &Fields,
+) -> TokenStream2 {
+    match fields {
+        Fields::Named(named) => {
+            let bindings: Vec<TokenStream2> = named
+                .named
+                .iter()
+                .map(|f| {
+                    let name = f.ident.as_ref().unwrap();
+                    quote! { #name }
+                })
+                .collect();
+            quote! { #ident::#variant_ident { #(#bindings),* } }
+        }
+        Fields::Unnamed(unnamed) => {
+            let bindings: Vec<TokenStream2> = (0..unnamed.unnamed.len())
+                .map(|i| {
+                    let var = format_ident!("_{}", i);
+                    quote! { #var }
+                })
+                .collect();
+            quote! { #ident::#variant_ident(#(#bindings),*) }
+        }
+        Fields::Unit => quote! { #ident::#variant_ident },
+    }
+}

--- a/turbopack/crates/turbo-tasks-macros/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/lib.rs
@@ -57,6 +57,11 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
     derive::derive_task_input(input)
 }
 
+#[proc_macro_derive(ValueToString, attributes(value_to_string))]
+pub fn derive_value_to_string(input: TokenStream) -> TokenStream {
+    derive::value_to_string_macro::derive_value_to_string(input)
+}
+
 /// <!--
 /// Documentation for this macro is available on the re-export:
 /// <https://turbopack-rust-docs.vercel.sh/rustdoc/turbo_tasks/attr.task_storage.html>

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -1,10 +1,94 @@
+use std::{
+    fmt::{self, Display},
+    future::Future,
+};
+
+use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
+pub use turbo_tasks_macros::ValueToString;
 
-use crate::{self as turbo_tasks};
+use crate::{self as turbo_tasks, ReadRef, vc::ResolvedVc};
 
 #[turbo_tasks::value_trait]
 pub trait ValueToString {
     #[turbo_tasks::function]
     fn to_string(self: Vc<Self>) -> Vc<RcStr>;
+}
+
+/// A helper trait used by the `#[derive(ValueToString)]` macro.
+///
+/// Provides async string conversion with a blanket implementation for `Display`
+/// types. `Vc<T>` and `ResolvedVc<T>` have specialized implementations that
+/// await the inner value's `ValueToString` implementation.
+pub trait ValueToStringify {
+    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send;
+}
+
+pub enum StringifyType {
+    RcStr(ReadRef<RcStr>),
+    String(String),
+}
+
+impl AsRef<str> for StringifyType {
+    fn as_ref(&self) -> &str {
+        match self {
+            StringifyType::RcStr(s) => s.as_str(),
+            StringifyType::String(s) => s.as_str(),
+        }
+    }
+}
+
+impl Display for StringifyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+impl From<StringifyType> for RcStr {
+    fn from(s: StringifyType) -> Self {
+        match s {
+            StringifyType::RcStr(r) => (*r).clone(),
+            StringifyType::String(s) => RcStr::from(s),
+        }
+    }
+}
+
+/// Blanket implementation for all `Display` types.
+impl<T: Display + Send + Sync> ValueToStringify for T {
+    #[inline(always)]
+    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
+        let s = self.to_string();
+        async move { Ok(StringifyType::String(s)) }
+    }
+}
+
+/// Implementation for `Vc<T>` that awaits the turbo-tasks `ValueToString` result.
+impl<T: Send> ValueToStringify for Vc<T>
+where
+    T: ValueToString,
+{
+    #[inline(always)]
+    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
+        let vc = *self;
+        async move {
+            let s = vc.to_string().await?;
+            Ok(StringifyType::RcStr(s))
+        }
+    }
+}
+
+/// Implementation for `ResolvedVc<T>` that delegates to the `Vc<T>` implementation.
+impl<T: Send> ValueToStringify for ResolvedVc<T>
+where
+    T: ValueToString,
+{
+    #[inline(always)]
+    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
+        let vc = *self;
+        async move {
+            let s = vc.to_string().await?;
+            Ok(StringifyType::RcStr(s))
+        }
+    }
 }

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -10,6 +10,7 @@ pub use turbo_tasks_macros::ValueToString;
 
 use crate::{self as turbo_tasks, ReadRef, vc::ResolvedVc};
 
+/// Converts a value to a string, like [`Display`], but returning `Vc<RcStr>`.
 #[turbo_tasks::value_trait]
 pub trait ValueToString {
     #[turbo_tasks::function]
@@ -27,9 +28,6 @@ pub trait ValueToString {
 #[doc(hidden)]
 pub trait ValueToStringify {
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send;
-    fn is_async() -> bool {
-        true
-    }
 }
 
 /// Used only for macro codegen.
@@ -69,10 +67,6 @@ impl<T: Display + Send + Sync> ValueToStringify for T {
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
         let s = self.to_string();
         async move { Ok(StringifyType::String(s)) }
-    }
-    #[inline(always)]
-    fn is_async() -> bool {
-        false
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -21,10 +21,19 @@ pub trait ValueToString {
 /// Provides async string conversion with a blanket implementation for `Display`
 /// types. `Vc<T>` and `ResolvedVc<T>` have specialized implementations that
 /// await the inner value's `ValueToString` implementation.
+///
+/// Note that these methods are inlined and these function calls are only used for
+/// effecient macro codegen.
+#[doc(hidden)]
 pub trait ValueToStringify {
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send;
+    fn is_async() -> bool {
+        true
+    }
 }
 
+/// Used only for macro codegen.
+#[doc(hidden)]
 pub enum StringifyType {
     RcStr(ReadRef<RcStr>),
     String(String),
@@ -60,6 +69,10 @@ impl<T: Display + Send + Sync> ValueToStringify for T {
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
         let s = self.to_string();
         async move { Ok(StringifyType::String(s)) }
+    }
+    #[inline(always)]
+    fn is_async() -> bool {
+        false
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -45,7 +45,7 @@ mod capture_future;
 mod collectibles;
 mod completion;
 pub mod debug;
-mod display;
+pub mod display;
 pub mod duration_span;
 mod effect;
 mod error;

--- a/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/chunk.rs
@@ -17,6 +17,8 @@ use crate::{BrowserChunkingContext, ecmascript::content::EcmascriptBrowserChunkC
 
 /// Development Ecmascript chunk.
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("Ecmascript Dev Chunk")]
 pub struct EcmascriptBrowserChunk {
     chunking_context: ResolvedVc<BrowserChunkingContext>,
     chunk: ResolvedVc<EcmascriptChunk>,
@@ -53,14 +55,6 @@ impl EcmascriptBrowserChunk {
         self.chunk
             .ident()
             .with_modifier(rcstr!("ecmascript dev chunk"))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptBrowserChunk {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Dev Chunk"))
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -4,7 +4,7 @@ use anyhow::{Result, bail};
 use either::Either;
 use indoc::writedoc;
 use serde::Serialize;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -36,6 +36,8 @@ use crate::{
 /// * Contains the Turbopack browser runtime code; and
 /// * Evaluates a list of runtime entries.
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("Ecmascript Browser Evaluate Chunk")]
 pub(crate) struct EcmascriptBrowserEvaluateChunk {
     chunking_context: ResolvedVc<BrowserChunkingContext>,
     ident: ResolvedVc<AssetIdent>,
@@ -235,14 +237,6 @@ impl EcmascriptBrowserEvaluateChunk {
             self.ident_for_path(),
             Vc::upcast(self),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptBrowserEvaluateChunk {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Browser Evaluate Chunk"))
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/asset.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use serde::{Deserialize, Serialize};
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, trace::TraceRawVcs};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -27,6 +27,8 @@ use crate::BrowserChunkingContext;
 /// * moving a module from one chunk to another;
 /// * changing a chunk's path.
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("Ecmascript Dev Chunk List")]
 pub(crate) struct EcmascriptDevChunkList {
     pub(super) chunking_context: ResolvedVc<BrowserChunkingContext>,
     pub(super) ident: ResolvedVc<AssetIdent>,
@@ -59,14 +61,6 @@ impl EcmascriptDevChunkList {
     #[turbo_tasks::function]
     fn own_content(self: Vc<Self>) -> Vc<EcmascriptDevChunkListContent> {
         EcmascriptDevChunkListContent::new(self)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptDevChunkList {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Dev Chunk List"))
     }
 }
 

--- a/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/worker.rs
@@ -21,6 +21,8 @@ use turbopack_ecmascript::minify::minify;
 /// The worker receives a JSON array via URL params of the following structure:
 /// `[TURBOPACK_NEXT_CHUNK_URLS, ASSET_SUFFIX, ...forwarded_global_values]`
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("Ecmascript Browser Worker Entrypoint")]
 pub struct EcmascriptBrowserWorkerEntrypoint {
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
     /// Global variable names to forward from main thread to worker.
@@ -81,14 +83,6 @@ impl EcmascriptBrowserWorkerEntrypoint {
             self.ident_for_path(),
             Vc::upcast(self),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptBrowserWorkerEntrypoint {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Browser Worker Entrypoint"))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -48,7 +48,7 @@ use crate::{
 
 /// A module id, which can be a number or string
 #[turbo_tasks::value(shared, operation)]
-#[derive(Debug, Clone, Hash, Ord, PartialOrd, DeterministicHash, Serialize)]
+#[derive(Debug, Clone, Hash, Ord, PartialOrd, DeterministicHash, Serialize, ValueToString)]
 #[serde(untagged)]
 pub enum ModuleId {
     Number(u64),
@@ -61,14 +61,6 @@ impl Display for ModuleId {
             ModuleId::Number(i) => write!(f, "{i}"),
             ModuleId::String(s) => write!(f, "{s}"),
         }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for ModuleId {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.to_string().into())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -60,6 +60,8 @@ impl ModuleReferences {
 
 /// A reference that always resolves to a single module.
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("{description}")]
 pub struct SingleModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
     description: RcStr,
@@ -70,14 +72,6 @@ impl ModuleReference for SingleModuleReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::module(self.asset)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for SingleModuleReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.description.clone())
     }
 }
 
@@ -98,6 +92,8 @@ impl SingleModuleReference {
 }
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("{description}")]
 pub struct SingleChunkableModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
     description: RcStr,
@@ -145,16 +141,10 @@ impl ModuleReference for SingleChunkableModuleReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for SingleChunkableModuleReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.description.clone())
-    }
-}
-
 /// A reference that always resolves to a single module.
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("{description}")]
 pub struct SingleOutputAssetReference {
     asset: ResolvedVc<Box<dyn OutputAsset>>,
     description: RcStr,
@@ -165,14 +155,6 @@ impl ModuleReference for SingleOutputAssetReference {
     #[turbo_tasks::function]
     fn resolve_reference(&self) -> Vc<ModuleResolveResult> {
         *ModuleResolveResult::output_asset(RequestKey::default(), self.asset)
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for SingleOutputAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.description.clone())
     }
 }
 
@@ -230,6 +212,8 @@ pub async fn referenced_modules_and_affecting_sources(
 }
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("traced {}", self.module.ident())]
 pub struct TracedModuleReference {
     module: ResolvedVc<Box<dyn Module>>,
 }
@@ -244,16 +228,6 @@ impl ModuleReference for TracedModuleReference {
     #[turbo_tasks::function]
     fn chunking_type(&self) -> Vc<ChunkingTypeOption> {
         Vc::cell(Some(ChunkingType::Traced))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for TracedModuleReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("traced {}", self.module.ident().to_string().await?).into(),
-        ))
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -61,7 +61,7 @@ impl ModuleReferences {
 /// A reference that always resolves to a single module.
 #[turbo_tasks::value]
 #[derive(ValueToString)]
-#[value_to_string("{description}")]
+#[value_to_string(self.description)]
 pub struct SingleModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
     description: RcStr,
@@ -93,7 +93,7 @@ impl SingleModuleReference {
 
 #[turbo_tasks::value]
 #[derive(ValueToString)]
-#[value_to_string("{description}")]
+#[value_to_string(self.description)]
 pub struct SingleChunkableModuleReference {
     asset: ResolvedVc<Box<dyn Module>>,
     description: RcStr,
@@ -144,7 +144,7 @@ impl ModuleReference for SingleChunkableModuleReference {
 /// A reference that always resolves to a single module.
 #[turbo_tasks::value]
 #[derive(ValueToString)]
-#[value_to_string("{description}")]
+#[value_to_string(self.description)]
 pub struct SingleOutputAssetReference {
     asset: ResolvedVc<Box<dyn OutputAsset>>,
     description: RcStr,

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -12,7 +12,7 @@ use crate::{
 
 #[turbo_tasks::value]
 #[derive(ValueToString)]
-#[value_to_string("source map file is referenced by {}", self.from)]
+#[value_to_string("source map file is referenced by {from}")]
 pub struct SourceMapReference {
     from: FileSystemPath,
     file: FileSystemPath,

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -70,4 +70,3 @@ impl GenerateSourceMap for SourceMapReference {
         }
     }
 }
-

--- a/turbopack/crates/turbopack-core/src/reference/source_map.rs
+++ b/turbopack/crates/turbopack-core/src/reference/source_map.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemEntryType, FileSystemPath};
 
@@ -12,6 +11,8 @@ use crate::{
 };
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("source map file is referenced by {}", self.from)]
 pub struct SourceMapReference {
     from: FileSystemPath,
     file: FileSystemPath,
@@ -70,16 +71,3 @@ impl GenerateSourceMap for SourceMapReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for SourceMapReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!(
-                "source map file is referenced by {}",
-                self.from.value_to_string().await?
-            )
-            .into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbopack-core/src/resolve/pattern.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/pattern.rs
@@ -19,7 +19,8 @@ use turbo_tasks_fs::{
 use turbo_unix_path::normalize_path;
 
 #[turbo_tasks::value]
-#[derive(Hash, Clone, Debug, Default)]
+#[derive(Hash, Clone, Debug, Default, ValueToString)]
+#[value_to_string(self.describe_as_string())]
 pub enum Pattern {
     Constant(RcStr),
     #[default]
@@ -1480,14 +1481,6 @@ impl Pattern {
                 .collect::<Vec<_>>()
                 .join(" "),
         }
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for Pattern {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.describe_as_string().into())
     }
 }
 

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -49,4 +49,3 @@ impl FileSystem for ServerFileSystem {
         bail!("Reading is not possible from the marker filesystem for the server")
     }
 }
-

--- a/turbopack/crates/turbopack-core/src/server_fs.rs
+++ b/turbopack/crates/turbopack-core/src/server_fs.rs
@@ -1,11 +1,12 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ValueToString, Vc};
 use turbo_tasks_fs::{
     FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent,
 };
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("root-of-the-server")]
 pub struct ServerFileSystem {}
 
 #[turbo_tasks::value_impl]
@@ -49,10 +50,3 @@ impl FileSystem for ServerFileSystem {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for ServerFileSystem {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("root-of-the-server"))
-    }
-}

--- a/turbopack/crates/turbopack-core/src/target.rs
+++ b/turbopack/crates/turbopack-core/src/target.rs
@@ -1,10 +1,10 @@
 use std::fmt::Display;
 
 use bincode::{Decode, Encode};
-use turbo_tasks::{NonLocalValue, Vc, trace::TraceRawVcs};
+use turbo_tasks::{NonLocalValue, ValueToString, Vc, trace::TraceRawVcs};
 
 #[turbo_tasks::value(shared)]
-#[derive(Hash, Debug, Copy, Clone)]
+#[derive(Hash, Debug, Copy, Clone, ValueToString)]
 pub struct CompileTarget {
     /// <https://nodejs.org/api/os.html#osarch>
     pub arch: Arch,

--- a/turbopack/crates/turbopack-css/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-css/src/chunk/mod.rs
@@ -522,17 +522,10 @@ impl Introspectable for CssChunk {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, ValueToString)]
+#[value_to_string("css")]
 #[turbo_tasks::value]
 pub struct CssChunkType {}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for CssChunkType {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("css"))
-    }
-}
 
 #[turbo_tasks::value_impl]
 impl ChunkType for CssChunkType {

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -50,4 +50,3 @@ impl ModuleReference for CssModuleComposeReference {
         }))
     }
 }
-

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -11,7 +11,7 @@ use crate::references::css_resolve;
 /// A `composes: ... from ...` CSS module reference.
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("compose(url) {}", self.request)]
+#[value_to_string("compose(url) {request}")]
 pub struct CssModuleComposeReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkingType, ChunkingTypeOption},
@@ -12,7 +10,8 @@ use crate::references::css_resolve;
 
 /// A `composes: ... from ...` CSS module reference.
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("compose(url) {}", self.request)]
 pub struct CssModuleComposeReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -52,12 +51,3 @@ impl ModuleReference for CssModuleComposeReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for CssModuleComposeReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("compose(url) {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -80,7 +80,7 @@ impl ImportAttributes {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("import(url) {}", self.request)]
+#[value_to_string("import(url) {request}")]
 pub struct ImportAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-css/src/references/import.rs
+++ b/turbopack/crates/turbopack-css/src/references/import.rs
@@ -6,7 +6,6 @@ use lightningcss::{
     traits::ToCss,
     values::string::CowArcStr,
 };
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption},
@@ -80,7 +79,8 @@ impl ImportAttributes {
 }
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("import(url) {}", self.request)]
 pub struct ImportAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -148,16 +148,6 @@ impl ModuleReference for ImportAssetReference {
             inherit_async: false,
             hoisted: false,
         }))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for ImportAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("import(url) {}", self.request.to_string().await?,).into(),
-        ))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/internal.rs
+++ b/turbopack/crates/turbopack-css/src/references/internal.rs
@@ -38,4 +38,3 @@ impl ModuleReference for InternalCssAssetReference {
         }))
     }
 }
-

--- a/turbopack/crates/turbopack-css/src/references/internal.rs
+++ b/turbopack/crates/turbopack-css/src/references/internal.rs
@@ -1,5 +1,3 @@
-use anyhow::Result;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     chunk::{ChunkingType, ChunkingTypeOption},
@@ -10,7 +8,8 @@ use turbopack_core::{
 
 /// A reference to an internal CSS asset.
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("internal css {}", self.module.ident())]
 pub struct InternalCssAssetReference {
     module: ResolvedVc<Box<dyn Module>>,
 }
@@ -40,12 +39,3 @@ impl ModuleReference for InternalCssAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for InternalCssAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("internal css {}", self.module.ident().to_string().await?).into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -30,7 +30,8 @@ pub enum ReferencedAsset {
 }
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("url {}", self.request)]
 pub struct UrlAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -91,16 +92,6 @@ impl ModuleReference for UrlAssetReference {
             inherit_async: false,
             hoisted: false,
         }))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for UrlAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("url {}", self.request.to_string().await?,).into(),
-        ))
     }
 }
 

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -31,7 +31,7 @@ pub enum ReferencedAsset {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("url {}", self.request)]
+#[value_to_string("url {request}")]
 pub struct UrlAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -1,5 +1,4 @@
 use anyhow::{Result, bail};
-use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueDefault, ValueToString, Vc};
 use turbopack_core::chunk::{
     AsyncModuleInfo, Chunk, ChunkItem, ChunkItemBatchGroup, ChunkItemOrBatchWithAsyncModuleInfo,
@@ -10,16 +9,9 @@ use super::{EcmascriptChunk, EcmascriptChunkContent, EcmascriptChunkItem};
 use crate::chunk::batch::{EcmascriptChunkItemBatchGroup, EcmascriptChunkItemOrBatchWithAsyncInfo};
 
 #[turbo_tasks::value]
-#[derive(Default)]
+#[derive(Default, ValueToString)]
+#[value_to_string("ecmascript")]
 pub struct EcmascriptChunkType {}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptChunkType {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("ecmascript"))
-    }
-}
 
 #[turbo_tasks::value_impl]
 impl ChunkType for EcmascriptChunkType {

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/mod.rs
@@ -176,16 +176,6 @@ impl Chunk for EcmascriptChunk {
 }
 
 #[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptChunk {
-    #[turbo_tasks::function]
-    async fn to_string(self: Vc<Self>) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("chunk {}", self.ident().to_string().await?).into(),
-        ))
-    }
-}
-
-#[turbo_tasks::value_impl]
 impl EcmascriptChunk {
     #[turbo_tasks::function]
     pub fn chunk_content(&self) -> Vc<EcmascriptChunkContent> {

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -35,7 +35,7 @@ use crate::{
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("AMD define dependency {}", self.request)]
+#[value_to_string("AMD define dependency {request}")]
 pub struct AmdDefineAssetReference {
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -10,7 +10,6 @@ use swc_core::{
     },
     quote, quote_expr,
 };
-use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ReadRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -35,7 +34,8 @@ use crate::{
 };
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("AMD define dependency {}", self.request)]
 pub struct AmdDefineAssetReference {
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     request: ResolvedVc<Request>,
@@ -83,15 +83,6 @@ impl ModuleReference for AmdDefineAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for AmdDefineAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("AMD define dependency {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}
 
 #[derive(
     ValueDebugFormat, Debug, PartialEq, Eq, TraceRawVcs, Clone, NonLocalValue, Hash, Encode, Decode,

--- a/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/amd.rs
@@ -83,7 +83,6 @@ impl ModuleReference for AmdDefineAssetReference {
     }
 }
 
-
 #[derive(
     ValueDebugFormat, Debug, PartialEq, Eq, TraceRawVcs, Clone, NonLocalValue, Hash, Encode, Decode,
 )]

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -77,7 +77,6 @@ impl ModuleReference for CjsAssetReference {
     }
 }
 
-
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("require {}", self.request)]
@@ -125,7 +124,6 @@ impl ModuleReference for CjsRequireAssetReference {
         }))
     }
 }
-
 
 impl IntoCodeGenReference for CjsRequireAssetReference {
     fn into_code_gen_reference(
@@ -249,7 +247,6 @@ impl ModuleReference for CjsRequireResolveAssetReference {
         }))
     }
 }
-
 
 impl IntoCodeGenReference for CjsRequireResolveAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -29,7 +29,7 @@ use crate::{
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("generic commonjs {}", self.request)]
+#[value_to_string("generic commonjs {request}")]
 pub struct CjsAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -79,7 +79,7 @@ impl ModuleReference for CjsAssetReference {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("require {}", self.request)]
+#[value_to_string("require {request}")]
 pub struct CjsRequireAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -202,7 +202,7 @@ impl CjsRequireAssetReferenceCodeGen {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("require.resolve {}", self.request)]
+#[value_to_string("require.resolve {request}")]
 pub struct CjsRequireResolveAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -5,7 +5,6 @@ use swc_core::{
     ecma::ast::{CallExpr, Expr, ExprOrSpread, Lit},
     quote,
 };
-use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
@@ -29,7 +28,8 @@ use crate::{
 };
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("generic commonjs {}", self.request)]
 pub struct CjsAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -77,18 +77,10 @@ impl ModuleReference for CjsAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for CjsAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("generic commonjs {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("require {}", self.request)]
 pub struct CjsRequireAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -134,15 +126,6 @@ impl ModuleReference for CjsRequireAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for CjsRequireAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("require {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}
 
 impl IntoCodeGenReference for CjsRequireAssetReference {
     fn into_code_gen_reference(
@@ -220,7 +203,8 @@ impl CjsRequireAssetReferenceCodeGen {
 }
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("require.resolve {}", self.request)]
 pub struct CjsRequireResolveAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -266,15 +250,6 @@ impl ModuleReference for CjsRequireResolveAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for CjsRequireResolveAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("require.resolve {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}
 
 impl IntoCodeGenReference for CjsRequireResolveAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -319,7 +319,7 @@ impl EsmAssetReferences {
 
 #[turbo_tasks::value(shared)]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("import {} with {}", self.request, self.annotations)]
+#[value_to_string("import {request} with {annotations}")]
 pub struct EsmAssetReference {
     pub module: ResolvedVc<EcmascriptModuleAsset>,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -513,7 +513,6 @@ impl ModuleReference for EsmAssetReference {
     }
 }
 
-
 impl EsmAssetReference {
     pub async fn code_generation(
         self: ResolvedVc<Self>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -318,7 +318,8 @@ impl EsmAssetReferences {
 }
 
 #[turbo_tasks::value(shared)]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("import {} with {}", self.request, self.annotations)]
 pub struct EsmAssetReference {
     pub module: ResolvedVc<EcmascriptModuleAsset>,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
@@ -512,13 +513,6 @@ impl ModuleReference for EsmAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for EsmAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(format!("import {} with {}", self.request, self.annotations).into())
-    }
-}
 
 impl EsmAssetReference {
     pub async fn code_generation(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -94,7 +94,6 @@ impl ModuleReference for EsmAsyncAssetReference {
     }
 }
 
-
 impl IntoCodeGenReference for EsmAsyncAssetReference {
     fn into_code_gen_reference(
         self,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -34,7 +34,7 @@ use crate::{
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("dynamic import {}", self.request)]
+#[value_to_string("dynamic import {request}")]
 pub struct EsmAsyncAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/dynamic.rs
@@ -5,7 +5,6 @@ use swc_core::{
     ecma::ast::{CallExpr, Callee, Expr, ExprOrSpread, Lit},
     quote_expr,
 };
-use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
@@ -34,7 +33,8 @@ use crate::{
 };
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("dynamic import {}", self.request)]
 pub struct EsmAsyncAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -94,15 +94,6 @@ impl ModuleReference for EsmAsyncAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for EsmAsyncAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("dynamic import {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}
 
 impl IntoCodeGenReference for EsmAsyncAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use swc_core::quote;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
 };
@@ -22,7 +21,8 @@ use crate::{
 };
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("module id of {}", self.inner)]
 pub struct EsmModuleIdAssetReference {
     inner: ResolvedVc<EsmAssetReference>,
 }
@@ -46,15 +46,6 @@ impl ModuleReference for EsmModuleIdAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for EsmModuleIdAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("module id of {}", self.inner.to_string().await?,).into(),
-        ))
-    }
-}
 
 impl IntoCodeGenReference for EsmModuleIdAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -46,7 +46,6 @@ impl ModuleReference for EsmModuleIdAssetReference {
     }
 }
 
-
 impl IntoCodeGenReference for EsmModuleIdAssetReference {
     fn into_code_gen_reference(
         self,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/module_id.rs
@@ -22,7 +22,7 @@ use crate::{
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("module id of {}", self.inner)]
+#[value_to_string("module id of {inner}")]
 pub struct EsmModuleIdAssetReference {
     inner: ResolvedVc<EsmAssetReference>,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -108,7 +108,6 @@ impl ModuleReference for UrlAssetReference {
     }
 }
 
-
 impl IntoCodeGenReference for UrlAssetReference {
     fn into_code_gen_reference(
         self,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -52,7 +52,7 @@ pub enum UrlRewriteBehavior {
 /// referenced file to be imported/fetched/etc.
 #[turbo_tasks::value]
 #[derive(ValueToString)]
-#[value_to_string("new URL({})", self.request)]
+#[value_to_string("new URL({request})")]
 pub struct UrlAssetReference {
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/url.rs
@@ -4,7 +4,6 @@ use swc_core::{
     ecma::ast::{Expr, ExprOrSpread, NewExpr},
     quote,
 };
-use turbo_rcstr::RcStr;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, TaskInput, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -52,6 +51,8 @@ pub enum UrlRewriteBehavior {
 /// It's responsible rewriting the `URL` constructor's arguments to allow the
 /// referenced file to be imported/fetched/etc.
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string("new URL({})", self.request)]
 pub struct UrlAssetReference {
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     request: ResolvedVc<Request>,
@@ -107,15 +108,6 @@ impl ModuleReference for UrlAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for UrlAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("new URL({})", self.request.to_string().await?,).into(),
-        ))
-    }
-}
 
 impl IntoCodeGenReference for UrlAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -8,7 +8,7 @@ use turbopack_core::{
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug, ValueToString)]
-#[value_to_string("package.json {}", self.package_json)]
+#[value_to_string("package.json {package_json}")]
 pub struct PackageJsonReference {
     pub package_json: FileSystemPath,
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -8,7 +7,8 @@ use turbopack_core::{
 };
 
 #[turbo_tasks::value]
-#[derive(Hash, Clone, Debug)]
+#[derive(Hash, Clone, Debug, ValueToString)]
+#[value_to_string("package.json {}", self.package_json)]
 pub struct PackageJsonReference {
     pub package_json: FileSystemPath,
 }
@@ -33,16 +33,3 @@ impl ModuleReference for PackageJsonReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for PackageJsonReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!(
-                "package.json {}",
-                self.package_json.value_to_string().await?
-            )
-            .into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbopack-ecmascript/src/references/node.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/node.rs
@@ -32,4 +32,3 @@ impl ModuleReference for PackageJsonReference {
         )))
     }
 }
-

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use tracing::Instrument;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -19,7 +19,8 @@ use turbopack_core::{
 use crate::references::util::check_and_emit_too_many_matches_warning;
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("raw asset {}", self.path)]
 pub struct FileSourceReference {
     context_dir: FileSystemPath,
     path: ResolvedVc<Pattern>,
@@ -83,18 +84,10 @@ impl ModuleReference for FileSourceReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for FileSourceReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("raw asset {}", self.path.to_string().await?,).into(),
-        ))
-    }
-}
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("directory assets {}", self.path)]
 pub struct DirAssetReference {
     context_dir: FileSystemPath,
     path: ResolvedVc<Pattern>,
@@ -221,12 +214,3 @@ impl ModuleReference for DirAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for DirAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("directory assets {}", self.path.to_string().await?,).into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -84,7 +84,6 @@ impl ModuleReference for FileSourceReference {
     }
 }
 
-
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("directory assets {}", self.path)]
@@ -213,4 +212,3 @@ impl ModuleReference for DirAssetReference {
         Vc::cell(Some(ChunkingType::Traced))
     }
 }
-

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -20,7 +20,7 @@ use crate::references::util::check_and_emit_too_many_matches_warning;
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("raw asset {}", self.path)]
+#[value_to_string("raw asset {path}")]
 pub struct FileSourceReference {
     context_dir: FileSystemPath,
     path: ResolvedVc<Pattern>,
@@ -86,7 +86,7 @@ impl ModuleReference for FileSourceReference {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("directory assets {}", self.path)]
+#[value_to_string("directory assets {path}")]
 pub struct DirAssetReference {
     context_dir: FileSystemPath,
     path: ResolvedVc<Pattern>,

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -14,7 +14,7 @@ use swc_core::{
     quote, quote_expr,
 };
 use turbo_esregex::EsRegex;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexMap, NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat,
     trace::TraceRawVcs,
@@ -227,7 +227,8 @@ impl RequireContextMap {
 /// A reference for `require.context()`, will replace it with an inlined map
 /// wrapped in `__turbopack_module_context__`;
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("require.context {}/{}", self.dir, {if self.include_subdirs { "**" } else { "*" }})]
 pub struct RequireContextAssetReference {
     pub inner: ResolvedVc<RequireContextAsset>,
     pub dir: RcStr,
@@ -293,20 +294,6 @@ impl ModuleReference for RequireContextAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for RequireContextAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(
-            format!(
-                "require.context {}/{}",
-                self.dir,
-                if self.include_subdirs { "**" } else { "*" },
-            )
-            .into(),
-        )
-    }
-}
 
 impl IntoCodeGenReference for RequireContextAssetReference {
     fn into_code_gen_reference(
@@ -366,6 +353,8 @@ impl RequireContextAssetReferenceCodeGen {
 }
 
 #[turbo_tasks::value(transparent)]
+#[derive(ValueToString)]
+#[value_to_string("resolved reference")]
 pub struct ResolvedModuleReference(ResolvedVc<ModuleResolveResult>);
 
 #[turbo_tasks::value_impl]
@@ -384,13 +373,6 @@ impl ModuleReference for ResolvedModuleReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for ResolvedModuleReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("resolved reference"))
-    }
-}
 
 #[turbo_tasks::value]
 pub struct RequireContextAsset {

--- a/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/require_context.rs
@@ -294,7 +294,6 @@ impl ModuleReference for RequireContextAssetReference {
     }
 }
 
-
 impl IntoCodeGenReference for RequireContextAssetReference {
     fn into_code_gen_reference(
         self,
@@ -372,7 +371,6 @@ impl ModuleReference for ResolvedModuleReference {
         }))
     }
 }
-
 
 #[turbo_tasks::value]
 pub struct RequireContextAsset {

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -14,7 +14,8 @@ use turbopack_resolve::typescript::type_resolve;
 use crate::typescript::TsConfigModuleAsset;
 
 #[turbo_tasks::value]
-#[derive(Hash, Clone, Debug)]
+#[derive(Hash, Clone, Debug, ValueToString)]
+#[value_to_string("tsconfig {}", self.tsconfig)]
 pub struct TsConfigReference {
     pub tsconfig: FileSystemPath,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
@@ -43,18 +44,10 @@ impl ModuleReference for TsConfigReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for TsConfigReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("tsconfig {}", self.tsconfig.value_to_string().await?).into(),
-        ))
-    }
-}
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("typescript reference path comment {}", self.path)]
 pub struct TsReferencePathAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub path: RcStr,
@@ -98,16 +91,10 @@ impl ModuleReference for TsReferencePathAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for TsReferencePathAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(format!("typescript reference path comment {}", self.path,).into())
-    }
-}
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("typescript reference type comment {}", self.module)]
 pub struct TsReferenceTypeAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub module: RcStr,
@@ -137,10 +124,3 @@ impl ModuleReference for TsReferenceTypeAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for TsReferenceTypeAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(format!("typescript reference type comment {}", self.module,).into())
-    }
-}

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -15,7 +15,7 @@ use crate::typescript::TsConfigModuleAsset;
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug, ValueToString)]
-#[value_to_string("tsconfig {}", self.tsconfig)]
+#[value_to_string("tsconfig {tsconfig}")]
 pub struct TsConfigReference {
     pub tsconfig: FileSystemPath,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
@@ -46,7 +46,7 @@ impl ModuleReference for TsConfigReference {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("typescript reference path comment {}", self.path)]
+#[value_to_string("typescript reference path comment {path}")]
 pub struct TsReferencePathAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub path: RcStr,
@@ -92,7 +92,7 @@ impl ModuleReference for TsReferencePathAssetReference {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("typescript reference type comment {}", self.module)]
+#[value_to_string("typescript reference type comment {module}")]
 pub struct TsReferenceTypeAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub module: RcStr,

--- a/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/typescript.rs
@@ -44,7 +44,6 @@ impl ModuleReference for TsConfigReference {
     }
 }
 
-
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("typescript reference path comment {}", self.path)]
@@ -91,7 +90,6 @@ impl ModuleReference for TsReferencePathAssetReference {
     }
 }
 
-
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("typescript reference type comment {}", self.module)]
@@ -123,4 +121,3 @@ impl ModuleReference for TsReferenceTypeAssetReference {
         )
     }
 }
-

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -265,6 +265,21 @@ impl ModuleReference for WorkerAssetReference {
     }
 }
 
+impl WorkerAssetReference {
+    /// Downgrade errors to warnings if we are not in Error mode or if loose errors is enabled
+    async fn get_module_type_issue_severity(&self) -> Result<IssueSeverity> {
+        Ok(
+            if self.error_mode != ResolveErrorMode::Error
+                || self.origin.resolve_options().await?.loose_errors
+            {
+                IssueSeverity::Warning
+            } else {
+                IssueSeverity::Error
+            },
+        )
+    }
+}
+
 #[turbo_tasks::value_impl]
 impl ValueToString for WorkerAssetReference {
     #[turbo_tasks::function]
@@ -284,21 +299,6 @@ impl ValueToString for WorkerAssetReference {
             )
             .into(),
         ))
-    }
-}
-
-impl WorkerAssetReference {
-    /// Downgrade errors to warnings if we are not in Error mode or if loose errors is enabled
-    async fn get_module_type_issue_severity(&self) -> Result<IssueSeverity> {
-        Ok(
-            if self.error_mode != ResolveErrorMode::Error
-                || self.origin.resolve_options().await?.loose_errors
-            {
-                IssueSeverity::Warning
-            } else {
-                IssueSeverity::Error
-            },
-        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -302,7 +302,6 @@ impl WorkerAssetReference {
     }
 }
 
-
 impl IntoCodeGenReference for WorkerAssetReference {
     fn into_code_gen_reference(
         self,

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -265,21 +265,6 @@ impl ModuleReference for WorkerAssetReference {
     }
 }
 
-impl WorkerAssetReference {
-    /// Downgrade errors to warnings if we are not in Error mode or if loose errors is enabled
-    async fn get_module_type_issue_severity(&self) -> Result<IssueSeverity> {
-        Ok(
-            if self.error_mode != ResolveErrorMode::Error
-                || self.origin.resolve_options().await?.loose_errors
-            {
-                IssueSeverity::Warning
-            } else {
-                IssueSeverity::Error
-            },
-        )
-    }
-}
-
 #[turbo_tasks::value_impl]
 impl ValueToString for WorkerAssetReference {
     #[turbo_tasks::function]
@@ -301,6 +286,22 @@ impl ValueToString for WorkerAssetReference {
         ))
     }
 }
+
+impl WorkerAssetReference {
+    /// Downgrade errors to warnings if we are not in Error mode or if loose errors is enabled
+    async fn get_module_type_issue_severity(&self) -> Result<IssueSeverity> {
+        Ok(
+            if self.error_mode != ResolveErrorMode::Error
+                || self.origin.resolve_options().await?.loose_errors
+            {
+                IssueSeverity::Warning
+            } else {
+                IssueSeverity::Error
+            },
+        )
+    }
+}
+
 
 impl IntoCodeGenReference for WorkerAssetReference {
     fn into_code_gen_reference(

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -85,7 +85,6 @@ impl EcmascriptModulePartReference {
     }
 }
 
-
 #[turbo_tasks::value_impl]
 impl ModuleReference for EcmascriptModulePartReference {
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/side_effect_optimization/reference.rs
@@ -5,7 +5,6 @@ use swc_core::{
     ecma::ast::{Ident, Lit},
     quote,
 };
-use turbo_rcstr::RcStr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, ValueToString, Vc, trace::TraceRawVcs};
 use turbopack_core::{
     chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption, ModuleChunkItemIdExt},
@@ -35,6 +34,8 @@ enum EcmascriptModulePartReferenceMode {
 /// A reference to the [EcmascriptModuleLocalsModule] variant of an original
 /// module.
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string(self.part)]
 pub struct EcmascriptModulePartReference {
     module: ResolvedVc<Box<dyn EcmascriptChunkPlaceable>>,
     part: ModulePart,
@@ -84,13 +85,6 @@ impl EcmascriptModulePartReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptModulePartReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(self.part.to_string().into())
-    }
-}
 
 #[turbo_tasks::value_impl]
 impl ModuleReference for EcmascriptModulePartReference {

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -179,7 +179,7 @@ impl Module for TsConfigModuleAsset {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("compiler reference {}", self.request)]
+#[value_to_string("compiler reference {request}")]
 pub struct CompilerReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -237,7 +237,7 @@ impl ModuleReference for TsExtendsReference {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("tsconfig tsnode require {}", self.request)]
+#[value_to_string("tsconfig tsnode require {request}")]
 pub struct TsNodeRequireReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -270,7 +270,7 @@ impl ModuleReference for TsNodeRequireReference {
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("tsconfig types {}", self.request)]
+#[value_to_string("tsconfig types {request}")]
 pub struct TsConfigTypesReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -178,7 +178,8 @@ impl Module for TsConfigModuleAsset {
 }
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("compiler reference {}", self.request)]
 pub struct CompilerReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -209,18 +210,10 @@ impl ModuleReference for CompilerReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for CompilerReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("compiler reference {}", self.request.to_string().await?).into(),
-        ))
-    }
-}
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("tsconfig extends {}", self.config.ident())]
 pub struct TsExtendsReference {
     pub config: ResolvedVc<Box<dyn Source>>,
 }
@@ -243,22 +236,10 @@ impl ModuleReference for TsExtendsReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for TsExtendsReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!(
-                "tsconfig extends {}",
-                self.config.ident().to_string().await?,
-            )
-            .into(),
-        ))
-    }
-}
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("tsconfig tsnode require {}", self.request)]
 pub struct TsNodeRequireReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -289,22 +270,10 @@ impl ModuleReference for TsNodeRequireReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for TsNodeRequireReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!(
-                "tsconfig tsnode require {}",
-                self.request.to_string().await?
-            )
-            .into(),
-        ))
-    }
-}
 
 #[turbo_tasks::value]
-#[derive(Hash, Debug)]
+#[derive(Hash, Debug, ValueToString)]
+#[value_to_string("tsconfig types {}", self.request)]
 pub struct TsConfigTypesReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -329,12 +298,3 @@ impl ModuleReference for TsConfigTypesReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for TsConfigTypesReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("tsconfig types {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/typescript/mod.rs
@@ -210,7 +210,6 @@ impl ModuleReference for CompilerReference {
     }
 }
 
-
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("tsconfig extends {}", self.config.ident())]
@@ -235,7 +234,6 @@ impl ModuleReference for TsExtendsReference {
         )))
     }
 }
-
 
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
@@ -270,7 +268,6 @@ impl ModuleReference for TsNodeRequireReference {
     }
 }
 
-
 #[turbo_tasks::value]
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("tsconfig types {}", self.request)]
@@ -297,4 +294,3 @@ impl ModuleReference for TsConfigTypesReference {
         type_resolve(*self.origin, *self.request)
     }
 }
-

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -142,7 +142,7 @@ impl ModuleReference for WebpackEntryAssetReference {
 
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
-#[value_to_string("webpack {}", self.request)]
+#[value_to_string("webpack {request}")]
 pub struct WebpackRuntimeAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -109,7 +109,6 @@ impl ModuleReference for WebpackChunkAssetReference {
     }
 }
 
-
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
 #[value_to_string("webpack entry")]
@@ -130,7 +129,6 @@ impl ModuleReference for WebpackEntryAssetReference {
         )))
     }
 }
-
 
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
@@ -170,4 +168,3 @@ impl ModuleReference for WebpackRuntimeAssetReference {
             .cell())
     }
 }
-

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use swc_core::ecma::ast::Lit;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     file_source::FileSource,
@@ -69,6 +69,8 @@ impl Module for WebpackModuleAsset {
 }
 
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("webpack chunk {}", {match &self.chunk_id { Lit::Str(str) => str.value.to_string_lossy().into_owned(), Lit::Num(num) => format!("{num}"), _ => todo!() }})]
 pub struct WebpackChunkAssetReference {
     #[turbo_tasks(trace_ignore)]
     #[bincode(with_serde)]
@@ -107,20 +109,10 @@ impl ModuleReference for WebpackChunkAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for WebpackChunkAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        let chunk_id = match &self.chunk_id {
-            Lit::Str(str) => str.value.to_string_lossy().into_owned(),
-            Lit::Num(num) => format!("{num}"),
-            _ => todo!(),
-        };
-        Vc::cell(format!("webpack chunk {chunk_id}").into())
-    }
-}
 
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("webpack entry")]
 pub struct WebpackEntryAssetReference {
     pub source: ResolvedVc<Box<dyn Source>>,
     pub runtime: ResolvedVc<WebpackRuntime>,
@@ -139,15 +131,10 @@ impl ModuleReference for WebpackEntryAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for WebpackEntryAssetReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("webpack entry"))
-    }
-}
 
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("webpack {}", self.request)]
 pub struct WebpackRuntimeAssetReference {
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     pub request: ResolvedVc<Request>,
@@ -184,12 +171,3 @@ impl ModuleReference for WebpackRuntimeAssetReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for WebpackRuntimeAssetReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("webpack {}", self.request.to_string().await?,).into(),
-        ))
-    }
-}

--- a/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/webpack/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use swc_core::ecma::ast::Lit;
-use turbo_rcstr::rcstr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbopack_core::{
     file_source::FileSource,
@@ -70,13 +70,23 @@ impl Module for WebpackModuleAsset {
 
 #[turbo_tasks::value(shared)]
 #[derive(ValueToString)]
-#[value_to_string("webpack chunk {}", {match &self.chunk_id { Lit::Str(str) => str.value.to_string_lossy().into_owned(), Lit::Num(num) => format!("{num}"), _ => todo!() }})]
+#[value_to_string("webpack chunk {}", self.chunk_id())]
 pub struct WebpackChunkAssetReference {
     #[turbo_tasks(trace_ignore)]
     #[bincode(with_serde)]
     pub chunk_id: Lit,
     pub runtime: ResolvedVc<WebpackRuntime>,
     pub transforms: ResolvedVc<EcmascriptInputTransforms>,
+}
+
+impl WebpackChunkAssetReference {
+    pub fn chunk_id(&self) -> RcStr {
+        match &self.chunk_id {
+            Lit::Str(s) => RcStr::from(s.value.to_string_lossy().to_string()),
+            Lit::Num(n) => RcStr::from(n.to_string()),
+            _ => panic!("Unexpected literal type"),
+        }
+    }
 }
 
 #[turbo_tasks::value_impl]

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -342,4 +342,3 @@ impl ModuleReference for WorkerModuleReference {
         }))
     }
 }
-

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use indoc::formatdoc;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
 use turbopack_core::{
     chunk::{
@@ -306,6 +306,8 @@ impl EcmascriptChunkPlaceable for WorkerLoaderModule {
 }
 
 #[turbo_tasks::value]
+#[derive(ValueToString)]
+#[value_to_string({match self.worker_type { WorkerType::WebWorker => "web worker module", WorkerType::NodeWorkerThread => "node worker thread module", WorkerType::SharedWebWorker => "shared web worker module" }})]
 struct WorkerModuleReference {
     module: ResolvedVc<Box<dyn Module>>,
     worker_type: WorkerType,
@@ -341,14 +343,3 @@ impl ModuleReference for WorkerModuleReference {
     }
 }
 
-#[turbo_tasks::value_impl]
-impl ValueToString for WorkerModuleReference {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(match self.worker_type {
-            WorkerType::WebWorker => rcstr!("web worker module"),
-            WorkerType::NodeWorkerThread => rcstr!("node worker thread module"),
-            WorkerType::SharedWebWorker => rcstr!("shared web worker module"),
-        })
-    }
-}

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -307,7 +307,7 @@ impl EcmascriptChunkPlaceable for WorkerLoaderModule {
 
 #[turbo_tasks::value]
 #[derive(ValueToString)]
-#[value_to_string({match self.worker_type { WorkerType::WebWorker => "web worker module", WorkerType::NodeWorkerThread => "node worker thread module", WorkerType::SharedWebWorker => "shared web worker module" }})]
+#[value_to_string("{} module", self.worker_type.friendly_str())]
 struct WorkerModuleReference {
     module: ResolvedVc<Box<dyn Module>>,
     worker_type: WorkerType,

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/worker_type.rs
@@ -27,6 +27,14 @@ impl WorkerType {
         }
     }
 
+    pub fn friendly_str(&self) -> RcStr {
+        match self {
+            WorkerType::WebWorker => rcstr!("web worker"),
+            WorkerType::SharedWebWorker => rcstr!("shared web worker"),
+            WorkerType::NodeWorkerThread => rcstr!("node worker thread"),
+        }
+    }
+
     pub fn reference_type(&self) -> ReferenceType {
         ReferenceType::Worker(match self {
             WorkerType::WebWorker => WorkerReferenceSubType::WebWorker,

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/chunk.rs
@@ -17,6 +17,8 @@ use crate::NodeJsChunkingContext;
 
 /// Production Ecmascript chunk targeting Node.js.
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("Ecmascript Build Node Chunk")]
 pub(crate) struct EcmascriptBuildNodeChunk {
     chunking_context: ResolvedVc<NodeJsChunkingContext>,
     chunk: ResolvedVc<EcmascriptChunk>,
@@ -45,14 +47,6 @@ impl EcmascriptBuildNodeChunk {
             this.chunk.ident().with_modifier(modifier()),
             Vc::upcast(self),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptBuildNodeChunk {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Build Node Chunk"))
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 
 use anyhow::{Result, bail};
 use indoc::writedoc;
-use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
@@ -24,6 +23,8 @@ use crate::NodeJsChunkingContext;
 /// An Ecmascript chunk that loads a list of parallel chunks, then instantiates
 /// runtime entries.
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("Ecmascript Build Node Entry Chunk")]
 pub(crate) struct EcmascriptBuildNodeEntryChunk {
     path: FileSystemPath,
     other_chunks: ResolvedVc<OutputAssets>,
@@ -159,14 +160,6 @@ impl EcmascriptBuildNodeEntryChunk {
             this.path.clone(),
             Vc::upcast(self),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptBuildNodeEntryChunk {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Build Node Entry Chunk"))
     }
 }
 

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use anyhow::{Result, bail};
 use indoc::writedoc;
-use turbo_rcstr::{RcStr, rcstr};
+use turbo_rcstr::rcstr;
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystem, FileSystemPath};
 use turbopack_core::{
@@ -20,6 +20,8 @@ use crate::NodeJsChunkingContext;
 
 /// An Ecmascript chunk that contains the Node.js runtime code.
 #[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("Ecmascript Build Node Runtime Chunk")]
 pub(crate) struct EcmascriptBuildNodeRuntimeChunk {
     chunking_context: ResolvedVc<NodeJsChunkingContext>,
 }
@@ -140,14 +142,6 @@ impl EcmascriptBuildNodeRuntimeChunk {
             self.ident_for_path(),
             Vc::upcast(self),
         ))
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for EcmascriptBuildNodeRuntimeChunk {
-    #[turbo_tasks::function]
-    fn to_string(&self) -> Vc<RcStr> {
-        Vc::cell(rcstr!("Ecmascript Build Node Runtime Chunk"))
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -32,7 +32,8 @@ struct NodePreGypConfig {
 }
 
 #[turbo_tasks::value]
-#[derive(Hash, Clone, Debug)]
+#[derive(Hash, Clone, Debug, ValueToString)]
+#[value_to_string("node-gyp in {} with {} for {}", self.context_dir.value_to_string().await?, self.config_file_pattern, self.compile_target.await?)]
 pub struct NodePreGypConfigReference {
     pub context_dir: FileSystemPath,
     pub config_file_pattern: ResolvedVc<Pattern>,
@@ -69,20 +70,6 @@ impl ModuleReference for NodePreGypConfigReference {
             self.collect_affecting_sources,
         )
         .await
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for NodePreGypConfigReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let context_dir = self.context_dir.value_to_string().await?;
-        let config_file_pattern = self.config_file_pattern.to_string().await?;
-        let compile_target = self.compile_target.await?;
-        Ok(Vc::cell(
-            format!("node-gyp in {context_dir} with {config_file_pattern} for {compile_target}")
-                .into(),
-        ))
     }
 }
 
@@ -229,7 +216,8 @@ async fn resolve_node_pre_gyp_files(
 }
 
 #[turbo_tasks::value]
-#[derive(Hash, Clone, Debug)]
+#[derive(Hash, Clone, Debug, ValueToString)]
+#[value_to_string("node-gyp in {} for {}", self.context_dir.value_to_string().await?, self.compile_target.await?)]
 pub struct NodeGypBuildReference {
     pub context_dir: FileSystemPath,
     collect_affecting_sources: bool,
@@ -262,18 +250,6 @@ impl ModuleReference for NodeGypBuildReference {
             self.compile_target,
         )
         .await
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for NodeGypBuildReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let context_dir = self.context_dir.value_to_string().await?;
-        let compile_target = self.compile_target.await?;
-        Ok(Vc::cell(
-            format!("node-gyp in {context_dir} for {compile_target}").into(),
-        ))
     }
 }
 
@@ -362,7 +338,8 @@ async fn resolve_node_gyp_build_files(
 }
 
 #[turbo_tasks::value]
-#[derive(Hash, Clone, Debug)]
+#[derive(Hash, Clone, Debug, ValueToString)]
+#[value_to_string("bindings in {}", self.context_dir.value_to_string().await?)]
 pub struct NodeBindingsReference {
     pub context_dir: FileSystemPath,
     pub file_name: RcStr,
@@ -395,16 +372,6 @@ impl ModuleReference for NodeBindingsReference {
             self.collect_affecting_sources,
         )
         .await
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl ValueToString for NodeBindingsReference {
-    #[turbo_tasks::function]
-    async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!("bindings in {}", self.context_dir.value_to_string().await?,).into(),
-        ))
     }
 }
 

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -33,7 +33,7 @@ struct NodePreGypConfig {
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug, ValueToString)]
-#[value_to_string("node-gyp in {} with {} for {}", self.context_dir.value_to_string().await?, self.config_file_pattern, self.compile_target.await?)]
+#[value_to_string("node-gyp in {context_dir} with {config_file_pattern} for {compile_target}")]
 pub struct NodePreGypConfigReference {
     pub context_dir: FileSystemPath,
     pub config_file_pattern: ResolvedVc<Pattern>,
@@ -217,7 +217,7 @@ async fn resolve_node_pre_gyp_files(
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug, ValueToString)]
-#[value_to_string("node-gyp in {} for {}", self.context_dir.value_to_string().await?, self.compile_target.await?)]
+#[value_to_string("node-gyp in {context_dir} for {compile_target}")]
 pub struct NodeGypBuildReference {
     pub context_dir: FileSystemPath,
     collect_affecting_sources: bool,
@@ -339,7 +339,7 @@ async fn resolve_node_gyp_build_files(
 
 #[turbo_tasks::value]
 #[derive(Hash, Clone, Debug, ValueToString)]
-#[value_to_string("bindings in {}", self.context_dir.value_to_string().await?)]
+#[value_to_string("bindings in {context_dir}")]
 pub struct NodeBindingsReference {
     pub context_dir: FileSystemPath,
     pub file_name: RcStr,


### PR DESCRIPTION
## What

Add a `#[derive(ValueToString)]` proc macro and convert ~45 manual `ValueToString` implementations across turbopack crates to use it (-660 lines of boilerplate, 49 files touched).

## Why

Nearly every `ValueToString` impl follows the same pattern: format some fields into a string, possibly awaiting `Vc` values first. These hand-written impls are noisy boilerplate that obscure the actual format string.

## How

The derive macro generates the `#[turbo_tasks::value_impl] impl ValueToString` block automatically. A helper trait `ValueToStringify` with a blanket impl for `Display` and specializations for `Vc<T>`/`ResolvedVc<T>` handles async resolution of fields.

### Supported forms

- **No attribute** — delegates to `Display::to_string(&self)`
- `#[value_to_string("constant")]` — emits `rcstr!` directly
- `#[value_to_string("{field} text {other_field}")]` — auto-resolves named/positional fields via `ValueToStringify`
- `#[value_to_string("fmt {}", expr1, expr2)]` — explicit expressions as format args
- `#[value_to_string(expr)]` — single expression delegation

Enums support per-variant attributes (defaulting to variant name) or a single top-level attribute.