### PR TITLE
segment cache: fix segment cache normalizer

### DIFF
--- a/packages/next/src/server/normalizers/request/segment-prefix-rsc.test.ts
+++ b/packages/next/src/server/normalizers/request/segment-prefix-rsc.test.ts
@@ -9,4 +9,28 @@ describe('SegmentPrefixRSCPathnameNormalizer', () => {
       segmentPath: '/_tree',
     })
   })
+
+  it('should extract segment prefetch paths for catch-all params named segments', () => {
+    const normalizer = new SegmentPrefixRSCPathnameNormalizer()
+    const result = normalizer.extract(
+      '/catch/[...segments].segments/catch/$c$segments/__PAGE__.segment.rsc'
+    )
+
+    expect(result).toEqual({
+      originalPathname: '/catch/[...segments]',
+      segmentPath: '/catch/$c$segments/__PAGE__',
+    })
+  })
+
+  it('should still extract segment prefetch paths for other catch-all param names', () => {
+    const normalizer = new SegmentPrefixRSCPathnameNormalizer()
+    const result = normalizer.extract(
+      '/catch/[...foobar].segments/catch/$c$foobar/__PAGE__.segment.rsc'
+    )
+
+    expect(result).toEqual({
+      originalPathname: '/catch/[...foobar]',
+      segmentPath: '/catch/$c$foobar/__PAGE__',
+    })
+  })
 })

--- a/packages/next/src/server/normalizers/request/segment-prefix-rsc.ts
+++ b/packages/next/src/server/normalizers/request/segment-prefix-rsc.ts
@@ -4,9 +4,10 @@ import {
   RSC_SEGMENT_SUFFIX,
   RSC_SEGMENTS_DIR_SUFFIX,
 } from '../../../lib/constants'
+import { escapeStringRegexp } from '../../../shared/lib/escape-regexp'
 
 const PATTERN = new RegExp(
-  `^(/.*)${RSC_SEGMENTS_DIR_SUFFIX}(/.*)${RSC_SEGMENT_SUFFIX}$`
+  `^(/.*)${escapeStringRegexp(RSC_SEGMENTS_DIR_SUFFIX)}(/.*)${escapeStringRegexp(RSC_SEGMENT_SUFFIX)}$`
 )
 
 export class SegmentPrefixRSCPathnameNormalizer implements PathnameNormalizer {


### PR DESCRIPTION
This fixes an issue where deploying an app that explicitly named a catch-all segments as `[...segments]` or `[[...segments]]` would lead to repeated ISR cache misses on that route, even if it was generated at build time.

This is because the normalizer that is responsible for extracting the segment path wasn't escaping the `.segments` directory value, so the `.` was treated as a wildcard. That meant when the server attempted to look up the underlying segment data, it wouldn't find it and would have responded with a 204, which signals to the upstream CDN that it is not a cacheable response. 

Fixes #87090