### PR TITLE
Update flakey E2E deploy tests no-prefetch

### DIFF
--- a/test/e2e/app-dir/segment-cache/no-prefetch/no-prefetch.test.ts
+++ b/test/e2e/app-dir/segment-cache/no-prefetch/no-prefetch.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import { createRouterAct } from 'router-act'
+import { retry } from 'next-test-utils'
 
 describe('navigating without a prefetch', () => {
   const { next } = nextTestSetup({
@@ -7,23 +7,18 @@ describe('navigating without a prefetch', () => {
   })
 
   it('can show a loading boundary from the dynamic response', async () => {
-    let act: ReturnType<typeof createRouterAct>
-    const browser = await next.browser('/', {
-      beforePageLoad(page) {
-        act = createRouterAct(page)
-      },
-    })
+    const browser = await next.browser('/')
 
     // Navigate to a dynamic page with a `loading.tsx` without a prefetch.
-    await act(async () => {
-      await browser.elementByCss('a[href="/with-loading"]').click()
-    })
+    await browser.elementByCss('a[href="/with-loading"]').click()
 
     // The page suspends on the client, so we should display the `loading` that we got from the dynamic response.
-    expect(
-      await browser
-        .elementByCss('#loading-component', { state: 'visible' })
-        .text()
-    ).toContain('Loading...')
+    await retry(async () => {
+      expect(
+        await browser
+          .elementByCss('#loading-component', { state: 'visible' })
+          .text()
+      ).toContain('Loading...')
+    })
   })
 })


### PR DESCRIPTION
Addressing this test being very flakey as well

x-ref: https://github.com/vercel/next.js/actions/runs/21887115229/job/63188106850