### PR TITLE
Prevent unstable_instant in client components

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1130,7 +1130,12 @@ impl AppEndpoint {
 
             for layout in root_layouts.iter().rev() {
                 let source = Vc::upcast(FileSource::new(layout.clone()));
-                let layout_config = parse_segment_config_from_source(source, ParseSegmentMode::App);
+                let layout_config = parse_segment_config_from_source(
+                    source,
+                    ParseSegmentMode::App {
+                        page_route: self.page.to_string().into(),
+                    },
+                );
                 config.apply_parent_config(&*layout_config.await?);
             }
 

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -36,7 +36,12 @@ pub async fn get_app_route_entry(
     original_segment_config: Option<Vc<NextSegmentConfig>>,
     next_config: Vc<NextConfig>,
 ) -> Result<Vc<AppEntry>> {
-    let segment_from_source = parse_segment_config_from_source(source, ParseSegmentMode::App);
+    let segment_from_source = parse_segment_config_from_source(
+        source,
+        ParseSegmentMode::App {
+            page_route: page.to_string().into(),
+        },
+    );
     let config = if let Some(original_segment_config) = original_segment_config {
         let mut segment_config = segment_from_source.owned().await?;
         segment_config.apply_parent_config(&*original_segment_config.await?);

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -69,7 +69,12 @@ pub async fn get_app_metadata_route_entry(
     let original_path = metadata.clone().into_path();
 
     let source = Vc::upcast(FileSource::new(original_path));
-    let segment_config = parse_segment_config_from_source(source, ParseSegmentMode::App);
+    let segment_config = parse_segment_config_from_source(
+        source,
+        ParseSegmentMode::App {
+            page_route: page.to_string().into(),
+        },
+    );
     let is_dynamic_metadata = matches!(metadata, MetadataItem::Dynamic { .. });
     let is_multi_dynamic: bool = if Some(segment_config).is_some() {
         // is_multi_dynamic is true when config.generateSitemaps or

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -209,9 +209,18 @@ pub struct NextSegmentConfigParsingIssue {
     ident: ResolvedVc<AssetIdent>,
     key: RcStr,
     error: RcStr,
+    title_style: NextSegmentConfigIssueTitleStyle,
     detail: Option<ResolvedVc<StyledString>>,
     source: IssueSource,
     severity: IssueSeverity,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, TaskInput, NonLocalValue, TraceRawVcs, Encode, Decode,
+)]
+enum NextSegmentConfigIssueTitleStyle {
+    Prefixed,
+    Verbatim,
 }
 
 #[turbo_tasks::value_impl]
@@ -221,6 +230,7 @@ impl NextSegmentConfigParsingIssue {
         ident: ResolvedVc<AssetIdent>,
         key: RcStr,
         error: RcStr,
+        title_style: NextSegmentConfigIssueTitleStyle,
         detail: Option<ResolvedVc<StyledString>>,
         source: IssueSource,
         severity: IssueSeverity,
@@ -229,6 +239,7 @@ impl NextSegmentConfigParsingIssue {
             ident,
             key,
             error,
+            title_style,
             detail,
             source,
             severity,
@@ -245,17 +256,22 @@ impl Issue for NextSegmentConfigParsingIssue {
 
     #[turbo_tasks::function]
     async fn title(&self) -> Result<Vc<StyledString>> {
-        Ok(StyledString::Line(vec![
-            StyledString::Text(
-                format!(
-                    "Next.js can't recognize the exported `{}` field in route. ",
-                    self.key,
-                )
-                .into(),
-            ),
-            StyledString::Text(self.error.clone()),
-        ])
-        .cell())
+        Ok(match self.title_style {
+            NextSegmentConfigIssueTitleStyle::Prefixed => StyledString::Line(vec![
+                StyledString::Text(
+                    format!(
+                        "Next.js can't recognize the exported `{}` field in route. ",
+                        self.key,
+                    )
+                    .into(),
+                ),
+                StyledString::Text(self.error.clone()),
+            ])
+            .cell(),
+            NextSegmentConfigIssueTitleStyle::Verbatim => {
+                StyledString::Text(self.error.clone()).cell()
+            }
+        })
     }
 
     #[turbo_tasks::function]
@@ -298,15 +314,25 @@ impl Issue for NextSegmentConfigParsingIssue {
 }
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, TaskInput, NonLocalValue, TraceRawVcs, Encode, Decode,
+    Debug, Clone, PartialEq, Eq, Hash, TaskInput, NonLocalValue, TraceRawVcs, Encode, Decode,
 )]
 pub enum ParseSegmentMode {
     Base,
     // Disallows "use client + generateStatic" and "use client + unstable_instant", and
     // ignores/warns about `export const config`.
-    App,
+    App { page_route: RcStr },
     // Disallows config = { runtime: "edge" }
     Proxy,
+}
+
+fn normalize_app_page_route_for_error(page_route: &str) -> String {
+    if page_route == "/" {
+        "/page".to_string()
+    } else if page_route.ends_with("/page") {
+        page_route.to_string()
+    } else {
+        format!("{page_route}/page")
+    }
 }
 
 /// Parse the raw source code of a file to get the segment config local to that file.
@@ -425,7 +451,16 @@ pub async fn parse_segment_config_from_source(
             let mut config = NextSegmentConfig::default();
 
             let mut parse = async |ident, init, span| {
-                parse_config_value(source, mode, &mut config, eval_context, ident, init, span).await
+                parse_config_value(
+                    source,
+                    mode.clone(),
+                    &mut config,
+                    eval_context,
+                    ident,
+                    init,
+                    span,
+                )
+                .await
             };
 
             for item in &module_ast.body {
@@ -525,7 +560,7 @@ pub async fn parse_segment_config_from_source(
             _ => false,
         });
 
-    if mode == ParseSegmentMode::App && has_use_client_directive {
+    if matches!(mode, ParseSegmentMode::App { .. }) && has_use_client_directive {
         if let Some(span) = config.generate_static_params {
             invalid_config(
                 source,
@@ -542,14 +577,25 @@ pub async fn parse_segment_config_from_source(
         }
 
         if let Some(span) = config.unstable_instant {
-            invalid_config(
-                source,
-                "unstable_instant",
-                span,
+            let error: RcStr = if let ParseSegmentMode::App { page_route } = &mode {
+                let normalized_route = normalize_app_page_route_for_error(page_route);
+                format!(
+                    "Page \"{normalized_route}\" cannot use both \"use client\" and `export const \
+                     unstable_instant = ...`."
+                )
+                .into()
+            } else {
                 rcstr!(
                     "App pages cannot use both \"use client\" and export const \
                      \"unstable_instant\"."
-                ),
+                )
+            };
+            invalid_config_with_title_style(
+                source,
+                "unstable_instant",
+                span,
+                error,
+                NextSegmentConfigIssueTitleStyle::Verbatim,
                 None,
                 IssueSeverity::Error,
             )
@@ -568,6 +614,27 @@ async fn invalid_config(
     value: Option<&JsValue>,
     severity: IssueSeverity,
 ) -> Result<()> {
+    invalid_config_with_title_style(
+        source,
+        key,
+        span,
+        error,
+        NextSegmentConfigIssueTitleStyle::Prefixed,
+        value,
+        severity,
+    )
+    .await
+}
+
+async fn invalid_config_with_title_style(
+    source: ResolvedVc<Box<dyn Source>>,
+    key: &str,
+    span: Span,
+    error: RcStr,
+    title_style: NextSegmentConfigIssueTitleStyle,
+    value: Option<&JsValue>,
+    severity: IssueSeverity,
+) -> Result<()> {
     let detail = if let Some(value) = value {
         let (explainer, hints) = value.explain(2, 0);
         Some(*StyledString::Text(format!("Got {explainer}.{hints}").into()).resolved_cell())
@@ -579,6 +646,7 @@ async fn invalid_config(
         source.ident(),
         key.into(),
         error,
+        title_style,
         detail,
         IssueSource::from_swc_offsets(source, span.lo.to_u32(), span.hi.to_u32()),
         severity,
@@ -634,7 +702,7 @@ async fn parse_config_value(
                 .await;
             };
 
-            if mode == ParseSegmentMode::App {
+            if matches!(mode, ParseSegmentMode::App { .. }) {
                 return invalid_config(
                     source,
                     "config",
@@ -1324,6 +1392,7 @@ async fn parse_segment_config_from_loader_tree_internal(
     loader_tree: &AppPageLoaderTree,
 ) -> Result<NextSegmentConfig> {
     let mut config = NextSegmentConfig::default();
+    let page_route: RcStr = loader_tree.page.to_string().into();
 
     let parallel_configs = loader_tree
         .parallel_routes
@@ -1349,7 +1418,13 @@ async fn parse_segment_config_from_loader_tree_internal(
     {
         let source = Vc::upcast(FileSource::new(path.clone()));
         config.apply_parent_config(
-            &*parse_segment_config_from_source(source, ParseSegmentMode::App).await?,
+            &*parse_segment_config_from_source(
+                source,
+                ParseSegmentMode::App {
+                    page_route: page_route.clone(),
+                },
+            )
+            .await?,
         );
     }
 

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -117,6 +117,9 @@ pub struct NextSegmentConfig {
     pub generate_sitemaps: bool,
     #[turbo_tasks(trace_ignore)]
     #[bincode(with_serde)]
+    pub unstable_instant: Option<Span>,
+    #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
     pub generate_static_params: Option<Span>,
 }
 
@@ -299,7 +302,8 @@ impl Issue for NextSegmentConfigParsingIssue {
 )]
 pub enum ParseSegmentMode {
     Base,
-    // Disallows "use client + generateStatic" and ignores/warns about `export const config`
+    // Disallows "use client + generateStatic" and "use client + unstable_instant", and
+    // ignores/warns about `export const config`.
     App,
     // Disallows config = { runtime: "edge" }
     Proxy,
@@ -505,36 +509,52 @@ pub async fn parse_segment_config_from_source(
     )
     .await?;
 
-    if mode == ParseSegmentMode::App
-        && let Some(span) = config.generate_static_params
-        && module_ast
-            .body
-            .iter()
-            .take_while(|i| match i {
-                ModuleItem::Stmt(stmt) => stmt.directive_continue(),
-                ModuleItem::ModuleDecl(_) => false,
-            })
-            .filter_map(|i| i.as_stmt())
-            .any(|f| match f {
-                Stmt::Expr(ExprStmt { expr, .. }) => match &**expr {
-                    Expr::Lit(Lit::Str(Str { value, .. })) => value == "use client",
-                    _ => false,
-                },
+    let has_use_client_directive = module_ast
+        .body
+        .iter()
+        .take_while(|i| match i {
+            ModuleItem::Stmt(stmt) => stmt.directive_continue(),
+            ModuleItem::ModuleDecl(_) => false,
+        })
+        .filter_map(|i| i.as_stmt())
+        .any(|f| match f {
+            Stmt::Expr(ExprStmt { expr, .. }) => match &**expr {
+                Expr::Lit(Lit::Str(Str { value, .. })) => value == "use client",
                 _ => false,
-            })
-    {
-        invalid_config(
-            source,
-            "generateStaticParams",
-            span,
-            rcstr!(
-                "App pages cannot use both \"use client\" and export function \
-                 \"generateStaticParams()\"."
-            ),
-            None,
-            IssueSeverity::Error,
-        )
-        .await?;
+            },
+            _ => false,
+        });
+
+    if mode == ParseSegmentMode::App && has_use_client_directive {
+        if let Some(span) = config.generate_static_params {
+            invalid_config(
+                source,
+                "generateStaticParams",
+                span,
+                rcstr!(
+                    "App pages cannot use both \"use client\" and export function \
+                     \"generateStaticParams()\"."
+                ),
+                None,
+                IssueSeverity::Error,
+            )
+            .await?;
+        }
+
+        if let Some(span) = config.unstable_instant {
+            invalid_config(
+                source,
+                "unstable_instant",
+                span,
+                rcstr!(
+                    "App pages cannot use both \"use client\" and export const \
+                     \"unstable_instant\"."
+                ),
+                None,
+                IssueSeverity::Error,
+            )
+            .await?;
+        }
     }
 
     Ok(config.cell())
@@ -948,6 +968,9 @@ async fn parse_config_value(
         }
         "generateSitemaps" => {
             config.generate_sitemaps = true;
+        }
+        "unstable_instant" => {
+            config.unstable_instant = Some(span);
         }
         "generateStaticParams" => {
             config.generate_static_params = Some(span);

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1051,5 +1051,6 @@
   "1050": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.\\n\\nTo build on this platform, use Webpack instead:\\n  next build --webpack\\n\\nFor more information, see: https://nextjs.org/docs/app/api-reference/turbopack#supported-platforms",
   "1051": "Turbopack trace server is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings.",
   "1052": "Turbopack is not supported on this platform (%s/%s) because native bindings are not available. Only WebAssembly (WASM) bindings were loaded, and Turbopack requires native bindings. Use the --webpack flag instead.",
-  "1053": "Export encountered errors on %s %s:\\n\\t%s"
+  "1053": "Export encountered errors on %s %s:\\n\\t%s",
+  "1054": "Page \"%s\" cannot use both \"use client\" and \\`export const unstable_instant = ...\\`."
 }

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -690,6 +690,12 @@ export async function getAppPageStaticInfo({
     )
   }
 
+  if (directives?.has('client') && 'unstable_instant' in config) {
+    throw new Error(
+      `Page "${page}" cannot use both "use client" and \`export const unstable_instant = ...\`.`
+    )
+  }
+
   return {
     type: PAGE_TYPES.APP,
     rsc,

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -121,6 +121,10 @@ const ACTION_MODULE_LABEL =
 const CLIENT_DIRECTIVE = 'use client'
 const SERVER_ACTION_DIRECTIVE = 'use server'
 
+function getClientUnstableInstantErrorMessage(page: string): string {
+  return `Page "${page}" cannot use both "use client" and \`export const unstable_instant = ...\`.`
+}
+
 export type RSCModuleType = 'server' | 'client'
 export function getRSCModuleInformation(
   source: string,
@@ -691,9 +695,7 @@ export async function getAppPageStaticInfo({
   }
 
   if (directives?.has('client') && 'unstable_instant' in config) {
-    throw new Error(
-      `Page "${page}" cannot use both "use client" and \`export const unstable_instant = ...\`.`
-    )
+    throw new Error(getClientUnstableInstantErrorMessage(page))
   }
 
   return {

--- a/test/development/acceptance-app/fixtures/rsc-build-errors/app/client-with-errors/unstable-instant/page.js
+++ b/test/development/acceptance-app/fixtures/rsc-build-errors/app/client-with-errors/unstable-instant/page.js
@@ -1,0 +1,7 @@
+'use client'
+
+export const unstable_instant = false
+
+export default function Page() {
+  return 'client-unstable-instant'
+}

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -92,6 +92,28 @@ describe('Error overlay - RSC build errors', () => {
     )
   })
 
+  it('should throw an error when unstable_instant is exported from a client component', async () => {
+    await using sandbox = await createSandbox(
+      next,
+      new Map([
+        [
+          'next.config.js',
+          outdent`
+            module.exports = { experimental: { cacheComponents: true } }
+          `,
+        ],
+      ]),
+      '/client-with-errors/unstable-instant'
+    )
+    const { session } = sandbox
+
+    await session.waitForRedbox()
+    const source = await session.getRedboxSource()
+
+    expect(source).toInclude('"use client"')
+    expect(source).toInclude('unstable_instant')
+  })
+
   // TODO: investigate flakey test case
   it.skip('should throw an error when getStaticProps is used', async () => {
     await using sandbox = await createSandbox(

--- a/test/e2e/app-dir/unstable-instant-client-error/app/hard/page.tsx
+++ b/test/e2e/app-dir/unstable-instant-client-error/app/hard/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+export const unstable_instant = false
+
+export default function HardPage() {
+  return <div>hard nav unstable_instant client page</div>
+}

--- a/test/e2e/app-dir/unstable-instant-client-error/app/layout.tsx
+++ b/test/e2e/app-dir/unstable-instant-client-error/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/unstable-instant-client-error/app/page.tsx
+++ b/test/e2e/app-dir/unstable-instant-client-error/app/page.tsx
@@ -1,0 +1,14 @@
+import Link from 'next/link'
+
+export default function HomePage() {
+  return (
+    <main>
+      <Link id="hard-link" href="/hard">
+        hard nav
+      </Link>
+      <Link id="soft-link" href="/soft">
+        soft nav
+      </Link>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/unstable-instant-client-error/app/soft/page.tsx
+++ b/test/e2e/app-dir/unstable-instant-client-error/app/soft/page.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+export const unstable_instant = false
+
+export default function SoftPage() {
+  return <div>soft nav unstable_instant client page</div>
+}

--- a/test/e2e/app-dir/unstable-instant-client-error/next.config.js
+++ b/test/e2e/app-dir/unstable-instant-client-error/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  cacheComponents: true,
+}

--- a/test/e2e/app-dir/unstable-instant-client-error/unstable-instant-client-error.test.ts
+++ b/test/e2e/app-dir/unstable-instant-client-error/unstable-instant-client-error.test.ts
@@ -1,0 +1,53 @@
+import { nextTestSetup } from 'e2e-utils'
+import {
+  getRedboxDescription,
+  getRedboxSource,
+  retry,
+  waitForRedbox,
+} from 'next-test-utils'
+
+describe('unstable-instant-client-error', () => {
+  const { next, skipped, isNextDev, isTurbopack } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should error when unstable_instant is exported from a client component', async () => {
+    const webpackExpectedError =
+      'Page "/page" cannot use both "use client" and `export const unstable_instant = ...`.'
+    const turbopackExpectedError =
+      'Next.js can\'t recognize the exported `unstable_instant` field in route. App pages cannot use both "use client" and export const "unstable_instant".'
+
+    try {
+      await next.start()
+    } catch {
+      // Expected: build/start should fail in this fixture.
+    }
+
+    if (isNextDev) {
+      if (isTurbopack) {
+        return
+      }
+
+      const browser = await next.browser('/')
+      await waitForRedbox(browser)
+      const description = await getRedboxDescription(browser)
+      const source = await getRedboxSource(browser)
+
+      expect(`${description}\n${source ?? ''}`).toContain(webpackExpectedError)
+    } else {
+      const expectedError = isTurbopack
+        ? turbopackExpectedError
+        : webpackExpectedError
+
+      await retry(async () => {
+        expect(next.cliOutput).toContain(expectedError)
+      })
+    }
+  })
+})

--- a/test/e2e/app-dir/unstable-instant-client-error/unstable-instant-client-error.test.ts
+++ b/test/e2e/app-dir/unstable-instant-client-error/unstable-instant-client-error.test.ts
@@ -18,10 +18,10 @@ describe('unstable-instant-client-error', () => {
   }
 
   it('should error when unstable_instant is exported from a client component', async () => {
-    const webpackExpectedError =
-      'Page "/page" cannot use both "use client" and `export const unstable_instant = ...`.'
-    const turbopackExpectedError =
-      'Next.js can\'t recognize the exported `unstable_instant` field in route. App pages cannot use both "use client" and export const "unstable_instant".'
+    const hardPageExpectedError =
+      'Page "/hard/page" cannot use both "use client" and `export const unstable_instant = ...`.'
+    const softPageExpectedError =
+      'Page "/soft/page" cannot use both "use client" and `export const unstable_instant = ...`.'
 
     try {
       await next.start()
@@ -34,19 +34,26 @@ describe('unstable-instant-client-error', () => {
         return
       }
 
+      const hardNavBrowser = await next.browser('/hard')
+      await waitForRedbox(hardNavBrowser)
+      const hardNavDescription = await getRedboxDescription(hardNavBrowser)
+      const hardNavSource = await getRedboxSource(hardNavBrowser)
+      expect(`${hardNavDescription}\n${hardNavSource ?? ''}`).toContain(
+        hardPageExpectedError
+      )
+
       const browser = await next.browser('/')
+      await browser.elementByCss('#soft-link').click()
       await waitForRedbox(browser)
       const description = await getRedboxDescription(browser)
       const source = await getRedboxSource(browser)
-
-      expect(`${description}\n${source ?? ''}`).toContain(webpackExpectedError)
+      expect(`${description}\n${source ?? ''}`).toContain(softPageExpectedError)
     } else {
-      const expectedError = isTurbopack
-        ? turbopackExpectedError
-        : webpackExpectedError
-
       await retry(async () => {
-        expect(next.cliOutput).toContain(expectedError)
+        expect(
+          next.cliOutput.includes(hardPageExpectedError) ||
+            next.cliOutput.includes(softPageExpectedError)
+        ).toBe(true)
       })
     }
   })


### PR DESCRIPTION
### Why?
- App pages using the client directive should not export `unstable_instant`, yet build/runtime code allowed it and produced unclear errors.
- Tests and configs now cover the combined restriction to avoid confusing diagnostics.

### How?
- Track `unstable_instant` spans in the segment config parser and emit a targeted error when detected on client pages.
- Throw an error during page static info analysis and add localized error messaging.
- Add sandbox and e2e fixtures plus tests to ensure the redbox and CLI errors surface the full message.

### Summary
- Added validation and error messaging for `unstable_instant` on client components.
- Extended tests (dev overlay, e2e) to cover the new conflict scenario and confirm diagnostics.

### Testing
- Not run (not requested)