### PR TITLE
[Instant] test: add Instant Navigation tests without Cache Components

### DIFF
--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -52,6 +52,61 @@ export function navigate(
   shouldScroll: boolean,
   navigateType: 'push' | 'replace'
 ): AppRouterState | Promise<AppRouterState> {
+  // Instant Navigation Testing API: If the navigation lock is active,
+  // ensure all segment cache entries for the target route exist before
+  // proceeding. This is hoisted to the top of navigate so it runs even
+  // when a route cache entry already exists, ensuring tests can reliably
+  // assert on prefetch state via the onComplete callback.
+  if (process.env.__NEXT_EXPOSE_TESTING_API) {
+    const { isNavigationLocked } =
+      require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
+    if (isNavigationLocked()) {
+      return ensureNavigationIsPrefetched(
+        url,
+        nextUrl,
+        currentFlightRouterState
+      ).then(() =>
+        navigateImpl(
+          state,
+          url,
+          currentUrl,
+          currentRenderedSearch,
+          currentCacheNode,
+          currentFlightRouterState,
+          nextUrl,
+          freshnessPolicy,
+          shouldScroll,
+          navigateType
+        )
+      )
+    }
+  }
+  return navigateImpl(
+    state,
+    url,
+    currentUrl,
+    currentRenderedSearch,
+    currentCacheNode,
+    currentFlightRouterState,
+    nextUrl,
+    freshnessPolicy,
+    shouldScroll,
+    navigateType
+  )
+}
+
+function navigateImpl(
+  state: AppRouterState,
+  url: URL,
+  currentUrl: URL,
+  currentRenderedSearch: string,
+  currentCacheNode: CacheNode | null,
+  currentFlightRouterState: FlightRouterState,
+  nextUrl: string | null,
+  freshnessPolicy: FreshnessPolicy,
+  shouldScroll: boolean,
+  navigateType: 'push' | 'replace'
+): AppRouterState | Promise<AppRouterState> {
   const now = Date.now()
   const href = url.href
 
@@ -300,27 +355,6 @@ async function navigateToUnknownRoute(
   shouldScroll: boolean,
   navigateType: 'push' | 'replace'
 ): Promise<AppRouterState> {
-  // If the Instant Navigation Testing API lock is active, try to prefetch the
-  // route first. If the prefetch succeeds, navigate using the prefetched route
-  // tree. If it fails, fall through to the normal path.
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    const prefetchResult = await tryNavigateUsingTestingAPIPrefetch(
-      state,
-      url,
-      currentUrl,
-      currentRenderedSearch,
-      nextUrl,
-      currentCacheNode,
-      currentFlightRouterState,
-      freshnessPolicy,
-      shouldScroll,
-      navigateType
-    )
-    if (prefetchResult !== null) {
-      return prefetchResult
-    }
-  }
-
   // Runs when a navigation happens but there's no cached prefetch we can use.
   // Don't bother to wait for a prefetch response; go straight to a full
   // navigation that contains both static and dynamic data in a single stream.
@@ -775,79 +809,31 @@ function convertServerPatchToFullTreeImpl(
 }
 
 /**
- * Helper for the Instant Navigation Testing API. If the navigation lock is
- * active, schedules a prefetch task, waits for it to complete, and navigates
- * using the prefetched route tree.
- *
- * Returns the new router state if navigation succeeded via prefetch, or null
- * if the lock isn't active or the prefetch failed (caller should fall through
- * to the normal unknown route path).
+ * Helper for the Instant Navigation Testing API. Ensures that all segment
+ * cache entries for a target route exist (at least as pending) before the
+ * navigation proceeds. This is called before every locked navigation so tests
+ * can reliably assert on prefetch state via the onComplete callback.
  *
  * Not exposed in production builds by default.
  */
-async function tryNavigateUsingTestingAPIPrefetch(
-  state: AppRouterState,
+async function ensureNavigationIsPrefetched(
   url: URL,
-  currentUrl: URL,
-  currentRenderedSearch: string,
   nextUrl: string | null,
-  currentCacheNode: CacheNode | null,
-  currentFlightRouterState: FlightRouterState,
-  freshnessPolicy: FreshnessPolicy,
-  shouldScroll: boolean,
-  navigateType: 'push' | 'replace'
-): Promise<AppRouterState | null> {
+  currentFlightRouterState: FlightRouterState
+): Promise<void> {
   if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    // Lazy require to ensure dead code elimination
-    const { isNavigationLocked } =
-      require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
-    if (!isNavigationLocked()) {
-      return null
-    }
-
-    // Use the link's fetch strategy so the test behavior matches what would
-    // happen if the route had been prefetched before navigation
     const link = getLinkForCurrentNavigation()
     const fetchStrategy = link !== null ? link.fetchStrategy : FetchStrategy.PPR
-
     const cacheKey = createCacheKey(url.href, nextUrl)
-    const { promise, resolve } = Promise.withResolvers<void>()
-
-    schedulePrefetchTask(
-      cacheKey,
-      currentFlightRouterState,
-      fetchStrategy,
-      PrefetchPriority.Default,
-      null, // onInvalidate
-      resolve // _onComplete callback
-    )
-
-    await promise
-
-    // Re-read from cache (should now be populated)
-    const now = Date.now()
-    const route = readRouteCacheEntry(now, cacheKey)
-    if (route !== null && route.status === EntryStatus.Fulfilled) {
-      return navigateUsingPrefetchedRouteTree(
-        now,
-        state,
-        url,
-        currentUrl,
-        currentRenderedSearch,
-        nextUrl,
-        currentCacheNode,
+    await new Promise<void>((resolve) => {
+      schedulePrefetchTask(
+        cacheKey,
         currentFlightRouterState,
-        freshnessPolicy,
-        shouldScroll,
-        navigateType,
-        route
+        fetchStrategy,
+        PrefetchPriority.Default,
+        null,
+        resolve
       )
-    }
-
-    // Prefetch failed - fall through to normal unknown route path. This is fine
-    // because the lock will still be held, and waitForNavigationLockIfActive()
-    // in the dynamic data path will block until the lock is released.
-    return null
+    })
   }
-  return null
 }

--- a/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/full-prefetch-target/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/full-prefetch-target/page.tsx
@@ -1,0 +1,14 @@
+import { connection } from 'next/server'
+
+export default async function FullPrefetchTargetPage() {
+  await connection()
+
+  return (
+    <div>
+      <h1>Full Prefetch Target</h1>
+      <div data-testid="full-prefetch-content">
+        Full prefetch content loaded
+      </div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/loading.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <div data-testid="loading-shell">Loading target page...</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/page.tsx
@@ -1,0 +1,19 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <div>
+      <h1 data-testid="home-title">Instant Navigation API Test</h1>
+      <Link href="/target-page" id="link-to-target">
+        Go to target page
+      </Link>
+      <Link
+        href="/full-prefetch-target"
+        prefetch={true}
+        id="link-to-full-prefetch"
+      >
+        Go to full prefetch target
+      </Link>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/target-page/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/app/target-page/page.tsx
@@ -1,0 +1,12 @@
+import { connection } from 'next/server'
+
+export default async function TargetPage() {
+  await connection()
+
+  return (
+    <div>
+      <h1>Target Page</h1>
+      <div data-testid="dynamic-content">Dynamic content loaded</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/instant-navigation-testing-api-without-cache-components.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/instant-navigation-testing-api-without-cache-components.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the Instant Navigation Testing API without Cache Components.
+ *
+ * This is a companion to the instant-navigation-testing-api suite, which has
+ * cacheComponents: true. This suite verifies the API also works with the
+ * legacy prefetch model where there's no PPR / per-segment caching.
+ *
+ * Without Cache Components:
+ *   - Default prefetch renders up to the first loading.tsx boundary
+ *   - prefetch={true} eagerly prefetches the full page including dynamic data
+ *   - MPA navigations have no static shell concept (all-or-nothing), so the
+ *     MPA tests from the cache-components suite have no analog here
+ *
+ * Tests NOT ported from the cache-components suite:
+ *   - "renders runtime-prefetched content instantly" — unstable_instant with
+ *     runtime prefetch requires Cache Components
+ *   - All 5 MPA tests (reload, plain anchor, successive, hydration) — no PPR
+ *     shell without Cache Components
+ */
+
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+
+describe('instant-navigation-testing-api-without-cache-components', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    // Skip deployment tests because the exposeTestingApiInProductionBuild flag
+    // doesn't exist in the production version of Next.js yet
+    skipDeployment: true,
+  })
+
+  /**
+   * Opens a browser and returns the underlying Playwright Page instance.
+   *
+   * We use this pattern so our test assertions look as close as possible to
+   * what users would write with the actual Playwright helper package. The
+   * Next.js test infra wraps Playwright with its own BrowserInterface, but
+   * the Instant Navigation Testing API is designed to work with native
+   * Playwright.
+   */
+  async function openPage(url: string): Promise<Playwright.Page> {
+    let page: Playwright.Page
+    await next.browser(url, {
+      beforePageLoad(p) {
+        page = p
+      },
+    })
+    return page!
+  }
+
+  /**
+   * Runs a function with instant navigation enabled. Within this scope,
+   * navigations render the prefetched UI immediately and wait for the
+   * callback to complete before streaming in dynamic data.
+   *
+   * This is the inline implementation of what will eventually be extracted
+   * to a Playwright helper package.
+   */
+  async function instant<T>(
+    page: Playwright.Page,
+    fn: () => Promise<T>
+  ): Promise<T> {
+    await page.evaluate(() =>
+      (window as any).__EXPERIMENTAL_NEXT_TESTING__?.navigation.lock()
+    )
+    try {
+      return await fn()
+    } finally {
+      // Wait for the page to be ready before unlocking. This is only necessary
+      // when fn() triggers a full page navigation (e.g. page.reload() or
+      // clicking a plain anchor), since the new page needs time to initialize.
+      await page.waitForFunction(
+        () =>
+          typeof (window as any).__EXPERIMENTAL_NEXT_TESTING__ !== 'undefined'
+      )
+      await page.evaluate(() =>
+        (window as any).__EXPERIMENTAL_NEXT_TESTING__?.navigation.unlock()
+      )
+    }
+  }
+
+  it('renders prefetched loading shell instantly during navigation', async () => {
+    const page = await openPage('/')
+
+    await instant(page, async () => {
+      await page.click('#link-to-target')
+
+      // The loading shell appears immediately, without waiting for
+      // dynamic data
+      const loadingShell = page.locator('[data-testid="loading-shell"]')
+      await loadingShell.waitFor({ state: 'visible' })
+      expect(await loadingShell.textContent()).toContain(
+        'Loading target page...'
+      )
+
+      // Dynamic content has not streamed in yet
+      const dynamicContent = page.locator('[data-testid="dynamic-content"]')
+      expect(await dynamicContent.count()).toBe(0)
+    })
+
+    // After exiting the instant scope, dynamic content streams in
+    const dynamicContent = page.locator('[data-testid="dynamic-content"]')
+    await dynamicContent.waitFor({ state: 'visible' })
+    expect(await dynamicContent.textContent()).toContain(
+      'Dynamic content loaded'
+    )
+  })
+
+  it('renders full prefetch content instantly when prefetch={true}', async () => {
+    const page = await openPage('/')
+
+    await instant(page, async () => {
+      await page.click('#link-to-full-prefetch')
+
+      // With prefetch={true}, the dynamic content is included in the prefetch
+      // response, so it appears immediately without a loading state
+      const content = page.locator('[data-testid="full-prefetch-content"]')
+      await content.waitFor({ state: 'visible' })
+      expect(await content.textContent()).toContain(
+        'Full prefetch content loaded'
+      )
+    })
+  })
+
+  it('logs an error when attempting to nest instant scopes', async () => {
+    const page = await openPage('/')
+
+    await instant(page, async () => {
+      // Wait for the console error that fires when a nested lock is attempted.
+      const consoleError = page.waitForEvent('console', {
+        predicate: (msg) =>
+          msg.type() === 'error' && msg.text().includes('already acquired'),
+      })
+      // Attempt to nest another instant scope — should log an error
+      await instant(page, async () => {})
+      await consoleError
+    })
+  })
+
+  it('subsequent navigations after instant scope are not locked', async () => {
+    const page = await openPage('/')
+
+    // Use full prefetch link since it works in both dev and prod modes
+    await instant(page, async () => {
+      await page.click('#link-to-full-prefetch')
+
+      const content = page.locator('[data-testid="full-prefetch-content"]')
+      await content.waitFor({ state: 'visible' })
+    })
+
+    // Navigate back to home
+    await page.goBack()
+    const homeTitle = page.locator('[data-testid="home-title"]')
+    await homeTitle.waitFor({ state: 'visible' })
+
+    // After exiting the instant scope, navigations work normally again.
+    // Navigate to target page — dynamic content should load without blocking.
+    await page.click('#link-to-target')
+    const dynamicContent = page.locator('[data-testid="dynamic-content"]')
+    await dynamicContent.waitFor({ state: 'visible' })
+    expect(await dynamicContent.textContent()).toContain(
+      'Dynamic content loaded'
+    )
+  })
+})

--- a/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api-without-cache-components/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    // Enable the testing API in production builds for these tests
+    exposeTestingApiInProductionBuild: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Add a companion test suite that verifies the Instant Navigation Testing API works with the legacy prefetch model (no Cache Components / PPR). Without Cache Components, default prefetch renders up to the first loading.tsx boundary, and prefetch={true} eagerly fetches the full page.

Tests cover: loading shell rendered instantly during navigation, full prefetch content rendered instantly, nested Instant scope error, and normal navigation after scope exits.

MPA tests are intentionally excluded — without PPR there is no static shell concept for MPA navigations, so those tests have no analog here.

Includes a small refactor to hoist the prefetch-ensure logic to the main navigate function, so it fires for all locked navigations regardless of whether the route is already cached.