### PR TITLE
Support hydration during MPA navigations in instant test mode

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -63,6 +63,7 @@ import {
 } from '../../lib/constants'
 import type { CacheControl } from '../../server/lib/cache-control'
 import { ENCODED_TAGS } from '../../server/stream-utils/encoded-tags'
+import { serveStaticShellForInstantNavigationTest } from '../../server/stream-utils/node-web-streams-helper'
 import { sendRenderResult } from '../../server/send-payload'
 import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 import {
@@ -1466,6 +1467,31 @@ export async function handler(
           poweredByHeader: nextConfig.poweredByHeader,
           result: body,
           cacheControl: cacheEntry.cacheControl,
+        })
+      }
+
+      // Instant Navigation Testing API: serve the static shell only. Hydration
+      // is allowed to proceed; the dynamic data will not stream in until after
+      // the testing scope has ended.
+      if (isInstantNavigationTest) {
+        const staticHtml = body.toUnchunkedString()
+        // In dev mode, generate a request ID for the HMR WebSocket.
+        const instantTestRequestId =
+          routeModule.isDev === true ? crypto.randomUUID() : null
+        const resultStream = serveStaticShellForInstantNavigationTest(
+          staticHtml,
+          instantTestRequestId
+        )
+        return sendRenderResult({
+          req,
+          res,
+          generateEtags: nextConfig.generateEtags,
+          poweredByHeader: nextConfig.poweredByHeader,
+          result: new RenderResult(resultStream, {
+            contentType: HTML_CONTENT_TYPE_HEADER,
+            metadata: {},
+          }),
+          cacheControl: { revalidate: 0, expire: undefined },
         })
       }
 

--- a/packages/next/src/client/app-bootstrap.ts
+++ b/packages/next/src/client/app-bootstrap.ts
@@ -76,34 +76,6 @@ export function appBootstrap(hydrate: (assetPrefix: string) => void) {
       }
     }
 
-    // Instant Navigation Testing API: If the page was loaded with the instant
-    // test cookie set (from an MPA navigation while locked), skip hydration
-    // and set up a minimal testing API. Hydration would fail because the
-    // static shell response doesn't include the full Flight data stream.
-    // When unlock() is called, we clear the cookie and reload the page.
-    if (process.env.__NEXT_EXPOSE_TESTING_API) {
-      const NEXT_INSTANT_TEST_COOKIE = 'next-instant-navigation-testing'
-      if (document.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=')) {
-        // Set up minimal testing API for the static shell
-        window.__EXPERIMENTAL_NEXT_TESTING__ = {
-          navigation: {
-            lock: () => {
-              console.error(
-                'Navigation lock already acquired. Concurrent locks are not allowed. ' +
-                  'Did you forget to release the previous lock?'
-              )
-            },
-            unlock: () => {
-              // Clear the cookie and reload to get the full page with dynamic data
-              document.cookie = `${NEXT_INSTANT_TEST_COOKIE}=;path=/;max-age=0`
-              window.location.reload()
-            },
-          },
-        }
-        return
-      }
-    }
-
     hydrate(assetPrefix)
   })
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -67,7 +67,8 @@ declare global {
     __next_f: NextFlight
     /**
      * Testing API that allows e2e tests to assert on the prefetched UI state
-     * before dynamic data streams in. Dev-only.
+     * before dynamic data streams in. Not exposed in production builds
+     * by default.
      */
     __EXPERIMENTAL_NEXT_TESTING__?: {
       navigation: {
@@ -147,6 +148,15 @@ function nextServerDataRegisterWriter(ctr: ReadableStreamDefaultController) {
   initialServerDataWriter = ctr
 }
 
+// Check if the page load was triggered during an Instant Navigation test. If
+// so, the server only rendered the static shell.
+let isDuringInstantNavigationTest = false
+if (process.env.__NEXT_EXPOSE_TESTING_API) {
+  const { initializeInstantNavigationTestState } =
+    require('./components/segment-cache/navigation-testing-lock') as typeof import('./components/segment-cache/navigation-testing-lock')
+  isDuringInstantNavigationTest = initializeInstantNavigationTestState()
+}
+
 // When `DOMContentLoaded`, we can close all pending writers to finish hydration.
 const DOMContentLoaded = function () {
   if (initialServerDataWriter && !initialServerDataFlushed) {
@@ -211,6 +221,9 @@ if (clientResumeFetch) {
       callServer,
       findSourceMapURL,
       debugChannel,
+      // During an instant navigation test, the server only sends the
+      // static shell, so the Flight stream may be incomplete.
+      unstable_allowPartialStream: isDuringInstantNavigationTest,
     })
   ).then(async (fallbackInitialRSCPayload) =>
     createInitialRSCPayloadFromFallbackPrerender(
@@ -311,10 +324,10 @@ export async function hydrate(
   let webSocket: WebSocket | undefined
 
   if (process.env.NODE_ENV !== 'production') {
+    staticIndicatorState = { pathname: null, appIsrManifest: null }
+
     const { createWebSocket } =
       require('./dev/hot-reloader/app/web-socket') as typeof import('./dev/hot-reloader/app/web-socket')
-
-    staticIndicatorState = { pathname: null, appIsrManifest: null }
     webSocket = createWebSocket(assetPrefix, staticIndicatorState)
   }
   const initialRSCPayload = await initialServerResponse

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -372,6 +372,24 @@ function gesturePush(href: string, options?: NavigateOptions): void {
   }
 }
 
+export function refreshAfterInstantNavigationTest(): void {
+  // This is called when the initial page load (SSR) was triggered during an
+  // Instant Navigation test. It happens at the end of the test scope, to
+  // trigger a refresh of the page with the full dynamic data.
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    if (globalActionQueue === null) {
+      location.reload()
+      return
+    }
+    startTransition(() => {
+      dispatchAppRouterAction({
+        type: ACTION_REFRESH,
+        devBypassCacheInvalidation: true,
+      })
+    })
+  }
+}
+
 /**
  * The app router that is exposed through `useRouter`. These are public API
  * methods. Internal Next.js code should call the lower level methods directly

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -94,7 +94,8 @@ export function acquireNavigationLock(): void {
  * a refresh to fetch the dynamic data that was blocked during the initial
  * page load.
  *
- * No-op if the lock is not currently acquired.
+ * The cookie is always cleared to prevent stale state, even if the
+ * in-memory lock was not acquired.
  *
  * Not exposed in production builds by default.
  */
@@ -112,20 +113,24 @@ export function releaseNavigationLock(): void {
     // refresh to fetch the dynamic data that was blocked during SSR.
     if (mpaLockedStateNeedsRefresh) {
       mpaLockedStateNeedsRefresh = false
-      triggerRefresh()
+      const { refreshAfterInstantNavigationTest } =
+        require('../app-router-instance') as typeof import('../app-router-instance')
+      refreshAfterInstantNavigationTest()
     }
   }
 }
 
 /**
- * Returns true if the navigation lock is currently acquired.
+ * Returns true if the navigation lock is currently active. Checks the cookie
+ * rather than in-memory lockState because the cookie survives across MPA
+ * navigations (page reloads).
  *
  * Not exposed in production builds by default. Always returns false when the
  * testing API is not available.
  */
 export function isNavigationLocked(): boolean {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    return lockState !== null
+    return document.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=')
   }
   return false
 }
@@ -145,15 +150,22 @@ export async function waitForNavigationLockIfActive(): Promise<void> {
 }
 
 /**
- * Called during page initialization when the instant test cookie is detected.
- * Sets up the lock state so that:
+ * Called during page initialization to check if the page was loaded during an
+ * instant navigation test (i.e. the test cookie is set). If so, sets up the
+ * lock state so that:
  * 1. Client-side navigations during the instant scope also block dynamic data
  * 2. When the lock is released, a refresh is triggered to fetch dynamic data
  *
+ * Returns true if the page was loaded during an instant navigation test.
+ *
  * Not exposed in production builds by default.
  */
-export function initializeMpaLockedState(): void {
+export function initializeInstantNavigationTestState(): boolean {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    if (!document.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=')) {
+      return false
+    }
+
     // Set the MPA flag so we know to trigger a refresh when the lock is released
     mpaLockedStateNeedsRefresh = true
 
@@ -166,23 +178,8 @@ export function initializeMpaLockedState(): void {
       })
       lockState = { promise, resolve: resolve! }
     }
-  }
-}
 
-/**
- * Triggers a router refresh to fetch dynamic data. Used after releasing the
- * navigation lock following an MPA navigation.
- */
-function triggerRefresh(): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    const { dispatchAppRouterAction } =
-      require('../use-action-queue') as typeof import('../use-action-queue')
-    const { ACTION_REFRESH } =
-      require('../router-reducer/router-reducer-types') as typeof import('../router-reducer/router-reducer-types')
-
-    dispatchAppRouterAction({
-      type: ACTION_REFRESH,
-      devBypassCacheInvalidation: true,
-    })
+    return true
   }
+  return false
 }

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -190,7 +190,7 @@ export function useWebSocketPing(webSocket: WebSocket | undefined) {
 
   useEffect(() => {
     if (!webSocket) {
-      throw new InvariantError('Expected webSocket to be defined in dev mode.')
+      return
     }
 
     // Never send pings when using Turbopack as it's not used.

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -19,6 +19,7 @@ import {
   NEXT_ROUTER_PREFETCH_HEADER,
   NEXT_ROUTER_SEGMENT_PREFETCH_HEADER,
   NEXT_RSC_UNION_QUERY,
+  NEXT_REQUEST_ID_HEADER,
 } from '../../client/components/app-router-headers'
 import { computeCacheBustingSearchParam } from '../../shared/lib/router/utils/cache-busting-search-param'
 
@@ -458,10 +459,9 @@ function createHeadInsertionTransformStream(
   })
 }
 
-function createClientResumeScriptInsertionTransformStream(): TransformStream<
-  Uint8Array,
-  Uint8Array
-> {
+function createClientResumeScriptInsertionTransformStream(
+  requestId: string | null
+): TransformStream<Uint8Array, Uint8Array> {
   const segmentPath = '/_full'
   const cacheBustingHeader = computeCacheBustingSearchParam(
     '1', //            headers[NEXT_ROUTER_PREFETCH_HEADER]
@@ -470,7 +470,17 @@ function createClientResumeScriptInsertionTransformStream(): TransformStream<
     undefined //       headers[NEXT_URL]
   )
   const searchStr = `${NEXT_RSC_UNION_QUERY}=${cacheBustingHeader}`
-  const NEXT_CLIENT_RESUME_SCRIPT = `<script>__NEXT_CLIENT_RESUME=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}': '1','${NEXT_ROUTER_PREFETCH_HEADER}': '1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}': '${segmentPath}'}})</script>`
+  const requestIdHeader =
+    requestId !== null ? `,'${NEXT_REQUEST_ID_HEADER}':self.__next_r` : ''
+  // When a requestId is provided, inject self.__next_r before the resume
+  // fetch so the fetch can include it as a header. This lets the server set up
+  // the debug channel for this request, and the client reuses the same ID for
+  // the HMR WebSocket connection.
+  const requestIdScript =
+    requestId !== null
+      ? `<script>self.__next_r=${JSON.stringify(requestId)}</script>`
+      : ''
+  const NEXT_CLIENT_RESUME_SCRIPT = `${requestIdScript}<script>__NEXT_CLIENT_RESUME=fetch(location.pathname+'?${searchStr}',{credentials:'same-origin',headers:{'${RSC_HEADER}': '1','${NEXT_ROUTER_PREFETCH_HEADER}': '1','${NEXT_ROUTER_SEGMENT_PREFETCH_HEADER}': '${segmentPath}'${requestIdHeader}}})</script>`
 
   let didAlreadyInsert = false
   return new TransformStream({
@@ -988,7 +998,7 @@ export async function continueStaticFallbackPrerender(
     // Insert generated tags to head
     createHeadInsertionTransformStream(getServerInsertedHTML),
     // Insert the client resume script into the head
-    createClientResumeScriptInsertionTransformStream(),
+    createClientResumeScriptInsertionTransformStream(null),
     // Transform metadata
     createMetadataTransformStream(getServerInsertedMetadata),
     // Insert the inlined data (Flight data, form state, etc.) stream into the HTML
@@ -996,6 +1006,24 @@ export async function continueStaticFallbackPrerender(
     // Close tags should always be deferred to the end
     createMoveSuffixStream(),
   ])
+}
+
+/**
+ * Serves a PPR static shell for the Instant Navigation Testing API.
+ *
+ * The static shell doesn't include inline Flight data — that's normally
+ * provided by the resume render at request time. Instead of performing a
+ * resume render, this inserts a client resume script that fetches the static
+ * data only, then closes the document.
+ */
+export function serveStaticShellForInstantNavigationTest(
+  staticShellHtml: string,
+  requestId: string | null
+): ReadableStream<Uint8Array> {
+  const transformed = chainTransformers(streamFromString(staticShellHtml), [
+    createClientResumeScriptInsertionTransformStream(requestId),
+  ])
+  return chainStreams(transformed, streamFromString(CLOSE_TAG))
 }
 
 type ContinueResumeOptions = {

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test-target/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test-target/layout.tsx
@@ -1,0 +1,14 @@
+import { HydrationTest } from '../hydration-test'
+
+export default function HydrationTestLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div>
+      <HydrationTest />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test-target/loading.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test-target/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div data-testid="hydration-test-loading">Loading...</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test-target/page.tsx
@@ -1,0 +1,12 @@
+import { connection } from 'next/server'
+
+export default async function HydrationTestTargetPage() {
+  await connection()
+
+  return (
+    <div>
+      <h1>Hydration Test Target</h1>
+      <div data-testid="hydration-test-dynamic">Dynamic content loaded</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/hydration-test.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useState } from 'react'
+
+export function HydrationTest() {
+  const [revealed, setRevealed] = useState(false)
+
+  return (
+    <>
+      <button
+        data-testid="hydration-test-button"
+        onClick={() => setRevealed(true)}
+      >
+        Reveal
+      </button>
+      {revealed && (
+        <div data-testid="hydration-test-revealed">
+          Revealed after hydration
+        </div>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -340,4 +340,36 @@ describe('instant-navigation-testing-api', () => {
       'Dynamic content loaded'
     )
   })
+
+  it('hydrates the page during MPA navigation in instant mode', async () => {
+    const page = await openPage('/hydration-test-target')
+
+    // Wait for the page to fully load with dynamic content
+    const dynamicContent = page.locator(
+      '[data-testid="hydration-test-dynamic"]'
+    )
+    await dynamicContent.waitFor({ state: 'visible' })
+
+    await instant(page, async () => {
+      await page.reload()
+
+      // Click a button that reveals a new element. This verifies hydration
+      // completed because the onClick handler must be attached for this to work.
+      const button = page.locator('[data-testid="hydration-test-button"]')
+      await button.waitFor({ state: 'visible' })
+      await button.click()
+
+      const revealed = page.locator('[data-testid="hydration-test-revealed"]')
+      await revealed.waitFor({ state: 'visible' })
+
+      // Dynamic content should not be visible yet
+      expect(await dynamicContent.count()).toBe(0)
+    })
+
+    // After exiting the instant scope, dynamic content streams in
+    await dynamicContent.waitFor({ state: 'visible' })
+    expect(await dynamicContent.textContent()).toContain(
+      'Dynamic content loaded'
+    )
+  })
 })


### PR DESCRIPTION
The Instant Navigation Testing API lets e2e tests assert on the prefetched UI state before dynamic data streams in. This simulates what happens on a slow network or slow database: the CDN instantly serves a cached static shell, but dynamic data takes an indefinite amount of time to arrive.

Previously, MPA navigations (page reload, plain anchor links) within an instant test scope served the static shell without hydration data, so the page couldn't hydrate. This adds proper hydration support: on initial page load, the static shell renders and hydration proceeds normally, but dynamic data is held back until the test scope ends.