### PR TITLE
chore: Don't run build-and-deploy CI job on graphite-base branches

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -3,9 +3,9 @@ name: build-and-deploy
 
 on:
   push:
-    # Don't run when tags are pushed
-    branches:
-      - '**'
+    # Don't run when tags or graphite base branches are pushed
+    branches-ignore:
+      - 'graphite-base/**'
   # we need the preview tarball for deploy tests
   pull_request:
     types: [opened, synchronize]


### PR DESCRIPTION
We don't need/want preview builds for these base branches, it's a waste of CI capacity.

Relevant docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushbranchestagsbranches-ignoretags-ignore

> Use the branches filter when you want to include branch name patterns or when you want to both include and exclude branch names patterns. Use the branches-ignore filter when you only want to exclude branch name patterns. You cannot use both the branches and branches-ignore filters for the same event in a workflow.

> If you define only tags/tags-ignore or only branches/branches-ignore, the workflow won't run for events affecting the undefined Git ref. If you define neither tags/tags-ignore or branches/branches-ignore, the workflow will run for events affecting either branches or tags.

