### PR TITLE
fix(eslint-plugin-next): respect next.config pageExtensions in no-htm…

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -8,6 +8,7 @@ import {
   normalizeURL,
   execOnce,
   getUrlFromAppDirectory,
+  DEFAULT_PAGE_EXTENSIONS,
 } from '../utils/url'
 
 const pagesDirWarning = execOnce((pagesDirs) => {
@@ -20,6 +21,16 @@ const pagesDirWarning = execOnce((pagesDirs) => {
 // Cache for fs.existsSync lookup.
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsExistsSyncCache = {}
+const fsReadFileSyncCache = {}
+const pageExtensionsCache = {}
+const nextConfigFiles = [
+  'next.config.js',
+  'next.config.mjs',
+  'next.config.cjs',
+  'next.config.ts',
+  'next.config.mts',
+  'next.config.cts',
+]
 
 const memoize = <T = any>(fn: (...args: any[]) => T) => {
   const cache = {}
@@ -36,6 +47,75 @@ const cachedGetUrlFromPagesDirectories = memoize(getUrlFromPagesDirectories)
 const cachedGetUrlFromAppDirectory = memoize(getUrlFromAppDirectory)
 
 const url = 'https://nextjs.org/docs/messages/no-html-link-for-pages'
+
+const parsePageExtensions = (nextConfigContents: string) => {
+  const pageExtensionsMatch = nextConfigContents.match(
+    /\bpageExtensions\s*:\s*\[([\s\S]*?)\]/
+  )
+  if (!pageExtensionsMatch) {
+    return
+  }
+
+  const extensions = []
+  const extensionRegex = /(['"`])((?:\\.|(?!\1)[\s\S])*)\1/g
+
+  let extensionMatch
+  while ((extensionMatch = extensionRegex.exec(pageExtensionsMatch[1]))) {
+    const extension = extensionMatch[2].trim().replace(/^\./, '')
+    if (extension.length > 0) {
+      extensions.push(extension)
+    }
+  }
+
+  if (extensions.length === 0) {
+    return
+  }
+
+  return Array.from(new Set(extensions))
+}
+
+const getPageExtensions = (rootDirs: string[]) => {
+  const discoveredPageExtensions = rootDirs.flatMap((rootDir) => {
+    if (pageExtensionsCache[rootDir] !== undefined) {
+      return pageExtensionsCache[rootDir]
+    }
+
+    let pageExtensions = DEFAULT_PAGE_EXTENSIONS
+
+    for (const nextConfigFile of nextConfigFiles) {
+      const nextConfigPath = path.join(rootDir, nextConfigFile)
+      if (fsExistsSyncCache[nextConfigPath] === undefined) {
+        fsExistsSyncCache[nextConfigPath] = fs.existsSync(nextConfigPath)
+      }
+
+      if (!fsExistsSyncCache[nextConfigPath]) {
+        continue
+      }
+
+      if (fsReadFileSyncCache[nextConfigPath] === undefined) {
+        fsReadFileSyncCache[nextConfigPath] = fs.readFileSync(
+          nextConfigPath,
+          'utf8'
+        )
+      }
+
+      const configuredPageExtensions = parsePageExtensions(
+        fsReadFileSyncCache[nextConfigPath]
+      )
+      if (configuredPageExtensions) {
+        pageExtensions = configuredPageExtensions
+      }
+      break
+    }
+
+    pageExtensionsCache[rootDir] = pageExtensions
+    return pageExtensions
+  })
+
+  return discoveredPageExtensions.length > 0
+    ? Array.from(new Set(discoveredPageExtensions))
+    : DEFAULT_PAGE_EXTENSIONS
+}
 
 export default defineRule({
   meta: {
@@ -107,8 +187,17 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageExtensions = getPageExtensions(rootDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories(
+      '/',
+      foundPagesDirs,
+      pageExtensions
+    )
+    const appDirUrls = cachedGetUrlFromAppDirectory(
+      '/',
+      foundAppDirs,
+      pageExtensions
+    )
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -4,29 +4,69 @@ import * as fs from 'fs'
 // Cache for fs.readdirSync lookup.
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
+export const DEFAULT_PAGE_EXTENSIONS = ['tsx', 'ts', 'jsx', 'js']
+
+function escapeStringRegexp(value: string) {
+  return value.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&')
+}
+
+function getPageExtensionsRegexString(pageExtensions: string[]) {
+  const extensions = Array.from(
+    new Set(
+      (pageExtensions.length > 0 ? pageExtensions : DEFAULT_PAGE_EXTENSIONS)
+        .map((ext) => ext.trim().replace(/^\./, ''))
+        .filter(Boolean)
+    )
+  )
+
+  return extensions
+    .sort((a, b) => b.length - a.length)
+    .map(escapeStringRegexp)
+    .join('|')
+}
+
+function createPageExtensionRegex(pageExtensions: string[]) {
+  return new RegExp(`\\.(?:${getPageExtensionsRegexString(pageExtensions)})$`)
+}
+
+function createNamedFileRegex(name: string, pageExtensions: string[]) {
+  return new RegExp(
+    `^${escapeStringRegexp(name)}\\.(?:${getPageExtensionsRegexString(
+      pageExtensions
+    )})$`
+  )
+}
 
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensionRegex: RegExp,
+  indexFileRegex: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (pageExtensionRegex.test(dirent.name)) {
+      if (indexFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexFileRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(pageExtensionRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensionRegex,
+            indexFileRegex
+          )
+        )
       }
     }
   })
@@ -36,24 +76,36 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensionRegex: RegExp,
+  pageFileRegex: RegExp,
+  layoutFileRegex: RegExp,
+  indexFileRegex: RegExp
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (pageExtensionRegex.test(dirent.name)) {
+      if (pageFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageFileRegex, '')}`)
+      } else if (!layoutFileRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageExtensionRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(
+            urlprefix + dirent.name + '/',
+            dirPath,
+            pageExtensionRegex,
+            indexFileRegex
+          )
+        )
       }
     }
   })
@@ -136,13 +188,24 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
+  const pageExtensionRegex = createPageExtensionRegex(pageExtensions)
+  const indexFileRegex = createNamedFileRegex('index', pageExtensions)
+
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(
+            urlPrefix,
+            directory,
+            pageExtensionRegex,
+            indexFileRegex
+          )
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +219,28 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
+  const pageExtensionRegex = createPageExtensionRegex(pageExtensions)
+  const pageFileRegex = createNamedFileRegex('page', pageExtensions)
+  const layoutFileRegex = createNamedFileRegex('layout', pageExtensions)
+  const indexFileRegex = createNamedFileRegex('index', pageExtensions)
+
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(
+            urlPrefix,
+            directory,
+            pageExtensionRegex,
+            pageFileRegex,
+            layoutFileRegex,
+            indexFileRegex
+          )
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -10,6 +10,10 @@ const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withCustomPageExtensionsDir = path.join(
+  __dirname,
+  'with-custom-page-extensions'
+)
 
 const linters = {
   withoutPages: new Linter({
@@ -18,6 +22,10 @@ const linters = {
   }),
   withApp: new Linter({
     cwd: withAppDir,
+    configType: 'eslintrc',
+  }),
+  withCustomPageExtensions: new Linter({
+    cwd: withCustomPageExtensionsDir,
     configType: 'eslintrc',
   }),
   withNestedPages: new Linter({
@@ -255,6 +263,21 @@ export class Blah extends Head {
   }
 }
 `
+
+const invalidCustomPageExtensionsCode = `
+import Link from 'next/link';
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/docs/about'>Docs</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+
 describe('no-html-link-for-pages', function () {
   it('does not print warning when there are "pages" or "app" directories with rootDir in context settings', function () {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
@@ -493,6 +516,30 @@ describe('no-html-link-for-pages', function () {
     assert.equal(
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid route with custom pageExtensions in pages directory', function () {
+    const [report] = linters.withCustomPageExtensions.verify(
+      invalidCustomPageExtensionsCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/docs/about/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  it('invalid root route with custom pageExtensions in app directory', function () {
+    const [report] = linters.withCustomPageExtensions.verify(
+      invalidStaticCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
 })

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/app/docs/page.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/app/docs/page.page.tsx
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/app/page.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/app/page.page.tsx
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/next.config.js
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
+}

--- a/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/docs/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-custom-page-extensions/pages/docs/about.page.tsx
@@ -1,0 +1,1 @@
+export default () => {}


### PR DESCRIPTION
## What

This PR updates `@next/next/no-html-link-for-pages` to respect custom `pageExtensions` from `next.config.*` when building internal route URL matchers.

## Why

The rule currently assumes only default extensions and can miss internal routes when projects use custom `pageExtensions` (for example `page.tsx`-style extensions). This leads to false negatives.

Fixes #53473.

## How

- Added `pageExtensions` resolution in the rule from supported config files:
  - `next.config.js`
  - `next.config.mjs`
  - `next.config.cjs`
  - `next.config.ts`
  - `next.config.mts`
  - `next.config.cts`
- Kept default fallback extensions when no config is found.
- Updated URL parsing utilities to use configurable extensions for both `pages` and `app` route discovery.
- Added regression tests and fixtures for custom `pageExtensions`.

## Testing

- `pnpm --filter=@next/eslint-plugin-next build`
- `pnpm exec jest test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts`
- `pnpm exec jest test/unit/eslint-plugin-next/`
