### PR TITLE
Turbopack: Update trybuild test dependency from 1.0.104 to 1.0.116

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,7 +2568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "stable_deref_trait",
 ]
 
@@ -2609,7 +2609,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2628,7 +2628,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3351,13 +3351,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3803,7 +3804,7 @@ dependencies = [
  "dashmap 5.5.3",
  "data-encoding",
  "getrandom 0.3.3",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "itertools 0.10.5",
  "lazy_static",
  "lightningcss-derive",
@@ -4401,7 +4402,7 @@ dependencies = [
  "byteorder",
  "either",
  "futures",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "next-core",
  "regex",
  "roaring",
@@ -4478,7 +4479,7 @@ dependencies = [
  "bincode 2.0.1",
  "either",
  "futures",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "indoc",
  "itertools 0.10.5",
  "mime_guess",
@@ -4536,7 +4537,7 @@ dependencies = [
  "easy-error",
  "either",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "indoc",
  "modularize_imports",
  "once_cell",
@@ -4864,7 +4865,7 @@ dependencies = [
  "crc32fast",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "memchr",
  "ruzstd",
 ]
@@ -5164,7 +5165,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
 ]
 
 [[package]]
@@ -5175,7 +5176,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "serde",
  "serde_derive",
 ]
@@ -6133,7 +6134,7 @@ dependencies = [
  "bytecheck 0.8.1",
  "bytes",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "munge",
  "ptr_meta 0.3.0",
  "rancor",
@@ -6420,7 +6421,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "schemars_derive",
  "serde",
  "serde_json",
@@ -6644,7 +6645,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "itoa",
  "memchr",
  "ryu",
@@ -6695,6 +6696,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6716,7 +6726,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -6744,7 +6754,7 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "itoa",
  "libyml",
  "memchr",
@@ -6807,7 +6817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "939a4c696178684fc5fc1426625b882805418bbb56e056d21f9d4946a9d6ff51"
 dependencies = [
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "serde_json",
  "shrink-to-fit-macro",
  "smallvec",
@@ -7020,7 +7030,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6635404b73efc136af3a7956e53c53d4f34b2f16c95a15c438929add0f69412"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "smallvec",
  "static-self-derive",
 ]
@@ -7149,7 +7159,7 @@ dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "jsonc-parser",
  "once_cell",
  "par-core",
@@ -7313,7 +7323,7 @@ dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
  "globset",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "once_cell",
  "regex",
  "regress",
@@ -7591,7 +7601,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f34c347e38ce9ed1cc6b7bad12e459e5ffec861e6dd195fbbb5d325c4750792f"
 dependencies = [
  "arrayvec 0.7.6",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "is-macro",
  "rustc-hash 2.1.1",
  "serde",
@@ -7805,7 +7815,7 @@ checksum = "0d62a924e6d201251cf10c94eb88bb88404aa9b24312d05622140202818159e4"
 dependencies = [
  "arrayvec 0.7.6",
  "bitflags 2.9.1",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "num-bigint",
  "num_cpus",
  "once_cell",
@@ -7863,7 +7873,7 @@ checksum = "c35d01f1b0d11bd915ff4757e1c9b045b287c5b6970f90b54eb9f3b638252d15"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "once_cell",
  "precomputed-map",
  "preset_env_base",
@@ -8004,7 +8014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf93abf3dc6d2b21a2a29c62b0197cd270b6105a483236ecba91993f895204e"
 dependencies = [
  "better_scoped_tls",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "once_cell",
  "par-core",
  "phf",
@@ -8038,7 +8048,7 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e472acb6e92135ab42646a41086ee8c81576b9e0e964b483ac6c504319b9d861"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "par-core",
  "serde",
  "swc_atoms",
@@ -8081,7 +8091,7 @@ dependencies = [
  "Inflector",
  "anyhow",
  "bitflags 2.9.1",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "is-macro",
  "path-clean 1.0.1",
  "pathdiff",
@@ -8108,7 +8118,7 @@ checksum = "ab76533e9da38c8f13ca1a9d0a6edd6b3de328a281441aee9810281e1b7ba4e9"
 dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "once_cell",
  "par-core",
  "petgraph 0.7.1",
@@ -8150,7 +8160,7 @@ checksum = "06920cb2277974a0000f58fb7a70d23f2419dddd53de0d5de8db014a9a1163f9"
 dependencies = [
  "base64 0.22.1",
  "bytes-str",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "once_cell",
  "rustc-hash 2.1.1",
  "serde",
@@ -8218,7 +8228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7aec80849cab609d92af5dd2670f18fc760f7029beb11beebcef3fed9ba3466"
 dependencies = [
  "bitflags 2.9.1",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
@@ -8236,7 +8246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3669c1d92ba315caff5a80df76141367acf61b2d846231a1960e25be65a20fbd"
 dependencies = [
  "dragonbox_ecma",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "num_cpus",
  "once_cell",
  "par-core",
@@ -8593,9 +8603,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "target-triple"
-version = "0.1.4"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tempfile"
@@ -8930,8 +8940,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit 0.19.15",
 ]
 
@@ -8941,11 +8951,26 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit 0.21.1",
+]
+
+[[package]]
+name = "toml"
+version = "1.0.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbe30f93627849fa362d4a602212d41bb237dc2bd0f8ba0b2ce785012e124220"
+dependencies = [
+ "indexmap 2.12.0",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.0+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.14",
 ]
 
 [[package]]
@@ -8958,15 +8983,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.0.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "winnow 0.5.15",
 ]
 
@@ -8976,10 +9010,10 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "winnow 0.5.15",
 ]
 
@@ -8989,10 +9023,25 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
- "toml_datetime",
- "winnow 0.7.11",
+ "indexmap 2.12.0",
+ "toml_datetime 0.6.11",
+ "winnow 0.7.14",
 ]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.8+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0742ff5ff03ea7e67c8ae6c93cac239e0d9784833362da3f9a9c1da8dfefcbdc"
+dependencies = [
+ "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
@@ -9202,9 +9251,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "trybuild"
-version = "1.0.104"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae08be68c056db96f0e6c6dd820727cca756ced9e1f4cc7fdd20e2a55e23898"
+checksum = "47c635f0191bd3a2941013e5062667100969f8c4e9cd787c14f977265d73616e"
 dependencies = [
  "glob",
  "serde",
@@ -9212,7 +9261,7 @@ dependencies = [
  "serde_json",
  "target-triple",
  "termcolor",
- "toml 0.8.9",
+ "toml 1.0.1+spec-1.1.0",
 ]
 
 [[package]]
@@ -9278,7 +9327,7 @@ version = "0.0.0"
 dependencies = [
  "bincode 2.0.1",
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "mime",
  "ringmap",
  "serde",
@@ -9306,7 +9355,7 @@ name = "turbo-frozenmap"
 version = "0.1.0"
 dependencies = [
  "bincode 2.0.1",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "serde",
 ]
 
@@ -9406,7 +9455,7 @@ dependencies = [
  "erased-serde",
  "event-listener",
  "futures",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "inventory",
  "once_cell",
  "parking_lot",
@@ -9447,7 +9496,7 @@ dependencies = [
  "either",
  "futures",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "indoc",
  "lmdb-rkv",
  "lzzzz",
@@ -9550,7 +9599,7 @@ dependencies = [
  "dunce",
  "futures",
  "include_dir",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "jsonc-parser",
  "mime",
  "notify",
@@ -9606,7 +9655,7 @@ name = "turbo-tasks-macros"
 version = "0.1.0"
 dependencies = [
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -9832,7 +9881,7 @@ dependencies = [
  "const_format",
  "data-encoding",
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "once_cell",
  "patricia_tree",
  "petgraph 0.8.3",
@@ -9955,7 +10004,7 @@ dependencies = [
  "dashmap 6.1.0",
  "data-encoding",
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "indoc",
  "itertools 0.10.5",
  "num-bigint",
@@ -10009,7 +10058,7 @@ dependencies = [
  "async-trait",
  "bincode 2.0.1",
  "either",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
@@ -10294,7 +10343,7 @@ dependencies = [
  "either",
  "flate2",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "itertools 0.10.5",
  "postcard",
  "rayon",
@@ -10653,7 +10702,7 @@ dependencies = [
  "fs_extra",
  "futures",
  "getrandom 0.2.15",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "libc",
  "pin-project-lite",
  "replace_with",
@@ -10965,7 +11014,7 @@ dependencies = [
  "cfg-if",
  "cmake",
  "derive_more 2.0.1",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "js-sys",
  "more-asserts",
  "paste",
@@ -11050,7 +11099,7 @@ dependencies = [
  "ciborium",
  "derive_builder 0.12.0",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "saffron",
  "schemars 0.8.21",
  "semver",
@@ -11141,7 +11190,7 @@ dependencies = [
  "enumset",
  "getrandom 0.2.15",
  "hex",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "more-asserts",
  "rkyv 0.8.10",
  "serde",
@@ -11166,7 +11215,7 @@ dependencies = [
  "dashmap 6.1.0",
  "enum-iterator",
  "fnv",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "libc",
  "libunwind",
  "mach2",
@@ -11296,7 +11345,7 @@ checksum = "161296c618fa2d63f6ed5fffd1112937e803cb9ec71b32b01a76321555660917"
 dependencies = [
  "bitflags 2.9.1",
  "hashbrown 0.15.4",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "semver",
  "serde",
 ]
@@ -11372,7 +11421,7 @@ dependencies = [
  "ciborium",
  "document-features",
  "ignore",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "leb128",
  "lexical-sort",
  "libc",
@@ -11818,9 +11867,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -11902,7 +11951,7 @@ dependencies = [
  "cargo-lock",
  "chrono",
  "clap",
- "indexmap 2.9.0",
+ "indexmap 2.12.0",
  "inquire",
  "num-format",
  "owo-colors",

--- a/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-macros-tests/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true }
-trybuild = { version = "1.0.104" }
+trybuild = { version = "1.0.116" }
 turbo-tasks = { workspace = true }
 turbo-tasks-testing = { workspace = true }
 turbo-tasks-backend = { workspace = true }

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_method_self_type.stderr
@@ -14,19 +14,19 @@ error[E0307]: invalid `self` parameter type: `OperationVc<Foobar>`
    = help: consider changing to `self`, `&self`, `&mut self`, or a type implementing `Receiver` such as `self: Box<Self>`, `self: Rc<Self>`, or `self: Arc<Self>`
 
 error[E0277]: the trait bound `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}: turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>` is not satisfied
- --> tests/function/fail_operation_method_self_type.rs:11:1
-  |
- 11 | #[turbo_tasks::value_impl]
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
-    |
-    = help: the trait `turbo_tasks::task::function::TaskFnInputFunctionWithThis<_, _, _>` is not implemented for fn item `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}`
-    = note: required for `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}` to implement `turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>`
+  --> tests/function/fail_operation_method_self_type.rs:11:1
+   |
+11 | #[turbo_tasks::value_impl]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^ unsatisfied trait bound
+   |
+   = help: the trait `turbo_tasks::task::function::TaskFnInputFunctionWithThis<_, _, _>` is not implemented for fn item `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}`
+   = note: required for `fn(OperationVc<Foobar>) -> Vc<()> {Foobar::arbitrary_self_type_turbo_tasks_function_inline}` to implement `turbo_tasks::task::function::IntoTaskFnWithThis<_, _, _>`
 note: required by a bound in `turbo_tasks::macro_helpers::NativeFunction::new_method`
-   --> $WORKSPACE/turbopack/crates/turbo-tasks/src/native_function.rs
-    |
-    |     pub fn new_method<Mode, This, Inputs, I>(
-    |            ---------- required by a bound in this associated function
+  --> $WORKSPACE/turbopack/crates/turbo-tasks/src/native_function.rs
+   |
+   |     pub fn new_method<Mode, This, Inputs, I>(
+   |            ---------- required by a bound in this associated function
 ...
-    |         I: IntoTaskFnWithThis<Mode, This, Inputs>,
-    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NativeFunction::new_method`
-    = note: this error originates in the attribute macro `turbo_tasks::value_impl` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |         I: IntoTaskFnWithThis<Mode, This, Inputs>,
+   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `NativeFunction::new_method`
+   = note: this error originates in the attribute macro `turbo_tasks::value_impl` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_operation_vc_arg.stderr
@@ -1,21 +1,21 @@
 error[E0277]: the trait bound `Vc<i32>: NonLocalValue` is not satisfied
  --> tests/function/fail_operation_vc_arg.rs:8:26
   |
- 8 | async fn multiply(value: Vc<i32>, coefficient: ResolvedVc<i32>) -> Result<Vc<i32>> {
-   |                          ^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`
-   |
-   = help: the following other types implement trait `NonLocalValue`:
-             &T
-             &mut T
-             ()
-             (A, Z, Y, X, W, V, U, T)
-             (B, A, Z, Y, X, W, V, U, T)
-             (C, B, A, Z, Y, X, W, V, U, T)
-             (D, C, B, A, Z, Y, X, W, V, U, T)
-             (E, D, C, B, A, Z, Y, X, W, V, U, T)
-           and $N others
+8 | async fn multiply(value: Vc<i32>, coefficient: ResolvedVc<i32>) -> Result<Vc<i32>> {
+  |                          ^^^^^^^ the trait `NonLocalValue` is not implemented for `Vc<i32>`
+  |
+  = help: the following other types implement trait `NonLocalValue`:
+            &T
+            &mut T
+            ()
+            (A, Z, Y, X, W, V, U, T)
+            (B, A, Z, Y, X, W, V, U, T)
+            (C, B, A, Z, Y, X, W, V, U, T)
+            (D, C, B, A, Z, Y, X, W, V, U, T)
+            (E, D, C, B, A, Z, Y, X, W, V, U, T)
+          and $N others
 note: required by a bound in `turbo_tasks::macro_helpers::assert_argument_is_non_local_value`
-  --> $WORKSPACE/turbopack/crates/turbo-tasks/src/macro_helpers.rs
-   |
-   | pub fn assert_argument_is_non_local_value<Argument: NonLocalValue>() {}
-   |                                                     ^^^^^^^^^^^^^ required by this bound in `assert_argument_is_non_local_value`
+ --> $WORKSPACE/turbopack/crates/turbo-tasks/src/macro_helpers.rs
+  |
+  | pub fn assert_argument_is_non_local_value<Argument: NonLocalValue>() {}
+  |                                                     ^^^^^^^^^^^^^ required by this bound in `assert_argument_is_non_local_value`


### PR DESCRIPTION
This fixes a bug where these tests could fail if your terminal was too wide: https://github.com/dtolnay/trybuild/pull/325