### PR TITLE
Cleanup all stage promises on abort

### DIFF
--- a/packages/next/src/server/app-render/staged-rendering.ts
+++ b/packages/next/src/server/app-render/staged-rendering.ts
@@ -34,18 +34,15 @@ export class StagedRenderingController {
       abortSignal.addEventListener(
         'abort',
         () => {
+          // Reject all stage promises that haven't already been resolved.
+          // If a promise was already resolved via advanceStage, the reject
+          // is a no-op. The ignoreReject handler suppresses unhandled
+          // rejection warnings for promises that no one is awaiting.
           const { reason } = abortSignal
-          if (this.currentStage < RenderStage.Runtime) {
-            this.runtimeStagePromise.promise.catch(ignoreReject) // avoid unhandled rejections
-            this.runtimeStagePromise.reject(reason)
-          }
-          if (
-            this.currentStage < RenderStage.Dynamic ||
-            this.currentStage === RenderStage.Abandoned
-          ) {
-            this.dynamicStagePromise.promise.catch(ignoreReject) // avoid unhandled rejections
-            this.dynamicStagePromise.reject(reason)
-          }
+          this.runtimeStagePromise.promise.catch(ignoreReject)
+          this.runtimeStagePromise.reject(reason)
+          this.dynamicStagePromise.promise.catch(ignoreReject)
+          this.dynamicStagePromise.reject(reason)
         },
         { once: true }
       )


### PR DESCRIPTION
Stacked on #89978

When the AbortSignal passed to the StagedRenderingController is aborted there is some logic to potentially abort any unresolved stage promises. Semantically anything we have a render with a stage controller that is aborted we must ensure no stage promises are left in a perpetually pending state.