### PR TITLE
fix(next/legacy/image): add deployment id (dpl) query string support

### DIFF
--- a/packages/next/src/client/legacy/image.tsx
+++ b/packages/next/src/client/legacy/image.tsx
@@ -24,6 +24,7 @@ import { ImageConfigContext } from '../../shared/lib/image-config-context.shared
 import { warnOnce } from '../../shared/lib/utils/warn-once'
 import { normalizePathTrailingSlash } from '../normalize-trailing-slash'
 import { findClosestQuality } from '../../shared/lib/find-closest-quality'
+import { getDeploymentId } from '../../shared/lib/deployment-id'
 
 function normalizeSrc(src: string): string {
   return src[0] === '/' ? src.slice(1) : src
@@ -126,6 +127,19 @@ function defaultLoader({
     return src
   }
 
+  // Extract dpl parameter early so validation uses the clean URL
+  let deploymentId = getDeploymentId()
+  if (src.startsWith('/')) {
+    const srcUrl = new URL(src, 'http://n')
+    const srcDpl = srcUrl.searchParams.get('dpl')
+    if (srcDpl) {
+      deploymentId = srcDpl
+      // Remove the dpl parameter from the src URL to avoid duplication
+      srcUrl.searchParams.delete('dpl')
+      src = srcUrl.href.slice('http://n'.length)
+    }
+  }
+
   if (
     src.startsWith('/') &&
     src.includes('?') &&
@@ -213,7 +227,9 @@ function defaultLoader({
 
   return `${normalizePathTrailingSlash(config.path)}?url=${encodeURIComponent(
     src
-  )}&w=${width}&q=${q}`
+  )}&w=${width}&q=${q}${
+    src.startsWith('/') && deploymentId ? `&dpl=${deploymentId}` : ''
+  }`
 }
 
 const loaders = new Map<


### PR DESCRIPTION
## What?

Add deployment ID (`?dpl`) query string support to `next/legacy/image`.

## Why?

The shared `image-loader.ts` (used by `next/image`) already extracts and appends the `?dpl` deployment ID to optimized image URLs. The legacy image component (`next/legacy/image`) has its own inline `defaultLoader` that was missing this handling, causing inconsistent behavior between the two components.

## How?

Ported the `?dpl` deployment ID logic from `image-loader.ts` to the legacy component's `defaultLoader`:

1. Import `getDeploymentId` from the shared deployment-id module
2. Extract `?dpl` from the src URL before validation (to avoid false positives on query string checks)
3. Append `&dpl=<deploymentId>` to the optimized image URL for local images