### PR TITLE
Add docs link to route segment config / cacheComponents error message

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -117,6 +117,19 @@ impl Display for NextConfigProperty {
     }
 }
 
+impl NextConfigProperty {
+    fn docs_url(&self) -> &'static str {
+        match self {
+            NextConfigProperty::CacheComponents => {
+                "https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
+            }
+            NextConfigProperty::UseCache => {
+                "https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
+            }
+        }
+    }
+}
+
 enum InvalidExportKind {
     General,
     Metadata,
@@ -358,7 +371,7 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
             vec![span],
         ),
         RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(span, segment, property) => (
-            format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`. Please remove it."),
+            format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`. Please remove it. Learn more: {}", property.docs_url()),
             vec![span],
         ),
         RSCErrorKind::NextRscErrTaintWithoutConfig((api_name, span)) => (

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
@@ -1,31 +1,31 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^
  2 | export const dynamic = 'force-dynamic'
    `----
-  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:2:1]
  1 | export const runtime = 'edge'
  2 | export const dynamic = 'force-dynamic'
    :              ^^^^^^^
  3 | export const dynamicParams = false
    `----
-  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:3:1]
  2 | export const dynamic = 'force-dynamic'
  3 | export const dynamicParams = false
    :              ^^^^^^^^^^^^^
  4 | export const fetchCache = 'force-no-store'
    `----
-  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:4:1]
  3 | export const dynamicParams = false
  4 | export const fetchCache = 'force-no-store'
    :              ^^^^^^^^^^
  5 | export const revalidate = 1
    `----
-  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:5:1]
  4 | export const fetchCache = 'force-no-store'
  5 | export const revalidate = 1

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
@@ -1,31 +1,36 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-
+  | dynamic
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^
  2 | export const dynamic = 'force-dynamic'
    `----
-  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-
+  | dynamic
    ,-[input.js:2:1]
  1 | export const runtime = 'edge'
  2 | export const dynamic = 'force-dynamic'
    :              ^^^^^^^
  3 | export const dynamicParams = false
    `----
-  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-
+  | components#dynamic--force-dynamic
    ,-[input.js:3:1]
  2 | export const dynamic = 'force-dynamic'
  3 | export const dynamicParams = false
    :              ^^^^^^^^^^^^^
  4 | export const fetchCache = 'force-no-store'
    `----
-  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-
+  | dynamic
    ,-[input.js:4:1]
  3 | export const dynamicParams = false
  4 | export const fetchCache = 'force-no-store'
    :              ^^^^^^^^^^
  5 | export const revalidate = 1
    `----
-  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-
+  | dynamic
    ,-[input.js:5:1]
  4 | export const fetchCache = 'force-no-store'
  5 | export const revalidate = 1

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
@@ -1,4 +1,4 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it.
+  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
@@ -1,4 +1,5 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
+  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-
+  | components#dynamic--force-dynamic
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -151,11 +151,11 @@ describe('Cache Components Dev Errors', () => {
         } else if (isRspack) {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+             "description": "  ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx
-             ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+             ╰─▶   × Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
                    │    ,-[1:1]
                    │  1 | export const revalidate = 10
                    │    :              ^^^^^^^^^^
@@ -170,11 +170,11 @@ describe('Cache Components Dev Errors', () => {
         } else {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx
-           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
               ,-[1:1]
             1 | export const revalidate = 10
               :              ^^^^^^^^^^

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -38,27 +38,27 @@ describe('cache-components-route-handler-errors', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"  x Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+          `"  x Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
         )
       }
       expect(redbox.source).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     } else {
       // In build mode, check for all three errors in the output
       expect(next.cliOutput).toContain('./app/route-with-dynamic/route.ts')
       expect(next.cliOutput).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/route-with-revalidate/route.ts')
       expect(next.cliOutput).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/route-with-fetchcache/route.ts')
       expect(next.cliOutput).toContain(
-        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     }
   })

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -54,7 +54,7 @@ function filterBrowserLogs(output: string): string {
            3 | export default function Page() {
            4 |   return <div>Test page under app/</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."
+         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"
         `)
         // Count occurrences of the layout error at the specific location
         // Filter out browser logs to avoid counting forwarded browser errors
@@ -69,10 +69,10 @@ function filterBrowserLogs(output: string): string {
         expect(next.cliOutput).toContain('./app/edge-with-layout/layout.tsx')
         expect(next.cliOutput).toContain('./app/edge-with-layout/edge/page.tsx')
         expect(next.cliOutput).toContain(
-          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+          '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
         )
         expect(next.cliOutput).toContain(
-          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+          '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
         )
         // Count occurrences of the layout error at the specific location
         const layoutErrorMatches = next.cliOutput.match(

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -38,31 +38,31 @@ describe('cache-components-segment-configs', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
         )
       }
       expect(redbox.source).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     } else {
       expect(next.cliOutput).toContain('./app/dynamic-params/[slug]/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
       expect(next.cliOutput).toContain('./app/dynamic/nested/page.tsx')
       expect(next.cliOutput).toContain('./app/dynamic/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/fetch-cache/page.tsx')
       expect(next.cliOutput).toContain(
-        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
 
       expect(next.cliOutput).toContain('./app/revalidate/page.tsx')
       expect(next.cliOutput).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
       )
     }
   })
@@ -99,16 +99,16 @@ describe('cache-components-segment-configs', () => {
             )
           } else {
             expect(redbox.description).toMatchInlineSnapshot(
-              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic"`
             )
           }
           expect(redbox.source).toContain(
-            '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+            '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
           )
         } else {
           await retry(async () => {
             expect(next.cliOutput).toContain(
-              '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+              '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic'
             )
 
             // the stack trace is different between turbopack/webpack

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -35,11 +35,11 @@ describe('use-cache-segment-configs', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "  ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
+           "description": "  ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "<FIXME-nextjs-internal-source>
-           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
                  │    ,-[1:1]
                  │  1 | export const runtime = 'edge'
                  │    :              ^^^^^^^
@@ -55,11 +55,11 @@ describe('use-cache-segment-configs', () => {
         // FIXME: Fix broken import trace for Webpack loader resource.
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
+           "description": "  x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "<FIXME-nextjs-internal-source>
-         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
             ,-[1:1]
           1 | export const runtime = 'edge'
             :              ^^^^^^^
@@ -87,7 +87,7 @@ describe('use-cache-segment-configs', () => {
            3 | export default function Page() {
            4 |   return <div>This page uses \`export const runtime\`.</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
 
 
              at <unknown> (./app/runtime/page.tsx:1:14)
@@ -97,7 +97,7 @@ describe('use-cache-segment-configs', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "
          // TODO(veil): Fix broken import trace for Webpack loader resource.
-           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+           ╰─▶   × Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
                  │    ,-[1:1]
                  │  1 | export const runtime = 'edge'
                  │    :              ^^^^^^^
@@ -118,7 +118,7 @@ describe('use-cache-segment-configs', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "
          // TODO(veil): Fix broken import trace for Webpack loader resource.
-         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Error:   x Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic
             ,-[1:1]
           1 | export const runtime = 'edge'
             :              ^^^^^^^


### PR DESCRIPTION
Adds a "Learn more" link to the error shown when route segment configs (e.g. dynamic, revalidate, runtime) are incompatible with nextConfig.cacheComponents or nextConfig.experimental.useCache.

 Before: Route segment config "dynamic" is not compatible with 'nextConfig.cacheComponents'. Please remove it.

 After: Route segment config "dynamic" is not compatible with 'nextConfig.cacheComponents'. Please remove it. Learn more: https://nextjs.org/docs/app/getting-started/cache-components#dynamic--force-dynamic

 Why?
 The previous message just said "Please remove it" without explaining what to do instead — which could change behavior. Users need guidance on how to migrate (e.g. using await connection()). The linked docs page explains the alternatives.

 How?
 - Added a docs_url() method to NextConfigProperty in [react_server_components.rs](http://react_server_components.rs/)
 - Appended the link to the error message format string
 - Updated all Rust .stderr test fixtures and JS/TS test snapshots (8 files)