### PR TITLE
Disable jest cache for CI instead of wiping

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -322,7 +322,7 @@ jobs:
       # Jest has a global cache, so PRs that poison the cache can bring down CI
       - name: Clean up stray files
         if: ${{ always() }}
-        run: rm -f /tmp/package-lock.json .jest-cache
+        run: rm -f /tmp/package-lock.json
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,6 @@ test-timings.json
 *.tsbuildinfo
 .swc/
 .turbo
-.jest-cache/
 
 # Storybook
 *storybook.log

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,3 @@
-const path = require('path')
 const nextJest = require('next/jest')
 
 const createJestConfig = nextJest()
@@ -26,10 +25,6 @@ const customJestConfig = {
   moduleNameMapper: {
     '@next/font/(.*)': '@next/font/$1',
   },
-}
-
-if (process.env.CI) {
-  customJestConfig.cacheDirectory = path.join(__dirname, '.jest-cache')
 }
 
 // Check if the environment variable is set to enable test report,

--- a/run-tests.js
+++ b/run-tests.js
@@ -497,6 +497,7 @@ ${ENDGROUP}`)
         ...(process.env.CI ? ['--ci'] : []),
         '--runInBand',
         '--forceExit',
+        '--no-cache',
         '--verbose',
         ...(isTestJob
           ? ['--json', `--outputFile=${test.file}${RESULTS_EXT}`]

--- a/run-tests.js
+++ b/run-tests.js
@@ -510,6 +510,7 @@ ${ENDGROUP}`)
               `^(?!(?:${test.excludedCases.map(escapeRegexp).join('|')})$).`,
             ]),
       ]
+      const deferNextTestWasm = !!process.env.NEXT_TEST_WASM
       const env = {
         // run tests in headless mode by default
         HEADLESS: 'true',
@@ -548,6 +549,13 @@ ${ENDGROUP}`)
                 .filter(Boolean)
                 .join(':'),
             }),
+        ...(deferNextTestWasm
+          ? {
+              // Let Next/Jest initialize native SWC for the transformer first.
+              NEXT_TEST_WASM: undefined,
+              NEXT_TEST_WASM_AFTER_JEST: process.env.NEXT_TEST_WASM,
+            }
+          : {}),
         ...(isFinalRun
           ? {
               // Events can be finicky in CI. This switches to a more

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -156,7 +156,12 @@ export const isNextDeploy = testMode === 'deploy'
  */
 export const isNextStart = !isNextDev && !isNextDeploy
 
+if (!process.env.NEXT_TEST_WASM && process.env.NEXT_TEST_WASM_AFTER_JEST) {
+  process.env.NEXT_TEST_WASM = process.env.NEXT_TEST_WASM_AFTER_JEST
+}
+
 export const isRspack = !!process.env.NEXT_RSPACK
+const isNextTestWasm = !!process.env.NEXT_TEST_WASM
 
 if (!testMode) {
   throw new Error(
@@ -230,7 +235,7 @@ export async function createNext(
 
     setupTracing()
     return await trace('createNext').traceAsyncFn(async (rootSpan) => {
-      const useTurbo = !!process.env.NEXT_TEST_WASM
+      const useTurbo = isNextTestWasm
         ? false
         : (opts?.turbo ?? shouldUseTurbopack())
 
@@ -363,9 +368,7 @@ export function nextTestSetup(
       return isNextStart
     },
     get isTurbopack() {
-      return Boolean(
-        !process.env.NEXT_TEST_WASM && (options.turbo ?? shouldUseTurbopack())
-      )
+      return Boolean(!isNextTestWasm && (options.turbo ?? shouldUseTurbopack()))
     },
     get isRspack() {
       return isRspack

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -102,6 +102,11 @@ export class NextInstance {
   constructor(opts: NextInstanceOpts) {
     this.env = {}
     Object.assign(this, opts)
+    const nextTestWasm =
+      process.env.NEXT_TEST_WASM ?? process.env.NEXT_TEST_WASM_AFTER_JEST
+    if (nextTestWasm) {
+      this.env.NEXT_TEST_WASM = nextTestWasm
+    }
 
     if (!isNextDeploy) {
       this.env = {

--- a/test/lib/next-modes/next-dev.ts
+++ b/test/lib/next-modes/next-dev.ts
@@ -127,6 +127,7 @@ export class NextDevInstance extends NextInstance {
 
     const useTurbo =
       !process.env.NEXT_TEST_WASM &&
+      !process.env.NEXT_TEST_WASM_AFTER_JEST &&
       ((this as any).turbo || (this as any).experimentalTurbo)
 
     let startArgs = [

--- a/test/lib/turbo.ts
+++ b/test/lib/turbo.ts
@@ -1,7 +1,7 @@
 let loggedTurbopack = false
 
 export function shouldUseTurbopack(): boolean {
-  if (!!process.env.NEXT_TEST_WASM) {
+  if (!!process.env.NEXT_TEST_WASM || !!process.env.NEXT_TEST_WASM_AFTER_JEST) {
     return false
   }
 

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -25,7 +25,7 @@ import { nextTestSetup } from 'e2e-utils'
 
 const glob = promisify(globOriginal)
 
-if (process.env.NEXT_TEST_WASM) {
+if (process.env.NEXT_TEST_WASM || process.env.NEXT_TEST_WASM_AFTER_JEST) {
   jest.setTimeout(120 * 1000)
 }
 


### PR DESCRIPTION
This is aiming to fix sporadic failures from jest transforms which is most likely caused by the change to output to custom jest-cache folder and wipe that between runs. Instead this disables the cache via `--no-cache` flag and also fixes WASM bindings issue that started due to cache not being available. 

x-ref: https://github.com/vercel/next.js/actions/runs/22109996356/job/63903450669?pr=90096#step:35:493
x-ref: https://github.com/vercel/next.js/actions/runs/22109996356/job/63903820197?pr=90096#step:35:18167
