### PR TITLE
Expand deferred entries test suite and fix turbopack build

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -806,11 +806,26 @@ impl AppProject {
 
     #[turbo_tasks::function]
     pub async fn routes(self: Vc<Self>) -> Result<Vc<Routes>> {
+        Ok(self.routes_with_filter(None))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn routes_with_filter(
+        self: Vc<Self>,
+        app_route_filter: Option<Vec<RcStr>>,
+    ) -> Result<Vc<Routes>> {
         let app_entrypoints = self.app_entrypoints();
         Ok(Vc::cell(
             app_entrypoints
                 .await?
                 .iter()
+                .filter(|(pathname, _)| {
+                    app_route_filter.as_ref().is_none_or(|app_routes| {
+                        app_routes
+                            .iter()
+                            .any(|route| route.as_str() == pathname.to_string())
+                    })
+                })
                 .map(|(pathname, app_entrypoint)| async {
                     Ok((
                         pathname.to_string().into(),
@@ -822,6 +837,18 @@ impl AppProject {
                 .try_join()
                 .await?
                 .into_iter()
+                .collect(),
+        ))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn route_keys(self: Vc<Self>) -> Result<Vc<Vec<RcStr>>> {
+        let app_entrypoints = self.app_entrypoints();
+        Ok(Vc::cell(
+            app_entrypoints
+                .await?
+                .iter()
+                .map(|(pathname, _)| pathname.to_string().into())
                 .collect(),
         ))
     }

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -226,14 +226,13 @@ impl DebugBuildPathsRouteKeys {
             .filter(|segment| !segment.is_empty())
             .collect::<Vec<_>>();
 
-        if let Some(last_segment) = segments.last() {
-            if *last_segment == "page"
+        if let Some(last_segment) = segments.last()
+            && (*last_segment == "page"
                 || last_segment.starts_with("page.")
                 || *last_segment == "route"
-                || last_segment.starts_with("route.")
-            {
-                segments.pop();
-            }
+                || last_segment.starts_with("route."))
+        {
+            segments.pop();
         }
 
         let normalized_path = segments.join("/");

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -219,23 +219,52 @@ struct DebugBuildPathsRouteKeys {
 }
 
 impl DebugBuildPathsRouteKeys {
+    fn app_route_key_from_debug_path(path: &str) -> Result<RcStr> {
+        let mut segments = path
+            .trim_start_matches('/')
+            .split('/')
+            .filter(|segment| !segment.is_empty())
+            .collect::<Vec<_>>();
+
+        if let Some(last_segment) = segments.last() {
+            if *last_segment == "page"
+                || last_segment.starts_with("page.")
+                || *last_segment == "route"
+                || last_segment.starts_with("route.")
+            {
+                segments.pop();
+            }
+        }
+
+        let normalized_path = segments.join("/");
+        Ok(AppPath::from(AppPage::parse(&normalized_path)?)
+            .to_string()
+            .into())
+    }
+
     fn from_debug_build_paths(paths: &DebugBuildPaths) -> Result<Self> {
         Ok(Self {
             app: paths
                 .app
                 .iter()
-                .map(|path| Ok(AppPath::from(AppPage::parse(path)?).to_string().into()))
+                .map(|path| Self::app_route_key_from_debug_path(path))
                 .collect::<Result<FxHashSet<_>>>()?,
             pages: paths
                 .pages
                 .iter()
                 .map(|path| {
                     // Pages router: "/foo.tsx" -> "/foo"
-                    if let Some(dot_idx) = path.rfind('.') {
-                        path[..dot_idx].into()
-                    } else {
-                        path.clone()
+                    // Catch-all routes like "/foo/[...slug]" contain dots in the segment name;
+                    // only treat the suffix as an extension when it is a plain alphanumeric token.
+                    let file_name = path.rsplit('/').next().unwrap_or(path);
+                    if let Some(dot_idx) = file_name.rfind('.') {
+                        let ext = &file_name[dot_idx + 1..];
+                        if !ext.is_empty() && ext.chars().all(|c| c.is_ascii_alphanumeric()) {
+                            let trimmed_len = path.len() - (file_name.len() - dot_idx);
+                            return path[..trimmed_len].into();
+                        }
                     }
+                    path.clone()
                 })
                 .collect(),
         })
@@ -326,6 +355,9 @@ pub struct ProjectOptions {
     /// Debug build paths for selective builds.
     /// When set, only routes matching these paths will be included in the build.
     pub debug_build_paths: Option<DebugBuildPaths>,
+
+    /// App-router page routes that should be built after non-deferred routes.
+    pub deferred_entries: Option<Vec<RcStr>>,
 
     /// Whether to enable persistent caching
     pub is_persistent_caching_enabled: bool,
@@ -713,6 +745,7 @@ impl ProjectContainer {
         let write_routes_hashes_manifest;
         let current_node_js_version;
         let debug_build_paths;
+        let deferred_entries;
         let is_persistent_caching_enabled;
         {
             let options = self.options_state.get();
@@ -739,6 +772,7 @@ impl ProjectContainer {
             write_routes_hashes_manifest = options.write_routes_hashes_manifest;
             current_node_js_version = options.current_node_js_version.clone();
             debug_build_paths = options.debug_build_paths.clone();
+            deferred_entries = options.deferred_entries.clone().unwrap_or_default();
             is_persistent_caching_enabled = options.is_persistent_caching_enabled;
         }
 
@@ -767,6 +801,7 @@ impl ProjectContainer {
             write_routes_hashes_manifest,
             current_node_js_version,
             debug_build_paths,
+            deferred_entries,
             is_persistent_caching_enabled,
         }
         .cell())
@@ -862,6 +897,9 @@ pub struct Project {
     /// Debug build paths for selective builds.
     /// When set, only routes matching these paths will be included in the build.
     debug_build_paths: Option<DebugBuildPaths>,
+
+    /// App-router page routes that should be built after non-deferred routes.
+    deferred_entries: Vec<RcStr>,
 
     /// Whether to enable persistent caching
     is_persistent_caching_enabled: bool,
@@ -1105,6 +1143,11 @@ impl Project {
     }
 
     #[turbo_tasks::function]
+    pub fn deferred_entries(&self) -> Vc<Vec<RcStr>> {
+        Vc::cell(self.deferred_entries.clone())
+    }
+
+    #[turbo_tasks::function]
     pub(super) async fn per_page_module_graph(&self) -> Result<Vc<bool>> {
         Ok(Vc::cell(*self.mode.await? == NextMode::Development))
     }
@@ -1167,9 +1210,20 @@ impl Project {
         self: Vc<Self>,
         app_dir_only: bool,
     ) -> Result<Vc<EndpointGroups>> {
+        Ok(self.get_all_endpoint_groups_with_app_route_filter(app_dir_only, None))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn get_all_endpoint_groups_with_app_route_filter(
+        self: Vc<Self>,
+        app_dir_only: bool,
+        app_route_filter: Option<Vec<RcStr>>,
+    ) -> Result<Vc<EndpointGroups>> {
         let mut endpoint_groups = Vec::new();
 
-        let entrypoints = self.entrypoints().await?;
+        let entrypoints = self
+            .entrypoints_with_app_route_filter(app_route_filter)
+            .await?;
         let mut add_pages_entries = false;
 
         if let Some(middleware) = &entrypoints.middleware {
@@ -1612,6 +1666,14 @@ impl Project {
     /// provided page_extensions).
     #[turbo_tasks::function]
     pub async fn entrypoints(self: Vc<Self>) -> Result<Vc<Entrypoints>> {
+        Ok(self.entrypoints_with_app_route_filter(None))
+    }
+
+    #[turbo_tasks::function]
+    pub async fn entrypoints_with_app_route_filter(
+        self: Vc<Self>,
+        app_route_filter: Option<Vec<RcStr>>,
+    ) -> Result<Vc<Entrypoints>> {
         self.collect_project_feature_telemetry().await?;
 
         let this = self.await?;
@@ -1627,7 +1689,7 @@ impl Project {
             .transpose()?;
 
         if let Some(app_project) = &*app_project.await? {
-            let app_routes = app_project.routes();
+            let app_routes = app_project.routes_with_filter(app_route_filter);
             routes.extend(
                 app_routes
                     .await?

--- a/crates/next-build-test/src/main.rs
+++ b/crates/next-build-test/src/main.rs
@@ -185,6 +185,7 @@ fn main() {
                 write_routes_hashes_manifest: false,
                 current_node_js_version: rcstr!("18.0.0"),
                 debug_build_paths: None,
+                deferred_entries: None,
                 is_persistent_caching_enabled: false,
             };
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -1302,7 +1302,7 @@ pub async fn project_write_all_entrypoints_to_disk(
                 .read_strongly_consistent()
                 .await?;
 
-            // Write the files to disk
+            // Apply phase side effects. Asset emission is performed once at the end.
             effects.apply().await?;
 
             Ok((
@@ -1348,6 +1348,7 @@ pub async fn project_write_all_entrypoints_to_disk(
                     .read_strongly_consistent()
                     .await?;
 
+                // Apply phase side effects. Asset emission is performed once at the end.
                 effects.apply().await?;
 
                 Ok((
@@ -1365,6 +1366,32 @@ pub async fn project_write_all_entrypoints_to_disk(
         issues.extend(deferred_issues);
         diags.extend(deferred_diags);
     }
+
+    let (emit_issues, emit_diags) = tt
+        .run(async move {
+            let emit_result_op = emit_all_output_assets_once_with_issues_operation(
+                container,
+                app_dir_only,
+                has_deferred_entrypoints,
+            );
+            let OperationResult {
+                issues,
+                diagnostics,
+                effects,
+            } = &*emit_result_op.read_strongly_consistent().await?;
+
+            effects.apply().await?;
+
+            Ok((
+                issues.iter().cloned().collect::<Vec<_>>(),
+                diagnostics.iter().cloned().collect::<Vec<_>>(),
+            ))
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+
+    issues.extend(emit_issues);
+    diags.extend(emit_diags);
 
     Ok(TurbopackResult {
         result: if let Some(entrypoints) = entrypoints {
@@ -1409,14 +1436,82 @@ pub async fn all_entrypoints_write_to_disk_operation(
     app_dir_only: bool,
     write_phase: EntrypointsWritePhase,
 ) -> Result<Vc<Entrypoints>> {
+    // Compute all outputs for this phase but do not emit to disk yet.
     let output_assets_operation = output_assets_operation(project, app_dir_only, write_phase);
-    project
+    let _ = output_assets_operation.connect().await?;
+
+    Ok(project.entrypoints())
+}
+
+#[turbo_tasks::function(operation)]
+async fn output_assets_for_single_emit_operation(
+    container: ResolvedVc<ProjectContainer>,
+    app_dir_only: bool,
+    has_deferred_entrypoints: bool,
+) -> Result<Vc<OutputAssets>> {
+    if !has_deferred_entrypoints {
+        return Ok(
+            output_assets_operation(container, app_dir_only, EntrypointsWritePhase::All).connect(),
+        );
+    }
+
+    let non_deferred_output_assets =
+        output_assets_operation(container, app_dir_only, EntrypointsWritePhase::NonDeferred)
+            .connect()
+            .await?;
+    let deferred_output_assets =
+        output_assets_operation(container, app_dir_only, EntrypointsWritePhase::Deferred)
+            .connect()
+            .await?;
+
+    let merged_output_assets: FxIndexSet<ResolvedVc<Box<dyn OutputAsset>>> =
+        non_deferred_output_assets
+            .iter()
+            .chain(deferred_output_assets.iter())
+            .copied()
+            .collect();
+
+    Ok(Vc::cell(merged_output_assets.into_iter().collect()))
+}
+
+#[turbo_tasks::function(operation)]
+async fn emit_all_output_assets_once_operation(
+    container: ResolvedVc<ProjectContainer>,
+    app_dir_only: bool,
+    has_deferred_entrypoints: bool,
+) -> Result<Vc<Entrypoints>> {
+    let output_assets_operation =
+        output_assets_for_single_emit_operation(container, app_dir_only, has_deferred_entrypoints);
+    container
         .project()
         .emit_all_output_assets(output_assets_operation)
         .as_side_effect()
         .await?;
 
-    Ok(project.entrypoints())
+    Ok(container.entrypoints())
+}
+
+#[turbo_tasks::function(operation)]
+async fn emit_all_output_assets_once_with_issues_operation(
+    container: ResolvedVc<ProjectContainer>,
+    app_dir_only: bool,
+    has_deferred_entrypoints: bool,
+) -> Result<Vc<OperationResult>> {
+    let entrypoints_operation = EntrypointsOperation::new(emit_all_output_assets_once_operation(
+        container,
+        app_dir_only,
+        has_deferred_entrypoints,
+    ));
+    let filter = issue_filter_from_container(container);
+    let (_, issues, diagnostics, effects) =
+        strongly_consistent_catch_collectables(entrypoints_operation, filter).await?;
+
+    Ok(OperationResult {
+        issues,
+        diagnostics,
+        effects,
+    }
+    .cell())
 }
 
 #[turbo_tasks::function(operation)]

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -24,9 +24,12 @@ use next_api::{
     route::{Endpoint, EndpointGroupKey, Route},
     routes_hashes_manifest::routes_hashes_manifest_asset_if_enabled,
 };
-use next_core::tracing_presets::{
-    TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBO_TASKS_TARGETS,
-    TRACING_NEXT_TURBOPACK_TARGETS,
+use next_core::{
+    app_structure::find_app_dir,
+    tracing_presets::{
+        TRACING_NEXT_OVERVIEW_TARGETS, TRACING_NEXT_TARGETS, TRACING_NEXT_TURBO_TASKS_TARGETS,
+        TRACING_NEXT_TURBOPACK_TARGETS,
+    },
 };
 use once_cell::sync::Lazy;
 use rand::Rng;
@@ -44,9 +47,10 @@ use turbo_tasks::{
 };
 use turbo_tasks_backend::{BackingStorage, db_invalidation::invalidation_reasons};
 use turbo_tasks_fs::{
-    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation, util::uri_from_file,
+    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation,
+    to_sys_path as fs_path_to_sys_path, util::uri_from_file,
 };
-use turbo_unix_path::{get_relative_path_to, sys_to_unix};
+use turbo_unix_path::{get_relative_path_to, sys_to_unix, unix_to_sys};
 use turbopack_core::{
     PROJECT_FILESYSTEM_NAME, SOURCE_URL_PROTOCOL,
     diagnostics::PlainDiagnostic,
@@ -1045,6 +1049,7 @@ fn is_deferred_app_route(route: &str, deferred_entries: &[RcStr]) -> bool {
 struct DeferredPhaseBuildPaths {
     non_deferred: DebugBuildPaths,
     all: DebugBuildPaths,
+    deferred_invalidation_dirs: Vec<RcStr>,
 }
 
 fn to_app_debug_path(route: &str, leaf: &'static str) -> RcStr {
@@ -1067,12 +1072,32 @@ fn to_app_debug_path(route: &str, leaf: &'static str) -> RcStr {
     }
 }
 
+fn app_entry_source_dir_from_original_name(original_name: &str) -> RcStr {
+    let normalized_name = normalize_deferred_route(original_name);
+    let mut segments = normalized_name
+        .trim_start_matches('/')
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>();
+
+    if !segments.is_empty() {
+        segments.pop();
+    }
+
+    if segments.is_empty() {
+        rcstr!("/")
+    } else {
+        format!("/{}", segments.join("/")).into()
+    }
+}
+
 fn compute_deferred_phase_build_paths(
     entrypoints: &Entrypoints,
     deferred_entries: &[RcStr],
 ) -> DeferredPhaseBuildPaths {
     let mut non_deferred_app = FxIndexSet::default();
     let mut deferred_app = FxIndexSet::default();
+    let mut deferred_invalidation_dirs = FxIndexSet::default();
     let mut pages = FxIndexSet::default();
 
     for (route_key, route) in entrypoints.routes.iter() {
@@ -1080,18 +1105,24 @@ fn compute_deferred_phase_build_paths(
             Route::Page { .. } | Route::PageApi { .. } => {
                 pages.insert(route_key.clone());
             }
-            Route::AppPage(_) => {
+            Route::AppPage(app_page_routes) => {
                 let app_debug_path = to_app_debug_path(route_key.as_str(), "page");
                 if is_deferred_app_route(route_key.as_str(), deferred_entries) {
                     deferred_app.insert(app_debug_path);
+                    deferred_invalidation_dirs.extend(app_page_routes.iter().map(|route| {
+                        app_entry_source_dir_from_original_name(route.original_name.as_str())
+                    }));
                 } else {
                     non_deferred_app.insert(app_debug_path);
                 }
             }
-            Route::AppRoute { .. } => {
+            Route::AppRoute { original_name, .. } => {
                 let app_debug_path = to_app_debug_path(route_key.as_str(), "route");
                 if is_deferred_app_route(route_key.as_str(), deferred_entries) {
                     deferred_app.insert(app_debug_path);
+                    deferred_invalidation_dirs.insert(app_entry_source_dir_from_original_name(
+                        original_name.as_str(),
+                    ));
                 } else {
                     non_deferred_app.insert(app_debug_path);
                 }
@@ -1118,7 +1149,61 @@ fn compute_deferred_phase_build_paths(
             app: all_app_vec,
             pages: pages_vec,
         },
+        deferred_invalidation_dirs: deferred_invalidation_dirs.into_iter().collect::<Vec<_>>(),
     }
+}
+
+async fn invalidate_deferred_entry_source_dirs_after_callback(
+    container: ResolvedVc<ProjectContainer>,
+    deferred_invalidation_dirs: Vec<RcStr>,
+) -> Result<()> {
+    if deferred_invalidation_dirs.is_empty() {
+        return Ok(());
+    }
+
+    let project = container.project();
+    let app_dir = find_app_dir(project.project_path().owned().await?).await?;
+
+    let Some(app_dir) = &*app_dir else {
+        return Ok(());
+    };
+
+    let paths_to_invalidate =
+        if let Some(app_dir_sys_path) = fs_path_to_sys_path(app_dir.clone()).await? {
+            deferred_invalidation_dirs
+                .into_iter()
+                .map(|dir| {
+                    let normalized_dir = normalize_deferred_route(dir.as_str());
+                    let relative_dir = normalized_dir.trim_start_matches('/');
+                    if relative_dir.is_empty() {
+                        app_dir_sys_path.clone()
+                    } else {
+                        app_dir_sys_path.join(unix_to_sys(relative_dir).as_ref())
+                    }
+                })
+                .collect::<FxIndexSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
+    let project_fs = project.project_fs().await?;
+
+    if paths_to_invalidate.is_empty() {
+        // Fallback to full invalidation when app dir paths are unavailable.
+        project_fs.invalidate_with_reason(|path| invalidation::Initialize {
+            path: RcStr::from(path.to_string_lossy()),
+        });
+    } else {
+        project_fs.invalidate_path_and_children_with_reason(paths_to_invalidate, |path| {
+            invalidation::Initialize {
+                path: RcStr::from(path.to_string_lossy()),
+            }
+        });
+    }
+
+    Ok(())
 }
 
 fn partial_project_options_with_debug_build_paths(
@@ -1318,13 +1403,19 @@ pub async fn project_write_all_entrypoints_to_disk(
         ctx.on_before_deferred_entries().await?;
 
         // onBeforeDeferredEntries can materialize deferred route source files on disk.
-        // Build mode does not run a filesystem watcher, so force an invalidation before
-        // compiling deferred entrypoints to avoid reusing stale stub route contents.
+        // Build mode does not run a filesystem watcher, so force invalidation for the
+        // deferred source subtrees before compiling deferred entrypoints.
+        let deferred_invalidation_dirs = phase_build_paths
+            .as_ref()
+            .map(|paths| paths.deferred_invalidation_dirs.clone())
+            .unwrap_or_default();
+
         tt.run(async move {
-            let project_fs = container.project().project_fs().await?;
-            project_fs.invalidate_with_reason(|path| invalidation::Initialize {
-                path: RcStr::from(path.to_string_lossy()),
-            });
+            invalidate_deferred_entry_source_dirs_after_callback(
+                container,
+                deferred_invalidation_dirs,
+            )
+            .await?;
             Ok(())
         })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -21,7 +21,7 @@ use next_api::{
         DebugBuildPaths, DefineEnv, DraftModeOptions, HmrTarget, PartialProjectOptions, Project,
         ProjectContainer, ProjectOptions, WatchOptions,
     },
-    route::Endpoint,
+    route::{Endpoint, EndpointGroupKey, Route},
     routes_hashes_manifest::routes_hashes_manifest_asset_if_enabled,
 };
 use next_core::tracing_presets::{
@@ -192,6 +192,9 @@ pub struct NapiProjectOptions {
     /// When set, only routes matching these paths will be included in the build.
     pub debug_build_paths: Option<NapiDebugBuildPaths>,
 
+    /// App-router page routes that should be built after non-deferred routes.
+    pub deferred_entries: Option<Vec<RcStr>>,
+
     // Whether persistent caching is enabled
     pub is_persistent_caching_enabled: bool,
 }
@@ -298,6 +301,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
             write_routes_hashes_manifest,
             current_node_js_version,
             debug_build_paths,
+            deferred_entries,
             is_persistent_caching_enabled,
         } = val;
         ProjectOptions {
@@ -319,6 +323,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
                 app: p.app,
                 pages: p.pages,
             }),
+            deferred_entries,
             is_persistent_caching_enabled,
         }
     }
@@ -989,6 +994,238 @@ pub struct NapiDebugBuildPaths {
     pub pages: Vec<RcStr>,
 }
 
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    NonLocalValue,
+    OperationValue,
+    PartialEq,
+    TaskInput,
+    TraceRawVcs,
+    Encode,
+    Decode,
+)]
+enum EntrypointsWritePhase {
+    All,
+    NonDeferred,
+    Deferred,
+}
+
+fn normalize_deferred_route(route: &str) -> String {
+    let with_leading_slash = if route.starts_with('/') {
+        route.to_owned()
+    } else {
+        format!("/{route}")
+    };
+
+    if with_leading_slash.len() > 1 && with_leading_slash.ends_with('/') {
+        with_leading_slash
+            .strip_suffix('/')
+            .unwrap_or_default()
+            .to_owned()
+    } else {
+        with_leading_slash
+    }
+}
+
+fn is_deferred_app_route(route: &str, deferred_entries: &[RcStr]) -> bool {
+    let normalized_route = normalize_deferred_route(route);
+
+    deferred_entries.iter().any(|entry| {
+        let normalized_entry = normalize_deferred_route(entry);
+        normalized_route == normalized_entry
+            || normalized_route.starts_with(&format!("{normalized_entry}/"))
+    })
+}
+
+#[derive(Clone, Debug, TraceRawVcs)]
+struct DeferredPhaseBuildPaths {
+    non_deferred: DebugBuildPaths,
+    all: DebugBuildPaths,
+}
+
+fn to_app_debug_path(route: &str, leaf: &'static str) -> RcStr {
+    let with_leading_slash = if route.starts_with('/') {
+        route.to_owned()
+    } else {
+        format!("/{route}")
+    };
+
+    let normalized_route = if with_leading_slash.len() > 1 && with_leading_slash.ends_with('/') {
+        with_leading_slash.trim_end_matches('/').to_owned()
+    } else {
+        with_leading_slash
+    };
+
+    if normalized_route == "/" {
+        format!("/{leaf}").into()
+    } else {
+        format!("{normalized_route}/{leaf}").into()
+    }
+}
+
+fn compute_deferred_phase_build_paths(
+    entrypoints: &Entrypoints,
+    deferred_entries: &[RcStr],
+) -> DeferredPhaseBuildPaths {
+    let mut non_deferred_app = FxIndexSet::default();
+    let mut deferred_app = FxIndexSet::default();
+    let mut pages = FxIndexSet::default();
+
+    for (route_key, route) in entrypoints.routes.iter() {
+        match route {
+            Route::Page { .. } | Route::PageApi { .. } => {
+                pages.insert(route_key.clone());
+            }
+            Route::AppPage(_) => {
+                let app_debug_path = to_app_debug_path(route_key.as_str(), "page");
+                if is_deferred_app_route(route_key.as_str(), deferred_entries) {
+                    deferred_app.insert(app_debug_path);
+                } else {
+                    non_deferred_app.insert(app_debug_path);
+                }
+            }
+            Route::AppRoute { .. } => {
+                let app_debug_path = to_app_debug_path(route_key.as_str(), "route");
+                if is_deferred_app_route(route_key.as_str(), deferred_entries) {
+                    deferred_app.insert(app_debug_path);
+                } else {
+                    non_deferred_app.insert(app_debug_path);
+                }
+            }
+            Route::Conflict => {}
+        }
+    }
+
+    let pages_vec = pages.into_iter().collect::<Vec<_>>();
+    let all_app_vec = non_deferred_app
+        .iter()
+        .chain(deferred_app.iter())
+        .cloned()
+        .collect::<FxIndexSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    DeferredPhaseBuildPaths {
+        non_deferred: DebugBuildPaths {
+            app: non_deferred_app.into_iter().collect::<Vec<_>>(),
+            pages: pages_vec.clone(),
+        },
+        all: DebugBuildPaths {
+            app: all_app_vec,
+            pages: pages_vec,
+        },
+    }
+}
+
+fn partial_project_options_with_debug_build_paths(
+    debug_build_paths: DebugBuildPaths,
+) -> PartialProjectOptions {
+    PartialProjectOptions {
+        root_path: None,
+        project_path: None,
+        next_config: None,
+        env: None,
+        define_env: None,
+        watch: None,
+        dev: None,
+        encryption_key: None,
+        build_id: None,
+        preview_props: None,
+        browserslist_query: None,
+        no_mangling: None,
+        write_routes_hashes_manifest: None,
+        debug_build_paths: Some(debug_build_paths),
+    }
+}
+
+fn is_deferred_endpoint_group(key: &EndpointGroupKey, deferred_entries: &[RcStr]) -> bool {
+    if deferred_entries.is_empty() {
+        return false;
+    }
+
+    let EndpointGroupKey::Route(route_key) = key else {
+        return false;
+    };
+
+    is_deferred_app_route(route_key.as_str(), deferred_entries)
+}
+
+fn should_include_endpoint_group(
+    write_phase: EntrypointsWritePhase,
+    key: &EndpointGroupKey,
+    deferred_entries: &[RcStr],
+) -> bool {
+    let is_deferred = is_deferred_endpoint_group(key, deferred_entries);
+
+    match write_phase {
+        EntrypointsWritePhase::All => true,
+        EntrypointsWritePhase::NonDeferred => !is_deferred,
+        EntrypointsWritePhase::Deferred => is_deferred,
+    }
+}
+
+async fn app_route_filter_for_write_phase(
+    project: Vc<Project>,
+    write_phase: EntrypointsWritePhase,
+    deferred_entries: &[RcStr],
+) -> Result<Option<Vec<RcStr>>> {
+    if matches!(write_phase, EntrypointsWritePhase::All) || deferred_entries.is_empty() {
+        return Ok(None);
+    }
+
+    let include_deferred = write_phase == EntrypointsWritePhase::Deferred;
+    let app_project = project.app_project().await?;
+    let app_route_keys = if let Some(app_project) = &*app_project {
+        app_project
+            .route_keys()
+            .await?
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
+
+    Ok(Some(
+        app_route_keys
+            .iter()
+            .filter(|route| {
+                is_deferred_app_route(route.as_str(), deferred_entries) == include_deferred
+            })
+            .cloned()
+            .collect::<Vec<_>>(),
+    ))
+}
+
+#[turbo_tasks::function(operation)]
+async fn has_deferred_entrypoints_operation(
+    container: ResolvedVc<ProjectContainer>,
+) -> Result<Vc<bool>> {
+    let project = container.project();
+    let deferred_entries = project.deferred_entries().owned().await?;
+
+    if deferred_entries.is_empty() {
+        return Ok(Vc::cell(false));
+    }
+
+    let app_project = project.app_project().await?;
+    let has_deferred = if let Some(app_project) = &*app_project {
+        app_project
+            .route_keys()
+            .await?
+            .iter()
+            .any(|route_key| is_deferred_app_route(route_key.as_str(), &deferred_entries))
+    } else {
+        false
+    };
+
+    Ok(Vc::cell(has_deferred))
+}
+
 #[tracing::instrument(level = "info", name = "write all entrypoints to disk", skip_all)]
 #[napi]
 pub async fn project_write_all_entrypoints_to_disk(
@@ -999,10 +1236,61 @@ pub async fn project_write_all_entrypoints_to_disk(
     let container = project.container;
     let tt = ctx.turbo_tasks();
 
-    let (entrypoints, issues, diags) = tt
+    let has_deferred_entrypoints = tt
         .run(async move {
-            let entrypoints_with_issues_op =
-                get_all_written_entrypoints_with_issues_operation(container, app_dir_only);
+            Ok(*has_deferred_entrypoints_operation(container)
+                .read_strongly_consistent()
+                .await?)
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+
+    let phase_build_paths = if has_deferred_entrypoints {
+        Some(
+            tt.run(async move {
+                let project = container.project();
+                let deferred_entries = project.deferred_entries().owned().await?;
+                let entrypoints = project.entrypoints().await?;
+
+                Ok(compute_deferred_phase_build_paths(
+                    &entrypoints,
+                    &deferred_entries,
+                ))
+            })
+            .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+            .await?,
+        )
+    } else {
+        None
+    };
+
+    if let Some(phase_build_paths) = phase_build_paths.as_ref() {
+        let non_deferred_build_paths = phase_build_paths.non_deferred.clone();
+        tt.run(async move {
+            container
+                .update(partial_project_options_with_debug_build_paths(
+                    non_deferred_build_paths,
+                ))
+                .await?;
+            Ok(())
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
+    }
+
+    let first_phase = if has_deferred_entrypoints {
+        EntrypointsWritePhase::NonDeferred
+    } else {
+        EntrypointsWritePhase::All
+    };
+
+    let (mut entrypoints, mut issues, mut diags) = tt
+        .run(async move {
+            let entrypoints_with_issues_op = get_all_written_entrypoints_with_issues_operation(
+                container,
+                app_dir_only,
+                first_phase,
+            );
 
             // Read and compile the files
             let AllWrittenEntrypointsWithIssues {
@@ -1017,10 +1305,66 @@ pub async fn project_write_all_entrypoints_to_disk(
             // Write the files to disk
             effects.apply().await?;
 
-            Ok((entrypoints.clone(), issues.clone(), diagnostics.clone()))
+            Ok((
+                entrypoints.clone(),
+                issues.iter().cloned().collect::<Vec<_>>(),
+                diagnostics.iter().cloned().collect::<Vec<_>>(),
+            ))
         })
         .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
         .await?;
+
+    if has_deferred_entrypoints {
+        ctx.on_before_deferred_entries().await?;
+
+        if let Some(phase_build_paths) = phase_build_paths.as_ref() {
+            let all_build_paths = phase_build_paths.all.clone();
+            tt.run(async move {
+                container
+                    .update(partial_project_options_with_debug_build_paths(
+                        all_build_paths,
+                    ))
+                    .await?;
+                Ok(())
+            })
+            .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+            .await?;
+        }
+
+        let (deferred_entrypoints, deferred_issues, deferred_diags) = tt
+            .run(async move {
+                let entrypoints_with_issues_op = get_all_written_entrypoints_with_issues_operation(
+                    container,
+                    app_dir_only,
+                    EntrypointsWritePhase::Deferred,
+                );
+
+                let AllWrittenEntrypointsWithIssues {
+                    entrypoints,
+                    issues,
+                    diagnostics,
+                    effects,
+                } = &*entrypoints_with_issues_op
+                    .read_strongly_consistent()
+                    .await?;
+
+                effects.apply().await?;
+
+                Ok((
+                    entrypoints.clone(),
+                    issues.iter().cloned().collect::<Vec<_>>(),
+                    diagnostics.iter().cloned().collect::<Vec<_>>(),
+                ))
+            })
+            .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+            .await?;
+
+        if deferred_entrypoints.is_some() {
+            entrypoints = deferred_entrypoints;
+        }
+        issues.extend(deferred_issues);
+        diags.extend(deferred_diags);
+    }
 
     Ok(TurbopackResult {
         result: if let Some(entrypoints) = entrypoints {
@@ -1040,10 +1384,12 @@ pub async fn project_write_all_entrypoints_to_disk(
 async fn get_all_written_entrypoints_with_issues_operation(
     container: ResolvedVc<ProjectContainer>,
     app_dir_only: bool,
+    write_phase: EntrypointsWritePhase,
 ) -> Result<Vc<AllWrittenEntrypointsWithIssues>> {
     let entrypoints_operation = EntrypointsOperation::new(all_entrypoints_write_to_disk_operation(
         container,
         app_dir_only,
+        write_phase,
     ));
     let filter = issue_filter_from_container(container);
     let (entrypoints, issues, diagnostics, effects) =
@@ -1061,8 +1407,9 @@ async fn get_all_written_entrypoints_with_issues_operation(
 pub async fn all_entrypoints_write_to_disk_operation(
     project: ResolvedVc<ProjectContainer>,
     app_dir_only: bool,
+    write_phase: EntrypointsWritePhase,
 ) -> Result<Vc<Entrypoints>> {
-    let output_assets_operation = output_assets_operation(project, app_dir_only);
+    let output_assets_operation = output_assets_operation(project, app_dir_only, write_phase);
     project
         .project()
         .emit_all_output_assets(output_assets_operation)
@@ -1076,12 +1423,30 @@ pub async fn all_entrypoints_write_to_disk_operation(
 async fn output_assets_operation(
     container: ResolvedVc<ProjectContainer>,
     app_dir_only: bool,
+    write_phase: EntrypointsWritePhase,
 ) -> Result<Vc<OutputAssets>> {
     let project = container.project();
-    let whole_app_module_graphs = project.whole_app_module_graphs();
-    let endpoint_assets = project
-        .get_all_endpoints(app_dir_only)
-        .await?
+    let deferred_entries = project.deferred_entries().owned().await?;
+    let app_route_filter =
+        app_route_filter_for_write_phase(project, write_phase, &deferred_entries).await?;
+
+    let endpoint_groups = project
+        .get_all_endpoint_groups_with_app_route_filter(app_dir_only, app_route_filter)
+        .await?;
+
+    let endpoints = endpoint_groups
+        .iter()
+        .filter(|(key, _)| should_include_endpoint_group(write_phase, key, &deferred_entries))
+        .flat_map(|(_, group)| {
+            group
+                .primary
+                .iter()
+                .chain(group.additional.iter())
+                .map(|entry| entry.endpoint)
+        })
+        .collect::<Vec<_>>();
+
+    let endpoint_assets = endpoints
         .iter()
         .map(|endpoint| async move { endpoint.output().await?.output_assets.await })
         .try_join()
@@ -1092,8 +1457,12 @@ async fn output_assets_operation(
         .flat_map(|assets| assets.iter().copied())
         .collect();
 
-    let nft = next_server_nft_assets(project).await?;
+    if write_phase == EntrypointsWritePhase::NonDeferred {
+        return Ok(Vc::cell(output_assets.into_iter().collect()));
+    }
 
+    let whole_app_module_graphs = project.whole_app_module_graphs();
+    let nft = next_server_nft_assets(project).await?;
     let routes_hashes_manifest = routes_hashes_manifest_asset_if_enabled(project).await?;
 
     whole_app_module_graphs.as_side_effect().await?;

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -44,7 +44,7 @@ use turbo_tasks::{
 };
 use turbo_tasks_backend::{BackingStorage, db_invalidation::invalidation_reasons};
 use turbo_tasks_fs::{
-    DiskFileSystem, FileContent, FileSystem, FileSystemPath, util::uri_from_file,
+    DiskFileSystem, FileContent, FileSystem, FileSystemPath, invalidation, util::uri_from_file,
 };
 use turbo_unix_path::{get_relative_path_to, sys_to_unix};
 use turbopack_core::{
@@ -1316,6 +1316,19 @@ pub async fn project_write_all_entrypoints_to_disk(
 
     if has_deferred_entrypoints {
         ctx.on_before_deferred_entries().await?;
+
+        // onBeforeDeferredEntries can materialize deferred route source files on disk.
+        // Build mode does not run a filesystem watcher, so force an invalidation before
+        // compiling deferred entrypoints to avoid reusing stale stub route contents.
+        tt.run(async move {
+            let project_fs = container.project().project_fs().await?;
+            project_fs.invalidate_with_reason(|path| invalidation::Initialize {
+                path: RcStr::from(path.to_string_lossy()),
+            });
+            Ok(())
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await?;
 
         if let Some(phase_build_paths) = phase_build_paths.as_ref() {
             let all_build_paths = phase_build_paths.all.clone();

--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -11,7 +11,7 @@ use std::{
 
 use anyhow::Result;
 use either::Either;
-use napi::{JsFunction, threadsafe_function::ThreadsafeFunction};
+use napi::{JsFunction, bindgen_prelude::Promise, threadsafe_function::ThreadsafeFunction};
 use napi_derive::napi;
 use once_cell::sync::Lazy;
 use owo_colors::OwoColorize;
@@ -123,6 +123,15 @@ impl NextTurbopackContext {
         let err_fut = self.throw_turbopack_internal_error(err);
         async move { Err(err_fut.await) }
     }
+
+    /// Calls the `onBeforeDeferredEntries` callback in Node.js if one was provided.
+    pub async fn on_before_deferred_entries(&self) -> napi::Result<()> {
+        if let Some(callback) = &self.inner.napi_callbacks.on_before_deferred_entries {
+            let promise = callback.call_async::<Promise<()>>(Ok(())).await?;
+            promise.await?;
+        }
+        Ok(())
+    }
 }
 
 /// A version of [`NapiNextTurbopackCallbacks`] that can accepted as an argument to a napi function.
@@ -139,6 +148,10 @@ pub struct NapiNextTurbopackCallbacksJsObject {
     /// can throw it instead.
     #[napi(ts_type = "(conversionError: Error | null, opts: TurbopackInternalErrorOpts) => never")]
     pub throw_turbopack_internal_error: JsFunction,
+
+    /// Called before deferred entries are processed in a production build.
+    #[napi(ts_type = "() => Promise<void>")]
+    pub on_before_deferred_entries: Option<JsFunction>,
 }
 
 /// A collection of helper JavaScript functions passed into
@@ -155,6 +168,7 @@ pub struct NapiNextTurbopackCallbacks {
     // think it could be `Send`, as long as `napi::Env` is checked at call-time, which it should be
     // anyways).
     throw_turbopack_internal_error: ThreadsafeFunction<TurbopackInternalErrorOpts>,
+    on_before_deferred_entries: Option<ThreadsafeFunction<()>>,
 }
 
 /// Arguments for `NapiNextTurbopackCallbacks::throw_turbopack_internal_error`.
@@ -175,6 +189,12 @@ impl NapiNextTurbopackCallbacks {
                     // PII-containing message in anonymized telemetry.
                     Ok(vec![ctx.value])
                 })?,
+            on_before_deferred_entries: obj
+                .on_before_deferred_entries
+                .map(|callback| {
+                    callback.create_threadsafe_function(0, |_| Ok::<Vec<()>, _>(vec![]))
+                })
+                .transpose()?,
         })
     }
 }

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -166,6 +166,8 @@ export interface NapiProjectOptions {
    * When set, only routes matching these paths will be included in the build.
    */
   debugBuildPaths?: NapiDebugBuildPaths
+  /** App-router page routes that should be built after non-deferred routes. */
+  deferredEntries?: Array<RcStr>
   isPersistentCachingEnabled: boolean
 }
 /** [NapiProjectOptions] with all fields optional. */
@@ -409,6 +411,8 @@ export interface NapiNextTurbopackCallbacksJsObject {
     conversionError: Error | null,
     opts: TurbopackInternalErrorOpts
   ) => never
+  /** Called before deferred entries are processed in a production build. */
+  onBeforeDeferredEntries?: () => Promise<void>
 }
 /** Arguments for `NapiNextTurbopackCallbacks::throw_turbopack_internal_error`. */
 export interface TurbopackInternalErrorOpts {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1220,7 +1220,8 @@ function bindingToApi(
 
   return async function createProject(
     options: ProjectOptions,
-    turboEngineOptions
+    turboEngineOptions,
+    callbacks?: import('./types').TurbopackProjectCallbacks
   ) {
     return new ProjectImpl(
       await binding.projectNew(
@@ -1228,6 +1229,7 @@ function bindingToApi(
         turboEngineOptions || {},
         {
           throwTurbopackInternalError,
+          onBeforeDeferredEntries: callbacks?.onBeforeDeferredEntries,
         }
       )
     )
@@ -1352,7 +1354,8 @@ async function loadWasm(importPath = '') {
     turbo: {
       createProject(
         _options: ProjectOptions,
-        _turboEngineOptions?: TurboEngineOptions | undefined
+        _turboEngineOptions?: TurboEngineOptions | undefined,
+        _callbacks?: import('./types').TurbopackProjectCallbacks | undefined
       ): Promise<Project> {
         throw new Error(
           `Turbopack is not supported on this platform (${PlatformName}/${ArchName}) because native bindings are not available. ` +

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -13,12 +13,17 @@ export type { NapiTurboEngineOptions as TurboEngineOptions }
 
 export type Lockfile = { __napiType: 'Lockfile' }
 
+export interface TurbopackProjectCallbacks {
+  onBeforeDeferredEntries?: () => Promise<void>
+}
+
 export interface Binding {
   isWasm: boolean
   turbo: {
     createProject(
       options: ProjectOptions,
-      turboEngineOptions?: NapiTurboEngineOptions
+      turboEngineOptions?: NapiTurboEngineOptions,
+      callbacks?: TurbopackProjectCallbacks
     ): Promise<Project>
     startTurbopackTraceServer(
       traceFilePath: string,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -2,11 +2,6 @@
 import { saveCpuProfile } from '../../server/lib/cpu-profile'
 import path from 'path'
 import { validateTurboNextConfig } from '../../lib/turbopack-warning'
-import { isMetadataRouteFile } from '../../lib/metadata/is-metadata-route'
-import {
-  normalizeMetadataPageToRoute,
-  normalizeMetadataRoute,
-} from '../../lib/metadata/get-metadata-route'
 import { isFileSystemCacheEnabledForBuild } from '../../shared/lib/turbopack/utils'
 import { NextBuildContext } from '../build-context'
 import { createDefineEnv, getBindingsSync } from '../swc'
@@ -26,162 +21,11 @@ import { isCI } from '../../server/ci-info'
 import { backgroundLogCompilationEvents } from '../../shared/lib/turbopack/compilation-events'
 import { getSupportedBrowsers, printBuildErrors } from '../utils'
 import { normalizePath } from '../../lib/normalize-path'
-import { normalizeAppPath } from '../../shared/lib/router/utils/app-paths'
-import {
-  collectAppFiles,
-  collectPagesFiles,
-  getPageFromPath,
-} from '../route-discovery'
-import { createValidFileMatcher } from '../../server/lib/find-page-file'
 import type {
   ProjectOptions,
   RawEntrypoints,
   TurbopackResult,
 } from '../swc/types'
-
-/**
- * Convert an app route path to debugBuildPaths format.
- * e.g. '/' -> '/page', '/blog' -> '/blog/page'
- */
-function toAppDebugPath(route: string, leaf: 'page' | 'route'): string {
-  const routePath = route.startsWith('/') ? route : `/${route}`
-  return routePath === '/' ? `/${leaf}` : `${routePath}/${leaf}`
-}
-
-function normalizeDeferredRoute(route: string): string {
-  const normalized = route.startsWith('/') ? route : `/${route}`
-  if (normalized.length > 1 && normalized.endsWith('/')) {
-    return normalized.slice(0, -1)
-  }
-  return normalized
-}
-
-/**
- * Matches deferred entries with webpack parity:
- * - exact route match
- * - prefix match for directory-style deferred entries
- */
-function isDeferredAppRoute(route: string, deferredEntries: string[]): boolean {
-  const normalizedRoute = normalizeDeferredRoute(route)
-
-  for (const entry of deferredEntries) {
-    const normalizedEntry = normalizeDeferredRoute(entry)
-    if (normalizedRoute === normalizedEntry) {
-      return true
-    }
-    if (normalizedRoute.startsWith(`${normalizedEntry}/`)) {
-      return true
-    }
-  }
-
-  return false
-}
-
-function getAppDebugPaths(
-  appPath: string,
-  pageExtensions: string[]
-): {
-  isPageRoute: boolean
-  normalizedRoute: string
-  isMetadataRoute: boolean
-  debugPaths: string[]
-} {
-  const page = getPageFromPath(appPath, pageExtensions)
-  const isMetadataRoute = isMetadataRouteFile(appPath, pageExtensions, true)
-  const metadataRoute = isMetadataRoute ? normalizeMetadataRoute(page) : null
-  const routeCandidates = isMetadataRoute
-    ? [
-        metadataRoute!,
-        normalizeMetadataPageToRoute(metadataRoute!, false),
-        normalizeMetadataPageToRoute(metadataRoute!, true),
-      ]
-    : [page]
-
-  const debugPaths = Array.from(
-    new Set(
-      routeCandidates.map((routeCandidate) =>
-        toAppDebugPath(
-          normalizeAppPath(routeCandidate),
-          routeCandidate.endsWith('/route') ? 'route' : 'page'
-        )
-      )
-    )
-  )
-
-  return {
-    isPageRoute: !isMetadataRoute && page.endsWith('/page'),
-    normalizedRoute: normalizeAppPath(page),
-    isMetadataRoute,
-    debugPaths,
-  }
-}
-
-/**
- * Collect deferred app routes and metadata routes in debugBuildPaths format.
- * @param pagesPaths - All pages routes to include (deferred entries only affects app routes)
- */
-function getDeferredBuildPaths(
-  deferredEntries: string[],
-  appPaths: string[],
-  pageExtensions: string[],
-  pagesPaths: string[]
-): {
-  app: string[]
-  pages: string[]
-} {
-  const deferredAppPaths: string[] = []
-  for (const appPath of appPaths) {
-    const { isPageRoute, normalizedRoute, isMetadataRoute, debugPaths } =
-      getAppDebugPaths(appPath, pageExtensions)
-    if (
-      (isPageRoute && isDeferredAppRoute(normalizedRoute, deferredEntries)) ||
-      isMetadataRoute
-    ) {
-      deferredAppPaths.push(...debugPaths)
-    }
-  }
-
-  return {
-    app: [...new Set(deferredAppPaths)],
-    // Include all pages routes so they are not filtered out
-    pages: pagesPaths,
-  }
-}
-
-/**
- * Collect app entries and filter out deferred app pages only.
- * This keeps non-page app entries (e.g. route handlers) in the non-deferred build.
- * @param pagesPaths - All pages routes to include (deferred entries only affects app routes)
- */
-function getNonDeferredBuildPaths(
-  appPaths: string[],
-  deferredEntries: string[],
-  pageExtensions: string[],
-  pagesPaths: string[]
-): { app: string[]; pages: string[] } | null {
-  if (deferredEntries.length === 0) {
-    return null
-  }
-
-  const nonDeferredAppPaths: string[] = []
-  for (const appPath of appPaths) {
-    const { isPageRoute, normalizedRoute, debugPaths } = getAppDebugPaths(
-      appPath,
-      pageExtensions
-    )
-    const isDeferredPage =
-      isPageRoute && isDeferredAppRoute(normalizedRoute, deferredEntries)
-    if (!isDeferredPage) {
-      nonDeferredAppPaths.push(...debugPaths)
-    }
-  }
-
-  return {
-    app: [...new Set(nonDeferredAppPaths)],
-    // Include all pages routes so they are not filtered out
-    pages: pagesPaths,
-  }
-}
 
 export async function turbopackBuild(): Promise<{
   duration: number
@@ -221,56 +65,8 @@ export async function turbopackBuild(): Promise<{
 
   const supportedBrowsers = getSupportedBrowsers(dir, dev)
 
-  // Handle deferred entries configuration
-  const deferredEntries = config.experimental.deferredEntries || []
-  const hasDeferredEntries = deferredEntries.length > 0
-  const onBeforeDeferredEntries = config.experimental.onBeforeDeferredEntries
-
-  // Collect all pages paths when using deferred entries to ensure pages routes
-  // are not filtered out (deferred entries only affects app routes)
-  let pagesPaths: string[] = []
-  let appPaths: string[] = []
-  if (hasDeferredEntries && NextBuildContext.pagesDir) {
-    const validFileMatcher = createValidFileMatcher(
-      config.pageExtensions!,
-      NextBuildContext.appDir
-    )
-    pagesPaths = await collectPagesFiles(
-      NextBuildContext.pagesDir,
-      validFileMatcher
-    )
-  }
-  if (hasDeferredEntries && NextBuildContext.appDir) {
-    const validFileMatcher = createValidFileMatcher(
-      config.pageExtensions!,
-      NextBuildContext.appDir
-    )
-    ;({ appPaths } = await collectAppFiles(
-      NextBuildContext.appDir,
-      validFileMatcher
-    ))
-  }
-
-  // For deferred entries, we use debugBuildPaths to control which routes are built
-  // First build excludes deferred entries, second build includes only deferred entries
-  const nonDeferredBuildPaths =
-    hasDeferredEntries && NextBuildContext.appDir
-      ? getNonDeferredBuildPaths(
-          appPaths,
-          deferredEntries,
-          config.pageExtensions!,
-          pagesPaths
-        )
-      : null
-  const deferredBuildPaths =
-    hasDeferredEntries && NextBuildContext.appDir
-      ? getDeferredBuildPaths(
-          deferredEntries,
-          appPaths,
-          config.pageExtensions!,
-          pagesPaths
-        )
-      : null
+  const hasDeferredEntries =
+    (config.experimental.deferredEntries?.length ?? 0) > 0
 
   const persistentCaching = isFileSystemCacheEnabledForBuild(config)
   const rootPath = config.turbopack?.root || config.outputFileTracingRoot || dir
@@ -308,11 +104,12 @@ export async function turbopackBuild(): Promise<{
       !!process.env.NEXT_TURBOPACK_WRITE_ROUTES_HASHES_MANIFEST,
     currentNodeJsVersion,
     isPersistentCachingEnabled: persistentCaching,
+    deferredEntries: config.experimental.deferredEntries,
   }
 
   const sharedTurboOptions = {
     memoryLimit: config.experimental?.turbopackMemoryLimit,
-    dependencyTracking: persistentCaching,
+    dependencyTracking: persistentCaching || hasDeferredEntries,
     isCi: isCI,
     isShortSession: true,
   }
@@ -320,11 +117,22 @@ export async function turbopackBuild(): Promise<{
   const project = await bindings.turbo.createProject(
     {
       ...sharedProjectOptions,
-      // For deferred entries, first build only non-deferred routes
-      debugBuildPaths:
-        nonDeferredBuildPaths ?? NextBuildContext.debugBuildPaths,
+      debugBuildPaths: NextBuildContext.debugBuildPaths,
     },
-    sharedTurboOptions
+    sharedTurboOptions,
+    hasDeferredEntries && config.experimental.onBeforeDeferredEntries
+      ? {
+          onBeforeDeferredEntries: async () => {
+            const workerConfig = await loadConfig(PHASE_PRODUCTION_BUILD, dir, {
+              debugPrerender: NextBuildContext.debugPrerender,
+              reactProductionProfiling:
+                NextBuildContext.reactProductionProfiling,
+            })
+
+            await workerConfig.experimental.onBeforeDeferredEntries?.()
+          },
+        }
+      : undefined
   )
   try {
     backgroundLogCompilationEvents(project)
@@ -345,62 +153,14 @@ export async function turbopackBuild(): Promise<{
 
     let appDirOnly = NextBuildContext.appDirOnly!
 
-    // First build: without deferred entries (they're renamed to .deferred)
-    let entrypoints = await project.writeAllEntrypointsToDisk(appDirOnly)
+    const entrypoints = await project.writeAllEntrypointsToDisk(appDirOnly)
     printBuildErrors(entrypoints, dev)
 
-    let routes = entrypoints.routes
+    const routes = entrypoints.routes
     if (!routes) {
       // This should never ever happen, there should be an error issue, or the bindings call should
       // have thrown.
       throw new Error(`Turbopack build failed`)
-    }
-
-    // Track which project to shutdown at the end
-    let activeProject = project
-
-    // Handle deferred entries: call callback and do second build
-    if (deferredBuildPaths) {
-      // Call onBeforeDeferredEntries callback after first build completes
-      if (onBeforeDeferredEntries) {
-        await onBeforeDeferredEntries()
-      }
-
-      // Shutdown the first project instance
-      await project.shutdown()
-
-      // Create a new project instance with debugBuildPaths for only deferred routes
-      // A new project is needed because turbo_tasks caches entrypoints discovery
-      activeProject = await bindings.turbo.createProject(
-        {
-          ...sharedProjectOptions,
-          debugBuildPaths: deferredBuildPaths,
-        },
-        sharedTurboOptions
-      )
-
-      backgroundLogCompilationEvents(activeProject)
-
-      // Second build: only build deferred entries
-      const deferredEntrypoints =
-        await activeProject.writeAllEntrypointsToDisk(appDirOnly)
-      printBuildErrors(deferredEntrypoints, dev)
-
-      const deferredRoutes = deferredEntrypoints.routes
-      if (!deferredRoutes) {
-        throw new Error(`Turbopack build failed`)
-      }
-
-      // Merge deferred routes into the main routes
-      for (const [key, value] of deferredRoutes) {
-        routes.set(key, value)
-      }
-
-      // Update entrypoints to include merged routes for manifest processing
-      entrypoints = {
-        ...entrypoints,
-        routes,
-      }
     }
 
     const hasPagesEntries = Array.from(routes.values()).some((route) => {
@@ -485,10 +245,10 @@ export async function turbopackBuild(): Promise<{
     })
 
     if (NextBuildContext.analyze) {
-      await activeProject.writeAnalyzeData(appDirOnly)
+      await project.writeAnalyzeData(appDirOnly)
     }
 
-    const shutdownPromise = activeProject.shutdown()
+    const shutdownPromise = project.shutdown()
 
     const time = process.hrtime(startTime)
     return {

--- a/test/e2e/deferred-entries/app/app-catch-all/[...slug]/page.tsx
+++ b/test/e2e/deferred-entries/app/app-catch-all/[...slug]/page.tsx
@@ -1,0 +1,11 @@
+type AppCatchAllPageProps = {
+  params: Promise<{ slug: string[] }>
+}
+
+export default async function AppCatchAllPage({
+  params,
+}: AppCatchAllPageProps) {
+  const { slug } = await params
+
+  return <h1>App Catch-all Segment: {slug.join('/')}</h1>
+}

--- a/test/e2e/deferred-entries/app/app-dynamic/[slug]/page.tsx
+++ b/test/e2e/deferred-entries/app/app-dynamic/[slug]/page.tsx
@@ -1,0 +1,9 @@
+type AppDynamicPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function AppDynamicPage({ params }: AppDynamicPageProps) {
+  const { slug } = await params
+
+  return <h1>App Dynamic Segment: {slug}</h1>
+}

--- a/test/e2e/deferred-entries/app/app-optional-catch-all/[[...slug]]/page.tsx
+++ b/test/e2e/deferred-entries/app/app-optional-catch-all/[[...slug]]/page.tsx
@@ -1,0 +1,12 @@
+type AppOptionalCatchAllPageProps = {
+  params: Promise<{ slug?: string[] }>
+}
+
+export default async function AppOptionalCatchAllPage({
+  params,
+}: AppOptionalCatchAllPageProps) {
+  const { slug } = await params
+  const value = slug?.join('/') ?? 'root'
+
+  return <h1>App Optional Catch-all Segment: {value}</h1>
+}

--- a/test/e2e/deferred-entries/app/apple-icon.tsx
+++ b/test/e2e/deferred-entries/app/apple-icon.tsx
@@ -1,0 +1,12 @@
+import { ImageResponse } from 'next/og'
+
+export const size = {
+  width: 180,
+  height: 180,
+}
+
+export const contentType = 'image/png'
+
+export default function AppleIcon() {
+  return new ImageResponse(<div>Deferred Entries Apple Icon</div>)
+}

--- a/test/e2e/deferred-entries/app/edge-runtime/page.tsx
+++ b/test/e2e/deferred-entries/app/edge-runtime/page.tsx
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function EdgeRuntimePage() {
+  return <h1>Edge Runtime App Router Page</h1>
+}

--- a/test/e2e/deferred-entries/app/layout.tsx
+++ b/test/e2e/deferred-entries/app/layout.tsx
@@ -1,3 +1,5 @@
+import { Suspense } from 'react'
+
 export default function RootLayout({
   children,
 }: {
@@ -5,7 +7,9 @@ export default function RootLayout({
 }) {
   return (
     <html>
-      <body>{children}</body>
+      <body>
+        <Suspense fallback={null}>{children}</Suspense>
+      </body>
     </html>
   )
 }

--- a/test/e2e/deferred-entries/app/opengraph-image.tsx
+++ b/test/e2e/deferred-entries/app/opengraph-image.tsx
@@ -1,0 +1,12 @@
+import { ImageResponse } from 'next/og'
+
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+export default function OpenGraphImage() {
+  return new ImageResponse(<div>Deferred Entries OpenGraph</div>)
+}

--- a/test/e2e/deferred-entries/app/parallel/@analytics/page.tsx
+++ b/test/e2e/deferred-entries/app/parallel/@analytics/page.tsx
@@ -1,0 +1,3 @@
+export default function ParallelAnalyticsSlotPage() {
+  return <p>Parallel Route Analytics Slot</p>
+}

--- a/test/e2e/deferred-entries/app/parallel/@team/page.tsx
+++ b/test/e2e/deferred-entries/app/parallel/@team/page.tsx
@@ -1,0 +1,3 @@
+export default function ParallelTeamSlotPage() {
+  return <p>Parallel Route Team Slot</p>
+}

--- a/test/e2e/deferred-entries/app/parallel/layout.tsx
+++ b/test/e2e/deferred-entries/app/parallel/layout.tsx
@@ -1,0 +1,17 @@
+export default function ParallelLayout({
+  children,
+  team,
+  analytics,
+}: {
+  children: React.ReactNode
+  team: React.ReactNode
+  analytics: React.ReactNode
+}) {
+  return (
+    <div>
+      <div id="parallel-children">{children}</div>
+      <div id="parallel-team">{team}</div>
+      <div id="parallel-analytics">{analytics}</div>
+    </div>
+  )
+}

--- a/test/e2e/deferred-entries/app/parallel/page.tsx
+++ b/test/e2e/deferred-entries/app/parallel/page.tsx
@@ -1,0 +1,3 @@
+export default function ParallelRoutePage() {
+  return <p>Parallel Route Children Slot</p>
+}

--- a/test/e2e/deferred-entries/app/route-handler/route.ts
+++ b/test/e2e/deferred-entries/app/route-handler/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from 'next/server'
 
+const ROUTE_HANDLER_CALLBACK_TIMESTAMP = 0
+
 export function GET() {
-  return NextResponse.json({ message: 'Hello from app route handler' })
+  return NextResponse.json({
+    message: 'Hello from app route handler',
+    callbackTimestamp: ROUTE_HANDLER_CALLBACK_TIMESTAMP,
+  })
 }

--- a/test/e2e/deferred-entries/app/twitter-image.tsx
+++ b/test/e2e/deferred-entries/app/twitter-image.tsx
@@ -1,0 +1,12 @@
+import { ImageResponse } from 'next/og'
+
+export const size = {
+  width: 1200,
+  height: 630,
+}
+
+export const contentType = 'image/png'
+
+export default function TwitterImage() {
+  return new ImageResponse(<div>Deferred Entries Twitter</div>)
+}

--- a/test/e2e/deferred-entries/deferred-entries.test.ts
+++ b/test/e2e/deferred-entries/deferred-entries.test.ts
@@ -2,6 +2,9 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 import fs from 'fs'
 import path from 'path'
+import { Response } from 'node-fetch'
+
+const isCacheComponentsEnabled = process.env.__NEXT_CACHE_COMPONENTS === 'true'
 
 interface LogEntry {
   timestamp: number
@@ -55,6 +58,17 @@ function parseDeferredCallbackTimestamp(html: string): number {
   return parseInt(match[1], 10)
 }
 
+async function expectPngResponse(res: Response) {
+  expect(res.status).toBe(200)
+  expect(res.headers.get('content-type')).toContain('image/png')
+
+  const body = Buffer.from(await res.arrayBuffer())
+  expect(body.byteLength).toBeGreaterThan(8)
+  expect(
+    body.subarray(0, 8).equals(Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]))
+  ).toBe(true)
+}
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
@@ -96,7 +110,7 @@ async function waitForCallbackTimestampToStabilize(
   )
 }
 
-describe('deferred-entries webpack', () => {
+describe('deferred-entries', () => {
   const { next, isNextStart, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -116,6 +130,14 @@ describe('deferred-entries webpack', () => {
     } catch (e) {
       // Ignore
     }
+
+    if (isCacheComponentsEnabled) {
+      // Cache Components does not allow route segment runtime configs.
+      await next.patchFile('app/edge-runtime/page.tsx', (content) =>
+        content.replace(/export const runtime = 'edge'[\r\n]+/, '')
+      )
+    }
+
     await next.start()
   })
 
@@ -204,6 +226,44 @@ describe('deferred-entries webpack', () => {
     })
   })
 
+  it('should build pages router dynamic and catch-all routes when using deferred entries', async () => {
+    await retry(async () => {
+      const dynamicRouteRes = await next.fetch('/pages-dynamic/alpha')
+      expect(dynamicRouteRes.status).toBe(200)
+      const html = await dynamicRouteRes.text()
+      expect(html).toMatch(/Pages Dynamic Route:\s*(?:<!-- -->)?alpha/)
+    })
+
+    await retry(async () => {
+      const catchAllRouteRes = await next.fetch('/pages-catch-all/alpha/beta')
+      expect(catchAllRouteRes.status).toBe(200)
+      const html = await catchAllRouteRes.text()
+      expect(html).toMatch(/Pages Catch-all Route:\s*(?:<!-- -->)?alpha\/beta/)
+    })
+
+    await retry(async () => {
+      const optionalCatchAllRootRes = await next.fetch(
+        '/pages-optional-catch-all'
+      )
+      expect(optionalCatchAllRootRes.status).toBe(200)
+      const html = await optionalCatchAllRootRes.text()
+      expect(html).toMatch(
+        /Pages Optional Catch-all Route:\s*(?:<!-- -->)?root/
+      )
+    })
+
+    await retry(async () => {
+      const optionalCatchAllSlugRes = await next.fetch(
+        '/pages-optional-catch-all/alpha/beta'
+      )
+      expect(optionalCatchAllSlugRes.status).toBe(200)
+      const html = await optionalCatchAllSlugRes.text()
+      expect(html).toMatch(
+        /Pages Optional Catch-all Route:\s*(?:<!-- -->)?alpha\/beta/
+      )
+    })
+  })
+
   it('should build app router dynamic route with generateStaticParams when using deferred entries', async () => {
     await retry(async () => {
       const staticParamsRes = await next.fetch('/static-params/alpha')
@@ -221,24 +281,88 @@ describe('deferred-entries webpack', () => {
     })
   })
 
+  it('should build app router parallel routes when using deferred entries', async () => {
+    await retry(async () => {
+      const parallelRouteRes = await next.fetch('/parallel')
+      expect(parallelRouteRes.status).toBe(200)
+
+      const html = await parallelRouteRes.text()
+      expect(html).toContain('Parallel Route Children Slot')
+      expect(html).toContain('Parallel Route Team Slot')
+      expect(html).toContain('Parallel Route Analytics Slot')
+    })
+  })
+
+  it('should build app router dynamic and catch-all routes when using deferred entries', async () => {
+    await retry(async () => {
+      const dynamicRouteRes = await next.fetch('/app-dynamic/alpha')
+      expect(dynamicRouteRes.status).toBe(200)
+      const html = await dynamicRouteRes.text()
+      expect(html).toMatch(/App Dynamic Segment:\s*(?:<!-- -->)?alpha/)
+    })
+
+    await retry(async () => {
+      const catchAllRouteRes = await next.fetch('/app-catch-all/alpha/beta')
+      expect(catchAllRouteRes.status).toBe(200)
+      const html = await catchAllRouteRes.text()
+      expect(html).toMatch(/App Catch-all Segment:\s*(?:<!-- -->)?alpha\/beta/)
+    })
+
+    await retry(async () => {
+      const optionalCatchAllRootRes = await next.fetch(
+        '/app-optional-catch-all'
+      )
+      expect(optionalCatchAllRootRes.status).toBe(200)
+      const html = await optionalCatchAllRootRes.text()
+      expect(html).toMatch(
+        /App Optional Catch-all Segment:\s*(?:<!-- -->)?root/
+      )
+    })
+
+    await retry(async () => {
+      const optionalCatchAllSlugRes = await next.fetch(
+        '/app-optional-catch-all/alpha/beta'
+      )
+      expect(optionalCatchAllSlugRes.status).toBe(200)
+      const html = await optionalCatchAllSlugRes.text()
+      expect(html).toMatch(
+        /App Optional Catch-all Segment:\s*(?:<!-- -->)?alpha\/beta/
+      )
+    })
+  })
+
   it('should build app router route handler when using deferred entries', async () => {
+    const callbackLogPath = path.join(next.testDir, '.callback-log')
     await retry(async () => {
       const routeHandlerRes = await next.fetch('/route-handler')
       expect(routeHandlerRes.status).toBe(200)
       const data = await routeHandlerRes.json()
       expect(data.message).toBe('Hello from app route handler')
+      const callbackTimestamp = parseCallbackLog(callbackLogPath)
+      expect(callbackTimestamp).not.toBeNull()
+      expect(data.callbackTimestamp).toBe(callbackTimestamp)
     })
   })
 
   it('should build app router metadata routes when using deferred entries', async () => {
     await retry(async () => {
-      const [faviconRes, manifestRes, robotsRes, sitemapRes] =
-        await Promise.all([
-          next.fetch('/favicon.ico'),
-          next.fetch('/manifest.json'),
-          next.fetch('/robots.txt'),
-          next.fetch('/sitemap.xml'),
-        ])
+      const [
+        faviconRes,
+        manifestRes,
+        robotsRes,
+        sitemapRes,
+        openGraphRes,
+        twitterRes,
+        appleIconRes,
+      ] = await Promise.all([
+        next.fetch('/favicon.ico'),
+        next.fetch('/manifest.json'),
+        next.fetch('/robots.txt'),
+        next.fetch('/sitemap.xml'),
+        next.fetch('/opengraph-image'),
+        next.fetch('/twitter-image'),
+        next.fetch('/apple-icon'),
+      ])
 
       expect(faviconRes.status).toBe(200)
       expect(manifestRes.status).toBe(200)
@@ -271,6 +395,10 @@ describe('deferred-entries webpack', () => {
       )
       expect(robotsRes.headers.get('content-type')).toContain('text/plain')
       expect(sitemapRes.headers.get('content-type')).toMatch(/xml/)
+
+      await expectPngResponse(openGraphRes)
+      await expectPngResponse(twitterRes)
+      await expectPngResponse(appleIconRes)
     })
   })
 
@@ -296,6 +424,57 @@ describe('deferred-entries webpack', () => {
       const data = await apiRes.json()
       expect(data.message).toBe('Hello from pages API route')
     })
+  })
+
+  it('should build pages router dynamic API routes when using deferred entries', async () => {
+    await retry(async () => {
+      const dynamicApiRes = await next.fetch('/api/dynamic/alpha')
+      expect(dynamicApiRes.status).toBe(200)
+      const data = await dynamicApiRes.json()
+      expect(data.slug).toBe('alpha')
+    })
+  })
+
+  it('should run middleware for app router, pages router, and API routes', async () => {
+    const routes = ['/deferred', '/legacy', '/api/hello', '/route-handler']
+
+    for (const route of routes) {
+      await retry(async () => {
+        const res = await next.fetch(route)
+        expect(res.status).toBe(200)
+        expect(res.headers.get('x-deferred-entries-middleware')).toBe('true')
+        expect(res.headers.get('x-deferred-entries-middleware-path')).toBe(
+          route
+        )
+      })
+    }
+  })
+
+  it('should run instrumentation hooks with deferred entries', async () => {
+    await retry(async () => {
+      const homeRes = await next.fetch('/')
+      expect(homeRes.status).toBe(200)
+    })
+
+    await retry(async () => {
+      expect(next.cliOutput).toContain(
+        '[TEST] deferred-entries instrumentation register (nodejs)'
+      )
+    })
+
+    await retry(async () => {
+      const edgeRes = await next.fetch('/edge-runtime')
+      expect(edgeRes.status).toBe(200)
+      expect(await edgeRes.text()).toContain('Edge Runtime App Router Page')
+    })
+
+    if (!isCacheComponentsEnabled) {
+      await retry(async () => {
+        expect(next.cliOutput).toContain(
+          '[TEST] deferred-entries instrumentation register (edge)'
+        )
+      })
+    }
   })
 
   it('should call onBeforeDeferredEntries before building deferred entry', async () => {

--- a/test/e2e/deferred-entries/instrumentation.ts
+++ b/test/e2e/deferred-entries/instrumentation.ts
@@ -1,0 +1,9 @@
+export function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    console.log('[TEST] deferred-entries instrumentation register (nodejs)')
+  }
+
+  if (process.env.NEXT_RUNTIME === 'edge') {
+    console.log('[TEST] deferred-entries instrumentation register (edge)')
+  }
+}

--- a/test/e2e/deferred-entries/middleware.ts
+++ b/test/e2e/deferred-entries/middleware.ts
@@ -1,0 +1,12 @@
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const response = NextResponse.next()
+  response.headers.set('x-deferred-entries-middleware', 'true')
+  response.headers.set(
+    'x-deferred-entries-middleware-path',
+    request.nextUrl.pathname
+  )
+  return response
+}

--- a/test/e2e/deferred-entries/next.config.js
+++ b/test/e2e/deferred-entries/next.config.js
@@ -4,6 +4,12 @@ const path = require('path')
 const logFile = path.join(__dirname, '.entry-log')
 const callbackLogFile = path.join(__dirname, '.callback-log')
 const deferredPageFile = path.join(__dirname, 'app', 'deferred', 'page.tsx')
+const routeHandlerFile = path.join(
+  __dirname,
+  'app',
+  'route-handler',
+  'route.ts'
+)
 const homePageFile = path.join(__dirname, 'app', 'page.tsx')
 
 let lastHomePageContent = null
@@ -11,7 +17,7 @@ let lastHomePageContent = null
 /** @type {import('next').NextConfig} */
 module.exports = {
   experimental: {
-    deferredEntries: ['/deferred'],
+    deferredEntries: ['/deferred', '/route-handler'],
     onBeforeDeferredEntries: async () => {
       const timestamp = Date.now()
       const homePageContent = fs.readFileSync(homePageFile, 'utf-8')
@@ -32,6 +38,18 @@ module.exports = {
           )
         }
         fs.writeFileSync(deferredPageFile, nextDeferredPageContent)
+
+        const routeHandlerContent = fs.readFileSync(routeHandlerFile, 'utf-8')
+        const nextRouteHandlerContent = routeHandlerContent.replace(
+          /const ROUTE_HANDLER_CALLBACK_TIMESTAMP = \d+/,
+          `const ROUTE_HANDLER_CALLBACK_TIMESTAMP = ${timestamp}`
+        )
+        if (nextRouteHandlerContent === routeHandlerContent) {
+          throw new Error(
+            'Failed to update ROUTE_HANDLER_CALLBACK_TIMESTAMP in route handler entry'
+          )
+        }
+        fs.writeFileSync(routeHandlerFile, nextRouteHandlerContent)
 
         // Persist only write-triggering callback timestamps.
         // This avoids deferred self-rebuild callback loops in webpack dev.
@@ -54,6 +72,13 @@ module.exports = {
   // Turbopack loader configuration
   turbopack: {
     rules: {
+      '*ts': {
+        loaders: [
+          {
+            loader: path.join(__dirname, 'entry-logger-loader.js'),
+          },
+        ],
+      },
       '*.tsx': {
         loaders: [
           {

--- a/test/e2e/deferred-entries/pages/api/dynamic/[slug].ts
+++ b/test/e2e/deferred-entries/pages/api/dynamic/[slug].ts
@@ -1,0 +1,16 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+
+type Data = {
+  slug: string
+}
+
+export default function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<Data>
+) {
+  const slug = Array.isArray(req.query.slug)
+    ? req.query.slug.join('/')
+    : (req.query.slug ?? '')
+
+  res.status(200).json({ slug })
+}

--- a/test/e2e/deferred-entries/pages/pages-catch-all/[...slug].tsx
+++ b/test/e2e/deferred-entries/pages/pages-catch-all/[...slug].tsx
@@ -1,0 +1,15 @@
+type PagesCatchAllRouteProps = {
+  slug: string[]
+}
+
+export function getServerSideProps({ params }: { params: { slug: string[] } }) {
+  return {
+    props: {
+      slug: params.slug,
+    },
+  }
+}
+
+export default function PagesCatchAllRoute({ slug }: PagesCatchAllRouteProps) {
+  return <h1>Pages Catch-all Route: {slug.join('/')}</h1>
+}

--- a/test/e2e/deferred-entries/pages/pages-dynamic/[slug].tsx
+++ b/test/e2e/deferred-entries/pages/pages-dynamic/[slug].tsx
@@ -1,0 +1,15 @@
+type PagesDynamicRouteProps = {
+  slug: string
+}
+
+export function getServerSideProps({ params }: { params: { slug: string } }) {
+  return {
+    props: {
+      slug: params.slug,
+    },
+  }
+}
+
+export default function PagesDynamicRoute({ slug }: PagesDynamicRouteProps) {
+  return <h1>Pages Dynamic Route: {slug}</h1>
+}

--- a/test/e2e/deferred-entries/pages/pages-optional-catch-all/[[...slug]].tsx
+++ b/test/e2e/deferred-entries/pages/pages-optional-catch-all/[[...slug]].tsx
@@ -1,0 +1,23 @@
+type PagesOptionalCatchAllRouteProps = {
+  slug?: string[]
+}
+
+export function getServerSideProps({
+  params,
+}: {
+  params?: { slug?: string[] }
+}) {
+  return {
+    props: {
+      slug: params?.slug ?? null,
+    },
+  }
+}
+
+export default function PagesOptionalCatchAllRoute({
+  slug,
+}: PagesOptionalCatchAllRouteProps) {
+  const value = slug?.join('/') ?? 'root'
+
+  return <h1>Pages Optional Catch-all Route: {value}</h1>
+}

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -79,6 +79,7 @@ use crate::{
     invalidator_map::{InvalidatorMap, WriteContent},
     json::UnparsableJson,
     mutex_map::MutexMap,
+    path_map::OrderedPathMapExt,
     read_glob::{read_glob, track_glob},
     retry::{can_retry, retry_blocking, retry_blocking_custom},
     rope::{Rope, RopeReader},
@@ -426,6 +427,75 @@ impl DiskFileSystemInner {
         });
     }
 
+    /// Invalidates tracked files/directories for `paths` and their children.
+    /// Also invalidates tracked directory reads for all parent directories to
+    /// account for file creations/deletions under the deferred subtree.
+    fn invalidate_path_and_children_with_reason<R: InvalidationReason + Clone>(
+        &self,
+        paths: impl IntoIterator<Item = PathBuf>,
+        reason: impl Fn(&Path) -> R + Sync,
+    ) {
+        let _span =
+            tracing::info_span!("invalidate filesystem paths", name = &*self.root).entered();
+        let Some(turbo_tasks) = self.turbo_tasks.upgrade() else {
+            return;
+        };
+        let _guard = self.tokio_handle.enter();
+
+        let mut invalidator_map = self.invalidator_map.lock().unwrap();
+        let mut dir_invalidator_map = self.dir_invalidator_map.lock().unwrap();
+        let mut invalidators = Vec::new();
+        let mut parent_dirs_to_invalidate = FxHashSet::default();
+
+        for path in paths {
+            let mut current_parent = path.parent();
+            while let Some(parent) = current_parent {
+                parent_dirs_to_invalidate.insert(parent.to_path_buf());
+                current_parent = parent.parent();
+            }
+
+            for (invalidated_path, path_invalidators) in
+                invalidator_map.extract_path_with_children(&path)
+            {
+                let reason_for_path = reason(&invalidated_path);
+                invalidators.extend(
+                    path_invalidators
+                        .into_keys()
+                        .map(|invalidator| (reason_for_path.clone(), invalidator)),
+                );
+            }
+
+            for (invalidated_path, path_invalidators) in
+                dir_invalidator_map.extract_path_with_children(&path)
+            {
+                let reason_for_path = reason(&invalidated_path);
+                invalidators.extend(
+                    path_invalidators
+                        .into_keys()
+                        .map(|invalidator| (reason_for_path.clone(), invalidator)),
+                );
+            }
+        }
+
+        for path in parent_dirs_to_invalidate {
+            if let Some(path_invalidators) = dir_invalidator_map.remove(&path) {
+                let reason_for_path = reason(&path);
+                invalidators.extend(
+                    path_invalidators
+                        .into_keys()
+                        .map(|invalidator| (reason_for_path.clone(), invalidator)),
+                );
+            }
+        }
+
+        drop(invalidator_map);
+        drop(dir_invalidator_map);
+
+        parallel::for_each_owned(invalidators, |(reason, invalidator)| {
+            invalidator.invalidate_with_reason(&*turbo_tasks, reason)
+        });
+    }
+
     fn invalidate_from_write(
         &self,
         full_path: &Path,
@@ -520,6 +590,15 @@ impl DiskFileSystem {
         reason: impl Fn(&Path) -> R + Sync,
     ) {
         self.inner.invalidate_with_reason(reason);
+    }
+
+    pub fn invalidate_path_and_children_with_reason<R: InvalidationReason + Clone>(
+        &self,
+        paths: impl IntoIterator<Item = PathBuf>,
+        reason: impl Fn(&Path) -> R + Sync,
+    ) {
+        self.inner
+            .invalidate_path_and_children_with_reason(paths, reason);
     }
 
     pub async fn start_watching(&self, poll_interval: Option<Duration>) -> Result<()> {


### PR DESCRIPTION
## Summary
Reworks Turbopack deferred entries in production build so deferred routes are processed last in the same project lifecycle, with `onBeforeDeferredEntries` executed between the non-deferred and deferred phases.

## What changed
- Moved deferred build phasing into Rust in `project_write_all_entrypoints_to_disk`:
  - non-deferred phase
  - `onBeforeDeferredEntries`
  - deferred phase
- Kept callback invocation on the Rust side via the existing node-worker callback plumbing.
- Narrowed invalidation after `onBeforeDeferredEntries` to deferred app source subtrees instead of invalidating the whole project filesystem cache.
  - Added `DiskFileSystem::invalidate_path_and_children_with_reason(...)` in `turbo-tasks-fs`.
  - Derived deferred invalidation dirs from deferred routes’ `original_name` values.
  - Retained a full-invalidation fallback only when app-dir path resolution is unavailable.
- Deferred route selection still includes both app pages and app route handlers.

## Validation
- `cargo check -p next-napi-bindings -p turbo-tasks-fs`
- `pnpm test-start-turbo test/e2e/deferred-entries/deferred-entries.test.ts` (21/21 passing)
- Validated against [workflows repo](https://github.com/vercel/workflow/pull/1058) and v0