### PR TITLE
Don't parse default postponedsizelimit

### DIFF
--- a/packages/next/src/shared/lib/size-limit.ts
+++ b/packages/next/src/shared/lib/size-limit.ts
@@ -2,6 +2,9 @@ import type { SizeLimit } from '../../types'
 
 export const DEFAULT_MAX_POSTPONED_STATE_SIZE: SizeLimit = '100 MB'
 
+// 100MB in bytes. Not using the parseSizeLimit for performance as parseMaxPostponedStateSize is in the hot path for rendering.
+const DEFAULT_MAX_POSTPONED_STATE_SIZE_BYTES = 104_857_600
+
 function parseSizeLimit(size: SizeLimit): number | undefined {
   const bytes = (
     require('next/dist/compiled/bytes') as typeof import('next/dist/compiled/bytes')
@@ -18,5 +21,8 @@ function parseSizeLimit(size: SizeLimit): number | undefined {
 export function parseMaxPostponedStateSize(
   size: SizeLimit | undefined
 ): number | undefined {
-  return parseSizeLimit(size ?? DEFAULT_MAX_POSTPONED_STATE_SIZE)
+  if (!size) {
+    return DEFAULT_MAX_POSTPONED_STATE_SIZE_BYTES
+  }
+  return parseSizeLimit(size)
 }


### PR DESCRIPTION
## For Maintainers

### What?

Optimize the `parseMaxPostponedStateSize` function by using a pre-calculated byte value for the default size limit instead of parsing it each time.

### Why?

This optimization improves performance (though it's a very small impact) since `parseMaxPostponedStateSize` is in the hot path for rendering. By using a pre-calculated constant value for the default case, we avoid unnecessary parsing operations.

### How?

- Added a constant `DEFAULT_MAX_POSTPONED_STATE_SIZE_BYTES` with the pre-calculated value of 100MB in bytes (104,857,600)
- Modified `parseMaxPostponedStateSize` to return the pre-calculated constant when no size is provided
- Only call `parseSizeLimit` when a custom size is specified
