### PR TITLE
test: allow dpl query suffix in scss url-global expectation

### DIFF
--- a/test/e2e/app-dir/scss/url-global/url-global.test.ts
+++ b/test/e2e/app-dir/scss/url-global/url-global.test.ts
@@ -33,7 +33,7 @@ describe.each([
           .elementByCss('.red-text')
           .getComputedCss('background-image')
         expect(background).toMatch(
-          /url\(".*\/_next\/static\/media\/dark\..*\.svg"\), url\(".*\/_next\/static\/media\/dark2\..*\.svg"\)/
+          /url\(".*\/_next\/static\/media\/dark\..*\.svg(?:\?.*)?"\), url\(".*\/_next\/static\/media\/dark2\..*\.svg(?:\?.*)?"\)/
         )
 
         const urls = getUrlFromBackgroundImage(background)


### PR DESCRIPTION
Fixes deployment test failure from https://github.com/vercel/next.js/pull/89771

x-ref: https://github.com/vercel/next.js/actions/runs/21921362927/job/63302154502

## Summary
- update the SCSS `url-global` background-image assertion to allow optional query suffixes on emitted svg asset URLs
- this handles deploy-mode URLs that include `?dpl=...` while keeping the existing path checks intact

## Verification
- validated against deploy logs from failing job `63302154502`: URLs are correct and include `?dpl=...`
- local run: `NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=dev pnpm testonly test/e2e/app-dir/scss/url-global/url-global.test.ts`
  - `sass` case passed
  - `sass-embedded` case blocked locally by missing `sass-embedded` module in this environment