### PR TITLE
docs: update adapter docs for routing, handlers, and PPR

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -3,7 +3,12 @@ title: experimental.adapterPath
 description: Configure a custom adapter for Next.js to hook into the build process with modifyConfig and onBuildComplete callbacks.
 ---
 
-Next.js provides an experimental API that allows you to create custom adapters to hook into the build process. This is useful for deployment platforms or custom build integrations that need to modify the Next.js configuration or process the build output.
+Next.js provides an experimental API that allows you to create custom adapters to hook into the build process. This is useful for deployment platforms or custom build integrations that need to modify Next.js configuration or process build outputs.
+
+> [!WARNING]
+> `experimental.adapterPath` is experimental and may change.
+
+For a full reference implementation, see [`nextjs/adapter-vercel`](https://github.com/nextjs/adapter-vercel).
 
 ## Configuration
 
@@ -25,6 +30,27 @@ module.exports = nextConfig
 An adapter is a module that exports an object implementing the `NextAdapter` interface:
 
 ```typescript
+type Route = {
+  source?: string
+  sourceRegex: string
+  destination?: string
+  headers?: Record<string, string>
+  has?: RouteHas[]
+  missing?: RouteHas[]
+  status?: number
+  priority?: boolean
+}
+
+export interface AdapterOutputs {
+  pages: Array<AdapterOutput['PAGES']>
+  middleware?: AdapterOutput['MIDDLEWARE']
+  appPages: Array<AdapterOutput['APP_PAGE']>
+  pagesApi: Array<AdapterOutput['PAGES_API']>
+  appRoutes: Array<AdapterOutput['APP_ROUTE']>
+  prerenders: Array<AdapterOutput['PRERENDER']>
+  staticFiles: Array<AdapterOutput['STATIC_FILE']>
+}
+
 export interface NextAdapter {
   name: string
   modifyConfig?: (
@@ -34,15 +60,15 @@ export interface NextAdapter {
     }
   ) => Promise<NextConfigComplete> | NextConfigComplete
   onBuildComplete?: (ctx: {
-    routes: {
-      headers: Array<ManifestHeaderRoute>
-      redirects: Array<ManifestRedirectRoute>
-      rewrites: {
-        beforeFiles: Array<ManifestRewriteRoute>
-        afterFiles: Array<ManifestRewriteRoute>
-        fallback: Array<ManifestRewriteRoute>
-      }
-      dynamicRoutes: ReadonlyArray<ManifestRoute>
+    routing: {
+      beforeMiddleware: Array<Route>
+      beforeFiles: Array<Route>
+      afterFiles: Array<Route>
+      dynamicRoutes: Array<Route>
+      onMatch: Array<Route>
+      fallback: Array<Route>
+      shouldNormalizeNextData: boolean
+      rsc: RoutesManifest['rsc']
     }
     outputs: AdapterOutputs
     projectDir: string
@@ -50,6 +76,7 @@ export interface NextAdapter {
     distDir: string
     config: NextConfigComplete
     nextVersion: string
+    buildId: string
   }) => Promise<void> | void
 }
 ```
@@ -75,18 +102,21 @@ const adapter = {
   },
 
   async onBuildComplete({
-    routes,
+    routing,
     outputs,
     projectDir,
     repoRoot,
     distDir,
     config,
     nextVersion,
+    buildId,
   }) {
     // Process the build output
     console.log('Build completed with', outputs.pages.length, 'pages')
+    console.log('Build ID:', buildId)
+    console.log('Dynamic routes:', routing.dynamicRoutes.length)
 
-    // Access different output types
+    // Access emitted output entries
     for (const page of outputs.pages) {
       console.log('Page:', page.pathname, 'at', page.filePath)
     }
@@ -127,11 +157,15 @@ Called after the build process completes with detailed information about routes 
 
 **Parameters:**
 
-- `routes`: Object containing route manifests for headers, redirects, rewrites, and dynamic routes
-  - `routes.headers`: Array of header route objects with `source`, `sourceRegex`, `headers`, `has`, `missing`, and optional `priority` fields
-  - `routes.redirects`: Array of redirect route objects with `source`, `sourceRegex`, `destination`, `statusCode`, `has`, `missing`, and optional `priority` fields
-  - `routes.rewrites`: Object with `beforeFiles`, `afterFiles`, and `fallback` arrays, each containing rewrite route objects with `source`, `sourceRegex`, `destination`, `has`, and `missing` fields
-  - `routes.dynamicRoutes`: Array of dynamic route objects with `source`, `sourceRegex`, `destination`, `has`, and `missing` fields
+- `routing`: Object containing Next.js routing phases and metadata
+  - `routing.beforeMiddleware`: Routes executed before middleware (includes header and redirect handling)
+  - `routing.beforeFiles`: Rewrite routes checked before filesystem route matching
+  - `routing.afterFiles`: Rewrite routes checked after filesystem route matching
+  - `routing.dynamicRoutes`: Dynamic route matching table
+  - `routing.onMatch`: Routes applied after a successful match (for example immutable static asset cache headers)
+  - `routing.fallback`: Final rewrite fallback routes
+  - `routing.shouldNormalizeNextData`: Whether `/_next/data/<buildId>/...` URLs should be normalized during matching
+  - `routing.rsc`: Route metadata used for React Server Components routing behavior
 - `outputs`: Detailed information about all build outputs organized by type
 - `projectDir`: Absolute path to the Next.js project directory
 - `repoRoot`: Absolute path to the detected repository root
@@ -139,6 +173,178 @@ Called after the build process completes with detailed information about routes 
 - `config`: The final Next.js configuration (with `modifyConfig` applied)
 - `nextVersion`: Version of Next.js being used
 - `buildId`: Unique identifier for the current build
+
+## Routing with `@next/routing`
+
+You can use [`@next/routing`](https://www.npmjs.com/package/@next/routing) to reproduce Next.js route matching behavior with data from `onBuildComplete`.
+
+> [!NOTE]
+> `@next/routing` is experimental and will stabilize with the adapters API.
+
+```typescript
+import { resolveRoutes } from '@next/routing'
+
+const pathnames = [
+  ...outputs.pages,
+  ...outputs.pagesApi,
+  ...outputs.appPages,
+  ...outputs.appRoutes,
+  ...outputs.staticFiles,
+].map((output) => output.pathname)
+
+const result = await resolveRoutes({
+  url: requestUrl,
+  buildId,
+  basePath: config.basePath || '',
+  i18n: config.i18n,
+  headers: requestHeaders,
+  requestBody,
+  pathnames,
+  routes: routing,
+  invokeMiddleware: async (ctx) => {
+    // platform-specific middleware invocation
+    return {}
+  },
+})
+```
+
+## Implementing PPR in an Adapter
+
+For partially prerendered app routes, `onBuildComplete` gives you the data needed to seed and resume PPR:
+
+- `outputs.prerenders[].fallback.filePath`: path to the generated fallback shell (for example HTML)
+- `outputs.prerenders[].fallback.postponedState`: serialized postponed state used to resume rendering
+
+### 1. Seed shell + postponed state at build time
+
+```ts filename="my-adapter.ts"
+import { readFile } from 'node:fs/promises'
+
+async function seedPprEntries(outputs: AdapterOutputs) {
+  for (const prerender of outputs.prerenders) {
+    const fallback = prerender.fallback
+    if (!fallback?.filePath || !fallback.postponedState) continue
+
+    const shell = await readFile(fallback.filePath, 'utf8')
+    await platformCache.set(prerender.pathname, {
+      shell,
+      postponedState: fallback.postponedState,
+      initialHeaders: fallback.initialHeaders,
+      initialStatus: fallback.initialStatus,
+      initialRevalidate: fallback.initialRevalidate,
+      initialExpiration: fallback.initialExpiration,
+    })
+  }
+}
+```
+
+### 2. Runtime flow: serve cached shell and resume in background
+
+At request time, you can stream a single response that is the concatenation of:
+
+1. cached HTML shell stream
+2. resumed render stream (generated after invoking `handler` with postponed state)
+
+```text
+Client
+  | GET /ppr-route
+  v
+Adapter Router
+  |-- read cached shell + postponedState --> Platform Cache
+  |<------------- cache hit --------------|
+  |-- create responseStream = concat(shellStream, resumedStream)
+  |-- start piping shellStream -----------> Client (first bytes)
+  |-- invoke handler(req, res, { requestMeta: { postponed } })
+  |   ------------------------------------> Entrypoint (handler)
+  |   <------------------------------------ resumed chunks/cache entry
+  |-- append resumed chunks to resumedStream
+  '-- client receives one HTTP response:
+      [shell bytes........][resumed bytes........]
+```
+
+### 3. Update cache with `requestMeta.onCacheEntryV2`
+
+`requestMeta.onCacheEntryV2` is called when a response cache entry is looked up or generated. Use it to persist updated shell/postponed data.
+
+> [!NOTE]
+> `requestMeta.onCacheEntry` still works, but is deprecated. Prefer `requestMeta.onCacheEntryV2`.
+> If your adapter uses an internal `onCacheCallback` abstraction, wire it to `requestMeta.onCacheEntryV2`.
+
+```ts filename="my-adapter.ts"
+await handler(req, res, {
+  waitUntil,
+  requestMeta: {
+    postponed: cachedPprEntry?.postponedState,
+    onCacheEntryV2: async (cacheEntry, meta) => {
+      if (cacheEntry.value?.kind === 'APP_PAGE') {
+        const html =
+          cacheEntry.value.html &&
+          typeof cacheEntry.value.html.toUnchunkedString === 'function'
+            ? cacheEntry.value.html.toUnchunkedString()
+            : null
+
+        await platformCache.set(meta.url || req.url || '/', {
+          shell: html,
+          postponedState: cacheEntry.value.postponed,
+          headers: cacheEntry.value.headers,
+          status: cacheEntry.value.status,
+          cacheControl: cacheEntry.cacheControl,
+        })
+      }
+
+      // Return true only if your adapter already wrote the response itself.
+      return false
+    },
+  },
+})
+```
+
+```text
+Entrypoint (handler)
+  | onCacheEntryV2(cacheEntry, { url })
+  v
+requestMeta.onCacheEntryV2 callback
+  |-- if APP_PAGE --> persist html + postponedState + headers --> Platform Cache
+  |
+  '-- return false: continue normal Next.js response flow
+      return true: adapter already handled response (short-circuit)
+```
+
+## Invoking Entrypoints
+
+Build output entrypoints now use a `handler(..., ctx)` interface, with runtime-specific request/response types.
+
+### Node.js runtime (`runtime: 'nodejs'`)
+
+Node entrypoints (see `packages/next/src/build/templates/app-page.ts`, `packages/next/src/build/templates/app-route.ts`, and `packages/next/src/build/templates/pages-api.ts`) use:
+
+```typescript
+handler(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: {
+    waitUntil?: (prom: Promise<void>) => void
+    requestMeta?: RequestMeta
+  }
+): Promise<void>
+```
+
+### Edge runtime (`runtime: 'edge'`)
+
+Edge entrypoints (see `packages/next/src/build/templates/edge-ssr.ts`, `packages/next/src/build/templates/edge-app-route.ts`, `packages/next/src/build/templates/pages-edge-api.ts`, and `packages/next/src/build/templates/middleware.ts`) use:
+
+```typescript
+handler(
+  request: Request,
+  ctx: {
+    waitUntil?: (prom: Promise<void>) => void
+    signal?: AbortSignal
+    requestMeta?: RequestMeta
+  }
+): Promise<Response>
+```
+
+The shape is aligned around `handler(..., ctx)`, but node and edge runtimes use different request/response primitives.
 
 ## Output Types
 
@@ -246,14 +452,14 @@ ISR-enabled routes and static prerenders:
   pprChain?: {
     headers: Record<string, string>  // PPR chain headers (e.g., 'x-nextjs-resume': '1')
   }
-  parentFallbackMode?: 'blocking' | false | null  // Fallback mode from getStaticPaths
+  parentFallbackMode?: DynamicPrerenderManifestRoute['fallback']
   fallback?: {
-    filePath: string
+    filePath: string | undefined
     initialStatus?: number
     initialHeaders?: Record<string, string | string[]>
     initialExpiration?: number
     initialRevalidate?: number
-    postponedState?: string  // PPR postponed state
+    postponedState: string | undefined
   }
   config: {
     allowQuery?: string[]     // Allowed query parameters
@@ -306,52 +512,46 @@ Middleware function (if present):
 }
 ```
 
-## Routes Information
+## Routing Information
 
-The `routes` object in `onBuildComplete` provides complete routing information with processed patterns ready for deployment:
+The `routing` object in `onBuildComplete` provides complete routing information with processed patterns ready for deployment:
 
-### Headers
+### `routing.beforeMiddleware`
 
-Each header route includes:
+Routes applied before middleware execution. These include generated header and redirect behavior.
 
-- `source`: Original route pattern (e.g., `/about`)
+### `routing.beforeFiles`
+
+Rewrite routes checked before filesystem route matching.
+
+### `routing.afterFiles`
+
+Rewrite routes checked after filesystem route matching.
+
+### `routing.dynamicRoutes`
+
+Dynamic matchers generated from route segments such as `[slug]` and catch-all routes.
+
+### `routing.onMatch`
+
+Routes that apply after a successful match, such as immutable cache headers for hashed static assets.
+
+### `routing.fallback`
+
+Final rewrite routes checked when earlier phases did not produce a match.
+
+### Common Route Fields
+
+Each route entry can include:
+
+- `source`: Original route pattern (optional for generated internal rules)
 - `sourceRegex`: Compiled regex for matching requests
-- `headers`: Key-value pairs of headers to apply
-- `has`: Optional conditions that must be met
-- `missing`: Optional conditions that must not be met
-- `priority`: Optional flag for internal routes
-
-### Redirects
-
-Each redirect route includes:
-
-- `source`: Original route pattern
-- `sourceRegex`: Compiled regex for matching
-- `destination`: Target URL (can include captured groups)
-- `statusCode`: HTTP status code (301, 302, 307, 308)
-- `has`: Optional positive conditions
-- `missing`: Optional negative conditions
-- `priority`: Optional flag for internal routes
-
-### Rewrites
-
-Rewrites are categorized into three phases:
-
-- `beforeFiles`: Checked before filesystem (including pages and public files)
-- `afterFiles`: Checked after pages/public files but before dynamic routes
-- `fallback`: Checked after all other routes
-
-Each rewrite includes `source`, `sourceRegex`, `destination`, `has`, and `missing`.
-
-### Dynamic Routes
-
-Generated from dynamic route segments (e.g., `[slug]`, `[...path]`). Each includes:
-
-- `source`: Route pattern
-- `sourceRegex`: Compiled regex with named capture groups
-- `destination`: Internal destination with parameter substitution
-- `has`: Optional positive conditions
-- `missing`: Optional negative conditions
+- `destination`: Internal destination or redirect destination
+- `headers`: Headers to apply
+- `has`: Positive matching conditions
+- `missing`: Negative matching conditions
+- `status`: Redirect status code
+- `priority`: Internal route priority flag
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary
- update `experimental.adapterPath` docs to match current `onBuildComplete` shape (`routing`, `buildId`, and latest output types)
- document `@next/routing` usage and note its experimental status
- add runtime entrypoint signature details for Node.js and Edge (`handler(..., ctx)`)
- add a new PPR implementation section with markdown flow diagrams for shell/resume stream composition and `requestMeta.onCacheEntryV2` cache updates
- link to `nextjs/adapter-vercel` as the reference adapter example
