### PR TITLE
Turbopack: Update rust toolchain to nightly-2026-02-18

### DIFF
--- a/.devcontainer/rust/devcontainer-feature.json
+++ b/.devcontainer/rust/devcontainer-feature.json
@@ -5,7 +5,7 @@
   "dependsOn": {
     "ghcr.io/devcontainers/features/rust:1": {
       // this should match the `rust-toolchain.toml`
-      "version": "nightly-2026-02-05",
+      "version": "nightly-2026-02-18",
       "profile": "minimal",
       "components": "rustfmt,clippy,rust-analyzer"
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
 [toolchain]
-channel = "nightly-2026-02-15"
+channel = "nightly-2026-02-18"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
 [toolchain]
-channel = "nightly-2026-02-05"
+channel = "nightly-2026-02-13"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
 [toolchain]
-channel = "nightly-2026-02-13"
+channel = "nightly-2026-02-15"
 components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"

--- a/turbopack/crates/turbopack-core/src/lib.rs
+++ b/turbopack/crates/turbopack-core/src/lib.rs
@@ -1,6 +1,5 @@
 #![feature(min_specialization)]
 #![feature(type_alias_impl_trait)]
-#![feature(assert_matches)]
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 #![feature(impl_trait_in_assoc_type)]

--- a/turbopack/crates/turbopack-ecmascript/src/source_map.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/source_map.rs
@@ -56,10 +56,8 @@ fn maybe_decode_data_url(url: &str) -> Option<Rope> {
 
     let data_b64 = if let Some(data) = url.strip_prefix(DATA_PREAMBLE) {
         data
-    } else if let Some(data) = url.strip_prefix(DATA_PREAMBLE_CHARSET) {
-        data
     } else {
-        return None;
+        url.strip_prefix(DATA_PREAMBLE_CHARSET)?
     };
 
     data_encoding::BASE64


### PR DESCRIPTION
Rust finally merged a fix to the "trying to encode a dep node twice" ICE we seem to most frequently run into, triggered by the rustc parallel frontend feature: https://github.com/rust-lang/rust/pull/151509

- @mischnic  commented on the issue: https://github.com/rust-lang/rust/issues/150018#issuecomment-3754877064
- @mischnic just updated our toolchain last week, but I'd like to get this fix in.

CI Job for build-and-release that covers all platforms: https://github.com/vercel/next.js/actions/runs/22156881743  
  
In the process of this upgrade, I found and reported https://github.com/rust-lang/rust/issues/152735 upstream (fixed `nightly-2026-02-18`).