### PR TITLE
Fix validator.ts import path in isolated dev builds

### DIFF
--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -610,7 +610,7 @@ export function generateValidatorFile(
 
   const routeImportStatement =
     routeImports.length > 0
-      ? `import type { ${routeImports.join(', ')} } from "./routes.js"`
+      ? `import type { ${routeImports.join(', ')} } from "./route-types.d.ts"`
       : ''
 
   const nextRequestImport = hasAppRouteHandlers
@@ -845,7 +845,7 @@ export function generateValidatorFileStrict(
 
   const routeImportStatement =
     routeImports.length > 0
-      ? `import type { ${routeImports.join(', ')} } from "./routes.js"`
+      ? `import type { ${routeImports.join(', ')} } from "./route-types.d.ts"`
       : ''
 
   const nextRequestImport = hasAppRouteHandlers

--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -610,7 +610,7 @@ export function generateValidatorFile(
 
   const routeImportStatement =
     routeImports.length > 0
-      ? `import type { ${routeImports.join(', ')} } from "./route-types.d.ts"`
+      ? `import type { ${routeImports.join(', ')} } from "./routes.js"`
       : ''
 
   const nextRequestImport = hasAppRouteHandlers

--- a/test/development/app-dir/isolated-dev-build-strict-route-types/isolated-dev-build-strict-route-types.test.ts
+++ b/test/development/app-dir/isolated-dev-build-strict-route-types/isolated-dev-build-strict-route-types.test.ts
@@ -49,4 +49,14 @@ describe('isolated-dev-build with strictRouteTypes', () => {
       expect(await next.hasFile('.next/dev/types/validator.ts')).toBe(true)
     })
   })
+
+  it('should generate validator.ts importing route-types.d.ts in dev types dir', async () => {
+    await retry(async () => {
+      // validator.ts should import from route-types.d.ts, not routes.js
+      // since routes.d.ts doesn't exist in .next/dev/types/ (only in .next/types/)
+      const validator = await next.readFile('.next/dev/types/validator.ts')
+      expect(validator).toContain('from "./route-types.d.ts"')
+      expect(validator).not.toContain('from "./routes.js"')
+    })
+  })
 })


### PR DESCRIPTION
In dev mode with strictRouteTypes enabled, the generated validator.ts file in `.next/dev/types/` was importing from `./routes.js`, but `routes.d.ts` doesn't exist in that directory - only `route-types.d.ts` does. This caused `TS2307: Cannot find module './routes.js'`.

Changed the import path from `./routes.js` to `./route-types.d.ts` in generateValidatorFileStrict().

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
