### PR TITLE
Turbopack: Move turbopackIgnoreIssue from experimental to turbopack.ignoreIssue

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -1087,7 +1087,7 @@ impl Project {
     }
 
     /// Build the `IssueFilter` for this project, incorporating any
-    /// `experimental.turbopackIgnoreIssue` rules from the Next.js config.
+    /// `turbopack.ignoreIssue` rules from the Next.js config.
     #[turbo_tasks::function]
     pub async fn issue_filter(self: Vc<Self>) -> Result<Vc<IssueFilter>> {
         let ignore_rules = self.next_config().turbopack_ignore_issue_rules().await?;

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -611,6 +611,9 @@ pub struct TurbopackConfig {
     pub resolve_alias: Option<FxIndexMap<RcStr, JsonValue>>,
     pub resolve_extensions: Option<Vec<RcStr>>,
     pub debug_ids: Option<bool>,
+    /// Issue patterns to ignore (suppress) from Turbopack output.
+    #[serde(default)]
+    pub ignore_issue: Option<Vec<TurbopackIgnoreIssueRule>>,
 }
 
 #[derive(
@@ -970,7 +973,7 @@ pub enum ReactCompilerOptionsOrBoolean {
 #[turbo_tasks::value(transparent)]
 pub struct OptionalReactCompilerOptions(Option<ResolvedVc<ReactCompilerOptions>>);
 
-/// Serialized representation of a path pattern for `turbopackIgnoreIssue`.
+/// Serialized representation of a path pattern for `turbopack.ignoreIssue`.
 /// Strings are serialized as `{ "type": "glob", "value": "..." }` and
 /// RegExp as `{ "type": "regex", "source": "...", "flags": "..." }`.
 #[derive(
@@ -998,7 +1001,7 @@ impl TurbopackIgnoreIssuePathPattern {
 }
 
 /// Serialized representation of a text pattern (title/description) for
-/// `turbopackIgnoreIssue`. Strings are serialized as
+/// `turbopack.ignoreIssue`. Strings are serialized as
 /// `{ "type": "string", "value": "..." }` and RegExp as
 /// `{ "type": "regex", "source": "...", "flags": "..." }`.
 #[derive(
@@ -1025,7 +1028,7 @@ impl TurbopackIgnoreIssueTextPattern {
     }
 }
 
-/// A single rule in `experimental.turbopackIgnoreIssue`.
+/// A single rule in `turbopack.ignoreIssue`.
 #[derive(
     Clone, Debug, PartialEq, Deserialize, TraceRawVcs, NonLocalValue, OperationValue, Encode, Decode,
 )]
@@ -1168,9 +1171,6 @@ pub struct ExperimentalConfig {
     turbopack_remove_unused_exports: Option<bool>,
     /// Enable local analysis to infer side effect free modules. Defaults to true.
     turbopack_infer_module_side_effects: Option<bool>,
-    /// Issue patterns to ignore (suppress) from Turbopack output.
-    #[serde(default)]
-    turbopack_ignore_issue: Option<Vec<TurbopackIgnoreIssueRule>>,
     /// Devtool option for the segment explorer.
     devtool_segment_explorer: Option<bool>,
     /// Whether to report inlined system environment variables as warnings or errors.
@@ -2205,14 +2205,14 @@ impl NextConfig {
         }
     }
 
-    /// Returns the list of ignore-issue rules from the experimental config,
+    /// Returns the list of ignore-issue rules from the turbopack config,
     /// converted to the `IgnoreIssue` type used by `IssueFilter`.
     #[turbo_tasks::function]
     pub fn turbopack_ignore_issue_rules(&self) -> Result<Vc<IgnoreIssues>> {
         let rules = self
-            .experimental
-            .turbopack_ignore_issue
-            .as_deref()
+            .turbopack
+            .as_ref()
+            .and_then(|tp| tp.ignore_issue.as_deref())
             .unwrap_or_default()
             .iter()
             .map(|rule| {

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackIgnoreIssue.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackIgnoreIssue.mdx
@@ -1,7 +1,6 @@
 ---
-title: turbopackIgnoreIssue
+title: turbopack.ignoreIssue
 description: Suppress specific Turbopack errors and warnings from the CLI output and error overlay.
-version: experimental
 related:
   title: Next Steps
   description: Learn more about Turbopack configuration.
@@ -10,7 +9,7 @@ related:
     - app/api-reference/turbopack
 ---
 
-The `turbopackIgnoreIssue` option allows you to filter out specific [Turbopack](/docs/app/api-reference/turbopack) errors and warnings so they do not appear in the CLI output or the error overlay. This is useful for suppressing known warnings that do not affect your application, such as intentionally unresolved optional dependencies.
+The `turbopack.ignoreIssue` option allows you to filter out specific [Turbopack](/docs/app/api-reference/turbopack) errors and warnings so they do not appear in the CLI output or the error overlay. This is useful for suppressing known warnings that do not affect your application, such as intentionally unresolved optional dependencies.
 
 This option is only available when using Turbopack (`next dev --turbopack`).
 
@@ -20,8 +19,8 @@ This option is only available when using Turbopack (`next dev --turbopack`).
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       {
         path: '**/vendor/**',
       },
@@ -35,8 +34,8 @@ export default nextConfig
 ```js filename="next.config.js" switcher
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       {
         path: '**/vendor/**',
       },
@@ -49,7 +48,7 @@ module.exports = nextConfig
 
 ## Options
 
-Each rule in the `turbopackIgnoreIssue` array is an object with the following fields:
+Each rule in the `ignoreIssue` array is an object with the following fields:
 
 | Field                         | Type               | Required | Description                                |
 | ----------------------------- | ------------------ | -------- | ------------------------------------------ |
@@ -59,7 +58,7 @@ Each rule in the `turbopackIgnoreIssue` array is an object with the following fi
 
 An issue is suppressed when it matches the `path` **and** all other specified fields in a rule. If only `path` is provided, any issue from a matching file is suppressed.
 
-> **Good to know:** Issue titles and descriptions may change between Turbopack versions. The `path` field is generally stable, but is not guaranteed to remain consistent for all issue types. When possible, prefer using `path` patterns over `title` or `description` matching.
+> **Good to know:** Issue titles and descriptions may change between Turbopack versions. The `path` field is generally stable, but is not guaranteed to remain consistent for all issue types. When possible, prefer using more specific `path` patterns over `title` or `description` matching.
 
 ### `path`
 
@@ -67,8 +66,8 @@ A **glob pattern** (when a string) or **regular expression** that matches agains
 
 ```js filename="next.config.js"
 module.exports = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       // Glob pattern: suppress issues from any file under vendor/
       { path: '**/vendor/**' },
       // RegExp: suppress issues from files matching a pattern
@@ -84,8 +83,8 @@ An **exact string match** (when a string) or **regular expression** that matches
 
 ```js filename="next.config.js"
 module.exports = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       {
         path: '**/src/**',
         title: 'Module not found',
@@ -101,8 +100,8 @@ An **exact string match** (when a string) or **regular expression** that matches
 
 ```js filename="next.config.js"
 module.exports = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       {
         path: '**/src/**',
         description: /Cannot find module 'optional-dep'/,
@@ -122,8 +121,8 @@ If your code uses `try/catch` around an optional `require()` call, Turbopack may
 import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       {
         path: '**/lib/optional-feature/**',
         title: 'Module not found',
@@ -138,8 +137,8 @@ export default nextConfig
 ```js filename="next.config.js" switcher
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       {
         path: '**/lib/optional-feature/**',
         title: 'Module not found',
@@ -157,8 +156,8 @@ You can specify multiple rules to suppress different issues:
 
 ```js filename="next.config.js"
 module.exports = {
-  experimental: {
-    turbopackIgnoreIssue: [
+  turbopack: {
+    ignoreIssue: [
       { path: '**/vendor/**' },
       { path: '**/legacy/**', title: 'Module not found' },
       { path: /generated\//, description: /expected identifier/ },
@@ -169,6 +168,7 @@ module.exports = {
 
 ## Version History
 
-| Version   | Changes                            |
-| --------- | ---------------------------------- |
-| `v16.2.0` | `turbopackIgnoreIssue` introduced. |
+| Version   | Changes                                                      |
+| --------- | ------------------------------------------------------------ |
+| `v16.2.0` | Moved to `turbopack.ignoreIssue` (stable, non-experimental). |
+| `v16.2.0` | `turbopackIgnoreIssue` introduced under `experimental`.      |

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackIgnoreIssue.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/turbopackIgnoreIssue.mdx
@@ -168,7 +168,6 @@ module.exports = {
 
 ## Version History
 
-| Version   | Changes                                                      |
-| --------- | ------------------------------------------------------------ |
-| `v16.2.0` | Moved to `turbopack.ignoreIssue` (stable, non-experimental). |
-| `v16.2.0` | `turbopackIgnoreIssue` introduced under `experimental`.      |
+| Version   | Changes                             |
+| --------- | ----------------------------------- |
+| `v16.2.0` | `turbopack.ignoreIssue` introduced. |

--- a/docs/01-app/03-api-reference/08-turbopack.mdx
+++ b/docs/01-app/03-api-reference/08-turbopack.mdx
@@ -232,6 +232,8 @@ Turbopack can be configured via `next.config.js` (or `next.config.ts`) under the
   Create manual aliases (like `resolve.alias` in webpack).
 - **`resolveExtensions`**
   Change or extend file extensions for module resolution.
+- **[`ignoreIssue`](/docs/app/api-reference/config/next-config-js/turbopackIgnoreIssue)**
+  Suppress specific Turbopack errors and warnings from the CLI output and error overlay.
 
 Additionally, the following experimental options are available under `experimental` in `next.config.js`:
 
@@ -239,7 +241,6 @@ Additionally, the following experimental options are available under `experiment
 | ------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ------------- | ----------------------------- |
 | [`turbopackFileSystemCacheForDev`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache)   | Enable filesystem cache for the dev server.                                            | `true`        | N/A                           |
 | [`turbopackFileSystemCacheForBuild`](/docs/app/api-reference/config/next-config-js/turbopackFileSystemCache) | Enable filesystem cache for builds.                                                    | N/A           | `false`                       |
-| [`turbopackIgnoreIssue`](/docs/app/api-reference/config/next-config-js/turbopackIgnoreIssue)                 | Suppress specific Turbopack errors and warnings from the CLI output and error overlay. | `[]`          | `[]`                          |
 | `turbopackMinify`                                                                                            | Enable minification.                                                                   | `false`       | `true`                        |
 | `turbopackSourceMaps`                                                                                        | Enable source maps.                                                                    | `true`        | `productionBrowserSourceMaps` |
 | `turbopackInputSourceMaps`                                                                                   | Enable extraction of source maps from input files.                                     | `true`        | `true`                        |

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -962,46 +962,42 @@ function bindingToApi(
         turbopack.rules = serializeTurbopackRules(turbopack.rules)
       }
 
-      nextConfigSerializable.turbopack = turbopack
-    }
-
-    // Serialize turbopackIgnoreIssue rules: convert RegExp to {source, flags}
-    if (nextConfigSerializable.experimental?.turbopackIgnoreIssue) {
-      function serializePatternField(
-        value: string | RegExp,
-        stringType: 'glob' | 'string'
-      ) {
-        if (value instanceof RegExp) {
-          return {
-            type: 'regex' as const,
-            source: value.source,
-            flags: value.flags,
+      // Serialize ignoreIssue rules: convert RegExp to {source, flags}
+      if (turbopack.ignoreIssue) {
+        function serializePatternField(
+          value: string | RegExp,
+          stringType: 'glob' | 'string'
+        ) {
+          if (value instanceof RegExp) {
+            return {
+              type: 'regex' as const,
+              source: value.source,
+              flags: value.flags,
+            }
           }
+          return { type: stringType, value }
         }
-        return { type: stringType, value }
+
+        turbopack.ignoreIssue = turbopack.ignoreIssue.map(
+          (rule: {
+            path: string | RegExp
+            title?: string | RegExp
+            description?: string | RegExp
+          }) => ({
+            path: serializePatternField(rule.path, 'glob'),
+            title:
+              rule.title != null
+                ? serializePatternField(rule.title, 'string')
+                : undefined,
+            description:
+              rule.description != null
+                ? serializePatternField(rule.description, 'string')
+                : undefined,
+          })
+        )
       }
 
-      nextConfigSerializable.experimental = {
-        ...nextConfigSerializable.experimental,
-        turbopackIgnoreIssue:
-          nextConfigSerializable.experimental.turbopackIgnoreIssue.map(
-            (rule: {
-              path: string | RegExp
-              title?: string | RegExp
-              description?: string | RegExp
-            }) => ({
-              path: serializePatternField(rule.path, 'glob'),
-              title:
-                rule.title != null
-                  ? serializePatternField(rule.title, 'string')
-                  : undefined,
-              description:
-                rule.description != null
-                  ? serializePatternField(rule.description, 'string')
-                  : undefined,
-            })
-          ),
-      }
+      nextConfigSerializable.turbopack = turbopack
     }
 
     return JSON.stringify(nextConfigSerializable, null, 2)

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -175,6 +175,15 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
   resolveExtensions: z.array(z.string()).optional(),
   root: z.string().optional(),
   debugIds: z.boolean().optional(),
+  ignoreIssue: z
+    .array(
+      z.object({
+        path: z.union([z.string(), z.instanceof(RegExp)]),
+        title: z.union([z.string(), z.instanceof(RegExp)]).optional(),
+        description: z.union([z.string(), z.instanceof(RegExp)]).optional(),
+      })
+    )
+    .optional(),
 })
 
 export const experimentalSchema = {
@@ -330,15 +339,6 @@ export const experimentalSchema = {
   turbopackUseBuiltinSass: z.boolean().optional(),
   turbopackModuleIds: z.enum(['named', 'deterministic']).optional(),
   turbopackInferModuleSideEffects: z.boolean().optional(),
-  turbopackIgnoreIssue: z
-    .array(
-      z.object({
-        path: z.union([z.string(), z.instanceof(RegExp)]),
-        title: z.union([z.string(), z.instanceof(RegExp)]).optional(),
-        description: z.union([z.string(), z.instanceof(RegExp)]).optional(),
-      })
-    )
-    .optional(),
   optimizePackageImports: z.array(z.string()).optional(),
   optimizeServerReact: z.boolean().optional(),
   strictRouteTypes: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -215,6 +215,19 @@ export interface TurbopackOptions {
    * @see https://github.com/tc39/ecma426/blob/main/proposals/debug-id.md TC39 Debug ID Proposal
    */
   debugIds?: boolean
+
+  /**
+   * An array of issue filter rules to ignore specific Turbopack issues.
+   * Each rule must have a `path` field (mandatory) and optionally `title`
+   * and `description`. String paths are treated as glob patterns. String
+   * titles/descriptions are exact matches. RegExp values match anywhere
+   * within the string (use `^` and `$` anchors for full-string matching).
+   */
+  ignoreIssue?: Array<{
+    path: string | RegExp
+    title?: string | RegExp
+    description?: string | RegExp
+  }>
 }
 
 export interface WebpackConfigContext {
@@ -556,19 +569,6 @@ export interface ExperimentalConfig {
    * Defaults to `true`
    */
   turbopackInferModuleSideEffects?: boolean
-
-  /**
-   * An array of issue filter rules to ignore specific Turbopack issues.
-   * Each rule must have a `path` field (mandatory) and optionally `title`
-   * and `description`. String paths are treated as glob patterns. String
-   * titles/descriptions are exact matches. RegExp values match anywhere
-   * within the string (use `^` and `$` anchors for full-string matching).
-   */
-  turbopackIgnoreIssue?: Array<{
-    path: string | RegExp
-    title?: string | RegExp
-    description?: string | RegExp
-  }>
 
   /**
    * Set this to `false` to disable the automatic configuration of the babel loader when a Babel

--- a/test/development/app-dir/turbopack-ignore-issue/turbopack-ignore-issue.test.ts
+++ b/test/development/app-dir/turbopack-ignore-issue/turbopack-ignore-issue.test.ts
@@ -3,14 +3,14 @@ import { retry, waitForNoRedbox, waitForRedbox } from 'next-test-utils'
 import stripAnsi from 'strip-ansi'
 
 describe('turbopack-ignore-issue', () => {
-  describe('with turbopackIgnoreIssue config', () => {
+  describe('with turbopack.ignoreIssue config', () => {
     const { next, skipped, isTurbopack } = nextTestSetup({
       files: __dirname,
-      // turbopackIgnoreIssue is turbopack-only
+      // turbopack.ignoreIssue is turbopack-only
       skipDeployment: true,
       nextConfig: {
-        experimental: {
-          turbopackIgnoreIssue: [
+        turbopack: {
+          ignoreIssue: [
             {
               // glob string pattern for path
               path: '**/with-warning/**',
@@ -37,7 +37,7 @@ describe('turbopack-ignore-issue', () => {
 
     if (skipped) return
     if (!isTurbopack) {
-      it('should skip tests since turbopackIgnoreIssue only works with Turbopack', () => {})
+      it('should skip tests since turbopack.ignoreIssue only works with Turbopack', () => {})
       return
     }
 
@@ -54,7 +54,7 @@ describe('turbopack-ignore-issue', () => {
       })
 
       // Now that compilation is complete, the warning should be absent
-      // because our turbopackIgnoreIssue rule matches the path.
+      // because our turbopack.ignoreIssue rule matches the path.
       const output = stripAnsi(next.cliOutput.slice(outputIndex))
       expect(output).not.toContain('a-missing-module-for-testing')
     })
@@ -122,7 +122,7 @@ describe('turbopack-ignore-issue', () => {
     })
   })
 
-  describe('without turbopackIgnoreIssue config', () => {
+  describe('without turbopack.ignoreIssue config', () => {
     const { next, skipped, isTurbopack } = nextTestSetup({
       files: __dirname,
       skipDeployment: true,
@@ -136,7 +136,7 @@ describe('turbopack-ignore-issue', () => {
       await next.fetch('/with-warning')
 
       // The warning about 'a-missing-module-for-testing' should appear
-      // since there is no turbopackIgnoreIssue config
+      // since there is no turbopack.ignoreIssue config
       await retry(async () => {
         const output = stripAnsi(next.cliOutput.slice(outputIndex))
         expect(output).toContain('a-missing-module-for-testing')
@@ -145,12 +145,12 @@ describe('turbopack-ignore-issue', () => {
 
     it('should show error in error overlay when not ignored', async () => {
       if (!isTurbopack) {
-        // turbopackIgnoreIssue only works with Turbopack
+        // turbopack.ignoreIssue only works with Turbopack
         return
       }
 
       // Navigate to the page with a top-level require of a missing module.
-      // Without turbopackIgnoreIssue, the error should appear in the overlay.
+      // Without turbopack.ignoreIssue, the error should appear in the overlay.
       const browser = await next.browser('/with-error')
       await waitForRedbox(browser)
     })


### PR DESCRIPTION
## What?

Moves the `turbopackIgnoreIssue` config from `experimental` to the stable `turbopack` config as `turbopack.ignoreIssue`.

## Why?

Reviewers on #89682 agreed the API is stable enough to graduate from experimental. Also addresses a docs wording suggestion.

## How?

- **TypeScript types**: Moved `ignoreIssue` field from `ExperimentalConfig` to `TurbopackOptions` in `config-shared.ts`
- **Zod schema**: Moved validation from `experimentalSchema` to `zTurbopackConfig` in `config-schema.ts`
- **Serialization**: Moved RegExp serialization logic into the turbopack block in `build/swc/index.ts`
- **Rust**: Moved `ignore_issue` field from `ExperimentalConfig` to `TurbopackConfig` in `next_config.rs`, updated the `turbopack_ignore_issue_rules()` method to read from `self.turbopack`
- **Tests**: Updated config in test to use `turbopack.ignoreIssue` instead of `experimental.turbopackIgnoreIssue`
- **Docs**: Removed `version: experimental`, updated all code examples, moved entry from experimental table to stable config list in turbopack.mdx, fixed "Good to know" wording to say "prefer using more specific `path` patterns" (since `path` is already required)