### PR TITLE
Turbopack: Fix slow filesystem benchmark warning for `next dev`

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -82,7 +82,7 @@ use crate::{
 
 /// Used by [`benchmark_file_io`]. This is a noisy benchmark, so set the
 /// threshold high.
-const SLOW_FILESYSTEM_THRESHOLD: Duration = Duration::from_millis(100);
+const SLOW_FILESYSTEM_THRESHOLD: Duration = Duration::from_millis(200);
 static SOURCE_MAP_PREFIX: Lazy<String> = Lazy::new(|| format!("{SOURCE_URL_PROTOCOL}///"));
 static SOURCE_MAP_PREFIX_PROJECT: Lazy<String> =
     Lazy::new(|| format!("{SOURCE_URL_PROTOCOL}///[{PROJECT_FILESYSTEM_NAME}]/"));
@@ -602,8 +602,8 @@ impl CompilationEvent for SlowFilesystemEvent {
     fn message(&self) -> String {
         format!(
             "Slow filesystem detected. The benchmark took {}ms. If {} is a network drive, \
-             consider moving it to a local folder. If you have an antivirus enabled, consider \
-             excluding your project directory.",
+             consider moving it to a local folder.\n\
+            See more: https://nextjs.org/docs/app/guides/local-development",
             self.duration_ms, self.directory
         )
     }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -387,7 +387,11 @@ export async function createHotReloaderTurbopack(
     }
   )
   backgroundLogCompilationEvents(project, {
-    eventTypes: ['StartupCacheInvalidationEvent', 'TimingEvent'],
+    eventTypes: [
+      'StartupCacheInvalidationEvent',
+      'TimingEvent',
+      'SlowFilesystemEvent',
+    ],
   })
   setBundlerFindSourceMapImplementation(
     getSourceMapFromTurbopack.bind(null, project, projectPath)


### PR DESCRIPTION
Apparently we broke this about 6 months ago and didn't notice:

- We briefly had both a `println` (legacy) and a compilation event, leading to duplicate logging.
- First: https://github.com/vercel/next.js/pull/80631 - I added a filter to `backgroundLogCompilationEvents` that inadvertently filtered out `SlowFilesystemEvent` on dev.
- Around the same time: https://github.com/vercel/next.js/pull/81972 - This removed the old `println` in favor of the compilation event

Changes in this PR:

- Add `SlowFilesystemEvent` to the filter used in dev.
- Increase the threshold from 100ms to 200ms. I'm concerned that with Turbopack's File System cache, that the FS might be more heavily loaded during this benchmark than it was before, and I'd rather err on the "less aggressive" side.
- Add a link to https://nextjs.org/docs/app/guides/local-development, which now has documentation on the antivirus thing.

Tested with a threshold of 0ms:

![Screenshot 2026-02-10 at 5.09.41 PM.png](https://app.graphite.com/user-attachments/assets/e871ad6d-c718-4308-9a14-ba70bda23efb.png)

There's not any easy way to test this, but it's also clearly not a big deal if it does break, as it's just a debugging hint for performance issues.