### PR TITLE
Change UrlBehavior.static_suffix to ResolvedVc<Option<RcStr>>

### DIFF
--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -475,7 +475,6 @@ pub async fn get_client_chunking_context(
         should_use_absolute_url_references,
         css_url_suffix,
     } = options;
-    let css_url_suffix = css_url_suffix.owned().await?;
 
     let next_mode = mode.await?;
     let asset_prefix = asset_prefix.owned().await?;
@@ -510,7 +509,7 @@ pub async fn get_client_chunking_context(
     .worker_forwarded_globals(worker_forwarded_globals())
     .default_url_behavior(UrlBehavior {
         suffix: AssetSuffix::Inferred,
-        static_suffix: css_url_suffix,
+        static_suffix: css_url_suffix.to_resolved().await?,
     });
 
     if next_mode.is_development() {

--- a/crates/next-core/src/next_edge/context.rs
+++ b/crates/next-core/src/next_edge/context.rs
@@ -249,7 +249,6 @@ pub async fn get_edge_chunking_context_with_client_assets(
         asset_prefix,
         css_url_suffix,
     } = options;
-    let css_url_suffix = css_url_suffix.owned().await?;
     let output_root = node_root.join("server/edge")?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
@@ -265,7 +264,7 @@ pub async fn get_edge_chunking_context_with_client_assets(
     .asset_base_path(Some(asset_prefix))
     .default_url_behavior(UrlBehavior {
         suffix: AssetSuffix::Inferred,
-        static_suffix: css_url_suffix,
+        static_suffix: css_url_suffix.to_resolved().await?,
     })
     .minify_type(if *turbo_minify.await? {
         MinifyType::Minify {
@@ -327,7 +326,7 @@ pub async fn get_edge_chunking_context(
         asset_prefix,
         css_url_suffix,
     } = options;
-    let css_url_suffix = css_url_suffix.owned().await?;
+    let css_url_suffix = css_url_suffix.to_resolved().await?;
     let output_root = node_root.join("server/edge")?;
     let next_mode = mode.await?;
     let mut builder = BrowserChunkingContext::builder(
@@ -347,7 +346,7 @@ pub async fn get_edge_chunking_context(
         rcstr!("client"),
         UrlBehavior {
             suffix: AssetSuffix::FromGlobal(rcstr!("NEXT_CLIENT_ASSET_SUFFIX")),
-            static_suffix: css_url_suffix.clone(),
+            static_suffix: css_url_suffix,
         },
     )
     .default_url_behavior(UrlBehavior {

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -1062,7 +1062,7 @@ pub async fn get_server_chunking_context_with_client_assets(
         asset_prefix,
         css_url_suffix,
     } = options;
-    let css_url_suffix = css_url_suffix.owned().await?;
+    let css_url_suffix = css_url_suffix.to_resolved().await?;
 
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
@@ -1083,7 +1083,7 @@ pub async fn get_server_chunking_context_with_client_assets(
         rcstr!("client"),
         UrlBehavior {
             suffix: AssetSuffix::FromGlobal(rcstr!("NEXT_CLIENT_ASSET_SUFFIX")),
-            static_suffix: css_url_suffix.clone(),
+            static_suffix: css_url_suffix,
         },
     )
     .default_url_behavior(UrlBehavior {
@@ -1160,7 +1160,7 @@ pub async fn get_server_chunking_context(
         asset_prefix,
         css_url_suffix,
     } = options;
-    let css_url_suffix = css_url_suffix.owned().await?;
+    let css_url_suffix = css_url_suffix.to_resolved().await?;
     let next_mode = mode.await?;
     // TODO(alexkirsz) This should return a trait that can be implemented by the
     // different server chunking contexts. OR the build chunking context should
@@ -1182,7 +1182,7 @@ pub async fn get_server_chunking_context(
         rcstr!("client"),
         UrlBehavior {
             suffix: AssetSuffix::FromGlobal(rcstr!("NEXT_CLIENT_ASSET_SUFFIX")),
-            static_suffix: css_url_suffix.clone(),
+            static_suffix: css_url_suffix,
         },
     )
     .default_url_behavior(UrlBehavior {

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -680,7 +680,7 @@ impl ChunkingContext for BrowserChunkingContext {
             .or_else(|| self.default_url_behavior.clone())
             .unwrap_or(UrlBehavior {
                 suffix: AssetSuffix::Inferred,
-                static_suffix: None,
+                static_suffix: ResolvedVc::cell(None),
             })
             .cell()
     }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -100,7 +100,7 @@ pub struct UrlBehavior {
     pub suffix: AssetSuffix,
     /// Static suffix for contexts that cannot use dynamic JS expressions (e.g., CSS `url()`
     /// references). Must be a constant string known at build time (e.g., `?dpl=<deployment_id>`).
-    pub static_suffix: Option<RcStr>,
+    pub static_suffix: ResolvedVc<Option<RcStr>>,
 }
 
 #[derive(
@@ -361,7 +361,7 @@ pub trait ChunkingContext {
     fn url_behavior(self: Vc<Self>, _tag: Option<RcStr>) -> Vc<UrlBehavior> {
         UrlBehavior {
             suffix: AssetSuffix::Inferred,
-            static_suffix: None,
+            static_suffix: ResolvedVc::cell(None),
         }
         .cell()
     }

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -126,7 +126,7 @@ pub async fn resolve_url_reference(
 
         // Append the static suffix from UrlBehavior if configured (e.g., ?dpl=<deployment_id>).
         let url_behavior = chunking_context.url_behavior(None).await?;
-        let url_with_suffix = if let Some(ref suffix) = url_behavior.static_suffix {
+        let url_with_suffix = if let Some(ref suffix) = *url_behavior.static_suffix.await? {
             format!("{}{}", url_path, suffix).into()
         } else {
             url_path

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -488,7 +488,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             .or_else(|| self.default_url_behavior.clone())
             .unwrap_or(UrlBehavior {
                 suffix: AssetSuffix::Inferred,
-                static_suffix: None,
+                static_suffix: ResolvedVc::cell(None),
             })
             .cell()
     }


### PR DESCRIPTION
## Summary

Changes `UrlBehavior.static_suffix` from `Option<RcStr>` to `ResolvedVc<Option<RcStr>>` so that `css_url_suffix` stays as a Vc longer instead of being eagerly resolved at the call site. This improves caching behavior by keeping the value cell-based through the chunking context construction.

- Updated `UrlBehavior` struct definition in `turbopack-core`
- Updated default fallbacks in browser/nodejs chunking contexts
- Updated CSS url reference consumer to `.await?` the `ResolvedVc`
- Replaced `.owned().await?` with `.to_resolved().await?` in next-core callers