### PR TITLE
Turbopack: turbofmt/turbobail macros

### DIFF
--- a/crates/next-api/src/font.rs
+++ b/crates/next-api/src/font.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use next_core::next_manifests::NextFontManifest;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ResolvedVc, Vc, turbofmt};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -77,8 +77,7 @@ impl Asset for FontManifest {
         let next_font_manifest = if !has_fonts {
             Default::default()
         } else if *app_dir {
-            let dir_str = dir.value_to_string().await?;
-            let page_path = format!("{dir_str}{original_name}").into();
+            let page_path = turbofmt!("{dir}{original_name}").await?;
 
             NextFontManifest {
                 app: [(page_path, font_paths)].into_iter().collect(),

--- a/crates/next-api/src/nft_json.rs
+++ b/crates/next-api/src/nft_json.rs
@@ -7,6 +7,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, ReadRef, ResolvedVc, TryFlatJoinIterExt, TryJoinIterExt, ValueToString, Vc,
     graph::{AdjacencyMap, GraphTraversal, Visit},
+    turbobail, turbofmt,
 };
 use turbo_tasks_fs::{
     DirectoryEntry, File, FileContent, FileSystem, FileSystemPath,
@@ -286,11 +287,10 @@ impl Asset for NftJsonAsset {
                             &*current_path.get_type().await?,
                             FileSystemEntryType::Symlink
                         ) {
-                            bail!(
-                                "Encountered file inside of symlink in NFT list: {} is a symlink, \
-                                 but {} was created inside of it",
-                                current_path.value_to_string().await?,
-                                referenced_chunk_path.value_to_string().await?
+                            turbobail!(
+                                "Encountered file inside of symlink in NFT list: {current_path} \
+                                 is a symlink, but {referenced_chunk_path} was created inside of \
+                                 it"
                             );
                         }
 
@@ -307,12 +307,14 @@ impl Asset for NftJsonAsset {
                 ) {
                     Ok(specifier) => specifier,
                     Err(err) => {
-                        return Err(err.context(format!(
-                            "NftJsonAsset: cannot handle filepath '{chunk_path}' for \
-                             {referenced_chunk:?} it is not under the output_root: \
-                             '{output_root_ref}' or the project_root: '{project_root_ref}'",
-                            chunk_path = referenced_chunk_path.value_to_string().await?
-                        )));
+                        return Err(err.context(
+                            turbofmt!(
+                                "NftJsonAsset: cannot handle filepath '{referenced_chunk_path}' \
+                                 for {referenced_chunk:?} it is not under the output_root: \
+                                 '{output_root_ref}' or the project_root: '{project_root_ref}'",
+                            )
+                            .await?,
+                        ));
                     }
                 };
 

--- a/crates/next-api/src/versioned_content_map.rs
+++ b/crates/next-api/src/versioned_content_map.rs
@@ -1,11 +1,11 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use bincode::{Decode, Encode};
 use next_core::emit_assets;
 use rustc_hash::{FxHashMap, FxHashSet};
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, OperationValue, OperationVc, ResolvedVc, State, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueDefault, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    TryJoinIterExt, ValueDefault, Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
@@ -209,8 +209,7 @@ impl VersionedContentMap {
                 generate_source_map.generate_source_map()
             })
         } else {
-            let path = path.value_to_string().await?;
-            bail!("no source map for path {}", path);
+            turbobail!("no source map for path {path}");
         }
     }
 

--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -8,7 +8,7 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueDefault, Vc,
-    debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
+    debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_fs::{DirectoryContent, DirectoryEntry, FileSystemEntryType, FileSystemPath};
 use turbopack_core::issue::{
@@ -99,10 +99,7 @@ pub async fn get_metadata_route_name(meta: MetadataItem) -> Result<Vc<RcStr>> {
         MetadataItem::Static { path } => Vc::cell(path.file_name().into()),
         MetadataItem::Dynamic { path } => {
             let Some(stem) = path.file_stem() else {
-                bail!(
-                    "unable to resolve file stem for metadata item at {}",
-                    path.value_to_string().await?
-                );
+                turbobail!("unable to resolve file stem for metadata item at {path}");
             };
 
             match stem {

--- a/crates/next-core/src/bootstrap.rs
+++ b/crates/next-core/src/bootstrap.rs
@@ -1,6 +1,6 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use turbo_rcstr::rcstr;
-use turbo_tasks::{FxIndexMap, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, ResolvedVc, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::AssetContent,
@@ -35,11 +35,7 @@ pub async fn bootstrap(
 ) -> Result<Vc<Box<dyn EvaluatableAsset>>> {
     let path = asset.ident().path().await?;
     let Some(path) = base_path.get_path_to(&path) else {
-        bail!(
-            "asset {} is not in base path {}",
-            asset.ident().to_string().await?,
-            base_path.value_to_string().await?
-        );
+        turbobail!("asset {} is not in base path {base_path}", asset.ident())
     };
     let path = if let Some((name, ext)) = path.rsplit_once('.') {
         if !ext.contains('/') { name } else { path }

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -567,15 +567,14 @@ impl Issue for StaticMetadataFileSizeIssue {
 
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
-        let current_size = format!("{:.1}", (self.file_size as f32) / 1024.0 / 1024.0);
+        let current_size = (self.file_size as f32) / 1024.0 / 1024.0;
         Ok(Vc::cell(Some(
             StyledString::Text(
                 turbofmt!(
-                    "File size for {} image \"{}\" exceeds {}MB. (Current: {}MB)",
+                    "File size for {} image \"{}\" exceeds {}MB. (Current: {current_size:.1}MB)",
                     self.img_name,
                     self.path,
                     self.file_size_limit_mb,
-                    current_size
                 )
                 .await?,
             )

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -2,11 +2,11 @@
 //!
 //! See `next/src/build/webpack/loaders/next-metadata-route-loader`
 
-use anyhow::{Ok, Result, bail};
+use anyhow::{Ok, Result};
 use base64::{display::Base64Display, engine::general_purpose::STANDARD};
 use indoc::formatdoc;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::Vc;
+use turbo_tasks::{Vc, turbobail, turbofmt};
 use turbo_tasks_fs::{self, File, FileContent, FileSystemPath};
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
@@ -123,10 +123,7 @@ async fn get_base64_file_content(path: FileSystemPath) -> Result<String> {
             Base64Display::new(&content, &STANDARD).to_string()
         }
         FileContent::NotFound => {
-            bail!(
-                "metadata file not found: {}",
-                &path.value_to_string().await?
-            );
+            turbobail!("metadata file not found: {path}")
         }
     })
 }
@@ -570,16 +567,17 @@ impl Issue for StaticMetadataFileSizeIssue {
 
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<OptionStyledString>> {
+        let current_size = format!("{:.1}", (self.file_size as f32) / 1024.0 / 1024.0);
         Ok(Vc::cell(Some(
             StyledString::Text(
-                format!(
-                    "File size for {} image \"{}\" exceeds {}MB. (Current: {:.1}MB)",
+                turbofmt!(
+                    "File size for {} image \"{}\" exceeds {}MB. (Current: {}MB)",
                     self.img_name,
-                    self.path.value_to_string().await?,
+                    self.path,
                     self.file_size_limit_mb,
-                    (self.file_size as f32) / 1024.0 / 1024.0
+                    current_size
                 )
-                .into(),
+                .await?,
             )
             .resolved_cell(),
         )))

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
@@ -50,9 +50,9 @@ impl RuntimeEntry {
             if let Some(entry) = ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module) {
                 runtime_entries.push(entry);
             } else {
-                bail!(
+                turbobail!(
                     "runtime reference resolved to an asset ({}) that cannot be evaluated",
-                    module.ident().to_string().await?
+                    module.ident()
                 );
             }
         }

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -68,7 +68,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
     enable_mdx_rs: bool,
 ) -> Result<Option<ModuleRule>> {
     use anyhow::bail;
-    use turbo_tasks::{TryFlatJoinIterExt, ValueToString};
+    use turbo_tasks::TryFlatJoinIterExt;
     use turbo_tasks_fs::FileContent;
     use turbopack_core::{
         asset::Asset,
@@ -135,11 +135,9 @@ pub async fn get_swc_ecma_transform_rule_impl(
                 };
 
                 let Some(plugin_source) = &*plugin_module.source().await? else {
-                    use anyhow::bail;
-
-                    bail!(
+                    turbo_tasks::turbobail!(
                         "Expected source for plugin module: {}",
-                        plugin_module.ident().to_string().await?
+                        plugin_module.ident()
                     );
                 };
 

--- a/crates/next-core/src/util.rs
+++ b/crates/next-core/src/util.rs
@@ -1,11 +1,13 @@
 use std::{fmt::Display, str::FromStr};
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, bail};
 use bincode::{Decode, Encode};
 use next_taskless::{expand_next_js_template, expand_next_js_template_no_imports};
 use serde::{Deserialize, de::DeserializeOwned};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, NonLocalValue, TaskInput, Vc, fxindexset, trace::TraceRawVcs};
+use turbo_tasks::{
+    FxIndexMap, NonLocalValue, TaskInput, Vc, fxindexset, trace::TraceRawVcs, turbobail,
+};
 use turbo_tasks_fs::{File, FileContent, FileJsonContent, FileSystem, FileSystemPath, rope::Rope};
 use turbopack::module_options::RuleCondition;
 use turbopack_core::{
@@ -221,11 +223,7 @@ pub async fn pathname_for_path(
     let path = if let Some(path) = server_root.get_path_to(&server_path_value) {
         path
     } else {
-        bail!(
-            "server_path ({}) is not in server_root ({})",
-            server_path.value_to_string().await?,
-            server_root.value_to_string().await?
-        )
+        turbobail!("server_path ({server_path}) is not in server_root ({server_root})");
     };
     let path = match (path_ty, path) {
         // "/" is special-cased to "/index" for data routes.
@@ -482,11 +480,8 @@ pub async fn load_next_js_json_file<T: DeserializeOwned>(
     let content = &*file_path.read().await?;
 
     match content.parse_json_ref() {
-        FileJsonContent::Unparsable(e) => Err(anyhow!("File is not valid JSON: {}", e)),
-        FileJsonContent::NotFound => Err(anyhow!(
-            "File not found: {:?}",
-            file_path.value_to_string().await?
-        )),
+        FileJsonContent::Unparsable(e) => bail!("File is not valid JSON: {e}"),
+        FileJsonContent::NotFound => turbobail!("File not found: {file_path:?}",),
         FileJsonContent::Content(value) => Ok(serde_json::from_value(value)?),
     }
 }
@@ -502,11 +497,8 @@ pub async fn load_next_js_jsonc_file<T: DeserializeOwned>(
     let content = &*file_path.read().await?;
 
     match content.parse_json_with_comments_ref() {
-        FileJsonContent::Unparsable(e) => Err(anyhow!("File is not valid JSON: {}", e)),
-        FileJsonContent::NotFound => Err(anyhow!(
-            "File not found: {:?}",
-            file_path.value_to_string().await?
-        )),
+        FileJsonContent::Unparsable(e) => turbobail!("File is not valid JSON: {e}"),
+        FileJsonContent::NotFound => turbobail!("File not found: {file_path}",),
         FileJsonContent::Content(value) => Ok(serde_json::from_value(value)?),
     }
 }

--- a/turbopack/crates/turbo-rcstr/src/lib.rs
+++ b/turbopack/crates/turbo-rcstr/src/lib.rs
@@ -182,6 +182,12 @@ impl Borrow<str> for RcStr {
     }
 }
 
+impl AsRef<str> for RcStr {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
 impl From<BytesStr> for RcStr {
     fn from(s: BytesStr) -> Self {
         let bytes: Vec<u8> = s.into_bytes().into();

--- a/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
@@ -4,7 +4,7 @@
 
 use std::fmt;
 
-use turbo_rcstr::RcStr;
+use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ReadRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_testing::{Registration, register, run_once};
 
@@ -346,7 +346,7 @@ async fn test_torture_enum() {
         // AllFieldTypes: Display + RcStr + ResolvedVc + ResolvedVc
         let v1 = (TortureEnum::AllFieldTypes {
             display_val: DisplayVal(42),
-            rc_str: "hello".into(),
+            rc_str: rcstr!("hello"),
             resolved_named: named_resolved,
             resolved_const: const_resolved,
         })

--- a/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
@@ -344,30 +344,41 @@ async fn test_torture_enum() {
         let const_resolved = ConstantString.resolved_cell();
 
         // AllFieldTypes: Display + RcStr + ResolvedVc + ResolvedVc
-        let v1 = (TortureEnum::AllFieldTypes {
-            display_val: DisplayVal(42),
-            rc_str: rcstr!("hello"),
-            resolved_named: named_resolved,
-            resolved_const: const_resolved,
-        })
-        .cell();
+        let v1 = ResolvedVc::upcast(
+            (TortureEnum::AllFieldTypes {
+                display_val: DisplayVal(42),
+                rc_str: rcstr!("hello"),
+                resolved_named: named_resolved,
+                resolved_const: const_resolved,
+            })
+            .resolved_cell(),
+        );
         assert_eq!(
-            &*v1.to_string().await?,
+            &*to_string_operation(v1).read_strongly_consistent().await?,
             "d=dv:42 r=hello rv1=item x (count: 1) rv2=constant-value"
         );
 
         // ExprVc: FormatExprs with ResolvedVc positional arg
-        let v2 = TortureEnum::ExprVc(named_resolved2).cell();
-        assert_eq!(&*v2.to_string().await?, "expr(item y (count: 2))");
+        let v2 = ResolvedVc::upcast(TortureEnum::ExprVc(named_resolved2).resolved_cell());
+        assert_eq!(
+            &*to_string_operation(v2).read_strongly_consistent().await?,
+            "expr(item y (count: 2))"
+        );
 
         // DelegateVc: DirectExpr delegating to ResolvedVc
-        let v3 = TortureEnum::DelegateVc(const_resolved).cell();
-        assert_eq!(&*v3.to_string().await?, "constant-value");
+        let v3 = ResolvedVc::upcast(TortureEnum::DelegateVc(const_resolved).resolved_cell());
+        assert_eq!(
+            &*to_string_operation(v3).read_strongly_consistent().await?,
+            "constant-value"
+        );
 
         // WithReadRef: ReadRef field
         let named_read: ReadRef<NamedFields> = named_resolved.await?;
-        let v4 = TortureEnum::WithReadRef(named_read).cell();
-        assert_eq!(&*v4.to_string().await?, "read=item x (count: 1)");
+        let v4 = ResolvedVc::upcast(TortureEnum::WithReadRef(named_read).resolved_cell());
+        assert_eq!(
+            &*to_string_operation(v4).read_strongly_consistent().await?,
+            "read=item x (count: 1)"
+        );
 
         anyhow::Ok(())
     })

--- a/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/derive_value_to_string.rs
@@ -5,7 +5,7 @@
 use std::fmt;
 
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, ValueToString, Vc};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -287,6 +287,87 @@ async fn test_mixed_enum() {
             &*to_string_operation(v3).read_strongly_consistent().await?,
             "wrapped(world)"
         );
+
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+/// A Display type for torture-testing enum field resolution.
+#[turbo_tasks::value(shared)]
+struct DisplayVal(u32);
+
+impl fmt::Display for DisplayVal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "dv:{}", self.0)
+    }
+}
+
+/// Torture test: one enum variant with Display, RcStr, Vc, and ResolvedVc fields,
+/// exercising all ValueToStringify dispatch levels in a single match arm.
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+enum TortureEnum {
+    /// Auto-field format with Display, RcStr, and ResolvedVc in one variant.
+    #[value_to_string("d={display_val} r={rc_str} rv1={resolved_named} rv2={resolved_const}")]
+    AllFieldTypes {
+        display_val: DisplayVal,
+        rc_str: RcStr,
+        resolved_named: ResolvedVc<NamedFields>,
+        resolved_const: ResolvedVc<ConstantString>,
+    },
+    /// FormatExprs form with a ResolvedVc positional arg.
+    #[value_to_string("expr({})", _0)]
+    ExprVc(ResolvedVc<NamedFields>),
+    /// DirectExpr form delegating to a ResolvedVc field.
+    #[value_to_string(_0)]
+    DelegateVc(ResolvedVc<ConstantString>),
+    /// ReadRef field.
+    #[value_to_string("read={0}")]
+    WithReadRef(ReadRef<NamedFields>),
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_torture_enum() {
+    run_once(&REGISTRATION, || async {
+        let named_resolved = NamedFields {
+            name: "x".into(),
+            count: 1,
+        }
+        .resolved_cell();
+        let named_resolved2 = NamedFields {
+            name: "y".into(),
+            count: 2,
+        }
+        .resolved_cell();
+        let const_resolved = ConstantString.resolved_cell();
+
+        // AllFieldTypes: Display + RcStr + ResolvedVc + ResolvedVc
+        let v1 = (TortureEnum::AllFieldTypes {
+            display_val: DisplayVal(42),
+            rc_str: "hello".into(),
+            resolved_named: named_resolved,
+            resolved_const: const_resolved,
+        })
+        .cell();
+        assert_eq!(
+            &*v1.to_string().await?,
+            "d=dv:42 r=hello rv1=item x (count: 1) rv2=constant-value"
+        );
+
+        // ExprVc: FormatExprs with ResolvedVc positional arg
+        let v2 = TortureEnum::ExprVc(named_resolved2).cell();
+        assert_eq!(&*v2.to_string().await?, "expr(item y (count: 2))");
+
+        // DelegateVc: DirectExpr delegating to ResolvedVc
+        let v3 = TortureEnum::DelegateVc(const_resolved).cell();
+        assert_eq!(&*v3.to_string().await?, "constant-value");
+
+        // WithReadRef: ReadRef field
+        let named_read: ReadRef<NamedFields> = named_resolved.await?;
+        let v4 = TortureEnum::WithReadRef(named_read).cell();
+        assert_eq!(&*v4.to_string().await?, "read=item x (count: 1)");
 
         anyhow::Ok(())
     })

--- a/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
@@ -41,12 +41,7 @@ async fn test_turbobail() {
         }
         .cell();
 
-        let result: anyhow::Result<()> = async {
-            turbobail!("error: {} with {}", 42u32, v);
-            #[allow(unreachable_code)]
-            Ok(())
-        }
-        .await;
+        let result: anyhow::Result<()> = async { turbobail!("error: {} with {}", 42u32, v) }.await;
 
         assert!(result.is_err());
         assert_eq!(

--- a/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
 
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ValueToString, Vc, turbobail, turbofmt};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail, turbofmt};
 use turbo_tasks_testing::{Registration, register, run_once};
 
 static REGISTRATION: Registration = register!();
@@ -16,16 +16,29 @@ struct FmtTest {
     count: u32,
 }
 
+#[turbo_tasks::function(operation)]
+async fn turbofmt_operation(value: ResolvedVc<FmtTest>) -> anyhow::Result<Vc<RcStr>> {
+    let s: RcStr = turbofmt!("prefix {} vc {}", 42u32, value).await?;
+    Ok(Vc::cell(s))
+}
+
+#[turbo_tasks::function(operation)]
+async fn turbobail_operation(value: ResolvedVc<FmtTest>) -> anyhow::Result<Vc<RcStr>> {
+    turbobail!("error: {} with {}", 42u32, value)
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_turbofmt() {
     run_once(&REGISTRATION, || async {
-        let v: Vc<FmtTest> = FmtTest {
+        let v = FmtTest {
             name: "foo".into(),
             count: 7,
         }
-        .cell();
-        let s: RcStr = turbofmt!("prefix {} vc {}", 42u32, v).await?;
-        assert_eq!(&*s, "prefix 42 vc item foo (count: 7)");
+        .resolved_cell();
+        assert_eq!(
+            &*turbofmt_operation(v).read_strongly_consistent().await?,
+            "prefix 42 vc item foo (count: 7)"
+        );
         anyhow::Ok(())
     })
     .await
@@ -35,19 +48,17 @@ async fn test_turbofmt() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_turbobail() {
     run_once(&REGISTRATION, || async {
-        let v: Vc<FmtTest> = FmtTest {
+        let v = FmtTest {
             name: "bar".into(),
             count: 3,
         }
-        .cell();
+        .resolved_cell();
 
-        let result: anyhow::Result<()> = async { turbobail!("error: {} with {}", 42u32, v) }.await;
+        let result = turbobail_operation(v).read_strongly_consistent().await;
 
-        assert!(result.is_err());
-        assert_eq!(
-            result.unwrap_err().to_string(),
-            "error: 42 with item bar (count: 3)"
-        );
+        let err = result.unwrap_err();
+        let root = err.root_cause().to_string();
+        assert_eq!(root, "error: 42 with item bar (count: 3)");
         anyhow::Ok(())
     })
     .await

--- a/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
+++ b/turbopack/crates/turbo-tasks-backend/tests/turbofmt.rs
@@ -1,0 +1,60 @@
+#![feature(arbitrary_self_types)]
+#![feature(arbitrary_self_types_pointers)]
+#![allow(clippy::needless_return)] // tokio macro-generated code doesn't respect this
+
+use turbo_rcstr::RcStr;
+use turbo_tasks::{ValueToString, Vc, turbobail, turbofmt};
+use turbo_tasks_testing::{Registration, register, run_once};
+
+static REGISTRATION: Registration = register!();
+
+#[turbo_tasks::value(shared)]
+#[derive(ValueToString)]
+#[value_to_string("item {name} (count: {count})")]
+struct FmtTest {
+    name: RcStr,
+    count: u32,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_turbofmt() {
+    run_once(&REGISTRATION, || async {
+        let v: Vc<FmtTest> = FmtTest {
+            name: "foo".into(),
+            count: 7,
+        }
+        .cell();
+        let s: RcStr = turbofmt!("prefix {} vc {}", 42u32, v).await?;
+        assert_eq!(&*s, "prefix 42 vc item foo (count: 7)");
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_turbobail() {
+    run_once(&REGISTRATION, || async {
+        let v: Vc<FmtTest> = FmtTest {
+            name: "bar".into(),
+            count: 3,
+        }
+        .cell();
+
+        let result: anyhow::Result<()> = async {
+            turbobail!("error: {} with {}", 42u32, v);
+            #[allow(unreachable_code)]
+            Ok(())
+        }
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().to_string(),
+            "error: 42 with item bar (count: 3)"
+        );
+        anyhow::Ok(())
+    })
+    .await
+    .unwrap()
+}

--- a/turbopack/crates/turbo-tasks-env/src/dotenv.rs
+++ b/turbopack/crates/turbo-tasks-env/src/dotenv.rs
@@ -1,8 +1,8 @@
 use std::{env, sync::MutexGuard};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, Vc};
+use turbo_tasks::{FxIndexMap, ReadRef, ResolvedVc, Vc, turbofmt};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 
 use crate::{GLOBAL_ENV_LOCK, ProcessEnv, TransientEnvMap, sorted_env_vars};
@@ -62,10 +62,8 @@ impl DotenvProcessEnv {
             }
 
             if let Err(e) = res {
-                return Err(e).context(anyhow!(
-                    "unable to read {} for env vars",
-                    self.path.value_to_string().await?
-                ));
+                return Err(e)
+                    .context(turbofmt!("unable to read {} for env vars", self.path).await?);
             }
 
             Ok(Vc::cell(vars))

--- a/turbopack/crates/turbo-tasks-fs/src/attach.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/attach.rs
@@ -1,6 +1,6 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 
 use crate::{FileContent, FileMeta, FileSystem, FileSystemPath, LinkContent, RawDirectoryContent};
 
@@ -54,12 +54,9 @@ impl AttachedFileSystem {
         let self_fs: ResolvedVc<Box<dyn FileSystem>> = ResolvedVc::upcast(self);
 
         if path.fs != self_fs {
-            let self_fs_str = self_fs.to_string().await?;
-            let path_fs_str = path.fs.to_string().await?;
-            bail!(
-                "path fs does not match (expected {}, got {})",
-                self_fs_str,
-                path_fs_str
+            turbobail!(
+                "path fs does not match (expected {self_fs}, got {})",
+                path.fs
             )
         }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1364,8 +1364,7 @@ fn remove_symbolic_link_dir_helper(path: &Path) -> io::Result<()> {
     }
 }
 
-#[derive(Debug, Clone, Hash, TaskInput, ValueToString)]
-#[value_to_string("[{fs}]/{path}")]
+#[derive(Debug, Clone, Hash, TaskInput)]
 #[turbo_tasks::value(shared)]
 pub struct FileSystemPath {
     pub fs: ResolvedVc<Box<dyn FileSystem>>,
@@ -1375,7 +1374,7 @@ pub struct FileSystemPath {
 impl FileSystemPath {
     /// Mimics `ValueToString::to_string`.
     pub fn value_to_string(&self) -> Vc<RcStr> {
-        value_to_string(self.clone())
+        <FileSystemPath as ValueToString>::to_string(self.clone().cell())
     }
 }
 
@@ -1389,9 +1388,12 @@ impl ValueToStringRef for FileSystemPath {
     }
 }
 
-#[turbo_tasks::function]
-async fn value_to_string(path: FileSystemPath) -> Result<Vc<RcStr>> {
-    Ok(Vc::cell(path.to_string_ref().await?))
+#[turbo_tasks::value_impl]
+impl ValueToString for FileSystemPath {
+    #[turbo_tasks::function]
+    async fn to_string(&self) -> Result<Vc<RcStr>> {
+        Ok(Vc::cell(self.to_string_ref().await?))
+    }
 }
 
 impl FileSystemPath {

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1380,11 +1380,7 @@ impl FileSystemPath {
 
 impl ValueToStringRef for FileSystemPath {
     async fn to_string_ref(&self) -> Result<RcStr> {
-        if ResolvedVc::try_downcast_type::<DiskFileSystem>(self.fs).is_some() {
-            Ok(self.path.clone())
-        } else {
-            turbofmt!("[{}]/{}", self.fs, self.path).await
-        }
+        turbofmt!("[{}]/{}", self.fs, self.path).await
     }
 }
 

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -36,7 +36,7 @@ use std::{
     borrow::Cow,
     cmp::{Ordering, min},
     env,
-    fmt::{self, Debug, Display, Formatter},
+    fmt::{self, Debug, Formatter},
     fs::FileType,
     future::Future,
     io::{self, BufRead, BufReader, ErrorKind, Read, Write as _},
@@ -65,7 +65,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     ApplyEffectsContext, Completion, InvalidationReason, Invalidator, NonLocalValue, ReadRef,
     ResolvedVc, TaskInput, TurboTasksApi, ValueToString, Vc, debug::ValueDebugFormat, effect,
-    mark_session_dependent, parallel, trace::TraceRawVcs, turbo_tasks_weak,
+    mark_session_dependent, parallel, trace::TraceRawVcs, turbo_tasks_weak, turbobail, turbofmt,
 };
 use turbo_tasks_hash::{
     DeterministicHash, DeterministicHasher, HashAlgorithm, deterministic_hash, hash_xxh3_hash64,
@@ -976,10 +976,7 @@ impl FileSystem for DiskFileSystem {
 
         // Check if path is denied - if so, return an error
         if self.inner.is_path_denied(&fs_path) {
-            bail!(
-                "Cannot write to denied path: {}",
-                fs_path.value_to_string().await?
-            );
+            turbobail!("Cannot write to denied path: {fs_path}");
         }
         let full_path = self.to_sys_path(&fs_path);
 
@@ -1109,10 +1106,7 @@ impl FileSystem for DiskFileSystem {
 
         // Check if path is denied - if so, return an error
         if self.inner.is_path_denied(&fs_path) {
-            bail!(
-                "Cannot write link to denied path: {}",
-                fs_path.value_to_string().await?
-            );
+            turbobail!("Cannot write link to denied path: {fs_path}");
         }
 
         let content = target.await?;
@@ -1322,10 +1316,7 @@ impl FileSystem for DiskFileSystem {
 
         // Check if path is denied - if so, return an error (metadata shouldn't be readable)
         if self.inner.is_path_denied(&fs_path) {
-            bail!(
-                "Cannot read metadata from denied path: {}",
-                fs_path.value_to_string().await?
-            );
+            turbobail!("Cannot read metadata from denied path: {fs_path}");
         }
 
         self.inner.register_read_invalidator(&full_path)?;
@@ -1387,11 +1378,15 @@ impl FileSystemPath {
     }
 }
 
+impl turbo_tasks::display::ValueToStringRef for FileSystemPath {
+    async fn to_string_ref(&self) -> Result<turbo_rcstr::RcStr> {
+        turbofmt!("[{}]/{}", self.fs, self.path).await
+    }
+}
+
 #[turbo_tasks::function]
 async fn value_to_string(path: FileSystemPath) -> Result<Vc<RcStr>> {
-    Ok(Vc::cell(
-        format!("[{}]/{}", path.fs.to_string().await?, path.path).into(),
-    ))
+    Ok(Vc::cell(turbofmt!("[{}]/{}", path.fs, path.path).await?))
 }
 
 impl FileSystemPath {
@@ -1694,9 +1689,9 @@ impl FileSystemPath {
     }
 }
 
-impl Display for FileSystemPath {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.path)
+impl std::fmt::Display for FileSystemPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.path)
     }
 }
 
@@ -1716,7 +1711,7 @@ pub async fn rebase(
     } else {
         let base_path = [&old_base.path, "/"].concat();
         if !fs_path.path.starts_with(&base_path) {
-            bail!(
+            turbobail!(
                 "rebasing {fs_path} from {old_base} onto {new_base} doesn't work because it's not \
                  part of the source path",
             );
@@ -1793,7 +1788,7 @@ impl FileSystemPath {
         let result = &(*self.realpath_with_links().await?);
         match &result.path_result {
             Ok(path) => Ok(path.clone()),
-            Err(error) => Err(anyhow::anyhow!(error.as_error_message(self, result))),
+            Err(error) => Err(anyhow::anyhow!(error.as_error_message(self, result).await?)),
         }
     }
 
@@ -1859,22 +1854,33 @@ pub enum RealPathResultError {
 
 impl RealPathResultError {
     /// Formats the error message
-    pub fn as_error_message(&self, orig: &FileSystemPath, result: &RealPathResult) -> String {
-        match self {
-            RealPathResultError::TooManySymlinks => format!(
-                "Symlink {orig} leads to too many other symlinks ({len} links)",
-                len = result.symlinks.len()
-            ),
+    pub async fn as_error_message(
+        &self,
+        orig: &FileSystemPath,
+        result: &RealPathResult,
+    ) -> Result<RcStr> {
+        Ok(match self {
+            RealPathResultError::TooManySymlinks => {
+                let len = result.symlinks.len();
+                turbofmt!("Symlink {orig} leads to too many other symlinks ({len} links)").await?
+            }
             RealPathResultError::CycleDetected => {
-                format!("Symlink {orig} is in a symlink loop: {:?}", result.symlinks)
+                // symlinks is Vec<FileSystemPath> — format with Debug since
+                // turbofmt can't resolve a whole Vec asynchronously.
+                let symlinks_dbg = format!(
+                    "{:?}",
+                    result.symlinks.iter().map(|s| &s.path).collect::<Vec<_>>()
+                );
+                turbofmt!("Symlink {orig} is in a symlink loop: {symlinks_dbg}").await?
             }
             RealPathResultError::Invalid => {
-                format!("Symlink {orig} is invalid, it points out of the filesystem root")
+                turbofmt!("Symlink {orig} is invalid, it points out of the filesystem root").await?
             }
             RealPathResultError::NotFound => {
-                format!("Symlink {orig} is invalid, it points at a file that doesn't exist")
+                turbofmt!("Symlink {orig} is invalid, it points at a file that doesn't exist")
+                    .await?
             }
-        }
+        })
     }
 }
 
@@ -2491,7 +2497,7 @@ impl DirectoryEntry {
                 Ok(path) => path,
                 Err(error) => {
                     return Ok(DirectoryEntry::Error(
-                        error.as_error_message(symlink, result).into(),
+                        error.as_error_message(symlink, result).await?,
                     ));
                 }
             };
@@ -2500,10 +2506,11 @@ impl DirectoryEntry {
                 FileSystemEntryType::File => DirectoryEntry::File(real_path.clone()),
                 // Happens if the link is to a non-existent file
                 FileSystemEntryType::NotFound => DirectoryEntry::Error(
-                    format!("Symlink {symlink} points at {real_path} which does not exist").into(),
+                    turbofmt!("Symlink {symlink} points at {real_path} which does not exist")
+                        .await?,
                 ),
                 // This is caused by eventual consistency
-                FileSystemEntryType::Symlink => bail!(
+                FileSystemEntryType::Symlink => turbobail!(
                     "Symlink {symlink} points at a symlink but realpath_with_links returned a path"
                 ),
                 _ => self,

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1379,7 +1379,7 @@ impl FileSystemPath {
 }
 
 impl turbo_tasks::display::ValueToStringRef for FileSystemPath {
-    async fn to_string_ref(&self) -> Result<turbo_rcstr::RcStr> {
+    async fn to_string_ref(&self) -> Result<RcStr> {
         turbofmt!("[{}]/{}", self.fs, self.path).await
     }
 }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -64,8 +64,9 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     ApplyEffectsContext, Completion, InvalidationReason, Invalidator, NonLocalValue, ReadRef,
-    ResolvedVc, TaskInput, TurboTasksApi, ValueToString, Vc, debug::ValueDebugFormat, effect,
-    mark_session_dependent, parallel, trace::TraceRawVcs, turbo_tasks_weak, turbobail, turbofmt,
+    ResolvedVc, TaskInput, TurboTasksApi, ValueToString, ValueToStringRef, Vc,
+    debug::ValueDebugFormat, effect, mark_session_dependent, parallel, trace::TraceRawVcs,
+    turbo_tasks_weak, turbobail, turbofmt,
 };
 use turbo_tasks_hash::{
     DeterministicHash, DeterministicHasher, HashAlgorithm, deterministic_hash, hash_xxh3_hash64,
@@ -1378,7 +1379,7 @@ impl FileSystemPath {
     }
 }
 
-impl turbo_tasks::display::ValueToStringRef for FileSystemPath {
+impl ValueToStringRef for FileSystemPath {
     async fn to_string_ref(&self) -> Result<RcStr> {
         turbofmt!("[{}]/{}", self.fs, self.path).await
     }

--- a/turbopack/crates/turbo-tasks-fs/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/lib.rs
@@ -1381,13 +1381,17 @@ impl FileSystemPath {
 
 impl ValueToStringRef for FileSystemPath {
     async fn to_string_ref(&self) -> Result<RcStr> {
-        turbofmt!("[{}]/{}", self.fs, self.path).await
+        if ResolvedVc::try_downcast_type::<DiskFileSystem>(self.fs).is_some() {
+            Ok(self.path.clone())
+        } else {
+            turbofmt!("[{}]/{}", self.fs, self.path).await
+        }
     }
 }
 
 #[turbo_tasks::function]
 async fn value_to_string(path: FileSystemPath) -> Result<Vc<RcStr>> {
-    Ok(Vc::cell(turbofmt!("[{}]/{}", path.fs, path.path).await?))
+    Ok(Vc::cell(path.to_string_ref().await?))
 }
 
 impl FileSystemPath {

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
 use futures::try_join;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
@@ -122,7 +122,7 @@ async fn resolve_symlink_safely(entry: DirectoryEntry) -> Result<DirectoryEntry>
         // match.
         let source_path = entry.path().unwrap();
         if source_path.is_inside_or_equal(&resolved_entry.clone().path().unwrap()) {
-            turbobail!("'{source_path}' is a symlink causes that causes an infinite loop!",)
+            bail!("'{source_path}' is a symlink causes that causes an infinite loop!",)
         }
     }
     Ok(resolved_entry)

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -1,8 +1,8 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use futures::try_join;
 use rustc_hash::FxHashMap;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{Completion, ResolvedVc, TryJoinIterExt, Vc};
+use turbo_tasks::{Completion, ResolvedVc, TryJoinIterExt, Vc, turbobail};
 
 use crate::{
     DirectoryContent, DirectoryEntry, FileSystem, FileSystemPath, LinkContent, LinkType, glob::Glob,
@@ -122,10 +122,7 @@ async fn resolve_symlink_safely(entry: DirectoryEntry) -> Result<DirectoryEntry>
         // match.
         let source_path = entry.path().unwrap();
         if source_path.is_inside_or_equal(&resolved_entry.clone().path().unwrap()) {
-            bail!(
-                "'{}' is a symlink causes that causes an infinite loop!",
-                source_path.path,
-            )
+            turbobail!("'{source_path}' is a symlink causes that causes an infinite loop!",)
         }
     }
     Ok(resolved_entry)
@@ -197,12 +194,10 @@ async fn track_glob_internal(
                             reads.push(fs.read(path.clone()))
                         }
                     }
-                    DirectoryEntry::Symlink(symlink_path) => bail!(
+                    DirectoryEntry::Symlink(symlink_path) => turbobail!(
                         "resolve_symlink_safely() should have resolved all symlinks or returned \
-                         an error, but found unresolved symlink at path: '{}'. Found path: '{}'. \
-                         Please report this as a bug.",
-                        entry_path,
-                        symlink_path
+                         an error, but found unresolved symlink at path: '{entry_path}'. Found \
+                         path: '{symlink_path}'. Please report this as a bug.",
                     ),
                     DirectoryEntry::Other(path) => {
                         if glob_value.matches(&entry_path) {

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
@@ -7,6 +7,8 @@ use syn::{
     punctuated::Punctuated,
 };
 
+use crate::turbofmt_macro::{FormatIter, FormatPart, generate_arg_vars, generate_resolve_stmts};
+
 /// The parsed form of a `#[value_to_string(...)]` attribute.
 enum AttrForm {
     /// `#[value_to_string("{field} text")]` — format string with auto-field references.
@@ -65,7 +67,9 @@ impl Field {
 /// - `#[value_to_string("fmt {}", expr)]`: format string with explicit expression arguments
 /// - `#[value_to_string(expr)]`: direct expression delegation
 ///
-/// For enums, each variant can have its own attribute. Variants without one default to their name.
+/// For enums, each variant can have its own attribute. Variants without one
+/// default to their name.
+#[doc = include_str!("../../../turbo-tasks/FORMATTING.md")]
 pub fn derive_value_to_string(input: TokenStream) -> TokenStream {
     let derive_input = parse_macro_input!(input as DeriveInput);
     let ident = &derive_input.ident;
@@ -109,6 +113,8 @@ fn wrap_impl(ident: &syn::Ident, is_async: bool, body: TokenStream2) -> TokenStr
         impl turbo_tasks::ValueToString for #ident {
             #[turbo_tasks::function]
             #async_kw fn to_string(&self) -> #ret_ty {
+                #[allow(unused_imports)]
+                use turbo_tasks::display::ValueToStringify as _;
                 #body
             }
         }
@@ -174,22 +180,21 @@ fn parse_attr(attr: &Attribute) -> syn::Result<AttrForm> {
 }
 
 /// If `fmt` is exactly `{field_name}` (single field, no format specifier, no surrounding text),
-/// returns a `self.field_name` expression. This lets us skip `format!` entirely and delegate
-/// directly to `ValueToStringify::to_stringify`.
+/// returns a `self.field_name` expression. This lets us skip `format!` entirely.
 fn try_single_field_self_expr(fmt: &str) -> Option<Expr> {
-    if fmt.starts_with('{') && fmt.ends_with('}') && fmt.len() > 2 {
-        let inner = &fmt[1..fmt.len() - 1];
-        if !inner.contains('{') && !inner.contains('}') && !inner.contains(':') {
-            return Some(if inner.chars().all(|c| c.is_ascii_digit()) {
-                let idx = syn::Index::from(inner.parse::<usize>().unwrap());
+    let mut iter = FormatIter::new(fmt);
+    match (iter.next(), iter.next()) {
+        (Some(FormatPart::VarRef(name)), None) if !name.is_empty() => {
+            Some(if name.chars().all(|c| c.is_ascii_digit()) {
+                let idx = syn::Index::from(name.parse::<usize>().unwrap());
                 syn::parse_quote!(self.#idx)
             } else {
-                let ident = format_ident!("{}", inner);
+                let ident = format_ident!("{}", name);
                 syn::parse_quote!(self.#ident)
-            });
+            })
         }
+        _ => None,
     }
-    None
 }
 
 /// Extract `{field}` references from a format string. Returns the transformed format string
@@ -201,58 +206,34 @@ fn parse_format_fields(fmt: &str) -> (String, Vec<Field>) {
     let mut fields: IndexSet<Field> = IndexSet::new();
     let mut transformed = String::new();
 
-    let chars: Vec<char> = fmt.chars().collect();
-    let mut i = 0;
-
-    while i < chars.len() {
-        if chars[i] == '{' {
-            if i + 1 < chars.len() && chars[i + 1] == '{' {
-                transformed.push_str("{{");
-                i += 2;
-                continue;
+    for part in FormatIter::new(fmt) {
+        match part {
+            FormatPart::RawString(s) | FormatPart::EscapedBrace(s) => {
+                transformed.push_str(s);
             }
-            i += 1;
-            let start = i;
-            while i < chars.len() && chars[i] != '}' {
-                i += 1;
+            FormatPart::VarRef(name) => {
+                let field = Field::new(name.to_owned());
+                transformed.push('{');
+                transformed.push_str(&field.var.to_string());
+                transformed.push('}');
+                fields.insert(field);
             }
-            let full_contents: String = chars[start..i].iter().collect();
-            i += 1;
-
-            // Split off any format specifier (e.g., "field:?" → name="field", spec=":?")
-            let (field_name, spec) = match full_contents.find(':') {
-                Some(colon) => (&full_contents[..colon], &full_contents[colon..]),
-                None => (full_contents.as_str(), ""),
-            };
-
-            let field = Field::new(field_name.to_owned());
-
-            transformed.push('{');
-            transformed.push_str(&field.var.to_string());
-            transformed.push_str(spec);
-            transformed.push('}');
-
-            fields.insert(field);
-        } else if chars[i] == '}' && i + 1 < chars.len() && chars[i + 1] == '}' {
-            transformed.push_str("}}");
-            i += 2;
-        } else {
-            transformed.push(chars[i]);
-            i += 1;
+            FormatPart::VarRefFormat(name, spec) => {
+                let field = Field::new(name.to_owned());
+                transformed.push('{');
+                transformed.push_str(&field.var.to_string());
+                transformed.push_str(spec);
+                transformed.push('}');
+                fields.insert(field);
+            }
         }
     }
 
     (transformed, fields.into_iter().collect())
 }
 
-/// Generate `let var = ValueToStringify::to_stringify([&]access).await?;`
-/// `add_ref` adds `&` for struct context (owned values); enum context already has references.
-fn generate_resolve(var_name: &syn::Ident, access: &TokenStream2, add_ref: bool) -> TokenStream2 {
-    if add_ref {
-        quote! { let #var_name = turbo_tasks::display::ValueToStringify::to_stringify(&(#access)).await?; }
-    } else {
-        quote! { let #var_name = turbo_tasks::display::ValueToStringify::to_stringify(#access).await?; }
-    }
+fn generate_resolve(var_name: &syn::Ident, access: &TokenStream2) -> TokenStream2 {
+    quote! { let #var_name = turbo_tasks::__turbo_stringify!(#access); }
 }
 
 fn generate_struct_impl(
@@ -270,7 +251,7 @@ fn generate_struct_impl(
         Some(AttrForm::DirectExpr(expr)) => (
             true,
             quote! {
-                let __val = turbo_tasks::display::ValueToStringify::to_stringify(&(#expr)).await?;
+                let __val = turbo_tasks::__turbo_stringify!(&(#expr));
                 Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(__val)))
             },
         ),
@@ -294,7 +275,7 @@ fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
         .iter()
         .map(|f| {
             let access = f.struct_access();
-            generate_resolve(&f.var, &access, true)
+            generate_resolve(&f.var, &quote! { &#access })
         })
         .collect();
 
@@ -307,17 +288,13 @@ fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
     )
 }
 
+/// Generate the body for `#[value_to_string("fmt {}", expr1, expr2)]` on structs.
+///
+/// Uses the shared `generate_resolve_stmts`/`generate_arg_vars` from `turbofmt_macro`
+/// so that format expression resolution shares a single codepath with `turbofmt!`.
 fn struct_format_exprs_body(fmt: &str, exprs: &[Expr]) -> (bool, TokenStream2) {
-    let (resolve_stmts, vars): (Vec<TokenStream2>, Vec<syn::Ident>) = exprs
-        .iter()
-        .enumerate()
-        .map(|(i, expr)| {
-            let var = format_ident!("__arg{}", i);
-            let stmt =
-                quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(&(#expr)).await?; };
-            (stmt, var)
-        })
-        .unzip();
+    let resolve_stmts = generate_resolve_stmts(exprs);
+    let vars = generate_arg_vars(exprs.len());
 
     (
         true,
@@ -387,16 +364,13 @@ fn generate_enum_impl(
         quote! { turbo_tasks::Vc::cell(s.into()) }
     };
 
-    wrap_impl(
-        ident,
-        needs_async,
-        quote! {
-            let s = match self {
-                #(#match_arms)*
-            };
-            #result_expr
-        },
-    )
+    let body = quote! {
+        let s = match self {
+            #(#match_arms)*
+        };
+        #result_expr
+    };
+    wrap_impl(ident, needs_async, body)
 }
 
 fn generate_enum_format_auto_fields(
@@ -437,7 +411,7 @@ fn generate_enum_format_auto_fields(
                 .iter()
                 .map(|field| {
                     let field_ident = format_ident!("{}", field.name);
-                    generate_resolve(&field.var, &quote! { #field_ident }, false)
+                    generate_resolve(&field.var, &quote! { #field_ident })
                 })
                 .collect();
             quote! {
@@ -463,7 +437,7 @@ fn generate_enum_format_auto_fields(
                 .iter()
                 .map(|field| {
                     let var = &field.var;
-                    generate_resolve(var, &quote! { #var }, false)
+                    generate_resolve(var, &quote! { #var })
                 })
                 .collect();
             quote! {
@@ -479,6 +453,10 @@ fn generate_enum_format_auto_fields(
     }
 }
 
+/// Generate an enum match arm for `#[value_to_string("fmt {}", expr1, expr2)]`.
+///
+/// Unlike `turbofmt!` (which operates on owned values), enum match arms bind
+/// fields by reference via match ergonomics, so we must not add an extra `&`.
 fn generate_enum_format_exprs(
     ident: &syn::Ident,
     variant_ident: &syn::Ident,
@@ -487,16 +465,17 @@ fn generate_enum_format_exprs(
     exprs: &[Expr],
 ) -> TokenStream2 {
     let pattern = enum_destructure_all(ident, variant_ident, fields);
-    let (resolve_stmts, vars): (Vec<TokenStream2>, Vec<syn::Ident>) = exprs
+    let vars = generate_arg_vars(exprs.len());
+    let resolve_stmts: Vec<TokenStream2> = exprs
         .iter()
         .enumerate()
         .map(|(i, expr)| {
             let var = format_ident!("__arg{}", i);
-            let stmt =
-                quote! { let #var = turbo_tasks::display::ValueToStringify::to_stringify(#expr).await?; };
-            (stmt, var)
+            quote! {
+                let #var = turbo_tasks::__turbo_stringify!(#expr);
+            }
         })
-        .unzip();
+        .collect();
     quote! {
         #pattern => {
             #(#resolve_stmts)*
@@ -513,9 +492,7 @@ fn generate_enum_direct_expr(
 ) -> TokenStream2 {
     let pattern = enum_destructure_all(ident, variant_ident, fields);
     quote! {
-        #pattern => {
-            turbo_rcstr::RcStr::from(turbo_tasks::display::ValueToStringify::to_stringify(#expr).await?)
-        }
+        #pattern => turbo_rcstr::RcStr::from(turbo_tasks::__turbo_stringify!(#expr)),
     }
 }
 

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
@@ -233,7 +233,7 @@ fn parse_format_fields(fmt: &str) -> (String, Vec<Field>) {
 }
 
 fn generate_resolve(var_name: &syn::Ident, access: &TokenStream2) -> TokenStream2 {
-    quote! { let #var_name = turbo_tasks::__turbo_stringify!(#access); }
+    quote! { turbo_tasks::__turbo_stringify!(#var_name, #access); }
 }
 
 fn generate_struct_impl(
@@ -251,7 +251,7 @@ fn generate_struct_impl(
         Some(AttrForm::DirectExpr(expr)) => (
             true,
             quote! {
-                let __val = turbo_tasks::__turbo_stringify!(&(#expr));
+                turbo_tasks::__turbo_stringify!(__val, &(#expr));
                 Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(__val)))
             },
         ),
@@ -472,7 +472,7 @@ fn generate_enum_format_exprs(
         .map(|(i, expr)| {
             let var = format_ident!("__arg{}", i);
             quote! {
-                let #var = turbo_tasks::__turbo_stringify!(#expr);
+                turbo_tasks::__turbo_stringify!(#var, #expr);
             }
         })
         .collect();
@@ -492,7 +492,10 @@ fn generate_enum_direct_expr(
 ) -> TokenStream2 {
     let pattern = enum_destructure_all(ident, variant_ident, fields);
     quote! {
-        #pattern => turbo_rcstr::RcStr::from(turbo_tasks::__turbo_stringify!(#expr)),
+        #pattern => {
+            turbo_tasks::__turbo_stringify!(__val, #expr);
+            turbo_rcstr::RcStr::from(__val)
+        }
     }
 }
 

--- a/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/derive/value_to_string_macro.rs
@@ -69,6 +69,8 @@ impl Field {
 ///
 /// For enums, each variant can have its own attribute. Variants without one
 /// default to their name.
+///
+/// Also generates `ValueToStringRef` for efficient non-Vc formatting.
 #[doc = include_str!("../../../turbo-tasks/FORMATTING.md")]
 pub fn derive_value_to_string(input: TokenStream) -> TokenStream {
     let derive_input = parse_macro_input!(input as DeriveInput);
@@ -96,26 +98,27 @@ pub fn derive_value_to_string(input: TokenStream) -> TokenStream {
     }
 }
 
-/// Wrap a function body in the `#[turbo_tasks::value_impl] impl ValueToString` boilerplate.
-fn wrap_impl(ident: &syn::Ident, is_async: bool, body: TokenStream2) -> TokenStream {
-    let async_kw = if is_async {
-        quote! { async }
-    } else {
-        quote! {}
-    };
-    let ret_ty = if is_async {
-        quote! { anyhow::Result<turbo_tasks::Vc<turbo_rcstr::RcStr>> }
-    } else {
-        quote! { turbo_tasks::Vc<turbo_rcstr::RcStr> }
-    };
+/// Wrap a `ValueToStringRef` body and `ValueToString` impl for the given ident.
+///
+/// The `ref_body` should produce `Result<RcStr>`. The `ValueToString` impl
+/// delegates to `ValueToStringRef::to_string_ref()`.
+fn wrap_impl(ident: &syn::Ident, ref_body: TokenStream2) -> TokenStream {
     quote! {
+        impl turbo_tasks::ValueToStringRef for #ident {
+            async fn to_string_ref(&self) -> anyhow::Result<turbo_rcstr::RcStr> {
+                #[allow(unused_imports)]
+                use turbo_tasks::display::macro_helpers::ValueToStringify as _;
+                #ref_body
+            }
+        }
+
         #[turbo_tasks::value_impl]
         impl turbo_tasks::ValueToString for #ident {
             #[turbo_tasks::function]
-            #async_kw fn to_string(&self) -> #ret_ty {
-                #[allow(unused_imports)]
-                use turbo_tasks::display::ValueToStringify as _;
-                #body
+            async fn to_string(&self) -> anyhow::Result<turbo_tasks::Vc<turbo_rcstr::RcStr>> {
+                Ok(turbo_tasks::Vc::cell(
+                    turbo_tasks::ValueToStringRef::to_string_ref(self).await?
+                ))
             }
         }
     }
@@ -241,34 +244,29 @@ fn generate_struct_impl(
     _fields: &Fields,
     attr: Option<AttrForm>,
 ) -> TokenStream {
-    let (is_async, body) = match attr {
-        None => (
-            false,
-            quote! { turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(self.to_string())) },
-        ),
-        Some(AttrForm::FormatAutoFields(fmt)) => struct_format_auto_fields_body(&fmt),
-        Some(AttrForm::FormatExprs(fmt, exprs)) => struct_format_exprs_body(&fmt, &exprs),
-        Some(AttrForm::DirectExpr(expr)) => (
-            true,
+    let ref_body = match attr {
+        None => {
+            quote! { Ok(turbo_rcstr::RcStr::from(std::string::ToString::to_string(self))) }
+        }
+        Some(AttrForm::FormatAutoFields(fmt)) => struct_format_auto_fields_ref_body(&fmt),
+        Some(AttrForm::FormatExprs(fmt, exprs)) => struct_format_exprs_ref_body(&fmt, &exprs),
+        Some(AttrForm::DirectExpr(expr)) => {
             quote! {
                 turbo_tasks::__turbo_stringify!(__val, &(#expr));
-                Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(__val)))
-            },
-        ),
+                Ok(turbo_rcstr::RcStr::from(__val))
+            }
+        }
     };
-    wrap_impl(ident, is_async, body)
+    wrap_impl(ident, ref_body)
 }
 
-fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
+fn struct_format_auto_fields_ref_body(fmt: &str) -> TokenStream2 {
     let (transformed_fmt, field_refs) = parse_format_fields(fmt);
 
     if field_refs.is_empty() {
         // No fields to resolve — unescape `{{`/`}}` at compile time and use rcstr!
         let unescaped = transformed_fmt.replace("{{", "{").replace("}}", "}");
-        return (
-            false,
-            quote! { turbo_tasks::Vc::cell(turbo_rcstr::rcstr!(#unescaped)) },
-        );
+        return quote! { Ok(turbo_rcstr::rcstr!(#unescaped)) };
     }
 
     let resolves: Vec<TokenStream2> = field_refs
@@ -279,30 +277,21 @@ fn struct_format_auto_fields_body(fmt: &str) -> (bool, TokenStream2) {
         })
         .collect();
 
-    (
-        true,
-        quote! {
-            #(#resolves)*
-            Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(format!(#transformed_fmt))))
-        },
-    )
+    quote! {
+        #(#resolves)*
+        Ok(turbo_rcstr::RcStr::from(format!(#transformed_fmt)))
+    }
 }
 
-/// Generate the body for `#[value_to_string("fmt {}", expr1, expr2)]` on structs.
-///
-/// Uses the shared `generate_resolve_stmts`/`generate_arg_vars` from `turbofmt_macro`
-/// so that format expression resolution shares a single codepath with `turbofmt!`.
-fn struct_format_exprs_body(fmt: &str, exprs: &[Expr]) -> (bool, TokenStream2) {
+/// Generate the ref body for `#[value_to_string("fmt {}", expr1, expr2)]` on structs.
+fn struct_format_exprs_ref_body(fmt: &str, exprs: &[Expr]) -> TokenStream2 {
     let resolve_stmts = generate_resolve_stmts(exprs);
     let vars = generate_arg_vars(exprs.len());
 
-    (
-        true,
-        quote! {
-            #(#resolve_stmts)*
-            Ok(turbo_tasks::Vc::cell(turbo_rcstr::RcStr::from(format!(#fmt, #(#vars),*))))
-        },
-    )
+    quote! {
+        #(#resolve_stmts)*
+        Ok(turbo_rcstr::RcStr::from(format!(#fmt, #(#vars),*)))
+    }
 }
 
 fn generate_enum_impl(
@@ -358,19 +347,15 @@ fn generate_enum_impl(
         }
     }
 
-    let result_expr = if needs_async {
-        quote! { Ok(turbo_tasks::Vc::cell(s.into())) }
-    } else {
-        quote! { turbo_tasks::Vc::cell(s.into()) }
-    };
-
-    let body = quote! {
-        let s = match self {
+    // Enum: match arms produce RcStr, wrap_impl handles the rest
+    let _ = needs_async; // ref body is always async
+    let ref_body = quote! {
+        let s: turbo_rcstr::RcStr = match self {
             #(#match_arms)*
         };
-        #result_expr
+        Ok(s)
     };
-    wrap_impl(ident, needs_async, body)
+    wrap_impl(ident, ref_body)
 }
 
 fn generate_enum_format_auto_fields(

--- a/turbopack/crates/turbo-tasks-macros/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/lib.rs
@@ -17,6 +17,7 @@ mod expand;
 mod ident;
 mod primitive_input;
 mod self_filter;
+mod turbofmt_macro;
 mod value_trait_arguments;
 
 use proc_macro::TokenStream;
@@ -57,6 +58,8 @@ pub fn derive_task_input(input: TokenStream) -> TokenStream {
     derive::derive_task_input(input)
 }
 
+/// Derive macro for `ValueToString`. Also generates `ValueToStringify for &T`.
+#[doc = include_str!("../../turbo-tasks/FORMATTING.md")]
 #[proc_macro_derive(ValueToString, attributes(value_to_string))]
 pub fn derive_value_to_string(input: TokenStream) -> TokenStream {
     derive::value_to_string_macro::derive_value_to_string(input)
@@ -119,4 +122,26 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn primitive(input: TokenStream) -> TokenStream {
     primitive_macro::primitive(input)
+}
+
+/// Async format macro. Returns `impl Future<Output = Result<RcStr>>`.
+///
+/// ```ignore
+/// let s: RcStr = turbofmt!("asset {} in path {}", asset.ident(), base_path).await?;
+/// ```
+#[doc = include_str!("../../turbo-tasks/FORMATTING.md")]
+#[proc_macro]
+pub fn turbofmt(input: TokenStream) -> TokenStream {
+    turbofmt_macro::turbofmt(input)
+}
+
+/// Async bail macro. Resolves arguments then calls `anyhow::bail!()`.
+///
+/// ```ignore
+/// turbobail!("asset {} is not in path {}", asset.ident(), base_path);
+/// ```
+#[doc = include_str!("../../turbo-tasks/FORMATTING.md")]
+#[proc_macro]
+pub fn turbobail(input: TokenStream) -> TokenStream {
+    turbofmt_macro::turbobail(input)
 }

--- a/turbopack/crates/turbo-tasks-macros/src/turbofmt_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/turbofmt_macro.rs
@@ -128,7 +128,7 @@ pub(crate) fn generate_resolve_stmts(exprs: &[Expr]) -> Vec<TokenStream2> {
         .map(|(i, expr)| {
             let var = format_ident!("__arg{}", i);
             quote! {
-                let #var = turbo_tasks::__turbo_stringify!(&(#expr));
+                turbo_tasks::__turbo_stringify!(#var, &(#expr));
             }
         })
         .collect()
@@ -148,7 +148,7 @@ fn generate_captured_resolve_stmts(captured_vars: &[String]) -> Vec<TokenStream2
         .map(|name| {
             let ident = format_ident!("{}", name);
             quote! {
-                let #ident = turbo_tasks::__turbo_stringify!(&#ident);
+                turbo_tasks::__turbo_stringify!(#ident, &#ident);
             }
         })
         .collect()

--- a/turbopack/crates/turbo-tasks-macros/src/turbofmt_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/turbofmt_macro.rs
@@ -1,0 +1,293 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{format_ident, quote};
+use syn::{Expr, ExprLit, Lit, Token, punctuated::Punctuated};
+
+/// Parts of a format string, yielded by [`FormatIter`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum FormatPart<'a> {
+    /// Raw text between format specifiers.
+    RawString(&'a str),
+    /// An escaped brace: `{{` or `}}`.
+    EscapedBrace(&'a str),
+    /// A variable reference without format spec: `{ident}`.
+    /// The slice is the variable name (may be empty for positional `{}`).
+    VarRef(&'a str),
+    /// A variable reference with format spec: `{ident:spec}`.
+    /// First slice is the variable name, second is the spec including `:`.
+    VarRefFormat(&'a str, &'a str),
+}
+
+/// Zero-allocation iterator over parts of a `format!`-style string.
+///
+/// All returned string slices reference the original input.
+pub(crate) struct FormatIter<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> FormatIter<'a> {
+    pub fn new(input: &'a str) -> Self {
+        FormatIter { input, pos: 0 }
+    }
+}
+
+impl<'a> Iterator for FormatIter<'a> {
+    type Item = FormatPart<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let bytes = self.input.as_bytes();
+        if self.pos >= bytes.len() {
+            return None;
+        }
+
+        let start = self.pos;
+
+        match bytes[self.pos] {
+            b'{' => {
+                self.pos += 1;
+                if self.pos < bytes.len() && bytes[self.pos] == b'{' {
+                    self.pos += 1;
+                    return Some(FormatPart::EscapedBrace(&self.input[start..self.pos]));
+                }
+                let content_start = self.pos;
+                let mut colon_pos = None;
+                while self.pos < bytes.len() && bytes[self.pos] != b'}' {
+                    if bytes[self.pos] == b':' && colon_pos.is_none() {
+                        colon_pos = Some(self.pos);
+                    }
+                    self.pos += 1;
+                }
+                let content_end = self.pos;
+                if self.pos < bytes.len() {
+                    self.pos += 1; // skip closing '}'
+                }
+                match colon_pos {
+                    Some(cp) => Some(FormatPart::VarRefFormat(
+                        &self.input[content_start..cp],
+                        &self.input[cp..content_end],
+                    )),
+                    None => Some(FormatPart::VarRef(&self.input[content_start..content_end])),
+                }
+            }
+            b'}' => {
+                self.pos += 1;
+                if self.pos < bytes.len() && bytes[self.pos] == b'}' {
+                    self.pos += 1;
+                    return Some(FormatPart::EscapedBrace(&self.input[start..self.pos]));
+                }
+                // Lone '}' — treat as raw text
+                Some(FormatPart::RawString(&self.input[start..self.pos]))
+            }
+            _ => {
+                while self.pos < bytes.len() && bytes[self.pos] != b'{' && bytes[self.pos] != b'}' {
+                    self.pos += 1;
+                }
+                Some(FormatPart::RawString(&self.input[start..self.pos]))
+            }
+        }
+    }
+}
+
+/// Returns true if `name` is a valid captured identifier for `turbofmt!`.
+///
+/// Must start with an alphabetic character or `_`, and contain only
+/// alphanumeric characters or `_`. Empty strings and numeric-only
+/// names (positional args) return false.
+fn is_captured_ident(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c.is_alphabetic() || c == '_' => chars.all(|c| c.is_alphanumeric() || c == '_'),
+        _ => false,
+    }
+}
+
+/// Extract captured variable names from a format string.
+///
+/// Only extracts plain `{ident}` captures (no format spec). Variables with
+/// format specs like `{ident:?}` are left as-is (they use `Debug`/`Display`
+/// directly, not `ValueToStringify`).
+fn extract_captured_variables(fmt: &str) -> Vec<String> {
+    let mut vars = Vec::new();
+    for part in FormatIter::new(fmt) {
+        if let FormatPart::VarRef(name) = part
+            && is_captured_ident(name)
+            && !vars.iter().any(|v: &String| v == name)
+        {
+            vars.push(name.to_string());
+        }
+    }
+    vars
+}
+
+/// Generate resolve statements for a list of positional expressions.
+pub(crate) fn generate_resolve_stmts(exprs: &[Expr]) -> Vec<TokenStream2> {
+    exprs
+        .iter()
+        .enumerate()
+        .map(|(i, expr)| {
+            let var = format_ident!("__arg{}", i);
+            quote! {
+                let #var = turbo_tasks::__turbo_stringify!(&(#expr));
+            }
+        })
+        .collect()
+}
+
+/// Generate variable identifiers `__arg0`, `__arg1`, etc. for a given count.
+pub(crate) fn generate_arg_vars(count: usize) -> Vec<syn::Ident> {
+    (0..count).map(|i| format_ident!("__arg{}", i)).collect()
+}
+
+/// Generate shadow bindings that resolve captured format string variables via
+/// `ValueToStringify`. Shadows each captured variable with its resolved string
+/// value so `format!()` can consume it.
+fn generate_captured_resolve_stmts(captured_vars: &[String]) -> Vec<TokenStream2> {
+    captured_vars
+        .iter()
+        .map(|name| {
+            let ident = format_ident!("{}", name);
+            quote! {
+                let #ident = turbo_tasks::__turbo_stringify!(&#ident);
+            }
+        })
+        .collect()
+}
+
+/// Core code generation shared by `turbofmt!` and the derive macro.
+///
+/// Returns a `TokenStream2` evaluating to `impl Future<Output = Result<RcStr>>`.
+pub(crate) fn generate_turbofmt(fmt: &str, exprs: &[Expr]) -> TokenStream2 {
+    generate_turbofmt_inner(fmt, exprs)
+}
+
+/// Like `generate_turbofmt` but with control over whether `&` is added to expressions.
+pub(crate) fn generate_turbofmt_inner(fmt: &str, exprs: &[Expr]) -> TokenStream2 {
+    let captured_vars = extract_captured_variables(fmt);
+    let captured_stmts = generate_captured_resolve_stmts(&captured_vars);
+    let resolve_stmts = generate_resolve_stmts(exprs);
+    let vars = generate_arg_vars(exprs.len());
+
+    if vars.is_empty() {
+        quote! {
+            async {
+                #(#captured_stmts)*
+                anyhow::Ok(turbo_rcstr::RcStr::from(format!(#fmt)))
+            }
+        }
+    } else {
+        quote! {
+            async {
+                #(#captured_stmts)*
+                #(#resolve_stmts)*
+                anyhow::Ok(turbo_rcstr::RcStr::from(format!(#fmt, #(#vars),*)))
+            }
+        }
+    }
+}
+
+fn parse_fmt_args(input: TokenStream) -> syn::Result<(String, Vec<Expr>)> {
+    let args: Punctuated<Expr, Token![,]> =
+        syn::parse::Parser::parse(Punctuated::parse_terminated, input)?;
+    let mut iter = args.into_iter();
+
+    let first = iter
+        .next()
+        .ok_or_else(|| syn::Error::new(proc_macro2::Span::call_site(), "expected format string"))?;
+
+    let fmt = match &first {
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(s), ..
+        }) => s.value(),
+        _ => {
+            return Err(syn::Error::new_spanned(
+                first,
+                "first argument must be a format string literal",
+            ));
+        }
+    };
+
+    let exprs: Vec<Expr> = iter.collect();
+    Ok((fmt, exprs))
+}
+
+/// `turbofmt!("format string {}", expr1, expr2)` — async format macro.
+///
+/// Returns `impl Future<Output = Result<RcStr>>`. Must be `.await`ed.
+/// Each argument is resolved via `ValueToStringify` before formatting.
+#[doc = include_str!("../../turbo-tasks/FORMATTING.md")]
+pub fn turbofmt(input: TokenStream) -> TokenStream {
+    match parse_fmt_args(input) {
+        Ok((fmt, exprs)) => generate_turbofmt(&fmt, &exprs).into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+/// `turbobail!("error: {}", expr)` — async bail macro.
+///
+/// Resolves arguments via `ValueToStringify` then calls `anyhow::bail!()`.
+/// Has implicit `.await` and return flow.
+#[doc = include_str!("../../turbo-tasks/FORMATTING.md")]
+pub fn turbobail(input: TokenStream) -> TokenStream {
+    match parse_fmt_args(input) {
+        Ok((fmt, exprs)) => {
+            let captured_vars = extract_captured_variables(&fmt);
+            let captured_stmts = generate_captured_resolve_stmts(&captured_vars);
+            let resolve_stmts = generate_resolve_stmts(&exprs);
+            let vars = generate_arg_vars(exprs.len());
+
+            let output = if vars.is_empty() {
+                quote! {
+                    {
+                        #(#captured_stmts)*
+                        #(#resolve_stmts)*
+                        anyhow::bail!(#fmt)
+                    }
+                }
+            } else {
+                quote! {
+                    {
+                        #(#captured_stmts)*
+                        #(#resolve_stmts)*
+                        anyhow::bail!(#fmt, #(#vars),*)
+                    }
+                }
+            };
+
+            output.into()
+        }
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_iter_all_parts() {
+        let parts: Vec<_> = FormatIter::new("{{}} hello {name}, {age:>3} {} {0}").collect();
+        assert_eq!(
+            parts,
+            vec![
+                FormatPart::EscapedBrace("{{"),
+                FormatPart::EscapedBrace("}}"),
+                FormatPart::RawString(" hello "),
+                FormatPart::VarRef("name"),
+                FormatPart::RawString(", "),
+                FormatPart::VarRefFormat("age", ":>3"),
+                FormatPart::RawString(" "),
+                FormatPart::VarRef(""),
+                FormatPart::RawString(" "),
+                FormatPart::VarRef("0"),
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_captures() {
+        // Only plain idents (not positional, not format-specced, not escaped), deduplicated
+        let vars = extract_captured_variables("{{x}} {name} {age:?} {_x} {0} {name}");
+        assert_eq!(vars, vec!["name", "_x"]);
+    }
+}

--- a/turbopack/crates/turbo-tasks/FORMATTING.md
+++ b/turbopack/crates/turbo-tasks/FORMATTING.md
@@ -34,9 +34,9 @@ turbobail!("asset {} is not in path {}", asset.ident(), base_path);
 
 ## `#[derive(ValueToString)]`
 
-Generates an async `to_string()` method returning `Vc<RcStr>`. Fields are
-resolved asynchronously, so `Vc<T>` and `ResolvedVc<T>` fields work directly
-in format strings.
+Generates both `ValueToStringRef` (returning `RcStr`) and `ValueToString`
+(returning `Vc<RcStr>`) impls. Fields are resolved asynchronously, so `Vc<T>`
+and `ResolvedVc<T>` fields work directly in format strings.
 
 **No attribute** — delegates to `Display::to_string()`:
 
@@ -99,13 +99,16 @@ pub trait ValueToString {
 When a value is used in `turbofmt!` or `turbobail!`, it is resolved using the
 first matching rule (highest priority first):
 
-| Priority | Type                       | Resolution                                 |
-| -------- | -------------------------- | ------------------------------------------ |
-| 1        | `ValueToString` impl       | Derive-generated async body                |
-| 2        | `ValueToStringRef` impl    | Awaits `ValueToStringRef::to_string_ref()` |
-| 3        | Owned value with `Display` | Synchronous `Display::to_string()`         |
+| Priority | Type                      | Resolution                                 |
+| -------- | ------------------------- | ------------------------------------------ |
+| 1        | `ValueToStringRef` impl   | Awaits `ValueToStringRef::to_string_ref()` |
+| 2        | `Vc<T>` / `ResolvedVc<T>` | Awaits `ValueToString::to_string()`        |
+| 3        | `Display` impl            | Synchronous `Display::to_string()`         |
 
-This means `#[derive(ValueToString)]` takes priority over `Display` for owned
-values. A type can implement `Display` for a short synchronous representation
-while `ValueToString` provides a richer async format. `Display` is still used
-in synchronous contexts like `format!()`.
+`#[derive(ValueToString)]` generates both `ValueToStringRef` and
+`ValueToString` impls, so derived types resolve at priority 1 when used as
+owned values and at priority 2 when used behind `Vc`/`ResolvedVc`.
+
+A type may implement `Display` for a short synchronous representation while
+`ValueToStringRef` provides a richer async format, but this is strongly discouraged
+and causes confusion. In general, only the sync _XOR_ async formatting functions should be implemented.

--- a/turbopack/crates/turbo-tasks/FORMATTING.md
+++ b/turbopack/crates/turbo-tasks/FORMATTING.md
@@ -1,130 +1,75 @@
-# Turbo-Tasks Formatting System
-
-This document describes the async-aware formatting system used across turbo-tasks.
-It covers `ValueToString`, `ValueToStringify`, `turbofmt!`, `turbobail!`, and
-`#[derive(ValueToString)]`.
-
-## Overview
+# Async Formatting
 
 Standard Rust formatting (`format!`, `Display`) is synchronous. In turbo-tasks,
 many values live behind `Vc<T>` or `ResolvedVc<T>`, which require `.await` to
-read. The formatting system bridges this gap with async-aware alternatives that
-can format both plain Rust types and turbo-tasks virtual cell types.
+read. These macros handle that automatically.
 
-## Key Traits
+## `turbofmt!` — async `format!`
 
-### `ValueToString`
-
-The async counterpart to `Display`. Returns `Vc<RcStr>` instead of writing to a
-formatter:
+Returns `Result<RcStr>` after resolving all arguments asynchronously.
 
 ```rust
-#[turbo_tasks::value_trait]
-pub trait ValueToString {
-    fn to_string(self: Vc<Self>) -> Vc<RcStr>;
-}
-```
+// Positional arguments
+let msg = turbofmt!("asset {} in path {}", asset.ident(), base_path).await?;
 
-Use `#[derive(ValueToString)]` to implement this automatically.
-
-### `ValueToStringify`
-
-A helper trait that provides unified async string conversion. It uses a
-`ValueToStringifyWrap<T>` newtype and const-generic `LEVEL` parameter to enable
-**priority-based dispatch** via Rust's auto-deref method resolution, avoiding
-coherence conflicts that would arise with plain `&`-level overloading.
-
-The macro `__turbo_stringify!(expr)` wraps the expression in
-`ValueToStringifyWrap` and calls `.to_stringify()` through `&&&wrap`, so
-auto-deref tries impls in this order (highest priority first):
-
-| Level | Implementation                                  | Matches                     | Behavior                             |
-| ----- | ----------------------------------------------- | --------------------------- | ------------------------------------ |
-| 0     | `&&&Wrap<&T>` (derive-generated, concrete)      | Owned turbo-tasks values    | Runs the derive-generated async body |
-| 1     | `&Wrap<&T> where T: Display` (blanket)          | Owned values with `Display` | Synchronous `Display::to_string()`   |
-| 2     | `&&Wrap<&Vc<T>> where T: ValueToString`         | `Vc<T>` references          | Awaits `ValueToString::to_string()`  |
-| 2     | `&&Wrap<&ResolvedVc<T>> where T: ValueToString` | `ResolvedVc<T>` references  | Awaits `ValueToString::to_string()`  |
-| 3     | `&&&Wrap<&ReadRef<T>> where T: ValueToString`   | `ReadRef<T>` references     | Re-cells then awaits `ValueToString` |
-
-### Resolution Priority
-
-When a type implements **both** `Display` and has a derive-generated
-`ValueToStringify`, the derive-generated impl (level 0) takes priority because
-it matches at a lower auto-deref depth than the `Display` blanket (level 1).
-
-This means **`ValueToString` takes priority over `Display`** for owned values
-in `turbofmt!` and `turbobail!`. A type can implement `Display` for a short
-synchronous representation while `ValueToString` provides a richer async format.
-
-**Example:** `FileSystemPath` implements `Display` (writes only `self.path`) and
-derives `ValueToString` with `#[value_to_string("[{fs}]/{path}")]`. In
-`turbofmt!("{source_path}", ...)`, the `ValueToString` impl is used (full path
-with filesystem prefix). The `Display` impl is available for synchronous contexts
-like `format!()` or `println!()`.
-
-## Macros
-
-### `turbofmt!`
-
-Async `format!` replacement. Returns `impl Future<Output = Result<RcStr>>`.
-
-```rust
-let msg: RcStr = turbofmt!("asset {} in path {}", asset.ident(), base_path).await?;
-```
-
-Each argument is resolved via `ValueToStringify::to_stringify().await?`, then
-passed to `format!()`. Supports both positional arguments and captured variables:
-
-```rust
+// Captured variables
 let name = some_vc;
-turbofmt!("hello {name}").await?  // captures `name` from scope
+let msg = turbofmt!("hello {name}").await?;
 ```
 
-Variables with format specifiers (e.g., `{x:?}`) are **not** resolved via
-`ValueToStringify` — they use standard `Debug`/`Display` formatting directly.
+Arguments can be `Vc<T>`, `ResolvedVc<T>`, `ReadRef<T>`, or any type
+implementing `Display` — they are all resolved automatically.
 
-### `turbobail!`
+Arguments with format specifiers (e.g., `{x:?}`) use standard `Debug`/`Display`
+formatting directly and are **not** resolved asynchronously.
 
-Async `bail!` replacement. Resolves arguments then calls `anyhow::bail!()`.
+## `turbobail!` — async `bail!`
+
+Same as `turbofmt!`, but calls `anyhow::bail!()` with the formatted message.
+Has implicit `.await` and return flow.
 
 ```rust
 turbobail!("asset {} is not in path {}", asset.ident(), base_path);
 ```
 
-Has implicit `.await` and return flow, like `bail!()`. Same argument
-resolution rules as `turbofmt!`.
+## `#[derive(ValueToString)]`
 
-### `#[derive(ValueToString)]`
+Generates an async `to_string()` method returning `Vc<RcStr>`. Fields are
+resolved asynchronously, so `Vc<T>` and `ResolvedVc<T>` fields work directly
+in format strings.
 
-Generates both a `ValueToString` implementation and a concrete
-`ValueToStringify<0> for &&&ValueToStringifyWrap<&T>` implementation. The latter
-ensures the derive-generated async body takes priority over the `Display` blanket
-when the type is used in `turbofmt!` or `turbobail!`.
-
-**Struct forms:**
+**No attribute** — delegates to `Display::to_string()`:
 
 ```rust
-// No attribute: delegates to Display::to_string(self)
 #[derive(ValueToString)]
 struct Foo { ... } // requires Display impl
+```
 
-// Format string with auto-field references:
+**Format string with field references** — fields are resolved async:
+
+```rust
 #[derive(ValueToString)]
 #[value_to_string("[{fs}]/{path}")]
 struct FileSystemPath { fs: ResolvedVc<...>, path: RcStr }
+```
 
-// Format string with explicit expressions:
+**Format string with explicit expressions:**
+
+```rust
 #[derive(ValueToString)]
 #[value_to_string("{}", self.name())]
 struct Bar { ... }
+```
 
-// Direct expression delegation:
+**Direct expression:**
+
+```rust
 #[derive(ValueToString)]
 #[value_to_string(self.inner)]
 struct Wrapper { inner: RcStr }
 ```
 
-**Enum forms:**
+**Enums** — variants without an attribute default to their name:
 
 ```rust
 #[derive(ValueToString)]
@@ -137,6 +82,30 @@ enum Kind {
 }
 ```
 
-Field references in format strings are resolved via `ValueToStringify`, so they
-work with `Vc<T>`, `ResolvedVc<T>`, `Display` types, and any type with a
-`ValueToStringify` impl.
+## `ValueToString` trait
+
+The underlying async trait. You rarely need to implement this manually —
+prefer `#[derive(ValueToString)]` instead.
+
+```rust
+#[turbo_tasks::value_trait]
+pub trait ValueToString {
+    fn to_string(self: Vc<Self>) -> Vc<RcStr>;
+}
+```
+
+## Resolution Priority
+
+When a value is used in `turbofmt!` or `turbobail!`, it is resolved using the
+first matching rule (highest priority first):
+
+| Priority | Type                       | Resolution                                 |
+| -------- | -------------------------- | ------------------------------------------ |
+| 1        | `ValueToString` impl       | Derive-generated async body                |
+| 2        | `ValueToStringRef` impl    | Awaits `ValueToStringRef::to_string_ref()` |
+| 3        | Owned value with `Display` | Synchronous `Display::to_string()`         |
+
+This means `#[derive(ValueToString)]` takes priority over `Display` for owned
+values. A type can implement `Display` for a short synchronous representation
+while `ValueToString` provides a richer async format. `Display` is still used
+in synchronous contexts like `format!()`.

--- a/turbopack/crates/turbo-tasks/FORMATTING.md
+++ b/turbopack/crates/turbo-tasks/FORMATTING.md
@@ -1,0 +1,142 @@
+# Turbo-Tasks Formatting System
+
+This document describes the async-aware formatting system used across turbo-tasks.
+It covers `ValueToString`, `ValueToStringify`, `turbofmt!`, `turbobail!`, and
+`#[derive(ValueToString)]`.
+
+## Overview
+
+Standard Rust formatting (`format!`, `Display`) is synchronous. In turbo-tasks,
+many values live behind `Vc<T>` or `ResolvedVc<T>`, which require `.await` to
+read. The formatting system bridges this gap with async-aware alternatives that
+can format both plain Rust types and turbo-tasks virtual cell types.
+
+## Key Traits
+
+### `ValueToString`
+
+The async counterpart to `Display`. Returns `Vc<RcStr>` instead of writing to a
+formatter:
+
+```rust
+#[turbo_tasks::value_trait]
+pub trait ValueToString {
+    fn to_string(self: Vc<Self>) -> Vc<RcStr>;
+}
+```
+
+Use `#[derive(ValueToString)]` to implement this automatically.
+
+### `ValueToStringify`
+
+A helper trait that provides unified async string conversion. It uses a
+`ValueToStringifyWrap<T>` newtype and const-generic `LEVEL` parameter to enable
+**priority-based dispatch** via Rust's auto-deref method resolution, avoiding
+coherence conflicts that would arise with plain `&`-level overloading.
+
+The macro `__turbo_stringify!(expr)` wraps the expression in
+`ValueToStringifyWrap` and calls `.to_stringify()` through `&&&wrap`, so
+auto-deref tries impls in this order (highest priority first):
+
+| Level | Implementation                                  | Matches                     | Behavior                             |
+| ----- | ----------------------------------------------- | --------------------------- | ------------------------------------ |
+| 0     | `&&&Wrap<&T>` (derive-generated, concrete)      | Owned turbo-tasks values    | Runs the derive-generated async body |
+| 1     | `&Wrap<&T> where T: Display` (blanket)          | Owned values with `Display` | Synchronous `Display::to_string()`   |
+| 2     | `&&Wrap<&Vc<T>> where T: ValueToString`         | `Vc<T>` references          | Awaits `ValueToString::to_string()`  |
+| 2     | `&&Wrap<&ResolvedVc<T>> where T: ValueToString` | `ResolvedVc<T>` references  | Awaits `ValueToString::to_string()`  |
+| 3     | `&&&Wrap<&ReadRef<T>> where T: ValueToString`   | `ReadRef<T>` references     | Re-cells then awaits `ValueToString` |
+
+### Resolution Priority
+
+When a type implements **both** `Display` and has a derive-generated
+`ValueToStringify`, the derive-generated impl (level 0) takes priority because
+it matches at a lower auto-deref depth than the `Display` blanket (level 1).
+
+This means **`ValueToString` takes priority over `Display`** for owned values
+in `turbofmt!` and `turbobail!`. A type can implement `Display` for a short
+synchronous representation while `ValueToString` provides a richer async format.
+
+**Example:** `FileSystemPath` implements `Display` (writes only `self.path`) and
+derives `ValueToString` with `#[value_to_string("[{fs}]/{path}")]`. In
+`turbofmt!("{source_path}", ...)`, the `ValueToString` impl is used (full path
+with filesystem prefix). The `Display` impl is available for synchronous contexts
+like `format!()` or `println!()`.
+
+## Macros
+
+### `turbofmt!`
+
+Async `format!` replacement. Returns `impl Future<Output = Result<RcStr>>`.
+
+```rust
+let msg: RcStr = turbofmt!("asset {} in path {}", asset.ident(), base_path).await?;
+```
+
+Each argument is resolved via `ValueToStringify::to_stringify().await?`, then
+passed to `format!()`. Supports both positional arguments and captured variables:
+
+```rust
+let name = some_vc;
+turbofmt!("hello {name}").await?  // captures `name` from scope
+```
+
+Variables with format specifiers (e.g., `{x:?}`) are **not** resolved via
+`ValueToStringify` — they use standard `Debug`/`Display` formatting directly.
+
+### `turbobail!`
+
+Async `bail!` replacement. Resolves arguments then calls `anyhow::bail!()`.
+
+```rust
+turbobail!("asset {} is not in path {}", asset.ident(), base_path);
+```
+
+Has implicit `.await` and return flow, like `bail!()`. Same argument
+resolution rules as `turbofmt!`.
+
+### `#[derive(ValueToString)]`
+
+Generates both a `ValueToString` implementation and a concrete
+`ValueToStringify<0> for &&&ValueToStringifyWrap<&T>` implementation. The latter
+ensures the derive-generated async body takes priority over the `Display` blanket
+when the type is used in `turbofmt!` or `turbobail!`.
+
+**Struct forms:**
+
+```rust
+// No attribute: delegates to Display::to_string(self)
+#[derive(ValueToString)]
+struct Foo { ... } // requires Display impl
+
+// Format string with auto-field references:
+#[derive(ValueToString)]
+#[value_to_string("[{fs}]/{path}")]
+struct FileSystemPath { fs: ResolvedVc<...>, path: RcStr }
+
+// Format string with explicit expressions:
+#[derive(ValueToString)]
+#[value_to_string("{}", self.name())]
+struct Bar { ... }
+
+// Direct expression delegation:
+#[derive(ValueToString)]
+#[value_to_string(self.inner)]
+struct Wrapper { inner: RcStr }
+```
+
+**Enum forms:**
+
+```rust
+#[derive(ValueToString)]
+enum Kind {
+    Foo,                                    // → "Foo"
+    #[value_to_string("custom")]
+    Bar,                                    // → "custom"
+    #[value_to_string("value is {0}")]
+    Baz(ResolvedVc<RcStr>),                 // → "value is ..."
+}
+```
+
+Field references in format strings are resolved via `ValueToStringify`, so they
+work with `Vc<T>`, `ResolvedVc<T>`, `Display` types, and any type with a
+`ValueToStringify` impl.

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -26,6 +26,13 @@ pub trait ValueToStringRef {
     fn to_string_ref(&self) -> impl Future<Output = Result<RcStr>> + Send;
 }
 
+/// Ref-following: `&T` delegates to `T`'s `ValueToStringRef`.
+impl<T: ValueToStringRef + Sync> ValueToStringRef for &T {
+    fn to_string_ref(&self) -> impl Future<Output = Result<RcStr>> + Send {
+        (**self).to_string_ref()
+    }
+}
+
 /// Identity implementation: `RcStr` just returns itself.
 #[turbo_tasks::value_impl]
 impl ValueToString for RcStr {

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -1,14 +1,11 @@
-use std::{
-    fmt::{self, Display},
-    future::Future,
-};
+use std::future::Future;
 
 use anyhow::Result;
 use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 pub use turbo_tasks_macros::ValueToString;
 
-use crate::{self as turbo_tasks, ReadRef, VcValueType, vc::ResolvedVc};
+use crate::{self as turbo_tasks};
 
 /// Async counterpart to `Display`, returning `Vc<RcStr>`.
 ///
@@ -49,126 +46,133 @@ impl ValueToStringRef for RcStr {
     }
 }
 
+/// Deref-following: `ReadRef<T>` delegates to the deref target's `ValueToStringRef`.
+impl<T> ValueToStringRef for crate::ReadRef<T>
+where
+    T: crate::VcValueType,
+    <T::Read as crate::VcRead<T>>::Target: ValueToStringRef,
+{
+    fn to_string_ref(&self) -> impl Future<Output = Result<RcStr>> + Send {
+        (**self).to_string_ref()
+    }
+}
+
 /// Part of the auto-deref specialization system.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __turbo_stringify {
     ($name:ident, $i:expr) => {
-        let __tmp = $crate::display::ValueToStringifyWrap($i);
         // Ugh: https://sabrinajewson.org/blog/truly-hygienic-let
         // This "let mut" makes errors more obvious in this case
-        let mut $name: $crate::display::StringifyType = {
-            use $crate::display::ValueToStringify as _;
-            (&&&__tmp).to_stringify().await?
+        let mut $name: $crate::display::macro_helpers::StringifyType = {
+            use $crate::display::macro_helpers::ValueToStringify as _;
+            let tmp = $crate::display::macro_helpers::ValueToStringifyWrap($i);
+            (&&&tmp).to_stringify().await?
         };
     };
 }
 
-/// Part of the auto-deref specialization system.
+/// Runtime helpers for the `turbofmt!`/`turbobail!` macros. Not part of the
+/// public API.
 #[doc(hidden)]
-pub struct ValueToStringifyWrap<T>(pub T);
+pub mod macro_helpers {
+    use std::{
+        fmt::{self, Display},
+        future::Future,
+    };
 
-/// Part of the auto-deref specialization system.
-#[doc(hidden)]
-pub trait ValueToStringify<const LEVEL: u8> {
-    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send;
-}
+    use anyhow::Result;
+    use turbo_rcstr::RcStr;
 
-/// Part of the auto-deref specialization system.
-#[doc(hidden)]
-pub enum StringifyType {
-    RcStrRef(ReadRef<RcStr>),
-    RcStr(RcStr),
-    String(String),
-}
+    use super::{ValueToString, ValueToStringRef};
+    use crate::vc::ResolvedVc;
 
-impl AsRef<str> for StringifyType {
-    fn as_ref(&self) -> &str {
-        match self {
-            StringifyType::RcStrRef(s) => s.as_str(),
-            StringifyType::RcStr(s) => s.as_str(),
-            StringifyType::String(s) => s.as_str(),
+    pub struct ValueToStringifyWrap<T>(pub T);
+
+    pub trait ValueToStringify<const LEVEL: u8> {
+        fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send;
+    }
+
+    pub enum StringifyType {
+        RcStr(RcStr),
+        String(String),
+    }
+
+    impl AsRef<str> for StringifyType {
+        fn as_ref(&self) -> &str {
+            match self {
+                StringifyType::RcStr(s) => s.as_str(),
+                StringifyType::String(s) => s.as_str(),
+            }
         }
     }
-}
 
-impl fmt::Debug for StringifyType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Debug::fmt(self.as_ref(), f)
-    }
-}
-
-impl Display for StringifyType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_ref())
-    }
-}
-
-impl From<StringifyType> for RcStr {
-    fn from(s: StringifyType) -> Self {
-        match s {
-            StringifyType::RcStrRef(r) => (*r).clone(),
-            StringifyType::RcStr(r) => r.clone(),
-            StringifyType::String(s) => RcStr::from(s),
+    impl fmt::Debug for StringifyType {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            fmt::Debug::fmt(self.as_ref(), f)
         }
     }
-}
 
-/// Blanket impl: uses synchronous `Display::to_string()` for owned values.
-impl<T: Display + Send + Sync> ValueToStringify<1> for &ValueToStringifyWrap<&T> {
-    #[inline(always)]
-    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
-        let s = (self.0).to_string();
-        async move { Ok(StringifyType::String(s)) }
-    }
-}
-
-impl<T: Send> ValueToStringify<2> for &&ValueToStringifyWrap<&Vc<T>>
-where
-    T: ValueToString,
-{
-    #[inline(always)]
-    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
-        let vc = self.0;
-        async move {
-            let s = vc.to_string().await?;
-            Ok(StringifyType::RcStrRef(s))
+    impl Display for StringifyType {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(self.as_ref())
         }
     }
-}
 
-impl<T: Send> ValueToStringify<2> for &&ValueToStringifyWrap<&ResolvedVc<T>>
-where
-    T: ValueToString,
-{
-    #[inline(always)]
-    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
-        let vc = self.0;
-        async move {
-            let s = vc.to_string().await?;
-            Ok(StringifyType::RcStrRef(s))
+    impl From<StringifyType> for RcStr {
+        fn from(s: StringifyType) -> Self {
+            match s {
+                StringifyType::RcStr(r) => r,
+                StringifyType::String(s) => RcStr::from(s),
+            }
         }
     }
-}
 
-impl<T: Send> ValueToStringify<2> for &&&ValueToStringifyWrap<&T>
-where
-    T: ValueToStringRef,
-{
-    #[inline(always)]
-    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> {
-        let s = self.0.to_string_ref();
-        async move { Ok(StringifyType::RcStr(s.await?)) }
+    /// Blanket impl: uses synchronous `Display::to_string()` for owned values.
+    impl<T: Display + Send + Sync> ValueToStringify<1> for &ValueToStringifyWrap<&T> {
+        #[inline(always)]
+        fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
+            let s = (self.0).to_string();
+            async move { Ok(StringifyType::String(s)) }
+        }
     }
-}
 
-impl<T: Send> ValueToStringify<3> for &&&ValueToStringifyWrap<&ReadRef<T>>
-where
-    T: ValueToString + VcValueType,
-{
-    #[inline(always)]
-    async fn to_stringify(&self) -> Result<StringifyType> {
-        let s = ReadRef::<T>::cell((self.0).clone()).to_string().await?;
-        Ok(StringifyType::RcStrRef(s))
+    impl<T: Send> ValueToStringify<2> for &&ValueToStringifyWrap<&crate::Vc<T>>
+    where
+        T: ValueToString,
+    {
+        #[inline(always)]
+        fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
+            let vc = self.0;
+            async move {
+                let s = vc.to_string().await?;
+                Ok(StringifyType::RcStr((*s).clone()))
+            }
+        }
+    }
+
+    impl<T: Send> ValueToStringify<2> for &&ValueToStringifyWrap<&ResolvedVc<T>>
+    where
+        T: ValueToString,
+    {
+        #[inline(always)]
+        fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
+            let vc = self.0;
+            async move {
+                let s = vc.to_string().await?;
+                Ok(StringifyType::RcStr((*s).clone()))
+            }
+        }
+    }
+
+    impl<T: Send> ValueToStringify<2> for &&&ValueToStringifyWrap<&T>
+    where
+        T: ValueToStringRef,
+    {
+        #[inline(always)]
+        fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> {
+            let s = self.0.to_string_ref();
+            async move { Ok(StringifyType::RcStr(s.await?)) }
+        }
     }
 }

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -46,12 +46,15 @@ impl ValueToStringRef for RcStr {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __turbo_stringify {
-    ($i:expr) => {{
-        use $crate::display::ValueToStringify as _;
-        (&&&$crate::display::ValueToStringifyWrap($i))
-            .to_stringify()
-            .await?
-    }};
+    ($name:ident, $i:expr) => {
+        let __tmp = $crate::display::ValueToStringifyWrap($i);
+        // Ugh: https://sabrinajewson.org/blog/truly-hygienic-let
+        // This "let mut" makes errors more obvious in this case
+        let mut $name: $crate::display::StringifyType = {
+            use $crate::display::ValueToStringify as _;
+            (&&&__tmp).to_stringify().await?
+        };
+    };
 }
 
 /// Part of the auto-deref specialization system.

--- a/turbopack/crates/turbo-tasks/src/display.rs
+++ b/turbopack/crates/turbo-tasks/src/display.rs
@@ -8,41 +8,83 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::Vc;
 pub use turbo_tasks_macros::ValueToString;
 
-use crate::{self as turbo_tasks, ReadRef, vc::ResolvedVc};
+use crate::{self as turbo_tasks, ReadRef, VcValueType, vc::ResolvedVc};
 
-/// Converts a value to a string, like [`Display`], but returning `Vc<RcStr>`.
+/// Async counterpart to `Display`, returning `Vc<RcStr>`.
+///
+/// Use `#[derive(ValueToString)]` to generate an implementation.
+#[doc = include_str!("../FORMATTING.md")]
 #[turbo_tasks::value_trait]
 pub trait ValueToString {
     #[turbo_tasks::function]
     fn to_string(self: Vc<Self>) -> Vc<RcStr>;
 }
 
-/// A helper trait used by the `#[derive(ValueToString)]` macro.
-///
-/// Provides async string conversion with a blanket implementation for `Display`
-/// types. `Vc<T>` and `ResolvedVc<T>` have specialized implementations that
-/// await the inner value's `ValueToString` implementation.
-///
-/// Note that these methods are inlined and these function calls are only used for
-/// effecient macro codegen.
+/// Implements an async counterpart to `Display`, returning `RcStr`. This may
+/// act as an optimization.
+pub trait ValueToStringRef {
+    fn to_string_ref(&self) -> impl Future<Output = Result<RcStr>> + Send;
+}
+
+/// Identity implementation: `RcStr` just returns itself.
+#[turbo_tasks::value_impl]
+impl ValueToString for RcStr {
+    #[turbo_tasks::function]
+    fn to_string(self: Vc<Self>) -> Vc<RcStr> {
+        self
+    }
+}
+
+/// Identity implementation: `RcStr` just returns itself.
+impl ValueToStringRef for RcStr {
+    async fn to_string_ref(&self) -> Result<RcStr> {
+        Ok(self.clone())
+    }
+}
+
+/// Part of the auto-deref specialization system.
 #[doc(hidden)]
-pub trait ValueToStringify {
+#[macro_export]
+macro_rules! __turbo_stringify {
+    ($i:expr) => {{
+        use $crate::display::ValueToStringify as _;
+        (&&&$crate::display::ValueToStringifyWrap($i))
+            .to_stringify()
+            .await?
+    }};
+}
+
+/// Part of the auto-deref specialization system.
+#[doc(hidden)]
+pub struct ValueToStringifyWrap<T>(pub T);
+
+/// Part of the auto-deref specialization system.
+#[doc(hidden)]
+pub trait ValueToStringify<const LEVEL: u8> {
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send;
 }
 
-/// Used only for macro codegen.
+/// Part of the auto-deref specialization system.
 #[doc(hidden)]
 pub enum StringifyType {
-    RcStr(ReadRef<RcStr>),
+    RcStrRef(ReadRef<RcStr>),
+    RcStr(RcStr),
     String(String),
 }
 
 impl AsRef<str> for StringifyType {
     fn as_ref(&self) -> &str {
         match self {
+            StringifyType::RcStrRef(s) => s.as_str(),
             StringifyType::RcStr(s) => s.as_str(),
             StringifyType::String(s) => s.as_str(),
         }
+    }
+}
+
+impl fmt::Debug for StringifyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_ref(), f)
     }
 }
 
@@ -55,47 +97,68 @@ impl Display for StringifyType {
 impl From<StringifyType> for RcStr {
     fn from(s: StringifyType) -> Self {
         match s {
-            StringifyType::RcStr(r) => (*r).clone(),
+            StringifyType::RcStrRef(r) => (*r).clone(),
+            StringifyType::RcStr(r) => r.clone(),
             StringifyType::String(s) => RcStr::from(s),
         }
     }
 }
 
-/// Blanket implementation for all `Display` types.
-impl<T: Display + Send + Sync> ValueToStringify for T {
+/// Blanket impl: uses synchronous `Display::to_string()` for owned values.
+impl<T: Display + Send + Sync> ValueToStringify<1> for &ValueToStringifyWrap<&T> {
     #[inline(always)]
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
-        let s = self.to_string();
+        let s = (self.0).to_string();
         async move { Ok(StringifyType::String(s)) }
     }
 }
 
-/// Implementation for `Vc<T>` that awaits the turbo-tasks `ValueToString` result.
-impl<T: Send> ValueToStringify for Vc<T>
+impl<T: Send> ValueToStringify<2> for &&ValueToStringifyWrap<&Vc<T>>
 where
     T: ValueToString,
 {
     #[inline(always)]
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
-        let vc = *self;
+        let vc = self.0;
         async move {
             let s = vc.to_string().await?;
-            Ok(StringifyType::RcStr(s))
+            Ok(StringifyType::RcStrRef(s))
         }
     }
 }
 
-/// Implementation for `ResolvedVc<T>` that delegates to the `Vc<T>` implementation.
-impl<T: Send> ValueToStringify for ResolvedVc<T>
+impl<T: Send> ValueToStringify<2> for &&ValueToStringifyWrap<&ResolvedVc<T>>
 where
     T: ValueToString,
 {
     #[inline(always)]
     fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> + Send {
-        let vc = *self;
+        let vc = self.0;
         async move {
             let s = vc.to_string().await?;
-            Ok(StringifyType::RcStr(s))
+            Ok(StringifyType::RcStrRef(s))
         }
+    }
+}
+
+impl<T: Send> ValueToStringify<2> for &&&ValueToStringifyWrap<&T>
+where
+    T: ValueToStringRef,
+{
+    #[inline(always)]
+    fn to_stringify(&self) -> impl Future<Output = Result<StringifyType>> {
+        let s = self.0.to_string_ref();
+        async move { Ok(StringifyType::RcStr(s.await?)) }
+    }
+}
+
+impl<T: Send> ValueToStringify<3> for &&&ValueToStringifyWrap<&ReadRef<T>>
+where
+    T: ValueToString + VcValueType,
+{
+    #[inline(always)]
+    async fn to_stringify(&self) -> Result<StringifyType> {
+        let s = ReadRef::<T>::cell((self.0).clone()).to_string().await?;
+        Ok(StringifyType::RcStrRef(s))
     }
 }

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -46,6 +46,7 @@ mod capture_future;
 mod collectibles;
 mod completion;
 pub mod debug;
+#[doc = include_str!("../FORMATTING.md")]
 pub mod display;
 pub mod duration_span;
 mod effect;
@@ -97,13 +98,13 @@ pub use anyhow::{Error, Result};
 use auto_hash_map::AutoSet;
 use rustc_hash::FxHasher;
 pub use shrink_to_fit::ShrinkToFit;
-pub use turbo_tasks_macros::{TaskInput, function, value_impl};
+pub use turbo_tasks_macros::{TaskInput, function, turbobail, turbofmt, value_impl};
 
 pub use crate::{
     capture_future::TurboTasksPanic,
     collectibles::CollectiblesSource,
     completion::{Completion, Completions},
-    display::ValueToString,
+    display::{ValueToString, ValueToStringRef},
     effect::{ApplyEffectsContext, Effects, apply_effects, effect, get_effects},
     error::PrettyPrintError,
     id::{ExecutionId, LocalTaskId, TRANSIENT_TASK_BIT, TaskId, TraitTypeId, ValueTypeId},

--- a/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/content.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use either::Either;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ResolvedVc, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent};
 use turbopack_core::{
     asset::AssetContent,
@@ -84,7 +84,7 @@ impl EcmascriptBrowserChunkContent {
                 let chunk_server_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
                     path
                 } else {
-                    bail!("chunk path {chunk_path} is not in output root {output_root}");
+                    turbobail!("chunk path {chunk_path} is not in output root {output_root}");
                 };
                 Either::Left(StringifyJs(chunk_server_path))
             }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/evaluate/chunk.rs
@@ -1,11 +1,11 @@
 use std::io::Write;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use either::Either;
 use indoc::writedoc;
 use serde::Serialize;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -101,7 +101,7 @@ impl EcmascriptBrowserEvaluateChunk {
                 let chunk_server_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
                     path
                 } else {
-                    bail!("chunk path {chunk_path} is not in output root {output_root}");
+                    turbobail!("chunk path {chunk_path} is not in output root {output_root}");
                 };
                 Either::Left(StringifyJs(chunk_server_path))
             }

--- a/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/version.rs
@@ -1,6 +1,6 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, Vc};
+use turbo_tasks::{FxIndexMap, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{Xxh3Hash64Hasher, encode_hex};
 use turbopack_core::{chunk::ModuleId, version::Version};
@@ -27,7 +27,7 @@ impl EcmascriptBrowserChunkVersion {
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {
-            bail!("chunk path {chunk_path} is not in client root {output_root}");
+            turbobail!("chunk path {chunk_path} is not in client root {output_root}");
         };
         let entries = EcmascriptBrowserChunkContentEntries::new(content).await?;
         let mut entries_hashes =

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{EvaluatableAsset, EvaluatableAssetExt, EvaluatableAssets},
@@ -50,9 +50,9 @@ impl RuntimeEntry {
             if let Some(entry) = ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(module) {
                 runtime_entries.push(entry);
             } else {
-                bail!(
+                turbobail!(
                     "runtime reference resolved to an asset ({}) that cannot be evaluated",
-                    module.ident().to_string().await?
+                    module.ident()
                 );
             }
         }

--- a/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/available_modules.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use bincode::{Decode, Encode};
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc,
-    trace::TraceRawVcs,
+    trace::TraceRawVcs, turbofmt,
 };
 use turbo_tasks_hash::Xxh3Hash64Hasher;
 
@@ -30,9 +30,9 @@ impl AvailableModuleItem {
             AvailableModuleItem::Batch(batch) => {
                 IdentStrings::Multiple(batch.ident_strings().await?)
             }
-            AvailableModuleItem::AsyncLoader(module) => IdentStrings::Single(
-                format!("async loader {}", module.ident().to_string().await?).into(),
-            ),
+            AvailableModuleItem::AsyncLoader(module) => {
+                IdentStrings::Single(turbofmt!("async loader {}", module.ident()).await?)
+            }
         })
     }
 }

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_id_strategy.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_id_strategy.rs
@@ -1,8 +1,9 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use bincode::{Decode, Encode};
 use rustc_hash::FxHashMap;
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    turbobail,
 };
 use turbo_tasks_hash::hash_xxh3_hash64;
 
@@ -61,7 +62,7 @@ impl ModuleIdStrategy {
                     ));
                 }
 
-                bail!("ModuleId not found for ident: {}", ident.to_string().await?);
+                turbobail!("ModuleId not found for ident: {}", ident);
             }
             ModuleIdFallback::Ident => Ok(ModuleId::String(ident.to_string().owned().await?)),
         }

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -1,9 +1,11 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use bincode::{Decode, Encode};
 use rustc_hash::{FxHashMap, FxHashSet};
 use serde::{Deserialize, Serialize};
 use turbo_rcstr::RcStr;
-use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Upcast, Vc, trace::TraceRawVcs};
+use turbo_tasks::{
+    NonLocalValue, ResolvedVc, TaskInput, Upcast, Vc, trace::TraceRawVcs, turbobail,
+};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::DeterministicHash;
 
@@ -488,10 +490,7 @@ pub trait ChunkingContext {
     /// Returns the worker entrypoint for this chunking context.
     #[turbo_tasks::function]
     async fn worker_entrypoint(self: Vc<Self>) -> Result<Vc<Box<dyn OutputAsset>>> {
-        bail!(
-            "Worker entrypoint is not supported by {name}",
-            name = self.name().await?
-        );
+        turbobail!("Worker entrypoint is not supported by {}", self.name());
     }
 }
 pub trait ChunkingContextExt {
@@ -716,11 +715,10 @@ async fn relative_path_from_chunk_root_to_project_root(
     let output_root = chunking_context.output_root().await?;
     let chunk_to_output_root = chunk_root_path.get_relative_path_to(&output_root);
     let Some(chunk_to_output_root) = chunk_to_output_root else {
-        bail!(
-            "expected chunk_root_path: {chunk_root_path} to be inside of output_root: \
-             {output_root}",
-            chunk_root_path = chunk_root_path.value_to_string().await?,
-            output_root = output_root.value_to_string().await?
+        turbobail!(
+            "expected chunk_root_path: {} to be inside of output_root: {}",
+            chunking_context.chunk_root_path(),
+            chunking_context.output_root()
         );
     };
     let output_root_to_chunk_root_path = chunking_context.output_root_to_root_path().await?;

--- a/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/evaluate.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, Upcast, ValueToString, Vc};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, Upcast, Vc, turbobail};
 
 use super::ChunkableModule;
 use crate::{
@@ -46,10 +46,7 @@ async fn to_evaluatable(
     let Some(entry) =
         ResolvedVc::try_downcast::<Box<dyn EvaluatableAsset>>(module.to_resolved().await?)
     else {
-        bail!(
-            "{} is not a valid evaluated entry",
-            module.ident().to_string().await?
-        )
+        turbobail!("{} is not a valid evaluated entry", module.ident());
     };
     Ok(*entry)
 }

--- a/turbopack/crates/turbopack-core/src/ident.rs
+++ b/turbopack/crates/turbopack-core/src/ident.rs
@@ -6,7 +6,7 @@ use once_cell::sync::Lazy;
 use regex::Regex;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
-    NonLocalValue, ReadRef, ResolvedVc, TaskInput, ValueToString, Vc, trace::TraceRawVcs,
+    NonLocalValue, ReadRef, ResolvedVc, TaskInput, ValueToString, Vc, trace::TraceRawVcs, turbofmt,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{DeterministicHash, Xxh3Hash64Hasher, encode_hex, hash_xxh3_hash64};
@@ -376,12 +376,11 @@ impl AssetIdent {
 impl ValueToString for AssetIdent {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        let mut s = self.path.value_to_string().owned().await?.into_owned();
-
-        // The query string is either empty or non-empty starting with `?` so we can just concat
-        s.push_str(&self.query);
-        // ditto for fragment
-        s.push_str(&self.fragment);
+        // The query string/fragment is either empty or non-empty starting with
+        // `?` so we can just concat
+        let mut s = turbofmt!("{}{}{}", self.path, self.query, self.fragment)
+            .await?
+            .into_owned();
 
         if !self.assets.is_empty() {
             s.push_str(" {");

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -101,7 +101,7 @@ impl Issue for ResolvingIssue {
         writeln!(
             detail,
             "Path where resolving has started: {context}",
-            context = self.file_path.value_to_string().await?
+            context = self.file_path
         )?;
         writeln!(
             detail,

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -2,7 +2,9 @@ use std::fmt::Write;
 
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{PrettyPrintError, ReadRef, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{
+    PrettyPrintError, ReadRef, ResolvedVc, ValueToString, Vc, display::ValueToStringRef,
+};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{Issue, IssueSource, IssueStage, OptionStyledString, StyledString};
@@ -101,7 +103,7 @@ impl Issue for ResolvingIssue {
         writeln!(
             detail,
             "Path where resolving has started: {context}",
-            context = self.file_path
+            context = self.file_path.to_string_ref().await?
         )?;
         writeln!(
             detail,

--- a/turbopack/crates/turbopack-core/src/issue/resolve.rs
+++ b/turbopack/crates/turbopack-core/src/issue/resolve.rs
@@ -2,9 +2,7 @@ use std::fmt::Write;
 
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{
-    PrettyPrintError, ReadRef, ResolvedVc, ValueToString, Vc, display::ValueToStringRef,
-};
+use turbo_tasks::{PrettyPrintError, ReadRef, ResolvedVc, ValueToString, ValueToStringRef, Vc};
 use turbo_tasks_fs::FileSystemPath;
 
 use super::{Issue, IssueSource, IssueStage, OptionStyledString, StyledString};

--- a/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/chunk_group_info.rs
@@ -13,7 +13,7 @@ use tracing::Instrument;
 use turbo_rcstr::RcStr;
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString,
-    Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    Vc, debug::ValueDebugFormat, trace::TraceRawVcs, turbofmt,
 };
 
 use crate::{
@@ -228,18 +228,15 @@ impl ChunkGroup {
                     .try_join()
                     .await?
             ),
-            ChunkGroup::Async(entry) => {
-                format!("ChunkGroup::Async({:?})", entry.ident().to_string().await?)
-            }
-            ChunkGroup::Isolated(entry) => {
-                format!(
-                    "ChunkGroup::Isolated({:?})",
-                    entry.ident().to_string().await?
-                )
-            }
-            ChunkGroup::Shared(entry) => {
-                format!("ChunkGroup::Shared({:?})", entry.ident().to_string().await?)
-            }
+            ChunkGroup::Async(entry) => turbofmt!("ChunkGroup::Async({:?})", entry.ident())
+                .await?
+                .to_string(),
+            ChunkGroup::Isolated(entry) => turbofmt!("ChunkGroup::Isolated({:?})", entry.ident())
+                .await?
+                .to_string(),
+            ChunkGroup::Shared(entry) => turbofmt!("ChunkGroup::Shared({:?})", entry.ident())
+                .await?
+                .to_string(),
             ChunkGroup::IsolatedMerged {
                 parent,
                 merge_tag,
@@ -315,11 +312,11 @@ impl ChunkGroupKey {
                     .await?
             ),
             ChunkGroupKey::Async(module) => {
-                format!("Async({:?})", module.ident().to_string().await?)
+                turbofmt!("Async({:?})", module.ident()).await?.to_string()
             }
-            ChunkGroupKey::Isolated(module) => {
-                format!("Isolated({:?})", module.ident().to_string().await?)
-            }
+            ChunkGroupKey::Isolated(module) => turbofmt!("Isolated({:?})", module.ident())
+                .await?
+                .to_string(),
             ChunkGroupKey::IsolatedMerged { parent, merge_tag } => {
                 format!(
                     "IsolatedMerged {{ parent: {}, merge_tag: {:?} }}",
@@ -328,7 +325,7 @@ impl ChunkGroupKey {
                 )
             }
             ChunkGroupKey::Shared(module) => {
-                format!("Shared({:?})", module.ident().to_string().await?)
+                turbofmt!("Shared({:?})", module.ident()).await?.to_string()
             }
             ChunkGroupKey::SharedMerged { parent, merge_tag } => {
                 format!(

--- a/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/module_batches.rs
@@ -4,7 +4,7 @@ use std::{
     mem::take,
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use either::Either;
 use petgraph::graph::{DiGraph, EdgeIndex, NodeIndex};
@@ -14,7 +14,7 @@ use tracing::Instrument;
 use turbo_prehash::BuildHasherExt;
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString,
-    Vc, trace::TraceRawVcs,
+    Vc, trace::TraceRawVcs, turbobail,
 };
 
 use crate::{
@@ -79,14 +79,18 @@ pub struct ModuleBatchesGraph {
 impl ModuleBatchesGraph {
     pub async fn get_entry_index(&self, entry: ResolvedVc<Box<dyn Module>>) -> Result<NodeIndex> {
         let Some(entry) = self.entries.get(&entry) else {
-            bail!(
-                "Entry {} is not in graph (possible entries: {:#?})",
-                entry.ident().to_string().await?,
+            let possible_entries = format!(
+                "{:#?}",
                 self.entries
                     .keys()
                     .map(|e| e.ident().to_string())
                     .try_join()
                     .await?
+            );
+            turbobail!(
+                "Entry {} is not in graph (possible entries: {})",
+                entry.ident(),
+                possible_entries
             );
         };
         Ok(*entry)

--- a/turbopack/crates/turbopack-core/src/node_addon_module.rs
+++ b/turbopack/crates/turbopack-core/src/node_addon_module.rs
@@ -127,7 +127,7 @@ async fn dir_references(package_dir: FileSystemPath) -> Result<Vc<ModuleReferenc
                     Ok(path) => {
                         results.insert(path.clone());
                     }
-                    Err(e) => bail!(e.as_error_message(file, &realpath)),
+                    Err(e) => bail!(e.as_error_message(file, &realpath).await?),
                 }
             }
             PatternMatch::Directory(..) => {}

--- a/turbopack/crates/turbopack-core/src/rebase.rs
+++ b/turbopack/crates/turbopack-core/src/rebase.rs
@@ -1,7 +1,7 @@
 use std::hash::Hash;
 
-use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -78,10 +78,7 @@ impl Asset for RebasedAsset {
         if let Some(source) = *self.module.source().await? {
             Ok(source.content())
         } else {
-            bail!(
-                "Module {} has no source",
-                self.module.ident().to_string().await?
-            )
+            turbobail!("Module {} has no source", self.module.ident());
         }
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -1169,7 +1169,7 @@ async fn realpath(
     }
     match &result.path_result {
         Ok(path) => Ok(path.clone()),
-        Err(e) => bail!(e.as_error_message(fs_path, &result)),
+        Err(e) => bail!(e.as_error_message(fs_path, &result).await?),
     }
 }
 
@@ -1375,7 +1375,7 @@ async fn find_package(
         if let Some(name) = basepath.get_path_to(package_dir) {
             Ok(name.into())
         } else {
-            bail!("Package directory {package_dir} is not inside the lookup path {basepath}");
+            bail!("Package directory {package_dir} is not inside the lookup path {basepath}",);
         }
     }
 
@@ -1531,7 +1531,7 @@ pub async fn resolve_raw(
         let result = &*path.realpath_with_links().await?;
         let path = match &result.path_result {
             Ok(path) => path,
-            Err(e) => bail!(e.as_error_message(path, result)),
+            Err(e) => bail!(e.as_error_message(path, result).await?),
         };
         let request_key = RequestKey::new(request);
         let source = ResolvedVc::upcast(FileSource::new(path.clone()).to_resolved().await?);
@@ -3121,7 +3121,7 @@ async fn resolved(
     let result = &*fs_path.realpath_with_links().await?;
     let path = match &result.path_result {
         Ok(path) => path,
-        Err(e) => bail!(e.as_error_message(&fs_path, result)),
+        Err(e) => bail!(e.as_error_message(&fs_path, result).await?),
     };
 
     let path_ref = path.clone();

--- a/turbopack/crates/turbopack-core/src/resolve/options.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/options.rs
@@ -5,7 +5,7 @@ use bincode::{Decode, Encode};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexSet, NonLocalValue, ResolvedVc, TryJoinIterExt, ValueToString, Vc,
-    debug::ValueDebugFormat, trace::TraceRawVcs,
+    debug::ValueDebugFormat, trace::TraceRawVcs, turbofmt,
 };
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
@@ -510,16 +510,11 @@ impl ValueToString for ImportMapResult {
             ImportMapResult::AliasExternal { .. } => Ok(Vc::cell(rcstr!("TODO external"))),
             ImportMapResult::Alias(request, context) => {
                 let s = if let Some(path) = context {
-                    let path = path.value_to_string().await?;
-                    format!(
-                        "aliased to {} inside of {}",
-                        request.to_string().await?,
-                        path
-                    )
+                    turbofmt!("aliased to {} inside of {path}", *request).await?
                 } else {
-                    format!("aliased to {}", request.to_string().await?)
+                    turbofmt!("aliased to {}", *request).await?
                 };
-                Ok(Vc::cell(s.into()))
+                Ok(Vc::cell(s))
             }
             ImportMapResult::Alternatives(alternatives) => {
                 // The .cell() calls happen synchronously during iteration, before try_join()

--- a/turbopack/crates/turbopack-core/src/resolve/parse.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/parse.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use anyhow::{Ok, Result};
 use regex::Regex;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc, turbofmt};
 
 use super::pattern::Pattern;
 
@@ -652,7 +652,7 @@ impl Request {
                 encoding,
                 data,
             } => {
-                let data = ResolvedVc::cell(format!("{}{}", data.await?, suffix).into());
+                let data = ResolvedVc::cell(turbofmt!("{}{suffix}", *data).await?);
                 Self::DataUri {
                     media_type: media_type.clone(),
                     encoding: encoding.clone(),

--- a/turbopack/crates/turbopack-core/src/source_map/utils.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/utils.rs
@@ -7,7 +7,7 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, ValueToString};
+use turbo_tasks::{ResolvedVc, turbofmt};
 use turbo_tasks_fs::{
     DiskFileSystem, FileContent, FileSystemPath, rope::Rope, util::uri_from_path_buf,
 };
@@ -86,7 +86,7 @@ pub async fn resolve_source_map_sources(
     origin: &FileSystemPath,
 ) -> Result<Option<Rope>> {
     let fs_vc = origin.fs().to_resolved().await?;
-    let fs_str = &*format!("[{}]", fs_vc.to_string().await?);
+    let fs_str = &*turbofmt!("[{fs_vc}]").await?;
 
     let disk_fs = if let Some(fs_vc) = ResolvedVc::try_downcast_type::<DiskFileSystem>(fs_vc) {
         Some((fs_vc, fs_vc.await?))

--- a/turbopack/crates/turbopack-core/src/traced_asset.rs
+++ b/turbopack/crates/turbopack-core/src/traced_asset.rs
@@ -1,5 +1,5 @@
-use anyhow::{Result, bail};
-use turbo_tasks::{ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use anyhow::Result;
+use turbo_tasks::{ResolvedVc, TryJoinIterExt, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 
 use crate::{
@@ -58,10 +58,7 @@ impl Asset for TracedAsset {
         if let Some(source) = *self.module.source().await? {
             Ok(source.content())
         } else {
-            bail!(
-                "Module {} has no source",
-                self.module.ident().to_string().await?,
-            )
+            turbobail!("Module {} has no source", self.module.ident());
         }
     }
 }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{IntoTraitRef, ResolvedVc, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{IntoTraitRef, ResolvedVc, TryJoinIterExt, Vc, turbofmt};
 use turbo_tasks_fs::{FileContent, FileSystemPath};
 use turbopack_core::{
     chunk::{ChunkItem, ChunkType, ChunkableModule, ChunkingContext, MinifyType},
@@ -344,11 +344,10 @@ impl CssChunkItem for CssModuleChunkItem {
             .cell())
         } else {
             Ok(CssChunkItemContent {
-                inner_code: format!(
-                    "/* unparsable {} */",
-                    self.module.ident().to_string().await?
-                )
-                .into(),
+                inner_code: turbofmt!("/* unparsable {} */", self.module.ident())
+                    .await?
+                    .to_string()
+                    .into(),
                 imports: vec![],
                 import_context: None,
                 source_map: FileContent::NotFound.resolved_cell(),

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -1,11 +1,10 @@
 use std::{fmt::Write, sync::Arc};
 
 use anyhow::{Context, Result};
-use indoc::formatdoc;
 use lightningcss::css_modules::CssModuleReference;
 use swc_core::common::{BytePos, FileName, LineCol, SourceMap};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{FxIndexMap, IntoTraitRef, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{FxIndexMap, IntoTraitRef, ResolvedVc, Vc, turbofmt};
 use turbo_tasks_fs::{FileSystemPath, rope::Rope};
 use turbopack_core::{
     chunk::{AsyncModuleInfo, ChunkableModule, ChunkingContext, ModuleChunkItemIdExt},
@@ -288,15 +287,18 @@ impl EcmascriptChunkPlaceable for ModuleCssAsset {
                         let Some(resolved_module) = &*resolved_module else {
                             CssModuleComposesIssue {
                                 severity: IssueSeverity::Error,
-                                // TODO(PACK-4879): this should include detailed location information
+                                // TODO(PACK-4879): this should include detailed location
+                                // information
                                 source: IssueSource::from_source_only(self.await?.source),
-                                message: formatdoc! {
-                                    r#"
-                                        Module {from} referenced in `composes: ... from {from};` can't be resolved.
-                                    "#,
-                                    from = &*from.await?.request.to_string().await?
-                                }.into(),
-                            }.resolved_cell().emit();
+                                message: turbofmt!(
+                                    "Module {} referenced in `composes: ... from ...;` can't be \
+                                     resolved.\n",
+                                    from.await?.request
+                                )
+                                .await?,
+                            }
+                            .resolved_cell()
+                            .emit();
                             continue;
                         };
 
@@ -305,15 +307,18 @@ impl EcmascriptChunkPlaceable for ModuleCssAsset {
                         else {
                             CssModuleComposesIssue {
                                 severity: IssueSeverity::Error,
-                                // TODO(PACK-4879): this should include detailed location information
+                                // TODO(PACK-4879): this should include detailed location
+                                // information
                                 source: IssueSource::from_source_only(self.await?.source),
-                                message: formatdoc! {
-                                    r#"
-                                        Module {from} referenced in `composes: ... from {from};` is not a CSS module.
-                                    "#,
-                                    from = &*from.await?.request.to_string().await?
-                                }.into(),
-                            }.resolved_cell().emit();
+                                message: turbofmt!(
+                                    "Module {} referenced in `composes: ... from ...;` is not a \
+                                     CSS module.\n",
+                                    from.await?.request
+                                )
+                                .await?,
+                            }
+                            .resolved_cell()
+                            .emit();
                             continue;
                         };
 
@@ -353,7 +358,7 @@ impl EcmascriptChunkPlaceable for ModuleCssAsset {
             // displayed in dev tools.
             source_map: if source_map {
                 Some(generate_minimal_source_map(
-                    self.ident().to_string().await?.to_string(),
+                    turbofmt!("{}", self.ident()).await?.to_string(),
                     code,
                 )?)
             } else {

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -78,7 +78,7 @@ use tracing::{Instrument, Level, instrument};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxDashMap, FxIndexMap, IntoTraitRef, NonLocalValue, ReadRef, ResolvedVc, TaskInput,
-    TryJoinIterExt, Upcast, ValueToString, Vc, trace::TraceRawVcs,
+    TryJoinIterExt, Upcast, ValueToString, Vc, trace::TraceRawVcs, turbofmt,
 };
 use turbo_tasks_fs::{FileJsonContent, FileSystemPath, glob::Glob, rope::Rope};
 use turbopack_core::{
@@ -1559,10 +1559,9 @@ async fn merge_modules(
     let (merged_ast, inserted) = match result {
         Ok(v) => v,
         Err((content_idx, err)) => {
-            return Err(err.context(format!(
-                "Processing {}",
-                contents[content_idx].0.ident().to_string().await?
-            )));
+            return Err(
+                err.context(turbofmt!("Processing {}", contents[content_idx].0.ident()).await?)
+            );
         }
     };
 
@@ -1803,7 +1802,7 @@ async fn process_parse_result(
                         Some(Comment {
                             kind: CommentKind::Line,
                             span: DUMMY_SP,
-                            text: format!(" MERGED MODULE: {}", ident.to_string().await?).into(),
+                            text: (&*turbofmt!(" MERGED MODULE: {}", ident).await?).into(),
                         })
                     } else {
                         None
@@ -1918,12 +1917,15 @@ async fn process_parse_result(
             Ok(match parse_result {
                 ParseResult::Ok { .. } => unreachable!(),
                 ParseResult::Unparsable { messages } => {
-                    let path = ident.path().to_string().await?;
                     let error_messages = messages
                         .as_ref()
                         .and_then(|m| m.first().map(|f| format!("\n{f}")))
                         .unwrap_or("".into());
-                    let msg = format!("Could not parse module '{path}'\n{error_messages}");
+                    let msg = &*turbofmt!(
+                        "Could not parse module '{}'\n{error_messages}",
+                        ident.path()
+                    )
+                    .await?;
                     let body = vec![
                         quote!(
                             "const e = new Error($msg);" as Stmt,
@@ -1949,8 +1951,9 @@ async fn process_parse_result(
                     }
                 }
                 ParseResult::NotFound => {
-                    let path = ident.path().to_string().await?;
-                    let msg = format!("Could not parse module '{path}', file not found");
+                    let msg =
+                        &*turbofmt!("Could not parse module '{}', file not found", ident.path())
+                            .await?;
                     let body = vec![
                         quote!(
                             "const e = new Error($msg);" as Stmt,

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, sync::Arc};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use bytes_str::BytesStr;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_core::{
@@ -31,7 +31,7 @@ use swc_core::{
 };
 use tracing::{Instrument, instrument};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{PrettyPrintError, ResolvedVc, ValueToString, Vc, util::WrapFuture};
+use turbo_tasks::{PrettyPrintError, ResolvedVc, ValueToString, Vc, turbofmt, util::WrapFuture};
 use turbo_tasks_fs::{FileContent, FileSystemPath, rope::Rope};
 use turbo_tasks_hash::hash_xxh3_hash64;
 use turbopack_core::{
@@ -284,10 +284,7 @@ pub async fn parse(
         .await
     {
         Ok(result) => Ok(result),
-        Err(error) => Err(error.context(format!(
-            "failed to parse {}",
-            source.ident().to_string().await?
-        ))),
+        Err(error) => Err(error.context(turbofmt!("failed to parse {}", source.ident()).await?)),
     }
 }
 
@@ -347,10 +344,13 @@ async fn parse_internal(
                         {
                             Ok(result) => result,
                             Err(e) => {
-                                return Err(e).context(anyhow!(
-                                    "Transforming and/or parsing of {} failed",
-                                    source.ident().to_string().await?
-                                ));
+                                return Err(e).context(
+                                    turbofmt!(
+                                        "Transforming and/or parsing of {} failed",
+                                        source.ident()
+                                    )
+                                    .await?,
+                                );
                             }
                         }
                     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -10,7 +10,7 @@ use swc_core::{
     quote,
 };
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     chunk::{ChunkingContext, ChunkingType, ChunkingTypeOption, ModuleChunkItemIdExt},
@@ -669,11 +669,10 @@ impl EsmAssetReference {
                                             .supports_esm_externals()
                                             .await?
                                         {
-                                            bail!(
+                                            turbobail!(
                                                 "the chunking context ({}) does not support \
-                                                 external modules (esm request: {})",
-                                                chunking_context.name().await?,
-                                                request
+                                                 external modules (esm request: {request})",
+                                                chunking_context.name()
                                             );
                                         }
                                         let (sym, ctxt) =
@@ -720,11 +719,10 @@ impl EsmAssetReference {
                                             .supports_commonjs_externals()
                                             .await?
                                         {
-                                            bail!(
+                                            turbobail!(
                                                 "the chunking context ({}) does not support \
-                                                 external modules (request: {})",
-                                                chunking_context.name().await?,
-                                                request
+                                                 external modules (request: {request})",
+                                                chunking_context.name()
                                             );
                                         }
                                         let (sym, ctxt) =

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/export.rs
@@ -12,8 +12,7 @@ use swc_core::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, ValueToString, Vc,
-    trace::TraceRawVcs,
+    FxIndexMap, NonLocalValue, ResolvedVc, TryFlatJoinIterExt, Vc, trace::TraceRawVcs, turbofmt,
 };
 use turbopack_core::{
     chunk::{ChunkingContext, ModuleChunkItemIdExt},
@@ -416,27 +415,27 @@ pub async fn expand_star_exports(
             EcmascriptExports::None | EcmascriptExports::EmptyCommonJs => {
                 emit_star_exports_issue(
                     asset.ident(),
-                    format!(
+                    turbofmt!(
                         "export * used with module {} which has no exports\nTypescript only: Did \
                          you want to export only types with `export type * from \"...\"`?\nNote: \
                          Using `export type` is more efficient than `export *` as it won't emit \
                          any runtime code.",
-                        asset.ident().to_string().await?
+                        asset.ident()
                     )
-                    .into(),
+                    .await?,
                 )
                 .await?
             }
             EcmascriptExports::Value => {
                 emit_star_exports_issue(
                     asset.ident(),
-                    format!(
+                    turbofmt!(
                         "export * used with module {} which only has a default export (default \
                          export is not exported with export *)\nDid you want to use `export {{ \
                          default }} from \"...\";` instead?",
-                        asset.ident().to_string().await?
+                        asset.ident()
                     )
-                    .into(),
+                    .await?,
                 )
                 .await?
             }
@@ -444,14 +443,14 @@ pub async fn expand_star_exports(
                 dynamic_exporting_modules.push(asset);
                 emit_star_exports_issue(
                     asset.ident(),
-                    format!(
+                    turbofmt!(
                         "export * used with module {} which is a CommonJS module with exports \
                          only available at runtime\nList all export names manually (`export {{ a, \
                          b, c }} from \"...\") or rewrite the module to ESM, to avoid the \
                          additional runtime code.`",
-                        asset.ident().to_string().await?
+                        asset.ident()
                     )
-                    .into(),
+                    .await?,
                 )
                 .await?;
             }

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -63,7 +63,7 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     FxIndexMap, FxIndexSet, NonLocalValue, PrettyPrintError, ReadRef, ResolvedVc, TaskInput,
-    TryJoinIterExt, Upcast, ValueToString, Vc, trace::TraceRawVcs,
+    TryJoinIterExt, Upcast, ValueToString, Vc, trace::TraceRawVcs, turbofmt,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -533,10 +533,8 @@ pub async fn analyze_ecmascript_module(
 
     match result {
         Ok(result) => Ok(result),
-        Err(err) => Err(err.context(format!(
-            "failed to analyze ecmascript module '{}'",
-            module.ident().to_string().await?
-        ))),
+        Err(err) => Err(err
+            .context(turbofmt!("failed to analyze ecmascript module '{}'", module.ident()).await?)),
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/raw.rs
@@ -164,7 +164,7 @@ async fn resolve_reference_from_dir(
                 }
                 let path: FileSystemPath = match &realpath.path_result {
                     Ok(path) => path.clone(),
-                    Err(e) => bail!(e.as_error_message(file, &realpath)),
+                    Err(e) => bail!(e.as_error_message(file, &realpath).await?),
                 };
                 results.push((
                     RequestKey::new(matched_path.clone()),

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use swc_core::{ecma::ast::Expr, quote};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, Vc, turbofmt};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     self,
@@ -92,13 +92,13 @@ impl Issue for TooManyMatchesWarning {
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<StyledString>> {
         Ok(StyledString::Text(
-            format!(
-                "The file pattern {pattern} matches {num_matches} files in {context_dir}",
-                pattern = self.pattern.to_string().await?,
-                context_dir = self.context_dir.value_to_string().await?,
-                num_matches = self.num_matches
+            turbofmt!(
+                "The file pattern {} matches {} files in {}",
+                self.pattern,
+                self.num_matches,
+                self.context_dir
             )
-            .into(),
+            .await?,
         )
         .cell())
     }

--- a/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/worker.rs
@@ -8,6 +8,7 @@ use swc_core::{
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     NonLocalValue, ResolvedVc, ValueToString, Vc, debug::ValueDebugFormat, trace::TraceRawVcs,
+    turbofmt,
 };
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
@@ -177,8 +178,6 @@ impl ModuleReference for WorkerAssetReference {
         for (request_key, resolve_item) in result_ref.primary.iter() {
             match resolve_item {
                 ModuleResolveResultItem::Module(module) => {
-                    let module_ident = module.ident().to_string().await?;
-
                     let Some(chunkable) =
                         ResolvedVc::try_downcast::<Box<dyn ChunkableModule>>(*module)
                     else {
@@ -187,13 +186,13 @@ impl ModuleReference for WorkerAssetReference {
                             title: StyledString::Text(rcstr!("non-chunkable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
-                                format!(
+                                turbofmt!(
                                     "Worker entry point module '{}' is not chunkable and cannot \
                                      be used as a worker module. This may happen if the module \
                                      type doesn't support bundling.",
-                                    module_ident
+                                    module.ident()
                                 )
-                                .into(),
+                                .await?,
                             )
                             .resolved_cell(),
                             path: self.origin.origin_path().owned().await?,
@@ -215,14 +214,14 @@ impl ModuleReference for WorkerAssetReference {
                             title: StyledString::Text(rcstr!("non-evaluatable module"))
                                 .resolved_cell(),
                             message: StyledString::Text(
-                                format!(
+                                turbofmt!(
                                     "Worker thread entry point module '{}' must be evaluatable to \
                                      serve as an entry point. This module cannot be used as a \
                                      Node.js worker_threads Worker entry point because it doesn't \
                                      support direct evaluation.",
-                                    module_ident
+                                    module.ident()
                                 )
-                                .into(),
+                                .await?,
                             )
                             .resolved_cell(),
                             path: self.origin.origin_path().owned().await?,
@@ -285,21 +284,16 @@ impl WorkerAssetReference {
 impl ValueToString for WorkerAssetReference {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
-        Ok(Vc::cell(
-            format!(
-                "new {}({})",
-                match self.worker_type {
-                    WorkerType::WebWorker => "WebWorker",
-                    WorkerType::SharedWebWorker => "SharedWorker",
-                    WorkerType::NodeWorkerThread => "NodeWorkerThread",
-                },
-                match &self.request {
-                    WorkerRequest::Url(request) => request.to_string().await?,
-                    WorkerRequest::Pattern { path, .. } => path.to_string().await?,
-                }
-            )
-            .into(),
-        ))
+        let worker_type = match self.worker_type {
+            WorkerType::WebWorker => "WebWorker",
+            WorkerType::SharedWebWorker => "SharedWorker",
+            WorkerType::NodeWorkerThread => "NodeWorkerThread",
+        };
+        let request = match &self.request {
+            WorkerRequest::Url(request) => request.to_string(),
+            WorkerRequest::Pattern { path, .. } => path.to_string(),
+        };
+        Ok(Vc::cell(turbofmt!("new {worker_type}({request})").await?))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/mod.rs
@@ -13,7 +13,7 @@ use swc_core::{
     },
 };
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{FxIndexSet, ResolvedVc, ValueToString, Vc, turbobail};
 use turbopack_core::{ident::AssetIdent, resolve::ModulePart, source::Source};
 
 use self::graph::{DepGraph, ItemData, ItemId, ItemIdGroupKind, Mode, SplitModuleResult};
@@ -716,11 +716,11 @@ pub(crate) async fn part_of_module(
             let part_id = get_part_id(&split_data, &part).await?;
 
             if part_id as usize >= modules.len() {
-                bail!(
+                turbobail!(
                     "part_id is out of range: {part_id} >= {}; asset = {}; entrypoints = \
                      {entrypoints:?}: part_deps = {deps:?}",
-                    asset_ident.to_string().await?,
                     modules.len(),
+                    *asset_ident
                 );
             }
 

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, env::current_dir, path::PathBuf};
 
 use anyhow::Result;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, TransientInstance, TryJoinIterExt, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, TransientInstance, TryJoinIterExt, Vc, turbofmt};
 use turbo_tasks_fs::{DiskFileSystem, FileSystem};
 use turbopack::{
     ModuleAssetContext,
@@ -155,17 +155,18 @@ async fn to_graph(asset: ResolvedVc<Box<dyn OutputAsset>>, max_depth: usize) -> 
         for _ in 0..depth {
             indent.push_str("  ");
         }
+        let path = asset.path();
         if visited.insert(asset) {
             if depth < max_depth {
                 for &asset in references.iter().rev() {
                     queue.push((depth + 1, asset));
                 }
             }
-            result.push(format!("{}{}", indent, asset.path().to_string().await?).into());
+            result.push(turbofmt!("{indent}{path}").await?);
         } else if references.is_empty() {
-            result.push(format!("{}{} *", indent, asset.path().to_string().await?).into());
+            result.push(turbofmt!("{indent}{path} *").await?);
         } else {
-            result.push(format!("{}{} *...", indent, asset.path().to_string().await?).into());
+            result.push(turbofmt!("{indent}{path} *...").await?);
         }
     }
     result.push("".into());

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -155,7 +155,7 @@ async fn to_graph(asset: ResolvedVc<Box<dyn OutputAsset>>, max_depth: usize) -> 
         for _ in 0..depth {
             indent.push_str("  ");
         }
-        let path = asset.path();
+        let path = &asset.path().await?.path;
         if visited.insert(asset) {
             if depth < max_depth {
                 for &asset in references.iter().rev() {

--- a/turbopack/crates/turbopack-nft/src/nft.rs
+++ b/turbopack/crates/turbopack-nft/src/nft.rs
@@ -155,7 +155,7 @@ async fn to_graph(asset: ResolvedVc<Box<dyn OutputAsset>>, max_depth: usize) -> 
         for _ in 0..depth {
             indent.push_str("  ");
         }
-        let path = &asset.path().await?.path;
+        let path = asset.path();
         if visited.insert(asset) {
             if depth < max_depth {
                 for &asset in references.iter().rev() {

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -11,7 +11,7 @@ use serde_with::serde_as;
 use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    Completion, OperationVc, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc,
+    Completion, OperationVc, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, Vc,
     trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_env::ProcessEnv;

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -12,7 +12,7 @@ use tracing::Instrument;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, OperationVc, ReadRef, ResolvedVc, TaskInput, TryJoinIterExt, ValueToString, Vc,
-    trace::TraceRawVcs,
+    trace::TraceRawVcs, turbobail,
 };
 use turbo_tasks_env::ProcessEnv;
 use turbo_tasks_fs::{
@@ -262,10 +262,10 @@ impl WebpackLoadersProcessedAsset {
 
             let resource_fs_path = self.source.ident().path().await?;
             let Some(resource_path) = project_path.get_relative_path_to(&resource_fs_path) else {
-                bail!(format!(
-                    "Resource path \"{}\" need to be on project filesystem \"{}\"",
-                    resource_fs_path, project_path
-                ));
+                turbobail!(
+                    "Resource path \"{resource_fs_path}\" needs to be on project filesystem \
+                     \"{project_path}\"",
+                );
             };
             let config_value = evaluate_webpack_loader(WebpackLoaderContext {
                 entries,
@@ -610,18 +610,13 @@ impl EvaluateContext for WebpackLoaderContext {
                     {
                         Ok(ResponseMessage::Resolve { path })
                     } else {
-                        bail!(
-                            "Resolving {} in {} ends up on a different filesystem",
-                            request.to_string().await?,
-                            lookup_path.value_to_string().await?
+                        turbobail!(
+                            "Resolving {request} in {lookup_path} ends up on a different \
+                             filesystem"
                         );
                     }
                 } else {
-                    bail!(
-                        "Unable to resolve {} in {}",
-                        request.to_string().await?,
-                        lookup_path.value_to_string().await?
-                    );
+                    turbobail!("Unable to resolve {request} in {lookup_path}");
                 }
             }
             RequestMessage::TrackFileRead { file } => {

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/chunk.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use indoc::writedoc;
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -75,7 +75,7 @@ impl EcmascriptBuildNodeEntryChunk {
             if let Some(path) = chunk_directory.get_relative_path_to(&runtime_path) {
                 path
             } else {
-                bail!(
+                turbobail!(
                     "cannot find a relative path from the chunk ({chunk_path}) to the runtime \
                      chunk ({runtime_path})",
                 );
@@ -83,7 +83,7 @@ impl EcmascriptBuildNodeEntryChunk {
         let chunk_public_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {
-            bail!("chunk path ({chunk_path}) is not in output root ({output_root})");
+            turbobail!("chunk path ({chunk_path}) is not in output root ({output_root})");
         };
 
         let mut code = CodeBuilder::default();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/entry/runtime.rs
@@ -1,9 +1,9 @@
 use std::io::Write;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use indoc::writedoc;
 use turbo_rcstr::rcstr;
-use turbo_tasks::{ResolvedVc, ValueToString, Vc};
+use turbo_tasks::{ResolvedVc, ValueToString, Vc, turbobail};
 use turbo_tasks_fs::{File, FileContent, FileSystem, FileSystemPath};
 use turbopack_core::{
     asset::{Asset, AssetContent},
@@ -48,7 +48,7 @@ impl EcmascriptBuildNodeRuntimeChunk {
         let runtime_public_path = if let Some(path) = output_root.get_path_to(&runtime_path) {
             path
         } else {
-            bail!("runtime path {runtime_path} is not in output root {output_root}");
+            turbobail!("runtime path {runtime_path} is not in output root {output_root}");
         };
 
         let mut code = CodeBuilder::default();

--- a/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
+++ b/turbopack/crates/turbopack-nodejs/src/ecmascript/node/version.rs
@@ -1,6 +1,6 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{FxIndexMap, ReadRef, Vc};
+use turbo_tasks::{FxIndexMap, ReadRef, Vc, turbobail};
 use turbo_tasks_fs::FileSystemPath;
 use turbo_tasks_hash::{Xxh3Hash64Hasher, encode_hex};
 use turbopack_core::{
@@ -31,7 +31,7 @@ impl EcmascriptBuildNodeChunkVersion {
         let chunk_path = if let Some(path) = output_root.get_path_to(&chunk_path) {
             path
         } else {
-            bail!("chunk path {chunk_path} is not in client root {output_root}");
+            turbobail!("chunk path {chunk_path} is not in client root {output_root}");
         };
         let chunk_items = content.await?.chunk_item_code_and_ids().await?;
 

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -184,7 +184,9 @@ async fn resolve_node_pre_gyp_files(
                             format!("deps/lib/{key}").into(),
                             Vc::upcast(FileSource::new(match &realpath_with_links.path_result {
                                 Ok(path) => path.clone(),
-                                Err(e) => bail!(e.as_error_message(dylib, &realpath_with_links)),
+                                Err(e) => {
+                                    bail!(e.as_error_message(dylib, &realpath_with_links).await?)
+                                }
                             })),
                         );
                     }

--- a/turbopack/crates/turbopack-test-utils/src/snapshot.rs
+++ b/turbopack/crates/turbopack-test-utils/src/snapshot.rs
@@ -6,7 +6,7 @@ use regex::Regex;
 use rustc_hash::{FxHashMap, FxHashSet};
 use similar::TextDiff;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ReadRef, TryJoinIterExt, Vc};
+use turbo_tasks::{ReadRef, TryJoinIterExt, Vc, turbofmt};
 use turbo_tasks_fs::{
     DirectoryContent, DirectoryEntry, File, FileContent, FileSystemEntryType, FileSystemPath,
 };
@@ -156,14 +156,14 @@ pub async fn diff(path: FileSystemPath, actual: Vc<AssetContent>) -> Result<()> 
 
 async fn get_contents(file: Vc<AssetContent>, path: FileSystemPath) -> Result<Option<String>> {
     Ok(
-        match &*file.await.context(format!(
-            "Unable to read AssetContent of {}",
-            path.value_to_string().await?
-        ))? {
-            AssetContent::File(file) => match &*file.await.context(format!(
-                "Unable to read FileContent of {}",
-                path.value_to_string().await?
-            ))? {
+        match &*file
+            .await
+            .context(turbofmt!("Unable to read AssetContent of {path}").await?)?
+        {
+            AssetContent::File(file) => match &*file
+                .await
+                .context(turbofmt!("Unable to read FileContent of {path}").await?)?
+            {
                 FileContent::NotFound => None,
                 FileContent::Content(expected) => {
                     let rope = expected.content();


### PR DESCRIPTION
# What                                                                                    
                                                                                                                                                                                                                                                                              
Add turbofmt! and turbobail! proc macros for async string formatting with Vc<T> and ResolvedVc<T> values. 

A new, agent-friendly `FORMATTING.md` file is added to help agents figure out how these macros work.                                                                                                                                                                  

# Why

Formatting strings that include turbo-tasks values currently requires manually .await?ing each Vc, then calling format!, then converting to RcStr via .into(). By using macros, we can reduce a lot of boilerplate and potentially offer some opportunities for optimizations by reducing intermediate, throwaway tasks.

# How

We make use of the "auto-deref" pattern in Rust to choose the "best" formatting option: ValueToString or Display. 

  - Zero-alloc FormatIter: A shared iterator parser over format strings (RawString, EscapedBrace, VarRef, VarRefFormat) that both macros and the derive use, replacing duplicated manual parsing.
  - Borrow-based capture: turbofmt! uses async { .. } (not async move), so non-Copy types like FileSystemPath can be used in multiple turbofmt! calls without cloning.
  - Debug on StringifyType: Enables {:?} format specs in turbofmt!.
  - Converted ~30 call sites across next-core, turbo-tasks-fs, turbopack-core, turbopack-ecmascript, and others.

# What's Left

 - Constants cannot be formatted with turbofmt! yet because of arcane Rust hygiene rules (similar issue to https://github.com/rust-lang/rust/issues/131446)
 - rust-analyzer doesn't show these format strings as "real" format strings yet because of limitations of the analyzer, but this should be possible to make work.
 - Automatic derive for ValueToStringRef to avoid intermediate tasks in a few places where formatting is trivial
 -  turbowrite!/turbowriteln! could clean up a bit more code