### PR TITLE
Fix OTEL propagation and add direct entrypoint e2e coverage

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -527,6 +527,9 @@ export async function handler(
   const method = req.method || 'GET'
   const tracer = getTracer()
   const activeSpan = tracer.getActiveScopeSpan()
+  const isWrappedByNextServer = Boolean(
+    routerServerContext?.isWrappedByNextServer
+  )
 
   const render404 = async () => {
     // TODO: should route-module itself handle rendering the 404
@@ -1544,22 +1547,26 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (activeSpan) {
+    if (isWrappedByNextServer && activeSpan) {
       await handleResponse(activeSpan)
     } else {
-      return await tracer.withPropagatedContext(req.headers, () =>
-        tracer.trace(
-          BaseServerSpan.handleRequest,
-          {
-            spanName: `${method} ${srcPage}`,
-            kind: SpanKind.SERVER,
-            attributes: {
-              'http.method': method,
-              'http.target': req.url,
+      return await tracer.withPropagatedContext(
+        req.headers,
+        () =>
+          tracer.trace(
+            BaseServerSpan.handleRequest,
+            {
+              spanName: `${method} ${srcPage}`,
+              kind: SpanKind.SERVER,
+              attributes: {
+                'http.method': method,
+                'http.target': req.url,
+              },
             },
-          },
-          handleResponse
-        )
+            handleResponse
+          ),
+        undefined,
+        !isWrappedByNextServer
       )
     }
   } catch (err) {

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -203,6 +203,9 @@ export async function handler(
   const method = req.method || 'GET'
   const tracer = getTracer()
   const activeSpan = tracer.getActiveScopeSpan()
+  const isWrappedByNextServer = Boolean(
+    routerServerContext?.isWrappedByNextServer
+  )
   const isMinimalMode = Boolean(getRequestMeta(req, 'minimalMode'))
 
   const incrementalCache =
@@ -491,22 +494,26 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (activeSpan) {
+    if (isWrappedByNextServer && activeSpan) {
       await handleResponse(activeSpan)
     } else {
-      await tracer.withPropagatedContext(req.headers, () =>
-        tracer.trace(
-          BaseServerSpan.handleRequest,
-          {
-            spanName: `${method} ${srcPage}`,
-            kind: SpanKind.SERVER,
-            attributes: {
-              'http.method': method,
-              'http.target': req.url,
+      await tracer.withPropagatedContext(
+        req.headers,
+        () =>
+          tracer.trace(
+            BaseServerSpan.handleRequest,
+            {
+              spanName: `${method} ${srcPage}`,
+              kind: SpanKind.SERVER,
+              attributes: {
+                'http.method': method,
+                'http.target': req.url,
+              },
             },
-          },
-          handleResponse
-        )
+            handleResponse
+          ),
+        undefined,
+        !isWrappedByNextServer
       )
     }
   } catch (err) {

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -80,6 +80,9 @@ export async function handler(
     const tracer = getTracer()
 
     const activeSpan = tracer.getActiveScopeSpan()
+    const isWrappedByNextServer = Boolean(
+      routerServerContext?.isWrappedByNextServer
+    )
     const onRequestError =
       routeModule.instrumentationOnRequestError.bind(routeModule)
 
@@ -151,22 +154,26 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (activeSpan) {
+    if (isWrappedByNextServer && activeSpan) {
       await invokeRouteModule(activeSpan)
     } else {
-      await tracer.withPropagatedContext(req.headers, () =>
-        tracer.trace(
-          BaseServerSpan.handleRequest,
-          {
-            spanName: `${method} ${srcPage}`,
-            kind: SpanKind.SERVER,
-            attributes: {
-              'http.method': method,
-              'http.target': req.url,
+      await tracer.withPropagatedContext(
+        req.headers,
+        () =>
+          tracer.trace(
+            BaseServerSpan.handleRequest,
+            {
+              spanName: `${method} ${srcPage}`,
+              kind: SpanKind.SERVER,
+              attributes: {
+                'http.method': method,
+                'http.target': req.url,
+              },
             },
-          },
-          invokeRouteModule
-        )
+            invokeRouteModule
+          ),
+        undefined,
+        !isWrappedByNextServer
       )
     }
   } catch (err) {

--- a/packages/next/src/server/lib/router-utils/router-server-context.ts
+++ b/packages/next/src/server/lib/router-utils/router-server-context.ts
@@ -49,6 +49,8 @@ export type RouterServerContext = Record<
       errorsRscStream: ReadableStream<Uint8Array>,
       htmlRequestId: string
     ) => void
+    // indicates request handlers are already wrapped by next-server tracing
+    isWrappedByNextServer?: boolean
   }
 >
 

--- a/packages/next/src/server/lib/trace/tracer.test.ts
+++ b/packages/next/src/server/lib/trace/tracer.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment node
+ */
+
+import type {
+  Context,
+  ContextManager,
+  TextMapGetter,
+  TextMapPropagator,
+} from '@opentelemetry/api'
+import {
+  ROOT_CONTEXT,
+  context,
+  createContextKey,
+  propagation,
+  trace,
+} from '@opentelemetry/api'
+
+import { getTracer } from './tracer'
+
+const customContextKey = createContextKey('next.tracer.test.custom-context')
+
+const getter: TextMapGetter<Record<string, string | undefined>> = {
+  keys: (carrier) => Object.keys(carrier),
+  get: (carrier, key) => carrier[key],
+}
+
+class TestContextManager implements ContextManager {
+  private currentContext: Context = ROOT_CONTEXT
+
+  active(): Context {
+    return this.currentContext
+  }
+
+  with<A extends unknown[], F extends (...args: A) => ReturnType<F>>(
+    newContext: Context,
+    fn: F,
+    thisArg?: ThisParameterType<F>,
+    ...args: A
+  ): ReturnType<F> {
+    const previousContext = this.currentContext
+    this.currentContext = newContext
+    try {
+      return fn.apply(thisArg, args)
+    } finally {
+      this.currentContext = previousContext
+    }
+  }
+
+  bind<T>(bindContext: Context, target: T): T {
+    if (typeof target !== 'function') {
+      return target
+    }
+
+    return ((...args: unknown[]) => {
+      return this.with(
+        bindContext,
+        target as (...args: unknown[]) => unknown,
+        undefined,
+        ...args
+      )
+    }) as T
+  }
+
+  enable(): this {
+    return this
+  }
+
+  disable(): this {
+    this.currentContext = ROOT_CONTEXT
+    return this
+  }
+}
+
+class CustomPropagator implements TextMapPropagator {
+  fields(): string[] {
+    return ['x-custom']
+  }
+
+  inject(): void {}
+
+  extract(
+    extractedContext: Context,
+    carrier: Record<string, string | undefined>,
+    mapGetter: TextMapGetter<Record<string, string | undefined>>
+  ): Context {
+    const value = mapGetter.get(carrier, 'x-custom')
+    if (!value || Array.isArray(value)) {
+      return extractedContext
+    }
+
+    return extractedContext.setValue(customContextKey, value)
+  }
+}
+
+describe('withPropagatedContext', () => {
+  beforeEach(() => {
+    context.disable()
+    propagation.disable()
+    context.setGlobalContextManager(new TestContextManager())
+    propagation.setGlobalPropagator(new CustomPropagator())
+  })
+
+  afterEach(() => {
+    propagation.disable()
+    context.disable()
+  })
+
+  it('merges extracted context in force mode when no remote span exists', () => {
+    const activeSpan = trace.wrapSpanContext({
+      traceId: '0123456789abcdef0123456789abcdef',
+      spanId: '0123456789abcdef',
+      traceFlags: 1,
+      isRemote: false,
+    })
+    const activeContext = trace.setSpan(ROOT_CONTEXT, activeSpan)
+
+    const result = context.with(activeContext, () =>
+      getTracer().withPropagatedContext(
+        { 'x-custom': 'custom1' },
+        () => {
+          const scopedContext = context.active()
+          return {
+            customValue: scopedContext.getValue(customContextKey),
+            activeSpanId: trace.getSpanContext(scopedContext)?.spanId,
+          }
+        },
+        getter,
+        true
+      )
+    )
+
+    expect(result).toEqual({
+      customValue: 'custom1',
+      activeSpanId: '0123456789abcdef',
+    })
+  })
+})

--- a/packages/next/src/server/lib/trace/tracer.ts
+++ b/packages/next/src/server/lib/trace/tracer.ts
@@ -227,13 +227,29 @@ class NextTracerImpl implements NextTracer {
   public withPropagatedContext<T, C>(
     carrier: C,
     fn: () => T,
-    getter?: TextMapGetter<C>
+    getter?: TextMapGetter<C>,
+    force = false
   ): T {
     const activeContext = context.active()
+
+    if (force) {
+      const remoteContext = propagation.extract(ROOT_CONTEXT, carrier, getter)
+
+      if (trace.getSpanContext(remoteContext)) {
+        return context.with(remoteContext, fn)
+      }
+
+      // Preserve the current active span while still merging any extracted
+      // baggage/context values from the carrier.
+      const mergedContext = propagation.extract(activeContext, carrier, getter)
+      return context.with(mergedContext, fn)
+    }
+
     if (trace.getSpanContext(activeContext)) {
       // Active span is already set, too late to propagate.
       return fn()
     }
+
     const remoteContext = propagation.extract(activeContext, carrier, getter)
     return context.with(remoteContext, fn)
   }

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1060,6 +1060,9 @@ export default class NextNodeServer extends BaseServer<
     routerServerGlobal[RouterServerContextSymbol][
       relativeProjectDir
     ].nextConfig = this.nextConfig
+    routerServerGlobal[RouterServerContextSymbol][
+      relativeProjectDir
+    ].isWrappedByNextServer = true
 
     try {
       // next.js core assumes page path without trailing slash

--- a/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
+++ b/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
@@ -1,0 +1,62 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'http'
+import path from 'path'
+import getPort from 'get-port'
+import { trace } from '@opentelemetry/api'
+
+import { register } from './instrumentation-custom-server'
+
+register()
+
+type EntrypointHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+  ctx: {
+    waitUntil?: (prom: Promise<void>) => void
+  }
+) => Promise<unknown>
+
+async function main() {
+  const port = await getPort()
+  const hostname = 'localhost'
+
+  require('next/dist/server/node-environment')
+
+  const entrypointPath = path.join(
+    __dirname,
+    '.next',
+    'server',
+    'app',
+    'app',
+    '[param]',
+    'rsc-fetch',
+    'page.js'
+  )
+  const { handler } = require(entrypointPath) as { handler: EntrypointHandler }
+
+  const tracer = trace.getTracer('custom-entrypoint-server', '1.0.0')
+
+  createServer((req, res) => {
+    // Simulate a custom parent span around direct entrypoint invocation.
+    tracer.startActiveSpan('custom-entrypoint-request', async (span) => {
+      try {
+        await handler(req, res, {
+          waitUntil: () => {},
+        })
+      } catch (err) {
+        span.recordException(err as Error)
+        res.statusCode = 500
+        res.end('Internal Server Error')
+      } finally {
+        span.end()
+      }
+    })
+  }).listen(port, undefined, (err?: Error) => {
+    if (err) throw err
+    console.log(`- Local: http://${hostname}:${port}`)
+  })
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1418,6 +1418,66 @@ describe('opentelemetry with custom server', () => {
   })
 })
 
+if (!isNextDev) {
+  describe('opentelemetry with direct entrypoint handler', () => {
+    const { next, skipped } = nextTestSetup({
+      files: __dirname,
+      skipDeployment: true,
+      dependencies: require('./package.json').dependencies,
+      startCommand: 'pnpm start-entrypoint',
+      packageJson: {
+        scripts: {
+          'start-entrypoint': 'pnpm tsx custom-entrypoint-server.ts',
+        },
+      },
+      serverReadyPattern: /- Local:/,
+      env: {
+        TEST_OTEL_COLLECTOR_PORT: String(COLLECTOR_PORT),
+        NEXT_TELEMETRY_DISABLED: '1',
+        NODE_ENV: 'production',
+      },
+    })
+
+    if (skipped) {
+      return
+    }
+
+    let collector: Collector
+
+    function getCollector(): Collector {
+      return collector
+    }
+
+    beforeEach(async () => {
+      collector = await connectCollector({ port: COLLECTOR_PORT })
+    })
+
+    afterEach(async () => {
+      await collector.shutdown()
+    })
+
+    it('should propagate incoming context without next-server wrapper', async () => {
+      await next.fetch('/app/param/rsc-fetch', {
+        headers: {
+          traceparent: `00-${EXTERNAL.traceId}-${EXTERNAL.spanId}-01`,
+        },
+      })
+
+      await expectTrace(getCollector(), [
+        {
+          name: 'GET /app/[param]/rsc-fetch/page',
+          traceId: EXTERNAL.traceId,
+          parentId: EXTERNAL.spanId,
+          attributes: {
+            'http.target': '/app/param/rsc-fetch',
+            'next.span_type': 'BaseServer.handleRequest',
+          },
+        },
+      ])
+    })
+  })
+}
+
 type HierSavedSpan = SavedSpan & { spans?: HierSavedSpan[] }
 type SpanMatch = Omit<Partial<HierSavedSpan>, 'spans'> & { spans?: SpanMatch[] }
 


### PR DESCRIPTION
## Summary
- update tracing propagation behavior so forced extraction does not drop active context when no remote span context is present
- keep existing custom-server OTEL e2e coverage intact
- add a new production e2e scenario that invokes the built app entrypoint handler directly (without next-server wrapper) and asserts incoming trace context propagation

## Testing
- pnpm testonly-dev-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t "opentelemetry with custom server"
- pnpm testonly-start-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t "direct entrypoint handler"
- pnpm testonly-start-turbo test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts -t "opentelemetry with custom server"


x-ref: https://vercel.slack.com/archives/C0AFFL7EDSR