### PR TITLE
feat: generate cache-life types during next build

### DIFF
--- a/test/e2e/app-dir/cache-life-types/app/layout.tsx
+++ b/test/e2e/app-dir/cache-life-types/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-life-types/app/page.tsx
+++ b/test/e2e/app-dir/cache-life-types/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/cache-life-types/cache-life-types.test.ts
+++ b/test/e2e/app-dir/cache-life-types/cache-life-types.test.ts
@@ -1,0 +1,25 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('cache-life-types', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should emit cache-life types', async () => {
+    await retry(async () => {
+      const content = await next.readFile(
+        `${next.distDir}/types/cache-life.d.ts`
+      )
+
+      expect(content).toContain(
+        'export function cacheLife(profile: "frequent"): void'
+      )
+    })
+  })
+})

--- a/test/e2e/app-dir/cache-life-types/next.config.js
+++ b/test/e2e/app-dir/cache-life-types/next.config.js
@@ -1,0 +1,14 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheLife: {
+    frequent: {
+      stale: 19,
+      revalidate: 100,
+      expire: 300,
+    },
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary

Make `next build` generate `.next/types/cache-life.d.ts` when `cacheLife` profiles are configured.

Previously, custom `cacheLife` profile types were generated in dev and via `next typegen`, but not during production builds.

## Changes

- Call the existing `writeCacheLifeTypes()` helper from the build pipeline
- Keep build aligned with the existing dev and `next typegen` codepath
- Add e2e test that asserts `.next/types/cache-life.d.ts` is emitted during build/dev