### PR TITLE
Turbopack: use file_content.hash() consistently

### DIFF
--- a/crates/next-api/src/paths.rs
+++ b/crates/next-api/src/paths.rs
@@ -34,7 +34,7 @@ async fn server_path(
 ) -> Result<Vc<OptionServerPath>> {
     Ok(Vc::cell(
         if let Some(path) = node_root.get_path_to(&*asset.path().await?) {
-            let content_hash = *asset.content().file_content().hash().await?;
+            let content_hash = *asset.content().hash().await?;
             Some(ServerPath {
                 path: RcStr::from(path),
                 content_hash,

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -2,12 +2,11 @@
 //!
 //! See `next/src/build/webpack/loaders/next-metadata-image-loader`
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
-use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
     asset::AssetContent,
     context::AssetContext,
@@ -24,23 +23,6 @@ use turbopack_ecmascript::{
 
 use crate::next_app::AppPage;
 
-async fn hash_file_content(path: FileSystemPath) -> Result<u64> {
-    let original_file_content = path.read().await?;
-
-    Ok(match &*original_file_content {
-        FileContent::Content(content) => {
-            let content = content.content().to_bytes();
-            hash_xxh3_hash64(&*content)
-        }
-        FileContent::NotFound => {
-            bail!(
-                "metadata file not found: {}",
-                &path.value_to_string().await?
-            );
-        }
-    })
-}
-
 async fn dynamic_image_metadata_with_generator_source(
     path: FileSystemPath,
     ty: RcStr,
@@ -51,7 +33,7 @@ async fn dynamic_image_metadata_with_generator_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
 
-    let hash_query = format!("?{:x}", hash_file_content(path.clone()).await?);
+    let hash_query = format!("?{:x}", *path.read().hash().await?);
 
     let use_numeric_sizes = ty == "twitter" || ty == "openGraph";
     let sizes = if use_numeric_sizes {
@@ -125,7 +107,7 @@ async fn dynamic_image_metadata_without_generator_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
 
-    let hash_query = format!("?{:x}", hash_file_content(path.clone()).await?);
+    let hash_query = format!("?{:x}", *path.read().hash().await?);
 
     let use_numeric_sizes = ty == "twitter" || ty == "openGraph";
     let sizes = if use_numeric_sizes {

--- a/crates/next-core/src/next_app/metadata/image.rs
+++ b/crates/next-core/src/next_app/metadata/image.rs
@@ -2,7 +2,7 @@
 //!
 //! See `next/src/build/webpack/loaders/next-metadata-image-loader`
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use indoc::formatdoc;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
@@ -33,7 +33,13 @@ async fn dynamic_image_metadata_with_generator_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
 
-    let hash_query = format!("?{:x}", *path.read().hash().await?);
+    let hash_query = format!(
+        "?{:x}",
+        path.read()
+            .content_hash()
+            .await?
+            .context("metadata file not found")?
+    );
 
     let use_numeric_sizes = ty == "twitter" || ty == "openGraph";
     let sizes = if use_numeric_sizes {
@@ -107,7 +113,13 @@ async fn dynamic_image_metadata_without_generator_source(
     let stem = stem.unwrap_or_default();
     let ext = path.extension();
 
-    let hash_query = format!("?{:x}", *path.read().hash().await?);
+    let hash_query = format!(
+        "?{:x}",
+        path.read()
+            .content_hash()
+            .await?
+            .context("metadata file not found")?
+    );
 
     let use_numeric_sizes = ty == "twitter" || ty == "openGraph";
     let sizes = if use_numeric_sizes {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2367,6 +2367,16 @@ impl FileContent {
     pub async fn hash(&self) -> Result<Vc<u64>> {
         Ok(Vc::cell(hash_xxh3_hash64(self)))
     }
+
+    /// Compared to [FileContent::hash], this hashes only the bytes of the file content and nothing
+    /// else. If there is no file content, it returns `None`.
+    #[turbo_tasks::function]
+    pub async fn content_hash(&self) -> Result<Vc<Option<u64>>> {
+        match self {
+            FileContent::Content(file) => Ok(Vc::cell(Some(hash_xxh3_hash64(&file.content)))),
+            FileContent::NotFound => Ok(Vc::cell(None)),
+        }
+    }
 }
 
 /// A file's content interpreted as a JSON value.

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -2364,8 +2364,8 @@ impl FileContent {
     }
 
     #[turbo_tasks::function]
-    pub async fn hash(self: Vc<Self>) -> Result<Vc<u64>> {
-        Ok(Vc::cell(hash_xxh3_hash64(&self.await?)))
+    pub async fn hash(&self) -> Result<Vc<u64>> {
+        Ok(Vc::cell(hash_xxh3_hash64(self)))
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/rope.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/rope.rs
@@ -893,6 +893,7 @@ mod test {
     };
 
     use anyhow::Result;
+    use turbo_tasks_hash::hash_xxh3_hash64;
 
     use super::{InnerRope, Rope, RopeBuilder, RopeElem};
 
@@ -1076,6 +1077,21 @@ mod test {
         let b = Rope::new(vec!["abc".into(), shared.into(), "hhh".into()]);
 
         assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hash_structure_invariance() {
+        let shared = Rope::from("def");
+        let a = Rope::new(vec!["abc".into(), shared.clone().into(), "ggg".into()]);
+        let b = Rope::new(vec![
+            "ab".into(),
+            "c".into(),
+            shared.into(),
+            "g".into(),
+            "gg".into(),
+        ]);
+
+        assert_eq!(hash_xxh3_hash64(a), hash_xxh3_hash64(b));
     }
 
     #[test]

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
-use turbo_tasks_hash::DeterministicHash;
+use turbo_tasks_hash::{DeterministicHash, encode_hex};
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -646,12 +646,13 @@ impl ChunkingContext for BrowserChunkingContext {
     #[turbo_tasks::function]
     async fn asset_path(
         &self,
-        content_hash: RcStr,
+        content_hash: Vc<u64>,
         original_asset_ident: Vc<AssetIdent>,
         tag: Option<RcStr>,
     ) -> Result<Vc<FileSystemPath>> {
         let source_path = original_asset_ident.path().await?;
         let basename = source_path.file_name();
+        let content_hash = encode_hex(*content_hash.await?);
         let asset_path = match source_path.extension_ref() {
             Some(ext) => format!(
                 "{basename}.{content_hash}.{ext}",

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -9,7 +9,7 @@ use turbo_tasks::{
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{DeterministicHash, encode_hex};
 use turbopack_core::{
-    asset::{Asset, AssetContent},
+    asset::Asset,
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
         ChunkingConfig, ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAsset,
@@ -577,20 +577,15 @@ impl ChunkingContext for BrowserChunkingContext {
                 let Some(asset) = asset else {
                     bail!("chunk_path requires an asset when content hashing is enabled");
                 };
-                let content = asset.content().await?;
-                if let AssetContent::File(file) = &*content {
-                    let hash = *file.hash().await?;
-                    let length = length as usize;
-                    if let Some(prefix) = prefix {
-                        format!("{prefix}-{hash:0length$x}{extension}").into()
-                    } else {
-                        format!("{hash:0length$x}{extension}").into()
-                    }
+                let hash = asset.content().content_hash().await?.context(
+                    "chunk_path requires an asset with file content when content hashing is \
+                     enabled",
+                )?;
+                let length = length as usize;
+                if let Some(prefix) = prefix {
+                    format!("{prefix}-{hash:0length$x}{extension}").into()
                 } else {
-                    bail!(
-                        "chunk_path requires an asset with file content when content hashing is \
-                         enabled"
-                    );
+                    format!("{hash:0length$x}{extension}").into()
                 }
             }
         };

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     trace::TraceRawVcs,
 };
 use turbo_tasks_fs::FileSystemPath;
-use turbo_tasks_hash::{DeterministicHash, hash_xxh3_hash64};
+use turbo_tasks_hash::DeterministicHash;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::{
@@ -579,7 +579,7 @@ impl ChunkingContext for BrowserChunkingContext {
                 };
                 let content = asset.content().await?;
                 if let AssetContent::File(file) = &*content {
-                    let hash = hash_xxh3_hash64(&file.await?);
+                    let hash = *file.hash().await?;
                     let length = length as usize;
                     if let Some(prefix) = prefix {
                         format!("{prefix}-{hash:0length$x}{extension}").into()

--- a/turbopack/crates/turbopack-core/src/asset.rs
+++ b/turbopack/crates/turbopack-core/src/asset.rs
@@ -117,4 +117,14 @@ impl AssetContent {
             }
         }
     }
+
+    /// Compared to [AssetContent::hash], this hashes only the bytes of the file content and nothing
+    /// else. If there is no file content, it returns `None`.
+    #[turbo_tasks::function]
+    pub async fn content_hash(&self) -> Result<Vc<Option<u64>>> {
+        match self {
+            AssetContent::File(content) => Ok(content.content_hash()),
+            AssetContent::Redirect { .. } => Ok(Vc::cell(None)),
+        }
+    }
 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -350,7 +350,7 @@ pub trait ChunkingContext {
     #[turbo_tasks::function]
     fn asset_path(
         self: Vc<Self>,
-        content_hash: RcStr,
+        content_hash: Vc<u64>,
         original_asset_ident: Vc<AssetIdent>,
         tag: Option<RcStr>,
     ) -> Vc<FileSystemPath>;

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     IntoTraitRef, NonLocalValue, OperationValue, ReadRef, ResolvedVc, State, TraitRef, Vc,
@@ -232,16 +232,12 @@ impl FileHashVersion {
     /// Computes a new [`Vc<FileHashVersion>`] from a path.
     pub async fn compute(asset_content: &AssetContent) -> Result<Vc<Self>> {
         match asset_content {
-            AssetContent::File(file_vc) => match &*file_vc.await? {
-                FileContent::Content(_) => {
-                    let hash = *file_vc.hash().await?;
-                    let hex_hash = encode_hex(hash);
-                    Ok(Self::cell(FileHashVersion {
-                        hash: hex_hash.into(),
-                    }))
-                }
-                FileContent::NotFound => Err(anyhow!("file not found")),
-            },
+            AssetContent::File(file_vc) => {
+                let hash = file_vc.content_hash().await?.context("file not found")?;
+                Ok(Self::cell(FileHashVersion {
+                    hash: encode_hex(hash).into(),
+                }))
+            }
             AssetContent::Redirect { .. } => Err(anyhow!("not a file")),
         }
     }

--- a/turbopack/crates/turbopack-core/src/version.rs
+++ b/turbopack/crates/turbopack-core/src/version.rs
@@ -7,7 +7,7 @@ use turbo_tasks::{
     debug::ValueDebugFormat, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileContent, LinkType};
-use turbo_tasks_hash::{encode_hex, hash_xxh3_hash64};
+use turbo_tasks_hash::encode_hex;
 
 use crate::asset::AssetContent;
 
@@ -233,8 +233,8 @@ impl FileHashVersion {
     pub async fn compute(asset_content: &AssetContent) -> Result<Vc<Self>> {
         match asset_content {
             AssetContent::File(file_vc) => match &*file_vc.await? {
-                FileContent::Content(file) => {
-                    let hash = hash_xxh3_hash64(file.content());
+                FileContent::Content(_) => {
+                    let hash = *file_vc.hash().await?;
                     let hex_hash = encode_hex(hash);
                     Ok(Self::cell(FileHashVersion {
                         hash: hex_hash.into(),

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -3,6 +3,7 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, ResolvedVc, TryJoinIterExt, Upcast, ValueToString, Vc};
 use turbo_tasks_fs::FileSystemPath;
+use turbo_tasks_hash::encode_hex;
 use turbopack_core::{
     asset::Asset,
     chunk::{
@@ -454,12 +455,13 @@ impl ChunkingContext for NodeJsChunkingContext {
     #[turbo_tasks::function]
     async fn asset_path(
         &self,
-        content_hash: RcStr,
+        content_hash: Vc<u64>,
         original_asset_ident: Vc<AssetIdent>,
         tag: Option<RcStr>,
     ) -> Result<Vc<FileSystemPath>> {
         let source_path = original_asset_ident.path().await?;
         let basename = source_path.file_name();
+        let content_hash = encode_hex(*content_hash.await?);
         let asset_path = match source_path.extension_ref() {
             Some(ext) => format!(
                 "{basename}.{content_hash}.{ext}",

--- a/turbopack/crates/turbopack-static/src/output_asset.rs
+++ b/turbopack/crates/turbopack-static/src/output_asset.rs
@@ -39,9 +39,9 @@ impl OutputAsset for StaticOutputAsset {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
         let content = self.source.content();
-        let content_hash = if let AssetContent::File(file) = &*content.await? {
-            if let FileContent::Content(file) = &*file.await? {
-                turbo_tasks_hash::hash_xxh3_hash64(file.content())
+        let content_hash = if let AssetContent::File(file_vc) = &*content.await? {
+            if let FileContent::Content(_) = &*file_vc.await? {
+                *file_vc.hash().await?
             } else {
                 anyhow::bail!("StaticAsset::path: not found")
             }

--- a/turbopack/crates/turbopack-static/src/output_asset.rs
+++ b/turbopack/crates/turbopack-static/src/output_asset.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbo_tasks_fs::FileSystemPath;
@@ -39,18 +39,14 @@ impl OutputAsset for StaticOutputAsset {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
         let content = self.source.content();
-        let content_hash = if let AssetContent::File(file) = &*content.await? {
-            if file.len().await?.is_some() {
-                file.hash()
-            } else {
-                anyhow::bail!("StaticAsset::path: not found")
-            }
-        } else {
-            anyhow::bail!("StaticAsset::path: unsupported file content")
-        };
-        Ok(self
-            .chunking_context
-            .asset_path(content_hash, self.source.ident(), self.tag.clone()))
+        let content_hash = content.content_hash().await?.context(
+            "Missing content when trying to generate the content hash for StaticOutputAsset",
+        )?;
+        Ok(self.chunking_context.asset_path(
+            Vc::cell(content_hash),
+            self.source.ident(),
+            self.tag.clone(),
+        ))
     }
 }
 

--- a/turbopack/crates/turbopack-static/src/output_asset.rs
+++ b/turbopack/crates/turbopack-static/src/output_asset.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{FileContent, FileSystemPath};
+use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     chunk::ChunkingContext,
@@ -39,21 +39,18 @@ impl OutputAsset for StaticOutputAsset {
     #[turbo_tasks::function]
     async fn path(&self) -> Result<Vc<FileSystemPath>> {
         let content = self.source.content();
-        let content_hash = if let AssetContent::File(file_vc) = &*content.await? {
-            if let FileContent::Content(_) = &*file_vc.await? {
-                *file_vc.hash().await?
+        let content_hash = if let AssetContent::File(file) = &*content.await? {
+            if file.len().await?.is_some() {
+                file.hash()
             } else {
                 anyhow::bail!("StaticAsset::path: not found")
             }
         } else {
             anyhow::bail!("StaticAsset::path: unsupported file content")
         };
-        let content_hash_b16 = turbo_tasks_hash::encode_hex(content_hash);
-        Ok(self.chunking_context.asset_path(
-            content_hash_b16.into(),
-            self.source.ident(),
-            self.tag.clone(),
-        ))
+        Ok(self
+            .chunking_context
+            .asset_path(content_hash, self.source.ident(), self.tag.clone()))
     }
 }
 

--- a/turbopack/crates/turbopack-wasm/src/lib.rs
+++ b/turbopack/crates/turbopack-wasm/src/lib.rs
@@ -9,7 +9,7 @@
 #![feature(arbitrary_self_types)]
 #![feature(arbitrary_self_types_pointers)]
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 use turbopack_core::asset::Asset;
@@ -23,8 +23,10 @@ pub mod source;
 
 #[turbo_tasks::function]
 pub async fn wasm_edge_var_name(asset: Vc<Box<dyn Asset>>) -> Result<Vc<RcStr>> {
-    let content = asset.content().file_content();
-    Ok(Vc::cell(
-        format!("wasm_{:08x}", *content.hash().await?).into(),
-    ))
+    let hash = asset
+        .content()
+        .content_hash()
+        .await?
+        .context("Missing content when trying to generate the content hash for a WASM asset")?;
+    Ok(Vc::cell(format!("wasm_{:08x}", hash).into()))
 }

--- a/turbopack/crates/turbopack-wasm/src/lib.rs
+++ b/turbopack/crates/turbopack-wasm/src/lib.rs
@@ -12,7 +12,6 @@
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
-use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::asset::Asset;
 
 pub(crate) mod analysis;
@@ -24,8 +23,8 @@ pub mod source;
 
 #[turbo_tasks::function]
 pub async fn wasm_edge_var_name(asset: Vc<Box<dyn Asset>>) -> Result<Vc<RcStr>> {
-    let content = asset.content().file_content().await?;
+    let content = asset.content().file_content();
     Ok(Vc::cell(
-        format!("wasm_{:08x}", hash_xxh3_hash64(content)).into(),
+        format!("wasm_{:08x}", *content.hash().await?).into(),
     ))
 }


### PR DESCRIPTION
So that we don't hash asset contents multiple times.

`hash_xxh3_hash64(file.content())`  isn't a turbotask, but `file.hash()` is cached