### PR TITLE
[devtools] Wrap overlay in Activity

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay/error-overlay.tsx
@@ -4,7 +4,7 @@ import {
   type OverlayState,
 } from '../../../shared'
 
-import { Suspense } from 'react'
+import { Activity } from 'react'
 import { BuildError } from '../../../container/build-error'
 import { Errors } from '../../../container/errors'
 import { useDelayedRender } from '../../../hooks/use-delayed-render'
@@ -62,26 +62,20 @@ export function ErrorOverlay({
 
   // No Runtime Errors.
   if (!runtimeErrors.length) {
-    // Workaround React quirk that triggers "Switch to client-side rendering" if
-    // we return no Suspense boundary here.
-    return <Suspense />
-  }
-
-  if (!mounted) {
-    // Workaround React quirk that triggers "Switch to client-side rendering" if
-    // we return no Suspense boundary here.
-    return <Suspense />
+    return null
   }
 
   return (
-    <Errors
-      {...commonProps}
-      debugInfo={state.debugInfo}
-      getSquashedHydrationErrorDetails={getSquashedHydrationErrorDetails}
-      runtimeErrors={runtimeErrors}
-      onClose={() => {
-        dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
-      }}
-    />
+    <Activity mode={mounted ? 'visible' : 'hidden'}>
+      <Errors
+        {...commonProps}
+        debugInfo={state.debugInfo}
+        getSquashedHydrationErrorDetails={getSquashedHydrationErrorDetails}
+        runtimeErrors={runtimeErrors}
+        onClose={() => {
+          dispatch({ type: ACTION_ERROR_OVERLAY_CLOSE })
+        }}
+      />
+    </Activity>
   )
 }


### PR DESCRIPTION
This allows rendering the overlay in the background at a lower priority while it's hidden.

Part of a larger refactor how we sourcemap errors. The end-goal is to lazily do the sourcemapping with some prefetching which should make the overlay more responsive for many errors or errors in modules with large sourcemaps or source content.