### PR TITLE
Instrumentation.ts loading consistency

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1050,5 +1050,7 @@
   "1049": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\\n\\nTo use Next.js on this platform, use Webpack instead:\\n  next dev --webpack\\n\\nFor more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms",
   "1050": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\\n\\nTo build on this platform, use Webpack instead:\\n  next build --webpack\\n\\nFor more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms",
   "1051": "Turbopack trace server is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.",
-  "1052": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings. Use the --webpack flag instead."
+  "1052": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings. Use the --webpack flag instead.",
+  "1053": "Conflicting instrumentation files detected: \"./%s\" and \"./%s\". Please remove one of them.",
+  "1054": "Conflicting instrumentation files detected: \"%s\" and \"%s\". Please remove one of them."
 }

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1215,6 +1215,8 @@ export default async function build(
         .map((file) => path.join(rootDir, file).replace(dir, ''))
 
       let instrumentationHookFilePath: string | undefined
+      let rootInstrumentationHookFilePath: string | undefined
+      let srcInstrumentationHookFilePath: string | undefined
       let proxyFilePath: string | undefined
       let middlewareFilePath: string | undefined
 
@@ -1235,8 +1237,29 @@ export default async function build(
           isAtConventionLevel &&
           fileBaseName === INSTRUMENTATION_HOOK_FILENAME
         ) {
+          if (normalizedFileDir === '/') {
+            rootInstrumentationHookFilePath = rootPath
+          } else if (normalizedFileDir === '/src') {
+            srcInstrumentationHookFilePath = rootPath
+          }
           instrumentationHookFilePath = rootPath
         }
+      }
+
+      if (rootInstrumentationHookFilePath && srcInstrumentationHookFilePath) {
+        const cwd = process.cwd()
+        const absoluteRootPath = path.join(
+          rootDir,
+          rootInstrumentationHookFilePath
+        )
+        const absoluteSrcPath = path.join(
+          rootDir,
+          srcInstrumentationHookFilePath
+        )
+
+        throw new Error(
+          `Conflicting instrumentation files detected: "./${path.relative(cwd, absoluteRootPath)}" and "./${path.relative(cwd, absoluteSrcPath)}". Please remove one of them.`
+        )
       }
 
       if (middlewareFilePath) {

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -391,6 +391,31 @@ async function startWatcher(
     ]
     let nestedMiddleware: string[] = []
 
+    // Check for conflicting instrumentation files before starting watch
+    const possibleInstrumentationFiles =
+      getPossibleInstrumentationHookFilenames(
+        path.join(rootDir!, '..'),
+        nextConfig.pageExtensions
+      )
+    let rootInstrumentationExists: string | undefined
+    let srcInstrumentationExists: string | undefined
+    for (const file of possibleInstrumentationFiles) {
+      if (fs.existsSync(file)) {
+        const isInSrc = file.includes(path.join(path.sep, 'src', path.sep))
+        if (isInSrc) {
+          srcInstrumentationExists = file
+        } else {
+          rootInstrumentationExists = file
+        }
+      }
+    }
+    if (rootInstrumentationExists && srcInstrumentationExists) {
+      const cwd = process.cwd()
+      throw new Error(
+        `Conflicting instrumentation files detected: "./${path.relative(cwd, rootInstrumentationExists)}" and "./${path.relative(cwd, srcInstrumentationExists)}". Please remove one of them.`
+      )
+    }
+
     const envFiles = [
       '.env.development.local',
       '.env.local',

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -78,6 +78,7 @@ import { getDefineEnv } from '../../../build/define-env'
 import { TurbopackInternalError } from '../../../shared/lib/turbopack/internal-error'
 import { normalizePath } from '../../../lib/normalize-path'
 import {
+  INSTRUMENTATION_HOOK_FILENAME,
   JSON_CONTENT_TYPE_HEADER,
   MIDDLEWARE_FILENAME,
   PROXY_FILENAME,
@@ -465,6 +466,8 @@ async function startWatcher(
 
       let proxyFilePath: string | undefined
       let middlewareFilePath: string | undefined
+      let rootInstrumentationFilePath: string | undefined
+      let srcInstrumentationFilePath: string | undefined
 
       for (const fileName of sortedKnownFiles) {
         if (
@@ -484,6 +487,25 @@ async function startWatcher(
         }
         if (isAtConventionLevel && fileBaseName === PROXY_FILENAME) {
           proxyFilePath = fileName
+        }
+        if (
+          isAtConventionLevel &&
+          fileBaseName === INSTRUMENTATION_HOOK_FILENAME
+        ) {
+          const isInSrc = fileDir === path.join(dir, 'src')
+          if (isInSrc) {
+            srcInstrumentationFilePath = fileName
+          } else {
+            rootInstrumentationFilePath = fileName
+          }
+        }
+
+        if (rootInstrumentationFilePath && srcInstrumentationFilePath) {
+          const cwd = process.cwd()
+
+          throw new Error(
+            `Conflicting instrumentation files detected: "./${path.relative(cwd, rootInstrumentationFilePath)}" and "./${path.relative(cwd, srcInstrumentationFilePath)}". Please remove one of them.`
+          )
         }
 
         if (middlewareFilePath) {
@@ -591,15 +613,6 @@ async function startWatcher(
           continue
         }
         if (isInstrumentationHookFile(rootFile)) {
-          if (
-            serverFields.actualInstrumentationHookFile &&
-            serverFields.actualInstrumentationHookFile !== rootFile
-          ) {
-            const existingFile = serverFields.actualInstrumentationHookFile
-            throw new Error(
-              `Conflicting instrumentation files detected: "${existingFile}" and "${rootFile}". Please remove one of them.`
-            )
-          }
           serverFields.actualInstrumentationHookFile = rootFile
           await propagateServerField(
             opts,

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -591,6 +591,15 @@ async function startWatcher(
           continue
         }
         if (isInstrumentationHookFile(rootFile)) {
+          if (
+            serverFields.actualInstrumentationHookFile &&
+            serverFields.actualInstrumentationHookFile !== rootFile
+          ) {
+            const existingFile = serverFields.actualInstrumentationHookFile
+            throw new Error(
+              `Conflicting instrumentation files detected: "${existingFile}" and "${rootFile}". Please remove one of them.`
+            )
+          }
           serverFields.actualInstrumentationHookFile = rootFile
           await propagateServerField(
             opts,

--- a/test/development/app-dir/instrumentation-conflict/app/layout.tsx
+++ b/test/development/app-dir/instrumentation-conflict/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/instrumentation-conflict/app/page.tsx
+++ b/test/development/app-dir/instrumentation-conflict/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/instrumentation-conflict/instrumentation-conflict.test.ts
+++ b/test/development/app-dir/instrumentation-conflict/instrumentation-conflict.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('instrumentation-conflict', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should throw an error when both root and src instrumentation files exist', async () => {
+    if (isNextDev) {
+      await expect(next.start()).rejects.toThrow(
+        /Conflicting instrumentation files detected/
+      )
+    } else {
+      // For production builds, the error should be thrown during build
+      await expect(next.build()).rejects.toThrow(
+        /Conflicting instrumentation files detected/
+      )
+    }
+  })
+})

--- a/test/development/app-dir/instrumentation-conflict/instrumentation-conflict.test.ts
+++ b/test/development/app-dir/instrumentation-conflict/instrumentation-conflict.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('instrumentation-conflict', () => {
-  const { next, isNextDev, skipped } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
   })
@@ -11,15 +11,10 @@ describe('instrumentation-conflict', () => {
   }
 
   it('should throw an error when both root and src instrumentation files exist', async () => {
-    if (isNextDev) {
-      await expect(next.start()).rejects.toThrow(
-        /Conflicting instrumentation files detected/
-      )
-    } else {
-      // For production builds, the error should be thrown during build
-      await expect(next.build()).rejects.toThrow(
-        /Conflicting instrumentation files detected/
-      )
-    }
+    await expect(() => next.start()).rejects.toThrow()
+
+    expect(next.cliOutput).toContain(
+      'Conflicting instrumentation files detected'
+    )
   })
 })

--- a/test/development/app-dir/instrumentation-conflict/instrumentation.ts
+++ b/test/development/app-dir/instrumentation-conflict/instrumentation.ts
@@ -1,0 +1,3 @@
+export function register() {
+  console.log('Root instrumentation loaded')
+}

--- a/test/development/app-dir/instrumentation-conflict/next.config.js
+++ b/test/development/app-dir/instrumentation-conflict/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/instrumentation-conflict/src/instrumentation.ts
+++ b/test/development/app-dir/instrumentation-conflict/src/instrumentation.ts
@@ -1,0 +1,3 @@
+export function register() {
+  console.log('Src instrumentation loaded')
+}

--- a/test/production/app-dir/instrumentation-conflict-build/app/layout.tsx
+++ b/test/production/app-dir/instrumentation-conflict-build/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/instrumentation-conflict-build/app/page.tsx
+++ b/test/production/app-dir/instrumentation-conflict-build/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/production/app-dir/instrumentation-conflict-build/instrumentation-conflict-build.test.ts
+++ b/test/production/app-dir/instrumentation-conflict-build/instrumentation-conflict-build.test.ts
@@ -1,10 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('instrumentation-conflict-build', () => {
-  const { skipped } = nextTestSetup({
+  const { next, skipped } = nextTestSetup({
     files: __dirname,
     skipStart: true,
-    skipDeploy: true,
+    skipDeployment: true,
   })
 
   if (skipped) {
@@ -12,14 +12,10 @@ describe('instrumentation-conflict-build', () => {
   }
 
   it('should throw an error during build when both root and src instrumentation files exist', async () => {
-    const { next } = nextTestSetup({
-      files: __dirname,
-      skipStart: true,
-      skipDeploy: true,
-    })
+    await expect(() => next.start()).rejects.toThrow()
 
-    await expect(next.build()).rejects.toThrow(
-      /Conflicting instrumentation files detected/
+    expect(next.cliOutput).toContain(
+      'Conflicting instrumentation files detected'
     )
   })
 })

--- a/test/production/app-dir/instrumentation-conflict-build/instrumentation-conflict-build.test.ts
+++ b/test/production/app-dir/instrumentation-conflict-build/instrumentation-conflict-build.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('instrumentation-conflict-build', () => {
+  const { skipped } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeploy: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should throw an error during build when both root and src instrumentation files exist', async () => {
+    const { next } = nextTestSetup({
+      files: __dirname,
+      skipStart: true,
+      skipDeploy: true,
+    })
+
+    await expect(next.build()).rejects.toThrow(
+      /Conflicting instrumentation files detected/
+    )
+  })
+})

--- a/test/production/app-dir/instrumentation-conflict-build/instrumentation.ts
+++ b/test/production/app-dir/instrumentation-conflict-build/instrumentation.ts
@@ -1,0 +1,3 @@
+export function register() {
+  console.log('Root instrumentation loaded')
+}

--- a/test/production/app-dir/instrumentation-conflict-build/next.config.js
+++ b/test/production/app-dir/instrumentation-conflict-build/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/app-dir/instrumentation-conflict-build/src/instrumentation.ts
+++ b/test/production/app-dir/instrumentation-conflict-build/src/instrumentation.ts
@@ -1,0 +1,3 @@
+export function register() {
+  console.log('Src instrumentation loaded')
+}


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Fixes inconsistent `instrumentation.ts` loading behavior between development and production environments. Introduces an error when conflicting `instrumentation.ts` files are detected at both the root and `src/` levels.

### Why?
Previously, if `instrumentation.ts` existed at both the root and `src/` directory, the loading behavior was inconsistent between development and production. This led to unexpected runtime behavior and confusion. This change ensures consistent behavior by throwing a clear error when such a conflict occurs, guiding users to resolve it by removing one of the conflicting files.

### How?
- Modified `packages/next/src/build/index.ts` to detect both `instrumentation.ts` and `src/instrumentation.ts` during the build process.
- Implemented a validation step to throw an error if both files are found, mirroring the existing middleware/proxy conflict detection pattern.
- Refactored `packages/next/src/server/lib/router-utils/setup-dev-bundler.ts` to apply the same conflict detection logic in the development server, ensuring consistent error handling across environments.
- Added new e2e tests (`test/development/app-dir/instrumentation-conflict/` and `test/production/app-dir/instrumentation-conflict-build/`) to verify the error is thrown correctly in both dev and production builds.

Closes NEXT-
Fixes #
Related Slack thread: <https://vercel.slack.com/archives/C03KAR5DCKC/p1723471806322009?thread_ts=1722634428.978659&channel=C03KAR5DCKC&message_ts=1723471806.322009>
-->

---
[Slack Thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1754816676935289?thread_ts=1754816676.935289&cid=C03KAR5DCKC)

<p><a href="https://cursor.com/background-agent?bcId=bc-05d4e8d8-45b2-51ad-88b8-ac89de9435ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-05d4e8d8-45b2-51ad-88b8-ac89de9435ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

