### PR TITLE
[Instant] test: remove unnecessary reactDebugChannel permutation

### DIFF
--- a/test/e2e/app-dir/instant-validation-static-shells/fixtures/invalid-blocking-page-below-static/next.config.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/fixtures/invalid-blocking-page-below-static/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   experimental: {
     prerenderEarlyExit: false,
-    reactDebugChannel: process.env.REACT_DEBUG_CHANNEL ? true : false,
   },
   typescript: {
     ignoreBuildErrors: true,

--- a/test/e2e/app-dir/instant-validation-static-shells/fixtures/valid/next.config.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/fixtures/valid/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   productionBrowserSourceMaps: true,
   experimental: {
     prerenderEarlyExit: false,
-    reactDebugChannel: process.env.REACT_DEBUG_CHANNEL ? true : false,
   },
   typescript: {
     ignoreBuildErrors: true,

--- a/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
+++ b/test/e2e/app-dir/instant-validation-static-shells/instant-validation-static-shells.test.ts
@@ -29,18 +29,12 @@ describe('instant validation - opting out of static shells', () => {
   })
 })
 
-describe.each([
-  { debugChannelEnabled: true, description: 'with debug channel' },
-  { debugChannelEnabled: false, description: 'without debug channel' },
-])('instant validation - $description', ({ debugChannelEnabled }) => {
+describe('instant validation', () => {
   describe('requires a static shell if a below a static layout page is configured as blocking', () => {
     const { next, skipped, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures', 'invalid-blocking-page-below-static'),
       skipStart: true,
       skipDeployment: true,
-      env: {
-        REACT_DEBUG_CHANNEL: debugChannelEnabled ? '1' : '',
-      },
     })
     if (skipped) return
 

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -11,16 +11,10 @@ import {
   RedboxSnapshot,
 } from '../../../lib/add-redbox-matchers'
 
-describe.each([
-  { debugChannelEnabled: true, description: 'with debug channel' },
-  { debugChannelEnabled: false, description: 'without debug channel' },
-])('instant validation - $description', ({ debugChannelEnabled }) => {
+describe('instant validation', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
-    env: {
-      REACT_DEBUG_CHANNEL: debugChannelEnabled ? '1' : '',
-    },
   })
   if (skipped) return
   if (!isNextDev) {

--- a/test/e2e/app-dir/instant-validation/next.config.ts
+++ b/test/e2e/app-dir/instant-validation/next.config.ts
@@ -3,9 +3,6 @@ import type { NextConfig } from 'next'
 const nextConfig: NextConfig = {
   cacheComponents: true,
   productionBrowserSourceMaps: true,
-  experimental: {
-    reactDebugChannel: process.env.REACT_DEBUG_CHANNEL ? true : false,
-  },
   typescript: {
     ignoreBuildErrors: true,
   },


### PR DESCRIPTION
This is already handled by our test sharding, we don't need to duplicate it