### PR TITLE
Turbopack: don't resolve to TS file in node_modules

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/ts-node-modules/input/index.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/ts-node-modules/input/index.js
@@ -1,0 +1,5 @@
+import foo from 'foo/plugin'
+
+it("shouldn't try to resolve TS file in node_modules", () => {
+  expect(foo).toBe('this is plugin.js')
+})

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/ts-node-modules/input/node_modules/foo/plugin.js
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/ts-node-modules/input/node_modules/foo/plugin.js
@@ -1,0 +1,1 @@
+export default 'this is plugin.js'

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/ts-node-modules/input/node_modules/foo/plugin.ts
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/resolving/ts-node-modules/input/node_modules/foo/plugin.ts
@@ -1,0 +1,1 @@
+export default 'this is plugin.ts'


### PR DESCRIPTION
Resolver `extension` list shouldn't actually be chosen depending on the importer,
but based on the resulting folder path (so that it doesn't use sub.ts for import "some-npm-package/sub" from user code)

Closes #76182
Closes PACK-3985