### PR TITLE
Improve server/client-only error messages

### DIFF
--- a/bench/app-router-server/app/rsc/page.js
+++ b/bench/app-router-server/app/rsc/page.js
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import 'client-only'
 
 export default function page() {
   return <div>hello</div>

--- a/bench/app-router-server/app/rsc/page.js
+++ b/bench/app-router-server/app/rsc/page.js
@@ -1,4 +1,4 @@
-import 'client-only'
+import * as React from 'react'
 
 export default function page() {
   return <div>hello</div>

--- a/bench/app-router-server/pages/index.js
+++ b/bench/app-router-server/pages/index.js
@@ -1,3 +1,5 @@
+import { cookies } from 'next/headers'
+
 import * as React from 'react'
 
 export default function page() {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1484,9 +1484,25 @@ fn insert_client_only_error_alias(import_map: &mut ImportMap) {
                 ])
                 .resolved_cell(),
                 description: ResolvedVc::cell(Some(
-                    StyledString::Line(vec![StyledString::Text(
-                        "It should only be used from a Client Component.".into(),
-                    )])
+                    StyledString::Stack(vec![
+                        StyledString::Line(vec![
+                            StyledString::Text("Modules use ".into()),
+                            StyledString::Code("import 'client-only'".into()),
+                            StyledString::Text(
+                                " to flag they shouldn't be used from Server Components.".into(),
+                            ),
+                        ]),
+                        StyledString::Line(vec![
+                            StyledString::Text("Usually this is caused by a missing ".into()),
+                            StyledString::Code("'use client'".into()),
+                            StyledString::Text("  in some module in the import chain.".into()),
+                        ]),
+                        StyledString::Text(
+                            "Alternatively an import of the import chain can be removed to avoid \
+                             referencing this module."
+                                .into(),
+                        ),
+                    ])
                     .resolved_cell(),
                 )),
             }
@@ -1505,11 +1521,18 @@ fn insert_client_only_error_alias(import_map: &mut ImportMap) {
             ])
             .resolved_cell(),
             description: ResolvedVc::cell(Some(
-                StyledString::Line(vec![StyledString::Text(
-                    "It only works in a Client Component but none of its parents are marked with \
-                     'use client', so they're Server Components by default."
-                        .into(),
-                )])
+                StyledString::Stack(vec![
+                    StyledString::Line(vec![
+                        StyledString::Text("Usually this is caused by a missing ".into()),
+                        StyledString::Code("'use client'".into()),
+                        StyledString::Text("  in some module in the import chain.".into()),
+                    ]),
+                    StyledString::Text(
+                        "Alternatively an import of the import chain can be removed to avoid \
+                         referencing this module."
+                            .into(),
+                    ),
+                ])
                 .resolved_cell(),
             )),
         }
@@ -1533,9 +1556,25 @@ fn insert_server_only_error_alias(import_map: &mut ImportMap) {
                 ])
                 .resolved_cell(),
                 description: ResolvedVc::cell(Some(
-                    StyledString::Line(vec![StyledString::Text(
-                        "It should only be used from a Server Component.".into(),
-                    )])
+                    StyledString::Stack(vec![
+                        StyledString::Line(vec![
+                            StyledString::Text("Modules use ".into()),
+                            StyledString::Code("import 'server-only'".into()),
+                            StyledString::Text(
+                                " to flag they shouldn't be used from Client Components.".into(),
+                            ),
+                        ]),
+                        StyledString::Line(vec![
+                            StyledString::Text("This might be caused by an incorrect ".into()),
+                            StyledString::Code("'use client'".into()),
+                            StyledString::Text("  in some module in the import chain.".into()),
+                        ]),
+                        StyledString::Text(
+                            "Alternatively an import of the import chain can be removed to avoid \
+                             referencing this module."
+                                .into(),
+                        ),
+                    ])
                     .resolved_cell(),
                 )),
             }

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -280,7 +280,10 @@ pub async fn get_next_client_import_map(
     insert_turbopack_dev_alias(&mut import_map).await?;
     insert_instrumentation_client_alias(&mut import_map, project_path).await?;
 
-    insert_invalid_import_mappings_client(&mut import_map);
+    insert_invalid_import_mappings_client(
+        &mut import_map,
+        matches!(ty, ClientContextType::Pages { .. }),
+    );
 
     Ok(import_map.cell())
 }
@@ -1535,7 +1538,10 @@ fn insert_invalid_import_mappings_server(import_map: &mut ImportMap) {
     }
 }
 
-fn insert_invalid_import_mappings_client(import_map: &mut ImportMap) {
+fn insert_invalid_import_mappings_client(import_map: &mut ImportMap, is_pages: bool) {
+    // Putting this value inline below breaks rustfmt for the whole file
+    let server_components_hint: RcStr = rcstr!("Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components");
+
     for pkg in [
         rcstr!("server-only"),
         rcstr!("next/headers"),
@@ -1564,22 +1570,33 @@ fn insert_invalid_import_mappings_client(import_map: &mut ImportMap) {
                                     ),
                                 ]))
                                 .into_iter()
-                                .chain([
-                                    StyledString::Line(vec![
+                                .chain(if is_pages {
+                                    vec![
                                         StyledString::Text(
-                                            "This might be caused by an incorrect ".into(),
+                                            "It only works in a Server Component which is not \
+                                             supported in the pages/ directory. "
+                                                .into(),
                                         ),
-                                        StyledString::Code("'use client'".into()),
+                                        StyledString::Text(server_components_hint.clone()),
+                                    ]
+                                } else {
+                                    vec![
+                                        StyledString::Line(vec![
+                                            StyledString::Text(
+                                                "This might be caused by an incorrect ".into(),
+                                            ),
+                                            StyledString::Code("'use client'".into()),
+                                            StyledString::Text(
+                                                " in some module in the import chain.".into(),
+                                            ),
+                                        ]),
                                         StyledString::Text(
-                                            " in some module in the import chain.".into(),
+                                            "Alternatively, an import of the import chain can be \
+                                             removed to avoid referencing this module."
+                                                .into(),
                                         ),
-                                    ]),
-                                    StyledString::Text(
-                                        "Alternatively, an import of the import chain can be \
-                                         removed to avoid referencing this module."
-                                            .into(),
-                                    ),
-                                ])
+                                    ]
+                                })
                                 .collect(),
                         )
                         .resolved_cell(),

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -280,7 +280,7 @@ pub async fn get_next_client_import_map(
     insert_turbopack_dev_alias(&mut import_map).await?;
     insert_instrumentation_client_alias(&mut import_map, project_path).await?;
 
-    insert_server_only_error_alias(&mut import_map);
+    insert_invalid_import_mappings_client(&mut import_map);
 
     Ok(import_map.cell())
 }
@@ -560,7 +560,7 @@ pub async fn get_next_edge_import_map(
             | ServerContextType::Middleware { .. }
             | ServerContextType::Instrumentation { .. }
     ) {
-        insert_client_only_error_alias(&mut import_map);
+        insert_invalid_import_mappings_server(&mut import_map);
     }
 
     Ok(import_map.cell())
@@ -783,7 +783,7 @@ async fn insert_next_server_special_aliases(
                     rcstr!("next/dist/compiled/client-only") => rcstr!("next/dist/compiled/client-only/error"),
                 },
             );
-            insert_client_only_error_alias(import_map);
+            insert_invalid_import_mappings_server(import_map);
         }
         ServerContextType::AppSSR { .. } => {
             insert_exact_alias_map(
@@ -1471,117 +1471,125 @@ async fn insert_instrumentation_client_alias(
     Ok(())
 }
 
-fn insert_client_only_error_alias(import_map: &mut ImportMap) {
-    import_map.insert_exact_alias(
+fn insert_invalid_import_mappings_server(import_map: &mut ImportMap) {
+    for pkg in [
         rcstr!("client-only"),
-        ImportMapping::Error(ResolvedVc::upcast(
+        // styled-jsx imports client-only. So this is effectively the same as above but produces a
+        // nicer import trace.
+        rcstr!("styled-jsx"),
+        rcstr!("react-dom/client"),
+        rcstr!("react-dom/server"),
+        rcstr!("next/router"),
+    ] {
+        let mapping = ImportMapping::Error(ResolvedVc::upcast(
             InvalidImportIssue {
                 title: StyledString::Line(vec![
-                    StyledString::Code(rcstr!("'client-only'")),
+                    StyledString::Code(format!("'{}'", pkg).into()),
                     StyledString::Text(rcstr!(
                         " cannot be imported from a Server Component module"
                     )),
                 ])
                 .resolved_cell(),
                 description: ResolvedVc::cell(Some(
-                    StyledString::Stack(vec![
-                        StyledString::Line(vec![
-                            StyledString::Text("Modules use ".into()),
-                            StyledString::Code("import 'client-only'".into()),
-                            StyledString::Text(
-                                " to flag they shouldn't be used from Server Components.".into(),
-                            ),
-                        ]),
-                        StyledString::Line(vec![
-                            StyledString::Text("Usually this is caused by a missing ".into()),
-                            StyledString::Code("'use client'".into()),
-                            StyledString::Text("  in some module in the import chain.".into()),
-                        ]),
-                        StyledString::Text(
-                            "Alternatively an import of the import chain can be removed to avoid \
-                             referencing this module."
-                                .into(),
-                        ),
-                    ])
+                    StyledString::Stack(
+                        (pkg == "client-only")
+                            .then_some(StyledString::Line(vec![
+                                StyledString::Text("Modules use ".into()),
+                                StyledString::Code("import 'client-only'".into()),
+                                StyledString::Text(
+                                    " to flag they shouldn't be used from Server Components."
+                                        .into(),
+                                ),
+                            ]))
+                            .into_iter()
+                            .chain([
+                                StyledString::Line(vec![
+                                    StyledString::Text(
+                                        "Usually this is caused by a missing ".into(),
+                                    ),
+                                    StyledString::Code("'use client'".into()),
+                                    StyledString::Text(
+                                        " in some module in the import chain.".into(),
+                                    ),
+                                ]),
+                                StyledString::Text(
+                                    "Alternatively, an import of the import chain can be removed \
+                                     to avoid referencing this module."
+                                        .into(),
+                                ),
+                            ])
+                            .collect(),
+                    )
                     .resolved_cell(),
                 )),
             }
             .resolved_cell(),
         ))
-        .resolved_cell(),
-    );
+        .resolved_cell();
 
-    // styled-jsx imports client-only. So this is effectively the same as above but produces a nicer
-    // import trace.
-    let mapping = ImportMapping::Error(ResolvedVc::upcast(
-        InvalidImportIssue {
-            title: StyledString::Line(vec![
-                StyledString::Code(rcstr!("'styled-jsx'")),
-                StyledString::Text(rcstr!(" cannot be imported from a Server Component module")),
-            ])
-            .resolved_cell(),
-            description: ResolvedVc::cell(Some(
-                StyledString::Stack(vec![
-                    StyledString::Line(vec![
-                        StyledString::Text("Usually this is caused by a missing ".into()),
-                        StyledString::Code("'use client'".into()),
-                        StyledString::Text("  in some module in the import chain.".into()),
-                    ]),
-                    StyledString::Text(
-                        "Alternatively an import of the import chain can be removed to avoid \
-                         referencing this module."
-                            .into(),
-                    ),
-                ])
-                .resolved_cell(),
-            )),
+        let is_styled_jsx = pkg == "styled-jsx";
+        import_map.insert_exact_alias(pkg, mapping);
+        if is_styled_jsx {
+            import_map.insert_wildcard_alias(rcstr!("styled-jsx/"), mapping);
         }
-        .resolved_cell(),
-    ))
-    .resolved_cell();
-    import_map.insert_exact_alias(rcstr!("styled-jsx"), mapping);
-    import_map.insert_wildcard_alias(rcstr!("styled-jsx/"), mapping);
+    }
 }
 
-fn insert_server_only_error_alias(import_map: &mut ImportMap) {
-    import_map.insert_exact_alias(
+fn insert_invalid_import_mappings_client(import_map: &mut ImportMap) {
+    for pkg in [
         rcstr!("server-only"),
-        ImportMapping::Error(ResolvedVc::upcast(
-            InvalidImportIssue {
-                title: StyledString::Line(vec![
-                    StyledString::Code(rcstr!("'server-only'")),
-                    StyledString::Text(rcstr!(
-                        " cannot be imported from a Client Component module"
-                    )),
-                ])
-                .resolved_cell(),
-                description: ResolvedVc::cell(Some(
-                    StyledString::Stack(vec![
-                        StyledString::Line(vec![
-                            StyledString::Text("Modules use ".into()),
-                            StyledString::Code("import 'server-only'".into()),
-                            StyledString::Text(
-                                " to flag they shouldn't be used from Client Components.".into(),
-                            ),
-                        ]),
-                        StyledString::Line(vec![
-                            StyledString::Text("This might be caused by an incorrect ".into()),
-                            StyledString::Code("'use client'".into()),
-                            StyledString::Text("  in some module in the import chain.".into()),
-                        ]),
-                        StyledString::Text(
-                            "Alternatively an import of the import chain can be removed to avoid \
-                             referencing this module."
-                                .into(),
-                        ),
+        rcstr!("next/headers"),
+        rcstr!("next/root-params"),
+    ] {
+        import_map.insert_exact_alias(
+            pkg.clone(),
+            ImportMapping::Error(ResolvedVc::upcast(
+                InvalidImportIssue {
+                    title: StyledString::Line(vec![
+                        StyledString::Code(format!("'{}'", pkg).into()),
+                        StyledString::Text(rcstr!(
+                            " cannot be imported from a Client Component module"
+                        )),
                     ])
                     .resolved_cell(),
-                )),
-            }
+                    description: ResolvedVc::cell(Some(
+                        StyledString::Stack(
+                            (pkg == "server-only")
+                                .then_some(StyledString::Line(vec![
+                                    StyledString::Text("Modules use ".into()),
+                                    StyledString::Code("import 'server-only'".into()),
+                                    StyledString::Text(
+                                        " to flag they shouldn't be used from Client Components."
+                                            .into(),
+                                    ),
+                                ]))
+                                .into_iter()
+                                .chain([
+                                    StyledString::Line(vec![
+                                        StyledString::Text(
+                                            "This might be caused by an incorrect ".into(),
+                                        ),
+                                        StyledString::Code("'use client'".into()),
+                                        StyledString::Text(
+                                            " in some module in the import chain.".into(),
+                                        ),
+                                    ]),
+                                    StyledString::Text(
+                                        "Alternatively, an import of the import chain can be \
+                                         removed to avoid referencing this module."
+                                            .into(),
+                                    ),
+                                ])
+                                .collect(),
+                        )
+                        .resolved_cell(),
+                    )),
+                }
+                .resolved_cell(),
+            ))
             .resolved_cell(),
-        ))
-        .resolved_cell(),
-    );
+        );
+    }
 }
 
 #[turbo_tasks::value(shared)]

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -11,19 +11,19 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
-    atoms::{Atom, Wtf8Atom, atom},
+    atoms::{atom, Atom, Wtf8Atom},
     common::{
-        DUMMY_SP, FileName, Span, Spanned,
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
         util::take::Take,
+        FileName, Span, Spanned, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        utils::{ExprFactory, prepend_stmts, quote_ident, quote_str},
+        utils::{prepend_stmts, quote_ident, quote_str, ExprFactory},
         visit::{
-            Visit, VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type, noop_visit_type,
-            visit_mut_pass,
+            noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith,
+            VisitWith,
         },
     },
 };

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -11,19 +11,19 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
-    atoms::{atom, Atom, Wtf8Atom},
+    atoms::{Atom, Wtf8Atom, atom},
     common::{
+        DUMMY_SP, FileName, Span, Spanned,
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
         util::take::Take,
-        FileName, Span, Spanned, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        utils::{prepend_stmts, quote_ident, quote_str, ExprFactory},
+        utils::{ExprFactory, prepend_stmts, quote_ident, quote_str},
         visit::{
-            noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith,
-            VisitWith,
+            Visit, VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type, noop_visit_type,
+            visit_mut_pass,
         },
     },
 };
@@ -135,6 +135,7 @@ impl<C: Comments> VisitMut for ReactServerComponents<C> {
             self.taint_enabled,
             self.filepath.clone(),
             self.app_dir.clone(),
+            true,
         );
 
         module.visit_with(&mut validator);
@@ -584,12 +585,15 @@ fn collect_module_info(
 
 /// A visitor to assert given module file is a valid React server component.
 struct ReactServerComponentValidator {
+    // Options
     is_react_server_layer: bool,
     cache_components_enabled: bool,
     use_cache_enabled: bool,
     taint_enabled: bool,
     filepath: String,
     app_dir: Option<PathBuf>,
+
+    // State
     invalid_server_imports: Vec<Wtf8Atom>,
     invalid_server_lib_apis_mapping: FxHashMap<Wtf8Atom, Vec<&'static str>>,
     deprecated_apis_mapping: FxHashMap<Wtf8Atom, Vec<&'static str>>,
@@ -610,6 +614,7 @@ impl ReactServerComponentValidator {
         taint_enabled: bool,
         filename: String,
         app_dir: Option<PathBuf>,
+        validate_context_only_import: bool,
     ) -> Self {
         Self {
             is_react_server_layer,
@@ -618,6 +623,7 @@ impl ReactServerComponentValidator {
             taint_enabled,
             filepath: filename,
             app_dir,
+
             module_directive: None,
             export_names: vec![],
             // react -> [apis]
@@ -677,18 +683,26 @@ impl ReactServerComponentValidator {
                 vec!["ImageResponse"],
             )]),
 
-            invalid_server_imports: vec![
-                atom!("client-only").into(),
-                atom!("react-dom/client").into(),
-                atom!("react-dom/server").into(),
-                atom!("next/router").into(),
-            ],
+            invalid_server_imports: if validate_context_only_import {
+                vec![
+                    atom!("client-only").into(),
+                    atom!("react-dom/client").into(),
+                    atom!("react-dom/server").into(),
+                    atom!("next/router").into(),
+                ]
+            } else {
+                vec![]
+            },
 
-            invalid_client_imports: vec![
-                atom!("server-only").into(),
-                atom!("next/headers").into(),
-                atom!("next/root-params").into(),
-            ],
+            invalid_client_imports: if validate_context_only_import {
+                vec![
+                    atom!("server-only").into(),
+                    atom!("next/headers").into(),
+                    atom!("next/root-params").into(),
+                ]
+            } else {
+                vec![]
+            },
 
             invalid_client_lib_apis_mapping: FxHashMap::from_iter([
                 (atom!("next/server").into(), vec!["after"]),
@@ -1162,6 +1176,7 @@ pub fn server_components_assert(
         taint_enabled,
         filename,
         app_dir,
+        false,
     )
 }
 

--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -11,19 +11,19 @@ use regex::Regex;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use swc_core::{
-    atoms::{atom, Atom, Wtf8Atom},
+    atoms::{Atom, Wtf8Atom, atom},
     common::{
+        DUMMY_SP, FileName, Span, Spanned,
         comments::{Comment, CommentKind, Comments},
         errors::HANDLER,
         util::take::Take,
-        FileName, Span, Spanned, DUMMY_SP,
     },
     ecma::{
         ast::*,
-        utils::{prepend_stmts, quote_ident, quote_str, ExprFactory},
+        utils::{ExprFactory, prepend_stmts, quote_ident, quote_str},
         visit::{
-            noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith,
-            VisitWith,
+            Visit, VisitMut, VisitMutWith, VisitWith, noop_visit_mut_type, noop_visit_type,
+            visit_mut_pass,
         },
     },
 };
@@ -292,10 +292,10 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
         RSCErrorKind::NextRscErrServerImport((source, span)) => {
             let msg = match source.as_str() {
                 // If importing "react-dom/server", we should show a different error.
-                "react-dom/server" => "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering".to_string(),
+                "react-dom/server" => "'react-dom/server' cannot be imported from a Server Component module.\nTo fix it, render or return the content directly as a Server Component instead for perf and security.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering".to_string(),
                 // If importing "next/router", we should tell them to use "next/navigation".
-                "next/router" => "You have a Server Component that imports next/router. Use next/navigation instead.\nLearn more: https://nextjs.org/docs/app/api-reference/functions/use-router".to_string(),
-                _ => format!("You're importing a component that imports {source}. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering")
+                "next/router" => "'next/router' cannot be imported from a Server Component module.\nUse next/navigation instead.\nLearn more: https://nextjs.org/docs/app/api-reference/functions/use-router".to_string(),
+                _ => format!("'{source}' cannot be imported from a Server Component module.\nIt only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering")
             };
 
             (msg, vec![span])
@@ -313,36 +313,36 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
                 .unwrap_or_default();
 
             let msg = if !is_app_dir {
-                format!("You're importing a component that needs \"{source}\". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components\n\n")
+                format!("\'{source}\' cannot be imported from a Client Component module.\nThat only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components\n\n")
             } else {
-                format!("You're importing a component that needs \"{source}\". That only works in a Server Component but one of its parents is marked with \"use client\", so it's a Client Component.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering\n\n")
+                format!("\'{source}\' cannot be imported from a Client Component module.\nThat only works in a Server Component but one of its parents is marked with \"use client\", so it's a Client Component.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering\n\n")
             };
             (msg, vec![span])
         }
         RSCErrorKind::NextRscErrReactApi((source, span)) => {
             let msg = if source == "Component" {
-                "You’re importing a class component. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n".to_string()
+                "Class components cannot be imported from a Server Component module. It only works in a Client Component but none of its parents are marked with \"use client\", so they're Server Components by default.\nLearn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components\n\n".to_string()
             } else {
-                format!("You're importing a component that needs `{source}`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `\"use client\"` directive.\n\n Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client\n\n")
+                format!("The hook '{source}' cannot be imported from a Server Component module.\nTo fix, mark the file (or its parent) with the `\"use client\"` directive.\n\n Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client\n\n")
             };
 
             (msg, vec![span])
         },
         RSCErrorKind::NextRscErrErrorFileServerComponent(span) => {
             (
-                format!("{filepath} must be a Client Component. Add the \"use client\" directive the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/app/api-reference/directives/use-client\n\n"),
+                format!("{filepath} must be a Client Component.\nAdd the \"use client\" directive the top of the file to resolve this issue.\nLearn more: https://nextjs.org/docs/app/api-reference/directives/use-client\n\n"),
                 vec![span]
             )
         },
         RSCErrorKind::NextRscErrClientMetadataExport((source, span)) => {
-            (format!("You are attempting to export \"{source}\" from a component marked with \"use client\", which is disallowed. \"{source}\" must be resolved on the server before the page component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-component-only\n\n"), vec![span])
+            (format!("You are attempting to export \"{source}\" from a component marked with \"use client\", which is disallowed.\n\"{source}\" must be resolved on the server before the page component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-component-only\n\n"), vec![span])
         },
         RSCErrorKind::NextRscErrConflictMetadataExport((span1, span2)) => (
             "\"metadata\" and \"generateMetadata\" cannot be exported at the same time, please keep one of them. Read more: https://nextjs.org/docs/app/api-reference/file-conventions/metadata\n\n".to_string(),
             vec![span1, span2]
         ),
         RSCErrorKind::NextRscErrInvalidApi((source, span)) => (
-            format!("\"{source}\" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching\n\n"), vec![span]
+            format!("\"{source}\" is not supported in app/.\nRead more: https://nextjs.org/docs/app/building-your-application/data-fetching\n\n"), vec![span]
         ),
         RSCErrorKind::NextRscErrDeprecatedApi((source, item, span)) => match (&*source, &*item) {
             ("next/server", "ImageResponse") => (
@@ -354,17 +354,17 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
             _ => (format!("\"{source}\" is deprecated."), vec![span]),
         },
         RSCErrorKind::NextSsrDynamicFalseNotAllowed(span) => (
-            "`ssr: false` is not allowed with `next/dynamic` in Server Components. Please move it into a Client Component."
+            "`ssr: false` is not allowed with `next/dynamic` in Server Components.\nPlease move it into a Client Component."
                 .to_string(),
             vec![span],
         ),
         RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(span, segment, property) => (
-            format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`. Please remove it."),
+            format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`.\nPlease remove it."),
             vec![span],
         ),
         RSCErrorKind::NextRscErrTaintWithoutConfig((api_name, span)) => (
             format!(
-                "You're importing `{api_name}` from React which requires `experimental.taint: true` in your Next.js config. Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/taint"
+                "You're importing `{api_name}` from React which requires `experimental.taint: true` in your Next.js config.\nLearn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/taint"
             ),
             vec![span],
         ),

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/cache-life/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/cache-life/output.stderr
@@ -1,4 +1,5 @@
-  x You're importing a component that needs "cacheLife". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
+  x 'cacheLife' cannot be imported from a Client Component module.
+  | That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
   | 
   | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/cache-tag/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/cache-tag/output.stderr
@@ -1,4 +1,5 @@
-  x You're importing a component that needs "cacheTag". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
+  x 'cacheTag' cannot be imported from a Client Component module.
+  | That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
   | 
   | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/root-params/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/root-params/output.stderr
@@ -1,4 +1,5 @@
-  x You're importing a component that needs "next/root-params". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
+  x 'next/root-params' cannot be imported from a Client Component module.
+  | That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
   | 
   | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/server-only/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/app-dir/server-only/output.stderr
@@ -1,4 +1,5 @@
-  x You're importing a component that needs "server-only". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
+  x 'server-only' cannot be imported from a Client Component module.
+  | That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
   | 
   | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/cache-life/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/cache-life/output.stderr
@@ -1,5 +1,5 @@
-  x You're importing a component that needs "cacheLife". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-
-  | application/rendering/server-components
+  x 'cacheLife' cannot be imported from a Client Component module.
+  | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/cache-tag/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/cache-tag/output.stderr
@@ -1,5 +1,5 @@
-  x You're importing a component that needs "cacheTag". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-
-  | application/rendering/server-components
+  x 'cacheTag' cannot be imported from a Client Component module.
+  | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/generate-metadata/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/generate-metadata/output.stderr
@@ -1,6 +1,6 @@
-  x You are attempting to export "generateMetadata" from a component marked with "use client", which is disallowed. "generateMetadata" must be resolved on the server before the page component is
-  | rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-
-  | generatemetadata-is-server-component-only
+  x You are attempting to export "generateMetadata" from a component marked with "use client", which is disallowed.
+  | "generateMetadata" must be resolved on the server before the page component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more:
+  | https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-component-only
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/get-server-side-props/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/get-server-side-props/output.stderr
@@ -1,4 +1,5 @@
-  x "getServerSideProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+  x "getServerSideProps" is not supported in app/.
+  | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/get-static-props/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/get-static-props/output.stderr
@@ -1,4 +1,5 @@
-  x "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+  x "getStaticProps" is not supported in app/.
+  | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/metadata/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/metadata/output.stderr
@@ -1,6 +1,6 @@
-  x You are attempting to export "metadata" from a component marked with "use client", which is disallowed. "metadata" must be resolved on the server before the page component is rendered. Keep your
-  | page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-
-  | component-only
+  x You are attempting to export "metadata" from a component marked with "use client", which is disallowed.
+  | "metadata" must be resolved on the server before the page component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://
+  | nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-component-only
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/multiple/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/multiple/output.stderr
@@ -1,15 +1,15 @@
-  x You are attempting to export "metadata" from a component marked with "use client", which is disallowed. "metadata" must be resolved on the server before the page component is rendered. Keep your
-  | page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-
-  | component-only
+  x You are attempting to export "metadata" from a component marked with "use client", which is disallowed.
+  | "metadata" must be resolved on the server before the page component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://
+  | nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-component-only
   | 
   | 
    ,-[input.js:1:1]
  1 | export const metadata = {}
    :              ^^^^^^^^
    `----
-  x You are attempting to export "generateMetadata" from a component marked with "use client", which is disallowed. "generateMetadata" must be resolved on the server before the page component is
-  | rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more: https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-
-  | generatemetadata-is-server-component-only
+  x You are attempting to export "generateMetadata" from a component marked with "use client", which is disallowed.
+  | "generateMetadata" must be resolved on the server before the page component is rendered. Keep your page as a Server Component and move Client Component logic to a separate file. Read more:
+  | https://nextjs.org/docs/app/api-reference/functions/generate-metadata#why-generatemetadata-is-server-component-only
   | 
   | 
    ,-[input.js:3:1]
@@ -17,7 +17,8 @@
  3 | export function generateMetadata() {}
    :                 ^^^^^^^^^^^^^^^^
    `----
-  x "getServerSideProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+  x "getServerSideProps" is not supported in app/.
+  | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
   | 
   | 
    ,-[input.js:5:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/root-params/output.stderr
@@ -1,5 +1,5 @@
-  x You're importing a component that needs "next/root-params". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-
-  | your-application/rendering/server-components
+  x 'next/root-params' cannot be imported from a Client Component module.
+  | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
   | 
   | 
    ,-[input.js:9:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/server-only/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/client-graph/server-only/output.stderr
@@ -1,5 +1,5 @@
-  x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-
-  | application/rendering/server-components
+  x 'server-only' cannot be imported from a Client Component module.
+  | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
   | 
   | 
    ,-[input.js:9:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/output.stderr
@@ -1,31 +1,36 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "runtime" is not compatible with `nextConfig.cacheComponents`.
+  | Please remove it.
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^
  2 | export const dynamic = 'force-dynamic'
    `----
-  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "dynamic" is not compatible with `nextConfig.cacheComponents`.
+  | Please remove it.
    ,-[input.js:2:1]
  1 | export const runtime = 'edge'
  2 | export const dynamic = 'force-dynamic'
    :              ^^^^^^^
  3 | export const dynamicParams = false
    `----
-  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "dynamicParams" is not compatible with `nextConfig.cacheComponents`.
+  | Please remove it.
    ,-[input.js:3:1]
  2 | export const dynamic = 'force-dynamic'
  3 | export const dynamicParams = false
    :              ^^^^^^^^^^^^^
  4 | export const fetchCache = 'force-no-store'
    `----
-  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "fetchCache" is not compatible with `nextConfig.cacheComponents`.
+  | Please remove it.
    ,-[input.js:4:1]
  3 | export const dynamicParams = false
  4 | export const fetchCache = 'force-no-store'
    :              ^^^^^^^^^^
  5 | export const revalidate = 1
    `----
-  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.
+  x Route segment config "revalidate" is not compatible with `nextConfig.cacheComponents`.
+  | Please remove it.
    ,-[input.js:5:1]
  4 | export const fetchCache = 'force-no-store'
  5 | export const revalidate = 1

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/client-only/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/client-only/output.stderr
@@ -1,4 +1,5 @@
-  x You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+  x 'client-only' cannot be imported from a Server Component module.
+  | It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
    ,-[input.js:9:1]
  8 | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/dynamic-ssr-false/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/dynamic-ssr-false/output.stderr
@@ -1,4 +1,5 @@
-  x `ssr: false` is not allowed with `next/dynamic` in Server Components. Please move it into a Client Component.
+  x `ssr: false` is not allowed with `next/dynamic` in Server Components.
+  | Please move it into a Client Component.
    ,-[input.js:4:1]
  3 | export default function () {
  4 |   return dynamic(() => import('client-only'), { ssr: false })

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/get-server-side-props/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/get-server-side-props/output.stderr
@@ -1,4 +1,5 @@
-  x "getServerSideProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+  x "getServerSideProps" is not supported in app/.
+  | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/get-static-props/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/get-static-props/output.stderr
@@ -1,4 +1,5 @@
-  x "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+  x "getStaticProps" is not supported in app/.
+  | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
   | 
   | 
    ,-[input.js:1:1]

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-api/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-api/output.stderr
@@ -1,4 +1,5 @@
-  x You're importing a component that needs `useState`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useState' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -7,7 +8,8 @@
  1 | import { useState } from 'react'
    :          ^^^^^^^^
    `----
-  x You're importing a component that needs `createContext`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'createContext' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -17,7 +19,8 @@
  3 | import { createContext } from 'react'
    :          ^^^^^^^^^^^^^
    `----
-  x You're importing a component that needs `useEffect`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useEffect' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -27,7 +30,8 @@
  5 | import { useEffect, useImperativeHandle } from 'react'
    :          ^^^^^^^^^
    `----
-  x You're importing a component that needs `useImperativeHandle`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useImperativeHandle' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -37,7 +41,8 @@
  5 | import { useEffect, useImperativeHandle } from 'react'
    :                     ^^^^^^^^^^^^^^^^^^^
    `----
-  x You’re importing a class component. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+  x Class components cannot be imported from a Server Component module. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by
+  | default.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering/client-components
   | 
   | 
@@ -47,7 +52,8 @@
    :   ^^^^^^^^^
  9 |   createFactory,
    `----
-  x You're importing a component that needs `createFactory`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'createFactory' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -58,7 +64,8 @@
     :   ^^^^^^^^^^^^^
  10 |   PureComponent,
     `----
-  x You're importing a component that needs `PureComponent`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'PureComponent' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -69,7 +76,8 @@
     :   ^^^^^^^^^^^^^
  11 |   useDeferredValue,
     `----
-  x You're importing a component that needs `useDeferredValue`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useDeferredValue' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -80,7 +88,8 @@
     :   ^^^^^^^^^^^^^^^^
  12 |   useInsertionEffect,
     `----
-  x You're importing a component that needs `useInsertionEffect`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useInsertionEffect' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -91,7 +100,8 @@
     :   ^^^^^^^^^^^^^^^^^^
  13 |   useLayoutEffect,
     `----
-  x You're importing a component that needs `useLayoutEffect`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useLayoutEffect' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -102,7 +112,8 @@
     :   ^^^^^^^^^^^^^^^
  14 |   useReducer,
     `----
-  x You're importing a component that needs `useReducer`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useReducer' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -113,7 +124,8 @@
     :   ^^^^^^^^^^
  15 |   useRef,
     `----
-  x You're importing a component that needs `useRef`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useRef' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -124,7 +136,8 @@
     :   ^^^^^^
  16 |   useSyncExternalStore,
     `----
-  x You're importing a component that needs `useSyncExternalStore`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useSyncExternalStore' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -135,7 +148,8 @@
     :   ^^^^^^^^^^^^^^^^^^^^
  17 | } from 'react'
     `----
-  x You're importing a component that needs `experimental_useOptimistic`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'experimental_useOptimistic' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-dom-api/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-dom-api/output.stderr
@@ -1,4 +1,5 @@
-  x You're importing a component that needs `flushSync`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'flushSync' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -7,7 +8,8 @@
  1 | import { flushSync, unstable_batchedUpdates } from 'react-dom'
    :          ^^^^^^^^^
    `----
-  x You're importing a component that needs `unstable_batchedUpdates`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'unstable_batchedUpdates' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -16,7 +18,8 @@
  1 | import { flushSync, unstable_batchedUpdates } from 'react-dom'
    :                     ^^^^^^^^^^^^^^^^^^^^^^^
    `----
-  x You're importing a component that needs `useActionState`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useActionState' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -26,7 +29,8 @@
  3 | import { useActionState } from 'react'
    :          ^^^^^^^^^^^^^^
    `----
-  x You're importing a component that needs `useFormStatus`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useFormStatus' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 
@@ -36,7 +40,8 @@
  5 | import { useFormStatus, useFormState } from 'react-dom'
    :          ^^^^^^^^^^^^^
    `----
-  x You're importing a component that needs `useFormState`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the `"use client"` directive.
+  x The hook 'useFormState' cannot be imported from a Server Component module.
+  | To fix, mark the file (or its parent) with the `"use client"` directive.
   | 
   |  Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
   | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/react-dom-server-client/output.stderr
@@ -1,11 +1,13 @@
-  x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+  x 'react-dom/server' cannot be imported from a Server Component module.
+  | To fix it, render or return the content directly as a Server Component instead for perf and security.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
    ,-[input.js:9:1]
  8 | 
  9 | import 'react-dom/server'
    : ^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
-  x You're importing a component that imports react-dom/client. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+  x 'react-dom/client' cannot be imported from a Server Component module.
+  | It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
     ,-[input.js:11:1]
  10 | 

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/taint-without-config/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/taint-without-config/output.stderr
@@ -1,11 +1,11 @@
-  x You're importing `experimental_taintObjectReference` from React which requires `experimental.taint: true` in your Next.js config. Learn more: https://nextjs.org/docs/app/api-reference/config/
-  | next-config-js/taint
+  x You're importing `experimental_taintObjectReference` from React which requires `experimental.taint: true` in your Next.js config.
+  | Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/taint
    ,-[input.js:1:1]
  1 | import { experimental_taintObjectReference } from 'react'
    :          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
-  x You're importing `experimental_taintUniqueValue` from React which requires `experimental.taint: true` in your Next.js config. Learn more: https://nextjs.org/docs/app/api-reference/config/next-
-  | config-js/taint
+  x You're importing `experimental_taintUniqueValue` from React which requires `experimental.taint: true` in your Next.js config.
+  | Learn more: https://nextjs.org/docs/app/api-reference/config/next-config-js/taint
    ,-[input.js:3:1]
  2 | 
  3 | import { experimental_taintUniqueValue } from 'react'

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/use-cache/output.stderr
@@ -1,4 +1,5 @@
-  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`. Please remove it.
+  x Route segment config "runtime" is not compatible with `nextConfig.experimental.useCache`.
+  | Please remove it.
    ,-[input.js:1:1]
  1 | export const runtime = 'edge'
    :              ^^^^^^^

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -72,11 +72,12 @@ describe('ReactRefreshLogBox app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  x "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching",
+         "description": "  x "getStaticProps" is not supported in app/.",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js
-       Error:   x "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
+       Error:   x "getStaticProps" is not supported in app/.
+         | Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
          |
           ,-[3:1]
         1 | 'use client'

--- a/test/development/acceptance-app/invalid-imports.test.ts
+++ b/test/development/acceptance-app/invalid-imports.test.ts
@@ -68,7 +68,8 @@ describe('Error Overlay invalid imports', () => {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/comp2.js
        'styled-jsx' cannot be imported from a Server Component module
-       It only works in a Client Component but none of its parents are marked with 'use client', so they're Server Components by default.
+       Usually this is caused by a missing 'use client' in some module in the import chain.
+       Alternatively, an import of the import chain can be removed to avoid referencing this module.
 
        Import trace:
          Server Component:
@@ -140,7 +141,9 @@ describe('Error Overlay invalid imports', () => {
        > 1 | require("client-only")
            | ^^^^^^^^^^^^^^^^^^^^^^
 
-       It should only be used from a Client Component.
+       Modules use import 'client-only' to flag they shouldn't be used from Server Components.
+       Usually this is caused by a missing 'use client' in some module in the import chain.
+       Alternatively, an import of the import chain can be removed to avoid referencing this module.
 
        Import trace:
          Server Component:
@@ -239,7 +242,9 @@ describe('Error Overlay invalid imports', () => {
        > 1 | require("client-only")
            | ^^^^^^^^^^^^^^^^^^^^^^
 
-       It should only be used from a Client Component.
+       Modules use import 'client-only' to flag they shouldn't be used from Server Components.
+       Usually this is caused by a missing 'use client' in some module in the import chain.
+       Alternatively, an import of the import chain can be removed to avoid referencing this module.
 
        Import trace:
          Server Component:
@@ -340,7 +345,9 @@ describe('Error Overlay invalid imports', () => {
        > 1 | require("server-only")
            | ^^^^^^^^^^^^^^^^^^^^^^
 
-       It should only be used from a Server Component.
+       Modules use import 'server-only' to flag they shouldn't be used from Client Components.
+       This might be caused by an incorrect 'use client' in some module in the import chain.
+       Alternatively, an import of the import chain can be removed to avoid referencing this module.
 
        Import traces:
          Client Component Browser:

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -194,7 +194,7 @@ describe('Error overlay - RSC build errors', () => {
       `)
     } else {
       expect(await session.getRedboxSource()).toInclude(
-        `You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
+        `'client-only' cannot be imported from a Server Component module`
       )
     }
   })

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -150,7 +150,7 @@ describe('Error overlay - RSC build errors', () => {
 
     await session.waitForRedbox()
     expect(await session.getRedboxSource()).toInclude(
-      `You’re importing a class component. It only works in a Client Component`
+      `Class components cannot be imported from a Server Component module.`
     )
   })
 
@@ -230,8 +230,8 @@ describe('Error overlay - RSC build errors', () => {
       expect(await session.getRedboxSource()).toInclude(
         // `Component` has a custom error message
         api === 'Component'
-          ? `You’re importing a class component. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.`
-          : `You're importing a component that needs \`${api}\`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
+          ? `Class components cannot be imported from a Server Component module.`
+          : `The hook '${api}' cannot be imported from a Server Component module.`
       )
     })
   }
@@ -252,7 +252,7 @@ describe('Error overlay - RSC build errors', () => {
       const { session } = sandbox
       await session.waitForRedbox()
       expect(await session.getRedboxSource()).toInclude(
-        `You're importing a component that needs \`${api}\`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
+        `The hook '${api}' cannot be imported from a Server Component module.`
       )
     })
   }
@@ -276,7 +276,7 @@ describe('Error overlay - RSC build errors', () => {
 
     await session.waitForRedbox()
     expect(await session.getRedboxSource()).toInclude(
-      `You're importing a component that needs "server-only". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.`
+      `'server-only' cannot be imported from a Client Component module`
     )
   })
 
@@ -292,7 +292,7 @@ describe('Error overlay - RSC build errors', () => {
         const { session } = sandbox
         await session.waitForRedbox()
         expect(await session.getRedboxSource()).toInclude(
-          `You're importing a component that needs "${api}". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.`
+          `'${api}' cannot be imported from a Client Component module.`
         )
       }
     )
@@ -428,7 +428,8 @@ describe('Error overlay - RSC build errors', () => {
        > 1 | export default function Error() {}
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-       app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
+       app/server-with-errors/error-file/error.js must be a Client Component.
+       Add the "use client" directive the top of the file to resolve this issue.
        Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client"
       `)
     } else {

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -176,15 +176,16 @@ describe('Error overlay - RSC build errors', () => {
       // turbopack emits the resolve issue first instead of the transform issue.
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/server-with-errors/client-only-in-server/client-only-lib.js (1:1)
-       Ecmascript file had an error
+       'client-only' cannot be imported from a Server Component module
        > 1 | import 'client-only'
            | ^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function ClientOnlyLib() {
          4 |   return 'client-only-lib'
 
-       You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
-       Learn more: https://nextjs.org/docs/app/building-your-application/rendering
+       Modules use import 'client-only' to flag they shouldn't be used from Server Components.
+       Usually this is caused by a missing 'use client' in some module in the import chain.
+       Alternatively, an import of the import chain can be removed to avoid referencing this module.
 
        Import trace:
          Server Component:
@@ -354,7 +355,7 @@ describe('Error overlay - RSC build errors', () => {
       const { session } = sandbox
       await session.waitForRedbox()
       expect(await session.getRedboxSource()).toInclude(
-        `You're importing a component that needs "next/root-params". That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component.`
+        `'next/root-params' cannot be imported from a Client Component module`
       )
     })
 
@@ -377,7 +378,7 @@ describe('Error overlay - RSC build errors', () => {
       const { session } = sandbox
       await session.waitForRedbox()
       expect(await session.getRedboxSource()).toInclude(
-        `'next/root-params' cannot be imported from a Client Component module. It should only be used from a Server Component.`
+        `'next/root-params' cannot be imported from a Client Component module`
       )
     })
   })

--- a/test/development/acceptance-app/server-components.test.ts
+++ b/test/development/acceptance-app/server-components.test.ts
@@ -525,7 +525,7 @@ describe('Error Overlay for server components', () => {
       // So we need to check for the first part of the message.
       const normalizedSource = await session.getRedboxSource()
       expect(normalizedSource).toContain(
-        `You're importing a component that needs \`${hook}\`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
+        `The hook '${hook}' cannot be imported from a Server Component module.`
       )
       expect(normalizedSource).toContain(
         `import { ${hook} } from 'next/navigation'`
@@ -557,7 +557,7 @@ describe('Error Overlay for server components', () => {
         // So we need to check for the first part of the message.
         const normalizedSource = await session.getRedboxSource()
         expect(normalizedSource).toContain(
-          `You're importing a component that needs \`${hook}\`. This React Hook only works in a Client Component. To fix, mark the file (or its parent) with the \`"use client"\` directive.`
+          `The hook '${hook}' cannot be imported from a Server Component module.`
         )
         expect(normalizedSource).toContain(
           `import { ${hook} } from 'next/link'`

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -47,22 +47,20 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     )
 
     await session.waitForRedbox()
-    await expect(session.getRedboxSource()).resolves.toMatch(
-      /That only works in a Server Component/
-    )
 
     if (process.env.IS_TURBOPACK_TEST) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       Ecmascript file had an error
+       'next/headers' cannot be imported from a Client Component module
        > 1 | import { cookies } from 'next/headers'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function Page() {
          4 |   return <p>hello world</p>
 
-       You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       It only works in a Server Component which is not supported in the pages/ directory. 
+       Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
 
        Import traces:
          Browser:
@@ -81,7 +79,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
        "./components/Comp.js
-         ╰─▶   × Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+         ╰─▶   × Error:   x 'next/headers' cannot be imported from a Client Component module.
+               │   | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
                │   |
                │
                │    ,-[1:1]
@@ -96,7 +95,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js
-       Error:   x You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Error:   x 'next/headers' cannot be imported from a Client Component module.
+         | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
          |
 
           ,-[1:1]
@@ -130,22 +130,21 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     )
 
     await session.waitForRedbox()
-    await expect(session.getRedboxSource()).resolves.toMatch(
-      /That only works in a Server Component/
-    )
 
     if (process.env.IS_TURBOPACK_TEST) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       Ecmascript file had an error
+       'server-only' cannot be imported from a Client Component module
        > 1 | import 'server-only'
            | ^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function Page() {
          4 |   return 'hello world'
 
-       You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Modules use import 'server-only' to flag they shouldn't be used from Client Components.
+       It only works in a Server Component which is not supported in the pages/ directory. 
+       Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
 
        Import traces:
          Browser:
@@ -164,7 +163,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
        "./components/Comp.js
-         ╰─▶   × Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+         ╰─▶   × Error:   x 'server-only' cannot be imported from a Client Component module.
+               │   | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
                │   |
                │
                │    ,-[1:1]
@@ -183,7 +183,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
        "./components/Comp.js
-       Error:   x You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Error:   x 'server-only' cannot be imported from a Client Component module.
+         | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
          |
 
           ,-[1:1]
@@ -215,9 +216,6 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     )
 
     await session.waitForRedbox()
-    await expect(session.getRedboxSource()).resolves.toMatch(
-      /That only works in a Server Component/
-    )
 
     if (process.env.IS_TURBOPACK_TEST) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
@@ -230,7 +228,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
          3 | export default function Page() {
          4 |   return 'hello world'
 
-       You're importing a component that needs "after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       'after' cannot be imported from a Client Component module.
+       That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
 
        Import traces:
          Browser:
@@ -249,7 +248,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
        "./components/Comp.js
-         ╰─▶   × Error:   x You're importing a component that needs "after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+         ╰─▶   × Error:   x 'after' cannot be imported from a Client Component module.
+               │   | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
                │   |
                │
                │    ,-[1:1]
@@ -268,7 +268,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
        "./components/Comp.js
-       Error:   x You're importing a component that needs "after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Error:   x 'after' cannot be imported from a Client Component module.
+         | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
          |
 
           ,-[1:1]
@@ -309,22 +310,20 @@ describe('Error Overlay for server components compiler errors in pages', () => {
     const { session } = sandbox
 
     await session.waitForRedbox()
-    await expect(session.getRedboxSource()).resolves.toMatch(
-      /That only works in a Server Component/
-    )
 
     if (process.env.IS_TURBOPACK_TEST) {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       Ecmascript file had an error
+       'next/root-params' cannot be imported from a Client Component module
        > 1 | import { foo } from 'next/root-params'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function Page() {
          4 |   return 'hello world'
 
-       You're importing a component that needs "next/root-params". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       It only works in a Server Component which is not supported in the pages/ directory. 
+       Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
 
        Import traces:
          Browser:
@@ -343,7 +342,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
        "./components/Comp.js
-         ╰─▶   × Error:   x You're importing a component that needs "next/root-params". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+         ╰─▶   × Error:   x 'next/root-params' cannot be imported from a Client Component module.
+               │   | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
                │   |
                │
                │    ,-[1:1]
@@ -362,7 +362,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
         )
       ).toMatchInlineSnapshot(`
        "./components/Comp.js
-       Error:   x You're importing a component that needs "next/root-params". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Error:   x 'next/root-params' cannot be imported from a Client Component module.
+         | That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
          |
 
           ,-[1:1]
@@ -400,8 +401,8 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       )
 
       await session.waitForRedbox()
-      await expect(session.getRedboxSource()).resolves.toMatch(
-        `You're importing a component that needs "${api}". That only works in a Server Component which is not supported in the pages/ directory.`
+      await expect(session.getRedboxSource()).resolves.toContain(
+        `'${api}' cannot be imported from a Client Component module`
       )
     })
 

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -170,11 +170,12 @@ describe('Cache Components Dev Errors', () => {
         } else {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`.",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx
-           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`.
+             | Please remove it.
               ,-[1:1]
             1 | export const revalidate = 10
               :              ^^^^^^^^^^

--- a/test/development/app-dir/next-after-app-invalid-usage/index.test.ts
+++ b/test/development/app-dir/next-after-app-invalid-usage/index.test.ts
@@ -27,7 +27,7 @@ describe('after() - invalid usages', () => {
 
     await waitForRedbox(session)
     expect(await getRedboxSource(session)).toMatch(
-      /You're importing a component that needs "?after"?\. That only works in a Server Component but one of its parents is marked with "use client", so it's a Client Component\./
+      /'after' cannot be imported from a Client Component module/
     )
     expect(getAfterLogs()).toHaveLength(0)
   })

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -179,11 +179,11 @@ describe('react-dom/server in React Server environment', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Ecmascript file had an error",
+         "description": "'react-dom/server' cannot be imported from a Server Component module",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
-       Ecmascript file had an error
+       'react-dom/server' cannot be imported from a Server Component module
        > 3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
          "stack": [],
@@ -322,9 +322,9 @@ describe('react-dom/server in React Server environment', () => {
     if (isTurbopack) {
       expect(redbox).toMatchInlineSnapshot(`
        {
-         "description": "Ecmascript file had an error",
+         "description": "'react-dom/server' cannot be imported from a Server Component module",
          "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js (3:1)
-       Ecmascript file had an error
+       'react-dom/server' cannot be imported from a Server Component module
          1 | import * as ReactDOMServerNode from 'react-dom/server'
          2 | // Fine to drop once React is on ESM
        > 3 | import ReactDOMServerNodeDefault from 'react-dom/server'
@@ -333,8 +333,8 @@ describe('react-dom/server in React Server environment', () => {
          5 | export const runtime = 'nodejs'
          6 |
 
-       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-       Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
+       Usually this is caused by a missing 'use client' in some module in the import chain.
+       Alternatively, an import of the import chain can be removed to avoid referencing this module.",
        }
       `)
     } else if (isRspack) {
@@ -677,14 +677,8 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(redbox).toMatchInlineSnapshot(`
          {
-           "description": "react-dom/server is not supported in React Server Components.",
-           "source": "internal-pkg/server.node.js (1:1) @ module evaluation
-
-         > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
-             | ^
-           2 | // Fine to drop once React is on ESM
-           3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'
-           4 |",
+           "description": "Cannot read properties of null (reading 'useInsertionEffect')",
+           "source": null,
          }
         `)
       }

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -677,8 +677,14 @@ describe('react-dom/server in React Server environment', () => {
       } else {
         expect(redbox).toMatchInlineSnapshot(`
          {
-           "description": "Cannot read properties of null (reading 'useInsertionEffect')",
-           "source": null,
+           "description": "react-dom/server is not supported in React Server Components.",
+           "source": "internal-pkg/server.node.js (1:1) @ module evaluation
+
+         > 1 | import * as ReactDOMServerEdge from 'react-dom/server.node'
+             | ^
+           2 | // Fine to drop once React is on ESM
+           3 | import ReactDOMServerEdgeDefault from 'react-dom/server.node'
+           4 |",
          }
         `)
       }

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -192,11 +192,12 @@ describe('react-dom/server in React Server environment', () => {
     } else if (isRspack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  ╰─▶   × Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
+         "description": "  ╰─▶   × Error:   x 'react-dom/server' cannot be imported from a Server Component module.",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "<FIXME-nextjs-internal-source>
-         ╰─▶   × Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+         ╰─▶   × Error:   x 'react-dom/server' cannot be imported from a Server Component module.
+               │   | To fix it, render or return the content directly as a Server Component instead for perf and security.
                │   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
                │    ,-[1:1]
                │  1 | import * as ReactDOMServerEdge from 'react-dom/server'
@@ -204,7 +205,8 @@ describe('react-dom/server in React Server environment', () => {
                │  2 | // Fine to drop once React is on ESM
                │  3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
                │    \`----
-               │   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+               │   x 'react-dom/server' cannot be imported from a Server Component module.
+               │   | To fix it, render or return the content directly as a Server Component instead for perf and security.
                │   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
                │    ,-[3:1]
                │  1 | import * as ReactDOMServerEdge from 'react-dom/server'
@@ -224,11 +226,12 @@ describe('react-dom/server in React Server environment', () => {
       // Observed: `./node_modules/.pnpm/next@file+..+next-repo.../page.js?__next_edge_ssr_entry__
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
+         "description": "  x 'react-dom/server' cannot be imported from a Server Component module.",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "<FIXME-nextjs-internal-source>
-       Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+       Error:   x 'react-dom/server' cannot be imported from a Server Component module.
+         | To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
           ,-[1:1]
         1 | import * as ReactDOMServerEdge from 'react-dom/server'
@@ -236,7 +239,8 @@ describe('react-dom/server in React Server environment', () => {
         2 | // Fine to drop once React is on ESM
         3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
           \`----
-         x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+         x 'react-dom/server' cannot be imported from a Server Component module.
+         | To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
           ,-[3:1]
         1 | import * as ReactDOMServerEdge from 'react-dom/server'
@@ -340,9 +344,10 @@ describe('react-dom/server in React Server environment', () => {
     } else if (isRspack) {
       expect(redbox).toMatchInlineSnapshot(`
        {
-         "description": "  ╰─▶   × Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
+         "description": "  ╰─▶   × Error:   x 'react-dom/server' cannot be imported from a Server Component module.",
          "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js
-         ╰─▶   × Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+         ╰─▶   × Error:   x 'react-dom/server' cannot be imported from a Server Component module.
+               │   | To fix it, render or return the content directly as a Server Component instead for perf and security.
                │   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
                │    ,-[1:1]
                │  1 | import * as ReactDOMServerNode from 'react-dom/server'
@@ -350,7 +355,8 @@ describe('react-dom/server in React Server environment', () => {
                │  2 | // Fine to drop once React is on ESM
                │  3 | import ReactDOMServerNodeDefault from 'react-dom/server'
                │    \`----
-               │   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+               │   x 'react-dom/server' cannot be imported from a Server Component module.
+               │   | To fix it, render or return the content directly as a Server Component instead for perf and security.
                │   | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
                │    ,-[3:1]
                │  1 | import * as ReactDOMServerNode from 'react-dom/server'
@@ -366,9 +372,10 @@ describe('react-dom/server in React Server environment', () => {
     } else {
       expect(redbox).toMatchInlineSnapshot(`
        {
-         "description": "  x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
+         "description": "  x 'react-dom/server' cannot be imported from a Server Component module.",
          "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js
-       Error:   x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+       Error:   x 'react-dom/server' cannot be imported from a Server Component module.
+         | To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
           ,-[1:1]
         1 | import * as ReactDOMServerNode from 'react-dom/server'
@@ -376,7 +383,8 @@ describe('react-dom/server in React Server environment', () => {
         2 | // Fine to drop once React is on ESM
         3 | import ReactDOMServerNodeDefault from 'react-dom/server'
           \`----
-         x You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+         x 'react-dom/server' cannot be imported from a Server Component module.
+         | To fix it, render or return the content directly as a Server Component instead for perf and security.
          | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
           ,-[3:1]
         1 | import * as ReactDOMServerNode from 'react-dom/server'

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -38,31 +38,31 @@ describe('cache-components-segment-configs', () => {
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+          `"  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`."`
         )
       }
       expect(redbox.source).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`.'
       )
     } else {
       expect(next.cliOutput).toContain('./app/dynamic-params/[slug]/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamicParams" is not compatible with `nextConfig.cacheComponents`.'
       )
       expect(next.cliOutput).toContain('./app/dynamic/nested/page.tsx')
       expect(next.cliOutput).toContain('./app/dynamic/page.tsx')
       expect(next.cliOutput).toContain(
-        '"dynamic" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"dynamic" is not compatible with `nextConfig.cacheComponents`.'
       )
 
       expect(next.cliOutput).toContain('./app/fetch-cache/page.tsx')
       expect(next.cliOutput).toContain(
-        '"fetchCache" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"fetchCache" is not compatible with `nextConfig.cacheComponents`.'
       )
 
       expect(next.cliOutput).toContain('./app/revalidate/page.tsx')
       expect(next.cliOutput).toContain(
-        '"revalidate" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+        '"revalidate" is not compatible with `nextConfig.cacheComponents`.'
       )
     }
   })
@@ -99,16 +99,16 @@ describe('cache-components-segment-configs', () => {
             )
           } else {
             expect(redbox.description).toMatchInlineSnapshot(
-              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+              `"  x Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`."`
             )
           }
           expect(redbox.source).toContain(
-            '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+            '"runtime" is not compatible with `nextConfig.cacheComponents`.'
           )
         } else {
           await retry(async () => {
             expect(next.cliOutput).toContain(
-              '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+              '"runtime" is not compatible with `nextConfig.cacheComponents`.'
             )
 
             // the stack trace is different between turbopack/webpack

--- a/test/e2e/app-dir/next-after-pages/index.test.ts
+++ b/test/e2e/app-dir/next-after-pages/index.test.ts
@@ -62,7 +62,7 @@ _describe('after() - pages', () => {
 
         await waitForRedbox(browser)
         expect(await getRedboxSource(browser)).toMatch(
-          /You're importing a component that needs "?after"?\. That only works in a Server Component which is not supported in the pages\/ directory\./
+          /'after' cannot be imported from a Client Component module\.\s*That only works in a Server Component which is not supported in the pages\/ directory\./
         )
         expect(getLogs()).toHaveLength(0)
       })

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -87,7 +87,8 @@ describe('use-cache-segment-configs', () => {
            3 | export default function Page() {
            4 |   return <div>This page uses \`export const runtime\`.</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`.
+         Please remove it.
 
 
              at <unknown> (./app/runtime/page.tsx:1:14)

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -2,7 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import {
   waitForRedbox,
   getRedboxSource,
-  retry,
   waitForNoRedbox,
 } from 'next-test-utils'
 
@@ -113,13 +112,27 @@ describe('module layer', () => {
                 "import './lib/mixed-lib'"
               ),
           async () => {
-            await retry(async () => {
-              await waitForRedbox(browser)
-              const source = await getRedboxSource(browser)
-              expect(source).toContain(
-                `You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client"`
-              )
-            })
+            await waitForRedbox(browser)
+            const source = await getRedboxSource(browser)
+            expect(source).toMatchInlineSnapshot(`
+             "./lib/mixed-lib/client.js (1:1)
+             'client-only' cannot be imported from a Server Component module
+             > 1 | import 'client-only'
+                 | ^^^^^^^^^^^^^^^^^^^^
+               2 |
+               3 | export const client = 'client:module'
+               4 |
+
+             Modules use import 'client-only' to flag they shouldn't be used from Server Components.
+             Usually this is caused by a missing 'use client' in some module in the import chain.
+             Alternatively, an import of the import chain can be removed to avoid referencing this module.
+
+             Import trace:
+               Edge Middleware:
+                 ./lib/mixed-lib/client.js
+                 ./lib/mixed-lib/index.js
+                 ./middleware.js"
+            `)
           }
         )
 

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -115,23 +115,20 @@ describe('module layer', () => {
             await waitForRedbox(browser)
             const source = await getRedboxSource(browser)
             expect(source).toMatchInlineSnapshot(`
-             "./lib/mixed-lib/client.js (1:1)
-             'client-only' cannot be imported from a Server Component module
-             > 1 | import 'client-only'
-                 | ^^^^^^^^^^^^^^^^^^^^
-               2 |
-               3 | export const client = 'client:module'
-               4 |
+             "./lib/mixed-lib/client.js
+             Error:   x 'client-only' cannot be imported from a Server Component module.
+               | It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+               | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
+                ,-[1:1]
+              1 | import 'client-only'
+                : ^^^^^^^^^^^^^^^^^^^^
+              2 |
+              3 | export const client = 'client:module'
+                \`----
 
-             Modules use import 'client-only' to flag they shouldn't be used from Server Components.
-             Usually this is caused by a missing 'use client' in some module in the import chain.
-             Alternatively, an import of the import chain can be removed to avoid referencing this module.
-
-             Import trace:
-               Edge Middleware:
-                 ./lib/mixed-lib/client.js
-                 ./lib/mixed-lib/index.js
-                 ./middleware.js"
+             Import trace for requested module:
+             ./lib/mixed-lib/client.js
+             ./lib/mixed-lib/index.js"
             `)
           }
         )

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -114,22 +114,9 @@ describe('module layer', () => {
           async () => {
             await waitForRedbox(browser)
             const source = await getRedboxSource(browser)
-            expect(source).toMatchInlineSnapshot(`
-             "./lib/mixed-lib/client.js
-             Error:   x 'client-only' cannot be imported from a Server Component module.
-               | It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
-               | Learn more: https://nextjs.org/docs/app/building-your-application/rendering
-                ,-[1:1]
-              1 | import 'client-only'
-                : ^^^^^^^^^^^^^^^^^^^^
-              2 |
-              3 | export const client = 'client:module'
-                \`----
-
-             Import trace for requested module:
-             ./lib/mixed-lib/client.js
-             ./lib/mixed-lib/index.js"
-            `)
+            expect(source).toContain(
+              "'client-only' cannot be imported from a Server Component module"
+            )
           }
         )
 


### PR DESCRIPTION
Before:

<img width="708" height="386" alt="Bildschirmfoto 2026-01-07 um 17 21 59" src="https://github.com/user-attachments/assets/4d49eff3-4959-4b70-aa47-6f3c10c75588" />



- [ ] https://github.com/vercel/next.js/pull/56501
```
  ● Error overlay - RSC runtime errors › should show runtime errors if invalid server API from node_modules is executed

    expect(received).toMatchInlineSnapshot(snapshot)

    Snapshot name: `Error overlay - RSC runtime errors should show runtime errors if invalid server API from node_modules is executed 1`

    - Snapshot  - 8
    + Received  + 7

      {
    -   "description": "`cookies` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
    +   "description": "'next/headers' cannot be imported from a Client Component module",
        "environmentLabel": null,
    -   "label": "Runtime Error",
    -   "source": "app/client/page.js (4:16) @ Page
    - > 4 |   callServerApi()
    -     |                ^",
    -   "stack": [
    -     "Page app/client/page.js (4:16)",
    -   ],
    +   "label": "Build Error",
    +   "source": "./node_modules/server-package/index.js (3:1)
    + 'next/headers' cannot be imported from a Client Component module
    + > 3 | import { cookies } from 'next/headers'
    +     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
    +   "stack": [],
      }

      52 |     const browser = await next.browser('/client')
      53 |
    > 54 |     await expect(browser).toDisplayRedbox(`
         |                           ^
      55 |      {
      56 |        "description": "\`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
      57 |        "environmentLabel": null,

      at Object.toDisplayRedbox (development/acceptance-app/rsc-runtime-errors.test.ts:54:27)

```