### PR TITLE
ci: only cancel pull_request_stats on PR updates

### DIFF
--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -8,8 +8,9 @@ on:
 name: Generate Stats
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Keep cancel-on-update behavior for PRs, but allow canary pushes to run independently.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   NAPI_CLI_VERSION: 2.18.4


### PR DESCRIPTION
This avoids cancelling on canary branch when a commit is merged while previous commit is still running

## Summary
- keep cancel-in-progress behavior for pull_request runs
- stop canceling in-progress runs for follow-up pushes to canary by using a per-run concurrency group for push events

x-ref: https://github.com/vercel/next.js/actions/runs/22113161316/job/63914496141