### PR TITLE
fix(metadata): escape XML special characters in generated sitemap

### DIFF
--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.test.ts
@@ -225,5 +225,105 @@ describe('resolveRouteData', () => {
         "
       `)
     })
+    it('should escape XML special characters in URLs', () => {
+      expect(
+        resolveSitemap([
+          {
+            url: 'https://example.com?a=1&b=2',
+            lastModified: '2021-01-01',
+          },
+        ])
+      ).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+        <url>
+        <loc>https://example.com?a=1&amp;b=2</loc>
+        <lastmod>2021-01-01</lastmod>
+        </url>
+        </urlset>
+        "
+      `)
+    })
+    it('should escape XML special characters in alternate URLs', () => {
+      expect(
+        resolveSitemap([
+          {
+            url: 'https://example.com?a=1&b=2',
+            alternates: {
+              languages: {
+                es: 'https://example.com/es?a=1&b=2',
+                de: 'https://example.com/de?x=1&y=2',
+              },
+            },
+          },
+        ])
+      ).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+        <url>
+        <loc>https://example.com?a=1&amp;b=2</loc>
+        <xhtml:link rel="alternate" hreflang="es" href="https://example.com/es?a=1&amp;b=2" />
+        <xhtml:link rel="alternate" hreflang="de" href="https://example.com/de?x=1&amp;y=2" />
+        </url>
+        </urlset>
+        "
+      `)
+    })
+    it('should escape XML special characters in image URLs', () => {
+      expect(
+        resolveSitemap([
+          {
+            url: 'https://example.com',
+            images: ['https://example.com/image?w=100&h=200'],
+          },
+        ])
+      ).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+        <url>
+        <loc>https://example.com</loc>
+        <image:image>
+        <image:loc>https://example.com/image?w=100&amp;h=200</image:loc>
+        </image:image>
+        </url>
+        </urlset>
+        "
+      `)
+    })
+    it('should escape XML special characters in video fields', () => {
+      expect(
+        resolveSitemap([
+          {
+            url: 'https://example.com',
+            videos: [
+              {
+                title: 'A & B <video>',
+                thumbnail_loc: 'https://example.com/thumb?a=1&b=2',
+                description: 'Description with "quotes" & <special> chars',
+                content_loc: 'https://example.com/video?id=1&fmt=mp4',
+                player_loc: 'https://example.com/player?v=1&autoplay=true',
+                tag: 'tag1&tag2',
+              },
+            ],
+          },
+        ])
+      ).toMatchInlineSnapshot(`
+        "<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+        <url>
+        <loc>https://example.com</loc>
+        <video:video>
+        <video:title>A &amp; B &lt;video&gt;</video:title>
+        <video:thumbnail_loc>https://example.com/thumb?a=1&amp;b=2</video:thumbnail_loc>
+        <video:description>Description with &quot;quotes&quot; &amp; &lt;special&gt; chars</video:description>
+        <video:content_loc>https://example.com/video?id=1&amp;fmt=mp4</video:content_loc>
+        <video:player_loc>https://example.com/player?v=1&amp;autoplay=true</video:player_loc>
+        <video:tag>tag1&amp;tag2</video:tag>
+        </video:video>
+        </url>
+        </urlset>
+        "
+      `)
+    })
   })
 })

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -123,7 +123,7 @@ export function resolveSitemap(data: MetadataRoute.Sitemap): string {
           video.platform &&
             `<video:platform relationship="${escapeXml(video.platform.relationship)}">${escapeXml(video.platform.content)}</video:platform>`,
           video.uploader &&
-            `<video:uploader${video.uploader.info && ` info="${escapeXml(video.uploader.info)}"`}>${escapeXml(video.uploader.content)}</video:uploader>`,
+            `<video:uploader${video.uploader.info ? ` info="${escapeXml(video.uploader.info)}"` : ""}>${escapeXml(video.uploader.content ?? "")}</video:uploader>`,
           `</video:video>\n`,
         ].filter(Boolean)
         content += videoFields.join('\n')

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -1,6 +1,15 @@
 import type { MetadataRoute } from '../../../../lib/metadata/types/metadata-interface'
 import { resolveArray } from '../../../../lib/metadata/generate/utils'
 
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
 // convert robots data to txt string
 export function resolveRobots(data: MetadataRoute.Robots): string {
   let content = ''
@@ -66,39 +75,39 @@ export function resolveSitemap(data: MetadataRoute.Sitemap): string {
   }
   for (const item of data) {
     content += '<url>\n'
-    content += `<loc>${item.url}</loc>\n`
+    content += `<loc>${escapeXml(item.url)}</loc>\n`
 
     const languages = item.alternates?.languages
     if (languages && Object.keys(languages).length) {
       // Since sitemap is separated from the page rendering, there's not metadataBase accessible yet.
       // we give the default setting that won't effect the languages resolving.
       for (const language in languages) {
-        content += `<xhtml:link rel="alternate" hreflang="${language}" href="${
-          languages[language as keyof typeof languages]
-        }" />\n`
+        content += `<xhtml:link rel="alternate" hreflang="${escapeXml(language)}" href="${escapeXml(
+          String(languages[language as keyof typeof languages])
+        )}" />\n`
       }
     }
     if (item.images?.length) {
       for (const image of item.images) {
-        content += `<image:image>\n<image:loc>${image}</image:loc>\n</image:image>\n`
+        content += `<image:image>\n<image:loc>${escapeXml(image)}</image:loc>\n</image:image>\n`
       }
     }
     if (item.videos?.length) {
       for (const video of item.videos) {
         let videoFields = [
           `<video:video>`,
-          `<video:title>${video.title}</video:title>`,
-          `<video:thumbnail_loc>${video.thumbnail_loc}</video:thumbnail_loc>`,
-          `<video:description>${video.description}</video:description>`,
+          `<video:title>${escapeXml(video.title)}</video:title>`,
+          `<video:thumbnail_loc>${escapeXml(video.thumbnail_loc)}</video:thumbnail_loc>`,
+          `<video:description>${escapeXml(video.description)}</video:description>`,
           video.content_loc &&
-            `<video:content_loc>${video.content_loc}</video:content_loc>`,
+            `<video:content_loc>${escapeXml(video.content_loc)}</video:content_loc>`,
           video.player_loc &&
-            `<video:player_loc>${video.player_loc}</video:player_loc>`,
+            `<video:player_loc>${escapeXml(video.player_loc)}</video:player_loc>`,
           video.duration &&
             `<video:duration>${video.duration}</video:duration>`,
           video.view_count &&
             `<video:view_count>${video.view_count}</video:view_count>`,
-          video.tag && `<video:tag>${video.tag}</video:tag>`,
+          video.tag && `<video:tag>${escapeXml(video.tag)}</video:tag>`,
           video.rating && `<video:rating>${video.rating}</video:rating>`,
           video.expiration_date &&
             `<video:expiration_date>${video.expiration_date}</video:expiration_date>`,
@@ -110,11 +119,11 @@ export function resolveSitemap(data: MetadataRoute.Sitemap): string {
             `<video:requires_subscription>${video.requires_subscription}</video:requires_subscription>`,
           video.live && `<video:live>${video.live}</video:live>`,
           video.restriction &&
-            `<video:restriction relationship="${video.restriction.relationship}">${video.restriction.content}</video:restriction>`,
+            `<video:restriction relationship="${escapeXml(video.restriction.relationship)}">${escapeXml(video.restriction.content)}</video:restriction>`,
           video.platform &&
-            `<video:platform relationship="${video.platform.relationship}">${video.platform.content}</video:platform>`,
+            `<video:platform relationship="${escapeXml(video.platform.relationship)}">${escapeXml(video.platform.content)}</video:platform>`,
           video.uploader &&
-            `<video:uploader${video.uploader.info && ` info="${video.uploader.info}"`}>${video.uploader.content}</video:uploader>`,
+            `<video:uploader${video.uploader.info && ` info="${escapeXml(video.uploader.info)}"`}>${escapeXml(video.uploader.content)}</video:uploader>`,
           `</video:video>\n`,
         ].filter(Boolean)
         content += videoFields.join('\n')


### PR DESCRIPTION
## What?

Escape XML special characters (`&`, `<`, `>`, `"`, `'`) in all user-provided strings interpolated into sitemap XML output.

## Why?

URLs containing query parameters (e.g., `https://example.com?a=1&b=2`) produce invalid XML in the generated sitemap. The unescaped `&` character breaks XML parsers and causes validation errors in tools like Google Search Console.

This affects all Next.js apps using `sitemap.ts` with URLs containing XML special characters.

## How?

Added an `escapeXml()` helper function that performs standard XML entity escaping, applied to all user-provided string interpolations in `resolveSitemap()`:

- `<loc>` URLs
- `<xhtml:link>` alternate language URLs and `hreflang` attributes
- `<image:loc>` URLs
- All `<video:*>` fields (title, description, URLs, tags, restriction, platform, uploader)

Numeric and enum fields (`duration`, `view_count`, `rating`, `family_friendly`, `requires_subscription`, `live`, date fields) are not escaped as they do not contain user-provided free-text strings.

Added test coverage for XML escaping across all sitemap field types.

Closes #77340