### PR TITLE
tests: defer NEXT_TEST_WASM until after Jest bootstrap

### DIFF
--- a/run-tests.js
+++ b/run-tests.js
@@ -509,6 +509,7 @@ ${ENDGROUP}`)
               `^(?!(?:${test.excludedCases.map(escapeRegexp).join('|')})$).`,
             ]),
       ]
+      const deferNextTestWasm = !!process.env.NEXT_TEST_WASM
       const env = {
         // run tests in headless mode by default
         HEADLESS: 'true',
@@ -547,6 +548,13 @@ ${ENDGROUP}`)
                 .filter(Boolean)
                 .join(':'),
             }),
+        ...(deferNextTestWasm
+          ? {
+              // Let Next/Jest initialize native SWC for the transformer first.
+              NEXT_TEST_WASM: undefined,
+              NEXT_TEST_WASM_AFTER_JEST: process.env.NEXT_TEST_WASM,
+            }
+          : {}),
         ...(isFinalRun
           ? {
               // Events can be finicky in CI. This switches to a more

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -156,7 +156,12 @@ export const isNextDeploy = testMode === 'deploy'
  */
 export const isNextStart = !isNextDev && !isNextDeploy
 
+if (!process.env.NEXT_TEST_WASM && process.env.NEXT_TEST_WASM_AFTER_JEST) {
+  process.env.NEXT_TEST_WASM = process.env.NEXT_TEST_WASM_AFTER_JEST
+}
+
 export const isRspack = !!process.env.NEXT_RSPACK
+const isNextTestWasm = !!process.env.NEXT_TEST_WASM
 
 if (!testMode) {
   throw new Error(
@@ -230,7 +235,7 @@ export async function createNext(
 
     setupTracing()
     return await trace('createNext').traceAsyncFn(async (rootSpan) => {
-      const useTurbo = !!process.env.NEXT_TEST_WASM
+      const useTurbo = isNextTestWasm
         ? false
         : (opts?.turbo ?? shouldUseTurbopack())
 
@@ -363,9 +368,7 @@ export function nextTestSetup(
       return isNextStart
     },
     get isTurbopack() {
-      return Boolean(
-        !process.env.NEXT_TEST_WASM && (options.turbo ?? shouldUseTurbopack())
-      )
+      return Boolean(!isNextTestWasm && (options.turbo ?? shouldUseTurbopack()))
     },
     get isRspack() {
       return isRspack

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -102,6 +102,11 @@ export class NextInstance {
   constructor(opts: NextInstanceOpts) {
     this.env = {}
     Object.assign(this, opts)
+    const nextTestWasm =
+      process.env.NEXT_TEST_WASM ?? process.env.NEXT_TEST_WASM_AFTER_JEST
+    if (nextTestWasm) {
+      this.env.NEXT_TEST_WASM = nextTestWasm
+    }
 
     if (!isNextDeploy) {
       this.env = {

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -127,6 +127,7 @@ export class NextDevInstance extends NextInstance {
 
     const useTurbo =
       !process.env.NEXT_TEST_WASM &&
+      !process.env.NEXT_TEST_WASM_AFTER_JEST &&
       ((this as any).turbo || (this as any).experimentalTurbo)
 
     let startArgs = [

--- a/test/lib/turbo.ts
+++ b/test/lib/turbo.ts
@@ -1,7 +1,7 @@
 let loggedTurbopack = false
 
 export function shouldUseTurbopack(): boolean {
-  if (!!process.env.NEXT_TEST_WASM) {
+  if (!!process.env.NEXT_TEST_WASM || !!process.env.NEXT_TEST_WASM_AFTER_JEST) {
     return false
   }
 

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -25,7 +25,7 @@ import { nextTestSetup } from 'e2e-utils'
 
 const glob = promisify(globOriginal)
 
-if (process.env.NEXT_TEST_WASM) {
+if (process.env.NEXT_TEST_WASM || process.env.NEXT_TEST_WASM_AFTER_JEST) {
   jest.setTimeout(120 * 1000)
 }
 


### PR DESCRIPTION
This started breaking after we added clearning jest cache since this was accidentally working from other jobs filling the cache then this one leveraging it instead of attempting to transpile in jest with the wasm bindings. 

This fixes it properly to use the native binaries for the jest transform but disable for the next process that's being tested. 

## Summary
- defer `NEXT_TEST_WASM` from the Jest child process in `run-tests.js` so Jest can initialize transforms first
- pass deferred wasm intent via `NEXT_TEST_WASM_AFTER_JEST`
- restore wasm-mode behavior in test runtime helpers by mapping the deferred env back to `NEXT_TEST_WASM` for spawned Next processes and mode gating

## Why
The CI job `test next-swc wasm / build` was failing during Jest startup/parsing when wasm mode was enabled too early. This keeps wasm coverage for the actual Next test runtime while avoiding early Jest-transform breakage.

x-ref: https://github.com/vercel/next.js/actions/runs/22082037176/job/63811265374
