### PR TITLE
[test] Current behavior of focus after `next/link` navigation

### DIFF
--- a/test/e2e/app-dir/navigation-focus/app/interactive-segment/page.tsx
+++ b/test/e2e/app-dir/navigation-focus/app/interactive-segment/page.tsx
@@ -1,0 +1,9 @@
+export default function InteractiveSegmentPage() {
+  return (
+    <textarea
+      data-testid="segment-container"
+      style={{ height: '50vh' }}
+      placeholder="Type here"
+    />
+  )
+}

--- a/test/e2e/app-dir/navigation-focus/app/layout.tsx
+++ b/test/e2e/app-dir/navigation-focus/app/layout.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import './styles.css'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <nav aria-label="Main navigation">
+          <ul>
+            <li>
+              <Link href="/">Home</Link>
+            </li>
+            <li>
+              <Link href="/interactive-segment">Interactive Segment</Link>
+            </li>
+            <li>
+              <Link href="/scrollable-segment">Scrollable Segment</Link>
+            </li>
+            <li>
+              <Link href="/segment-with-focusable-descendant">
+                Segment with focusable descendant
+              </Link>
+            </li>
+            <li>
+              <Link href="/uri-fragments#section-2">
+                to URI fragment in different Segment
+              </Link>
+            </li>
+            <li>
+              <Link href="/uri-fragments">Segment with URI fragments</Link>
+            </li>
+          </ul>
+        </nav>
+        <main>{children}</main>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/navigation-focus/app/page.tsx
+++ b/test/e2e/app-dir/navigation-focus/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p data-testid="segment-container">Hello, Dave!</p>
+}

--- a/test/e2e/app-dir/navigation-focus/app/scrollable-segment/page.tsx
+++ b/test/e2e/app-dir/navigation-focus/app/scrollable-segment/page.tsx
@@ -1,0 +1,10 @@
+export default function ScrollableSegmentPage() {
+  return (
+    <div
+      data-testid="segment-container"
+      style={{ height: '50vh', overflow: 'scroll' }}
+    >
+      <div style={{ height: '60vh' }}>Scroll me</div>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation-focus/app/segment-with-focusable-descendant/page.tsx
+++ b/test/e2e/app-dir/navigation-focus/app/segment-with-focusable-descendant/page.tsx
@@ -1,0 +1,7 @@
+export default function SegmentWithFocusableDescendant() {
+  return (
+    <div>
+      <button type="button">Focusable Button</button>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/navigation-focus/app/styles.css
+++ b/test/e2e/app-dir/navigation-focus/app/styles.css
@@ -1,0 +1,11 @@
+:target {
+  outline: 4px solid #1177cc;
+}
+
+:focus {
+  outline: 4px dashed #dd1199;
+}
+
+:focus-visible {
+  outline: 4px solid #dd1199;
+}

--- a/test/e2e/app-dir/navigation-focus/app/uri-fragments/page.tsx
+++ b/test/e2e/app-dir/navigation-focus/app/uri-fragments/page.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link'
+
+export default function UriFragmentsPage() {
+  return (
+    <>
+      <nav aria-label="table of contents">
+        <ol>
+          <li>
+            <Link href="#section-1">Section 1</Link>
+          </li>
+          <li>
+            <Link href="#section-2">Section 2</Link>
+          </li>
+          <li>
+            <Link href="#section-3">Section 3</Link>
+          </li>
+        </ol>
+      </nav>
+
+      <article style={{ height: '50vh', overflow: 'scroll' }}>
+        <h1>A post</h1>
+
+        <p style={{ height: '100vh' }}>some long intro</p>
+
+        <h2 id="section-1">Section 1</h2>
+        <p style={{ height: '100vh' }}>bla</p>
+
+        <h2 id="section-2">Section 2</h2>
+        <p style={{ height: '100vh' }}>bla</p>
+
+        <h2 id="section-3">Section 3</h2>
+        <p style={{ height: '100vh' }}>bla</p>
+
+        <h2 id="section-4">Section 4</h2>
+        <p style={{ height: '100vh' }}>bla</p>
+      </article>
+    </>
+  )
+}

--- a/test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
+++ b/test/e2e/app-dir/navigation-focus/navigation-focus.test.ts
@@ -1,0 +1,88 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+const enableNewScrollHandler =
+  process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER === 'true'
+
+describe('navigation-focus', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('navigation to an interactive segment', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('a[href="/interactive-segment"]').click()
+
+    await retry(async () => {
+      // Good debug info is a moving target. Use Playwright traces to find out
+      // what was focused if this fails
+      expect(
+        await browser.eval(() =>
+          document.activeElement.getAttribute('data-testid')
+        )
+      ).toBe('segment-container')
+    })
+  })
+
+  it('navigation to a scrollable segment', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('a[href="/scrollable-segment"]').click()
+
+    await retry(async () => {
+      expect(
+        await browser.eval(() =>
+          document.activeElement.getAttribute('data-testid')
+        )
+      ).toBe('segment-container')
+    })
+  })
+
+  it('navigation to a segment with a focusable descendant', async () => {
+    const browser = await next.browser('/')
+    await browser
+      .elementByCss('a[href="/segment-with-focusable-descendant"]')
+      .click()
+
+    await retry(async () => {
+      if (enableNewScrollHandler) {
+        // Focus goes to the focusable descendant, not the segment itself
+        expect(
+          await browser.eval(() => document.activeElement.textContent)
+        ).toBe('Focusable Button')
+      } else {
+        // Focus stays on the original link
+        expect(
+          await browser.eval(() => document.activeElement.getAttribute('href'))
+        ).toBe('/segment-with-focusable-descendant')
+      }
+    })
+  })
+
+  it('navigation to a fragment within a page', async () => {
+    const browser = await next.browser('/')
+    await browser.elementByCss('a[href="/uri-fragments#section-2"]').click()
+
+    await retry(async () => {
+      // Focus stays on the anchor unlike native behavior
+      expect(
+        await browser.eval(() => document.activeElement.getAttribute('href'))
+      ).toEqual('/uri-fragments#section-2')
+    })
+    // Fragment URI not targetted unlike native behavior
+    expect(await browser.locator(':target').isVisible()).toEqual(false)
+  })
+
+  it('navigation within a page to fragments', async () => {
+    const browser = await next.browser('/uri-fragments')
+    await browser.elementByCss('a[href="#section-1"]').click()
+
+    await retry(async () => {
+      // Focus stays on the anchor unlike native behavior
+      expect(
+        await browser.eval(() => document.activeElement.getAttribute('href'))
+      ).toEqual('#section-1')
+    })
+    // Fragment URI not targetted unlike native behavior
+    expect(await browser.locator(':target').isVisible()).toEqual(false)
+  })
+})

--- a/test/e2e/app-dir/navigation-focus/next.config.js
+++ b/test/e2e/app-dir/navigation-focus/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig


### PR DESCRIPTION
We try to focus the new Segment after navigation. This behavior currently has now tests. I plan to change that behavior behind `experimental.appNewScrollHandler` so I'm adding some tests for the current behavior. The test is also meant as a fixture for manual testing with a screen reader.