### PR TITLE
fix(eslint-plugin-next): recurse appDir parser in no-html-link-for-pages

### DIFF
--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -52,8 +52,8 @@ function parseUrlForAppDir(urlprefix: string, directory: string) {
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(...parseUrlForAppDir(urlprefix + dirent.name + '/', dirPath))
       }
     }
   })

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,7 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withLayoutOnlyAppDir = path.join(__dirname, 'with-app-dir-layout-only')
 
 const linters = {
   withoutPages: new Linter({
@@ -18,6 +19,10 @@ const linters = {
   }),
   withApp: new Linter({
     cwd: withAppDir,
+    configType: 'eslintrc',
+  }),
+  withLayoutOnlyApp: new Linter({
+    cwd: withLayoutOnlyAppDir,
     configType: 'eslintrc',
   }),
   withNestedPages: new Linter({
@@ -163,6 +168,21 @@ export class Blah extends Head {
     return (
       <div>
         <a href='/presentation.pdf'>View PDF</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
+const validNestedLayoutLinkCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/nested/layout'>Nested Layout</a>
         <h1>Hello title</h1>
       </div>
     );
@@ -433,6 +453,14 @@ describe('no-html-link-for-pages', function () {
     const report = linters.withApp.verify(validPublicFile, linterConfig, {
       filename: 'foo.js',
     })
+    assert.deepEqual(report, [])
+  })
+  it('valid nested layout file link element with appDir', function () {
+    const report = linters.withLayoutOnlyApp.verify(
+      validNestedLayoutLinkCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
     assert.deepEqual(report, [])
   })
   it('invalid static route with appDir', function () {

--- a/test/unit/eslint-plugin-next/with-app-dir-layout-only/app/nested/layout.tsx
+++ b/test/unit/eslint-plugin-next/with-app-dir-layout-only/app/nested/layout.tsx
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/unit/eslint-plugin-next/with-app-dir-layout-only/app/page.tsx
+++ b/test/unit/eslint-plugin-next/with-app-dir-layout-only/app/page.tsx
@@ -1,0 +1,1 @@
+export default () => {}


### PR DESCRIPTION
## What

This PR fixes app directory traversal in `no-html-link-for-pages` URL discovery.

`parseUrlForAppDir` was recursively delegating into `parseUrlForPages`, which uses pages-specific semantics.  
This change keeps recursion in app-dir mode (`parseUrlForAppDir` -> `parseUrlForAppDir`) and adds a regression test fixture to ensure `layout`-only paths are not treated as routable page paths.

## Why

The app router and pages router have different file semantics.  
Mixing parsers during recursion can produce incorrect URL candidates and false positives in linting.

This is a follow-up to the appDir support work in [#68770](https://github.com/vercel/next.js/issues/68770).

## How

- Updated recursion in:
  - `packages/eslint-plugin-next/src/utils/url.ts`
- Added regression coverage in:
  - `test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts`
- Added dedicated fixture:
  - `test/unit/eslint-plugin-next/with-app-dir-layout-only/app/page.tsx`
  - `test/unit/eslint-plugin-next/with-app-dir-layout-only/app/nested/layout.tsx`

## Testing

- `pnpm exec jest test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts` ✅
- `pnpm exec jest test/unit/eslint-plugin-next/` ✅

## Related

- Follow-up: #68770
- Original issue context: #51742
