### PR TITLE
fix: separate client component chunks for dynamic server component imports

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-flight-client-entry-loader.ts
@@ -14,6 +14,8 @@ export type CssImports = Record<string, string[]>
 
 export type NextFlightClientEntryLoaderOptions = {
   modules: string[] | string
+  /** Modules from dynamic import boundaries — imported lazily for code splitting */
+  dynamicModules?: string[] | string
   /** This is transmitted as a string to `getOptions` */
   server: boolean | 'true' | 'false'
 }
@@ -25,39 +27,71 @@ export type FlightClientEntryModuleItem = {
   ids: string[]
 }
 
+function generateImportCode(
+  item: FlightClientEntryModuleItem,
+  eager: boolean
+): string {
+  const importPath = JSON.stringify(
+    item.request.startsWith(BARREL_OPTIMIZATION_PREFIX)
+      ? item.request.replace(':', '!=!')
+      : item.request
+  )
+
+  if (eager) {
+    // Eager mode: include in the current chunk (no code splitting)
+    if (item.ids.length === 0 || item.ids.includes('*')) {
+      return `import(/* webpackMode: "eager" */ ${importPath});\n`
+    } else {
+      return `import(/* webpackMode: "eager", webpackExports: ${JSON.stringify(
+        item.ids
+      )} */ ${importPath});\n`
+    }
+  } else {
+    // Lazy mode: webpack creates a separate async chunk for this module,
+    // enabling per-component code splitting for client components reached
+    // through dynamic server component imports.
+    if (item.ids.length === 0 || item.ids.includes('*')) {
+      return `import(${importPath});\n`
+    } else {
+      return `import(/* webpackExports: ${JSON.stringify(
+        item.ids
+      )} */ ${importPath});\n`
+    }
+  }
+}
+
 export default function transformSource(
   this: webpack.LoaderContext<NextFlightClientEntryLoaderOptions>
 ) {
-  let { modules, server } = this.getOptions()
+  let { modules, dynamicModules, server } = this.getOptions()
   const isServer = server === 'true'
 
   if (!Array.isArray(modules)) {
     modules = modules ? [modules] : []
   }
+  if (!Array.isArray(dynamicModules)) {
+    dynamicModules = dynamicModules ? [dynamicModules] : []
+  }
 
-  const code = modules
+  // Eager imports: client components reachable through static imports only
+  const eagerCode = modules
     .map((x) => JSON.parse(x) as FlightClientEntryModuleItem)
-    // Filter out CSS files in the SSR compilation
     .filter(({ request }) => (isServer ? !regexCSS.test(request) : true))
-    .map(({ request, ids }: FlightClientEntryModuleItem) => {
-      const importPath = JSON.stringify(
-        request.startsWith(BARREL_OPTIMIZATION_PREFIX)
-          ? request.replace(':', '!=!')
-          : request
-      )
-
-      // When we cannot determine the export names, we use eager mode to include the whole module.
-      // Otherwise, we use eager mode with webpackExports to only include the necessary exports.
-      // If we have '*' in the ids, we include all the imports
-      if (ids.length === 0 || ids.includes('*')) {
-        return `import(/* webpackMode: "eager" */ ${importPath});\n`
-      } else {
-        return `import(/* webpackMode: "eager", webpackExports: ${JSON.stringify(
-          ids
-        )} */ ${importPath});\n`
-      }
-    })
+    .map((item) => generateImportCode(item, true))
     .join(';\n')
+
+  // Lazy imports: client components reachable through dynamic import boundaries
+  // in the server component tree. Only for browser compilation — SSR gets all
+  // modules as eager via the `modules` param (they're merged there).
+  const lazyCode = isServer
+    ? ''
+    : dynamicModules
+        .map((x) => JSON.parse(x) as FlightClientEntryModuleItem)
+        .filter(({ request }) => !regexCSS.test(request))
+        .map((item) => generateImportCode(item, false))
+        .join(';\n')
+
+  const code = eagerCode + lazyCode
 
   const buildInfo = getModuleBuildInfo(this._module!)
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -352,12 +352,16 @@ export class FlightClientEntryPlugin {
           }
         }
 
-        const { clientComponentImports, actionImports, cssImports } =
-          this.collectComponentInfoFromServerEntryDependency({
-            entryRequest,
-            compilation,
-            resolvedModule: connection.resolvedModule,
-          })
+        const {
+          clientComponentImports,
+          dynamicClientComponentImports,
+          actionImports,
+          cssImports,
+        } = this.collectComponentInfoFromServerEntryDependency({
+          entryRequest,
+          compilation,
+          resolvedModule: connection.resolvedModule,
+        })
 
         actionImports.forEach(([dep, actions]) =>
           actionEntryImports.set(dep, actions)
@@ -418,6 +422,7 @@ export class FlightClientEntryPlugin {
           compilation,
           entryName: name,
           clientComponentImports,
+          dynamicClientComponentImports,
           bundlePath,
           absolutePagePath: entryRequest,
         })
@@ -480,6 +485,8 @@ export class FlightClientEntryPlugin {
               return res
             }, {}),
           },
+          dynamicClientImports:
+            clientEntryToInject.dynamicClientComponentImports || {},
         })
 
         // Track all created SSR dependencies for each entry from the server layer.
@@ -733,6 +740,7 @@ export class FlightClientEntryPlugin {
   }): {
     cssImports: CssImports
     clientComponentImports: ClientComponentImports
+    dynamicClientComponentImports: ClientComponentImports
     actionImports: [string, ActionIdNamePair[]][]
   } {
     // Keep track of checked modules to avoid infinite loops with recursive imports.
@@ -740,12 +748,14 @@ export class FlightClientEntryPlugin {
 
     // Info to collect.
     const clientComponentImports: ClientComponentImports = {}
+    const dynamicClientComponentImports: ClientComponentImports = {}
     const actionImports: [string, ActionIdNamePair[]][] = []
     const CSSImports = new Set<string>()
 
     const filterClientComponents = (
       mod: webpack.NormalModule,
-      importedIdentifiers: string[]
+      importedIdentifiers: string[],
+      isFromDynamicImport: boolean = false
     ): void => {
       if (!mod) return
 
@@ -753,11 +763,31 @@ export class FlightClientEntryPlugin {
 
       if (!modResource) return
       if (visitedOfClientComponentsTraverse.has(modResource)) {
+        // If the module was previously classified as dynamic but we now reach it
+        // via a static path, upgrade it to eager (conservative — ensures it loads
+        // with the main entry rather than as a separate async chunk).
+        if (
+          dynamicClientComponentImports[modResource] &&
+          !isFromDynamicImport
+        ) {
+          clientComponentImports[modResource] =
+            dynamicClientComponentImports[modResource]
+          delete dynamicClientComponentImports[modResource]
+        }
+
         if (clientComponentImports[modResource]) {
           addClientImport(
             mod,
             modResource,
             clientComponentImports,
+            importedIdentifiers,
+            false
+          )
+        } else if (dynamicClientComponentImports[modResource]) {
+          addClientImport(
+            mod,
+            modResource,
+            dynamicClientComponentImports,
             importedIdentifiers,
             false
           )
@@ -799,13 +829,19 @@ export class FlightClientEntryPlugin {
 
         CSSImports.add(modResource)
       } else if (isClientComponentEntryModule(mod)) {
-        if (!clientComponentImports[modResource]) {
-          clientComponentImports[modResource] = new Set()
+        // Route to the correct collection based on whether we reached this
+        // module through a dynamic import boundary in the server component tree.
+        const targetImports = isFromDynamicImport
+          ? dynamicClientComponentImports
+          : clientComponentImports
+
+        if (!targetImports[modResource]) {
+          targetImports[modResource] = new Set()
         }
         addClientImport(
           mod,
           modResource,
-          clientComponentImports,
+          targetImports,
           importedIdentifiers,
           true
         )
@@ -825,16 +861,27 @@ export class FlightClientEntryPlugin {
             dependencyIds = ['*']
           }
 
-          filterClientComponents(connection.resolvedModule, dependencyIds)
+          // Detect dynamic import boundary: when the dependency type starts
+          // with 'import()', we've crossed into a dynamically-imported subtree.
+          // This pattern is consistent with react-loadable-plugin.ts.
+          const isDynamicImportConnection =
+            connection.dependency?.type?.startsWith('import()')
+
+          filterClientComponents(
+            connection.resolvedModule,
+            dependencyIds,
+            isFromDynamicImport || isDynamicImportConnection
+          )
         }
       )
     }
 
     // Traverse the module graph to find all client components.
-    filterClientComponents(resolvedModule, [])
+    filterClientComponents(resolvedModule, [], false)
 
     return {
       clientComponentImports,
+      dynamicClientComponentImports,
       cssImports: CSSImports.size
         ? {
             [entryRequest]: Array.from(CSSImports),
@@ -849,6 +896,7 @@ export class FlightClientEntryPlugin {
     compilation,
     entryName,
     clientImports,
+    dynamicClientImports,
     bundlePath,
     absolutePagePath,
   }: {
@@ -856,6 +904,7 @@ export class FlightClientEntryPlugin {
     compilation: webpack.Compilation
     entryName: string
     clientImports: ClientComponentImports
+    dynamicClientImports?: ClientComponentImports
     bundlePath: string
     absolutePagePath?: string
   }): [
@@ -874,25 +923,47 @@ export class FlightClientEntryPlugin {
         ids: [...clientImports[clientImportPath]],
       }))
 
-    // For the client entry, we always use the CJS build of Next.js. If the
-    // server is using the ESM build (when using the Edge runtime), we need to
-    // replace them.
-    const clientBrowserLoader = `next-flight-client-entry-loader?${stringify({
-      modules: (this.isEdgeServer
-        ? modules.map(({ request, ids }) => ({
+    // Modules from dynamic import boundaries — these will be loaded lazily
+    // (without webpackMode: "eager") in the browser entry, creating separate
+    // async chunks for better code splitting.
+    const dynamicModules = Object.keys(dynamicClientImports || {})
+      .sort((a, b) => a.localeCompare(b))
+      .map((clientImportPath) => ({
+        request: clientImportPath,
+        ids: [...(dynamicClientImports || {})[clientImportPath]],
+      }))
+
+    const edgeTransform = (mods: typeof modules) =>
+      this.isEdgeServer
+        ? mods.map(({ request, ids }) => ({
             request: request.replace(
               /[\\/]next[\\/]dist[\\/]esm[\\/]/,
               '/next/dist/'.replace(/\//g, path.sep)
             ),
             ids,
           }))
-        : modules
-      ).map((x) => JSON.stringify(x)),
+        : mods
+
+    // For the client entry, we always use the CJS build of Next.js. If the
+    // server is using the ESM build (when using the Edge runtime), we need to
+    // replace them.
+    const clientBrowserLoader = `next-flight-client-entry-loader?${stringify({
+      modules: edgeTransform(modules).map((x) => JSON.stringify(x)),
+      // Dynamic modules create separate async chunks (no webpackMode: "eager")
+      ...(dynamicModules.length > 0
+        ? {
+            dynamicModules: edgeTransform(dynamicModules).map((x) =>
+              JSON.stringify(x)
+            ),
+          }
+        : {}),
       server: false,
     })}!`
 
+    // SSR loader gets ALL modules as eager — no code splitting needed server-side
+    const allModules = [...modules, ...dynamicModules]
     const clientServerLoader = `next-flight-client-entry-loader?${stringify({
-      modules: modules.map((x) => JSON.stringify(x)),
+      modules: allModules.map((x) => JSON.stringify(x)),
       server: true,
     })}!`
 

--- a/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-manifest-plugin.ts
@@ -317,8 +317,75 @@ export class ClientReferenceManifestPlugin {
           }
         })
 
-      const requiredChunks = getAppPathRequiredChunks(entrypoint, rootMainFiles)
-      const recordModule = (modId: ModuleId, mod: webpack.NormalModule) => {
+      const entryRequiredChunks = getAppPathRequiredChunks(
+        entrypoint,
+        rootMainFiles
+      )
+
+      // Collect ALL chunks reachable from this entrypoint (including async
+      // children from dynamic imports). Used to scope per-module chunk
+      // lookups so we don't leak chunks from other routes.
+      const entrypointReachableChunks = new Set<webpack.Chunk>()
+      function collectReachableChunks(
+        chunkGroup: ChunkGroup,
+        visited = new Set<ChunkGroup>()
+      ) {
+        if (visited.has(chunkGroup)) return
+        visited.add(chunkGroup)
+        for (const chunk of chunkGroup.chunks) {
+          entrypointReachableChunks.add(chunk)
+        }
+        for (const child of chunkGroup.childrenIterable) {
+          collectReachableChunks(child, visited)
+        }
+      }
+      collectReachableChunks(entrypoint)
+
+      // Determine which chunks to list in the manifest for a given module.
+      // Uses webpack's chunk.canBeInitial() to distinguish:
+      // - Initial chunks (from eager imports): use entryRequiredChunks,
+      //   identical to original behavior.
+      // - Async chunks (from lazy imports for dynamic server component
+      //   boundaries): list the specific async chunk(s) scoped to this
+      //   entrypoint. This enables per-component code splitting.
+      function getModuleChunks(mod: webpack.Module): ManifestChunks {
+        const deploymentIdChunkQuery = getDeploymentIdQueryOrEmptyString()
+        const asyncChunks: string[] = []
+
+        for (const chunk of compilation.chunkGraph.getModuleChunksIterable(
+          mod
+        )) {
+          // If the module is in any initial chunk (loaded with the page HTML),
+          // use the standard entry chunks — same behavior as original code.
+          if (chunk.canBeInitial()) {
+            return entryRequiredChunks
+          }
+
+          // Accumulate async chunk references, scoped to this entrypoint
+          if (!entrypointReachableChunks.has(chunk)) continue
+          if (SYSTEM_ENTRYPOINTS.has(chunk.name || '')) continue
+          if (chunk.id == null) continue
+          const chunkId = '' + chunk.id
+          chunk.files.forEach((file) => {
+            if (!file.endsWith('.js')) return
+            if (file.endsWith('.hot-update.js')) return
+            if (rootMainFiles.has(file)) return
+            asyncChunks.push(
+              chunkId,
+              encodeURIPath(file) + deploymentIdChunkQuery
+            )
+          })
+        }
+
+        // Module is only in async chunks — return those, or fall back
+        return asyncChunks.length > 0 ? asyncChunks : entryRequiredChunks
+      }
+
+      const recordModule = (
+        modId: ModuleId,
+        mod: webpack.NormalModule,
+        chunks?: ManifestChunks
+      ) => {
         let resource =
           mod.type === 'css/mini-extract'
             ? mod.identifier().slice(mod.identifier().lastIndexOf('!') + 1)
@@ -379,11 +446,17 @@ export class ClientReferenceManifestPlugin {
               pluginState.edgeSsrModules[ssrNamedModuleId]?.async
           )
 
+          // Use per-chunk-group chunks if available, otherwise fall back to
+          // the entry's chunks. This enables granular code splitting for client
+          // components reached through dynamic server component imports.
+          const moduleChunks =
+            chunks && chunks.length > 0 ? chunks : entryRequiredChunks
+
           const exportName = resource
           manifest.clientModules[exportName] = {
             id: modId,
             name: '*',
-            chunks: requiredChunks,
+            chunks: moduleChunks,
             async: isAsync,
           }
           if (esmResource) {
@@ -477,6 +550,7 @@ export class ClientReferenceManifestPlugin {
         // Ensure recursion is stopped if we've already checked this chunk group.
         if (checkedChunkGroups.has(chunkGroup)) return
         checkedChunkGroups.add(chunkGroup)
+
         // Only apply following logic to client module requests from client entry,
         // or if the module is marked as client module. That's because other
         // client modules don't need to be in the manifest at all as they're
@@ -517,9 +591,16 @@ export class ClientReferenceManifestPlugin {
               ) as string | number | null
 
               if (modId !== null) {
-                recordModule(modId, clientEntryMod)
+                // Compute the actual chunks this module resides in.
+                // For eager imports, the module is in the entry chunks.
+                // For lazy imports (dynamic server component boundaries),
+                // webpack puts the module in a separate async chunk.
+                const moduleChunks = getModuleChunks(clientEntryMod)
+                recordModule(modId, clientEntryMod, moduleChunks)
               } else {
                 // If this is a concatenation, register each child to the parent ID.
+                // Use the concatenated module for chunk lookup since inner modules
+                // aren't independently tracked in the chunk graph.
                 if (
                   connection.module?.constructor.name === 'ConcatenatedModule'
                 ) {
@@ -527,7 +608,12 @@ export class ClientReferenceManifestPlugin {
                   const concatenatedModId =
                     compilation.chunkGraph.getModuleId(concatenatedMod)
                   if (concatenatedModId) {
-                    recordModule(concatenatedModId, clientEntryMod)
+                    const moduleChunks = getModuleChunks(concatenatedMod)
+                    recordModule(
+                      concatenatedModId,
+                      clientEntryMod,
+                      moduleChunks
+                    )
                   }
                 }
               }

--- a/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ClientComponent1.tsx
+++ b/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ClientComponent1.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function ClientComponent1() {
+  return <div id="client1">Client Component 1</div>
+}

--- a/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ClientComponent2.tsx
+++ b/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ClientComponent2.tsx
@@ -1,0 +1,5 @@
+'use client'
+
+export default function ClientComponent2() {
+  return <div id="client2">Client Component 2</div>
+}

--- a/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ServerComponent1.tsx
+++ b/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ServerComponent1.tsx
@@ -1,0 +1,10 @@
+import ClientComponent1 from './ClientComponent1'
+
+export default function ServerComponent1() {
+  return (
+    <div>
+      <h2>Server Component 1</h2>
+      <ClientComponent1 />
+    </div>
+  )
+}

--- a/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ServerComponent2.tsx
+++ b/test/production/app-dir/dynamic-server-component-client-splitting/app/components/ServerComponent2.tsx
@@ -1,0 +1,10 @@
+import ClientComponent2 from './ClientComponent2'
+
+export default function ServerComponent2() {
+  return (
+    <div>
+      <h2>Server Component 2</h2>
+      <ClientComponent2 />
+    </div>
+  )
+}

--- a/test/production/app-dir/dynamic-server-component-client-splitting/app/layout.tsx
+++ b/test/production/app-dir/dynamic-server-component-client-splitting/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/dynamic-server-component-client-splitting/app/page.tsx
+++ b/test/production/app-dir/dynamic-server-component-client-splitting/app/page.tsx
@@ -1,0 +1,29 @@
+// Reproduction case for https://github.com/vercel/next.js/issues/69865
+// This page dynamically imports server components based on a search param.
+// Only the client components from the rendered branch should be in the bundle.
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ slug?: string }>
+}) {
+  const { slug = 'page1' } = await searchParams
+
+  if (slug === 'page1') {
+    const { default: SC1 } = await import('./components/ServerComponent1')
+    return (
+      <div>
+        <h1>Page 1</h1>
+        <SC1 />
+      </div>
+    )
+  } else {
+    const { default: SC2 } = await import('./components/ServerComponent2')
+    return (
+      <div>
+        <h1>Page 2</h1>
+        <SC2 />
+      </div>
+    )
+  }
+}

--- a/test/production/app-dir/dynamic-server-component-client-splitting/dynamic-server-component-client-splitting.test.ts
+++ b/test/production/app-dir/dynamic-server-component-client-splitting/dynamic-server-component-client-splitting.test.ts
@@ -1,0 +1,81 @@
+import { nextTestSetup } from 'e2e-utils'
+import { getClientReferenceManifest } from 'next-test-utils'
+
+describe('dynamic-server-component-client-splitting', () => {
+  const { next, isNextStart, skipped } = nextTestSetup({
+    files: __dirname,
+    // This test is specifically for webpack code splitting behavior
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  // Functional tests: both branches render correctly
+  it('should render page1 with ClientComponent1', async () => {
+    const browser = await next.browser('/?slug=page1')
+    const text = await browser.elementByCss('#client1').text()
+    expect(text).toBe('Client Component 1')
+  })
+
+  it('should render page2 with ClientComponent2', async () => {
+    const browser = await next.browser('/?slug=page2')
+    const text = await browser.elementByCss('#client2').text()
+    expect(text).toBe('Client Component 2')
+  })
+
+  if (isNextStart) {
+    it('should include both client components in the manifest', () => {
+      const manifest = getClientReferenceManifest(next, '/page')
+
+      const modulePaths = Object.keys(manifest.clientModules)
+      const hasClient1 = modulePaths.some((p) => p.includes('ClientComponent1'))
+      const hasClient2 = modulePaths.some((p) => p.includes('ClientComponent2'))
+
+      // Both client components should be in the manifest
+      expect(hasClient1).toBe(true)
+      expect(hasClient2).toBe(true)
+    })
+
+    it('should have different chunks for client components from different dynamic import branches', () => {
+      const manifest = getClientReferenceManifest(next, '/page')
+
+      // Find the manifest entries for our two client components
+      const client1Entry = Object.entries(manifest.clientModules).find(
+        ([key]) => key.includes('ClientComponent1')
+      )
+      const client2Entry = Object.entries(manifest.clientModules).find(
+        ([key]) => key.includes('ClientComponent2')
+      )
+
+      expect(client1Entry).toBeDefined()
+      expect(client2Entry).toBeDefined()
+
+      const client1Chunks = client1Entry![1].chunks
+      const client2Chunks = client2Entry![1].chunks
+
+      // The key assertion: client components from different dynamic import
+      // branches should NOT share the same chunk set. If they do, it means
+      // loading one triggers loading the other (the bug from #69865).
+      //
+      // With the fix, each client component from a different dynamic import
+      // branch should be in its own async chunk.
+      const client1ChunkFiles = client1Chunks.filter(
+        (_: string, i: number) => i % 2 === 1
+      )
+      const client2ChunkFiles = client2Chunks.filter(
+        (_: string, i: number) => i % 2 === 1
+      )
+
+      // Not ALL chunks should be shared — at least one chunk should be unique
+      // to each component, indicating proper code splitting
+      const hasUniqueClient1Chunk = client1ChunkFiles.some(
+        (f: string) => !client2ChunkFiles.includes(f)
+      )
+      const hasUniqueClient2Chunk = client2ChunkFiles.some(
+        (f: string) => !client1ChunkFiles.includes(f)
+      )
+
+      expect(hasUniqueClient1Chunk || hasUniqueClient2Chunk).toBe(true)
+    })
+  }
+})


### PR DESCRIPTION
## fix: separate client component chunks for dynamic server component imports

### Why

Fixes #69865

When a server component uses dynamic `import()` to conditionally render different sub-trees (each containing their own client components), **all** client components from every branch were bundled into a single set of chunks. Visiting `/?slug=page1` would also download client code for `page2`, causing bundle bloat and potential data leakage.

### Root cause

Three compounding issues in the webpack build pipeline:

1. **`filterClientComponents`** collected all client component imports into a flat list without preserving dynamic import boundaries.
2. **`next-flight-client-entry-loader`** used `webpackMode: "eager"` for every client component, preventing webpack from creating separate async chunks.
3. **`flight-manifest-plugin`** assigned the same entry chunks to every client module regardless of which dynamic branch it belonged to.

### What changed

| File | Change |
|------|--------|
| `flight-client-entry-plugin.ts` | Track `isFromDynamicImport` flag through module graph traversal. Shared components reachable via both static and dynamic paths are conservatively classified as eager. Returns separate `dynamicClientComponentImports`. |
| `next-flight-client-entry-loader.ts` | New `dynamicModules` option. Browser compilation generates lazy `import()` (no `webpackMode: "eager"`) for dynamic modules, creating async chunks. SSR keeps all modules eager. |
| `flight-manifest-plugin.ts` | Uses `chunk.canBeInitial()` to distinguish initial vs async chunks. Modules in initial chunks use `entryRequiredChunks` (identical to original behavior). Modules in async chunks get per-module chunk references scoped to the entrypoint's reachable chunk graph. |

### Key design decisions

- **`chunk.canBeInitial()` over `entryDirectChunkSet`**: The `entryDirectChunkSet` approach broke `actions-tree-shaking` tests because `splitChunks` can move modules to shared chunks outside the entry's direct set. `canBeInitial()` correctly identifies the initial/async boundary regardless of chunk splitting.
- **Conservative eager upgrade for shared modules**: If a client component is reachable via both static and dynamic import paths, it's classified as eager to avoid breaking existing loading patterns.
- **SSR gets all modules as eager**: Server-side rendering doesn't benefit from code splitting and needs all modules available synchronously.

### Test plan

- [x] New test: `dynamic-server-component-client-splitting` (4 cases: render page1, render page2, manifest inclusion, chunk separation)
- [x] Regression: `actions-tree-shaking` (2 cases) 
- [x] Regression: `route-handler-manifest-size` (6 cases)
- [x] Regression: `reference-tree-shaking` (1 case)
- [x] Regression: `dynamic-import` (1 case)
- [ ] Full CI suite

### Limitations

- **Webpack only** — Turbopack requires a separate implementation
- Does not affect `next/dynamic` — only server component `import()` boundaries
- `splitChunks` optimization may merge small async chunks back together (acceptable)

<!-- DCCE:AI-BEGIN
{
  "dcceVersion": "0.1",
  "id": "89bcd0d1-4c14-4394-9b4b-44db16ed4153",
  "contentType": "pr_description",
  "ai": {
    "issue": "#69865",
    "type": "bug_fix",
    "scope": "webpack_build_pipeline",
    "root_cause": {
      "components": [
        "flight-client-entry-plugin.ts",
        "next-flight-client-entry-loader.ts",
        "flight-manifest-plugin.ts"
      ],
      "mechanism": "Three compounding issues: (1) filterClientComponents flattened all client imports without preserving dynamic import boundaries, (2) entry loader used webpackMode:eager for everything preventing code splitting, (3) manifest plugin assigned identical entry chunks to all client modules regardless of dynamic branch"
    },
    "solution": {
      "entry_plugin": "Added isFromDynamicImport flag to filterClientComponents, propagated through module graph traversal. Shared components conservatively classified as eager.",
      "loader": "Added dynamicModules option. Browser generates lazy import() for dynamic modules. SSR keeps all eager.",
      "manifest_plugin": "Uses chunk.canBeInitial() to distinguish initial vs async chunks. Per-module chunk references scoped to entrypoint reachable graph."
    },
    "key_decisions": [
      {"decision": "chunk.canBeInitial() over entryDirectChunkSet", "reason": "splitChunks compatibility"},
      {"decision": "Conservative eager upgrade for shared modules", "reason": "Avoid breaking existing loading"},
      {"decision": "SSR all eager", "reason": "No code splitting benefit server-side"}
    ],
    "files_changed": 3,
    "lines_added": 240,
    "lines_deleted": 47,
    "test_coverage": {
      "new_test": "dynamic-server-component-client-splitting (4 cases)",
      "regression_passed": ["actions-tree-shaking (2)", "route-handler-manifest-size (6)", "reference-tree-shaking (1)", "dynamic-import (1)"]
    },
    "risk_assessment": "Medium",
    "limitations": ["Webpack only", "Does not affect next/dynamic", "splitChunks may re-merge"]
  },
  "provenance": {
    "actor": "ai",
    "tool": "M7 MCP",
    "model": "claude-4.6-opus",
    "generatedAt": "2026-02-11T01:41:48.267Z"
  }
}
DCCE:AI-END -->
