### PR TITLE
test: allow query suffix in related media URL e2e assertions

### DIFF
--- a/test/e2e/app-dir/scss/url-global-asset-prefix-1/url-global-asset-prefix-1.test.ts
+++ b/test/e2e/app-dir/scss/url-global-asset-prefix-1/url-global-asset-prefix-1.test.ts
@@ -34,7 +34,7 @@ describe.skip('SCSS Support loader handling', () => {
           .elementByCss('.red-text')
           .getComputedCss('background-image')
         expect(background).toMatch(
-          /url\(".*\/foo\/_next\/static\/media\/dark\..*\.svg"\), url\(".*\/foo\/_next\/static\/media\/dark2\..*\.svg"\)/
+          /url\(".*\/foo\/_next\/static\/media\/dark\..*\.svg(?:\?.*)?"\), url\(".*\/foo\/_next\/static\/media\/dark2\..*\.svg(?:\?.*)?"\)/
         )
 
         const urls = getUrlFromBackgroundImage(background)

--- a/test/e2e/app-dir/scss/url-global-asset-prefix-2/url-global-asset-prefix-2.test.ts
+++ b/test/e2e/app-dir/scss/url-global-asset-prefix-2/url-global-asset-prefix-2.test.ts
@@ -34,7 +34,7 @@ describe.skip('SCSS Support loader handling', () => {
           .elementByCss('.red-text')
           .getComputedCss('background-image')
         expect(background).toMatch(
-          /url\(".*\/foo\/_next\/static\/media\/dark\..*\.svg"\), url\(".*\/foo\/_next\/static\/media\/dark2\..*\.svg"\)/
+          /url\(".*\/foo\/_next\/static\/media\/dark\..*\.svg(?:\?.*)?"\), url\(".*\/foo\/_next\/static\/media\/dark2\..*\.svg(?:\?.*)?"\)/
         )
 
         const urls = getUrlFromBackgroundImage(background)

--- a/test/e2e/app-dir/scss/url-global-partial/url-global-partial.test.ts
+++ b/test/e2e/app-dir/scss/url-global-partial/url-global-partial.test.ts
@@ -33,7 +33,7 @@ describe('SCSS Support loader handling', () => {
           .elementByCss('.red-text')
           .getComputedCss('background-image')
         expect(background).toMatch(
-          /url\(".*\/_next\/static\/media\/darka\..*\.svg"\), url\(".*\/_next\/static\/media\/darkb\..*\.svg"\)/
+          /url\(".*\/_next\/static\/media\/darka\..*\.svg(?:\?.*)?"\), url\(".*\/_next\/static\/media\/darkb\..*\.svg(?:\?.*)?"\)/
         )
 
         const urls = getUrlFromBackgroundImage(background)

--- a/test/e2e/url-imports/url-imports.test.ts
+++ b/test/e2e/url-imports/url-imports.test.ts
@@ -84,7 +84,7 @@ import { join } from 'path'
             .elementByCss('#static-css')
             .getComputedCss('background-image')
         ).toMatch(
-          /^url\("http(s)?:\/\/.+\/_next\/static\/media\/vercel\.[0-9a-f]{8}\.png"\)$/
+          /^url\("http(s)?:\/\/.+\/_next\/static\/media\/vercel\.[0-9a-f]{8}\.png(?:\?.*)?"\)$/
         )
       )
     })


### PR DESCRIPTION
## Summary
- apply the same deploy query-suffix tolerance (`(?:\?.*)?`) to related e2e background-image URL assertions
- update SCSS URL tests (`url-global-partial`, `url-global-asset-prefix-1`, `url-global-asset-prefix-2`) and `url-imports` CSS background-image assertion

## Context
- follow-up to #89856, which applied this fix to `url-global`

## Verification
- regex sanity checks with and without query suffixes passed
- attempted local `testonly` run for `url-imports`, but local Turbopack+urlImports limitations caused unrelated failures