### PR TITLE
docs: clarify async instrumentation register request 

### DIFF
--- a/docs/01-app/02-guides/instrumentation.mdx
+++ b/docs/01-app/02-guides/instrumentation.mdx
@@ -16,7 +16,7 @@ Instrumentation is the process of using code to integrate monitoring and logging
 
 To set up instrumentation, create `instrumentation.ts|js` file in the **root directory** of your project (or inside the [`src`](/docs/app/api-reference/file-conventions/src-folder) folder if using one).
 
-Then, export a `register` function in the file. This function will be called **once** during server startup and must complete before the server is ready to handle requests.
+Then, export a `register` function in the file. This function will be called **once** when a new Next.js server instance is initiated, and must complete before the server is ready to handle requests.
 
 For example, to use Next.js with [OpenTelemetry](https://opentelemetry.io/) and [@vercel/otel](https://vercel.com/docs/observability/otel-overview):
 

--- a/docs/01-app/02-guides/instrumentation.mdx
+++ b/docs/01-app/02-guides/instrumentation.mdx
@@ -18,6 +18,8 @@ To set up instrumentation, create `instrumentation.ts|js` file in the **root dir
 
 Then, export a `register` function in the file. This function will be called **once** when a new Next.js server instance is initiated.
 
+If `register` is async, Next.js will wait for it to finish before handling incoming requests.
+
 For example, to use Next.js with [OpenTelemetry](https://opentelemetry.io/) and [@vercel/otel](https://vercel.com/docs/observability/otel-overview):
 
 ```ts filename="instrumentation.ts" switcher

--- a/docs/01-app/02-guides/instrumentation.mdx
+++ b/docs/01-app/02-guides/instrumentation.mdx
@@ -16,9 +16,7 @@ Instrumentation is the process of using code to integrate monitoring and logging
 
 To set up instrumentation, create `instrumentation.ts|js` file in the **root directory** of your project (or inside the [`src`](/docs/app/api-reference/file-conventions/src-folder) folder if using one).
 
-Then, export a `register` function in the file. This function will be called **once** when a new Next.js server instance is initiated.
-
-If `register` is async, Next.js will wait for it to finish before handling incoming requests.
+Then, export a `register` function in the file. This function will be called **once** during server startup and must complete before the server is ready to handle requests.
 
 For example, to use Next.js with [OpenTelemetry](https://opentelemetry.io/) and [@vercel/otel](https://vercel.com/docs/observability/otel-overview):
 

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
@@ -15,7 +15,7 @@ To use it, place the file in the **root** of your application or inside a [`src`
 
 ### `register` (optional)
 
-The file exports a `register` function that is called **once** when a new Next.js server instance is initiated. `register` can be an async function, and Next.js will wait for it to finish before handling incoming requests.
+The file exports a `register` function that is called **once** during server startup and must complete before the server is ready to handle requests. `register` can be an async function.
 
 ```ts filename="instrumentation.ts" switcher
 import { registerOTel } from '@vercel/otel'

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
@@ -15,7 +15,7 @@ To use it, place the file in the **root** of your application or inside a [`src`
 
 ### `register` (optional)
 
-The file exports a `register` function that is called **once** during server startup and must complete before the server is ready to handle requests. `register` can be an async function.
+The file exports a `register` function that is called **once** when a new Next.js server instance is initiated, and must complete before the server is ready to handle requests. `register` can be an async function.
 
 ```ts filename="instrumentation.ts" switcher
 import { registerOTel } from '@vercel/otel'

--- a/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/instrumentation.mdx
@@ -15,7 +15,7 @@ To use it, place the file in the **root** of your application or inside a [`src`
 
 ### `register` (optional)
 
-The file exports a `register` function that is called **once** when a new Next.js server instance is initiated. `register` can be an async function.
+The file exports a `register` function that is called **once** when a new Next.js server instance is initiated. `register` can be an async function, and Next.js will wait for it to finish before handling incoming requests.
 
 ```ts filename="instrumentation.ts" switcher
 import { registerOTel } from '@vercel/otel'


### PR DESCRIPTION
Explicitly document that Next.js waits for an async instrumentation register function to complete before handling incoming requests, and align wording between the guide and API reference.
