### PR TITLE
feat(eslint): add no-invalid-head-children rule

### DIFF
--- a/errors/no-invalid-head-children.mdx
+++ b/errors/no-invalid-head-children.mdx
@@ -1,0 +1,106 @@
+---
+title: No Invalid Head Children
+---
+
+> Prevent usage of invalid HTML elements inside `next/head`.
+
+## Why This Error Occurred
+
+You have used an invalid HTML element as a direct child of the `next/head` component.
+
+The `<Head>` component from `next/head` only supports the following HTML elements as children:
+
+- `<title>`
+- `<meta>`
+- `<link>`
+- `<script>`
+- `<style>`
+- `<base>`
+- `<noscript>`
+
+Using other elements like `<html>`, `<body>`, `<div>`, `<span>`, or any other body-level elements inside `<Head>` can cause the browser to incorrectly parse your page. This often results in the confusing "next-head-count is missing" error at runtime because the browser moves invalid `<head>` elements into the `<body>`, breaking Next.js's internal tracking mechanism.
+
+## Possible Ways to Fix It
+
+### Remove invalid elements from Head
+
+If you have elements that don't belong in `<head>`, move them outside of the `<Head>` component.
+
+**Before**
+
+```jsx filename="pages/index.js"
+import Head from 'next/head'
+
+export default function Page() {
+  return (
+    <Head>
+      <title>My Page</title>
+      <html lang="en" />
+      <div>This should not be here</div>
+    </Head>
+  )
+}
+```
+
+**After**
+
+```jsx filename="pages/index.js"
+import Head from 'next/head'
+
+export default function Page() {
+  return (
+    <>
+      <Head>
+        <title>My Page</title>
+      </Head>
+      <div>Content goes in the body</div>
+    </>
+  )
+}
+```
+
+### Setting the lang attribute
+
+If you need to set the `lang` attribute on the `<html>` element, use a [Custom Document](/docs/pages/building-your-application/routing/custom-document):
+
+```jsx filename="pages/_document.js"
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}
+```
+
+### Setting body attributes
+
+If you need to set attributes on the `<body>` element, also use a Custom Document:
+
+```jsx filename="pages/_document.js"
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html>
+      <Head />
+      <body className="my-body-class">
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}
+```
+
+## Useful Links
+
+- [next/head](/docs/pages/api-reference/components/head)
+- [Custom Document](/docs/pages/building-your-application/routing/custom-document)
+- [MDN: head element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head)

--- a/packages/eslint-plugin-next/src/index.ts
+++ b/packages/eslint-plugin-next/src/index.ts
@@ -11,6 +11,7 @@ import noCssTags from './rules/no-css-tags'
 import noDocumentImportInPage from './rules/no-document-import-in-page'
 import noDuplicateHead from './rules/no-duplicate-head'
 import noHeadElement from './rules/no-head-element'
+import noInvalidHeadChildren from './rules/no-invalid-head-children'
 import noHeadImportInDocument from './rules/no-head-import-in-document'
 import noHtmlLinkForPages from './rules/no-html-link-for-pages'
 import noImgElement from './rules/no-img-element'
@@ -32,6 +33,7 @@ const recommendedRules = {
   '@next/next/no-css-tags': 'warn',
   '@next/next/no-head-element': 'warn',
   '@next/next/no-html-link-for-pages': 'warn',
+  '@next/next/no-invalid-head-children': 'warn',
   '@next/next/no-img-element': 'warn',
   '@next/next/no-page-custom-font': 'warn',
   '@next/next/no-styled-jsx-in-document': 'warn',
@@ -71,6 +73,7 @@ const plugin = {
     'no-duplicate-head': noDuplicateHead,
     'no-head-element': noHeadElement,
     'no-head-import-in-document': noHeadImportInDocument,
+    'no-invalid-head-children': noInvalidHeadChildren,
     'no-html-link-for-pages': noHtmlLinkForPages,
     'no-img-element': noImgElement,
     'no-page-custom-font': noPageCustomFont,

--- a/packages/eslint-plugin-next/src/rules/no-invalid-head-children.ts
+++ b/packages/eslint-plugin-next/src/rules/no-invalid-head-children.ts
@@ -1,0 +1,106 @@
+import { defineRule } from '../utils/define-rule'
+
+const url = 'https://nextjs.org/docs/messages/no-invalid-head-children'
+
+// Valid HTML elements that can be children of <head>
+// Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
+const VALID_HEAD_CHILDREN = new Set([
+  'title',
+  'meta',
+  'link',
+  'script',
+  'style',
+  'base',
+  'noscript',
+])
+
+export default defineRule({
+  meta: {
+    docs: {
+      description: 'Prevent usage of invalid HTML elements inside `next/head`.',
+      recommended: true,
+      url,
+    },
+    type: 'problem',
+    schema: [],
+  },
+  create(context) {
+    let nextHeadImportName: string | null = null
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'next/head') {
+          // Find the import name (could be renamed: import MyHead from 'next/head')
+          const defaultImport = node.specifiers.find(
+            (specifier) => specifier.type === 'ImportDefaultSpecifier'
+          )
+          if (defaultImport && defaultImport.local) {
+            nextHeadImportName = defaultImport.local.name
+          }
+        }
+      },
+      JSXElement(node) {
+        // Skip if next/head is not imported
+        if (!nextHeadImportName) {
+          return
+        }
+
+        // Check if this is a <Head> element from next/head
+        if (
+          !node.openingElement ||
+          !node.openingElement.name ||
+          !('name' in node.openingElement.name) ||
+          node.openingElement.name.name !== nextHeadImportName
+        ) {
+          return
+        }
+
+        // Check each child element
+        for (const child of node.children) {
+          // Only check JSX elements (skip text, expressions, etc.)
+          if (child.type !== 'JSXElement') {
+            continue
+          }
+
+          const childOpening = child.openingElement
+          if (!childOpening || !childOpening.name) {
+            continue
+          }
+
+          // Get the element name
+          let elementName: string | null = null
+          if ('name' in childOpening.name) {
+            // Regular JSX element like <div>
+            elementName = childOpening.name.name as string
+          } else if (
+            childOpening.name.type === 'JSXMemberExpression' ||
+            childOpening.name.type === 'JSXNamespacedName'
+          ) {
+            // Skip member expressions like <Component.Child> or namespaced <svg:rect>
+            // These are likely React components which are handled differently
+            continue
+          }
+
+          if (!elementName) {
+            continue
+          }
+
+          // Check if it's a React component (PascalCase) - skip those
+          // Components are allowed and may render valid head elements
+          if (elementName[0] === elementName[0].toUpperCase()) {
+            continue
+          }
+
+          // Check if the lowercase element name is valid
+          const lowerElementName = elementName.toLowerCase()
+          if (!VALID_HEAD_CHILDREN.has(lowerElementName)) {
+            context.report({
+              node: child,
+              message: `\`<${elementName}>\` is not a valid child of \`next/head\`. Only \`<title>\`, \`<meta>\`, \`<link>\`, \`<script>\`, \`<style>\`, \`<base>\`, and \`<noscript>\` are allowed. Using invalid elements can cause the "next-head-count is missing" error. See: ${url}`,
+            })
+          }
+        }
+      },
+    }
+  },
+})

--- a/test/unit/eslint-plugin-next/no-invalid-head-children.test.ts
+++ b/test/unit/eslint-plugin-next/no-invalid-head-children.test.ts
@@ -1,0 +1,463 @@
+import { RuleTester } from 'eslint'
+import { rules } from '@next/eslint-plugin-next'
+
+const NextESLintRule = rules['no-invalid-head-children']
+
+const errorMessage = (element: string) =>
+  `\`<${element}>\` is not a valid child of \`next/head\`. Only \`<title>\`, \`<meta>\`, \`<link>\`, \`<script>\`, \`<style>\`, \`<base>\`, and \`<noscript>\` are allowed. Using invalid elements can cause the "next-head-count is missing" error. See: https://nextjs.org/docs/messages/no-invalid-head-children`
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        modules: true,
+        jsx: true,
+      },
+    },
+  },
+})
+
+const tests = {
+  valid: [
+    // Valid: title element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <title>Page Title</title>
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: meta element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <meta name="description" content="A description" />
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: link element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <link rel="canonical" href="https://example.com" />
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: script element (native, not next/script)
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <script type="application/ld+json">{"@context": "https://schema.org"}</script>
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: style element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <style>{"body { margin: 0; }"}</style>
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: base element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <base href="https://example.com/" />
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: noscript element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <noscript>JavaScript is required</noscript>
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: multiple valid elements
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <title>My Page</title>
+              <meta name="description" content="Description" />
+              <link rel="icon" href="/favicon.ico" />
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: React component (PascalCase) - allowed since it may render valid elements
+    {
+      code: `
+        import Head from "next/head";
+        const MetaComponent = () => <meta name="test" content="test" />;
+        export default function Page() {
+          return (
+            <Head>
+              <MetaComponent />
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: Not using next/head import (different Head component)
+    {
+      code: `
+        const Head = ({children}) => <div>{children}</div>;
+        export default function Page() {
+          return (
+            <Head>
+              <div>This is fine</div>
+            </Head>
+          );
+        }
+      `,
+    },
+    // Valid: Renamed import
+    {
+      code: `
+        import MyHead from "next/head";
+        export default function Page() {
+          return (
+            <MyHead>
+              <title>Valid</title>
+            </MyHead>
+          );
+        }
+      `,
+    },
+    // Valid: Head element not from next/head
+    {
+      code: `
+        import { Helmet as Head } from "react-helmet";
+        export default function Page() {
+          return (
+            <Head>
+              <html lang="en" />
+            </Head>
+          );
+        }
+      `,
+    },
+  ],
+
+  invalid: [
+    // Invalid: html element inside Head
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <html lang="en" />
+              <title>Page</title>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('html') }],
+    },
+    // Invalid: body element inside Head
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <body className="dark" />
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('body') }],
+    },
+    // Invalid: div element inside Head
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <div>Invalid</div>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('div') }],
+    },
+    // Invalid: span element inside Head
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <span>Invalid</span>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('span') }],
+    },
+    // Invalid: p element inside Head
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <p>Invalid paragraph</p>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('p') }],
+    },
+    // Invalid: header element inside Head
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <header>Invalid</header>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('header') }],
+    },
+    // Invalid: img element inside Head
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <img src="/logo.png" alt="Logo" />
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('img') }],
+    },
+    // Invalid: multiple invalid elements
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <html lang="en" />
+              <div>Content</div>
+              <title>Page</title>
+            </Head>
+          );
+        }
+      `,
+      errors: [
+        { message: errorMessage('html') },
+        { message: errorMessage('div') },
+      ],
+    },
+    // Invalid: with renamed import
+    {
+      code: `
+        import MyHead from "next/head";
+        export default function Page() {
+          return (
+            <MyHead>
+              <div>Invalid</div>
+            </MyHead>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('div') }],
+    },
+    // Invalid: form element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <form>Invalid form</form>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('form') }],
+    },
+    // Invalid: nav element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <nav>Navigation</nav>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('nav') }],
+    },
+    // Invalid: section element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <section>Section content</section>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('section') }],
+    },
+    // Invalid: article element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <article>Article content</article>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('article') }],
+    },
+    // Invalid: aside element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <aside>Sidebar</aside>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('aside') }],
+    },
+    // Invalid: footer element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <footer>Footer</footer>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('footer') }],
+    },
+    // Invalid: main element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <main>Main content</main>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('main') }],
+    },
+    // Invalid: a (anchor) element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <a href="/">Home</a>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('a') }],
+    },
+    // Invalid: button element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <button>Click me</button>
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('button') }],
+    },
+    // Invalid: input element
+    {
+      code: `
+        import Head from "next/head";
+        export default function Page() {
+          return (
+            <Head>
+              <input type="text" />
+            </Head>
+          );
+        }
+      `,
+      errors: [{ message: errorMessage('input') }],
+    },
+  ],
+}
+
+describe('no-invalid-head-children', () => {
+  ruleTester.run('eslint', NextESLintRule, tests)
+})


### PR DESCRIPTION
## Summary

Adds a new ESLint rule `@next/next/no-invalid-head-children` that detects invalid HTML elements inside `next/head`.

This addresses the long-standing issue where putting elements like `<html>`, `<body>`, or `<div>` inside `<Head>` causes the browser to move them to the body, which then triggers the confusing "next-head-count is missing" error. Now users get a clear lint warning instead.

## What it does

- Warns when non-head elements are used inside `next/head`
- Allows only valid head children: `title`, `meta`, `link`, `script`, `style`, `base`, `noscript`
- Skips React components (PascalCase) since they might render valid elements
- Handles renamed imports (`import MyHead from 'next/head'`)

## Example

```jsx
import Head from 'next/head'

// This will now show a lint warning:
<Head>
  <html lang="en" />  // ❌ not valid
  <title>Page</title>  // ✓ valid
</Head>
```

## Changes

- Added `packages/eslint-plugin-next/src/rules/no-invalid-head-children.ts`
- Updated `packages/eslint-plugin-next/src/index.ts` to register the rule
- Added tests in `test/unit/eslint-plugin-next/`
- Added error docs in `errors/no-invalid-head-children.mdx`

## Related

Fixes #20924

This was suggested as an ESLint rule approach by @timneutkens in that issue.