### PR TITLE
fix: use Buffer.indexOf in uint8array helpers for faster byte scanning (3/8)

### DIFF
--- a/packages/next/src/server/stream-utils/uint8array-helpers.ts
+++ b/packages/next/src/server/stream-utils/uint8array-helpers.ts
@@ -5,6 +5,14 @@ export function indexOfUint8Array(a: Uint8Array, b: Uint8Array) {
   if (b.length === 0) return 0
   if (a.length === 0 || b.length > a.length) return -1
 
+  // Use Node's native implementation when available.
+  if (typeof Buffer !== 'undefined') {
+    const haystack = Buffer.isBuffer(a)
+      ? a
+      : Buffer.from(a.buffer, a.byteOffset, a.byteLength)
+    return haystack.indexOf(b)
+  }
+
   // start iterating through `a`
   for (let i = 0; i <= a.length - b.length; i++) {
     let completeMatch = true
@@ -50,8 +58,8 @@ export function removeFromUint8Array(a: Uint8Array, b: Uint8Array) {
   if (tagIndex === 0) return a.subarray(b.length)
   if (tagIndex > -1) {
     const removed = new Uint8Array(a.length - b.length)
-    removed.set(a.slice(0, tagIndex))
-    removed.set(a.slice(tagIndex + b.length), tagIndex)
+    removed.set(a.subarray(0, tagIndex))
+    removed.set(a.subarray(tagIndex + b.length), tagIndex)
     return removed
   } else {
     return a

--- a/test/unit/stream-utils/uint8array-helpers.test.ts
+++ b/test/unit/stream-utils/uint8array-helpers.test.ts
@@ -1,0 +1,42 @@
+import {
+  indexOfUint8Array,
+  isEquivalentUint8Arrays,
+  removeFromUint8Array,
+} from 'next/dist/server/stream-utils/uint8array-helpers'
+
+describe('uint8array-helpers', () => {
+  it('finds the start index of a nested sequence', () => {
+    const haystack = new Uint8Array([1, 2, 3, 4, 5, 6])
+    const needle = new Uint8Array([3, 4, 5])
+    expect(indexOfUint8Array(haystack, needle)).toBe(2)
+  })
+
+  it('handles Buffer input as Uint8Array', () => {
+    const haystack = Buffer.from([9, 8, 7, 6, 5, 4])
+    const needle = new Uint8Array([7, 6])
+    expect(indexOfUint8Array(haystack, needle)).toBe(2)
+  })
+
+  it('returns -1 when not found', () => {
+    const haystack = new Uint8Array([1, 2, 3, 4])
+    const needle = new Uint8Array([4, 5])
+    expect(indexOfUint8Array(haystack, needle)).toBe(-1)
+  })
+
+  it('removes a matching sequence from the middle', () => {
+    const haystack = new Uint8Array([10, 20, 30, 40, 50])
+    const needle = new Uint8Array([30, 40])
+
+    const result = removeFromUint8Array(haystack, needle)
+
+    expect(isEquivalentUint8Arrays(result, new Uint8Array([10, 20, 50]))).toBe(
+      true
+    )
+  })
+
+  it('returns original reference when no match exists', () => {
+    const haystack = new Uint8Array([1, 2, 3])
+    const needle = new Uint8Array([4, 5])
+    expect(removeFromUint8Array(haystack, needle)).toBe(haystack)
+  })
+})


### PR DESCRIPTION
## Summary

Use `Buffer.indexOf` when available in `uint8array-helpers.ts` for faster byte sequence scanning. Falls back to the existing manual loop on non-Node environments.

## Test plan

- [x] `pnpm test-unit test/unit/stream-utils/uint8array-helpers.test.ts` passes