### PR TITLE
Turbopack: Fix flake in task_statistics unit test

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/task_statistics.rs
@@ -362,7 +362,9 @@ fn inline_definitions() -> Result<Vc<()>> {
     #[turbo_tasks::value_trait]
     trait Trait {
         #[turbo_tasks::function]
-        fn trait_fn(&self) {}
+        fn trait_fn(&self) -> Vc<()> {
+            Vc::cell(())
+        }
     }
 
     #[turbo_tasks::value_impl]


### PR DESCRIPTION
If we don't explicitly return a `Vc::cell(())` here, then `<() as dyn turbo_tasks::vc::default::ValueDefault>::value_default` gets called in a non-deterministic way.  
  
That's not something we care about testing here, so just add a an explicit `Vc::cell(())` call to avoid it.