### PR TITLE
 validate sync IO in generateMetadata according to Page's prefetchable status

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -17,6 +17,11 @@ import type { MetadataContext } from './types/resolvers'
 import { createServerSearchParamsForMetadata } from '../../server/request/search-params'
 import { createServerPathnameForMetadata } from '../../server/request/pathname'
 import { isPostpone } from '../../server/lib/router-utils/is-postpone'
+import {
+  workUnitAsyncStorage,
+  getStagedRenderingController,
+} from '../../server/app-render/work-unit-async-storage.external'
+import { RenderStage } from '../../server/app-render/staged-rendering'
 
 import {
   MetadataBoundary,
@@ -41,6 +46,7 @@ export function createMetadataComponents({
   interpolatedParams,
   errorType,
   serveStreamingMetadata,
+  isRuntimePrefetchable,
 }: {
   tree: LoaderTree
   pathname: string
@@ -49,19 +55,37 @@ export function createMetadataComponents({
   interpolatedParams: Params
   errorType?: MetadataErrorType | 'redirect'
   serveStreamingMetadata: boolean
+  isRuntimePrefetchable: boolean
 }): {
   Viewport: React.ComponentType
   Metadata: React.ComponentType
   MetadataOutlet: React.ComponentType
 } {
-  const searchParams = createServerSearchParamsForMetadata(parsedQuery)
+  const searchParams = createServerSearchParamsForMetadata(
+    parsedQuery,
+    isRuntimePrefetchable
+  )
   const pathnameForMetadata = createServerPathnameForMetadata(pathname)
 
   async function Viewport() {
+    // Gate metadata to the correct render stage. If the page is not
+    // runtime-prefetchable, defer until the Static stage so that
+    // prefetchable segments get a head start.
+    if (!isRuntimePrefetchable) {
+      const workUnitStore = workUnitAsyncStorage.getStore()
+      if (workUnitStore) {
+        const stagedRendering = getStagedRenderingController(workUnitStore)
+        if (stagedRendering) {
+          await stagedRendering.waitForStage(RenderStage.Static)
+        }
+      }
+    }
+
     const tags = await getResolvedViewport(
       tree,
       searchParams,
       interpolatedParams,
+      isRuntimePrefetchable,
       errorType
     ).catch((viewportErr) => {
       // When Legacy PPR is enabled viewport can reject with a Postpone type
@@ -74,7 +98,8 @@ export function createMetadataComponents({
         return getNotFoundViewport(
           tree,
           searchParams,
-          interpolatedParams
+          interpolatedParams,
+          isRuntimePrefetchable
         ).catch(() => null)
       }
       // We're going to throw the error from the metadata outlet so we just render null here instead
@@ -94,12 +119,26 @@ export function createMetadataComponents({
   }
 
   async function Metadata() {
+    // Gate metadata to the correct render stage. If the page is not
+    // runtime-prefetchable, defer until the Static stage so that
+    // prefetchable segments get a head start.
+    if (!isRuntimePrefetchable) {
+      const workUnitStore = workUnitAsyncStorage.getStore()
+      if (workUnitStore) {
+        const stagedRendering = getStagedRenderingController(workUnitStore)
+        if (stagedRendering) {
+          await stagedRendering.waitForStage(RenderStage.Static)
+        }
+      }
+    }
+
     const tags = await getResolvedMetadata(
       tree,
       pathnameForMetadata,
       searchParams,
       interpolatedParams,
       metadataContext,
+      isRuntimePrefetchable,
       errorType
     ).catch((metadataErr) => {
       // When Legacy PPR is enabled metadata can reject with a Postpone type
@@ -114,7 +153,8 @@ export function createMetadataComponents({
           pathnameForMetadata,
           searchParams,
           interpolatedParams,
-          metadataContext
+          metadataContext,
+          isRuntimePrefetchable
         ).catch(() => null)
       }
       // We're going to throw the error from the metadata outlet so we just render null here instead
@@ -155,9 +195,16 @@ export function createMetadataComponents({
         searchParams,
         interpolatedParams,
         metadataContext,
+        isRuntimePrefetchable,
         errorType
       ),
-      getResolvedViewport(tree, searchParams, interpolatedParams, errorType),
+      getResolvedViewport(
+        tree,
+        searchParams,
+        interpolatedParams,
+        isRuntimePrefetchable,
+        errorType
+      ),
     ]).then(() => null)
 
     // TODO: We shouldn't change what we render based on whether we are streaming or not.
@@ -188,6 +235,7 @@ async function getResolvedMetadataImpl(
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
   metadataContext: MetadataContext,
+  isRuntimePrefetchable: boolean,
   errorType?: MetadataErrorType | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
@@ -197,6 +245,7 @@ async function getResolvedMetadataImpl(
     searchParams,
     interpolatedParams,
     metadataContext,
+    isRuntimePrefetchable,
     errorConvention
   )
 }
@@ -207,7 +256,8 @@ async function getNotFoundMetadataImpl(
   pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
-  metadataContext: MetadataContext
+  metadataContext: MetadataContext,
+  isRuntimePrefetchable: boolean
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
   return renderMetadata(
@@ -216,6 +266,7 @@ async function getNotFoundMetadataImpl(
     searchParams,
     interpolatedParams,
     metadataContext,
+    isRuntimePrefetchable,
     notFoundErrorConvention
   )
 }
@@ -225,23 +276,32 @@ async function getResolvedViewportImpl(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
+  isRuntimePrefetchable: boolean,
   errorType?: MetadataErrorType | 'redirect'
 ): Promise<React.ReactNode> {
   const errorConvention = errorType === 'redirect' ? undefined : errorType
-  return renderViewport(tree, searchParams, interpolatedParams, errorConvention)
+  return renderViewport(
+    tree,
+    searchParams,
+    interpolatedParams,
+    isRuntimePrefetchable,
+    errorConvention
+  )
 }
 
 const getNotFoundViewport = cache(getNotFoundViewportImpl)
 async function getNotFoundViewportImpl(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
-  interpolatedParams: Params
+  interpolatedParams: Params,
+  isRuntimePrefetchable: boolean
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
   return renderViewport(
     tree,
     searchParams,
     interpolatedParams,
+    isRuntimePrefetchable,
     notFoundErrorConvention
   )
 }
@@ -252,6 +312,7 @@ async function renderMetadata(
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
   metadataContext: MetadataContext,
+  isRuntimePrefetchable: boolean,
   errorConvention?: MetadataErrorType
 ) {
   const resolvedMetadata = await resolveMetadata(
@@ -260,7 +321,8 @@ async function renderMetadata(
     searchParams,
     errorConvention,
     interpolatedParams,
-    metadataContext
+    metadataContext,
+    isRuntimePrefetchable
   )
   return <>{createMetadataElements(resolvedMetadata)}</>
 }
@@ -269,13 +331,15 @@ async function renderViewport(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
+  isRuntimePrefetchable: boolean,
   errorConvention?: MetadataErrorType
 ) {
   const resolvedViewport = await resolveViewport(
     tree,
     searchParams,
     errorConvention,
-    interpolatedParams
+    interpolatedParams,
+    isRuntimePrefetchable
   )
   return <>{createViewportElements(resolvedViewport)}</>
 }

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -709,7 +709,8 @@ const resolveMetadataItems = cache(async function (
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
-  interpolatedParams: Params
+  interpolatedParams: Params,
+  isRuntimePrefetchable: boolean
 ) {
   const parentParams = {}
   const metadataItems: MetadataItems = []
@@ -723,7 +724,8 @@ const resolveMetadataItems = cache(async function (
     searchParams,
     errorConvention,
     errorMetadataItem,
-    interpolatedParams
+    interpolatedParams,
+    isRuntimePrefetchable
   )
 })
 
@@ -736,7 +738,8 @@ async function resolveMetadataItemsImpl(
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   errorMetadataItem: MetadataItems[number],
-  interpolatedParams: Params
+  interpolatedParams: Params,
+  isRuntimePrefetchable: boolean
 ): Promise<MetadataItems> {
   const [segment, parallelRoutes, { page }] = tree
   const currentTreePrefix =
@@ -756,7 +759,10 @@ async function resolveMetadataItemsImpl(
     }
   }
 
-  const params = createServerParamsForMetadata(currentParams)
+  const params = createServerParamsForMetadata(
+    currentParams,
+    isRuntimePrefetchable
+  )
   const props: SegmentProps = isPage ? { params, searchParams } : { params }
 
   await collectMetadata({
@@ -781,7 +787,8 @@ async function resolveMetadataItemsImpl(
       searchParams,
       errorConvention,
       errorMetadataItem,
-      interpolatedParams
+      interpolatedParams,
+      isRuntimePrefetchable
     )
   }
 
@@ -799,7 +806,8 @@ const resolveViewportItems = cache(async function (
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
-  interpolatedParams: Params
+  interpolatedParams: Params,
+  isRuntimePrefetchable: boolean
 ) {
   const parentParams = {}
   const viewportItems: ViewportItems = []
@@ -815,7 +823,8 @@ const resolveViewportItems = cache(async function (
     searchParams,
     errorConvention,
     errorViewportItemRef,
-    interpolatedParams
+    interpolatedParams,
+    isRuntimePrefetchable
   )
 })
 
@@ -828,7 +837,8 @@ async function resolveViewportItemsImpl(
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   errorViewportItemRef: ErrorViewportItemRef,
-  interpolatedParams: Params
+  interpolatedParams: Params,
+  isRuntimePrefetchable: boolean
 ): Promise<ViewportItems> {
   const [segment, parallelRoutes, { page }] = tree
   const currentTreePrefix =
@@ -848,7 +858,10 @@ async function resolveViewportItemsImpl(
     }
   }
 
-  const params = createServerParamsForMetadata(currentParams)
+  const params = createServerParamsForMetadata(
+    currentParams,
+    isRuntimePrefetchable
+  )
 
   let layerProps: LayoutProps | PageProps
   if (isPage) {
@@ -884,7 +897,8 @@ async function resolveViewportItemsImpl(
       searchParams,
       errorConvention,
       errorViewportItemRef,
-      interpolatedParams
+      interpolatedParams,
+      isRuntimePrefetchable
     )
   }
 
@@ -1253,13 +1267,15 @@ export async function resolveMetadata(
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   interpolatedParams: Params,
-  metadataContext: MetadataContext
+  metadataContext: MetadataContext,
+  isRuntimePrefetchable: boolean
 ): Promise<ResolvedMetadata> {
   const metadataItems = await resolveMetadataItems(
     tree,
     searchParams,
     errorConvention,
-    interpolatedParams
+    interpolatedParams,
+    isRuntimePrefetchable
   )
   const workStore = workAsyncStorage.getStore()
   if (!workStore) {
@@ -1278,13 +1294,15 @@ export async function resolveViewport(
   tree: LoaderTree,
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
-  interpolatedParams: Params
+  interpolatedParams: Params,
+  isRuntimePrefetchable: boolean
 ): Promise<ResolvedViewport> {
   const viewportItems = await resolveViewportItems(
     tree,
     searchParams,
     errorConvention,
-    interpolatedParams
+    interpolatedParams,
+    isRuntimePrefetchable
   )
   return accumulateViewport(viewportItems)
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -228,6 +228,7 @@ import { ImageConfigContext } from '../../shared/lib/image-config-context.shared
 import { imageConfigDefault } from '../../shared/lib/image-config'
 import { RenderStage, StagedRenderingController } from './staged-rendering'
 import {
+  anySegmentHasRuntimePrefetchEnabled,
   isPageAllowedToBlock,
   anySegmentNeedsInstantValidation,
 } from './instant-validation/instant-config'
@@ -544,6 +545,8 @@ async function generateDynamicRSCPayload(
       !options?.actionResult && // Only for navigations
       (await anySegmentNeedsInstantValidation(loaderTree))
 
+    const metadataIsRuntimePrefetchable =
+      await anySegmentHasRuntimePrefetchEnabled(loaderTree)
     const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
       tree: loaderTree,
       parsedQuery: query,
@@ -551,6 +554,7 @@ async function generateDynamicRSCPayload(
       metadataContext: createMetadataContext(ctx.renderOpts),
       interpolatedParams: ctx.interpolatedParams,
       serveStreamingMetadata,
+      isRuntimePrefetchable: metadataIsRuntimePrefetchable,
     })
 
     const rscHead = createElement(
@@ -943,6 +947,8 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
         devFallbackParams,
         validationDebugChannelClient
       )
+    } else {
+      logValidationSkipped(ctx)
     }
 
     debugChannel = returnedDebugChannel
@@ -1431,6 +1437,8 @@ async function getRSCPayload(
   const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
   const hasGlobalNotFound = !!tree[2]['global-not-found']
 
+  const metadataIsRuntimePrefetchable =
+    await anySegmentHasRuntimePrefetchEnabled(tree)
   const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
     tree,
     // When it's using global-not-found, metadata errorType is undefined, which will retrieve the
@@ -1444,6 +1452,7 @@ async function getRSCPayload(
     metadataContext: createMetadataContext(ctx.renderOpts),
     interpolatedParams: ctx.interpolatedParams,
     serveStreamingMetadata,
+    isRuntimePrefetchable: metadataIsRuntimePrefetchable,
   })
 
   const preloadCallbacks: PreloadCallbacks = []
@@ -1556,6 +1565,8 @@ async function getErrorRSCPayload(
   } = ctx
 
   const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
+  const metadataIsRuntimePrefetchable =
+    await anySegmentHasRuntimePrefetchEnabled(tree)
   const { Viewport, Metadata } = createMetadataComponents({
     tree,
     parsedQuery: query,
@@ -1564,6 +1575,7 @@ async function getErrorRSCPayload(
     errorType,
     interpolatedParams: ctx.interpolatedParams,
     serveStreamingMetadata: serveStreamingMetadata,
+    isRuntimePrefetchable: metadataIsRuntimePrefetchable,
   })
 
   const initialHead = createElement(
@@ -2714,6 +2726,8 @@ async function renderToStream(
           requestStore = finalRequestStore
           debugChannel = returnedDebugChannel
         } else {
+          logValidationSkipped(ctx)
+
           // We're either bypassing caches or we can't restart the render.
           // Do a dynamic render, but with (basic) environment labels.
 
@@ -3610,6 +3624,23 @@ async function logMessagesAndSendErrorsToBrowser(
     )
 
     sendErrorsToBrowser(errorsRscStream, htmlRequestId)
+  }
+}
+
+function logValidationSkipped(ctx: AppRenderContext) {
+  if (process.env.__NEXT_TEST_MODE && process.env.NEXT_TEST_LOG_VALIDATION) {
+    const requestId = ctx.requestId
+    const url = ctx.url.href
+    console.log(
+      '<VALIDATION_MESSAGE>' +
+        JSON.stringify({ type: 'validation_start', requestId, url }) +
+        '</VALIDATION_MESSAGE>'
+    )
+    console.log(
+      '<VALIDATION_MESSAGE>' +
+        JSON.stringify({ type: 'validation_end', requestId, url }) +
+        '</VALIDATION_MESSAGE>'
+    )
   }
 }
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -539,6 +539,27 @@ export function getDraftModeProviderForCacheScope(
   return undefined
 }
 
+export function getStagedRenderingController(
+  workUnitStore: WorkUnitStore
+): StagedRenderingController | null {
+  switch (workUnitStore.type) {
+    case 'request':
+    case 'prerender-runtime':
+      return workUnitStore.stagedRendering ?? null
+    case 'prerender':
+    case 'prerender-client':
+    case 'validation-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+      return null
+    default:
+      return workUnitStore satisfies never
+  }
+}
+
 export function getCacheSignal(
   workUnitStore: WorkUnitStore
 ): CacheSignal | null {

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -104,17 +104,16 @@ export function createParamsFromClient(
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
-// TODO: metadata should inherit the runtime prefetchability of the page segment
-const metadataIsRuntimePrefetchable = false
 export type CreateServerParamsForMetadata = typeof createServerParamsForMetadata
 export function createServerParamsForMetadata(
-  underlyingParams: Params
+  underlyingParams: Params,
+  isRuntimePrefetchable: boolean
 ): Promise<Params> {
   const metadataVaryParamsAccumulator = getMetadataVaryParamsAccumulator()
   return createServerParamsForServerSegment(
     underlyingParams,
     metadataVaryParamsAccumulator,
-    metadataIsRuntimePrefetchable
+    isRuntimePrefetchable
   )
 }
 

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -89,16 +89,15 @@ export function createSearchParamsFromClient(
 }
 
 // generateMetadata always runs in RSC context so it is equivalent to a Server Page Component
-// TODO: metadata should inherit the runtime prefetchability of the page segment
-const metadataIsRuntimePrefetchable = false
 export function createServerSearchParamsForMetadata(
-  underlyingSearchParams: SearchParams
+  underlyingSearchParams: SearchParams,
+  isRuntimePrefetchable: boolean
 ): Promise<SearchParams> {
   const metadataVaryParamsAccumulator = getMetadataVaryParamsAccumulator()
   return createServerSearchParamsForServerPage(
     underlyingSearchParams,
     metadataVaryParamsAccumulator,
-    metadataIsRuntimePrefetchable
+    isRuntimePrefetchable
   )
 }
 

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -47,6 +47,18 @@ export default async function Page() {
         <li>
           <DebugLinks href="/suspense-in-root/runtime/invalid-sync-io-after-cache-with-cookie-input" />
         </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page" />
+        </li>
       </ul>
 
       <h2>Static</h2>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx
@@ -1,0 +1,30 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export async function generateMetadata() {
+  await cookies()
+  const now = Date.now()
+  return {
+    title: `Sync IO in metadata: ${now}`,
+  }
+}
+
+async function Runtime() {
+  await cookies()
+  return <p>Runtime content</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Runtime />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/layout.tsx
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers'
+
+// This layout does NOT have runtime prefetch itself, but the child page
+// does. Since metadata belongs to the Page, the sync IO heuristic for
+// generateMetadata uses the Page's prefetchability. Because the child
+// page has runtime prefetch enabled, sync IO in this layout's
+// generateMetadata should error.
+
+export async function generateMetadata() {
+  await cookies()
+  const now = Date.now()
+  return {
+    title: `Layout metadata with sync IO: ${now}`,
+  }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/page.tsx
@@ -1,0 +1,22 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+async function Runtime() {
+  await cookies()
+  return <p>Runtime content</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Runtime />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page/page.tsx
@@ -1,0 +1,28 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+// No unstable_instant — this page is NOT runtime-prefetchable.
+// Sync IO in generateMetadata should be allowed.
+
+export async function generateMetadata() {
+  await cookies()
+  const now = Date.now()
+  return {
+    title: `Sync IO in metadata: ${now}`,
+  }
+}
+
+async function Runtime() {
+  await cookies()
+  return <p>Runtime content</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Runtime />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/layout.tsx
@@ -1,0 +1,17 @@
+import { cookies } from 'next/headers'
+
+// This layout does NOT have runtime prefetch and neither does the child
+// page. Since no segment has runtime prefetch enabled, sync IO in
+// generateMetadata should be allowed.
+
+export async function generateMetadata() {
+  await cookies()
+  const now = Date.now()
+  return {
+    title: `Layout metadata with sync IO: ${now}`,
+  }
+}
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page/page.tsx
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers'
+import { Suspense } from 'react'
+
+// No unstable_instant — this page is NOT runtime-prefetchable.
+
+async function Runtime() {
+  await cookies()
+  return <p>Runtime content</p>
+}
+
+export default function Page() {
+  return (
+    <main>
+      <Suspense fallback={<p>Loading...</p>}>
+        <Runtime />
+      </Suspense>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -698,6 +698,75 @@ describe('instant validation', () => {
       await expectNoValidationErrors(browser, await browser.url())
     })
 
+    it('invalid - runtime prefetch - sync IO in generateMetadata', async () => {
+      // The page has runtime prefetch enabled. generateMetadata uses
+      // cookies() then Date.now(). Since metadata belongs to the Page
+      // and the Page is runtime-prefetchable, this should error.
+      const browser = await navigateTo(
+        '/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata'
+      )
+      await expect(browser).toDisplayCollapsedRedbox(`
+       {
+         "description": "Route "/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
+         "environmentLabel": "Server",
+         "label": "Console Error",
+         "source": "app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (11:20) @ Module.generateMetadata
+       > 11 |   const now = Date.now()
+            |                    ^",
+         "stack": [
+           "Module.generateMetadata app/suspense-in-root/runtime/invalid-sync-io-in-generate-metadata/page.tsx (11:20)",
+           "Next.MetadataOutlet <anonymous>",
+         ],
+       }
+      `)
+    })
+
+    it('valid - runtime prefetch - sync IO in generateMetadata on a static page is allowed', async () => {
+      // The page does NOT have runtime prefetch. generateMetadata uses
+      // cookies() then Date.now(). Since no segment is runtime-prefetchable,
+      // sync IO in generateMetadata should be allowed.
+      const browser = await navigateTo(
+        '/suspense-in-root/runtime/valid-sync-io-in-generate-metadata-static-page'
+      )
+      await expectNoValidationErrors(browser, await browser.url())
+    })
+
+    it('invalid - runtime prefetch - sync IO in layout generateMetadata when page is prefetchable', async () => {
+      // The layout has generateMetadata with sync IO after cookies().
+      // The layout itself does NOT have runtime prefetch, but the child
+      // page does. Since metadata belongs to the Page, and the Page is
+      // runtime-prefetchable, sync IO in the layout's generateMetadata
+      // should error.
+      const browser = await navigateTo(
+        '/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata'
+      )
+      await expect(browser).toDisplayCollapsedRedbox(`
+       {
+         "description": "Route "/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata" used \`Date.now()\` before accessing either uncached data (e.g. \`fetch()\`) or awaiting \`connection()\`. When configured for Runtime prefetching, accessing the current time in a Server Component requires reading one of these data sources first. Alternatively, consider moving this expression into a Client Component or Cache Component. See more info here: https://nextjs.org/docs/messages/next-prerender-runtime-current-time",
+         "environmentLabel": "Server",
+         "label": "Console Error",
+         "source": "app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/layout.tsx (11:20) @ Module.generateMetadata
+       > 11 |   const now = Date.now()
+            |                    ^",
+         "stack": [
+           "Module.generateMetadata app/suspense-in-root/runtime/invalid-sync-io-in-layout-generate-metadata/layout.tsx (11:20)",
+           "Next.MetadataOutlet <anonymous>",
+         ],
+       }
+      `)
+    })
+
+    it('valid - runtime prefetch - sync IO in layout generateMetadata when page is NOT prefetchable', async () => {
+      // The layout has generateMetadata with sync IO after cookies().
+      // Neither the layout nor the page has runtime prefetch. Since no
+      // segment is runtime-prefetchable, sync IO in generateMetadata
+      // should be allowed.
+      const browser = await navigateTo(
+        '/suspense-in-root/runtime/valid-sync-io-in-layout-generate-metadata-static-page'
+      )
+      await expectNoValidationErrors(browser, await browser.url())
+    })
+
     it('invalid - missing suspense around dynamic (with loading.js)', async () => {
       const browser = await navigateTo(
         '/suspense-in-root/static/invalid-only-loading-around-dynamic'
@@ -1264,26 +1333,23 @@ describe('instant validation', () => {
     })
 
     describe('disabling validation', () => {
-      // We don't log any messages if validation is skipped, so the best we can do is wait.
-      const VALIDATION_SKIPPED_WAIT: Parameters<typeof waitForNoErrorToast>[1] =
-        { waitInMs: 3000 }
       it('in a layout', async () => {
         const browser = await navigateTo(
           '/suspense-in-root/disable-validation/in-layout'
         )
-        await waitForNoErrorToast(browser, VALIDATION_SKIPPED_WAIT)
+        await expectNoValidationErrors(browser, await browser.url())
       })
       it('in a page', async () => {
         const browser = await navigateTo(
           '/suspense-in-root/disable-validation/in-page'
         )
-        await waitForNoErrorToast(browser, VALIDATION_SKIPPED_WAIT)
+        await expectNoValidationErrors(browser, await browser.url())
       })
       it('in a page with a parent that has a config', async () => {
         const browser = await navigateTo(
           '/suspense-in-root/disable-validation/in-page-with-outer'
         )
-        await waitForNoErrorToast(browser, VALIDATION_SKIPPED_WAIT)
+        await expectNoValidationErrors(browser, await browser.url())
       })
     })
   })


### PR DESCRIPTION
While metadata is generated using functions defined in many Segments the actual final resolved metadata belongs to the Page Segment specifically. This means that we need to treat the sync IO heuristic for metadata based on whether the Page is considered runtime prefetchable.