### PR TITLE
fix: attempt to make eslint-config-next support v10

### DIFF
--- a/packages/eslint-config-next/package.json
+++ b/packages/eslint-config-next/package.json
@@ -12,6 +12,7 @@
     "dist"
   ],
   "dependencies": {
+    "@eslint/compat": "^1.4.0",
     "@next/eslint-plugin-next": "16.2.0-canary.46",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^3.5.2",

--- a/packages/eslint-config-next/src/index.ts
+++ b/packages/eslint-config-next/src/index.ts
@@ -1,4 +1,5 @@
 import type { Linter } from 'eslint'
+import { fixupPluginRules } from '@eslint/compat'
 
 // plugins
 import next from '@next/eslint-plugin-next'
@@ -19,10 +20,12 @@ const config: Linter.Config[] = [
     // Default files, users can overwrite this.
     files: ['**/*.{js,jsx,mjs,ts,tsx,mts,cts}'],
     plugins: {
-      react,
+      // Wrap plugins that use deprecated RuleContext methods removed in ESLint 10.
+      // fixupPluginRules is backward-compatible with ESLint 9.
+      react: fixupPluginRules(react),
       'react-hooks': reactHooks,
-      import: importPlugin,
-      'jsx-a11y': jsxA11yPlugin,
+      import: fixupPluginRules(importPlugin),
+      'jsx-a11y': fixupPluginRules(jsxA11yPlugin),
       '@next/next': next,
     },
     languageOptions: {

--- a/packages/eslint-config-next/src/parser.ts
+++ b/packages/eslint-config-next/src/parser.ts
@@ -3,9 +3,79 @@ import type { Linter } from 'eslint'
 import { parse, parseForESLint } from 'next/dist/compiled/babel/eslint-parser'
 import { version } from '../package.json'
 
+/**
+ * Polyfill `scopeManager.addGlobals()` for ESLint 10 compatibility.
+ *
+ * ESLint 10 requires scope managers to implement `addGlobals(names)` (added in
+ * eslint-scope 9.1.0). The compiled `@babel/eslint-parser` bundled in Next.js
+ * uses eslint-scope v5.x which lacks this method.
+ *
+ * Can be removed once `@babel/eslint-parser` is upgraded to a version with
+ * native eslint-scope 9+ support.
+ */
+function patchScopeManager(scopeManager: any): void {
+  if (!scopeManager || typeof scopeManager.addGlobals === 'function') {
+    return
+  }
+
+  scopeManager.addGlobals = function addGlobals(names: Iterable<string>): void {
+    const globalScope = this.globalScope
+    if (!globalScope) {
+      return
+    }
+
+    for (const name of names) {
+      // Skip if already defined
+      if (globalScope.set.has(name)) {
+        continue
+      }
+
+      // Create a Variable-like object
+      const variable: {
+        name: string
+        identifiers: any[]
+        references: any[]
+        defs: any[]
+        scope: any
+        eslintUsed: boolean
+      } = {
+        name,
+        identifiers: [],
+        references: [],
+        defs: [],
+        scope: globalScope,
+        eslintUsed: true,
+      }
+
+      globalScope.set.set(name, variable)
+      globalScope.variables.push(variable)
+
+      // Resolve any unresolved references that match this name
+      const newThrough: any[] = []
+      for (const ref of globalScope.through) {
+        if (ref.identifier.name === name) {
+          variable.references.push(ref)
+          ref.resolved = variable
+        } else {
+          newThrough.push(ref)
+        }
+      }
+      globalScope.through = newThrough
+    }
+  }
+}
+
+function patchedParseForESLint(
+  ...args: Parameters<typeof parseForESLint>
+): ReturnType<typeof parseForESLint> {
+  const result = parseForESLint(...args)
+  patchScopeManager(result.scopeManager)
+  return result
+}
+
 const parser: Linter.Parser = {
   parse,
-  parseForESLint,
+  parseForESLint: patchedParseForESLint,
   meta: {
     name: 'eslint-config-next/parser',
     version,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,7 +760,7 @@ importers:
         version: 9.37.0(jiti@2.5.1)
       eslint-config-next:
         specifier: canary
-        version: link:../../packages/eslint-config-next
+        version: 16.2.0-canary.47(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
       tailwindcss:
         specifier: 4.1.13
         version: 4.1.13
@@ -1010,6 +1010,9 @@ importers:
 
   packages/eslint-config-next:
     dependencies:
+      '@eslint/compat':
+        specifier: ^1.4.0
+        version: 1.4.0(eslint@9.37.0(jiti@2.5.1))
       '@next/eslint-plugin-next':
         specifier: 16.2.0-canary.46
         version: link:../eslint-plugin-next
@@ -4403,6 +4406,9 @@ packages:
 
   '@next/env@16.0.8':
     resolution: {integrity: sha512-xP4WrQZuj9MdmLJy3eWFHepo+R3vznsMSS8Dy3wdA7FKpjCiesQ6DxZvdGziQisj0tEtCgBKJzjcAc4yZOgLEQ==}
+
+  '@next/eslint-plugin-next@16.2.0-canary.47':
+    resolution: {integrity: sha512-B6ub4oQKYlUY5c/N03BAN3TOjpjg2JRCI82Bak0e58f92Ph63FBjLoDo8gsPZBnaW9MWGBvvf4RS9zeA6O24RA==}
 
   '@next/rspack-binding-android-arm-eabi@1.0.2':
     resolution: {integrity: sha512-ayoNrm5Z9xYIHdYfhUSvzPzNXRunMXx5B6Bonch9pJBfyC/3tUlcqVlI5+1HS+H4euWtPMeGqe8bARjQ71J/ug==}
@@ -9917,6 +9923,15 @@ packages:
     resolution: {integrity: sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==}
     engines: {node: '>=6.0'}
     hasBin: true
+
+  eslint-config-next@16.2.0-canary.47:
+    resolution: {integrity: sha512-q88BwANFJiLP4jjncmRRKbYRPqdXNLAM+5Rm+Tnddw4cBYlE1b2HqYXv97CkPEk9HHMZwTiymfO2t3kHWK475A==}
+    peerDependencies:
+      eslint: '>=9.0.0'
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   eslint-formatter-codeframe@7.32.1:
     resolution: {integrity: sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==}
@@ -21608,6 +21623,10 @@ snapshots:
 
   '@next/env@16.0.8': {}
 
+  '@next/eslint-plugin-next@16.2.0-canary.47':
+    dependencies:
+      fast-glob: 3.3.1
+
   '@next/rspack-binding-android-arm-eabi@1.0.2':
     optional: true
 
@@ -27910,6 +27929,26 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-config-next@16.2.0-canary.47(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.0-canary.47
+      eslint: 9.37.0(jiti@2.5.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-react: 7.37.0(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-react-hooks: 7.0.0(eslint@9.37.0(jiti@2.5.1))
+      globals: 16.4.0
+      typescript-eslint: 8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-formatter-codeframe@7.32.1:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -27920,6 +27959,22 @@ snapshots:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.0
+      eslint: 9.37.0(jiti@2.5.1)
+      get-tsconfig: 4.12.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-import-x: 4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -27977,6 +28032,16 @@ snapshots:
       eslint: 9.37.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@2.5.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      eslint: 9.37.0(jiti@2.5.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -28055,6 +28120,33 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.37.0(jiti@2.5.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.37.0(jiti@2.5.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/test/unit/eslint-config-next/core-web-vitals/eslint-config-next-core-web-vitals.test.ts
+++ b/test/unit/eslint-config-next/core-web-vitals/eslint-config-next-core-web-vitals.test.ts
@@ -3,6 +3,19 @@ import { execSync } from 'child_process'
 import { getEslintConfigSnapshot } from '../utils'
 
 describe('eslint-config-next/core-web-vitals', () => {
+  it('should run linting without runtime errors', () => {
+    expect(() => {
+      execSync(
+        `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} ${join(__dirname, 'test.js')}`,
+        {
+          cwd: __dirname,
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }
+      )
+    }).not.toThrow()
+  })
+
   it('should match expected resolved configuration', () => {
     const eslintConfigAfterSetupJSON = execSync(
       // Pass explicit absolute path to not get affected by the root eslint config.

--- a/test/unit/eslint-config-next/default/eslint-config-next-default.test.ts
+++ b/test/unit/eslint-config-next/default/eslint-config-next-default.test.ts
@@ -3,6 +3,21 @@ import { execSync } from 'child_process'
 import { getEslintConfigSnapshot } from '../utils'
 
 describe('eslint-config-next', () => {
+  it('should run linting without runtime errors', () => {
+    // Actually run eslint (not just --print-config) to catch runtime errors
+    // like missing scopeManager.addGlobals or removed RuleContext methods.
+    expect(() => {
+      execSync(
+        `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} ${join(__dirname, 'test.js')}`,
+        {
+          cwd: __dirname,
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }
+      )
+    }).not.toThrow()
+  })
+
   it('should match expected resolved configuration', () => {
     const eslintConfigAfterSetupJSON = execSync(
       // Pass explicit absolute path to not get affected by the root eslint config.

--- a/test/unit/eslint-config-next/typescript/eslint-config-next-typescript.test.ts
+++ b/test/unit/eslint-config-next/typescript/eslint-config-next-typescript.test.ts
@@ -3,6 +3,19 @@ import { execSync } from 'child_process'
 import { getEslintConfigSnapshot } from '../utils'
 
 describe('eslint-config-next/typescript', () => {
+  it('should run linting without runtime errors', () => {
+    expect(() => {
+      execSync(
+        `pnpm eslint --config ${join(__dirname, 'eslint.config.mjs')} ${join(__dirname, 'test.tsx')}`,
+        {
+          cwd: __dirname,
+          encoding: 'utf8',
+          stdio: ['pipe', 'pipe', 'pipe'],
+        }
+      )
+    }).not.toThrow()
+  })
+
   it('should match expected resolved configuration', () => {
     const eslintConfigAfterSetupJSON = execSync(
       // Pass explicit absolute path to not get affected by the root eslint config.


### PR DESCRIPTION


### What?

Fixes https://github.com/vercel/next.js/issues/89764 by using eslint compat to handle plugins that don't support eslint v10 yet. It also polyfills a needed function. I couldn't figure out how to upgrade the compiled in babel plugin.

### Why?

Eslint v10 is a pretty minor upgrade all things considered and it's surprising that this plugin clashes with it, so trying to get the plugin to support v10


