### PR TITLE
Error message documentation link

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -117,6 +117,19 @@ impl Display for NextConfigProperty {
     }
 }
 
+impl NextConfigProperty {
+    fn docs_url(&self) -> &'static str {
+        match self {
+            NextConfigProperty::CacheComponents => {
+                "https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
+            }
+            NextConfigProperty::UseCache => {
+                "https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
+            }
+        }
+    }
+}
+
 enum InvalidExportKind {
     General,
     Metadata,
@@ -358,7 +371,7 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
             vec![span],
         ),
         RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(span, segment, property) => (
-            format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`. Please remove it."),
+            format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`. Please remove it. Learn more: {}", property.docs_url()),
             vec![span],
         ),
         RSCErrorKind::NextRscErrTaintWithoutConfig((api_name, span)) => (

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -121,10 +121,10 @@ impl NextConfigProperty {
     fn docs_url(&self) -> &'static str {
         match self {
             NextConfigProperty::CacheComponents => {
-                "https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
+                "https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs"
             }
             NextConfigProperty::UseCache => {
-                "https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
+                "https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs"
             }
         }
     }

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
@@ -1,31 +1,31 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^
  2 | export const dynamic = 'force-dynamic'
    `----
-  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:2:1]
  1 | export const runtime = 'edge'
  2 | export const dynamic = 'force-dynamic'
    :              ^^^^^^^
  3 | export const dynamicParams = false
    `----
-  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:3:1]
  2 | export const dynamic = 'force-dynamic'
  3 | export const dynamicParams = false
    :              ^^^^^^^^^^^^^
  4 | export const fetchCache = 'force-no-store'
    `----
-  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:4:1]
  3 | export const dynamicParams = false
  4 | export const fetchCache = 'force-no-store'
    :              ^^^^^^^^^^
  5 | export const revalidate = 1
    `----
-  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:5:1]
  4 | export const fetchCache = 'force-no-store'
  5 | export const revalidate = 1

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
@@ -1,31 +1,31 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^
  2 | export const dynamic = 'force-dynamic'
    `----
-  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
    ,-[input.js:2:1]
  1 | export const runtime = 'edge'
  2 | export const dynamic = 'force-dynamic'
    :              ^^^^^^^
  3 | export const dynamicParams = false
    `----
-  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
    ,-[input.js:3:1]
  2 | export const dynamic = 'force-dynamic'
  3 | export const dynamicParams = false
    :              ^^^^^^^^^^^^^
  4 | export const fetchCache = 'force-no-store'
    `----
-  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
    ,-[input.js:4:1]
  3 | export const dynamicParams = false
  4 | export const fetchCache = 'force-no-store'
    :              ^^^^^^^^^^
  5 | export const revalidate = 1
    `----
-  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
    ,-[input.js:5:1]
  4 | export const fetchCache = 'force-no-store'
  5 | export const revalidate = 1

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
@@ -1,4 +1,4 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it.
+  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
@@ -1,4 +1,4 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -151,11 +151,11 @@ describe('Cache Components Dev Errors', () => {
         } else if (isRspack) {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
+             "description": "  ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx
-             ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+             ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
                    │    ,-[1:1]
                    │  1 | export const revalidate = 10
                    │    :              ^^^^^^^^^^
@@ -170,11 +170,11 @@ describe('Cache Components Dev Errors', () => {
         } else {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
+             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx
-           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
               ,-[1:1]
             1 | export const revalidate = 10
               :              ^^^^^^^^^^

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -151,11 +151,11 @@ describe('Cache Components Dev Errors', () => {
         } else if (isRspack) {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+             "description": "  ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx
-             ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+             ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
                    │    ,-[1:1]
                    │  1 | export const revalidate = 10
                    │    :              ^^^^^^^^^^
@@ -170,11 +170,11 @@ describe('Cache Components Dev Errors', () => {
         } else {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx
-           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
               ,-[1:1]
             1 | export const revalidate = 10
               :              ^^^^^^^^^^

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -38,27 +38,27 @@ describe('cache-components-route-handler-errors', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"  x Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
+          `"  x Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs"`
         )
       }
       expect(redbox.source).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
     } else {
       // In build mode, check for all three errors in the output
       expect(next.cliOutput).toContain('./app/route-with-dynamic/route.ts')
       expect(next.cliOutput).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
 
       expect(next.cliOutput).toContain('./app/route-with-revalidate/route.ts')
       expect(next.cliOutput).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
 
       expect(next.cliOutput).toContain('./app/route-with-fetchcache/route.ts')
       expect(next.cliOutput).toContain(
-        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
     }
   })

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -38,27 +38,27 @@ describe('cache-components-route-handler-errors', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"  x Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+          `"  x Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
         )
       }
       expect(redbox.source).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     } else {
       // In build mode, check for all three errors in the output
       expect(next.cliOutput).toContain('./app/route-with-dynamic/route.ts')
       expect(next.cliOutput).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/route-with-revalidate/route.ts')
       expect(next.cliOutput).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/route-with-fetchcache/route.ts')
       expect(next.cliOutput).toContain(
-        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     }
   })

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -54,7 +54,7 @@ function filterBrowserLogs(output: string): string {
            3 | export default function Page() {
            4 |   return <div>Test page under app/</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."
+         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
         `)
         // Count occurrences of the layout error at the specific location
         // Filter out browser logs to avoid counting forwarded browser errors
@@ -69,10 +69,10 @@ function filterBrowserLogs(output: string): string {
         expect(next.cliOutput).toContain('./app/edge-with-layout/layout.tsx')
         expect(next.cliOutput).toContain('./app/edge-with-layout/edge/page.tsx')
         expect(next.cliOutput).toContain(
-          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
         )
         expect(next.cliOutput).toContain(
-          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
         )
         // Count occurrences of the layout error at the specific location
         const layoutErrorMatches = next.cliOutput.match(

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -54,7 +54,7 @@ function filterBrowserLogs(output: string): string {
            3 | export default function Page() {
            4 |   return <div>Test page under app/</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
+         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs"
         `)
         // Count occurrences of the layout error at the specific location
         // Filter out browser logs to avoid counting forwarded browser errors
@@ -69,10 +69,10 @@ function filterBrowserLogs(output: string): string {
         expect(next.cliOutput).toContain('./app/edge-with-layout/layout.tsx')
         expect(next.cliOutput).toContain('./app/edge-with-layout/edge/page.tsx')
         expect(next.cliOutput).toContain(
-          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
         )
         expect(next.cliOutput).toContain(
-          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
         )
         // Count occurrences of the layout error at the specific location
         const layoutErrorMatches = next.cliOutput.match(

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -38,31 +38,31 @@ describe('cache-components-segment-configs', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
+          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs"`
         )
       }
       expect(redbox.source).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
     } else {
       expect(next.cliOutput).toContain('./app/dynamic-params/[slug]/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
       expect(next.cliOutput).toContain('./app/dynamic/nested/page.tsx')
       expect(next.cliOutput).toContain('./app/dynamic/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
 
       expect(next.cliOutput).toContain('./app/fetch-cache/page.tsx')
       expect(next.cliOutput).toContain(
-        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
 
       expect(next.cliOutput).toContain('./app/revalidate/page.tsx')
       expect(next.cliOutput).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
       )
     }
   })
@@ -99,16 +99,16 @@ describe('cache-components-segment-configs', () => {
             )
           } else {
             expect(redbox.description).toMatchInlineSnapshot(
-              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
+              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs"`
             )
           }
           expect(redbox.source).toContain(
-            '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+            '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
           )
         } else {
           await retry(async () => {
             expect(next.cliOutput).toContain(
-              '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
+              '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs'
             )
 
             // the stack trace is different between turbopack/webpack

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -38,31 +38,31 @@ describe('cache-components-segment-configs', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
         )
       }
       expect(redbox.source).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     } else {
       expect(next.cliOutput).toContain('./app/dynamic-params/[slug]/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
       expect(next.cliOutput).toContain('./app/dynamic/nested/page.tsx')
       expect(next.cliOutput).toContain('./app/dynamic/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/fetch-cache/page.tsx')
       expect(next.cliOutput).toContain(
-        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/revalidate/page.tsx')
       expect(next.cliOutput).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     }
   })
@@ -99,16 +99,16 @@ describe('cache-components-segment-configs', () => {
             )
           } else {
             expect(redbox.description).toMatchInlineSnapshot(
-              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
             )
           }
           expect(redbox.source).toContain(
-            '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+            '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
           )
         } else {
           await retry(async () => {
             expect(next.cliOutput).toContain(
-              '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+              '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
             )
 
             // the stack trace is different between turbopack/webpack

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -35,11 +35,11 @@ describe('use-cache-segment-configs', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "  ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
+           "description": "  ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "<FIXME-nextjs-internal-source>
-           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
                  │    ,-[1:1]
                  │  1 | export const runtime = 'edge'
                  │    :              ^^^^^^^
@@ -55,11 +55,11 @@ describe('use-cache-segment-configs', () => {
         // FIXME: Fix broken import trace for Webpack loader resource.
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
+           "description": "  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "<FIXME-nextjs-internal-source>
-         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
             ,-[1:1]
           1 | export const runtime = 'edge'
             :              ^^^^^^^
@@ -87,7 +87,7 @@ describe('use-cache-segment-configs', () => {
            3 | export default function Page() {
            4 |   return <div>This page uses \`export const runtime\`.</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
 
 
              at <unknown> (./app/runtime/page.tsx:1:14)
@@ -97,7 +97,7 @@ describe('use-cache-segment-configs', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "
          // TODO(veil): Fix broken import trace for Webpack loader resource.
-           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
                  │    ,-[1:1]
                  │  1 | export const runtime = 'edge'
                  │    :              ^^^^^^^
@@ -118,7 +118,7 @@ describe('use-cache-segment-configs', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "
          // TODO(veil): Fix broken import trace for Webpack loader resource.
-         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#migrating-route-segment-configs
             ,-[1:1]
           1 | export const runtime = 'edge'
             :              ^^^^^^^

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -35,11 +35,11 @@ describe('use-cache-segment-configs', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "  ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
+           "description": "  ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "<FIXME-nextjs-internal-source>
-           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
                  │    ,-[1:1]
                  │  1 | export const runtime = 'edge'
                  │    :              ^^^^^^^
@@ -55,11 +55,11 @@ describe('use-cache-segment-configs', () => {
         // FIXME: Fix broken import trace for Webpack loader resource.
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
+           "description": "  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "<FIXME-nextjs-internal-source>
-         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
             ,-[1:1]
           1 | export const runtime = 'edge'
             :              ^^^^^^^
@@ -87,7 +87,7 @@ describe('use-cache-segment-configs', () => {
            3 | export default function Page() {
            4 |   return <div>This page uses \`export const runtime\`.</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
 
 
              at <unknown> (./app/runtime/page.tsx:1:14)
@@ -97,7 +97,7 @@ describe('use-cache-segment-configs', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "
          // TODO(veil): Fix broken import trace for Webpack loader resource.
-           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
                  │    ,-[1:1]
                  │  1 | export const runtime = 'edge'
                  │    :              ^^^^^^^
@@ -118,7 +118,7 @@ describe('use-cache-segment-configs', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "
          // TODO(veil): Fix broken import trace for Webpack loader resource.
-         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
             ,-[1:1]
           1 | export const runtime = 'edge'
             :              ^^^^^^^


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Updates the "Route segment config is not compatible with `nextConfig.{property}`" error message.

### Why?
To provide users with immediate guidance and a direct link to relevant documentation when encountering this error related to `cacheComponents` or `experimental.useCache`.

### How?
- Added a `docs_url()` method to `NextConfigProperty` to return the appropriate documentation link.
- Modified the error message in `crates/next-custom-transforms/src/transforms/react_server_components.rs` to include "Learn more: [link]" using the new `docs_url()` method.
- Updated all relevant test fixtures and snapshots across various test files to reflect the new error message format.

Closes NEXT-
Fixes #

-->

---
[Slack Thread](https://vercel.slack.com/archives/C05KYT5S9FF/p1770729030958459?thread_ts=1770729030.958459&cid=C05KYT5S9FF)

<p><a href="https://cursor.com/background-agent?bcId=bc-5ae412eb-a572-5e87-8ae9-a4be7b055905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ae412eb-a572-5e87-8ae9-a4be7b055905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

