### PR TITLE
fix: clear inherited robots metadata on error pages to prevent duplicate meta tags

### DIFF
--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -1270,12 +1270,22 @@ export async function resolveMetadata(
     getDynamicParamFromSegment,
     workStore
   )
-  return accumulateMetadata(
+  const resolved = await accumulateMetadata(
     workStore.route,
     metadataItems,
     pathname,
     metadataContext
   )
+
+  // When rendering an error page (not-found, forbidden, unauthorized),
+  // clear any robots metadata inherited from parent layouts to prevent
+  // conflicting robots meta tags. The error boundary will independently
+  // render <meta name="robots" content="noindex" />.
+  if (errorConvention) {
+    resolved.robots = null
+  }
+
+  return resolved
 }
 
 // Exposed API for viewport component, that directly resolve the loader tree and related context as resolved viewport.

--- a/test/e2e/app-dir/metadata-navigation/app/async/robots-parent/layout.tsx
+++ b/test/e2e/app-dir/metadata-navigation/app/async/robots-parent/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }) {
+  return children
+}
+
+export const metadata = {
+  robots: { index: true, follow: true },
+}

--- a/test/e2e/app-dir/metadata-navigation/app/async/robots-parent/not-found.tsx
+++ b/test/e2e/app-dir/metadata-navigation/app/async/robots-parent/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return <h2>Not found</h2>
+}
+
+export const metadata = {
+  title: 'Not found',
+  description: 'Page not found',
+}

--- a/test/e2e/app-dir/metadata-navigation/app/async/robots-parent/page.tsx
+++ b/test/e2e/app-dir/metadata-navigation/app/async/robots-parent/page.tsx
@@ -1,0 +1,9 @@
+import { notFound } from 'next/navigation'
+
+export default function Page() {
+  return 'page'
+}
+
+export async function generateMetadata() {
+  notFound()
+}

--- a/test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
+++ b/test/e2e/app-dir/metadata-navigation/metadata-navigation.test.ts
@@ -73,6 +73,29 @@ describe('app dir - metadata navigation', () => {
       expect(await getTitle(browser)).toBe('Local not found')
     })
 
+    it('should not have conflicting robots meta tags when parent defines robots and notFound is called in generateMetadata', async () => {
+      const $ = await next.render$('/async/robots-parent')
+
+      // Should have exactly one robots meta tag with content "noindex"
+      const robotsMeta = $('meta[name="robots"]')
+      expect(robotsMeta.length).toBe(1)
+      expect(robotsMeta.attr('content')).toBe('noindex')
+
+      // Should NOT contain the parent's "index, follow" robots value
+      const html = $.html()
+      expect(html).not.toContain('content="index, follow"')
+
+      // Verify via browser navigation as well
+      const browser = await next.browser('/async/robots-parent')
+      const robotsElements = await browser.elementsByCss('meta[name="robots"]')
+      expect(robotsElements.length).toBe(1)
+      expect(
+        await browser
+          .elementByCss('meta[name="robots"]')
+          .getAttribute('content')
+      ).toBe('noindex')
+    })
+
     it('should support redirect in generateMetadata', async () => {
       const res = await next.fetch('/async/redirect', {
         redirect: 'manual',


### PR DESCRIPTION
## Summary

Fixes #67907

When `notFound()` is called in `generateMetadata()` and a parent layout defines `robots: { index: true, follow: true }`, the HTML output contains duplicate conflicting robots meta tags:

```html
<meta name="robots" content="noindex"/>
<meta name="robots" content="index, follow"/>
```

### Root Cause

Three independent sources emit robots meta tags:

1. **Metadata component** — resolves metadata via `resolveMetadata()` → `accumulateMetadata()` → `mergeMetadata()`, renders `<meta name="robots">` via `BasicMeta`.
2. **Error boundary** (`error-boundary.tsx`) — unconditionally renders `<meta name="robots" content="noindex" />` when catching `HTTPAccessFallbackError`.
3. **Server-inserted HTML** (`make-get-server-inserted-html.tsx`) — adds `<meta name="robots" content="noindex" />` for captured errors.

When `notFound()` is called in `generateMetadata()`, metadata resolution retries with `errorConvention='not-found'`. During `mergeMetadata()`, robots uses a "child overrides parent" strategy — if the not-found module doesn't set robots, the parent layout's `robots: { index: true, follow: true }` persists. The Metadata component renders "index, follow" while the error boundary independently renders "noindex", producing conflicting tags.

### Fix

In `resolveMetadata()`, after `accumulateMetadata()` returns, nullify `resolved.robots` when `errorConvention` is set. This way the Metadata component renders no robots tag, and the error boundary is the sole source of the noindex directive — producing exactly one `<meta name="robots" content="noindex"/>`.

This applies to all three error conventions: `not-found`, `forbidden`, and `unauthorized`.

## Test Plan

- Added test fixture with a parent layout defining `robots: { index: true, follow: true }` and a page calling `notFound()` in `generateMetadata()`
- Verified SSR HTML contains exactly 1 robots meta tag with content "noindex"
- Verified no "index, follow" robots content in HTML
- Verified client-side DOM matches after browser navigation
- Existing metadata-navigation tests remain unaffected