### PR TITLE
Handle null history.state in client-side router popstate handler

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -362,7 +362,11 @@ function Router({
      */
     const onPopState = (event: PopStateEvent) => {
       if (!event.state) {
-        // TODO-APP: this case only happens when pushState/replaceState was called outside of Next.js. It should probably reload the page in this case.
+        // This case happens when pushState/replaceState was called outside
+        // of Next.js with a null state, or the initial history entry has no
+        // state. The router tree would be completely out of sync so we need
+        // to do a hard navigation to get back to a consistent state.
+        window.location.reload()
         return
       }
 

--- a/test/e2e/app-dir/popstate-null-state/app/layout.tsx
+++ b/test/e2e/app-dir/popstate-null-state/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/popstate-null-state/app/other/page.tsx
+++ b/test/e2e/app-dir/popstate-null-state/app/other/page.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+
+export default function Page() {
+  const pathname = usePathname()
+  return <p id="pathname">{pathname}</p>
+}

--- a/test/e2e/app-dir/popstate-null-state/app/page.tsx
+++ b/test/e2e/app-dir/popstate-null-state/app/page.tsx
@@ -11,6 +11,12 @@ export default function Page() {
       <Link href="/other" id="to-other">
         Go to other
       </Link>
+      <a href="#hash" id="hash-link">
+        Hash link
+      </a>
+      <div id="hash" style={{ marginTop: 1000 }}>
+        Hash target
+      </div>
     </>
   )
 }

--- a/test/e2e/app-dir/popstate-null-state/app/page.tsx
+++ b/test/e2e/app-dir/popstate-null-state/app/page.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+export default function Page() {
+  const pathname = usePathname()
+  return (
+    <>
+      <p id="pathname">{pathname}</p>
+      <Link href="/other" id="to-other">
+        Go to other
+      </Link>
+    </>
+  )
+}

--- a/test/e2e/app-dir/popstate-null-state/next.config.js
+++ b/test/e2e/app-dir/popstate-null-state/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/popstate-null-state/popstate-null-state.test.ts
+++ b/test/e2e/app-dir/popstate-null-state/popstate-null-state.test.ts
@@ -46,4 +46,39 @@ describe('popstate-null-state', () => {
       expect(await browser.elementByCss('#pathname').text()).toBe('/')
     })
   })
+
+  it('should handle back navigation to a hash change without full reload', async () => {
+    const browser = await next.browser('/')
+
+    // Verify the initial page is rendered
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe('/')
+    })
+
+    // Click a regular anchor link. The browser pushes a new history entry
+    // with null state for the hash URL.
+    // History stack: [('/', nextjs), ('/#hash', null)]
+    await browser.elementByCss('#hash-link').click()
+
+    await retry(async () => {
+      expect(await browser.url()).toContain('#hash')
+    })
+
+    // Navigate to /other via Link so there's a forward entry.
+    // History stack: [('/', nextjs), ('/#hash', null), ('/other', nextjs)]
+    await browser.elementByCss('#to-other').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe('/other')
+    })
+
+    // Go back — popstate fires with the hash entry's state (null).
+    // Since only the hash changed, the page should remain functional
+    // without losing client-side state.
+    await browser.back()
+
+    await retry(async () => {
+      expect(await browser.url()).toContain('#hash')
+      expect(await browser.elementByCss('#pathname').text()).toBe('/')
+    })
+  })
 })

--- a/test/e2e/app-dir/popstate-null-state/popstate-null-state.test.ts
+++ b/test/e2e/app-dir/popstate-null-state/popstate-null-state.test.ts
@@ -1,0 +1,49 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('popstate-null-state', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should hard navigate when history.state is null on popstate', async () => {
+    const browser = await next.browser('/')
+
+    // Verify the initial page is rendered
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe('/')
+    })
+
+    // Navigate to /other via client-side navigation so the router tree updates
+    await browser.elementByCss('#to-other').click()
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe('/other')
+    })
+
+    // Push a history entry with null state for '/', bypassing the Next.js
+    // patched pushState (which copies internal state). The patch is on the
+    // instance, so calling via the prototype bypasses it.
+    // History stack: [('/', nextjs), ('/other', nextjs), ('/', null), ('/', null)]
+    await browser.eval(
+      `History.prototype.pushState.call(window.history, null, '', '/')`
+    )
+
+    await browser.eval(
+      `History.prototype.pushState.call(window.history, null, '', '/')`
+    )
+
+    // Validate the push worked: URL changed and history.state is null
+    expect(await browser.eval('window.location.pathname')).toBe('/')
+    expect(await browser.eval('window.history.state')).toBe(null)
+
+    // Now go back — this triggers popstate with event.state === null
+    // (the state from the ('/', null) entry).
+    // Without the fix the router would do nothing, leaving pathname as '/other'.
+    // With the fix a hard navigation (reload) occurs, loading '/' fresh.
+    await browser.back()
+
+    await retry(async () => {
+      expect(await browser.elementByCss('#pathname').text()).toBe('/')
+    })
+  })
+})


### PR DESCRIPTION
### What?

Handle `null` `history.state` in the client-side router's `popstate` handler.

### Why?

When `pushState` or `replaceState` is called outside of Next.js with a `null` state (or the initial history entry has no state), navigating back/forward to that entry fires a `popstate` event with `event.state === null`. Previously, the `onPopState` handler returned early without doing anything, leaving the router tree completely out of sync with the browser URL — `usePathname()`, `useSearchParams()`, etc. would return stale values.

### How?

When `event.state` is `null`, call `window.location.reload()` to perform a hard navigation, the same behavior as when a non-Next.js history entry is encountered (`!event.state.__NA`). This ensures the router always returns to a consistent state.

Added an e2e test that:
1. Navigates to a second page via client-side Link
2. Pushes history entries with truly `null` state (via `History.prototype.pushState` to bypass the Next.js patch)
3. Goes back and verifies the page correctly reloads

Fixes #90080