### PR TITLE
fix(webpack): enable PnP sourcemap support in next-swc-loader pitch  

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-swc-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-swc-loader.ts
@@ -31,6 +31,7 @@ import { type WebpackLayerName, WEBPACK_LAYERS } from '../../../lib/constants'
 import { getBindingsSync, transform } from '../../swc'
 import { installBindings } from '../../swc/install-bindings'
 import { getLoaderSWCOptions } from '../../swc/options'
+import fs from 'fs'
 import path, { isAbsolute } from 'path'
 import { babelIncludeRegexes } from '../../webpack-config'
 import { isResourceInPackages } from '../../handle-externals'
@@ -248,14 +249,26 @@ export function pitch(this: any) {
     if (
       // if it might be excluded/no-op we can't use pitch loader
       !shouldMaybeExclude &&
-      // TODO: investigate swc file reading in PnP mode?
-      !process.versions.pnp &&
-      !EXCLUDED_PATHS.test(this.resourcePath) &&
+      (process.versions.pnp || !EXCLUDED_PATHS.test(this.resourcePath)) &&
       this.loaders.length - 1 === this.loaderIndex &&
       isAbsolute(this.resourcePath) &&
       !getBindingsSync().isWasm
     ) {
       this.addDependency(this.resourcePath)
+
+      if (process.versions.pnp) {
+        // PnP: SWC native code cannot read from zip archives,
+        // so read via Node.js fs which Yarn PnP patches.
+        const source = await fs.promises.readFile(this.resourcePath, 'utf-8')
+        let inputSourceMap: any
+        try {
+          inputSourceMap = JSON.parse(
+            await fs.promises.readFile(this.resourcePath + '.map', 'utf-8')
+          )
+        } catch {}
+        return loaderTransform.call(this, source, inputSourceMap)
+      }
+
       return loaderTransform.call(this)
     }
   })().then((r) => {


### PR DESCRIPTION
fixes: #90129 

### What?

Enable pitch in next-swc-loader for Yarn PnP so sourcemap chaining works for Next.js internal files.
(These files are matched by babelIncludeRegexes and transformed via pitch — see https://github.com/vercel/next.js/blob/24c6e3e4de2e729c7e71d38173466cf9cf3d5399/packages/next/src/build/webpack-config.ts#L121)

### Why?

In PnP mode, `pitch` was skipped (`!process.versions.pnp`), so it fell through to `swcLoader`. But Webpack can't resolve `.map` files from zip archives, so `inputSourceMap` was always `undefined` — DevTools showed `.js` instead of `.ts` sources.

### How?

- Bypass `EXCLUDED_PATHS` check in PnP — PnP paths always contain `__virtual__`/`.zip` that would block pitch.
- In PnP, read the file and its `.map` via Node.js `fs`, then pass both to `loaderTransform`. Yarn PnP monkey-patches `fs` to read from zip archives, so this just works without special handling.
- Use `resourcePath + '.map'` directly instead of parsing from source. Next.js `dist/` always generates `.js.map` alongside `.js`, so there's no need to regex-parse the comment.
- This is done in `pitch` (not in `swcLoader`/`loaderTransform`) because files matching `babelIncludeRegexes` should go through `pitch` like they do in non-PnP mode.
