### PR TITLE
[turbopack] use type_ids to register turbo task traits on value types

### DIFF
--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -14,9 +14,7 @@ use crate::{
         DefinitionContext, FunctionArguments, NativeFn, TurboFn, filter_inline_attributes,
         split_function_attributes,
     },
-    global_name::{
-        global_name_for_method, global_name_for_trait_method_impl, global_name_for_type,
-    },
+    global_name::{global_name_for_method, global_name_for_trait_method_impl},
     ident::{
         get_cast_to_fat_pointer_ident, get_inherent_impl_function_ident, get_path_ident,
         get_trait_impl_function_ident, get_type_ident,
@@ -293,7 +291,6 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 });
             }
         }
-        let global_value_name = global_name_for_type(ty);
         quote! {
             // Register all the function impls so the ValueType can find them
             // This means objects resolve as
@@ -304,7 +301,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
             turbo_tasks::macro_helpers::inventory_submit!{
                 turbo_tasks::macro_helpers::CollectableTraitMethods(
                     || (
-                        #global_value_name,
+                        ::std::any::TypeId::of::<#ty>(),
                         <::std::boxed::Box<dyn #trait_path> as turbo_tasks::VcValueTrait>::get_trait_type_id(),
                         vec![#(#trait_methods)*]
                     )

--- a/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_macro.rs
@@ -425,11 +425,13 @@ pub fn value_type_and_register(
     };
 
     quote! {
-
         static #value_type_ident: turbo_tasks::macro_helpers::Lazy<turbo_tasks::ValueType> =
             turbo_tasks::macro_helpers::Lazy::new(|| {
                 let mut value_type = #new_value_type;
-                turbo_tasks::macro_helpers::register_trait_methods(&mut value_type);
+                turbo_tasks::macro_helpers::register_trait_methods(
+                    ::std::any::TypeId::of::<#ty>(),
+                    &mut value_type,
+                );
                 value_type
              });
 

--- a/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+++ b/turbopack/crates/turbo-tasks/src/macro_helpers.rs
@@ -1,5 +1,7 @@
 //! Runtime helpers for [turbo-tasks-macro].
 
+use std::any::TypeId;
+
 pub use async_trait::async_trait;
 pub use bincode;
 pub use once_cell::sync::{Lazy, OnceCell};
@@ -144,7 +146,7 @@ inventory::collect! {CollectableTraitCastFunctions}
 #[allow(clippy::type_complexity)]
 pub struct CollectableTraitMethods(
     pub  fn() -> (
-        &'static str, // A value type name
+        TypeId,
         TraitTypeId,
         Vec<(&'static str, &'static NativeFunction)>,
     ),
@@ -152,21 +154,21 @@ pub struct CollectableTraitMethods(
 inventory::collect!(CollectableTraitMethods);
 
 // Called when initializing ValueTypes by value_impl
-pub fn register_trait_methods(value_type: &mut ValueType) {
+pub fn register_trait_methods(type_id: TypeId, value_type: &mut ValueType) {
     #[allow(clippy::type_complexity)]
     static TRAIT_METHODS_BY_VALUE: Lazy<
-        FxDashMap<&'static str, Vec<(TraitTypeId, Vec<(&'static str, &'static NativeFunction)>)>>,
+        FxDashMap<TypeId, Vec<(TraitTypeId, Vec<(&'static str, &'static NativeFunction)>)>>,
     > = Lazy::new(|| {
-        let map: FxDashMap<&'static str, Vec<_>> = FxDashMap::default();
+        let map: FxDashMap<TypeId, Vec<_>> = FxDashMap::default();
         for CollectableTraitMethods(thunk) in inventory::iter::<CollectableTraitMethods> {
-            let (value_name, trait_type_id, fn_items) = thunk();
-            map.entry(value_name)
+            let (type_id, trait_type_id, fn_items) = thunk();
+            map.entry(type_id)
                 .or_default()
                 .push((trait_type_id, fn_items));
         }
         map
     });
-    match TRAIT_METHODS_BY_VALUE.remove(value_type.global_name) {
+    match TRAIT_METHODS_BY_VALUE.remove(&type_id) {
         Some((_, traits)) => {
             for (trait_type_id, methods) in traits {
                 let trait_type = crate::registry::get_trait(trait_type_id);

--- a/turbopack/crates/turbo-tasks/src/registry.rs
+++ b/turbopack/crates/turbo-tasks/src/registry.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU16;
 
 use anyhow::Error;
 use once_cell::sync::Lazy;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::FxHashMap;
 
 use crate::{
     TraitType, ValueType,
@@ -68,17 +68,20 @@ impl<T: RegistryItem> Registry<T> {
         items.sort_unstable_by_key(|item| item.global_name());
 
         let mut item_to_id = FxHashMap::with_capacity_and_hasher(items.len(), Default::default());
-        let mut names = FxHashSet::with_capacity_and_hasher(items.len(), Default::default());
 
         let mut id = NonZeroU16::MIN;
+        let mut prev_name: Option<&str> = None;
         for &item in items.iter() {
-            item_to_id.insert(item, id.into());
             let global_name = item.global_name();
-            assert!(
-                names.insert(global_name),
-                "multiple {ty} items registered with name: {global_name}!",
-                ty = T::TYPE_NAME
-            );
+            if let Some(prev) = prev_name {
+                assert!(
+                    prev != global_name,
+                    "multiple {ty} items registered with name: {global_name}!",
+                    ty = T::TYPE_NAME
+                );
+            }
+            prev_name = Some(global_name);
+            item_to_id.insert(item, id.into());
             id = id.checked_add(1).expect("overflowing item ids");
         }
 


### PR DESCRIPTION
Tiny optimization, there is no need to use global names for this usecase and we can save a bit of memory and time.
