### PR TITLE
Next.js sticky scroll standards

### DIFF
--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -438,3 +438,55 @@ export function LocaleSwitcher() {
   )
 }
 ```
+
+### Scrolling with sticky headers
+
+When navigating between routes, Next.js automatically scrolls to the top of the new content if it's not already visible. During this process, Next.js skips `sticky` and `fixed` positioned elements (like a navigation bar) to find the first scrollable content element.
+
+This can cause content to appear behind a sticky header after navigation. You can fix this using the CSS [`scroll-padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top) property, which tells the browser to account for the sticky element's height when calculating scroll positions:
+
+```css filename="app/globals.css"
+html {
+  scroll-padding-top: 64px; /* Height of the sticky header */
+}
+```
+
+```tsx filename="app/layout.tsx" switcher
+import './globals.css'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="sticky top-0 z-10 h-16 bg-white">
+          {/* Sticky navigation */}
+        </header>
+        {children}
+      </body>
+    </html>
+  )
+}
+```
+
+```jsx filename="app/layout.js" switcher
+import './globals.css'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="sticky top-0 z-10 h-16 bg-white">
+          {/* Sticky navigation */}
+        </header>
+        {children}
+      </body>
+    </html>
+  )
+}
+```
+
+This also works for hash fragment (`#id`) scrolling. See the [`<Link>` scroll prop](/docs/app/api-reference/components/link#scroll) for more details on how Next.js handles scroll behavior.

--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -158,7 +158,7 @@ Next.js avoids this with client-side transitions using the `<Link>` component. I
 
 Client-side transitions are what makes a server-rendered apps _feel_ like client-rendered apps. And when paired with [prefetching](#prefetching) and [streaming](#streaming), it enables fast transitions, even for dynamic routes.
 
-Next.js also automatically manages [scroll position](/docs/app/api-reference/components/link#scroll) during client-side transitions. If content scrolls behind a sticky or fixed header after navigation, you can fix this with CSS [`scroll-padding-top`](/docs/app/api-reference/components/link#scroll-offset-with-sticky-headers).
+Next.js also handles [scrolling to the top of the page](/docs/app/api-reference/components/link#scroll) during client-side transitions. If content scrolls behind a sticky or fixed header after navigation, you can fix this with CSS [`scroll-padding-top`](/docs/app/api-reference/components/link#scroll-offset-with-sticky-headers).
 
 ## What can make transitions slow?
 

--- a/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
+++ b/docs/01-app/01-getting-started/04-linking-and-navigating.mdx
@@ -158,6 +158,8 @@ Next.js avoids this with client-side transitions using the `<Link>` component. I
 
 Client-side transitions are what makes a server-rendered apps _feel_ like client-rendered apps. And when paired with [prefetching](#prefetching) and [streaming](#streaming), it enables fast transitions, even for dynamic routes.
 
+Next.js also automatically manages [scroll position](/docs/app/api-reference/components/link#scroll) during client-side transitions. If content scrolls behind a sticky or fixed header after navigation, you can fix this with CSS [`scroll-padding-top`](/docs/app/api-reference/components/link#scroll-offset-with-sticky-headers).
+
 ## What can make transitions slow?
 
 These Next.js optimizations make navigation fast and responsive. However, under certain conditions, transitions can still _feel_ slow. Here are some common causes and how to improve the user experience:
@@ -438,55 +440,3 @@ export function LocaleSwitcher() {
   )
 }
 ```
-
-### Scrolling with sticky headers
-
-When navigating between routes, Next.js automatically scrolls to the top of the new content if it's not already visible. During this process, Next.js skips `sticky` and `fixed` positioned elements (like a navigation bar) to find the first scrollable content element.
-
-This can cause content to appear behind a sticky header after navigation. You can fix this using the CSS [`scroll-padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top) property, which tells the browser to account for the sticky element's height when calculating scroll positions:
-
-```css filename="app/globals.css"
-html {
-  scroll-padding-top: 64px; /* Height of the sticky header */
-}
-```
-
-```tsx filename="app/layout.tsx" switcher
-import './globals.css'
-
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode
-}) {
-  return (
-    <html lang="en">
-      <body>
-        <header className="sticky top-0 z-10 h-16 bg-white">
-          {/* Sticky navigation */}
-        </header>
-        {children}
-      </body>
-    </html>
-  )
-}
-```
-
-```jsx filename="app/layout.js" switcher
-import './globals.css'
-
-export default function RootLayout({ children }) {
-  return (
-    <html lang="en">
-      <body>
-        <header className="sticky top-0 z-10 h-16 bg-white">
-          {/* Sticky navigation */}
-        </header>
-        {children}
-      </body>
-    </html>
-  )
-}
-```
-
-This also works for hash fragment (`#id`) scrolling. See the [`<Link>` scroll prop](/docs/app/api-reference/components/link#scroll) for more details on how Next.js handles scroll behavior.

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -234,20 +234,6 @@ When `scroll = {false}`, Next.js will not attempt to scroll to the first Page el
 
 > **Good to know**: Next.js checks if `scroll: false` before managing scroll behavior. If scrolling is enabled, it identifies the relevant DOM node for navigation and inspects each top-level element. All non-scrollable elements and those without rendered HTML are bypassed, this includes sticky or fixed positioned elements, and non-visible elements such as those calculated with `getBoundingClientRect`. Next.js then continues through siblings until it identifies a scrollable element that is visible in the viewport.
 
-#### Handling sticky headers with `scroll-padding-top`
-
-Because Next.js skips `sticky` and `fixed` positioned elements when scrolling, it scrolls to the first visible non-sticky content element. If you have a sticky header (e.g., a navigation bar), the page content may appear to scroll "behind" the header, making it look like the scroll didn't go all the way to the top.
-
-To fix this, use the CSS [`scroll-padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top) property on the scroll container (typically `html`) to account for the height of the sticky element:
-
-```css filename="app/globals.css"
-html {
-  scroll-padding-top: 64px; /* Height of the sticky header */
-}
-```
-
-This tells the browser to offset any scroll-based positioning by the specified amount, ensuring content isn't hidden behind the sticky header. This works for both Next.js auto-scrolling and hash fragment (`#id`) scrolling.
-
 <AppOnly>
 
 ```tsx filename="app/page.tsx" switcher
@@ -897,6 +883,58 @@ export default function Home() {
 ```
 
 </PagesOnly>
+
+### Scroll offset with sticky headers
+
+Because Next.js skips sticky and fixed positioned elements when finding the scroll target, content may end up behind a sticky header after navigation. For example, if your layout has a sticky header:
+
+```tsx filename="app/layout.tsx" switcher
+import './globals.css'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="sticky top-0 h-16 bg-white">
+          {/* Navigation */}
+        </header>
+        {children}
+      </body>
+    </html>
+  )
+}
+```
+
+```jsx filename="app/layout.js" switcher
+import './globals.css'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="sticky top-0 h-16 bg-white">
+          {/* Navigation */}
+        </header>
+        {children}
+      </body>
+    </html>
+  )
+}
+```
+
+You can account for its height using [`scroll-padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top) on the scroll container:
+
+```css filename="app/globals.css"
+html {
+  scroll-padding-top: 64px; /* Match the height of your sticky header */
+}
+```
+
+This is a browser CSS property that offsets scroll-based positioning. It applies whenever Next.js uses the native [`scrollIntoView()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) API, including hash fragment (`#id`) navigation. Alternatively, you can use [`scroll-margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-top) on individual target elements instead of setting a global offset.
 
 ### Prefetching links in Proxy
 

--- a/docs/01-app/03-api-reference/02-components/link.mdx
+++ b/docs/01-app/03-api-reference/02-components/link.mdx
@@ -234,6 +234,20 @@ When `scroll = {false}`, Next.js will not attempt to scroll to the first Page el
 
 > **Good to know**: Next.js checks if `scroll: false` before managing scroll behavior. If scrolling is enabled, it identifies the relevant DOM node for navigation and inspects each top-level element. All non-scrollable elements and those without rendered HTML are bypassed, this includes sticky or fixed positioned elements, and non-visible elements such as those calculated with `getBoundingClientRect`. Next.js then continues through siblings until it identifies a scrollable element that is visible in the viewport.
 
+#### Handling sticky headers with `scroll-padding-top`
+
+Because Next.js skips `sticky` and `fixed` positioned elements when scrolling, it scrolls to the first visible non-sticky content element. If you have a sticky header (e.g., a navigation bar), the page content may appear to scroll "behind" the header, making it look like the scroll didn't go all the way to the top.
+
+To fix this, use the CSS [`scroll-padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-top) property on the scroll container (typically `html`) to account for the height of the sticky element:
+
+```css filename="app/globals.css"
+html {
+  scroll-padding-top: 64px; /* Height of the sticky header */
+}
+```
+
+This tells the browser to offset any scroll-based positioning by the specified amount, ensuring content isn't hidden behind the sticky header. This works for both Next.js auto-scrolling and hash fragment (`#id`) scrolling.
+
 <AppOnly>
 
 ```tsx filename="app/page.tsx" switcher


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
### What?
Adds documentation for handling sticky headers with Next.js navigation using `scroll-padding-top`.

### Why?
Next.js's auto-scroll behavior explicitly skips sticky and fixed positioned elements. This can cause content to appear behind sticky headers when navigating to a hash fragment or using the `scroll` prop on `Link`. This documentation provides a web-standards solution using CSS `scroll-padding-top` to correctly position the scroll target.

### How?
- Added a new "Handling sticky headers with `scroll-padding-top`" subsection to the `Link` component API reference (`docs/01-app/03-api-reference/02-components/link.mdx`) under the `scroll` prop.
- Added a new "Scrolling with sticky headers" example to the "Linking and Navigating" guide (`docs/01-app/01-getting-started/04-linking-and-navigating.mdx`).

---
[Slack Thread](https://vercel.slack.com/archives/C03KAR5DCKC/p1771434038077029?thread_ts=1771434038.077029&cid=C03KAR5DCKC)

<p><a href="https://cursor.com/background-agent?bcId=bc-cc4b24d5-0e73-5b36-84a3-f40e65064f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc4b24d5-0e73-5b36-84a3-f40e65064f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

