### PR TITLE
test: Include full error message in toDisplayRedbox

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -99,7 +99,11 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./node_modules/my-package/index.js (1:1)
        Module not found: Can't resolve 'dns'
        > 1 | const dns = require('dns')
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found
+       Import trace for requested module:
+       ./index.js
+       ./app/page.js",
          "stack": [],
        }
       `)
@@ -177,7 +181,10 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./index.js (1:1)
        Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found
+       Import trace for requested module:
+       ./app/page.js",
          "stack": [],
        }
       `)
@@ -253,7 +260,8 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./app/page.js (2:1)
        Module not found: Can't resolve 'b'
        > 2 | import Comp from 'b'
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -325,7 +333,8 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./app/page.js (2:1)
        Module not found: Can't resolve './non-existent.css'
        > 2 | import './non-existent.css'
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox-builtins.test.ts
@@ -54,7 +54,19 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./node_modules/my-package/index.js (1:13)
        Module not found: Can't resolve 'dns'
        > 1 | const dns = require('dns')
-           |             ^^^^^^^^^^^^^^",
+           |             ^^^^^^^^^^^^^^
+       Import traces:
+         Client Component Browser:
+           ./node_modules/my-package/index.js [Client Component Browser]
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./node_modules/my-package/index.js [Client Component SSR]
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -121,7 +133,17 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./index.js (1:1)
        Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
-           | ^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^
+       Import traces:
+         Client Component Browser:
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -190,7 +212,15 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./app/page.js (2:1)
        Module not found: Can't resolve 'b'
        > 2 | import Comp from 'b'
-           | ^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^
+       Import traces:
+         Client Component Browser:
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -256,7 +286,15 @@ describe('ReactRefreshLogBox-builtins app', () => {
          "source": "./app/page.js (2:1)
        Module not found: Can't resolve './non-existent.css'
        > 2 | import './non-existent.css'
-           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       Import traces:
+         Client Component Browser:
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -287,7 +287,17 @@ describe('ReactRefreshLogBox app', () => {
          "source": "./index.js (7:1)
        Parsing ecmascript source code failed
        > 7 | }
-           | ^",
+           | ^
+       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+       Import traces:
+         Client Component Browser:
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -497,7 +497,19 @@ describe('ReactRefreshLogBox app', () => {
          "source": "./index.module.css (1:8)
        Parsing CSS source code failed
        > 1 | .button
-           |        ^",
+           |        ^
+       Unexpected end of input
+       Import traces:
+         Client Component Browser:
+           ./index.module.css [Client Component Browser]
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.module.css [Client Component SSR]
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)
@@ -1448,7 +1460,12 @@ describe('ReactRefreshLogBox app', () => {
          "source": "./app/module.js (1:1)
        Module not found: Can't resolve 'non-existing-module'
        > 1 | import "non-existing-module"
-           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       Import trace:
+         Server Component:
+           ./app/module.js
+           ./app/layout.js
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -1524,7 +1541,13 @@ describe('ReactRefreshLogBox app', () => {
          "source": "./app/styles2.css (1:1)
        Module not found: Can't resolve './boom.css'
        > 1 | @import "./boom.css"
-           | ^",
+           | ^
+       Import trace:
+         Client Component Browser:
+           ./app/styles2.css [Client Component Browser]
+           ./app/styles1.css [Client Component Browser]
+           ./app/layout.js [Server Component]
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1479,7 +1479,10 @@ describe('ReactRefreshLogBox app', () => {
          "source": "./app/module.js (1:1)
        Module not found: Can't resolve 'non-existing-module'
        > 1 | import "non-existing-module"
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found
+       Import trace for requested module:
+       ./app/layout.js",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -40,7 +40,15 @@ describe('ReactRefreshLogBox app', () => {
          "source": "./app/page.js (3:23)
        Ecmascript file had an error
        > 3 | export async function getStaticProps() {
-           |                       ^^^^^^^^^^^^^^",
+           |                       ^^^^^^^^^^^^^^
+       "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+       Import traces:
+         Client Component Browser:
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -49,7 +49,17 @@ describe('Error recovery app', () => {
          "source": "./index.js (1:27)
        Parsing ecmascript source code failed
        > 1 | export default () => <div/
-           |                           ^",
+           |                           ^
+       Expected '>', got '<eof>'
+       Import traces:
+         Client Component Browser:
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)
@@ -142,7 +152,8 @@ describe('Error recovery app', () => {
          "source": "./app/server/page.js (2:28)
        Parsing ecmascript source code failed
        > 2 |   return <p>Hello world</p>
-           |                            ^",
+           |                            ^
+       Expected '}', got '<eof>'",
          "stack": [],
        }
       `)
@@ -226,7 +237,15 @@ describe('Error recovery app', () => {
          "source": "./app/client/page.js (2:28)
        Parsing ecmascript source code failed
        > 2 |   return <p>Hello world</p>
-           |                            ^",
+           |                            ^
+       Expected '}', got '<eof>'
+       Import traces:
+         Client Component Browser:
+           ./app/client/page.js [Client Component Browser]
+           ./app/client/page.js [Server Component]
+         Client Component SSR:
+           ./app/client/page.js [Client Component SSR]
+           ./app/client/page.js [Server Component]",
          "stack": [],
        }
       `)
@@ -661,7 +680,17 @@ describe('Error recovery app', () => {
          "source": "./index.js (10:42)
        Parsing ecmascript source code failed
        > 10 | export default function FunctionNamed() {
-            |                                          ^",
+            |                                          ^
+       Expected '}', got '<eof>'
+       Import traces:
+         Client Component Browser:
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)
@@ -721,7 +750,17 @@ describe('Error recovery app', () => {
          "source": "./index.js (10:42)
        Parsing ecmascript source code failed
        > 10 | export default function FunctionNamed() {
-            |                                          ^",
+            |                                          ^
+       Expected '}', got '<eof>'
+       Import traces:
+         Client Component Browser:
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)
@@ -913,7 +952,17 @@ describe('Error recovery app', () => {
          "source": "./index.js (5:5)
        Parsing ecmascript source code failed
        > 5 |     return <h1>Default Export</h1>;
-           |     ^^^^^^",
+           |     ^^^^^^
+       Expected '{', got 'return'
+       Import traces:
+         Client Component Browser:
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)
@@ -996,7 +1045,17 @@ describe('Error recovery app', () => {
          "source": "./index.js (5:5)
        Parsing ecmascript source code failed
        > 5 |     throw new Error('nooo');
-           |     ^^^^^",
+           |     ^^^^^
+       Expected '{', got 'throw'
+       Import traces:
+         Client Component Browser:
+           ./index.js [Client Component Browser]
+           ./app/page.js [Client Component Browser]
+           ./app/page.js [Server Component]
+         Client Component SSR:
+           ./index.js [Client Component SSR]
+           ./app/page.js [Client Component SSR]
+           ./app/page.js [Server Component]",
          "stack": [],
        }
       `)
@@ -1122,7 +1181,8 @@ describe('Error recovery app', () => {
          "source": "./app/page.js (1:4)
        Parsing ecmascript source code failed
        > 1 | {{{
-           |    ^",
+           |    ^
+       Expected '}', got '<eof>'",
          "stack": [],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -112,7 +112,8 @@ describe('ReactRefreshLogBox _app _document', () => {
          "source": "./pages/_app.js (2:10)
        Parsing ecmascript source code failed
        > 2 |   return <<Component {...pageProps} />;
-           |          ^^",
+           |          ^^
+       Expression expected",
          "stack": [],
        }
       `)
@@ -231,7 +232,8 @@ describe('ReactRefreshLogBox _app _document', () => {
          "source": "./pages/_document.js (3:36)
        Parsing ecmascript source code failed
        > 3 | class MyDocument extends Document {{
-           |                                    ^",
+           |                                    ^
+       Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key",
          "stack": [],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -85,7 +85,11 @@ describe('ReactRefreshLogBox', () => {
          "source": "./node_modules/my-package/index.js (1:1)
        Module not found: Can't resolve 'dns'
        > 1 | const dns = require('dns')
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found
+       Import trace for requested module:
+       ./index.js
+       ./pages/index.js",
          "stack": [],
        }
       `)
@@ -154,7 +158,10 @@ describe('ReactRefreshLogBox', () => {
          "source": "./index.js (1:1)
        Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found
+       Import trace for requested module:
+       ./pages/index.js",
          "stack": [],
        }
       `)
@@ -222,7 +229,8 @@ describe('ReactRefreshLogBox', () => {
          "source": "./pages/index.js (1:1)
        Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -295,7 +303,8 @@ describe('ReactRefreshLogBox', () => {
          "source": "./pages/_app.js (1:1)
        Module not found: Can't resolve './non-existent.css'
        > 1 | import './non-existent.css'
-           | ^",
+           | ^
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-builtins.test.ts
@@ -53,7 +53,13 @@ describe('ReactRefreshLogBox', () => {
          "source": "./node_modules/my-package/index.js (1:13)
        Module not found: Can't resolve 'dns'
        > 1 | const dns = require('dns')
-           |             ^^^^^^^^^^^^^^",
+           |             ^^^^^^^^^^^^^^
+       Import trace:
+         Browser:
+           ./node_modules/my-package/index.js
+           ./index.js
+           ./pages/index.js
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -124,7 +130,15 @@ describe('ReactRefreshLogBox', () => {
          "source": "./index.js (1:1)
        Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
-           | ^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^
+       Import traces:
+         Browser:
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.js
+           ./pages/index.js
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -196,7 +210,8 @@ describe('ReactRefreshLogBox', () => {
          "source": "./pages/index.js (1:1)
        Module not found: Can't resolve 'b'
        > 1 | import Comp from 'b'
-           | ^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)
@@ -272,7 +287,8 @@ describe('ReactRefreshLogBox', () => {
          "source": "./pages/_app.js (1:1)
        Module not found: Can't resolve './non-existent.css'
        > 1 | import './non-existent.css'
-           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       https://nextjs.org/docs/messages/module-not-found",
          "stack": [],
        }
       `)

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -448,7 +448,15 @@ describe('ReactRefreshLogBox', () => {
          "source": "./index.js (7:1)
        Parsing ecmascript source code failed
        > 7 | }
-           | ^",
+           | ^
+       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
+       Import traces:
+         Browser:
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.js
+           ./pages/index.js",
          "stack": [],
        }
       `)
@@ -715,7 +723,17 @@ describe('ReactRefreshLogBox', () => {
          "source": "./index.module.css (1:8)
        Parsing CSS source code failed
        > 1 | .button
-           |        ^",
+           |        ^
+       Unexpected end of input
+       Import traces:
+         Browser:
+           ./index.module.css
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.module.css
+           ./index.js
+           ./pages/index.js",
          "stack": [],
        }
       `)

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -51,7 +51,15 @@ describe('pages/ error recovery', () => {
          "source": "./index.js (1:27)
        Parsing ecmascript source code failed
        > 1 | export default () => <div/
-           |                           ^",
+           |                           ^
+       Expected '>', got '<eof>'
+       Import traces:
+         Browser:
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.js
+           ./pages/index.js",
          "stack": [],
        }
       `)
@@ -409,7 +417,15 @@ describe('pages/ error recovery', () => {
          "source": "./index.js (5:5)
        Parsing ecmascript source code failed
        > 5 |     return <h1>Default Export</h1>;
-           |     ^^^^^^",
+           |     ^^^^^^
+       Expected '{', got 'return'
+       Import traces:
+         Browser:
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.js
+           ./pages/index.js",
          "stack": [],
        }
       `)
@@ -493,7 +509,15 @@ describe('pages/ error recovery', () => {
          "source": "./index.js (5:5)
        Parsing ecmascript source code failed
        > 5 |     throw new Error('nooo');
-           |     ^^^^^",
+           |     ^^^^^
+       Expected '{', got 'throw'
+       Import traces:
+         Browser:
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.js
+           ./pages/index.js",
          "stack": [],
        }
       `)
@@ -827,7 +851,15 @@ describe('pages/ error recovery', () => {
          "source": "./index.js (7:42)
        Parsing ecmascript source code failed
        > 7 | export default function FunctionNamed() {
-           |                                          ^",
+           |                                          ^
+       Expected '}', got '<eof>'
+       Import traces:
+         Browser:
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.js
+           ./pages/index.js",
          "stack": [],
        }
       `)
@@ -892,7 +924,15 @@ describe('pages/ error recovery', () => {
          "source": "./index.js (7:42)
        Parsing ecmascript source code failed
        > 7 | export default function FunctionNamed() {
-           |                                          ^",
+           |                                          ^
+       Expected '}', got '<eof>'
+       Import traces:
+         Browser:
+           ./index.js
+           ./pages/index.js
+         SSR:
+           ./index.js
+           ./pages/index.js",
          "stack": [],
        }
       `)

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -144,7 +144,8 @@ describe('Cache Components Dev Errors', () => {
              "source": "./app/page.tsx (1:14)
            Ecmascript file had an error
            > 1 | export const revalidate = 10
-               |              ^^^^^^^^^^",
+               |              ^^^^^^^^^^
+           Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
              "stack": [],
            }
           `)

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -185,7 +185,9 @@ describe('react-dom/server in React Server environment', () => {
          "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
        Ecmascript file had an error
        > 3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
-           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+           | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+       Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
          "stack": [],
        }
       `)

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -498,7 +498,8 @@ describe('middleware - development errors', () => {
            "source": "./middleware.js (1:28)
          Parsing ecmascript source code failed
          > 1 | export default function () }
-             |                            ^",
+             |                            ^
+         Expected '{', got '}'",
            "stack": [],
          }
         `)
@@ -583,7 +584,8 @@ describe('middleware - development errors', () => {
            "source": "./middleware.js (1:28)
          Parsing ecmascript source code failed
          > 1 | export default function () }
-             |                            ^",
+             |                            ^
+         Expected '{', got '}'",
            "stack": [],
          }
         `)

--- a/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
+++ b/test/e2e/app-dir/app-edge/app-edge-invalid-reexport.test.ts
@@ -36,7 +36,9 @@ describe('app-dir edge SSR invalid reexport', () => {
            "source": "./app/export/inherit/page.tsx (1:28)
          Next.js can't recognize the exported \`preferredRegion\` field in route. It mustn't be reexported.
          > 1 | export { default, runtime, preferredRegion } from '../basic/page'
-             |                            ^^^^^^^^^^^^^^^",
+             |                            ^^^^^^^^^^^^^^^
+         The exported configuration object in a source file needs to have a very specific format from which some properties can be statically parsed at compiled-time.
+         https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config",
            "stack": [],
          }
         `)

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -28,7 +28,8 @@ describe('use-cache-segment-configs', () => {
            "source": "./app/runtime/page.tsx (1:14)
          Ecmascript file had an error
          > 1 | export const runtime = 'edge'
-             |              ^^^^^^^",
+             |              ^^^^^^^
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
            "stack": [],
          }
         `)

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -91,8 +91,7 @@ export interface ErrorSnapshot {
 }
 
 /**
- * Focus source to just the header, errored line, and cursor.
- * Strips surrounding context lines.
+ * Strips surrounding context lines from the codeframe.
  */
 function focusSource(
   source: string | null,
@@ -102,6 +101,7 @@ function focusSource(
 
   let focusedSource = ''
   const sourceFrameLines = source.split('\n')
+  let encounteredCursor = false
   for (let i = 0; i < sourceFrameLines.length; i++) {
     const sourceFrameLine = sourceFrameLines[i].trimEnd()
     if (sourceFrameLine === '') {
@@ -109,12 +109,18 @@ function focusSource(
     }
 
     if (sourceFrameLine.startsWith('>')) {
-      // This is where the cursor will point
-      // Include the cursor and nothing below since it's just surrounding code.
-      focusedSource += '\n' + sourceFrameLine
-      focusedSource += '\n' + sourceFrameLines[i + 1]
-      break
+      if (!encounteredCursor) {
+        // This is where the cursor will point
+        // Include the cursor and nothing below since it's just surrounding code.
+        focusedSource += '\n' + sourceFrameLine
+        focusedSource += '\n' + sourceFrameLines[i + 1]
+        i++ // skip the next line since we already included it as context for the errored line
+        encounteredCursor = true
+      }
+      continue
     }
+
+    // Include error message before or after the code frame
     const isCodeFrameLine = /^ {2}\s*\d+ \|/.test(sourceFrameLine)
     if (!isCodeFrameLine) {
       focusedSource += '\n' + sourceFrameLine


### PR DESCRIPTION
Previously, the description after the codeframe was cut off
```
./app/edge-with-layout/edge/page.tsx:1:14
Ecmascript file had an error
> 1 | export const runtime = 'edge'
    |              ^^^^^^^
  2 |
  3 | export default function Page() {
  4 |   return <div>Test page under app/</div>

Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.

Import traces:
  Client Component Browser:
    ./app/page.js [Client Component Browser]
    ./app/page.js [Server Component]

  Client Component SSR:
    ./app/page.js [Client Component SSR]
    ./app/page.js [Server Component]
```
