### PR TITLE
[ci]: pin styled-components version in tests

### DIFF
--- a/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
+++ b/test/e2e/app-dir/rsc-webpack-loader/rsc-webpack-loader.test.ts
@@ -7,7 +7,9 @@ import { nextTestSetup } from 'e2e-utils'
     const { next } = nextTestSetup({
       files: __dirname,
       dependencies: {
-        'styled-components': 'latest',
+        // TODO: Temporarily pinned due to https://github.com/styled-components/styled-components/issues/5667
+        // which is breaking deployment tests
+        'styled-components': '6.3.9',
         'server-only': 'latest',
       },
       resolutions: {

--- a/test/e2e/app-dir/use-server-inserted-html/use-server-inserted-html.test.ts
+++ b/test/e2e/app-dir/use-server-inserted-html/use-server-inserted-html.test.ts
@@ -15,7 +15,9 @@ describe('use-server-inserted-html', () => {
   const { next } = nextTestSetup({
     files: __dirname,
     dependencies: {
-      'styled-components': 'latest',
+      // TODO: Temporarily pinned due to https://github.com/styled-components/styled-components/issues/5667
+      // which is breaking deployment tests
+      'styled-components': '6.3.9',
       'server-only': 'latest',
     },
   })


### PR DESCRIPTION
The latest version is causing deploy test failures. 

x-ref: https://github.com/styled-components/styled-components/issues/5667
 x-ref: https://github.com/vercel/next.js/actions/runs/22162110706/job/64084432174#step:34:375