### PR TITLE
Turbopack: Use `std::any::type_name` for global naming of turbo-task items

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
@@ -5,8 +5,6 @@
 use std::future::IntoFuture;
 
 use anyhow::Result;
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde_json::json;
 use turbo_tasks::Vc;
 use turbo_tasks_testing::{Registration, register, run_without_cache_check};
@@ -221,10 +219,6 @@ async fn test_inline_definitions() -> Result<()> {
         assert_eq!(
             stats_json(),
             json!({
-                "<() as dyn turbo_tasks::vc::default::ValueDefault>::value_default": {
-                    "cache_hit": 4,
-                    "cache_miss": 1
-                },
                 "<dyn task_statistics::inline_definitions_turbo_tasks_function_inline::Trait>::trait_fn": {
                     "cache_hit": 0,
                     "cache_miss": 1
@@ -317,7 +311,6 @@ fn stats_json() -> serde_json::Value {
 
 // Global task identifiers can contain the crate name, remove it to simplify test assertions
 fn make_stats_deterministic(mut json: serde_json::Value) -> serde_json::Value {
-    static HASH_RE: Lazy<Regex> = Lazy::new(|| Regex::new("^[^:@]+@[^:]+:+").unwrap());
     match &mut json {
         serde_json::Value::Object(map) => {
             let old_map = std::mem::take(map);
@@ -329,7 +322,7 @@ fn make_stats_deterministic(mut json: serde_json::Value) -> serde_json::Value {
                 // assert on it.
                 object.remove("duration");
                 object.remove("executions");
-                map.insert(HASH_RE.replace(&k, "").into_owned(), v);
+                map.insert(k, v);
             }
         }
         _ => unreachable!("expected object"),
@@ -338,14 +331,18 @@ fn make_stats_deterministic(mut json: serde_json::Value) -> serde_json::Value {
 }
 
 #[turbo_tasks::function]
-fn inline_definitions() {
+fn inline_definitions() -> Result<Vc<()>> {
     #[turbo_tasks::function]
-    fn inline_fn() {}
+    fn inline_fn() -> Vc<()> {
+        Vc::cell(())
+    }
     let _ = inline_fn();
 
     let closure = || {
         #[turbo_tasks::function]
-        fn inline_fn_in_closure() {}
+        fn inline_fn_in_closure() -> Vc<()> {
+            Vc::cell(())
+        }
         let _ = inline_fn_in_closure();
     };
     closure();
@@ -356,7 +353,9 @@ fn inline_definitions() {
     #[turbo_tasks::value_impl]
     impl Value {
         #[turbo_tasks::function]
-        fn value_fn(&self) {}
+        fn value_fn(&self) -> Vc<()> {
+            Vc::cell(())
+        }
     }
     let _ = Value.cell().value_fn();
 
@@ -369,4 +368,6 @@ fn inline_definitions() {
     #[turbo_tasks::value_impl]
     impl Trait for Value {}
     let _ = Value.cell().trait_fn();
+
+    Ok(Vc::cell(()))
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
@@ -28,7 +28,7 @@ async fn test_simple_task() -> Result<()> {
         assert_eq!(
             stats_json(),
             json!({
-                "double": {
+                "task_statistics::double": {
                     "cache_miss": 10,
                     "cache_hit": 15,
                 },
@@ -50,7 +50,7 @@ async fn test_await_same_vc_multiple_times() -> Result<()> {
         assert_eq!(
             stats_json(),
             json!({
-                "double": {
+                "task_statistics::double": {
                     "cache_miss": 1,
                     "cache_hit": 0,
                 },
@@ -78,11 +78,11 @@ async fn test_vc_receiving_task() -> Result<()> {
         assert_eq!(
             stats_json(),
             json!({
-                "double": {
+                "task_statistics::double": {
                     "cache_miss": 10,
                     "cache_hit": 5,
                 },
-                "double_vc": {
+                "task_statistics::double_vc": {
                     "cache_miss": 10,
                     "cache_hit": 15,
                 },
@@ -111,15 +111,15 @@ async fn test_trait_methods() -> Result<()> {
         assert_eq!(
             stats_json(),
             json!({
-                "wrap": {
+                "task_statistics::wrap": {
                     "cache_miss": 10,
                     "cache_hit": 5,
                 },
-                "WrappedU64::Doublable::double": {
+                "<task_statistics::WrappedU64 as dyn task_statistics::Doublable>::double": {
                     "cache_miss": 10,
                     "cache_hit": 15,
                 },
-                "WrappedU64::Doublable::double_vc": {
+                "<task_statistics::WrappedU64 as dyn task_statistics::Doublable>::double_vc": {
                     "cache_miss": 10,
                     "cache_hit": 15,
                 },
@@ -154,15 +154,15 @@ async fn test_dyn_trait_methods() -> Result<()> {
         assert_eq!(
             stats_json(),
             json!({
-                "wrap": {
+                "task_statistics::wrap": {
                     "cache_miss": 10,
                     "cache_hit": 7,
                 },
-                "WrappedU64::Doublable::double": {
+                "<task_statistics::WrappedU64 as dyn task_statistics::Doublable>::double": {
                     "cache_miss": 10,
                     "cache_hit": 17,
                 },
-                "WrappedU64::Doublable::double_vc": {
+                "<task_statistics::WrappedU64 as dyn task_statistics::Doublable>::double_vc": {
                     "cache_miss": 10,
                     "cache_hit": 17,
                 },
@@ -186,27 +186,66 @@ async fn test_no_execution() -> Result<()> {
         assert_eq!(
             stats_json(),
             json!({
-                "WrappedU64::Doublable::double": {
+                "<task_statistics::WrappedU64 as dyn task_statistics::Doublable>::double": {
                     "cache_hit": 0,
                     "cache_miss": 1
                 },
-                "WrappedU64::Doublable::double_vc":  {
+                "<task_statistics::WrappedU64 as dyn task_statistics::Doublable>::double_vc":  {
                     "cache_hit": 0,
                     "cache_miss": 1
                 },
-                "double":  {
+                "task_statistics::double":  {
                     "cache_hit": 0,
                     "cache_miss": 1
                 },
-                "double_vc":  {
+                "task_statistics::double_vc":  {
                     "cache_hit": 0,
                     "cache_miss": 1
                 },
-                "wrap_vc": {
+                "task_statistics::wrap_vc": {
                     "cache_hit": 0,
                     "cache_miss": 1
                 },
             })
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_inline_definitions() -> Result<()> {
+    run_without_cache_check(&REGISTRATION, async move {
+        enable_stats();
+        inline_definitions().await?;
+        assert_eq!(
+            stats_json(),
+            json!({
+                "<() as dyn turbo_tasks::vc::default::ValueDefault>::value_default": {
+                    "cache_hit": 4,
+                    "cache_miss": 1
+                },
+                "<dyn task_statistics::inline_definitions_turbo_tasks_function_inline::Trait>::trait_fn": {
+                    "cache_hit": 0,
+                    "cache_miss": 1
+                },
+                "task_statistics::inline_definitions": {
+                    "cache_hit": 0,
+                    "cache_miss": 1
+                },
+                "task_statistics::inline_definitions_turbo_tasks_function_inline::Value::value_fn": {
+                    "cache_hit": 0,
+                    "cache_miss": 1
+                },
+                "task_statistics::inline_definitions_turbo_tasks_function_inline::inline_fn": {
+                    "cache_hit": 0,
+                    "cache_miss": 1
+                },
+                "task_statistics::inline_definitions_turbo_tasks_function_inline::{{closure}}::inline_fn_in_closure": {
+                    "cache_hit": 0,
+                    "cache_miss": 1
+                }
+            }),
         );
         Ok(())
     })
@@ -296,4 +335,38 @@ fn make_stats_deterministic(mut json: serde_json::Value) -> serde_json::Value {
         _ => unreachable!("expected object"),
     };
     json
+}
+
+#[turbo_tasks::function]
+fn inline_definitions() {
+    #[turbo_tasks::function]
+    fn inline_fn() {}
+    let _ = inline_fn();
+
+    let closure = || {
+        #[turbo_tasks::function]
+        fn inline_fn_in_closure() {}
+        let _ = inline_fn_in_closure();
+    };
+    closure();
+
+    #[turbo_tasks::value]
+    struct Value;
+
+    #[turbo_tasks::value_impl]
+    impl Value {
+        #[turbo_tasks::function]
+        fn value_fn(&self) {}
+    }
+    let _ = Value.cell().value_fn();
+
+    #[turbo_tasks::value_trait]
+    trait Trait {
+        #[turbo_tasks::function]
+        fn trait_fn(&self) {}
+    }
+
+    #[turbo_tasks::value_impl]
+    impl Trait for Value {}
+    let _ = Value.cell().trait_fn();
 }

--- a/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/trace_transient.rs
@@ -9,14 +9,14 @@ use turbo_tasks_testing::{Registration, register, run_once_without_cache_check};
 static REGISTRATION: Registration = register!();
 
 const EXPECTED_TRACE: &str = "\
-Adder::add_method (read cell of type turbo-tasks@turbo_tasks::primitives::u64)
+Adder::add_method (read cell of type u64)
   self:
-    Adder::new (read cell of type turbo-tasks-backend@trace_transient::Adder)
+    Adder::new (read cell of type trace_transient::Adder)
       args:
-        unknown transient task (read cell of type turbo-tasks@turbo_tasks::primitives::())
+        unknown transient task (read cell of type ())
   args:
-    unknown transient task (read cell of type turbo-tasks@turbo_tasks::primitives::u16)
-    unknown transient task (read cell of type turbo-tasks@turbo_tasks::primitives::u32)";
+    unknown transient task (read cell of type u16)
+    unknown transient task (read cell of type u32)";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_trace_transient() {

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -57,6 +57,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let inline_attrs = filter_inline_attributes(&attrs[..]);
 
     let native_fn = NativeFn {
+        // depth = 2, this strips off a closure and a static item from the name
         function_global_name: global_name_for_scope(2, ident),
         function_path_string: ident.to_string(),
         function_path: quote! { #inline_function_ident },

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -4,7 +4,7 @@ use syn::{ItemFn, parse_macro_input};
 
 use crate::{
     func::{DefinitionContext, FunctionArguments, NativeFn, TurboFn, filter_inline_attributes},
-    global_name::global_name,
+    global_name::global_name_for_scope,
     ident::get_native_function_ident,
     self_filter::is_self_used,
 };
@@ -55,11 +55,10 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
     let inline_function_ident = turbo_fn.inline_ident();
     let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(&block);
     let inline_attrs = filter_inline_attributes(&attrs[..]);
-    let function_path_string = ident.to_string();
 
     let native_fn = NativeFn {
-        function_global_name: global_name(&function_path_string),
-        function_path_string,
+        function_global_name: global_name_for_scope(2, ident),
+        function_path_string: ident.to_string(),
         function_path: quote! { #inline_function_ident },
         is_method: turbo_fn.is_method(),
         is_self_used,

--- a/turbopack/crates/turbo-tasks-macros/src/global_name.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/global_name.rs
@@ -1,11 +1,45 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
+pub(crate) fn global_name_for_type(ty: impl quote::ToTokens) -> TokenStream {
+    quote! {
+        turbo_tasks::macro_helpers::global_name_for_type!(#ty)
+    }
+}
+
+pub(crate) fn global_name_for_method(
+    ty: impl quote::ToTokens,
+    method: impl quote::ToTokens,
+) -> TokenStream {
+    quote! {
+        turbo_tasks::macro_helpers::global_name_for_method!(#ty, #method)
+    }
+}
+
+pub(crate) fn global_name_for_trait_method(
+    trait_: impl quote::ToTokens,
+    method: impl quote::ToTokens,
+) -> TokenStream {
+    quote! {
+        turbo_tasks::macro_helpers::global_name_for_trait_method!(#trait_, #method)
+    }
+}
+
+pub(crate) fn global_name_for_trait_method_impl(
+    ty: impl quote::ToTokens,
+    trait_: impl quote::ToTokens,
+    method: impl quote::ToTokens,
+) -> TokenStream {
+    quote! {
+        turbo_tasks::macro_helpers::global_name_for_trait_method_impl!(#ty, #trait_, #method)
+    }
+}
+
 /// Composes an expression that will evaluate to a &'static str of the fully qualified name
 ///
 /// The name is prefixed with the current crate name and module path
-pub(crate) fn global_name(local_name: impl quote::ToTokens) -> TokenStream {
+pub(crate) fn global_name_for_scope(depth: usize, local_name: impl quote::ToTokens) -> TokenStream {
     quote! {
-        turbo_tasks::macro_helpers::global_name!(#local_name)
+        turbo_tasks::macro_helpers::global_name_for_scope!(#depth, #local_name)
     }
 }

--- a/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/primitive_macro.rs
@@ -3,7 +3,7 @@ use quote::quote;
 use syn::parse_macro_input;
 
 use crate::{
-    global_name::global_name,
+    global_name::global_name_for_type,
     ident::get_type_ident,
     primitive_input::{BincodeWrappers, PrimitiveInput},
     value_macro::value_type_and_register,
@@ -39,7 +39,7 @@ pub fn primitive(input: TokenStream) -> TokenStream {
         }
     };
 
-    let name = global_name(quote!(stringify!(#ty)));
+    let name = global_name_for_type(&ty);
     let new_value_type = if let Some(bincode_wrappers) = bincode_wrappers {
         let BincodeWrappers {
             encode_ty,

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -14,7 +14,9 @@ use crate::{
         DefinitionContext, FunctionArguments, NativeFn, TurboFn, filter_inline_attributes,
         split_function_attributes,
     },
-    global_name::global_name,
+    global_name::{
+        global_name_for_method, global_name_for_trait_method_impl, global_name_for_type,
+    },
     ident::{
         get_cast_to_fat_pointer_ident, get_inherent_impl_function_ident, get_path_ident,
         get_trait_impl_function_ident, get_type_ident,
@@ -116,10 +118,9 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             let inline_function_ident = turbo_fn.inline_ident();
             let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(block);
             let inline_attrs = filter_inline_attributes(attrs.iter().copied());
-            let function_path_string = format!("{ty}::{ident}", ty = ty.to_token_stream());
             let native_fn = NativeFn {
-                function_global_name: global_name(&function_path_string),
-                function_path_string,
+                function_global_name: global_name_for_method(ty, ident),
+                function_path_string: format!("{ty}::{ident}", ty = ty.to_token_stream()),
                 function_path: quote! { <#ty>::#inline_function_ident },
                 is_method: turbo_fn.is_method(),
                 is_self_used,
@@ -233,12 +234,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 let (inline_signature, inline_block) = turbo_fn.inline_signature_and_block(block);
                 let inline_attrs = filter_inline_attributes(attrs.iter().copied());
                 let native_fn = NativeFn {
-                    // This global name breaks the pattern.  It isn't clear if it is intentional
-                    function_global_name: global_name(format!(
-                        "{ty}::{trait_path}::{ident}",
-                        ty = ty.to_token_stream(),
-                        trait_path = trait_path.to_token_stream()
-                    )),
+                    function_global_name: global_name_for_trait_method_impl(ty, trait_path, ident),
                     function_path_string: format!(
                         "<{ty} as {trait_path}>::{ident}",
                         ty = ty.to_token_stream(),
@@ -297,7 +293,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 });
             }
         }
-        let value_name = global_name(quote! {stringify!(#ty_ident)});
+        let global_value_name = global_name_for_type(ty);
         quote! {
             // Register all the function impls so the ValueType can find them
             // This means objects resolve as
@@ -307,9 +303,11 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             // 4.VTableRegistries (requires ValueTypeIds)
             turbo_tasks::macro_helpers::inventory_submit!{
                 turbo_tasks::macro_helpers::CollectableTraitMethods(
-                    #value_name,
-                    || (<::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::get_trait_type_id(),
-                        vec![#(#trait_methods)*])
+                    || (
+                        #global_value_name,
+                        <::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::get_trait_type_id(),
+                        vec![#(#trait_methods)*]
+                    )
                 )
             }
 

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -12,7 +12,7 @@ use syn::{
     spanned::Spanned,
 };
 
-use crate::{global_name::global_name, ident::get_value_type_ident};
+use crate::{global_name::global_name_for_type, ident::get_value_type_ident};
 
 enum CellMode {
     KeyedCompare,
@@ -341,7 +341,7 @@ pub fn value(args: TokenStream, input: TokenStream) -> TokenStream {
         });
     }
 
-    let name = global_name(quote! {stringify!(#ident) });
+    let name = global_name_for_type(ident);
     let new_value_type = match serialization_mode {
         SerializationMode::None => quote! {
             turbo_tasks::ValueType::new::<#ident>(#name)
@@ -428,12 +428,14 @@ pub fn value_type_and_register(
 
         static #value_type_ident: turbo_tasks::macro_helpers::Lazy<turbo_tasks::ValueType> =
             turbo_tasks::macro_helpers::Lazy::new(|| {
-                let mut value = #new_value_type;
-                turbo_tasks::macro_helpers::register_trait_methods(&mut value);
-                value
+                let mut value_type = #new_value_type;
+                turbo_tasks::macro_helpers::register_trait_methods(&mut value_type);
+                value_type
              });
 
-        turbo_tasks::macro_helpers::inventory_submit!{turbo_tasks::macro_helpers::CollectableValueType(&#value_type_ident)}
+        turbo_tasks::macro_helpers::inventory_submit! {
+            turbo_tasks::macro_helpers::CollectableValueType(&#value_type_ident)
+        }
 
         #[automatically_derived]
         unsafe impl #impl_generics turbo_tasks::VcValueType for #ty #where_clause {

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -10,7 +10,7 @@ use crate::{
         DefinitionContext, FunctionArguments, NativeFn, TurboFn, filter_inline_attributes,
         get_receiver_style, split_function_attributes,
     },
-    global_name::global_name,
+    global_name::{global_name_for_trait_method, global_name_for_type},
     ident::{get_trait_default_impl_function_ident, get_trait_type_ident},
     self_filter::is_self_used,
     value_trait_arguments::ValueTraitArguments,
@@ -203,7 +203,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
 
             let function_path_string = format!("{trait_ident}::{ident}");
             let native_function = NativeFn {
-                function_global_name: global_name(&function_path_string),
+                function_global_name: global_name_for_trait_method(trait_ident, ident),
                 function_path_string,
                 function_path: quote! {
                     <Box<dyn #trait_ident> as #inline_extension_trait_ident>::#inline_function_ident
@@ -290,7 +290,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
         extended_supertraits.push(quote!(turbo_tasks::debug::ValueDebug));
     }
 
-    let trait_name = global_name(quote! {stringify!(#trait_ident)});
+    let trait_name = global_name_for_type(quote! { dyn #trait_ident });
     let expanded = quote! {
         #[must_use]
         #(#attrs)*

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -207,8 +207,7 @@ macro_rules! debug_assert_runs_once {
         {
             use ::std::sync::atomic::{AtomicBool, Ordering};
             static ONLY_RUN_ONCE: AtomicBool = AtomicBool::new(false);
-            assert!(!AtomicBool::load(&ONLY_RUN_ONCE, Ordering::Acquire));
-            AtomicBool::store(&ONLY_RUN_ONCE, true, Ordering::Release);
+            assert!(!AtomicBool::swap(&ONLY_RUN_ONCE, true, Ordering::AcqRel));
         }
     };
 }

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -12,7 +12,8 @@ use crate::{
     ValueTypeId, debug::ValueDebugFormatString,
 };
 pub use crate::{
-    global_name, inventory_submit,
+    global_name_for_method, global_name_for_scope, global_name_for_trait_method,
+    global_name_for_trait_method_impl, global_name_for_type, inventory_submit,
     magic_any::MagicAny,
     manager::{find_cell_by_id, find_cell_by_type, spawn_detached_for_testing},
     native_function::{
@@ -142,32 +143,36 @@ inventory::collect! {CollectableTraitCastFunctions}
 
 #[allow(clippy::type_complexity)]
 pub struct CollectableTraitMethods(
-    // A value type name
-    pub &'static str,
-    pub fn() -> (TraitTypeId, Vec<(&'static str, &'static NativeFunction)>),
+    pub  fn() -> (
+        &'static str, // A value type name
+        TraitTypeId,
+        Vec<(&'static str, &'static NativeFunction)>,
+    ),
 );
-inventory::collect! {CollectableTraitMethods}
+inventory::collect!(CollectableTraitMethods);
 
 // Called when initializing ValueTypes by value_impl
-pub fn register_trait_methods(value: &mut ValueType) {
+pub fn register_trait_methods(value_type: &mut ValueType) {
     #[allow(clippy::type_complexity)]
     static TRAIT_METHODS_BY_VALUE: Lazy<
         FxDashMap<&'static str, Vec<(TraitTypeId, Vec<(&'static str, &'static NativeFunction)>)>>,
     > = Lazy::new(|| {
         let map: FxDashMap<&'static str, Vec<_>> = FxDashMap::default();
-        for CollectableTraitMethods(value_name, thunk) in inventory::iter::<CollectableTraitMethods>
-        {
-            map.entry(*value_name).or_default().push(thunk());
+        for CollectableTraitMethods(thunk) in inventory::iter::<CollectableTraitMethods> {
+            let (value_name, trait_type_id, fn_items) = thunk();
+            map.entry(value_name)
+                .or_default()
+                .push((trait_type_id, fn_items));
         }
         map
     });
-    match TRAIT_METHODS_BY_VALUE.remove(value.global_name) {
+    match TRAIT_METHODS_BY_VALUE.remove(value_type.global_name) {
         Some((_, traits)) => {
             for (trait_type_id, methods) in traits {
                 let trait_type = crate::registry::get_trait(trait_type_id);
-                value.register_trait(trait_type_id);
+                value_type.register_trait(trait_type_id);
                 for (name, method) in methods {
-                    value.register_trait_method(trait_type.get(name), method);
+                    value_type.register_trait_method(trait_type.get(name), method);
                 }
             }
         }
@@ -181,6 +186,7 @@ pub fn register_trait_methods(value: &mut ValueType) {
 ///
 /// This macro is a wrapper around `inventory::submit` that adds a `#[not(cfg(rust_analyzer))]`
 /// attribute to the item. This is to avoid warnings about unused items when using Rust Analyzer.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! inventory_submit {
     ($($item:tt)*) => {
@@ -193,21 +199,99 @@ macro_rules! inventory_submit {
 #[doc(hidden)]
 pub use inventory::submit as inventory_submit_inner;
 
-/// Define a global name for a turbo-tasks value.
-#[cfg(not(rust_analyzer))] // ignore-rust-analyzer due to https://github.com/rust-lang/rust-analyzer/issues/19993
+#[doc(hidden)]
 #[macro_export]
-macro_rules! global_name {
-    ($($item:tt)*) => {
-
-        ::std::concat!(::std::env!("CARGO_PKG_NAME"), "@", ::std::module_path!(), "::", $($item)*)
-    }
+macro_rules! debug_assert_runs_once {
+    () => {
+        #[cfg(debug_assertions)]
+        {
+            use ::std::sync::atomic::{AtomicBool, Ordering};
+            static ONLY_RUN_ONCE: AtomicBool = AtomicBool::new(false);
+            assert!(!AtomicBool::load(&ONLY_RUN_ONCE, Ordering::Acquire));
+            AtomicBool::store(&ONLY_RUN_ONCE, true, Ordering::Release);
+        }
+    };
 }
-/// Define a global name for a turbo-tasks value.
-/// This has a dummy implementation for Rust Analyzer to avoid https://github.com/rust-lang/rust-analyzer/issues/19993
-#[cfg(rust_analyzer)]
+
+/// Use `type_name` to get globally unique identifier that's stable across multiple executions of
+/// the same Turbopack version, potentially allowing cache sharing across platforms/architectures.
+///
+/// The stdlib docs explicitly recommend against using type_name to get a unique identifier, but the
+/// way we're using it here seems unlikely to break. We've got runtime logic to panic if it breaks.
+#[doc(hidden)]
 #[macro_export]
-macro_rules! global_name {
-    ($($item:tt)*) => {
-        $($item)*
-    }
+macro_rules! global_name_for_type {
+    ($item:ty) => {
+        ::std::any::type_name::<$item>()
+    };
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! global_name_for_method {
+    ($ty:ty, $method:ident) => {{
+        // We cannot use `concat!` because `type_name` is not const, so we leak the string instead
+        // to get a &'static str.
+        //
+        // Assumption: the code that invokes this macro is only run once (e.g. part of an
+        // `inventory::submit!` callsite), so we're leaking a bounded number of strings.
+        $crate::debug_assert_runs_once!();
+        ::std::boxed::Box::leak(::std::string::String::into_boxed_str(::std::format!(
+            "{}::{}",
+            ::std::any::type_name::<$ty>(),
+            ::std::stringify!($method),
+        )))
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! global_name_for_trait_method {
+    ($trait:path, $method:ident) => {{
+        $crate::debug_assert_runs_once!();
+        ::std::boxed::Box::leak(::std::string::String::into_boxed_str(::std::format!(
+            "<{}>::{}",
+            ::std::any::type_name::<dyn $trait>(),
+            ::std::stringify!($method),
+        )))
+    }};
+}
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! global_name_for_trait_method_impl {
+    ($ty:ty, $trait:path, $method:ident) => {{
+        $crate::debug_assert_runs_once!();
+        ::std::boxed::Box::leak(::std::string::String::into_boxed_str(::std::format!(
+            "<{} as {}>::{}",
+            ::std::any::type_name::<$ty>(),
+            ::std::any::type_name::<dyn $trait>(),
+            ::std::stringify!($method),
+        )))
+    }};
+}
+
+/// Get a globally unique name for an identifier a current or parent scope.
+#[doc(hidden)]
+#[macro_export]
+macro_rules! global_name_for_scope {
+    ($depth:literal, $($item:tt)+) => {{
+        $crate::debug_assert_runs_once!();
+
+        struct PlaceholderMarkerType;
+        let mut base = ::std::any::type_name::<PlaceholderMarkerType>();
+
+        // strip a caller-defined number of ancestors from the end of the path
+        for _ in 0..($depth+1) {  // add one to `depth` for the placeholder
+            base = ::std::option::Option::unwrap(
+                ::std::primitive::str::rsplit_once(base, "::"),
+            ).0;
+        }
+
+        ::std::boxed::Box::leak(
+            ::std::string::String::into_boxed_str(
+                ::std::format!("{}::{}", base, ::std::stringify!($($item)+))
+            ),
+        )
+    }}
 }


### PR DESCRIPTION
_I wrote this PR by hand, because I wanted to make sure I got all the details right._  
  
The previous approach for computing global names was `module path` + `item name`.

Since @lukesandberg added support for inventory, we can now nest `turbo_task::function` and `turbo_task::value` macros inside any arbitrary scope:

![Screenshot 2026-02-11 at 2.57.26 PM.png](https://app.graphite.com/user-attachments/assets/1f5a4b80-bd45-4a95-8ac7-881c58d02f60.png)

This is a fantastic feature, but it does mean that our global names are no longer unique.

@mmastrac suggested using `std::any::type_name` with a dummy marker type to get a full path. This PR attempts to do that.