### PR TITLE
Use StageController for runtime prerendering

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -222,7 +222,6 @@ import {
 } from '../../shared/lib/router/utils/get-dynamic-param'
 import type { ExperimentalConfig } from '../config-shared'
 import type { Params } from '../request/params'
-import { createPromiseWithResolvers } from '../../shared/lib/promise-with-resolvers'
 import { ImageConfigContext } from '../../shared/lib/image-config-context.shared-runtime'
 import { imageConfigDefault } from '../../shared/lib/image-config'
 import { RenderStage, StagedRenderingController } from './staged-rendering'
@@ -1120,8 +1119,8 @@ async function prospectiveRuntimeServerPrerender(
     hmrRefreshHash: undefined,
     // We don't track vary params during initial prerender, only the final one
     varyParamsAccumulator: null,
-    // We only need task sequencing in the final prerender.
-    runtimeStagePromise: null,
+    // No stage sequencing needed for prospective renders.
+    stagedRendering: null,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
     headers,
     cookies,
@@ -1344,8 +1343,10 @@ async function finalRuntimeServerPrerender(
     isDebugDynamicAccesses
   )
 
-  const { promise: runtimeStagePromise, resolve: resolveBlockedRuntimeAPIs } =
-    createPromiseWithResolvers<void>()
+  const finalStageController = new StagedRenderingController(
+    finalServerController.signal,
+    true
+  )
 
   const finalServerPrerenderStore: PrerenderStoreModernRuntime = {
     type: 'prerender-runtime',
@@ -1369,7 +1370,7 @@ async function finalRuntimeServerPrerender(
     // TODO: Enable vary params tracking for runtime prefetches.
     varyParamsAccumulator: null,
     // Used to separate the "Static" stage from the "Runtime" stage.
-    runtimeStagePromise,
+    stagedRendering: finalStageController,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
     headers,
     cookies,
@@ -1409,7 +1410,7 @@ async function finalRuntimeServerPrerender(
       // We know that they don't contain any incorrect sync IO, because that'd have caused a build error.
       // After we unblock Runtime APIs, if we encounter sync IO (e.g. `await cookies(); Date.now()`),
       // we'll abort, but we'll produce at least as much output as a static prerender would.
-      resolveBlockedRuntimeAPIs()
+      finalStageController.advanceStage(RenderStage.Runtime)
     },
     () => {
       // Abort.

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -34,10 +34,10 @@ import React from 'react'
 import { DynamicServerError } from '../../client/components/hooks-server-context'
 import { StaticGenBailoutError } from '../../client/components/static-generation-bailout'
 import {
-  getRuntimeStagePromise,
   throwForMissingRequestStore,
   workUnitAsyncStorage,
 } from './work-unit-async-storage.external'
+import { RenderStage } from './staged-rendering'
 import { workAsyncStorage } from '../app-render/work-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 import {
@@ -539,11 +539,14 @@ export function createHangingInputAbortSignal(
         // render the content of this cache as deeply as we can so that we can
         // suspend as deeply as possible in the tree or not at all if we don't
         // end up waiting for the input.
-        const runtimeStagePromise = getRuntimeStagePromise(workUnitStore)
-        if (runtimeStagePromise) {
-          runtimeStagePromise.then(() =>
-            scheduleOnNextTick(() => controller.abort())
-          )
+        if (
+          // eslint-disable-next-line no-restricted-syntax -- We are discriminating between two different refined types and don't need an addition exhaustive switch here
+          workUnitStore.type === 'prerender-runtime' &&
+          workUnitStore.stagedRendering
+        ) {
+          workUnitStore.stagedRendering
+            .waitForStage(RenderStage.Runtime)
+            .then(() => scheduleOnNextTick(() => controller.abort()))
         } else {
           scheduleOnNextTick(() => controller.abort())
         }
@@ -1152,8 +1155,10 @@ export function delayUntilRuntimeStage<T>(
   prerenderStore: PrerenderStoreModernRuntime,
   result: Promise<T>
 ): Promise<T> {
-  if (prerenderStore.runtimeStagePromise) {
-    return prerenderStore.runtimeStagePromise.then(() => result)
+  if (prerenderStore.stagedRendering) {
+    return prerenderStore.stagedRendering
+      .waitForStage(RenderStage.Runtime)
+      .then(() => result)
   }
   return result
 }

--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -98,7 +98,7 @@ export class StagedRenderingController {
     }
 
     // If Sync IO occurs during an abandonable render, we trigger the abandon.
-    // The abandon listener will call abandonRenderImpl which advances through
+    // The abandon listener will call abandonRender which advances through
     // stages to let caches fill before marking as Abandoned.
     if (this.abandonController) {
       this.abandonController.abort()

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -125,16 +125,11 @@ export interface PrerenderStoreModernRuntime
   readonly type: 'prerender-runtime'
 
   /**
-   * A runtime prerender resolves APIs in two tasks:
-   *
-   * 1. Static data (available in a static prerender)
-   * 2. Runtime data (available in a runtime prerender)
-   *
-   * This separation is achieved by awaiting this promise in "runtime" APIs.
-   * In the final prerender, the promise will be resolved during the second task,
-   * and the render will be aborted in the task that follows it.
+   * The staged rendering controller for this prerender. Models stage
+   * transitions (Before → Static → Runtime → Dynamic). Null for prospective
+   * renders where all stages run without sequencing.
    */
-  readonly runtimeStagePromise: Promise<void> | null
+  readonly stagedRendering: StagedRenderingController | null
 
   readonly headers: RequestStore['headers']
   readonly cookies: RequestStore['cookies']
@@ -300,18 +295,6 @@ export interface PublicUseCacheStore extends CommonUseCacheStore {
 
 export interface PrivateUseCacheStore extends CommonUseCacheStore {
   readonly type: 'private-cache'
-
-  /**
-   * A runtime prerender resolves APIs in two tasks:
-   *
-   * 1. Static data (available in a static prerender)
-   * 2. Runtime data (available in a runtime prerender)
-   *
-   * This separation is achieved by awaiting this promise in "runtime" APIs.
-   * In the final prerender, the promise will be resolved during the second task,
-   * and the render will be aborted in the task that follows it.
-   */
-  readonly runtimeStagePromise: Promise<void> | null
 
   readonly headers: ReadonlyHeaders
   readonly cookies: ReadonlyRequestCookies
@@ -532,26 +515,6 @@ export function getCacheSignal(
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':
-    case 'unstable-cache':
-      return null
-    default:
-      return workUnitStore satisfies never
-  }
-}
-
-export function getRuntimeStagePromise(
-  workUnitStore: WorkUnitStore
-): Promise<void> | null {
-  switch (workUnitStore.type) {
-    case 'prerender-runtime':
-    case 'private-cache':
-      return workUnitStore.runtimeStagePromise
-    case 'prerender':
-    case 'prerender-client':
-    case 'prerender-ppr':
-    case 'prerender-legacy':
-    case 'request':
-    case 'cache':
     case 'unstable-cache':
       return null
     default:

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -34,7 +34,6 @@ import {
   getCacheSignal,
   isHmrRefresh,
   getServerComponentsHmrCache,
-  getRuntimeStagePromise,
 } from '../app-render/work-unit-async-storage.external'
 
 import {
@@ -221,7 +220,6 @@ function createUseCacheStore(
       isHmrRefresh: isHmrRefresh(outerWorkUnitStore),
       serverComponentsHmrCache: getServerComponentsHmrCache(outerWorkUnitStore),
       forceRevalidate: shouldForceRevalidate(workStore, outerWorkUnitStore),
-      runtimeStagePromise: getRuntimeStagePromise(outerWorkUnitStore),
       draftMode: getDraftModeProviderForCacheScope(
         workStore,
         outerWorkUnitStore
@@ -1055,8 +1053,9 @@ export async function cache(
       case 'prerender-runtime': {
         // In a runtime prerender, we have to make sure that APIs that would hang during a static prerender
         // are resolved with a delay, in the runtime stage. Private caches are one of these.
-        if (outerWorkUnitStore.runtimeStagePromise) {
-          await outerWorkUnitStore.runtimeStagePromise
+        const stagedRendering = outerWorkUnitStore.stagedRendering
+        if (stagedRendering) {
+          await stagedRendering.waitForStage(RenderStage.Runtime)
         }
         break
       }
@@ -1365,8 +1364,9 @@ export async function cache(
               // In the final phase of a runtime prerender, we have to make
               // sure that APIs that would hang during a static prerender
               // are resolved with a delay, in the runtime stage.
-              if (workUnitStore.runtimeStagePromise) {
-                await workUnitStore.runtimeStagePromise
+              const stagedRendering = workUnitStore.stagedRendering
+              if (stagedRendering) {
+                await stagedRendering.waitForStage(RenderStage.Runtime)
               }
               break
             }

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -2570,13 +2570,13 @@ describe('Cache Components Errors', () => {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route "/use-cache-low-expire/fast": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                        at cache (webpack:///<next-src>)
-                     1357 |                 cacheSignal.endRead()
-                     1358 |               }
-                   > 1359 |               return makeHangingPromise(
+                     1356 |                 cacheSignal.endRead()
+                     1357 |               }
+                   > 1358 |               return makeHangingPromise(
                           |                      ^
-                     1360 |                 workUnitStore.renderSignal,
-                     1361 |                 workStore.route,
-                     1362 |                 'dynamic "use cache"'
+                     1359 |                 workUnitStore.renderSignal,
+                     1360 |                 workStore.route,
+                     1361 |                 'dynamic "use cache"'
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -2714,13 +2714,13 @@ describe('Cache Components Errors', () => {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route "/use-cache-low-expire/slow": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                        at cache (webpack:///<next-src>)
-                     1357 |                 cacheSignal.endRead()
-                     1358 |               }
-                   > 1359 |               return makeHangingPromise(
+                     1356 |                 cacheSignal.endRead()
+                     1357 |               }
+                   > 1358 |               return makeHangingPromise(
                           |                      ^
-                     1360 |                 workUnitStore.renderSignal,
-                     1361 |                 workStore.route,
-                     1362 |                 'dynamic "use cache"'
+                     1359 |                 workUnitStore.renderSignal,
+                     1360 |                 workStore.route,
+                     1361 |                 'dynamic "use cache"'
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-low-expire/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-low-expire/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -2962,13 +2962,13 @@ describe('Cache Components Errors', () => {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route "/use-cache-revalidate-0/fast": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                        at cache (webpack:///<next-src>)
-                     1357 |                 cacheSignal.endRead()
-                     1358 |               }
-                   > 1359 |               return makeHangingPromise(
+                     1356 |                 cacheSignal.endRead()
+                     1357 |               }
+                   > 1358 |               return makeHangingPromise(
                           |                      ^
-                     1360 |                 workUnitStore.renderSignal,
-                     1361 |                 workStore.route,
-                     1362 |                 'dynamic "use cache"'
+                     1359 |                 workUnitStore.renderSignal,
+                     1360 |                 workStore.route,
+                     1361 |                 'dynamic "use cache"'
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/fast" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/fast". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3106,13 +3106,13 @@ describe('Cache Components Errors', () => {
                   expect(output).toMatchInlineSnapshot(`
                    "Error: Route "/use-cache-revalidate-0/slow": Uncached data was accessed outside of <Suspense>. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route
                        at cache (webpack:///<next-src>)
-                     1357 |                 cacheSignal.endRead()
-                     1358 |               }
-                   > 1359 |               return makeHangingPromise(
+                     1356 |                 cacheSignal.endRead()
+                     1357 |               }
+                   > 1358 |               return makeHangingPromise(
                           |                      ^
-                     1360 |                 workUnitStore.renderSignal,
-                     1361 |                 workStore.route,
-                     1362 |                 'dynamic "use cache"'
+                     1359 |                 workUnitStore.renderSignal,
+                     1360 |                 workStore.route,
+                     1361 |                 'dynamic "use cache"'
                    To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-revalidate-0/slow" in your browser to investigate the error.
                    Error occurred prerendering page "/use-cache-revalidate-0/slow". Read more: https://nextjs.org/docs/messages/prerender-error
 
@@ -3896,13 +3896,13 @@ describe('Cache Components Errors', () => {
                      at cache (webpack:///<next-src>)
                      at Private (webpack:///app/use-cache-private-without-suspense/page.tsx:15:1)
                      at Page (webpack:///app/use-cache-private-without-suspense/page.tsx:10:7)
-                   937 |       // "use cache: private" is dynamic in prerendering contexts.
-                   938 |       case 'prerender':
-                 > 939 |         return makeHangingPromise(
-                       |                ^
-                   940 |           workUnitStore.renderSignal,
-                   941 |           workStore.route,
-                   942 |           expression
+                   935 |       // "use cache: private" is dynamic in prerendering contexts.
+                   936 |       case 'prerender':
+                 > 937 |         return makeHangingPromise(
+                       |                                  ^
+                   938 |           workUnitStore.renderSignal,
+                   939 |           workStore.route,
+                   940 |           expression
                  To debug the issue, start the app in development mode by running \`next dev\`, then open "/use-cache-private-without-suspense" in your browser to investigate the error.
                  Error occurred prerendering page "/use-cache-private-without-suspense". Read more: https://nextjs.org/docs/messages/prerender-error
 


### PR DESCRIPTION
Stacked on #89971

This controller was introduced to help with dev time validation. It models stage transitions in a helpful way that will become more useful soon as we get more advanced with what kinds of sync IO are considered errors.

To prepare for this we will update the implementation to use the stage controller for build and runtime prerendering not just dev

We don't yet use it for static prerendering because that one is so simple and there is really no stage beyond the first one and then an abort so we will keep it as is

Additionally, the private cache store no longer has the `runtimeStagePromise`. when you first enter this store type during a runtime prerender we wait until the outer store's runtime stage has begun. Previously the proimse signifying this stage transition was included in the private cache store itself so nested caches could similarly wait, however you can't actually get to a nested cache until after it is resolved b/c the outermost one blocks.