### PR TITLE
[docs] Add `RedirectType` usage example to `permanentRedirect`

### DIFF
--- a/docs/01-app/03-api-reference/04-functions/permanentRedirect.mdx
+++ b/docs/01-app/03-api-reference/04-functions/permanentRedirect.mdx
@@ -29,6 +29,16 @@ permanentRedirect(path, type)
 
 By default, `permanentRedirect` will use `push` (adding a new entry to the browser history stack) in [Server Actions](/docs/app/getting-started/updating-data) and `replace` (replacing the current URL in the browser history stack) everywhere else. You can override this behavior by specifying the `type` parameter.
 
+The `RedirectType` object contains the available options for the `type` parameter.
+
+```ts
+import { permanentRedirect, RedirectType } from 'next/navigation'
+
+permanentRedirect('/redirect-to', RedirectType.replace)
+// or
+permanentRedirect('/redirect-to', RedirectType.push)
+```
+
 The `type` parameter has no effect when used in Server Components.
 
 ## Returns


### PR DESCRIPTION
Aligns docs of `permanentRedirect` with [`redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect#reference) with regards to mention of `RedirectType`. 

Motivated by [Vade getting confused about `permanentRedirect(url, type)` signature](https://github.com/vercel/next.js/pull/83245#discussion_r2311233588)


[Created via Cursor](https://cursor.com/agents/bc-1435d670-ca19-4924-bfec-dcb32c2477f3?id=bc-1435d670-ca19-4924-bfec-dcb32c2477f3)