### PR TITLE
fix: support `String.raw` tagged templates in segment config extraction

### DIFF
--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -4,6 +4,7 @@ import type {
   ExportDeclaration,
   Identifier,
   KeyValueProperty,
+  MemberExpression,
   Module,
   Node,
   NullLiteral,
@@ -11,6 +12,7 @@ import type {
   ObjectExpression,
   RegExpLiteral,
   StringLiteral,
+  TaggedTemplateExpression,
   TemplateLiteral,
   TsAsExpression,
   TsConstAssertion,
@@ -65,6 +67,12 @@ function isRegExpLiteral(node: Node): node is RegExpLiteral {
 
 function isTemplateLiteral(node: Node): node is TemplateLiteral {
   return node.type === 'TemplateLiteral'
+}
+
+function isTaggedTemplateExpression(
+  node: Node
+): node is TaggedTemplateExpression {
+  return node.type === 'TaggedTemplateExpression'
 }
 
 function isTsAsExpression(node: Node): node is TsAsExpression {
@@ -211,6 +219,32 @@ function extractValue(node: Node, path?: string[]): ExtractValueResult {
     const [{ cooked, raw }] = node.quasis
 
     return { value: cooked ?? raw }
+  } else if (isTaggedTemplateExpression(node)) {
+    // e.g. String.raw`/api/:path*`
+    // Only support String.raw with no expressions
+    const { tag, template } = node
+    if (
+      tag.type === 'MemberExpression' &&
+      (tag as MemberExpression).object.type === 'Identifier' &&
+      ((tag as MemberExpression).object as Identifier).value === 'String' &&
+      (tag as MemberExpression).property.type === 'Identifier' &&
+      ((tag as MemberExpression).property as Identifier).value === 'raw'
+    ) {
+      if (template.expressions.length !== 0) {
+        return {
+          unsupported:
+            'Unsupported String.raw template literal with expressions',
+          path: formatCodePath(path),
+        }
+      }
+      // String.raw returns the raw string without processing escape sequences
+      const [{ raw }] = template.quasis
+      return { value: raw }
+    }
+    return {
+      unsupported: `Unsupported tagged template expression`,
+      path: formatCodePath(path),
+    }
   } else if (
     isTsSatisfiesExpression(node) ||
     isTsAsExpression(node) ||

--- a/packages/next/src/build/analysis/extract-const-value.ts
+++ b/packages/next/src/build/analysis/extract-const-value.ts
@@ -4,6 +4,7 @@ import type {
   ExportDeclaration,
   Identifier,
   KeyValueProperty,
+  MemberExpression,
   Module,
   Node,
   NullLiteral,
@@ -11,6 +12,7 @@ import type {
   ObjectExpression,
   RegExpLiteral,
   StringLiteral,
+  TaggedTemplateExpression,
   TemplateLiteral,
   TsSatisfiesExpression,
   VariableDeclaration,
@@ -64,6 +66,12 @@ function isRegExpLiteral(node: Node): node is RegExpLiteral {
 
 function isTemplateLiteral(node: Node): node is TemplateLiteral {
   return node.type === 'TemplateLiteral'
+}
+
+function isTaggedTemplateExpression(
+  node: Node
+): node is TaggedTemplateExpression {
+  return node.type === 'TaggedTemplateExpression'
 }
 
 function isTsSatisfiesExpression(node: Node): node is TsSatisfiesExpression {
@@ -199,6 +207,31 @@ function extractValue(node: Node, path?: string[]): any {
     const [{ cooked, raw }] = node.quasis
 
     return cooked ?? raw
+  } else if (isTaggedTemplateExpression(node)) {
+    // e.g. String.raw`/api/:path*`
+    // Only support String.raw with no expressions
+    const { tag, template } = node
+    if (
+      tag.type === 'MemberExpression' &&
+      (tag as MemberExpression).object.type === 'Identifier' &&
+      ((tag as MemberExpression).object as Identifier).value === 'String' &&
+      (tag as MemberExpression).property.type === 'Identifier' &&
+      ((tag as MemberExpression).property as Identifier).value === 'raw'
+    ) {
+      if (template.expressions.length !== 0) {
+        throw new UnsupportedValueError(
+          'Unsupported String.raw template literal with expressions',
+          path
+        )
+      }
+      // String.raw returns the raw string without processing escape sequences
+      const [{ raw }] = template.quasis
+      return raw
+    }
+    throw new UnsupportedValueError(
+      `Unsupported tagged template expression`,
+      path
+    )
   } else if (isTsSatisfiesExpression(node)) {
     return extractValue(node.expression)
   } else {

--- a/test/unit/extract-const-value.test.ts
+++ b/test/unit/extract-const-value.test.ts
@@ -1,0 +1,74 @@
+import { extractExportedConstValue } from 'next/src/build/analysis/extract-const-value'
+import { parse } from '@swc/core'
+
+async function parseCode(code: string) {
+  return parse(code, { syntax: 'typescript' })
+}
+
+describe('extractExportedConstValue', () => {
+  it('extracts string literal', async () => {
+    const ast = await parseCode(`export const foo = "bar"`)
+    const result = extractExportedConstValue(ast, 'foo')
+    expect(result).not.toBeNull()
+    expect(result && 'value' in result && result.value).toBe('bar')
+  })
+
+  it('extracts template literal', async () => {
+    const ast = await parseCode('export const foo = `/api/test`')
+    const result = extractExportedConstValue(ast, 'foo')
+    expect(result).not.toBeNull()
+    expect(result && 'value' in result && result.value).toBe('/api/test')
+  })
+
+  it('extracts String.raw tagged template', async () => {
+    const ast = await parseCode(
+      'export const foo = String.raw`/api/:path*`'
+    )
+    const result = extractExportedConstValue(ast, 'foo')
+    expect(result).not.toBeNull()
+    expect(result && 'value' in result && result.value).toBe('/api/:path*')
+  })
+
+  it('extracts String.raw with backslashes preserved', async () => {
+    const ast = await parseCode(
+      'export const foo = String.raw`\\n\\t`'
+    )
+    const result = extractExportedConstValue(ast, 'foo')
+    expect(result).not.toBeNull()
+    expect(result && 'value' in result && result.value).toBe('\\n\\t')
+  })
+
+  it('extracts array with String.raw elements', async () => {
+    const ast = await parseCode(
+      'export const matcher = [String.raw`/api/:path*`, "/about"]'
+    )
+    const result = extractExportedConstValue(ast, 'matcher')
+    expect(result).not.toBeNull()
+    expect(result && 'value' in result && result.value).toEqual([
+      '/api/:path*',
+      '/about',
+    ])
+  })
+
+  it('returns unsupported for String.raw with expressions', async () => {
+    const ast = await parseCode(
+      'export const foo = String.raw`/api/${path}`'
+    )
+    const result = extractExportedConstValue(ast, 'foo')
+    expect(result).not.toBeNull()
+    expect(result && 'unsupported' in result).toBe(true)
+    expect(
+      result && 'unsupported' in result && result.unsupported
+    ).toContain('Unsupported String.raw template literal with expressions')
+  })
+
+  it('returns unsupported for non-String.raw tagged template', async () => {
+    const ast = await parseCode('export const foo = html`<div>test</div>`')
+    const result = extractExportedConstValue(ast, 'foo')
+    expect(result).not.toBeNull()
+    expect(result && 'unsupported' in result).toBe(true)
+    expect(
+      result && 'unsupported' in result && result.unsupported
+    ).toContain('Unsupported tagged template expression')
+  })
+})

--- a/test/unit/extract-const-value.test.ts
+++ b/test/unit/extract-const-value.test.ts
@@ -1,0 +1,58 @@
+import { extractExportedConstValue } from 'next/src/build/analysis/extract-const-value'
+import { parse } from '@swc/core'
+
+async function parseCode(code: string) {
+  return parse(code, { syntax: 'typescript' })
+}
+
+describe('extractExportedConstValue', () => {
+  it('extracts string literal', async () => {
+    const ast = await parseCode(`export const foo = "bar"`)
+    expect(extractExportedConstValue(ast, 'foo')).toBe('bar')
+  })
+
+  it('extracts template literal', async () => {
+    const ast = await parseCode('export const foo = `/api/test`')
+    expect(extractExportedConstValue(ast, 'foo')).toBe('/api/test')
+  })
+
+  it('extracts String.raw tagged template', async () => {
+    const ast = await parseCode(
+      'export const foo = String.raw`/api/:path*`'
+    )
+    expect(extractExportedConstValue(ast, 'foo')).toBe('/api/:path*')
+  })
+
+  it('extracts String.raw with backslashes preserved', async () => {
+    const ast = await parseCode(
+      'export const foo = String.raw`\\n\\t`'
+    )
+    expect(extractExportedConstValue(ast, 'foo')).toBe('\\n\\t')
+  })
+
+  it('extracts array with String.raw elements', async () => {
+    const ast = await parseCode(
+      'export const matcher = [String.raw`/api/:path*`, "/about"]'
+    )
+    expect(extractExportedConstValue(ast, 'matcher')).toEqual([
+      '/api/:path*',
+      '/about',
+    ])
+  })
+
+  it('throws on String.raw with expressions', async () => {
+    const ast = await parseCode(
+      'export const foo = String.raw`/api/${path}`'
+    )
+    expect(() => extractExportedConstValue(ast, 'foo')).toThrow(
+      'Unsupported String.raw template literal with expressions'
+    )
+  })
+
+  it('throws on non-String.raw tagged template', async () => {
+    const ast = await parseCode('export const foo = html`<div>test</div>`')
+    expect(() => extractExportedConstValue(ast, 'foo')).toThrow(
+      'Unsupported tagged template expression'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #89937

When using `String.raw` in middleware `config.matcher`:

```ts
export const config = {
  matcher: String.raw`/api/:path*`,
}
```

The build fails with a generic error:
```
Invalid segment configuration export detected. This can cause unexpected behavior...
```

## Root Cause

`extractExportedConstValue` in `extract-const-value.ts` handles `TemplateLiteral` nodes but not `TaggedTemplateExpression` nodes. `String.raw\`...\`` produces a `TaggedTemplateExpression` in the SWC AST.

## Fix

- Add support for `TaggedTemplateExpression` where the tag is `String.raw`
- Return the `raw` quasis value (preserving backslashes, as `String.raw` does)
- Expressions in `String.raw` templates throw `UnsupportedValueError` (same as regular templates)
- Non-`String.raw` tagged templates throw `UnsupportedValueError`
- Added unit tests for all cases

## Test Plan

- Added unit tests for `extractExportedConstValue` covering:
  - `String.raw` with simple path patterns
  - `String.raw` with backslash sequences (preserved as-is)
  - Array with mixed `String.raw` and string literal elements
  - `String.raw` with expressions (throws)
  - Non-`String.raw` tagged templates (throws)