### PR TITLE
Use cookie as sole protocol for instant navigation testing

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1470,6 +1470,15 @@ export async function handler(
         body.push(
           new ReadableStream({
             start(controller) {
+              if (isInstantNavigationTest) {
+                // Inject a global so the client can detect that this response
+                // is a partial static shell, independent of document.cookie
+                // (which may be empty on the new page in some browsers).
+                const encoder = new TextEncoder()
+                controller.enqueue(
+                  encoder.encode('<script>self.__next_instant_test=1</script>')
+                )
+              }
               controller.enqueue(ENCODED_TAGS.CLOSED.BODY_AND_HTML)
               controller.close()
             },

--- a/packages/next/src/client/app-bootstrap.ts
+++ b/packages/next/src/client/app-bootstrap.ts
@@ -76,29 +76,32 @@ export function appBootstrap(hydrate: (assetPrefix: string) => void) {
       }
     }
 
-    // Instant Navigation Testing API: If the page was loaded with the instant
-    // test cookie set (from an MPA navigation while locked), skip hydration
-    // and set up a minimal testing API. Hydration would fail because the
-    // static shell response doesn't include the full Flight data stream.
-    // When unlock() is called, we clear the cookie and reload the page.
+    // Instant Navigation Testing API: If the server returned a partial static
+    // shell (indicated by the __next_instant_test global injected into the
+    // HTML), skip hydration. The response doesn't include the full Flight data
+    // stream. When the test framework deletes the cookie, the CookieStore
+    // change event triggers a page reload.
     if (process.env.__NEXT_EXPOSE_TESTING_API) {
-      const NEXT_INSTANT_TEST_COOKIE = 'next-instant-navigation-testing'
-      if (document.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=')) {
-        // Set up minimal testing API for the static shell
-        window.__EXPERIMENTAL_NEXT_TESTING__ = {
-          navigation: {
-            lock: () => {
-              console.error(
-                'Navigation lock already acquired. Concurrent locks are not allowed. ' +
-                  'Did you forget to release the previous lock?'
-              )
-            },
-            unlock: () => {
-              // Clear the cookie and reload to get the full page with dynamic data
-              document.cookie = `${NEXT_INSTANT_TEST_COOKIE}=;path=/;max-age=0`
-              window.location.reload()
-            },
-          },
+      if (self.__next_instant_test) {
+        const NEXT_INSTANT_TEST_COOKIE = 'next-instant-navigation-testing'
+        if (
+          typeof cookieStore !== 'undefined' &&
+          document.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=')
+        ) {
+          // Cookie is still set. Wait for the test framework to delete it,
+          // then reload to get the full response.
+          cookieStore.addEventListener('change', (event: CookieChangeEvent) => {
+            for (const cookie of event.deleted) {
+              if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
+                window.location.reload()
+                return
+              }
+            }
+          })
+        } else {
+          // Cookie is already gone (or not accessible). Refresh immediately
+          // to get the full response.
+          window.location.reload()
         }
         return
       }

--- a/packages/next/src/client/app-globals.ts
+++ b/packages/next/src/client/app-globals.ts
@@ -6,16 +6,11 @@ if (process.env.__NEXT_DEV_SERVER) {
   require('../next-devtools/userspace/app/app-dev-overlay-setup') as typeof import('../next-devtools/userspace/app/app-dev-overlay-setup')
 }
 
-// Expose a testing API that allows e2e tests to assert on the prefetched UI
-// state before dynamic data streams in. Browser-only.
+// Start listening for the instant navigation test cookie. The test framework
+// (e.g. Playwright) sets/clears this cookie to control the navigation lock.
+// Browser-only.
 if (process.env.__NEXT_EXPOSE_TESTING_API && typeof window !== 'undefined') {
-  const { acquireNavigationLock, releaseNavigationLock } =
+  const { startListeningForInstantNavigationCookie } =
     require('./components/segment-cache/navigation-testing-lock') as typeof import('./components/segment-cache/navigation-testing-lock')
-
-  window.__EXPERIMENTAL_NEXT_TESTING__ = {
-    navigation: {
-      lock: acquireNavigationLock,
-      unlock: releaseNavigationLock,
-    },
-  }
+  startListeningForInstantNavigationCookie()
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -65,16 +65,6 @@ declare global {
      */
     __next_r?: string
     __next_f: NextFlight
-    /**
-     * Testing API that allows e2e tests to assert on the prefetched UI state
-     * before dynamic data streams in. Dev-only.
-     */
-    __EXPERIMENTAL_NEXT_TESTING__?: {
-      navigation: {
-        lock: () => void
-        unlock: () => void
-      }
-    }
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -1,16 +1,24 @@
 /**
  * Navigation lock for the Instant Navigation Testing API.
  *
- * This module is not meant to be used directly. It's exposed on the window
- * object and intended to be called via a wrapper API integrated into an
- * e2e testing framework like Playwright:
+ * This module is not meant to be used directly. It's exposed via a cookie-based
+ * protocol intended to be driven by an e2e testing framework like Playwright:
  *
  *   async function instant(page, fn) {
- *     await page.evaluate(() => window.__EXPERIMENTAL_NEXT_TESTING__.navigation.lock())
+ *     const context = page.context()
+ *     const domain = new URL(page.url()).hostname
+ *     await context.addCookies([{
+ *       name: 'next-instant-navigation-testing',
+ *       value: '1',
+ *       domain,
+ *       path: '/',
+ *     }])
  *     try {
  *       return await fn()
  *     } finally {
- *       await page.evaluate(() => window.__EXPERIMENTAL_NEXT_TESTING__.navigation.unlock())
+ *       await context.clearCookies({
+ *         name: 'next-instant-navigation-testing',
+ *       })
  *     }
  *   }
  *
@@ -20,6 +28,9 @@
  *     await expect(page.locator('[data-testid="loading"]')).toBeVisible()
  *   })
  *
+ * Next.js never writes to the cookie — it only reads and listens for changes
+ * via the CookieStore API's `change` event.
+ *
  * When the lock is acquired:
  * - Routes without a prefetch cache hit will wait for prefetch to complete
  *   before navigating.
@@ -27,12 +38,12 @@
  *   into the UI.
  *
  * For MPA navigations (page reload, full page load):
- * - A cookie is set that tells the server to render only the static shell.
- * - When the lock is released, the cookie is cleared and a refresh is
- *   triggered to fetch dynamic data.
+ * - The cookie tells the server to render only the static shell.
+ * - When the lock is released (cookie deleted), the page reloads to fetch
+ *   dynamic data (handled in app-bootstrap.ts).
  *
  * This allows tests to assert on the prefetched UI state before dynamic
- * content streams in. Network requests are not blocked - they proceed in
+ * content streams in. Network requests are not blocked — they proceed in
  * parallel while the lock is held.
  *
  * All functions in this module are wrapped in checks for the testing API,
@@ -49,83 +60,65 @@ type NavigationLockState = {
 
 let lockState: NavigationLockState | null = null
 
-// Tracks whether the page was loaded while the instant test cookie was set.
-// When true, releasing the lock will trigger a refresh to fetch dynamic data.
-let mpaLockedStateNeedsRefresh = false
+function acquireLock(): void {
+  let resolve: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  lockState = { promise, resolve: resolve! }
+}
 
 /**
- * Acquires the navigation lock. While locked, navigations will wait for
- * prefetch tasks to complete before proceeding.
+ * Starts listening for changes to the instant navigation test cookie via the
+ * CookieStore API. When the cookie is added (by the test framework), the
+ * in-memory lock is acquired. When the cookie is deleted, the lock is released.
  *
- * Also sets a cookie so that MPA navigations (page reload, full page load)
- * will render only the static shell.
- *
- * Logs an error if the lock is already acquired (concurrent locks are not
- * allowed).
- *
- * Not exposed in production builds by default.
+ * This should be called once during page initialization.
  */
-export function acquireNavigationLock(): void {
+export function startListeningForInstantNavigationCookie(): void {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (lockState !== null) {
-      console.error(
-        'Navigation lock already acquired. Concurrent locks are not allowed. ' +
-          'Did you forget to release the previous lock?'
-      )
+    if (typeof cookieStore === 'undefined') {
       return
     }
+    cookieStore.addEventListener('change', (event: CookieChangeEvent) => {
+      // Check if our cookie was added
+      for (const cookie of event.changed) {
+        if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
+          if (lockState !== null) {
+            console.error(
+              'Navigation lock already acquired. Concurrent locks ' +
+                'are not allowed. Did you forget to release the ' +
+                'previous lock?'
+            )
+            return
+          }
+          acquireLock()
+          return
+        }
+      }
 
-    let resolve: () => void
-    const promise = new Promise<void>((r) => {
-      resolve = r
+      // Check if our cookie was deleted
+      for (const cookie of event.deleted) {
+        if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
+          if (lockState !== null) {
+            lockState.resolve()
+            lockState = null
+          }
+          return
+        }
+      }
     })
-    lockState = { promise, resolve: resolve! }
-
-    // Set cookie for MPA navigations
-    document.cookie = `${NEXT_INSTANT_TEST_COOKIE}=1;path=/`
   }
 }
 
 /**
- * Releases the navigation lock. Any navigations that were waiting for
- * prefetch completion will now proceed with dynamic data fetching.
- *
- * If the page was loaded while locked (MPA navigation), this also triggers
- * a refresh to fetch the dynamic data that was blocked during the initial
- * page load.
- *
- * No-op if the lock is not currently acquired.
- *
- * Not exposed in production builds by default.
- */
-export function releaseNavigationLock(): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (lockState !== null) {
-      lockState.resolve()
-      lockState = null
-    }
-
-    // Clear the cookie
-    document.cookie = `${NEXT_INSTANT_TEST_COOKIE}=;path=/;max-age=0`
-
-    // If the page was loaded with the cookie set (MPA navigation), trigger a
-    // refresh to fetch the dynamic data that was blocked during SSR.
-    if (mpaLockedStateNeedsRefresh) {
-      mpaLockedStateNeedsRefresh = false
-      triggerRefresh()
-    }
-  }
-}
-
-/**
- * Returns true if the navigation lock is currently acquired.
- *
- * Not exposed in production builds by default. Always returns false when the
- * testing API is not available.
+ * Returns true if the navigation lock is currently active. Checks the cookie
+ * rather than in-memory lockState because the cookie survives across MPA
+ * navigations (page reloads). Returns false when the testing API is disabled.
  */
 export function isNavigationLocked(): boolean {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    return lockState !== null
+    return document.cookie.includes(NEXT_INSTANT_TEST_COOKIE + '=')
   }
   return false
 }
@@ -133,56 +126,11 @@ export function isNavigationLocked(): boolean {
 /**
  * Waits for the navigation lock to be released, if it's currently held.
  * No-op if the lock is not acquired.
- *
- * Not exposed in production builds by default.
  */
 export async function waitForNavigationLockIfActive(): Promise<void> {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
     if (lockState !== null) {
       await lockState.promise
     }
-  }
-}
-
-/**
- * Called during page initialization when the instant test cookie is detected.
- * Sets up the lock state so that:
- * 1. Client-side navigations during the instant scope also block dynamic data
- * 2. When the lock is released, a refresh is triggered to fetch dynamic data
- *
- * Not exposed in production builds by default.
- */
-export function initializeMpaLockedState(): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    // Set the MPA flag so we know to trigger a refresh when the lock is released
-    mpaLockedStateNeedsRefresh = true
-
-    // Also acquire the in-memory lock so client-side navigations during the
-    // instant scope also block dynamic data
-    if (lockState === null) {
-      let resolve: () => void
-      const promise = new Promise<void>((r) => {
-        resolve = r
-      })
-      lockState = { promise, resolve: resolve! }
-    }
-  }
-}
-
-/**
- * Triggers a router refresh to fetch dynamic data. Used after releasing the
- * navigation lock following an MPA navigation.
- */
-function triggerRefresh(): void {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    const { dispatchAppRouterAction } =
-      require('../use-action-queue') as typeof import('../use-action-queue')
-    const { ACTION_REFRESH } =
-      require('../router-reducer/router-reducer-types') as typeof import('../router-reducer/router-reducer-types')
-
-    dispatchAppRouterAction({
-      type: ACTION_REFRESH,
-      devBypassCacheInvalidation: true,
-    })
   }
 }

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -383,8 +383,8 @@ export interface ExperimentalConfig {
   externalMiddlewareRewritesResolve?: boolean
   externalProxyRewritesResolve?: boolean
   /**
-   * Exposes the experimental testing API (`__EXPERIMENTAL_NEXT_TESTING__`) in
-   * production builds. This API is always available in development mode.
+   * Exposes the Instant Navigation Testing API in production builds. This
+   * API is always available in development mode.
    *
    * The testing API allows e2e tests to control navigation timing, enabling
    * deterministic assertions on prefetched/cached UI before dynamic data

--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -82,6 +82,8 @@ interface Window {
     | 'top-right'
     | 'bottom-left'
     | 'bottom-right'
+  /** @internal - Set by the server when serving a static shell for instant navigation tests */
+  __next_instant_test?: 1
 }
 
 interface NextFetchRequestConfig {

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -51,34 +51,37 @@ describe('instant-navigation-testing-api', () => {
     return page!
   }
 
+  const INSTANT_COOKIE = 'next-instant-navigation-testing'
+
   /**
    * Runs a function with instant navigation enabled. Within this scope,
    * navigations render the prefetched UI immediately and wait for the
    * callback to complete before streaming in dynamic data.
    *
-   * This is the inline implementation of what will eventually be extracted
-   * to a Playwright helper package.
+   * Uses the cookie-based protocol: setting the cookie acquires the
+   * navigation lock (via CookieStore change event), and clearing it
+   * releases the lock.
    */
   async function instant<T>(
     page: Playwright.Page,
     fn: () => Promise<T>
   ): Promise<T> {
-    await page.evaluate(() =>
-      (window as any).__EXPERIMENTAL_NEXT_TESTING__?.navigation.lock()
-    )
+    // Acquire the lock by setting the cookie from within the page context.
+    // This triggers the CookieStore change event in navigation-testing-lock.ts,
+    // which acquires the in-memory navigation lock.
+    await page.evaluate((name) => {
+      document.cookie = name + '=1; path=/'
+    }, INSTANT_COOKIE)
     try {
       return await fn()
     } finally {
-      // Wait for the page to be ready before unlocking. This is only necessary
-      // when fn() triggers a full page navigation (e.g. page.reload() or
-      // clicking a plain anchor), since the new page needs time to initialize.
-      await page.waitForFunction(
-        () =>
-          typeof (window as any).__EXPERIMENTAL_NEXT_TESTING__ !== 'undefined'
-      )
-      await page.evaluate(() =>
-        (window as any).__EXPERIMENTAL_NEXT_TESTING__?.navigation.unlock()
-      )
+      // Release the lock by clearing the cookie. For SPA navigations, this
+      // triggers the CookieStore change event which resolves the in-memory
+      // lock. For MPA navigations (reload, plain anchor), the listener in
+      // app-bootstrap.ts triggers a page reload to fetch dynamic data.
+      await page.evaluate((name) => {
+        document.cookie = name + '=; path=/; max-age=0'
+      }, INSTANT_COOKIE)
     }
   }
 
@@ -167,19 +170,23 @@ describe('instant-navigation-testing-api', () => {
   it('logs an error when attempting to nest instant scopes', async () => {
     const page = await openPage('/')
 
-    const errors: string[] = []
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') {
-        errors.push(msg.text())
-      }
+    // Listen for the specific error message
+    const consolePromise = page.waitForEvent('console', {
+      predicate: (msg) =>
+        msg.type() === 'error' && msg.text().includes('already acquired'),
+      timeout: 5000,
     })
 
     await instant(page, async () => {
-      // Attempt to nest another instant scope - should log an error
-      await instant(page, async () => {})
+      // Attempt to acquire the lock again by changing the cookie value.
+      // The CookieStore change event fires, and the handler detects that
+      // the lock is already held, logging an error.
+      await page.evaluate((name) => {
+        document.cookie = name + '=nested; path=/'
+      }, INSTANT_COOKIE)
+      const msg = await consolePromise
+      expect(msg.text()).toContain('already acquired')
     })
-
-    expect(errors.some((e) => e.includes('already acquired'))).toBe(true)
   })
 
   it('renders static shell on page reload', async () => {


### PR DESCRIPTION
The Instant Navigation Testing API already uses a cookie to persist lock state across MPA navigations (page reloads, plain anchor links), since window globals don't survive navigation. Rather than maintaining two parallel mechanisms — a window global for SPA and a cookie for MPA — this makes the cookie the single source of truth for all cases.

Playwright sets/clears the cookie directly via the browser context, and the client reacts to changes through the CookieStore API's change event. This removes the window.__EXPERIMENTAL_NEXT_TESTING__ global and the page.evaluate() calls that went with it.