### PR TITLE
Add integration test reproducing inner_of_uppers_lost_follower panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9519,6 +9519,7 @@ dependencies = [
  "turbo-persistence",
  "turbo-rcstr",
  "turbo-tasks",
+ "turbo-tasks-backend",
  "turbo-tasks-malloc",
  "turbo-tasks-testing",
 ]

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -29,7 +29,6 @@ trace_task_modification = []
 trace_task_dirty = ["trace_aggregation_update_queue"]
 trace_task_output_dependencies = []
 trace_task_details = []
-test_aggregation_race = []
 lmdb = ["dep:lmdb-rkv"]
 
 [dependencies]

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -29,6 +29,7 @@ trace_task_modification = []
 trace_task_dirty = ["trace_aggregation_update_queue"]
 trace_task_output_dependencies = []
 trace_task_details = []
+test_aggregation_race = []
 lmdb = ["dep:lmdb-rkv"]
 
 [dependencies]

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -70,6 +70,9 @@ tempfile = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 rstest = { workspace = true }
 turbo-tasks-testing = { workspace = true }
+# Enable features in our tests by default.
+# This is a well known hack: https://github.com/rust-lang/cargo/issues/2911
+turbo-tasks-backend = { path = ".", features = ["verify_aggregation_graph"] }
 
 
 [[bench]]

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -3209,6 +3209,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                         child.iter_upper().map(|(&id, _)| id).collect();
                     drop(child);
 
+                    // If the child is also an upper of the task, it means the child is an inner
+                    // node of the task and we don't need to check the upper's followers
+                    if child_uppers.contains(&task_id) {
+                        continue;
+                    }
+
                     for &upper_id in &uppers {
                         let is_inner = child_uppers.contains(&upper_id);
                         if !is_inner {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1479,6 +1479,12 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         self.idle_end_event.notify(usize::MAX);
     }
 
+    #[allow(unused_variables)]
+    fn verify_graph(&self, turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>) {
+        #[cfg(feature = "verify_aggregation_graph")]
+        self.verify_aggregation_graph(turbo_tasks, false);
+    }
+
     fn get_or_create_persistent_task(
         &self,
         task_type: CachedTaskType,
@@ -3112,7 +3118,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
         use std::{collections::VecDeque, env, io::stdout};
 
-        use crate::backend::operation::{get_uppers, is_aggregating_node};
+        use crate::backend::operation::{get_aggregation_number, get_uppers, is_aggregating_node};
 
         let mut ctx = self.execute_context(turbo_tasks);
         let root_tasks = self.root_tasks.lock().clone();
@@ -3184,19 +3190,51 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 if is_aggregating_node(aggregation_number) {
                     aggregated_nodes.insert(task_id);
                 }
-                // println!(
-                //     "{task_id}: {} agg_num = {aggregation_number}, uppers = {:#?}",
-                //     ctx.get_task_description(task_id),
-                //     uppers
-                // );
 
-                for child_id in task.iter_children() {
-                    // println!("{task_id}: child -> {child_id}");
+                let children: Vec<TaskId> = task.iter_children().collect();
+                for &child_id in &children {
                     if visited.insert(child_id) {
                         queue.push_back(child_id);
                     }
                 }
                 drop(task);
+
+                // Verify that each child of this task is accounted for by each
+                // of this task's uppers: for upper U of task T, and child C of
+                // T, either C.upper[U] exists (C is an inner node of U) or
+                // U.followers[C] exists (C is a follower of U).
+                for &child_id in &children {
+                    let child = ctx.task(child_id, TaskDataCategory::All);
+                    let child_uppers: SmallVec<[TaskId; 4]> =
+                        child.iter_upper().map(|(&id, _)| id).collect();
+                    drop(child);
+
+                    for &upper_id in &uppers {
+                        let is_inner = child_uppers.contains(&upper_id);
+                        if !is_inner {
+                            let upper = ctx.task(upper_id, TaskDataCategory::All);
+                            let is_follower = upper.iter_followers().any(|(&id, _)| id == child_id);
+                            drop(upper);
+                            if !is_follower {
+                                let child_desc = ctx
+                                    .task(child_id, TaskDataCategory::Data)
+                                    .get_task_description();
+                                let upper_desc = ctx
+                                    .task(upper_id, TaskDataCategory::Data)
+                                    .get_task_description();
+                                let task_desc = ctx
+                                    .task(task_id, TaskDataCategory::Data)
+                                    .get_task_description();
+                                panic!(
+                                    "Child {child_id} ({child_desc}) of task {task_id} \
+                                     ({task_desc}) is not tracked by upper {upper_id} \
+                                     ({upper_desc}) — neither {child_id}.upper[{upper_id}] nor \
+                                     {upper_id}.followers[{child_id}] exists"
+                                );
+                            }
+                        }
+                    }
+                }
 
                 if should_be_in_upper {
                     for upper_id in uppers {
@@ -3382,6 +3420,10 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
 
     fn idle_end(&self, _turbo_tasks: &dyn TurboTasksBackendApi<Self>) {
         self.0.idle_end();
+    }
+
+    fn verify_graph(&self, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {
+        self.0.verify_graph(turbo_tasks);
     }
 
     fn get_or_create_persistent_task(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -3123,15 +3123,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let mut ctx = self.execute_context(turbo_tasks);
         let root_tasks = self.root_tasks.lock().clone();
 
-        for task_id in root_tasks.into_iter() {
+        {
             let mut queue = VecDeque::new();
             let mut visited = FxHashSet::default();
             let mut aggregated_nodes = FxHashSet::default();
             let mut collectibles = FxHashMap::default();
-            let root_task_id = task_id;
-            visited.insert(task_id);
-            aggregated_nodes.insert(task_id);
-            queue.push_back(task_id);
+            visited.extend(root_tasks.iter().copied());
+            aggregated_nodes.extend(root_tasks.iter().copied());
+            queue.extend(root_tasks.iter().copied());
             let mut counter = 0;
             while let Some(task_id) = queue.pop_front() {
                 counter += 1;
@@ -3149,7 +3148,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 }
 
                 let uppers = get_uppers(&task);
-                if task_id != root_task_id
+                if !root_tasks.contains(&task_id)
                     && !uppers.iter().any(|upper| aggregated_nodes.contains(upper))
                 {
                     panic!(

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -2749,10 +2749,10 @@ impl TaskIdWithOptionalCount for (TaskId, u32) {
 struct RetryTimeout;
 
 const MAX_YIELD_DURATION: Duration = Duration::from_millis(1);
-#[cfg(not(feature = "test_aggregation_race"))]
+// #[cfg(not(feature = "test_aggregation_race"))]
 const MAX_RETRIES: u16 = 60000;
-#[cfg(feature = "test_aggregation_race")]
-const MAX_RETRIES: u16 = 100;
+// #[cfg(feature = "test_aggregation_race")]
+// const MAX_RETRIES: u16 = 100;
 
 /// Retry the passed function for a few milliseconds, while yielding to other threads.
 /// Returns an error if the function was not able to complete and the timeout was reached.

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1216,17 +1216,7 @@ impl AggregationUpdateQueue {
                 {
                     #[cfg(feature = "trace_aggregation_update_queue")]
                     let _guard = span.map(|s| s.entered());
-                    #[cfg(feature = "test_aggregation_race")]
-                    let jobs_before = self.jobs.len();
                     self.balance_edge(ctx, upper, task);
-                    #[cfg(feature = "test_aggregation_race")]
-                    if self.jobs.len() > jobs_before {
-                        // balance_edge pushed jobs (likely InnerOfUppersLostFollower).
-                        // Stall so a concurrent cleanup on another thread can find
-                        // and consume the newly-created inner edge before our queue
-                        // processes the lost-follower notification.
-                        std::thread::sleep(std::time::Duration::from_millis(5));
-                    }
                     remaining -= 1;
                 } else {
                     break;
@@ -1599,9 +1589,6 @@ impl AggregationUpdateQueue {
             if upper_ids.is_empty() {
                 return ControlFlow::Break(());
             }
-            #[cfg(feature = "test_aggregation_race")]
-            let outer_upper_ids_snapshot: SmallVec<[TaskId; 4]> =
-                upper_ids.iter().copied().collect();
             swap_retain(&mut upper_ids, |&mut upper_id| {
                 let mut upper = ctx.task(
                     upper_id,
@@ -1639,22 +1626,6 @@ impl AggregationUpdateQueue {
                     }
                     // notify uppers about lost follower
                     if !propagation_upper_ids.is_empty() {
-                        #[cfg(feature = "test_aggregation_race")]
-                        {
-                            // Check if any of the propagation targets are also
-                            // in the outer upper_ids list — this would cause a
-                            // double-remove at that target.
-                            for &prop_upper in propagation_upper_ids.iter() {
-                                if outer_upper_ids_snapshot.contains(&prop_upper) {
-                                    eprintln!(
-                                        "[BUG] inner_of_uppers_lost_follower: propagation from \
-                                         removing {upper_id:?}.followers[{lost_follower_id:?}] \
-                                         targets {prop_upper:?}, which is also in the current \
-                                         upper_ids list! This will cause a double-remove."
-                                    );
-                                }
-                            }
-                        }
                         self.push(AggregationUpdateJob::InnerOfUppersLostFollower {
                             upper_ids: propagation_upper_ids,
                             lost_follower_id,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1216,7 +1216,17 @@ impl AggregationUpdateQueue {
                 {
                     #[cfg(feature = "trace_aggregation_update_queue")]
                     let _guard = span.map(|s| s.entered());
+                    #[cfg(feature = "test_aggregation_race")]
+                    let jobs_before = self.jobs.len();
                     self.balance_edge(ctx, upper, task);
+                    #[cfg(feature = "test_aggregation_race")]
+                    if self.jobs.len() > jobs_before {
+                        // balance_edge pushed jobs (likely InnerOfUppersLostFollower).
+                        // Stall so a concurrent cleanup on another thread can find
+                        // and consume the newly-created inner edge before our queue
+                        // processes the lost-follower notification.
+                        std::thread::sleep(std::time::Duration::from_millis(5));
+                    }
                     remaining -= 1;
                 } else {
                     break;
@@ -1589,6 +1599,9 @@ impl AggregationUpdateQueue {
             if upper_ids.is_empty() {
                 return ControlFlow::Break(());
             }
+            #[cfg(feature = "test_aggregation_race")]
+            let outer_upper_ids_snapshot: SmallVec<[TaskId; 4]> =
+                upper_ids.iter().copied().collect();
             swap_retain(&mut upper_ids, |&mut upper_id| {
                 let mut upper = ctx.task(
                     upper_id,
@@ -1616,7 +1629,7 @@ impl AggregationUpdateQueue {
 
                     let has_active_count = ctx.should_track_activeness()
                         && upper.get_activeness().is_some_and(|a| a.active_counter > 0);
-                    let upper_ids = get_uppers(&upper);
+                    let propagation_upper_ids = get_uppers(&upper);
                     drop(upper);
                     // update active count
                     if has_active_count {
@@ -1625,9 +1638,25 @@ impl AggregationUpdateQueue {
                         });
                     }
                     // notify uppers about lost follower
-                    if !upper_ids.is_empty() {
+                    if !propagation_upper_ids.is_empty() {
+                        #[cfg(feature = "test_aggregation_race")]
+                        {
+                            // Check if any of the propagation targets are also
+                            // in the outer upper_ids list — this would cause a
+                            // double-remove at that target.
+                            for &prop_upper in propagation_upper_ids.iter() {
+                                if outer_upper_ids_snapshot.contains(&prop_upper) {
+                                    eprintln!(
+                                        "[BUG] inner_of_uppers_lost_follower: propagation from \
+                                         removing {upper_id:?}.followers[{lost_follower_id:?}] \
+                                         targets {prop_upper:?}, which is also in the current \
+                                         upper_ids list! This will cause a double-remove."
+                                    );
+                                }
+                            }
+                        }
                         self.push(AggregationUpdateJob::InnerOfUppersLostFollower {
-                            upper_ids,
+                            upper_ids: propagation_upper_ids,
                             lost_follower_id,
                             retry: 0,
                         });
@@ -2720,7 +2749,10 @@ impl TaskIdWithOptionalCount for (TaskId, u32) {
 struct RetryTimeout;
 
 const MAX_YIELD_DURATION: Duration = Duration::from_millis(1);
+#[cfg(not(feature = "test_aggregation_race"))]
 const MAX_RETRIES: u16 = 60000;
+#[cfg(feature = "test_aggregation_race")]
+const MAX_RETRIES: u16 = 100;
 
 /// Retry the passed function for a few milliseconds, while yielding to other threads.
 /// Returns an error if the function was not able to complete and the timeout was reached.

--- a/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
@@ -2,36 +2,52 @@
 #![feature(arbitrary_self_types_pointers)]
 #![allow(clippy::needless_return)]
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
+/// This test reliably produces a panic when run with
+// ~/projects/next_2/next.js (aggregation_balance_race *$)$   cargo test -p turbo-tasks-backend
+// --test aggregation_balance_race --features test_aggregation_race
+use std::{future::Future, sync::Arc};
 
 use anyhow::Result;
-use tokio::time::{Duration, timeout};
+use tokio::sync::Notify;
 use turbo_tasks::{Completion, ResolvedVc, State, TryJoinIterExt, Vc, run_once};
 use turbo_tasks_testing::{Registration, register, run_with_tt};
 
 static REGISTRATION: Registration = register!();
 
+/// Races a future against a panic notification. Drops the future's value on success,
+/// or bails if the panic event fires first.
+async fn race_panic<T>(panic_event: &Notify, fut: impl Future<Output = Result<T>>) -> Result<()> {
+    tokio::select! {
+        biased;
+        _ = panic_event.notified() => {
+            anyhow::bail!("Worker thread panicked in aggregation update");
+        }
+        result = fut => {
+            let _ = result?;
+            Ok(())
+        }
+    }
+}
+
 #[turbo_tasks::value]
-struct Toggle {
-    state: State<bool>,
+struct CrossLink {
+    /// 0 = no cross-link, otherwise the coordinate of the interior node to link to.
+    state: State<u32>,
 }
 
 /// Grid task with conditional cross-links.
 #[turbo_tasks::function]
-async fn grid(a: u32, b: u32, toggle: Vc<Toggle>) -> Result<Vc<Completion>> {
+async fn grid(a: u32, b: u32, cross_link: Vc<CrossLink>) -> Result<Vc<Completion>> {
     if a > 0 {
-        grid(a - 1, b, toggle).await?;
+        grid(a - 1, b, cross_link).await?;
     }
     if b > 0 {
-        grid(a, b - 1, toggle).await?;
+        grid(a, b - 1, cross_link).await?;
     }
-    // Toggle-dependent: link to shared interior node
-    let should_cross = *toggle.await?.state.get();
-    if should_cross && (a > 2 || b > 2) {
-        grid(1, 1, toggle).await?;
+    // Cross-link to a different interior node each round
+    let target = *cross_link.await?.state.get();
+    if target > 0 && (a > target + 1 || b > target + 1) {
+        grid(target, target, cross_link).await?;
     }
     Ok(Completion::new())
 }
@@ -43,138 +59,109 @@ async fn grid(a: u32, b: u32, toggle: Vc<Toggle>) -> Result<Vc<Completion>> {
 /// the sleep that widens the race window.
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
 async fn balance_edge_race() -> Result<()> {
-    let grid_size: u32 = 14;
+    const GRID_SIZE: u32 = 20;
+    const ROUNDS: usize = 100;
 
     // Install a panic hook to detect panics on worker threads.
     // The panic in aggregation_update happens inside task_execution_completed
-    // on a tokio worker. tokio catches it via catch_unwind but the JoinHandle
-    // is dropped (WorkerFuture::spawn in priority_runner.rs), so the panic is
-    // silently swallowed and strongly_consistent() / run_once() hang forever.
-    let panicked = Arc::new(AtomicBool::new(false));
+    // on a tokio worker. tokio catches it via catch_unwind but turbotasks does not reliably
+    // propagate panics from core infrastructure
+    let panic_event = Arc::new(Notify::new());
     let prev_hook = std::panic::take_hook();
-    let panicked_clone = panicked.clone();
+    let panic_event_clone = panic_event.clone();
     std::panic::set_hook(Box::new(move |info| {
-        panicked_clone.store(true, Ordering::SeqCst);
+        panic_event_clone.notify_waiters();
         prev_hook(info);
     }));
 
     let result = run_with_tt(&REGISTRATION, move |tt| {
-        let panicked = panicked.clone();
+        let panic_event = panic_event.clone();
         async move {
-            // Wrap everything in a timeout. If the backend panics,
-            // run_once/strongly_consistent hang forever because the
-            // task never completes (WorkerFuture JoinHandle is dropped).
-            let panicked_inner = panicked.clone();
-            let inner_result = timeout(Duration::from_secs(10), async move {
-                let toggle: ResolvedVc<Toggle> = run_once(tt.clone(), async move {
-                    let t = Toggle {
-                        state: State::new(false),
-                    }
-                    .cell();
-                    Ok(t.to_resolved().await?)
-                })
-                .await?;
+            let cross_link: ResolvedVc<CrossLink> = run_once(tt.clone(), async move {
+                let t = CrossLink {
+                    state: State::new(0),
+                }
+                .cell();
+                t.to_resolved().await
+            })
+            .await?;
 
-                let edge_coords: Vec<(u32, u32)> = (0..grid_size)
-                    .map(|a| (a, grid_size - 1))
-                    .chain((0..grid_size - 1).map(|b| (grid_size - 1, b)))
-                    .collect();
+            let edge_coords: Vec<(u32, u32)> = (0..GRID_SIZE)
+                .map(|a| (a, GRID_SIZE - 1))
+                .chain((0..GRID_SIZE - 1).map(|b| (GRID_SIZE - 1, b)))
+                .collect();
 
-                // Establish initial grid
-                let setup_futs: Vec<_> = edge_coords
+            // Establish initial grid
+            race_panic(
+                &panic_event,
+                edge_coords
                     .iter()
                     .map(|&(a, b)| {
-                        let tt = tt.clone();
-                        async move {
-                            let _ = run_once(tt, async move {
-                                grid(a, b, *toggle).strongly_consistent().await?;
-                                Ok(Vc::<()>::default())
-                            })
-                            .await;
-                            anyhow::Ok(())
-                        }
+                        run_once(tt.clone(), async move {
+                            grid(a, b, *cross_link).strongly_consistent().await?;
+                            Ok(Vc::<()>::default())
+                        })
+                    })
+                    .try_join(),
+            )
+            .await?;
+
+            for round in 0..ROUNDS {
+                // Set cross-link target to a different interior node each round
+                let target = (round as u32 % (GRID_SIZE - 3)) + 1;
+                race_panic(
+                    &panic_event,
+                    run_once(tt.clone(), async move {
+                        cross_link.await?.state.set(target);
+                        Ok(Vc::<()>::default())
+                    }),
+                )
+                .await?;
+
+                // Fire all reads concurrently
+                let read_futs: Vec<_> = edge_coords
+                    .iter()
+                    .map(|&(a, b)| {
+                        run_once(tt.clone(), async move {
+                            grid(a, b, *cross_link).strongly_consistent().await?;
+                            Ok(Vc::<()>::default())
+                        })
                     })
                     .collect();
-                setup_futs.into_iter().try_join().await?;
 
-                for _round in 0..100 {
-                    if panicked_inner.load(Ordering::SeqCst) {
-                        anyhow::bail!(
-                            "Worker thread panicked in aggregation update \
-                             (inner_of_uppers_lost_follower)"
-                        );
-                    }
-
-                    // Toggle on
-                    let _ = run_once(tt.clone(), async move {
-                        toggle.await?.state.set(true);
+                // Immediately disable cross-links (while reads are still in progress!)
+                race_panic(
+                    &panic_event,
+                    run_once(tt.clone(), async move {
+                        cross_link.await?.state.set(0);
                         Ok(Vc::<()>::default())
-                    })
-                    .await?;
+                    }),
+                )
+                .await?;
 
-                    // Fire all reads concurrently
-                    let read_futs: Vec<_> = edge_coords
-                        .iter()
-                        .map(|&(a, b)| {
-                            let tt = tt.clone();
-                            async move {
-                                let _ = run_once(tt, async move {
-                                    grid(a, b, *toggle).strongly_consistent().await?;
-                                    Ok(Vc::<()>::default())
-                                })
-                                .await?;
-                                anyhow::Ok(())
-                            }
+                // Fire more reads while cleanup from cross-link is happening
+                let read_futs2: Vec<_> = edge_coords
+                    .iter()
+                    .map(|&(a, b)| {
+                        run_once(tt.clone(), async move {
+                            grid(a, b, *cross_link).strongly_consistent().await?;
+                            Ok(Vc::<()>::default())
                         })
-                        .collect();
-
-                    // Immediately toggle off (while reads are still in progress!)
-                    let _ = run_once(tt.clone(), async move {
-                        toggle.await?.state.set(false);
-                        Ok(Vc::<()>::default())
                     })
-                    .await?;
+                    .collect();
 
-                    // Fire more reads while cleanup from toggle-on is happening
-                    let read_futs2: Vec<_> = edge_coords
-                        .iter()
-                        .map(|&(a, b)| {
-                            let tt = tt.clone();
-                            async move {
-                                let _ = run_once(tt, async move {
-                                    grid(a, b, *toggle).strongly_consistent().await?;
-                                    Ok(Vc::<()>::default())
-                                })
-                                .await?;
-                                anyhow::Ok(())
-                            }
-                        })
-                        .collect();
-
-                    // Wait for all reads from both batches
-                    let _ = futures::future::try_join(
+                // Wait for all reads from both batches
+                race_panic(
+                    &panic_event,
+                    futures::future::try_join(
                         read_futs.into_iter().try_join(),
                         read_futs2.into_iter().try_join(),
-                    )
-                    .await;
-                }
-
-                anyhow::Ok(())
-            })
-            .await;
-
-            match inner_result {
-                Err(_elapsed) => {
-                    if panicked.load(Ordering::SeqCst) {
-                        anyhow::bail!(
-                            "Worker thread panicked in aggregation update \
-                             (inner_of_uppers_lost_follower)"
-                        );
-                    }
-                    anyhow::bail!("Timed out waiting for test to complete");
-                }
-                Ok(result) => result,
+                    ),
+                )
+                .await?;
             }
+
+            anyhow::Ok(())
         }
     })
     .await;

--- a/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
@@ -163,6 +163,10 @@ async fn balance_edge_race() -> Result<()> {
                 // Wait for all foreground jobs (including aggregation queue
                 // processing) to complete before starting the next round
                 tt.wait_foreground_done().await;
+
+                // Verify aggregation graph integrity (no-op without
+                // verify_aggregation_graph feature)
+                tt.verify_graph();
             }
 
             anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
@@ -1,0 +1,186 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)]
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
+
+use anyhow::Result;
+use tokio::time::{Duration, timeout};
+use turbo_tasks::{Completion, ResolvedVc, State, TryJoinIterExt, Vc, run_once};
+use turbo_tasks_testing::{Registration, register, run_with_tt};
+
+static REGISTRATION: Registration = register!();
+
+#[turbo_tasks::value]
+struct Toggle {
+    state: State<bool>,
+}
+
+/// Grid task with conditional cross-links.
+#[turbo_tasks::function]
+async fn grid(a: u32, b: u32, toggle: Vc<Toggle>) -> Result<Vc<Completion>> {
+    if a > 0 {
+        grid(a - 1, b, toggle).await?;
+    }
+    if b > 0 {
+        grid(a, b - 1, toggle).await?;
+    }
+    // Toggle-dependent: link to shared interior node
+    let should_cross = *toggle.await?.state.get();
+    if should_cross && (a > 2 || b > 2) {
+        grid(1, 1, toggle).await?;
+    }
+    Ok(Completion::new())
+}
+
+/// Reproduces a bug in `inner_of_uppers_lost_follower` where hierarchical
+/// uppers in the same `upper_ids` list cause a double-remove of follower edges.
+///
+/// Requires feature `test_aggregation_race` on turbo-tasks-backend to inject
+/// the sleep that widens the race window.
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn balance_edge_race() -> Result<()> {
+    let grid_size: u32 = 14;
+
+    // Install a panic hook to detect panics on worker threads.
+    // The panic in aggregation_update happens inside task_execution_completed
+    // on a tokio worker. tokio catches it via catch_unwind but the JoinHandle
+    // is dropped (WorkerFuture::spawn in priority_runner.rs), so the panic is
+    // silently swallowed and strongly_consistent() / run_once() hang forever.
+    let panicked = Arc::new(AtomicBool::new(false));
+    let prev_hook = std::panic::take_hook();
+    let panicked_clone = panicked.clone();
+    std::panic::set_hook(Box::new(move |info| {
+        panicked_clone.store(true, Ordering::SeqCst);
+        prev_hook(info);
+    }));
+
+    let result = run_with_tt(&REGISTRATION, move |tt| {
+        let panicked = panicked.clone();
+        async move {
+            // Wrap everything in a timeout. If the backend panics,
+            // run_once/strongly_consistent hang forever because the
+            // task never completes (WorkerFuture JoinHandle is dropped).
+            let panicked_inner = panicked.clone();
+            let inner_result = timeout(Duration::from_secs(10), async move {
+                let toggle: ResolvedVc<Toggle> = run_once(tt.clone(), async move {
+                    let t = Toggle {
+                        state: State::new(false),
+                    }
+                    .cell();
+                    Ok(t.to_resolved().await?)
+                })
+                .await?;
+
+                let edge_coords: Vec<(u32, u32)> = (0..grid_size)
+                    .map(|a| (a, grid_size - 1))
+                    .chain((0..grid_size - 1).map(|b| (grid_size - 1, b)))
+                    .collect();
+
+                // Establish initial grid
+                let setup_futs: Vec<_> = edge_coords
+                    .iter()
+                    .map(|&(a, b)| {
+                        let tt = tt.clone();
+                        async move {
+                            let _ = run_once(tt, async move {
+                                grid(a, b, *toggle).strongly_consistent().await?;
+                                Ok(Vc::<()>::default())
+                            })
+                            .await;
+                            anyhow::Ok(())
+                        }
+                    })
+                    .collect();
+                setup_futs.into_iter().try_join().await?;
+
+                for _round in 0..100 {
+                    if panicked_inner.load(Ordering::SeqCst) {
+                        anyhow::bail!(
+                            "Worker thread panicked in aggregation update \
+                             (inner_of_uppers_lost_follower)"
+                        );
+                    }
+
+                    // Toggle on
+                    let _ = run_once(tt.clone(), async move {
+                        toggle.await?.state.set(true);
+                        Ok(Vc::<()>::default())
+                    })
+                    .await?;
+
+                    // Fire all reads concurrently
+                    let read_futs: Vec<_> = edge_coords
+                        .iter()
+                        .map(|&(a, b)| {
+                            let tt = tt.clone();
+                            async move {
+                                let _ = run_once(tt, async move {
+                                    grid(a, b, *toggle).strongly_consistent().await?;
+                                    Ok(Vc::<()>::default())
+                                })
+                                .await?;
+                                anyhow::Ok(())
+                            }
+                        })
+                        .collect();
+
+                    // Immediately toggle off (while reads are still in progress!)
+                    let _ = run_once(tt.clone(), async move {
+                        toggle.await?.state.set(false);
+                        Ok(Vc::<()>::default())
+                    })
+                    .await?;
+
+                    // Fire more reads while cleanup from toggle-on is happening
+                    let read_futs2: Vec<_> = edge_coords
+                        .iter()
+                        .map(|&(a, b)| {
+                            let tt = tt.clone();
+                            async move {
+                                let _ = run_once(tt, async move {
+                                    grid(a, b, *toggle).strongly_consistent().await?;
+                                    Ok(Vc::<()>::default())
+                                })
+                                .await?;
+                                anyhow::Ok(())
+                            }
+                        })
+                        .collect();
+
+                    // Wait for all reads from both batches
+                    let _ = futures::future::try_join(
+                        read_futs.into_iter().try_join(),
+                        read_futs2.into_iter().try_join(),
+                    )
+                    .await;
+                }
+
+                anyhow::Ok(())
+            })
+            .await;
+
+            match inner_result {
+                Err(_elapsed) => {
+                    if panicked.load(Ordering::SeqCst) {
+                        anyhow::bail!(
+                            "Worker thread panicked in aggregation update \
+                             (inner_of_uppers_lost_follower)"
+                        );
+                    }
+                    anyhow::bail!("Timed out waiting for test to complete");
+                }
+                Ok(result) => result,
+            }
+        }
+    })
+    .await;
+
+    // Restore the default panic hook
+    let _ = std::panic::take_hook();
+
+    result
+}

--- a/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
@@ -9,7 +9,7 @@ use std::{future::Future, sync::Arc};
 
 use anyhow::Result;
 use tokio::sync::Notify;
-use turbo_tasks::{Completion, ResolvedVc, State, TryJoinIterExt, Vc, run_once};
+use turbo_tasks::{Completion, ResolvedVc, State, TryJoinIterExt, Vc, run, run_once};
 use turbo_tasks_testing::{Registration, register, run_with_tt};
 
 static REGISTRATION: Registration = register!();
@@ -107,11 +107,12 @@ async fn balance_edge_race() -> Result<()> {
             .await?;
 
             for round in 0..ROUNDS {
+                println!("Starting round {round}");
                 // Set cross-link target to a different interior node each round
                 let target = (round as u32 % (GRID_SIZE - 3)) + 1;
                 race_panic(
                     &panic_event,
-                    run_once(tt.clone(), async move {
+                    run(tt.clone(), async move {
                         cross_link.await?.state.set(target);
                         Ok(Vc::<()>::default())
                     }),
@@ -122,7 +123,7 @@ async fn balance_edge_race() -> Result<()> {
                 let read_futs: Vec<_> = edge_coords
                     .iter()
                     .map(|&(a, b)| {
-                        run_once(tt.clone(), async move {
+                        run(tt.clone(), async move {
                             grid(a, b, *cross_link).strongly_consistent().await?;
                             Ok(Vc::<()>::default())
                         })
@@ -132,7 +133,7 @@ async fn balance_edge_race() -> Result<()> {
                 // Immediately disable cross-links (while reads are still in progress!)
                 race_panic(
                     &panic_event,
-                    run_once(tt.clone(), async move {
+                    run(tt.clone(), async move {
                         cross_link.await?.state.set(0);
                         Ok(Vc::<()>::default())
                     }),
@@ -143,7 +144,7 @@ async fn balance_edge_race() -> Result<()> {
                 let read_futs2: Vec<_> = edge_coords
                     .iter()
                     .map(|&(a, b)| {
-                        run_once(tt.clone(), async move {
+                        run(tt.clone(), async move {
                             grid(a, b, *cross_link).strongly_consistent().await?;
                             Ok(Vc::<()>::default())
                         })

--- a/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/aggregation_balance_race.rs
@@ -159,6 +159,10 @@ async fn balance_edge_race() -> Result<()> {
                     ),
                 )
                 .await?;
+
+                // Wait for all foreground jobs (including aggregation queue
+                // processing) to complete before starting the next round
+                tt.wait_foreground_done().await;
             }
 
             anyhow::Ok(())

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -333,6 +333,8 @@ impl TurboTasksApi for VcStorage {
     fn wait_foreground_done(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
         Box::pin(async {})
     }
+
+    fn verify_graph(&self) {}
 }
 
 impl VcStorage {

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -329,6 +329,10 @@ impl TurboTasksApi for VcStorage {
     fn is_tracking_dependencies(&self) -> bool {
         false
     }
+
+    fn wait_foreground_done(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
 }
 
 impl VcStorage {

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -467,6 +467,11 @@ pub trait Backend: Sync + Send {
     #[allow(unused_variables)]
     fn idle_end(&self, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {}
 
+    /// Verifies the integrity of the aggregation graph. No-op unless the backend
+    /// is compiled with verification support.
+    #[allow(unused_variables)]
+    fn verify_graph(&self, turbo_tasks: &dyn TurboTasksBackendApi<Self>) {}
+
     fn invalidate_task(&self, task: TaskId, turbo_tasks: &dyn TurboTasksBackendApi<Self>);
 
     fn invalidate_tasks(&self, tasks: &[TaskId], turbo_tasks: &dyn TurboTasksBackendApi<Self>);

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -203,6 +203,10 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
     /// Waits until all currently scheduled foreground jobs have completed.
     /// This includes task executions and their associated aggregation update processing.
     fn wait_foreground_done(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
+
+    /// Verifies the integrity of the aggregation graph. No-op unless the backend
+    /// is compiled with verification support.
+    fn verify_graph(&self);
 }
 
 /// A wrapper around a value that is unused.
@@ -1635,6 +1639,10 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
 
     fn is_tracking_dependencies(&self) -> bool {
         self.backend.is_tracking_dependencies()
+    }
+
+    fn verify_graph(&self) {
+        self.backend.verify_graph(self);
     }
 }
 

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -199,6 +199,10 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
 
     // Returns true if TurboTasks is configured to track dependencies.
     fn is_tracking_dependencies(&self) -> bool;
+
+    /// Waits until all currently scheduled foreground jobs have completed.
+    /// This includes task executions and their associated aggregation update processing.
+    fn wait_foreground_done(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>>;
 }
 
 /// A wrapper around a value that is unused.
@@ -1079,6 +1083,19 @@ impl<B: Backend + 'static> TurboTasks<B> {
         }
     }
 
+    pub async fn wait_foreground_done(&self) {
+        let listener = self
+            .event_foreground_done
+            .listen_with_note(|| || "wait for foreground done".to_string());
+        if self
+            .currently_scheduled_foreground_jobs
+            .load(Ordering::Acquire)
+            != 0
+        {
+            listener.await;
+        }
+    }
+
     pub async fn stop_and_wait(&self) {
         turbo_tasks_future_scope(self.pin(), async move {
             self.backend.stopping(self);
@@ -1600,6 +1617,12 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         let this = self.pin();
         Box::pin(async move {
             this.stop_and_wait().await;
+        })
+    }
+
+    fn wait_foreground_done(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        Box::pin(async move {
+            self.wait_foreground_done().await;
         })
     }
 


### PR DESCRIPTION
Running with `cargo test -p turbo-tasks-backend --test aggregation_balance_race --features test_aggregation_race --no-default-features`  will reliably fail with something like

```

running 1 test
Run #1 (without cache)

thread 'tokio-runtime-worker' (39811338) panicked at turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs:1689:17:
inner_of_uppers_lost_follower is not able to remove follower TaskId 2147483890 (TaskId { id: 2147483890 } grid) from TaskId 2147484072 (TaskId { id: 2147484072 } grid) as they don't exist as upper or follower edges
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Error: Worker thread panicked in aggregation update
test balance_edge_race ... FAILED
```
