### PR TITLE
fix(next): avoid SegmentViewNode key warnings for shared cache props

### DIFF
--- a/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
+++ b/packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx
@@ -29,13 +29,13 @@ export type SegmentNodeState = {
   setBoundaryType: (type: SegmentBoundaryType | null) => void
 }
 
-function SegmentTrieNode({
+function useRegisterSegmentNode({
   type,
   pagePath,
 }: {
   type: string
   pagePath: string
-}): React.ReactNode {
+}): void {
   const { boundaryType, setBoundaryType } = useSegmentState()
   const nodeState: SegmentNodeState = useMemo(() => {
     return {
@@ -54,8 +54,6 @@ function SegmentTrieNode({
       dispatcher.segmentExplorerNodeRemove(nodeState)
     }
   }, [nodeState])
-
-  return null
 }
 
 function NotFoundSegmentNode(): React.ReactNode {
@@ -104,16 +102,8 @@ export function SegmentViewNode({
   pagePath: string
   children?: ReactNode
 }): React.ReactNode {
-  const segmentNode = (
-    <SegmentTrieNode key={type} type={type} pagePath={pagePath} />
-  )
-
-  return (
-    <>
-      {segmentNode}
-      {children}
-    </>
-  )
+  useRegisterSegmentNode({ type, pagePath })
+  return children ?? null
 }
 
 const SegmentStateContext = createContext<{

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -373,6 +373,52 @@ describe(`Terminal Logging (${bundlerName})`, () => {
     })
   })
 
+  describe('App Router - Cache Components', () => {
+    let next: NextInstance
+    let logs: string[] = []
+    let logCapture: ReturnType<typeof setupLogCapture>
+
+    beforeAll(async () => {
+      logCapture = setupLogCapture()
+      logs = logCapture.logs
+
+      next = await createNext({
+        files: {
+          app: new FileRef(join(__dirname, 'fixtures/cache-components-app')),
+          'next.config.js': new FileRef(
+            join(__dirname, 'fixtures/cache-components-next.config.js')
+          ),
+        },
+      })
+    })
+
+    afterAll(async () => {
+      logCapture.restore()
+      await next.destroy()
+    })
+
+    beforeEach(() => {
+      logCapture.clearLogs()
+    })
+
+    it('should not log key warnings at SegmentViewNode for shared object refs', async () => {
+      const outputIndex = logs.length
+      const browser = await webdriver(next.url, '/')
+      await browser.waitForElementByCss('p')
+      expect(await browser.elementByCss('p').text()).toBe('Apple: 1 items')
+
+      await retry(() => {
+        const newLogs = logs.slice(outputIndex).join('\n')
+        expect(newLogs).not.toContain(
+          'Each child in a list should have a unique "key" prop'
+        )
+        expect(newLogs).not.toContain('SegmentViewNode')
+      })
+
+      await browser.close()
+    })
+  })
+
   describe('App Router - Edge Runtime', () => {
     let next: NextInstance
     let logs: string[] = []

--- a/test/development/browser-logs/fixtures/cache-components-app/client.js
+++ b/test/development/browser-logs/fixtures/cache-components-app/client.js
@@ -1,0 +1,9 @@
+'use client'
+
+export function Display({ item, items }) {
+  return (
+    <p>
+      {item.name}: {items.length} items
+    </p>
+  )
+}

--- a/test/development/browser-logs/fixtures/cache-components-app/layout.js
+++ b/test/development/browser-logs/fixtures/cache-components-app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/browser-logs/fixtures/cache-components-app/page.js
+++ b/test/development/browser-logs/fixtures/cache-components-app/page.js
@@ -1,0 +1,8 @@
+'use cache'
+
+import { Display } from './client'
+
+export default async function Page() {
+  const item = { id: '1', name: 'Apple', tags: ['fruit'] }
+  return <Display item={item} items={[item]} />
+}

--- a/test/development/browser-logs/fixtures/cache-components-next.config.js
+++ b/test/development/browser-logs/fixtures/cache-components-next.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  logging: {
+    browserToTerminal: true,
+  },
+  cacheComponents: true,
+  turbopack: {
+    root: __dirname,
+  },
+}


### PR DESCRIPTION
﻿## What?

Fix spurious React key warnings emitted at the `SegmentViewNode` boundary when Cache Components pages pass shared object references across a `"use cache"` boundary.

- Preserve Segment Explorer registration side effects
- Remove extra wrapper child shape emitted by `SegmentViewNode`
- Add regression coverage for shared-object props scenario

## Why?

Issue #90099 reports a warning:

- `Each child in a list should have a unique "key" prop.`
- `Check the top-level render call using <SegmentViewNode>...`

The page itself is not rendering a keyed list. The warning comes from the devtools wrapper layer (`SegmentViewNode`) in dev mode, not userland list rendering.

## How?

### Runtime fix

Updated:

- `packages/next/src/next-devtools/userspace/app/segment-explorer-node.tsx`

Changes:

- Moved segment registration behavior into a hook-style helper (`useRegisterSegmentNode`)
- `SegmentViewNode` now returns only `children ?? null`
- Keeps `segmentExplorerNodeAdd/Remove` behavior unchanged

This avoids introducing an extra sibling wrapper shape that triggers key checks while preserving devtools node tracking.

### Tests

Added regression test and fixtures:

- `test/development/browser-logs/browser-logs.test.ts`
  - `should not log key warnings at SegmentViewNode for shared object refs`
- `test/development/browser-logs/fixtures/cache-components-next.config.js`
- `test/development/browser-logs/fixtures/cache-components-app/layout.js`
- `test/development/browser-logs/fixtures/cache-components-app/page.js`
- `test/development/browser-logs/fixtures/cache-components-app/client.js`

## Validation

- `pnpm --filter=next build` (pass)
- `pnpm test-dev-webpack test/development/browser-logs/browser-logs.test.ts -t "should not log key warnings at SegmentViewNode for shared object refs"` (pass)
- `pnpm lint-eslint ...` on changed files (pass)

Fixes #90099
