### PR TITLE
next-stats-action: avoid pnpm EXDEV during stats installs

### DIFF
--- a/.github/actions/next-stats-action/src/index.js
+++ b/.github/actions/next-stats-action/src/index.js
@@ -117,7 +117,9 @@ if (!allowedActions.has(actionInfo.actionName) && !actionInfo.isRelease) {
               usePnpm
                 ? // --no-frozen-lockfile is used here to tolerate lockfile
                   // changes from merging latest changes
-                  ` && pnpm install --no-frozen-lockfile`
+                  // --package-import-method=copy avoids EXDEV hardlink failures
+                  // on self-hosted runners where pnpm store/workdirs cross devices.
+                  ` && pnpm install --no-frozen-lockfile --package-import-method=copy`
                 : ' && yarn install --network-timeout 1000000'
             }`,
             { env: { PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '1' } }

--- a/.github/actions/next-stats-action/src/run/index.js
+++ b/.github/actions/next-stats-action/src/run/index.js
@@ -296,7 +296,7 @@ async function linkPkgs(pkgDir = '', pkgPaths) {
   await fs.writeFile(pkgJsonPath, JSON.stringify(pkgData, null, 2), 'utf8')
 
   await exec(
-    `cd ${pkgDir} && pnpm install --strict-peer-dependencies=false`,
+    `cd ${pkgDir} && pnpm install --strict-peer-dependencies=false --package-import-method=copy`,
     false
   )
 }


### PR DESCRIPTION
## Summary
- fix flaky `pnpm install` failures in the stats action caused by cross-device hardlinking (`ERR_PNPM_EXDEV`)
- force `pnpm` to use `--package-import-method=copy` for installs run in temp repos
- apply the same setting in both install paths used by the stats workflow

x-ref: https://github.com/vercel/next.js/actions/runs/22110883672/job/63906643545