### PR TITLE
[test] Remove references to removed, internal PPR environment variable

### DIFF
--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -3,7 +3,6 @@ import path from 'path'
 const { version: nextVersion } = require('next/package.json')
 
 const cacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
-const pprEnabled = process.env.__NEXT_EXPERIMENTAL_PPR === 'true'
 
 describe('build-output-prerender', () => {
   describe('with a next config file', () => {
@@ -29,20 +28,6 @@ describe('build-output-prerender', () => {
              - Cache Components enabled
              - Experiments (use with caution):
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
-            `)
-          }
-        } else if (pprEnabled) {
-          if (isTurbopack) {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Turbopack, Cache Components)
-              - Experiments (use with caution):
-                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
-            `)
-          } else {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (webpack, Cache Components)
-              - Experiments (use with caution):
-                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
             `)
           }
         } else {
@@ -129,28 +114,6 @@ describe('build-output-prerender', () => {
              - Experiments (use with caution):
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
-               ⨯ serverMinification (disabled by \`--debug-prerender\`)
-               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
-            `)
-          }
-        } else if (pprEnabled) {
-          if (isTurbopack) {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-             ▲ Next.js x.y.z (Turbopack, Cache Components)
-             - Experiments (use with caution):
-               ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-               ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
-            `)
-          } else {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-             ▲ Next.js x.y.z (webpack, Cache Components)
-             - Experiments (use with caution):
-               ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-               ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -277,20 +240,6 @@ describe('build-output-prerender', () => {
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
             `)
           }
-        } else if (pprEnabled) {
-          if (isTurbopack) {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (Turbopack)
-              - Experiments (use with caution):
-                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
-            `)
-          } else {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "▲ Next.js x.y.z (webpack)
-              - Experiments (use with caution):
-                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)"
-            `)
-          }
         } else {
           if (isTurbopack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
@@ -344,28 +293,6 @@ describe('build-output-prerender', () => {
                ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
-            `)
-          }
-        } else if (pprEnabled) {
-          if (isTurbopack) {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-              ▲ Next.js x.y.z (Turbopack)
-              - Experiments (use with caution):
-                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
-                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
-            `)
-          } else {
-            expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
-             "⚠ Prerendering is running in debug mode. Note: This may affect performance and should not be used for production.
-              ▲ Next.js x.y.z (webpack)
-              - Experiments (use with caution):
-                ✓ ppr (enabled by \`__NEXT_EXPERIMENTAL_PPR\`)
-                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-                ⨯ serverMinification (disabled by \`--debug-prerender\`)
-                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
           }
         } else {


### PR DESCRIPTION
Removes references to `__NEXT_EXPERIMENTAL_PPR` which was removed in https://github.com/vercel/next.js/pull/84280