### PR TITLE
Allow sitemap.ts and sitemap/page.tsx to coexist in Turbopack

### DIFF
--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -332,6 +332,8 @@ pub fn normalize_metadata_route(mut page: AppPage) -> Result<AppPage> {
         route += ".txt"
     } else if route == "/manifest" {
         route += ".webmanifest"
+    } else if route.ends_with("/sitemap") {
+        route += ".xml"
     } else {
         suffix = get_metadata_route_suffix(&route);
     }
@@ -380,6 +382,9 @@ mod test {
             ],
             ["/robots.txt", "/robots.txt/route"],
             ["/manifest.webmanifest", "/manifest.webmanifest/route"],
+            ["/sitemap", "/sitemap.xml/route"],
+            ["/sitemap.xml", "/sitemap.xml/route"],
+            ["/blog/sitemap", "/blog/sitemap.xml/route"],
         ];
 
         for [input, expected] in cases {

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -83,19 +83,18 @@ pub async fn get_app_metadata_route_entry(
     // Map dynamic sitemap and image routes based on the exports.
     // if there's generator export: add /[__metadata_id__] to the route;
     // otherwise keep the original route.
-    // For sitemap, if the last segment is sitemap, appending .xml suffix.
     if is_dynamic_metadata {
         // remove the last /route segment of page
         page.0.pop();
 
         if is_multi_dynamic {
-            page.push(PageSegment::Dynamic(rcstr!("__metadata_id__")))?;
-        } else {
-            // if page last segment is sitemap, change to sitemap.xml
-            if page.last() == Some(&PageSegment::Static(rcstr!("sitemap"))) {
+            // For sitemap.xml routes with generateSitemaps, revert to sitemap
+            // since multi-dynamic sitemaps use /sitemap/[__metadata_id__]
+            if page.last() == Some(&PageSegment::Static(rcstr!("sitemap.xml"))) {
                 page.0.pop();
-                page.push(PageSegment::Static(rcstr!("sitemap.xml")))?
+                page.push(PageSegment::Static(rcstr!("sitemap")))?;
             }
+            page.push(PageSegment::Dynamic(rcstr!("__metadata_id__")))?;
         };
         // Push /route back
         page.push(PageSegment::PageType(PageType::Route))?;

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -995,9 +995,10 @@ export function normalizedPageToTurbopackStructureRoute(
       if (entrypointKey.endsWith('/[__metadata_id__]')) {
         entrypointKey = entrypointKey.slice(0, -'/[__metadata_id__]'.length)
       }
-      if (entrypointKey.endsWith('/sitemap.xml') && ext !== '.xml') {
-        // For dynamic sitemap route, remove the extension
-        entrypointKey = entrypointKey.slice(0, -'.xml'.length)
+      // After stripping [__metadata_id__], add .xml for dynamic sitemap routes
+      // to match the Turbopack entry key from normalize_metadata_route
+      if (entrypointKey.endsWith('/sitemap') && ext !== '.xml') {
+        entrypointKey = entrypointKey + '.xml'
       }
     }
     entrypointKey = entrypointKey + '/route'

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -109,9 +109,14 @@ const getManifestPath = (
     // existsSync is faster than using the async version
     if (!existsSync(manifestPath) && page.endsWith('/route')) {
       // TODO: Improve implementation of metadata routes, currently it requires this extra check for the variants of the files that can be written.
-      let metadataPage = addRouteSuffix(
-        addMetadataIdToRoute(removeRouteSuffix(page))
-      )
+      let basePage = removeRouteSuffix(page)
+      // For sitemap.xml routes with generateSitemaps, the manifest is at
+      // /sitemap/[__metadata_id__]/route (without .xml), because the route
+      // handler serves at /sitemap/[id] not /sitemap.xml/[id]
+      if (basePage.endsWith('/sitemap.xml')) {
+        basePage = basePage.slice(0, -'.xml'.length)
+      }
+      let metadataPage = addRouteSuffix(addMetadataIdToRoute(basePage))
       manifestPath = getManifestPath(metadataPage, distDir, name, type, false)
     }
   }

--- a/test/e2e/app-dir/metadata-dynamic-routes/app/sitemap/page.tsx
+++ b/test/e2e/app-dir/metadata-dynamic-routes/app/sitemap/page.tsx
@@ -1,0 +1,4 @@
+// Renders at /sitemap, should not conflict with app/sitemap.ts
+export default function SitemapPage() {
+  return <div>Sitemap</div>
+}

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -545,6 +545,7 @@ describe('app dir - metadata dynamic routes', () => {
          "/opengraph-image",
          "/opengraph-image-1ow20b",
          "/robots.txt",
+         "/sitemap",
          "/sitemap-image/sitemap.xml",
          "/sitemap-video/sitemap.xml",
          "/sitemap.xml",


### PR DESCRIPTION
Solves #78609

Today, Turbopack maps `app/sitemap.ts` to an AppPage of `/sitemap/route`, and `app/sitemap/page.tsx` maps to `/sitemap/page`, which leads to a conflict.

This treats sitemap.xml the same way as robots.txt and site.webmanifest, and puts the xml extension in the AppPage, and not later in the path resolution. This creates an AppPage of `/sitemap.xml/route` which no longer conflicts. This is pretty much what webpack was doing.

Because the page segment is now sitemap.xml, I had to update downstream logic for routes that export sitemap / generateSitemap.

The turbopack-utils is needed for dynamic sitemap routes like the example here: https://nextjs.org/docs/app/api-reference/file-conventions/metadata/sitemap#generating-multiple-sitemaps

In that setup, when a request for /product/sitemap/1.xml comes in, the "multiple" matcher matches and definition.page is "/product/sitemap/[__metadata_id__]/route". This becomes the page in the hot reloader. After that, normalizedPageToTurbopackStructureRoute strips [__metadata_id__] and it becomes /products/sitemap, but our updated Rust key is now /products/sitemap.xml/route... so add back the .xml!

My demo app tests four things in parallel:
1) app/sitemap.ts renders at /sitemap.xml
2) app/sitemap/page.tsx renders at /sitemap and the two do not conflict 3) app/product/sitemap.ts works when generating a static sitemap (/product/sitemap.xml) 4) app/product/sitemap.ts works when generating a dynamic sitemapo (/product/sitemap/1.xml) as in the linked docs above

Also I asked Claude if I've fixed all the relevant codepaths, and here's its output:

```
  Case 1: Single dynamic sitemap — app/products/sitemap.ts (no generateSitemaps)
  - Input page: /products/sitemap.xml/route, ext: .ts
  - Strip /route → /products/sitemap.xml
  - No [__metadata_id__] → skip
  - Doesn't end with /sitemap (ends with /sitemap.xml) → skip
  - Add /route → /products/sitemap.xml/route
  - Entry key: /products/sitemap.xml/route ✓

  Case 2: Multi-dynamic sitemap — app/products/sitemap.ts with generateSitemaps
  - Input page: /products/sitemap/[__metadata_id__]/route, ext: .ts
  - Strip /route → /products/sitemap/[__metadata_id__]
  - Strip [__metadata_id__] → /products/sitemap
  - Ends with /sitemap and ext .ts ≠ .xml → add .xml → /products/sitemap.xml
  - Add /route → /products/sitemap.xml/route
  - Entry key: /products/sitemap.xml/route ✓

  Case 3: Static sitemap — app/sitemap.xml
  - Input page: /sitemap.xml/route, ext: .xml
  - Strip /route → /sitemap.xml
  - No [__metadata_id__] → skip
  - ext IS .xml → skip .xml addition
  - Add /route → /sitemap.xml/route
  - Entry key: /sitemap.xml/route ✓

  Case 4: Non-sitemap metadata — app/opengraph-image.tsx
  - Input page: /opengraph-image/route, ext: .tsx
  - Strip /route → /opengraph-image
  - No [__metadata_id__] → skip
  - Doesn't end with /sitemap → skip
  - Add /route → /opengraph-image/route ✓

  Case 5: Non-sitemap multi-dynamic — app/opengraph-image.tsx with generateImageMetadata
  - Input page: /opengraph-image/[__metadata_id__]/route, ext: .tsx
  - Strip /route → /opengraph-image/[__metadata_id__]
  - Strip [__metadata_id__] → /opengraph-image
  - Doesn't end with /sitemap → skip
  - Add /route → /opengraph-image/route ✓

  All cases produce the correct entry key.
```

Seems legit. Would still appreciate someone with more Next.js knowledge validating my assumptions