### PR TITLE
Ignore `prefetch={true}` on Links to routes with `instant`

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -154,11 +154,12 @@ type RouteTreeShared = {
   // like any other Suspense boundary.)
   hasLoadingBoundary: HasLoadingBoundary
 
-  // Indicates whether this route has a runtime prefetch that we can request.
-  // This is determined by the server; it's not purely a user configuration
-  // because the server may determine that a route is fully static and doesn't
-  // need runtime prefetching regardless of the configuration.
-  hasRuntimePrefetch: boolean
+  // Bitmask of PrefetchHint flags. Indicates whether this segment has a
+  // runtime prefetch, and whether the subtree contains any instant configs.
+  // Determined by the server; not purely a user configuration because the
+  // server may determine that a route is fully static and doesn't need
+  // runtime prefetching regardless of the configuration.
+  prefetchHints: number
 }
 
 export type RefreshState = {
@@ -722,7 +723,7 @@ function deprecated_createOptimisticRouteTree(
       slots: clonedSlots,
       isRootLayout: tree.isRootLayout,
       hasLoadingBoundary: tree.hasLoadingBoundary,
-      hasRuntimePrefetch: tree.hasRuntimePrefetch,
+      prefetchHints: tree.prefetchHints,
     }
   }
 
@@ -735,7 +736,7 @@ function deprecated_createOptimisticRouteTree(
     slots: clonedSlots,
     isRootLayout: tree.isRootLayout,
     hasLoadingBoundary: tree.hasLoadingBoundary,
-    hasRuntimePrefetch: tree.hasRuntimePrefetch,
+    prefetchHints: tree.prefetchHints,
   }
 }
 
@@ -1018,7 +1019,7 @@ export function createMetadataRouteTree(
     slots: null,
     isRootLayout: false,
     hasLoadingBoundary: HasLoadingBoundary.SubtreeHasNoLoadingBoundary,
-    hasRuntimePrefetch: false,
+    prefetchHints: 0,
   }
   return metadata
 }
@@ -1321,7 +1322,7 @@ function convertTreePrefetchToRouteTree(
     // This field is only relevant to dynamic routes. For a PPR/static route,
     // there's always some partial loading state we can fetch.
     hasLoadingBoundary: HasLoadingBoundary.SegmentHasLoadingBoundary,
-    hasRuntimePrefetch: prefetch.hasRuntimePrefetch,
+    prefetchHints: prefetch.prefetchHints,
   }
 }
 
@@ -1507,8 +1508,8 @@ function convertFlightRouterStateToRouteTree(
         : HasLoadingBoundary.SubtreeHasNoLoadingBoundary,
 
     // Non-static tree responses are only used by apps that haven't adopted
-    // Cache Components. So this is always false.
-    hasRuntimePrefetch: false,
+    // Cache Components. So this is always 0.
+    prefetchHints: 0,
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -764,7 +764,7 @@ function convertServerPatchToFullTreeImpl(
     newSeedDataChildren,
     null,
     isEmptySeedDataPartial,
-    false,
+    0,
     null,
   ]
 

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -799,7 +799,7 @@ function reifyRouteTree(
       slots: newSlots,
       isRootLayout: pattern.isRootLayout,
       hasLoadingBoundary: pattern.hasLoadingBoundary,
-      hasRuntimePrefetch: pattern.hasRuntimePrefetch,
+      prefetchHints: pattern.prefetchHints,
       isPage: true,
       varyPath: newVaryPath,
     }
@@ -816,7 +816,7 @@ function reifyRouteTree(
       slots: newSlots,
       isRootLayout: pattern.isRootLayout,
       hasLoadingBoundary: pattern.hasLoadingBoundary,
-      hasRuntimePrefetch: pattern.hasRuntimePrefetch,
+      prefetchHints: pattern.prefetchHints,
       isPage: false,
       varyPath: newVaryPath,
     }

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -3,7 +3,10 @@ import type {
   Segment as FlightRouterStateSegment,
   Segment,
 } from '../../../shared/lib/app-router-types'
-import { HasLoadingBoundary } from '../../../shared/lib/app-router-types'
+import {
+  HasLoadingBoundary,
+  PrefetchHint,
+} from '../../../shared/lib/app-router-types'
 import { matchSegment } from '../match-segments'
 import {
   readOrCreateRouteCacheEntry,
@@ -710,12 +713,28 @@ function pingRootRouteTree(
       // If it turned out that the route isn't PPR-enabled, we need to use `LoadingBoundary` instead.
       // We don't need to do this for runtime prefetches, because those are only available in
       // `cacheComponents`, where every route is PPR.
-      const fetchStrategy =
-        task.fetchStrategy === FetchStrategy.PPR
-          ? route.isPPREnabled
-            ? FetchStrategy.PPR
-            : FetchStrategy.LoadingBoundary
-          : task.fetchStrategy
+      let fetchStrategy: FetchStrategy
+      if (tree.prefetchHints & PrefetchHint.SubtreeHasInstant) {
+        // If `instant` is defined anywhere on the target route, ignore the
+        // fetch strategy and switch to unified strategy used by Cache
+        // Components (called `PPR` for now, will likely be renamed).
+        //
+        // In practice, this just means that a "full" prefetch (<Link
+        // prefetch={true}>) has no effect. You're meant to use Runtime
+        // Prefetching instead — that's the new pattern that replaces
+        // prefetch={true}.
+        //
+        // The reason we check for `instant` rather than the `cacheComponents`
+        // flag is to support incremental adoption. `prefetch={true}` will
+        // continue to work until you opt into `instant`.
+        fetchStrategy = FetchStrategy.PPR
+      } else if (task.fetchStrategy === FetchStrategy.PPR) {
+        fetchStrategy = route.isPPREnabled
+          ? FetchStrategy.PPR
+          : FetchStrategy.LoadingBoundary
+      } else {
+        fetchStrategy = task.fetchStrategy
+      }
 
       switch (fetchStrategy) {
         case FetchStrategy.PPR: {
@@ -962,7 +981,7 @@ function pingNewPartOfCacheComponentsTree(
   // shared layouts.) Segments in here default to being prefetched statically.
   // However, if the server instructs us to, we may switch to a runtime
   // prefetch instead. Traverse the tree and check at each segment.
-  if (tree.hasRuntimePrefetch) {
+  if (tree.prefetchHints & PrefetchHint.HasRuntimePrefetch) {
     // This route has a runtime prefetch response. Since we're below the shared
     // layout, everything from this point should be prefetched using a single,
     // combined runtime request, rather than using per-segment static requests.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1720,7 +1720,7 @@ async function getErrorRSCPayload(
     {},
     null,
     false,
-    false, // We don't currently support runtime prefetching for error pages.
+    0, // We don't currently support runtime prefetching for error pages.
     null, // varyParams - not tracked for error pages
   ]
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -66,8 +66,8 @@ export type TreePrefetch = {
     [parallelRouteKey: string]: TreePrefetch
   }
 
-  /** Whether this segment should be fetched using a runtime prefetch */
-  hasRuntimePrefetch: boolean
+  /** Bitmask of PrefetchHint flags for this segment and its subtree */
+  prefetchHints: number
 
   // Extra fields that only exist so we can reconstruct a FlightRouterState on
   // the client. We may be able to unify TreePrefetch and FlightRouterState
@@ -345,7 +345,7 @@ function collectSegmentDataImpl(
     slotMetadata[parallelRouteKey] = childTree
   }
 
-  const hasRuntimePrefetch = seedData !== null ? seedData[4] : false
+  const prefetchHints = seedData !== null ? seedData[4] : 0
 
   // Determine which params this segment varies on.
   // Read the vary params thenable directly from the seed data. By the time
@@ -402,7 +402,7 @@ function collectSegmentDataImpl(
   return {
     name,
     param,
-    hasRuntimePrefetch,
+    prefetchHints,
     slots: slotMetadata,
     isRootLayout: route[4] === true,
   }

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1,7 +1,8 @@
 import type { ComponentType } from 'react'
-import type {
-  CacheNodeSeedData,
-  LoadingModuleData,
+import {
+  PrefetchHint,
+  type CacheNodeSeedData,
+  type LoadingModuleData,
 } from '../../shared/lib/app-router-types'
 import type { PreloadCallbacks } from './types'
 import {
@@ -228,11 +229,13 @@ async function createComponentTreeInternal(
   const instantConfig = layoutOrPageMod
     ? (layoutOrPageMod as AppSegmentConfig).unstable_instant
     : undefined
-  /** Whether this segment should use a runtime prefetch instead of a static prefetch. */
-  const hasRuntimePrefetch =
-    instantConfig && typeof instantConfig === 'object'
-      ? instantConfig.prefetch === 'runtime'
-      : false
+  let prefetchHints = 0
+  if (instantConfig && typeof instantConfig === 'object') {
+    prefetchHints |= PrefetchHint.SubtreeHasInstant
+    if (instantConfig.prefetch === 'runtime') {
+      prefetchHints |= PrefetchHint.HasRuntimePrefetch
+    }
+  }
 
   const [Forbidden, forbiddenStyles] =
     authInterrupts && forbidden
@@ -694,7 +697,7 @@ async function createComponentTreeInternal(
       parallelRouteCacheNodeSeedData,
       loadingData,
       isPossiblyPartialResponse,
-      hasRuntimePrefetch,
+      prefetchHints,
       // No user-provided component, so no params will be accessed. Use the
       // pre-resolved empty tracker.
       emptyVaryParamsAccumulator
@@ -734,7 +737,7 @@ async function createComponentTreeInternal(
       parallelRouteCacheNodeSeedData,
       loadingData,
       true,
-      hasRuntimePrefetch,
+      prefetchHints,
       // force-dynamic postpones without rendering the component, so no params
       // are accessed. The vary params are empty.
       emptyVaryParamsAccumulator
@@ -862,7 +865,7 @@ async function createComponentTreeInternal(
       parallelRouteCacheNodeSeedData,
       loadingData,
       isPossiblyPartialResponse,
-      hasRuntimePrefetch,
+      prefetchHints,
       varyParamsAccumulator
     )
   } else {
@@ -1077,7 +1080,7 @@ async function createComponentTreeInternal(
       parallelRouteCacheNodeSeedData,
       loadingData,
       isPossiblyPartialResponse,
-      hasRuntimePrefetch,
+      prefetchHints,
       varyParamsAccumulator
     )
   }
@@ -1229,7 +1232,7 @@ function createSeedData(
   parallelRoutes: Record<string, CacheNodeSeedData | null>,
   loading: LoadingModuleData | null,
   isPossiblyPartialResponse: boolean,
-  hasRuntimePrefetch: boolean,
+  prefetchHints: number,
   varyParamsAccumulator: VaryParamsAccumulator | null
 ): CacheNodeSeedData {
   if (loading !== null) {
@@ -1245,12 +1248,22 @@ function createSeedData(
       children: rsc,
     })
   }
+  // Propagate SubtreeHasInstant from children so the root reflects the
+  // entire subtree.
+  // TODO: We should send the prefetch hints bitmask as part of the route tree,
+  // rather than the CacheNodeSeedData.
+  for (const key in parallelRoutes) {
+    const child = parallelRoutes[key]
+    if (child !== null) {
+      prefetchHints |= child[4] & PrefetchHint.SubtreeHasInstant
+    }
+  }
   return [
     rsc,
     parallelRoutes,
     null,
     isPossiblyPartialResponse,
-    hasRuntimePrefetch,
+    prefetchHints,
     varyParamsAccumulator ? getVaryParamsThenable(varyParamsAccumulator) : null,
   ]
 }

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -1041,7 +1041,7 @@ function deserializeFromChunks<T>(
 type SegmentData = {
   node: React.ReactNode | null
   isPartial: boolean
-  hasRuntimePrefetch: boolean
+  prefetchHints: number
   varyParams: VaryParamsThenable | null
 }
 
@@ -1051,13 +1051,13 @@ function createSegmentData(seedData: CacheNodeSeedData): SegmentData {
     _parallelRoutesData,
     _unused,
     isPartial,
-    hasRuntimePrefetch,
+    prefetchHints,
     varyParams,
   ] = seedData
   return {
     node,
     isPartial,
-    hasRuntimePrefetch,
+    prefetchHints,
     varyParams,
   }
 }
@@ -1072,7 +1072,7 @@ function getCacheNodeSeedDataFromSegment(
     slots,
     /* unused (previously `loading`) */ null,
     data.isPartial,
-    data.hasRuntimePrefetch,
+    data.prefetchHints,
     data.varyParams,
   ]
 }

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -162,6 +162,16 @@ export const enum HasLoadingBoundary {
   SubtreeHasNoLoadingBoundary = 3,
 }
 
+export const enum PrefetchHint {
+  // This segment has a runtime prefetch enabled (via unstable_instant with
+  // prefetch: 'runtime'). Per-segment only, does not propagate to ancestors.
+  HasRuntimePrefetch = 0b01,
+  // This segment or one of its descendants has an instant config defined
+  // (any truthy unstable_instant, regardless of prefetch mode). Propagates
+  // upward so the root segment reflects the entire subtree.
+  SubtreeHasInstant = 0b10,
+}
+
 /**
  * Individual Flight response path
  */
@@ -194,7 +204,7 @@ export type CacheNodeSeedData = [
   loading: null,
   isPartial: boolean,
   /** TODO: this doesn't feel like it belongs here, because it's only used during build, in `collectSegmentData` */
-  hasRuntimePrefetch: boolean,
+  prefetchHints: number,
   /**
    * A thenable that resolves to the set of route params this segment accessed
    * during server rendering. Used by the client router to determine cache key

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/layout.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from 'react'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{}],
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout-instant/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+
+// No instant config on the page — only the layout has it.
+
+export default async function Page() {
+  return (
+    <main>
+      <Suspense fallback={<div>Loading cached...</div>}>
+        <CachedWrapper />
+      </Suspense>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function CachedWrapper() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('test')?.value ?? 'default'
+  return <Cached value={value} />
+}
+
+async function Cached({ value }: { value: string }) {
+  'use cache'
+  return <div id="cached-content">Cached content: {value}</div>
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Dynamic content</div>
+}

--- a/test/e2e/app-dir/prefetch-true-instant/app/layout.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/layout.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <header>
+          <Link href="/" prefetch={false}>
+            Home
+          </Link>
+        </header>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-instant/app/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/page.tsx
@@ -1,0 +1,21 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/target-page" prefetch={true}>
+            /target-page (prefetch=true, instant on page)
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/layout-instant" prefetch={true}>
+            /layout-instant (prefetch=true, instant on layout)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/app/target-page/page.tsx
@@ -1,0 +1,32 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+import { connection } from 'next/server'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{}],
+}
+
+export default async function Page() {
+  return (
+    <main>
+      <Suspense fallback={<div>Loading cached...</div>}>
+        <Cached />
+      </Suspense>
+      <Suspense fallback={<div>Loading dynamic...</div>}>
+        <Dynamic />
+      </Suspense>
+    </main>
+  )
+}
+
+async function Cached() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('test')?.value ?? 'default'
+  return <div id="cached-content">Cached content: {value}</div>
+}
+
+async function Dynamic() {
+  await connection()
+  return <div id="dynamic-content">Dynamic content</div>
+}

--- a/test/e2e/app-dir/prefetch-true-instant/components/link-accordion.tsx
+++ b/test/e2e/app-dir/prefetch-true-instant/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/prefetch-true-instant/next.config.js
+++ b/test/e2e/app-dir/prefetch-true-instant/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/prefetch-true-instant/prefetch-true-instant.test.ts
+++ b/test/e2e/app-dir/prefetch-true-instant/prefetch-true-instant.test.ts
@@ -1,0 +1,129 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('prefetch={true} with instant route', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('is skipped', () => {})
+    return
+  }
+
+  it('does not include dynamic content in the prefetch when the target route has instant', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal the link to trigger a prefetch. Even though the Link has
+    // prefetch={true}, the route has unstable_instant defined, so the
+    // prefetch should be downgraded — it should include cached content
+    // but NOT dynamic content.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/target-page"]'
+      )
+      await linkToggle.click()
+    }, [
+      {
+        includes: 'Cached content',
+      },
+      {
+        includes: 'Dynamic content',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to the page. Block the navigation request so we can
+    // verify which parts appear instantly from the prefetch cache.
+    await act(async () => {
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/target-page"]').click()
+        },
+        {
+          // Temporarily block the navigation request that fetches the
+          // dynamic content. While blocked, the cached parts should
+          // already be visible on screen.
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+      // The cached content should be visible immediately from the prefetch.
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+      // The dynamic content should NOT be on screen yet because the
+      // navigation response is still blocked.
+      const dynamicElement = await browser.elementsByCss('#dynamic-content')
+      expect(dynamicElement.length).toBe(0)
+    })
+
+    // After the navigation response is unblocked, both parts should
+    // be visible.
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('dynamic-content').text()).toEqual(
+      'Dynamic content'
+    )
+  })
+
+  it('also disables full prefetch when instant is on a layout, not the page', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // The layout has unstable_instant but the page does not. The
+    // SubtreeHasInstant bit should propagate up from the layout, so
+    // prefetch={true} on the Link should still be downgraded.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/layout-instant"]'
+      )
+      await linkToggle.click()
+    }, [
+      {
+        includes: 'Cached content',
+      },
+      {
+        includes: 'Dynamic content',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate and verify the cached content appears instantly.
+    await act(async () => {
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/layout-instant"]').click()
+        },
+        {
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+      const dynamicElement = await browser.elementsByCss('#dynamic-content')
+      expect(dynamicElement.length).toBe(0)
+    })
+
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('dynamic-content').text()).toEqual(
+      'Dynamic content'
+    )
+  })
+})


### PR DESCRIPTION
When a route has `unstable_instant` defined on any segment, setting `prefetch={true}` on a Link to that route is now a no-op. The prefetch behaves the same as the default auto strategy — cached content is prefetched but dynamic content is deferred to navigation time.

A full static prefetch doesn't make sense for routes with instant configs, since those segments use runtime prefetching. Rather than silently doing something the developer didn't intend, we ignore the prop entirely.

To detect this on the client, the server now sends a bitmask instead of a boolean for the per-segment prefetch metadata. One bit tracks whether the subtree contains any instant config, which propagates up so the client can check it at the root without traversing.