### PR TITLE
fix: read middleware config when using grouped export (export { middleware, config })

### DIFF
--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -210,8 +210,28 @@ function extractValue(node: Node, path?: string[]): any {
 }
 
 /**
+ * Tries to extract the value of a const from a VariableDeclaration node.
+ * Returns undefined if the name doesn't match or there's no init.
+ */
+function tryExtractConstFromVariableDeclaration(
+  declaration: VariableDeclaration,
+  exportedName: string
+): any {
+  if (declaration.kind !== 'const') {
+    return undefined
+  }
+  for (const decl of declaration.declarations) {
+    if (isIdentifier(decl.id) && decl.id.value === exportedName && decl.init) {
+      return extractValue(decl.init, [exportedName])
+    }
+  }
+  return undefined
+}
+
+/**
  * Extracts the value of an exported const variable named `exportedName`
- * (e.g. "export const config = { runtime: 'edge' }") from swc's AST.
+ * (e.g. "export const config = { runtime: 'edge' }" or "const config = {}; export { config }")
+ * from swc's AST.
  * The value must be one of (or throws UnsupportedValueError):
  *   - string
  *   - boolean
@@ -228,27 +248,45 @@ export function extractExportedConstValue(
   exportedName: string
 ): any {
   for (const moduleItem of module.body) {
-    if (!isExportDeclaration(moduleItem)) {
-      continue
-    }
-
-    const declaration = moduleItem.declaration
-    if (!isVariableDeclaration(declaration)) {
-      continue
-    }
-
-    if (declaration.kind !== 'const') {
-      continue
-    }
-
-    for (const decl of declaration.declarations) {
-      if (
-        isIdentifier(decl.id) &&
-        decl.id.value === exportedName &&
-        decl.init
-      ) {
-        return extractValue(decl.init, [exportedName])
+    // "export const config = ..."
+    if (isExportDeclaration(moduleItem)) {
+      const declaration = moduleItem.declaration
+      if (isVariableDeclaration(declaration)) {
+        const value = tryExtractConstFromVariableDeclaration(
+          declaration,
+          exportedName
+        )
+        if (value !== undefined) return value
       }
+      continue
+    }
+
+    // "export const config = ..." (some parsers) or "export { config }" with declaration
+    if ((moduleItem as Node).type === 'ExportNamedDeclaration') {
+      const named = moduleItem as {
+        declaration?: VariableDeclaration
+        specifiers?: Array<{
+          orig?: { value?: string }
+          exported?: { value?: string }
+        }>
+      }
+      if (named.declaration && isVariableDeclaration(named.declaration)) {
+        const value = tryExtractConstFromVariableDeclaration(
+          named.declaration,
+          exportedName
+        )
+        if (value !== undefined) return value
+      }
+      continue
+    }
+
+    // Top-level "const config = ..." (e.g. before "export { middleware, config }")
+    if (isVariableDeclaration(moduleItem as Node)) {
+      const value = tryExtractConstFromVariableDeclaration(
+        moduleItem as VariableDeclaration,
+        exportedName
+      )
+      if (value !== undefined) return value
     }
   }
 

--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -210,6 +210,47 @@ function extractValue(node: Node, path?: string[]): any {
 }
 
 /**
+ * Returns the set of local names that are exported from the module.
+ * Used to ensure we only extract from top-level consts that are actually exported.
+ */
+function getExportedNames(module: Module): Set<string> {
+  const names = new Set<string>()
+  for (const moduleItem of module.body) {
+    if (isExportDeclaration(moduleItem)) {
+      const declaration = moduleItem.declaration
+      if (isVariableDeclaration(declaration)) {
+        for (const decl of declaration.declarations) {
+          if (isIdentifier(decl.id)) names.add(decl.id.value)
+        }
+      }
+      continue
+    }
+    if ((moduleItem as Node).type === 'ExportNamedDeclaration') {
+      const named = moduleItem as {
+        declaration?: VariableDeclaration
+        specifiers?: Array<{ type?: string; orig?: { type?: string; value?: string } }>
+      }
+      if (named.declaration && isVariableDeclaration(named.declaration)) {
+        for (const decl of named.declaration.declarations) {
+          if (isIdentifier(decl.id)) names.add(decl.id.value)
+        }
+      }
+      for (const spec of named.specifiers ?? []) {
+        if (
+          spec.type === 'ExportSpecifier' &&
+          spec.orig &&
+          (spec.orig as { type?: string }).type === 'Identifier'
+        ) {
+          const value = (spec.orig as Identifier).value
+          if (value !== undefined) names.add(value)
+        }
+      }
+    }
+  }
+  return names
+}
+
+/**
  * Tries to extract the value of a const from a VariableDeclaration node.
  * Returns undefined if the name doesn't match or there's no init.
  */
@@ -242,11 +283,14 @@ function tryExtractConstFromVariableDeclaration(
  *   - object containing values listed in this list
  *
  * Throws NoSuchDeclarationError if the declaration is not found.
+ * Only extracts from declarations that are actually exported (never from non-exported consts).
  */
 export function extractExportedConstValue(
   module: Module,
   exportedName: string
 ): any {
+  const exportedNames = getExportedNames(module)
+
   for (const moduleItem of module.body) {
     // "export const config = ..."
     if (isExportDeclaration(moduleItem)) {
@@ -280,8 +324,12 @@ export function extractExportedConstValue(
       continue
     }
 
-    // Top-level "const config = ..." (e.g. before "export { middleware, config }")
-    if (isVariableDeclaration(moduleItem as Node)) {
+    // Top-level "const config = ..." only when that name is actually exported
+    // (e.g. "const config = {}; export { middleware, config }")
+    if (
+      exportedNames.has(exportedName) &&
+      isVariableDeclaration(moduleItem as Node)
+    ) {
       const value = tryExtractConstFromVariableDeclaration(
         moduleItem as VariableDeclaration,
         exportedName

--- a/test/unit/fixtures/page-runtime/middleware-grouped-export.js
+++ b/test/unit/fixtures/page-runtime/middleware-grouped-export.js
@@ -1,0 +1,10 @@
+// Grouped export: config is declared then exported (issue #56451)
+const config = {
+  matcher: ['/api/:path*'],
+}
+
+function middleware() {
+  return new Response('ok')
+}
+
+export { middleware, config }

--- a/test/unit/parse-page-static-info.test.ts
+++ b/test/unit/parse-page-static-info.test.ts
@@ -76,4 +76,22 @@ describe('parse page static info', () => {
     expect(getStaticProps).toBe(false)
     expect(getServerSideProps).toBe(true)
   })
+
+  it('should parse middleware config from grouped export (const config; export { middleware, config })', async () => {
+    const { middleware: middlewareConfig } = await getPagesPageStaticInfo({
+      page: 'middleware',
+      pageFilePath: join(
+        fixtureDir,
+        'page-runtime/middleware-grouped-export.js'
+      ),
+      nextConfig: createNextConfig(),
+      pageType: PAGE_TYPES.PAGES,
+      isDev: false,
+    })
+    expect(middlewareConfig?.matchers).toBeDefined()
+    expect(Array.isArray(middlewareConfig?.matchers)).toBe(true)
+    expect(middlewareConfig!.matchers!.length).toBeGreaterThan(0)
+    expect(middlewareConfig!.matchers![0]).toHaveProperty('originalSource')
+    expect(middlewareConfig!.matchers![0].originalSource).toBe('/api/:path*')
+  })
 })


### PR DESCRIPTION
## For Contributors

### Fixing a bug

- [x] Related issues linked using `fixes #56451`
- [x] Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- [x] Errors have a helpful link attached (N/A – no new error messages)

---

### What?

When middleware uses a **grouped export** for config (e.g. `const config = { matcher: [...] }; export { middleware, config };`), the matcher was not applied. Middleware then ran for every request, including static assets. Inline `export const config = ...` worked correctly.

### Why?

`extractExportedConstValue()` only handled `ExportDeclaration` + `VariableDeclaration` (inline `export const config = ...`). It did not resolve a top-level `const config = ...` that was later re-exported via `export { middleware, config }`.

### How?

- **`packages/next/src/build/analysis/extract-const-value.ts`**: Extended `extractExportedConstValue()` to:
  1. Handle `ExportNamedDeclaration` with an inline `VariableDeclaration` (e.g. `export const config = ...` when parsed as a named export).
  2. If the exported name is still not found, scan the module body for a top-level `VariableDeclaration` with the same name, so that `const config = { matcher: [...] }; export { middleware, config };` is supported.
- **Test**: Added fixture `test/unit/fixtures/page-runtime/middleware-grouped-export.js` and a unit test in `test/unit/parse-page-static-info.test.ts` that asserts middleware config (matchers) is correctly parsed for the grouped-export case.

Fixes #56451