### PR TITLE
[create-next-app] Improve AGENTS.md prompt wording

### DIFF
--- a/packages/create-next-app/helpers/generate-agent-files.ts
+++ b/packages/create-next-app/helpers/generate-agent-files.ts
@@ -7,9 +7,9 @@ import path from 'path'
  */
 export function generateAgentFiles(root: string): void {
   const agentsMdContent = `<!-- BEGIN:nextjs-agent-rules -->
-# Next.js: ALWAYS read docs before coding
+# This is NOT the Next.js you know
 
-Before any Next.js work, find and read the relevant doc in \`node_modules/next/dist/docs/\`. Your training data is outdated — the docs are the source of truth.
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in \`node_modules/next/dist/docs/\` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
 `
 


### PR DESCRIPTION
Updates the `AGENTS.md` content generated by `create-next-app` to use clearer wording that better signals to models that their training data may be outdated.

The prompt wording was determined by running evals continuously until we found a prompt that is objectively unbiased and shows no signs of regression on any tests across all models.

**Before:**
> Next.js: ALWAYS read docs before coding
> Before any Next.js work, find and read the relevant doc in `node_modules/next/dist/docs/`. Your training data is outdated — the docs are the source of truth.

**After:**
> This is NOT the Next.js you know
> This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.