### PR TITLE
refactor: centralize _next/data pathname parsing

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -63,6 +63,7 @@ import { getBotType, isBot } from '../shared/lib/router/utils/is-bot'
 import RenderResult from './render-result'
 import { removeTrailingSlash } from '../shared/lib/router/utils/remove-trailing-slash'
 import { denormalizePagePath } from '../shared/lib/page-path/denormalize-page-path'
+import { parseDataPathname } from '../shared/lib/page-path/normalize-data-path'
 import * as Log from '../build/output/log'
 import { getServerUtils } from './server-utils'
 import isError, { getProperError } from '../lib/is-error'
@@ -117,8 +118,6 @@ import {
   NEXT_RESUME_HEADER,
 } from '../lib/constants'
 import { normalizeLocalePath } from '../shared/lib/i18n/normalize-locale-path'
-import { matchNextDataPathname } from './lib/match-next-data-pathname'
-import getRouteFromAssetPath from '../shared/lib/router/utils/get-route-from-asset-path'
 import { RSCPathnameNormalizer } from './normalizers/request/rsc'
 import { stripFlightHeaders } from './app-render/strip-flight-headers'
 import {
@@ -685,39 +684,32 @@ export default abstract class Server<
 
   private handleNextDataRequest: RouteHandler<ServerRequest, ServerResponse> =
     async (req, res, parsedUrl) => {
-      const middleware = await this.getMiddleware()
-      const params = matchNextDataPathname(parsedUrl.pathname)
+      const dataPathnameInfo = parseDataPathname(parsedUrl.pathname || '')
 
       // ignore for non-next data URLs
-      if (!params || !params.path) {
+      if (!dataPathnameInfo) {
+        if (parsedUrl.pathname?.startsWith('/_next/data/')) {
+          await this.render404(req, res, parsedUrl)
+          return true
+        }
+
         return false
       }
 
-      if (params.path[0] !== this.buildId) {
+      // show 404 if it doesn't match the expected build id
+      if (dataPathnameInfo.buildId !== this.buildId) {
         // Ignore if its a middleware request when we aren't on edge.
         if (getRequestMeta(req, 'middlewareInvoke')) {
           return false
         }
 
-        // Make sure to 404 if the buildId isn't correct
         await this.render404(req, res, parsedUrl)
         return true
       }
 
-      // remove buildId from URL
-      params.path.shift()
+      const middleware = await this.getMiddleware()
 
-      const lastParam = params.path[params.path.length - 1]
-
-      // show 404 if it doesn't end with .json
-      if (typeof lastParam !== 'string' || !lastParam.endsWith('.json')) {
-        await this.render404(req, res, parsedUrl)
-        return true
-      }
-
-      // re-create page's pathname
-      let pathname = `/${params.path.join('/')}`
-      pathname = getRouteFromAssetPath(pathname, '.json')
+      let pathname = dataPathnameInfo.pathname
 
       // ensure trailing slash is normalized per config
       if (middleware) {
@@ -2465,12 +2457,15 @@ export default abstract class Server<
   }
 
   private stripNextDataPath(filePath: string, stripLocale = true) {
-    if (filePath.includes(this.buildId)) {
-      const splitPath = filePath.substring(
-        filePath.indexOf(this.buildId) + this.buildId.length
-      )
+    const [pathname, ...searchParts] = filePath.split('?')
+    const dataPathnameInfo = parseDataPathname(pathname)
 
-      filePath = denormalizePagePath(splitPath.replace(/\.json$/, ''))
+    if (dataPathnameInfo?.buildId === this.buildId) {
+      filePath = denormalizePagePath(dataPathnameInfo.pathname)
+
+      if (searchParts.length > 0) {
+        filePath += `?${searchParts.join('?')}`
+      }
     }
 
     if (this.localeNormalizer && stripLocale) {

--- a/packages/next/src/server/lib/match-next-data-pathname.ts
+++ b/packages/next/src/server/lib/match-next-data-pathname.ts
@@ -1,9 +1,0 @@
-import { getPathMatch } from '../../shared/lib/router/utils/path-match'
-
-const matcher = getPathMatch('/_next/data/:path*')
-
-export function matchNextDataPathname(pathname: string | null | undefined) {
-  if (typeof pathname !== 'string') return false
-
-  return matcher(pathname)
-}

--- a/packages/next/src/server/lib/router-utils/filesystem.ts
+++ b/packages/next/src/server/lib/router-utils/filesystem.ts
@@ -46,6 +46,7 @@ import { normalizeMetadataRoute } from '../../../lib/metadata/get-metadata-route
 import { RSCPathnameNormalizer } from '../../normalizers/request/rsc'
 import { encodeURIPath } from '../../../shared/lib/encode-uri-path'
 import { isMetadataRouteFile } from '../../../lib/metadata/is-metadata-route'
+import { parseDataPathname } from '../../../shared/lib/page-path/normalize-data-path'
 
 export type FsOutput = {
   type:
@@ -582,22 +583,12 @@ export async function setupFsCheck(opts: {
           continue
         }
 
-        const nextDataPrefix = `/_next/data/${buildId}/`
+        const parsedDataPathname =
+          type === 'pageFile' ? parseDataPathname(curItemPath) : undefined
 
-        if (
-          type === 'pageFile' &&
-          curItemPath.startsWith(nextDataPrefix) &&
-          curItemPath.endsWith('.json')
-        ) {
+        if (parsedDataPathname?.buildId === buildId) {
           items = nextDataRoutes
-          // remove _next/data/<build-id> prefix
-          curItemPath = curItemPath.substring(nextDataPrefix.length - 1)
-
-          // remove .json postfix
-          curItemPath = curItemPath.substring(
-            0,
-            curItemPath.length - '.json'.length
-          )
+          curItemPath = parsedDataPathname.pathname
           const curLocaleResult = handleLocale(curItemPath)
           curItemPath =
             curLocaleResult.pathname === '/index'

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -31,6 +31,7 @@ import { normalizeLocalePath } from '../../../shared/lib/i18n/normalize-locale-p
 import { removePathPrefix } from '../../../shared/lib/router/utils/remove-path-prefix'
 import { NextDataPathnameNormalizer } from '../../normalizers/request/next-data'
 import { BasePathPathnameNormalizer } from '../../normalizers/request/base-path'
+import { parseDataPathname } from '../../../shared/lib/page-path/normalize-data-path'
 
 import { addRequestMeta } from '../../request-meta'
 import {
@@ -301,6 +302,19 @@ export function getResolveRoutes(
         }
         curPathname = curPathname?.substring(config.basePath.length) || '/'
       }
+
+      // Parse once and reuse for both the guard and isNextDataReq marking.
+      // If the path looks like _next/data but has no valid/matching build ID,
+      // short-circuit before dynamic route matching to avoid catch-all matches
+      // (e.g. pages/[...slug]) returning 200 instead of 404.
+      const isDataPath = curPathname?.startsWith('/_next/data/')
+      const parsedData = isDataPath
+        ? parseDataPathname(curPathname!)
+        : undefined
+      if (isDataPath && parsedData?.buildId !== fsChecker.buildId) {
+        return
+      }
+
       const localeResult = fsChecker.handleLocale(curPathname || '')
 
       for (const route of dynamicRoutes) {
@@ -327,7 +341,7 @@ export function getResolveRoutes(
             continue
           }
 
-          if (pageOutput && curPathname?.startsWith('/_next/data')) {
+          if (pageOutput && parsedData) {
             addRequestMeta(req, 'isNextDataReq', true)
           }
 

--- a/packages/next/src/server/normalizers/request/next-data.test.ts
+++ b/packages/next/src/server/normalizers/request/next-data.test.ts
@@ -1,6 +1,35 @@
 import { NextDataPathnameNormalizer } from './next-data'
+import { parseDataPathname } from '../../../shared/lib/page-path/normalize-data-path'
 
 describe('NextDataPathnameNormalizer', () => {
+  describe('parseDataPathname', () => {
+    it('should parse build id and pathname', () => {
+      expect(parseDataPathname('/_next/data/build-id/foo/bar.json')).toEqual({
+        buildId: 'build-id',
+        pathname: '/foo/bar',
+      })
+    })
+
+    it('should normalize index to root', () => {
+      expect(parseDataPathname('/_next/data/build-id/index.json')).toEqual({
+        buildId: 'build-id',
+        pathname: '/',
+      })
+    })
+
+    it('should handle root path with empty route segment', () => {
+      expect(parseDataPathname('/_next/data/build-id/.json')).toEqual({
+        buildId: 'build-id',
+        pathname: '/',
+      })
+    })
+
+    it('should return undefined for malformed data pathnames', () => {
+      expect(parseDataPathname('/_next/data/build-id/foo')).toBeUndefined()
+      expect(parseDataPathname('/_next/data//foo.json')).toBeUndefined()
+    })
+  })
+
   describe('constructor', () => {
     it('should error when no buildID is provided', () => {
       expect(() => {
@@ -37,6 +66,11 @@ describe('NextDataPathnameNormalizer', () => {
       for (const pathname of pathnames) {
         expect(normalizer.match(pathname)).toBe(true)
       }
+    })
+
+    it('should return false when the build id does not match', () => {
+      const normalizer = new NextDataPathnameNormalizer('build-id')
+      expect(normalizer.match('/_next/data/another-build/foo.json')).toBe(false)
     })
   })
 

--- a/packages/next/src/server/normalizers/request/next-data.ts
+++ b/packages/next/src/server/normalizers/request/next-data.ts
@@ -1,31 +1,34 @@
 import type { PathnameNormalizer } from './pathname-normalizer'
 
 import { denormalizePagePath } from '../../../shared/lib/page-path/denormalize-page-path'
-import { PrefixPathnameNormalizer } from './prefix'
-import { SuffixPathnameNormalizer } from './suffix'
+import { parseDataPathname } from '../../../shared/lib/page-path/normalize-data-path'
 
 export class NextDataPathnameNormalizer implements PathnameNormalizer {
-  private readonly prefix: PrefixPathnameNormalizer
-  private readonly suffix = new SuffixPathnameNormalizer('.json')
+  private readonly buildID: string
+
   constructor(buildID: string) {
     if (!buildID) {
       throw new Error('Invariant: buildID is required')
     }
 
-    this.prefix = new PrefixPathnameNormalizer(`/_next/data/${buildID}`)
+    this.buildID = buildID
   }
 
   public match(pathname: string) {
-    return this.prefix.match(pathname) && this.suffix.match(pathname)
+    const dataPathnameInfo = parseDataPathname(pathname)
+    return dataPathnameInfo?.buildId === this.buildID
   }
 
   public normalize(pathname: string, matched?: boolean): string {
     // If we're not matched and we don't match, we don't need to normalize.
     if (!matched && !this.match(pathname)) return pathname
 
-    pathname = this.prefix.normalize(pathname, true)
-    pathname = this.suffix.normalize(pathname, true)
+    const dataPathnameInfo = parseDataPathname(pathname)
 
-    return denormalizePagePath(pathname)
+    if (!dataPathnameInfo || dataPathnameInfo.buildId !== this.buildID) {
+      return pathname
+    }
+
+    return denormalizePagePath(dataPathnameInfo.pathname)
   }
 }

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -41,8 +41,7 @@ import type { PreviewData } from '../../types'
 import type { BuildManifest } from '../get-page-files'
 import type { ReactLoadableManifest } from '../load-components'
 import type { NextFontManifest } from '../../build/webpack/plugins/next-font-manifest-plugin'
-import { normalizeDataPath } from '../../shared/lib/page-path/normalize-data-path'
-import { pathHasPrefix } from '../../shared/lib/router/utils/path-has-prefix'
+import { parseDataPathname } from '../../shared/lib/page-path/normalize-data-path'
 import {
   addRequestMeta,
   getRequestMeta,
@@ -649,7 +648,8 @@ export abstract class RouteModule<
       ensureInstrumentationRegistered(absoluteProjectDir, this.distDir)
     }
     const manifests = this.loadManifests(srcPage, absoluteProjectDir)
-    const { routesManifest, prerenderManifest, serverFilesManifest } = manifests
+    const { buildId, routesManifest, prerenderManifest, serverFilesManifest } =
+      manifests
 
     const { basePath, i18n, rewrites } = routesManifest
 
@@ -683,10 +683,15 @@ export abstract class RouteModule<
       return
     }
     let isNextDataRequest = false
+    const normalizeDataPathname = (pathname: string) => {
+      const info = parseDataPathname(pathname)
+      return info?.buildId === buildId ? info.pathname : pathname
+    }
 
-    if (pathHasPrefix(parsedUrl.pathname || '/', '/_next/data')) {
+    const initialDataPathname = parseDataPathname(parsedUrl.pathname || '/')
+    if (initialDataPathname?.buildId === buildId) {
       isNextDataRequest = true
-      parsedUrl.pathname = normalizeDataPath(parsedUrl.pathname || '/')
+      parsedUrl.pathname = initialDataPathname.pathname
     }
     this.normalizeUrl(req, parsedUrl)
     let originalPathname = parsedUrl.pathname || '/'
@@ -779,7 +784,7 @@ export abstract class RouteModule<
     // attempt parsing from pathname
     if (!params && serverUtils.dynamicRouteMatcher) {
       const paramsMatch = serverUtils.dynamicRouteMatcher(
-        normalizeDataPath(
+        normalizeDataPathname(
           rewrittenParsedUrl?.pathname || parsedUrl.pathname || '/'
         )
       )
@@ -904,7 +909,7 @@ export abstract class RouteModule<
         } else {
           // use final params from URL matching
           const paramsMatch = serverUtils.dynamicRouteMatcher?.(
-            normalizeDataPath(
+            normalizeDataPathname(
               localeResult?.pathname || parsedUrl.pathname || '/'
             )
           )

--- a/packages/next/src/shared/lib/page-path/normalize-data-path.ts
+++ b/packages/next/src/shared/lib/page-path/normalize-data-path.ts
@@ -1,18 +1,23 @@
-import { pathHasPrefix } from '../router/utils/path-has-prefix'
+const NEXT_DATA_PATHNAME_REGEX = /^\/_next\/data\/([^/]+)\/(.*)\.json$/
+
+export function parseDataPathname(
+  pathname: string
+): { buildId: string; pathname: string } | undefined {
+  const match = pathname.match(NEXT_DATA_PATHNAME_REGEX)
+  if (!match) return
+
+  const [, buildId, routePath] = match
+  const routePathname = `/${routePath}`
+
+  return {
+    buildId,
+    pathname: routePathname === '/index' ? '/' : routePathname,
+  }
+}
 
 /**
  * strip _next/data/<build-id>/ prefix and .json suffix
  */
 export function normalizeDataPath(pathname: string) {
-  if (!pathHasPrefix(pathname || '/', '/_next/data')) {
-    return pathname
-  }
-  pathname = pathname
-    .replace(/\/_next\/data\/[^/]{1,}/, '')
-    .replace(/\.json$/, '')
-
-  if (pathname === '/index') {
-    return '/'
-  }
-  return pathname
+  return parseDataPathname(pathname)?.pathname ?? pathname
 }

--- a/packages/next/src/shared/lib/router/utils/get-next-pathname-info.ts
+++ b/packages/next/src/shared/lib/router/utils/get-next-pathname-info.ts
@@ -2,6 +2,7 @@ import { normalizeLocalePath } from '../../i18n/normalize-locale-path'
 import { removePathPrefix } from './remove-path-prefix'
 import { pathHasPrefix } from './path-has-prefix'
 import type { I18NProvider } from '../../../../server/lib/i18n-provider'
+import { parseDataPathname } from '../../page-path/normalize-data-path'
 
 export interface NextPathnameInfo {
   /**
@@ -66,19 +67,10 @@ export function getNextPathnameInfo(
   }
   let pathnameNoDataPrefix = info.pathname
 
-  if (
-    info.pathname.startsWith('/_next/data/') &&
-    info.pathname.endsWith('.json')
-  ) {
-    const paths = info.pathname
-      .replace(/^\/_next\/data\//, '')
-      .replace(/\.json$/, '')
-      .split('/')
-
-    const buildId = paths[0]
-    info.buildId = buildId
-    pathnameNoDataPrefix =
-      paths[1] !== 'index' ? `/${paths.slice(1).join('/')}` : '/'
+  const dataPathnameInfo = parseDataPathname(info.pathname)
+  if (dataPathnameInfo) {
+    info.buildId = dataPathnameInfo.buildId
+    pathnameNoDataPrefix = dataPathnameInfo.pathname
 
     // update pathname with normalized if enabled although
     // we use normalized to populate locale info still

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -1051,6 +1051,15 @@ describe('Prerender', () => {
       }
     })
 
+    it('should 404 for data urls with a wrong build id', async () => {
+      const res = await fetchViaHTTP(
+        next.url,
+        `/_next/data/${next.buildId}-wrong/index.json`
+      )
+
+      expect(res.status).toBe(404)
+    })
+
     it('should allow rewriting to SSG page with fallback: false', async () => {
       const html = await renderViaHTTP(next.url, '/about')
       expect(html).toMatch(/About:.*?en/)


### PR DESCRIPTION
## Summary
- centralize `_next/data` parsing into `parseDataPathname` and reuse it across server routing/normalization paths
- enforce build ID matching before treating a request as a data request, and return 404 for malformed or mismatched `_next/data` URLs
- remove the legacy `matchNextDataPathname` helper and add concise integration coverage for wrong-build-id data URLs

## Testing
- `pnpm testonly packages/next/src/server/normalizers/request/next-data.test.ts`
- `pnpm test-dev-turbo test/e2e/prerender.test.ts -t "wrong build id"`