### PR TITLE
Always set adapter deploy env variable

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -320,6 +320,8 @@ export class NextDeployInstance extends NextInstance {
     }
     if (process.env.NEXT_ENABLE_ADAPTER) {
       additionalEnv.push(`NEXT_ENABLE_ADAPTER=1`)
+    } else {
+      additionalEnv.push(`NEXT_ENABLE_ADAPTER=0`)
     }
 
     const deployRes = await execa(


### PR DESCRIPTION
This ensures we always set this env variable so that it overrides any flag opt ins when we specifically want to test with or without the adapter. 