### PR TITLE
fix: trigger MPA navigation for server action redirects with build ID mismatch

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1189,7 +1189,9 @@ export async function handler(
       // Set the build ID header for RSC navigation requests when deploymentId is configured. This
       // corresponds with maybeAppendBuildIdToRSCPayload in app-render.tsx which omits the build ID
       // from the RSC payload when deploymentId is set (relying on this header instead). Server
-      // actions are excluded because the client doesn't check the build ID for action responses.
+      // actions are excluded here because action redirect responses get the deployment ID header
+      // from the pre-fetched redirect target (via createRedirectRenderResult in action-handler.ts
+      // which copies headers from the internal RSC fetch).
       // For static prerenders served from CDN, routes-manifest.json adds a header.
       if (isRSCRequest && !isPossibleServerAction && deploymentId) {
         res.setHeader(NEXT_NAV_DEPLOYMENT_ID_HEADER, deploymentId)

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -48,6 +48,8 @@ import {
 import { invalidateEntirePrefetchCache } from '../../segment-cache/cache'
 import { startRevalidationCooldown } from '../../segment-cache/scheduler'
 import { getDeploymentId } from '../../../../shared/lib/deployment-id'
+import { getNavigationBuildId } from '../../../navigation-build-id'
+import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../../lib/constants'
 import {
   completeHardNavigation,
   convertServerPatchToFullTree,
@@ -215,13 +217,32 @@ async function fetchServerAction(
       }
     )
 
-    // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
-    actionResult = redirectLocation ? undefined : response.a
-    couldBeIntercepted = response.i
-    const maybeFlightData = normalizeFlightData(response.f)
-    if (maybeFlightData !== '') {
-      actionFlightData = maybeFlightData
-      actionFlightDataRenderedSearch = response.q as NormalizedSearch
+    // Check if the response build ID matches the client build ID.
+    // In a multi-zone setup, the server may pre-fetch the redirect target
+    // from a different Next.js project with a different build ID. If so,
+    // we should discard the flight data and let the redirect trigger an
+    // MPA navigation instead.
+    const responseBuildId =
+      res.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? response.b
+    if (
+      responseBuildId !== undefined &&
+      responseBuildId !== getNavigationBuildId()
+    ) {
+      // Build ID mismatch — the RSC data came from a different build.
+      // Discard the flight data. The redirect will still be processed,
+      // and the absence of flight data will cause an MPA navigation
+      // via completeHardNavigation().
+      actionResult = redirectLocation ? undefined : response.a
+      couldBeIntercepted = response.i
+    } else {
+      // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
+      actionResult = redirectLocation ? undefined : response.a
+      couldBeIntercepted = response.i
+      const maybeFlightData = normalizeFlightData(response.f)
+      if (maybeFlightData !== '') {
+        actionFlightData = maybeFlightData
+        actionFlightDataRenderedSearch = response.q as NormalizedSearch
+      }
     }
   } else {
     // An external redirect doesn't contain RSC data.

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -217,27 +217,28 @@ async function fetchServerAction(
       }
     )
 
+    // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
+    actionResult = redirectLocation ? undefined : response.a
+    couldBeIntercepted = response.i
+
     // Check if the response build ID matches the client build ID.
-    // In a multi-zone setup, the server may pre-fetch the redirect target
-    // from a different Next.js project with a different build ID. If so,
-    // we should discard the flight data and let the redirect trigger an
-    // MPA navigation instead.
+    // In a multi-zone setup, when a server action triggers a redirect,
+    // the server pre-fetches the redirect target as RSC. If the redirect
+    // target is served by a different Next.js zone (different build), the
+    // pre-fetched RSC data will have a foreign build ID. We must discard
+    // the flight data in that case so the redirect triggers an MPA
+    // navigation (full page load) instead of trying to apply the foreign
+    // RSC payload — which would result in a blank page.
     const responseBuildId =
       res.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? response.b
     if (
       responseBuildId !== undefined &&
       responseBuildId !== getNavigationBuildId()
     ) {
-      // Build ID mismatch — the RSC data came from a different build.
-      // Discard the flight data. The redirect will still be processed,
-      // and the absence of flight data will cause an MPA navigation
-      // via completeHardNavigation().
-      actionResult = redirectLocation ? undefined : response.a
-      couldBeIntercepted = response.i
+      // Build ID mismatch — discard the flight data. The redirect will
+      // still be processed, and the absence of flight data will cause an
+      // MPA navigation via completeHardNavigation().
     } else {
-      // An internal redirect can send an RSC response, but does not have a useful `actionResult`.
-      actionResult = redirectLocation ? undefined : response.a
-      couldBeIntercepted = response.i
       const maybeFlightData = normalizeFlightData(response.f)
       if (maybeFlightData !== '') {
         actionFlightData = maybeFlightData

--- a/test/e2e/app-dir/segment-cache/deployment-skew/app/action-redirect/page.jsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/app/action-redirect/page.jsx
@@ -1,10 +1,19 @@
-import { ActionRedirectButton } from '../../components/action-redirect-button'
+import { redirect } from 'next/navigation'
+
+async function redirectToOtherDeployment() {
+  'use server'
+  redirect('/dynamic-page?deployment=2')
+}
 
 export default function ActionRedirectPage() {
   return (
     <div>
       <h1 id="action-page">Action Redirect Page</h1>
-      <ActionRedirectButton />
+      <form action={redirectToOtherDeployment}>
+        <button id="redirect-action-button" type="submit">
+          Redirect via Server Action
+        </button>
+      </form>
     </div>
   )
 }

--- a/test/e2e/app-dir/segment-cache/deployment-skew/app/action-redirect/page.jsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/app/action-redirect/page.jsx
@@ -2,6 +2,11 @@ import { redirect } from 'next/navigation'
 
 async function redirectToOtherDeployment() {
   'use server'
+  // Route the redirect prefetch back through the test proxy so the action
+  // response can come from deployment 2 instead of the current worker.
+  if (process.env.TEST_PROXY_ORIGIN) {
+    process.env.__NEXT_PRIVATE_ORIGIN = process.env.TEST_PROXY_ORIGIN
+  }
   redirect('/dynamic-page?deployment=2')
 }
 

--- a/test/e2e/app-dir/segment-cache/deployment-skew/app/action-redirect/page.jsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/app/action-redirect/page.jsx
@@ -1,0 +1,10 @@
+import { ActionRedirectButton } from '../../components/action-redirect-button'
+
+export default function ActionRedirectPage() {
+  return (
+    <div>
+      <h1 id="action-page">Action Redirect Page</h1>
+      <ActionRedirectButton />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/components/action-redirect-button.tsx
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/components/action-redirect-button.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { redirectToOtherDeployment } from './redirect-action'
+
+export function ActionRedirectButton() {
+  return (
+    <form action={redirectToOtherDeployment}>
+      <button id="redirect-action-button" type="submit">
+        Redirect via Server Action
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/components/redirect-action.ts
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/components/redirect-action.ts
@@ -1,0 +1,8 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+
+export async function redirectToOtherDeployment() {
+  // Redirect to the dynamic page on deployment 2
+  redirect('/dynamic-page?deployment=2')
+}

--- a/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
@@ -165,14 +165,19 @@ function runTests(getPort: () => number) {
       const heading = await browser.elementById('action-page')
       expect(await heading.text()).toBe('Action Redirect Page')
 
-      // Click the button that triggers the server action redirect
+      // Click the button that triggers the server action redirect.
+      // The proxy intercepts the server action response and injects a
+      // foreign x-nextjs-deployment-id header, simulating a deployment
+      // skew scenario where the server response comes from a different
+      // deployment than the client.
       const button = await browser.elementById('redirect-action-button')
       await button.click()
 
       // Wait for the navigation to complete.
-      // The redirect target is served by deployment 2, which has a different
-      // build ID. The client should detect the build ID mismatch and perform
-      // an MPA navigation (full page load) instead of a client-side transition.
+      // The client detects the deployment ID mismatch in the response
+      // header and discards the flight data, triggering an MPA navigation
+      // (full page load) to the redirect target. The redirect URL
+      // (/dynamic-page?deployment=2) goes through the proxy to deployment 2.
       const buildId = await browser.waitForElementByCss('#build-id', 30000)
       expect(await buildId.text()).toBe('Build ID: 2')
     },

--- a/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
@@ -38,7 +38,7 @@ describe('segment cache (deployment skew)', () => {
         await cleanup()
       })
 
-      runTests(() => port)
+      runTests('BUILD_ID', () => port)
     })
 
     describe('with NEXT_DEPLOYMENT_ID', () => {
@@ -54,7 +54,7 @@ describe('segment cache (deployment skew)', () => {
         await cleanup()
       })
 
-      runTests(() => port)
+      runTests('DEPLOYMENT_ID', () => port)
     })
   }
 
@@ -84,7 +84,7 @@ describe('segment cache (deployment skew)', () => {
   })
 })
 
-function runTests(getPort: () => number) {
+function runTests(mode: 'BUILD_ID' | 'DEPLOYMENT_ID', getPort: () => number) {
   it(
     'does not crash when prefetching a dynamic, non-PPR page ' +
       'on a different deployment',
@@ -163,6 +163,7 @@ function runTests(getPort: () => number) {
       await browser.eval('window.next.router.push("/action-redirect")')
       await browser.waitForElementByCss('#action-page')
       let sawActionRequest = false
+      let sawRedirectActionResponse = false
       let actionResponseDeploymentId: string | undefined
       browser.on('request', (request: Playwright.Request) => {
         const headers = request.headers()
@@ -178,6 +179,7 @@ function runTests(getPort: () => number) {
 
         const headers = response.headers()
         if (headers['x-action-redirect']) {
+          sawRedirectActionResponse = true
           actionResponseDeploymentId = headers['x-nextjs-deployment-id']
         }
       })
@@ -187,28 +189,34 @@ function runTests(getPort: () => number) {
       expect(await heading.text()).toBe('Action Redirect Page')
 
       // Click the button that triggers the server action redirect.
-      // The proxy intercepts the server action response and injects a
-      // foreign x-nextjs-deployment-id header, simulating a deployment
-      // skew scenario where the server response comes from a different
-      // deployment than the client.
-      await retry(async () => {
-        if (!sawActionRequest) {
-          const button = await browser.elementById('redirect-action-button')
-          await button.click()
-        }
-        expect(sawActionRequest).toBe(true)
-      }, 10_000)
+      // In deployment ID mode, the proxy injects a foreign
+      // x-nextjs-deployment-id header to simulate skew. In build ID mode,
+      // the response omits that header so the client falls back to the
+      // build ID carried in the action Flight payload.
+      const button = await browser.elementById('redirect-action-button')
+      await button.click()
 
       await retry(async () => {
-        expect(actionResponseDeploymentId).toBe('foreign-deployment')
+        expect(sawActionRequest).toBe(true)
       })
 
+      await retry(async () => {
+        expect(sawRedirectActionResponse).toBe(true)
+      })
+
+      if (mode === 'DEPLOYMENT_ID') {
+        expect(actionResponseDeploymentId).toBe('foreign-deployment')
+      } else {
+        expect(actionResponseDeploymentId).toBeUndefined()
+      }
+
       // Wait for the navigation to complete.
-      // The client detects the deployment ID mismatch in the response
-      // header and discards the flight data, triggering an MPA navigation
-      // (full page load) to the redirect target. The redirect URL
-      // (/dynamic-page?deployment=2) goes through the proxy to deployment 2.
-      const buildId = await browser.waitForElementByCss('#build-id', 30000)
+      // The client detects the mismatch in either the response header or
+      // the fallback build ID field and discards the flight data,
+      // triggering an MPA navigation (full page load) to the redirect
+      // target. The redirect URL (/dynamic-page?deployment=2) goes through
+      // the proxy to deployment 2.
+      const buildId = await browser.waitForElementByCss('#build-id')
       expect(await buildId.text()).toBe('Build ID: 2')
     },
     60 * 1000

--- a/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
@@ -1,7 +1,7 @@
 import type * as Playwright from 'playwright'
 import webdriver from 'next-webdriver'
 import { createRouterAct } from 'router-act'
-import { findPort } from 'next-test-utils'
+import { findPort, retry } from 'next-test-utils'
 import { isNextDeploy, isNextDev, isNextStart, nextTestSetup } from 'e2e-utils'
 import { build, start } from './servers.mjs'
 
@@ -159,7 +159,28 @@ function runTests(getPort: () => number) {
       // target is served by a different deployment (different build ID), the
       // client falls back to an MPA navigation instead of attempting to apply
       // the foreign RSC payload.
-      const browser = await webdriver(getPort(), '/action-redirect')
+      const browser = await webdriver(getPort(), '/')
+      await browser.eval('window.next.router.push("/action-redirect")')
+      await browser.waitForElementByCss('#action-page')
+      let sawActionRequest = false
+      let actionResponseDeploymentId: string | undefined
+      browser.on('request', (request: Playwright.Request) => {
+        const headers = request.headers()
+        if (request.method() === 'POST' && headers['next-action']) {
+          sawActionRequest = true
+        }
+      })
+      browser.on('response', async (response: Playwright.Response) => {
+        const request = response.request()
+        if (request.method() !== 'POST') {
+          return
+        }
+
+        const headers = response.headers()
+        if (headers['x-action-redirect']) {
+          actionResponseDeploymentId = headers['x-nextjs-deployment-id']
+        }
+      })
 
       // Verify we're on the action redirect page
       const heading = await browser.elementById('action-page')
@@ -170,8 +191,17 @@ function runTests(getPort: () => number) {
       // foreign x-nextjs-deployment-id header, simulating a deployment
       // skew scenario where the server response comes from a different
       // deployment than the client.
-      const button = await browser.elementById('redirect-action-button')
-      await button.click()
+      await retry(async () => {
+        if (!sawActionRequest) {
+          const button = await browser.elementById('redirect-action-button')
+          await button.click()
+        }
+        expect(sawActionRequest).toBe(true)
+      }, 10_000)
+
+      await retry(async () => {
+        expect(actionResponseDeploymentId).toBe('foreign-deployment')
+      })
 
       // Wait for the navigation to complete.
       // The client detects the deployment ID mismatch in the response

--- a/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
@@ -151,4 +151,31 @@ function runTests(getPort: () => number) {
     },
     60 * 1000
   )
+
+  it(
+    'triggers MPA navigation when a server action redirects to a different deployment',
+    async () => {
+      // Verify that when a server action calls redirect() and the redirect
+      // target is served by a different deployment (different build ID), the
+      // client falls back to an MPA navigation instead of attempting to apply
+      // the foreign RSC payload.
+      const browser = await webdriver(getPort(), '/action-redirect')
+
+      // Verify we're on the action redirect page
+      const heading = await browser.elementById('action-page')
+      expect(await heading.text()).toBe('Action Redirect Page')
+
+      // Click the button that triggers the server action redirect
+      const button = await browser.elementById('redirect-action-button')
+      await button.click()
+
+      // Wait for the navigation to complete.
+      // The redirect target is served by deployment 2, which has a different
+      // build ID. The client should detect the build ID mismatch and perform
+      // an MPA navigation (full page load) instead of a client-side transition.
+      const buildId = await browser.waitForElementByCss('#build-id', 30000)
+      expect(await buildId.text()).toBe('Build ID: 2')
+    },
+    60 * 1000
+  )
 }

--- a/test/e2e/app-dir/segment-cache/deployment-skew/servers.mjs
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/servers.mjs
@@ -32,9 +32,12 @@ function getEnv(id, mode) {
   }
 }
 
-async function spawnNext(id, mode, port) {
+async function spawnNext(id, mode, port, extraEnv = {}) {
   const child = spawn('pnpm', ['next', 'start', '-p', port, dir], {
-    env: getEnv(id, mode),
+    env: {
+      ...getEnv(id, mode),
+      ...extraEnv,
+    },
     stdio: ['inherit', 'pipe', 'inherit'],
   })
 
@@ -75,24 +78,28 @@ export async function start(
   nextPort2 = mainPort + 2,
   mode = 'BUILD_ID'
 ) {
+  const extraEnv = {
+    TEST_PROXY_ORIGIN: `http://localhost:${mainPort}`,
+  }
+
   // Start two different Next.js servers, one with BUILD_ID=1 and one
   // with BUILD_ID=2
   const [next1, next2] = await Promise.all([
-    spawnNext('1', mode, nextPort1),
-    spawnNext('2', mode, nextPort2),
+    spawnNext('1', mode, nextPort1, extraEnv),
+    spawnNext('2', mode, nextPort2, extraEnv),
   ])
 
   // Create a proxy server. If search params include `deployment=2`, proxy to
   // to the second next server. Otherwise, proxy to the first.
   const proxy = httpProxy.createProxyServer()
 
-  // Simulate deployment skew for server action responses. When a POST
-  // (server action) is handled by deployment 1, inject a foreign
-  // x-nextjs-deployment-id header so the client detects a build ID
-  // mismatch and triggers an MPA navigation. This simulates the real-world
-  // scenario where a CDN/load balancer adds skew protection headers.
+  // Simulate deployment skew for deployment ID-based action responses. When a
+  // POST (server action) is handled by deployment 1, inject a foreign
+  // x-nextjs-deployment-id header so the client detects a mismatch and
+  // triggers an MPA navigation. BUILD_ID mode intentionally skips this so the
+  // test exercises the response.b fallback instead.
   proxy.on('proxyRes', (proxyRes, req) => {
-    if (req.method === 'POST') {
+    if (mode === 'DEPLOYMENT_ID' && req.method === 'POST') {
       proxyRes.headers['x-nextjs-deployment-id'] = 'foreign-deployment'
     }
   })

--- a/test/e2e/app-dir/segment-cache/deployment-skew/servers.mjs
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/servers.mjs
@@ -8,16 +8,23 @@ import process from 'node:process'
 const dir = dirname(fileURLToPath(import.meta.url))
 
 function getEnv(id, mode) {
+  const base = {
+    ...process.env,
+    DIST_DIR: id,
+    // Required so the build includes the __NEXT_HYDRATED callback used by
+    // webdriver() to detect hydration. Without this, the hydration check
+    // always times out and tests may interact with the page before the
+    // React app router is initialized.
+    __NEXT_TEST_MODE: 'e2e',
+  }
   if (mode === 'BUILD_ID') {
     return {
-      ...process.env,
-      DIST_DIR: id,
+      ...base,
       NEXT_PUBLIC_BUILD_ID: id,
     }
   } else if (mode === 'DEPLOYMENT_ID') {
     return {
-      ...process.env,
-      DIST_DIR: id,
+      ...base,
       NEXT_DEPLOYMENT_ID: id,
     }
   } else {
@@ -78,6 +85,18 @@ export async function start(
   // Create a proxy server. If search params include `deployment=2`, proxy to
   // to the second next server. Otherwise, proxy to the first.
   const proxy = httpProxy.createProxyServer()
+
+  // Simulate deployment skew for server action responses. When a POST
+  // (server action) is handled by deployment 1, inject a foreign
+  // x-nextjs-deployment-id header so the client detects a build ID
+  // mismatch and triggers an MPA navigation. This simulates the real-world
+  // scenario where a CDN/load balancer adds skew protection headers.
+  proxy.on('proxyRes', (proxyRes, req) => {
+    if (req.method === 'POST') {
+      proxyRes.headers['x-nextjs-deployment-id'] = 'foreign-deployment'
+    }
+  })
+
   const server = createServer((req, res) => {
     let port = nextPort1
     if (req.url) {


### PR DESCRIPTION
## Summary

- Fixes cross-zone server action redirect failure where `redirect()` inside a server action produces a blank page when the target path is served by a different Next.js zone (separate Vercel project, same domain)
- Adds build ID validation to `server-action-reducer.ts`, matching the existing pattern in `fetch-server-response.ts`
- Adds e2e test in the deployment-skew test suite to verify server action redirects with build ID mismatch trigger MPA navigation

## Background

When a server action calls `redirect()`, the server pre-fetches the redirect target and includes the RSC data in the response. In a multi-zone setup (same domain, different Next.js projects), this pre-fetched RSC data comes from a different build with a different build ID.

The `fetch-server-response.ts` file already checks for build ID mismatches during regular navigations (line 245-251) and triggers MPA navigation when detected. However, `server-action-reducer.ts` was missing this check, causing the client to try to apply the foreign RSC payload — resulting in a blank page.

## Fix

Added a build ID check in `fetchServerAction()` after parsing the RSC response. When a mismatch is detected, the flight data is discarded. The existing reducer logic at line 364-370 already handles this case:

```typescript
if (flightData === undefined && redirectLocation !== undefined) {
  return completeHardNavigation(state, redirectLocation, navigateType)
}
```

This triggers an MPA navigation (full page load), which is the correct behavior for cross-zone redirects.

## Repro

- https://repro-main-app.vercel.app/test-redirect
  - Red button (server action redirect) → blank page (before fix) / full page load (after fix)
  - Green link (normal `<a>`) → works fine

Closes https://linear.app/vercel/issue/NEXT-4856