### PR TITLE
Turbopack: Clean up unused register!() macro argument in test

### DIFF
--- a/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
+++ b/turbopack/crates/turbo-tasks-fetch/tests/fetch.rs
@@ -12,7 +12,7 @@ use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
 use turbo_tasks_testing::{Registration, register, run_once};
 use turbopack_core::issue::{Issue, IssueSeverity};
 
-static REGISTRATION: Registration = register!(turbo_tasks_fetch::register);
+static REGISTRATION: Registration = register!();
 
 /// We inspect information about the global client cache, so *every* test in this process *must*
 /// acquire and hold this lock to prevent potential flakiness.

--- a/turbopack/crates/turbo-tasks-testing/src/run.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/run.rs
@@ -20,7 +20,7 @@ impl Registration {
 
 #[macro_export]
 macro_rules! register {
-    ($($other_register_fns:expr),* $(,)?) => {{
+    () => {{
         use std::sync::Arc;
 
         use turbo_tasks::TurboTasksApi;

--- a/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
+++ b/turbopack/crates/turbopack-analyze/tests/split_chunk.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
     source_map::GenerateSourceMap,
 };
 
-static REGISTRATION: Registration = register!(turbo_tasks_fetch::register);
+static REGISTRATION: Registration = register!();
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn split_chunk() {


### PR DESCRIPTION
We don't need this argument now that @lukesandberg switched us to inventory.

We do still need some top-level macro and the `Registration` object to resolve the `test_config.trs` file relative to the currently-running test, though we could rename them if anyone thinks of a better name for it, now that it isn't doing function registration.