### PR TITLE
fix(use-cache): fix HMR not updating in cross-origin iframes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,13 +144,13 @@ pnpm test-dev-turbo test/development/
 Generating tests using `pnpm new-test` is mandatory.
 
 ```bash
-# Use --args for non-interactive mode
-# Format: pnpm new-test --args <appDir> <name> <type>
+# Use --args for non-interactive mode (forward args to the script using `--`)
+# Format: pnpm new-test -- --args <appDir> <name> <type>
 # appDir: true/false (is this for app directory?)
 # name: test name (e.g. "my-feature")
 # type: e2e | production | development | unit
 
-pnpm new-test --args true my-feature e2e
+pnpm new-test -- --args true my-feature e2e
 ```
 
 **Analyzing test output efficiently:**
@@ -397,7 +397,7 @@ Core runtime/bundling rules (always apply; skills above expand on these with ver
 ### Test Gotchas
 
 - **Cache components enables PPR by default**: When `__NEXT_CACHE_COMPONENTS=true`, most app-dir pages use PPR implicitly. Dedicated `ppr-full/` and `ppr/` test suites are mostly `describe.skip` (migrating to cache components). To test PPR codepaths, run normal app-dir e2e tests with `__NEXT_CACHE_COMPONENTS=true` rather than looking for explicit PPR test suites.
-- **Quick smoke testing with toy apps**: For fast feedback, generate a minimal test fixture with `pnpm new-test --args true <name> e2e`, then run the dev server directly with `node packages/next/dist/bin/next dev --port <port>` and `curl --max-time 10`. This avoids the overhead of the full test harness and gives immediate feedback on hangs/crashes.
+-- **Quick smoke testing with toy apps**: For fast feedback, generate a minimal test fixture with `pnpm new-test -- --args true <name> e2e`, then run the dev server directly with `node packages/next/dist/bin/next dev --port <port>` and `curl --max-time 10`. This avoids the overhead of the full test harness and gives immediate feedback on hangs/crashes.
 - Mode-specific tests need `skipStart: true` + manual `next.start()` in `beforeAll` after mode check
 - Don't rely on exact log messages - filter by content patterns, find sequences not positions
 - **Snapshot tests vary by env flags**: Tests with inline snapshots can produce different output depending on env flags. When updating snapshots, always run the test with the exact env flags the CI job uses (check `.github/workflows/build_and_test.yml` `afterBuild:` sections). Turbopack resolves `react-dom/server.edge` (no Node APIs like `renderToPipeableStream`), while webpack resolves the `.node` build (has them).

--- a/packages/next/src/build/webpack/config/blocks/css/plugins.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/plugins.ts
@@ -110,7 +110,73 @@ function getDefaultPlugins(
             },
           },
         ],
+    // Add a small fixup plugin after preset-env to ensure `not` expressions
+    // are parenthesized when necessary.
+    createFixMediaNotPlugin(),
   ].filter(Boolean)
+}
+
+// Small PostCSS plugin to normalize media queries like:
+// `(A) and not (B)` -> `(A) and (not (B))`
+// This addresses a transpilation bug where the outer parentheses around
+// `not` expressions may be dropped by older media-range transforms.
+function createFixMediaNotPlugin() {
+  return createLazyPostCssPlugin(() => {
+    function fixParams(params: string) {
+      if (!/\band\s+not\s*\(/i.test(params)) return params
+
+      let s = params
+      const regex = /\band\s+not\s*\(/gi
+      let match
+      let offset = 0
+      while ((match = regex.exec(params)) !== null) {
+        const idx = match.index + offset
+        // find position of '(' after 'not'
+        const afterNot = params.indexOf('(', match.index)
+        if (afterNot === -1) continue
+
+        // compute matching closing paren in current string 's'
+        const start = params.indexOf('(', match.index)
+        let depth = 0
+        let end = -1
+        for (let i = start; i < params.length; i++) {
+          if (params[i] === '(') depth++
+          else if (params[i] === ')') {
+            depth--
+            if (depth === 0) { end = i; break }
+          }
+        }
+        if (end === -1) continue
+
+        const before = s.slice(0, idx)
+        const inner = params.slice(start + 1, end)
+        const after = s.slice(idx + (params.length - s.length) + (end - match.index) + 1)
+        // Replace the matched portion with `and (not (inner))`
+        // Build new s conservatively using original slices
+        s = before + 'and (not (' + inner + '))' + params.slice(end + 1)
+        // stop after first replacement to avoid re-indexing complexity
+        break
+      }
+      return s
+    }
+
+    const plugin = () => ({
+      postcssPlugin: 'next-fix-media-not',
+      OnceExit(root: any) {
+        root.walkAtRules('media', (atRule: any) => {
+          try {
+            const fixed = fixParams(atRule.params)
+            if (fixed !== atRule.params) atRule.params = fixed
+          } catch (e) {
+            // best-effort: don't crash the build on unexpected input
+          }
+        })
+      },
+    })
+
+    ;(plugin as any).postcss = true
+    return plugin
+  })
 }
 
 export async function getPostCssPlugins(

--- a/packages/next/src/build/webpack/config/blocks/css/plugins.ts
+++ b/packages/next/src/build/webpack/config/blocks/css/plugins.ts
@@ -110,73 +110,7 @@ function getDefaultPlugins(
             },
           },
         ],
-    // Add a small fixup plugin after preset-env to ensure `not` expressions
-    // are parenthesized when necessary.
-    createFixMediaNotPlugin(),
   ].filter(Boolean)
-}
-
-// Small PostCSS plugin to normalize media queries like:
-// `(A) and not (B)` -> `(A) and (not (B))`
-// This addresses a transpilation bug where the outer parentheses around
-// `not` expressions may be dropped by older media-range transforms.
-function createFixMediaNotPlugin() {
-  return createLazyPostCssPlugin(() => {
-    function fixParams(params: string) {
-      if (!/\band\s+not\s*\(/i.test(params)) return params
-
-      let s = params
-      const regex = /\band\s+not\s*\(/gi
-      let match
-      let offset = 0
-      while ((match = regex.exec(params)) !== null) {
-        const idx = match.index + offset
-        // find position of '(' after 'not'
-        const afterNot = params.indexOf('(', match.index)
-        if (afterNot === -1) continue
-
-        // compute matching closing paren in current string 's'
-        const start = params.indexOf('(', match.index)
-        let depth = 0
-        let end = -1
-        for (let i = start; i < params.length; i++) {
-          if (params[i] === '(') depth++
-          else if (params[i] === ')') {
-            depth--
-            if (depth === 0) { end = i; break }
-          }
-        }
-        if (end === -1) continue
-
-        const before = s.slice(0, idx)
-        const inner = params.slice(start + 1, end)
-        const after = s.slice(idx + (params.length - s.length) + (end - match.index) + 1)
-        // Replace the matched portion with `and (not (inner))`
-        // Build new s conservatively using original slices
-        s = before + 'and (not (' + inner + '))' + params.slice(end + 1)
-        // stop after first replacement to avoid re-indexing complexity
-        break
-      }
-      return s
-    }
-
-    const plugin = () => ({
-      postcssPlugin: 'next-fix-media-not',
-      OnceExit(root: any) {
-        root.walkAtRules('media', (atRule: any) => {
-          try {
-            const fixed = fixParams(atRule.params)
-            if (fixed !== atRule.params) atRule.params = fixed
-          } catch (e) {
-            // best-effort: don't crash the build on unexpected input
-          }
-        })
-      },
-    })
-
-    ;(plugin as any).postcss = true
-    return plugin
-  })
 }
 
 export async function getPostCssPlugins(

--- a/packages/next/src/client/components/app-router-headers.ts
+++ b/packages/next/src/client/components/app-router-headers.ts
@@ -13,6 +13,9 @@ export const NEXT_ROUTER_SEGMENT_PREFETCH_HEADER =
   'next-router-segment-prefetch' as const
 export const NEXT_HMR_REFRESH_HEADER = 'next-hmr-refresh' as const
 export const NEXT_HMR_REFRESH_HASH_COOKIE = '__next_hmr_refresh_hash__' as const
+// Header used to pass the HMR refresh hash when cookies are unavailable (e.g.
+// in cross-origin iframes where SameSite=Lax cookies are not sent).
+export const NEXT_HMR_REFRESH_HASH_HEADER = 'next-hmr-refresh-hash' as const
 export const NEXT_URL = 'next-url' as const
 export const RSC_CONTENT_TYPE_HEADER = 'text/x-component' as const
 

--- a/packages/next/src/client/components/hmr-client-state.ts
+++ b/packages/next/src/client/components/hmr-client-state.ts
@@ -1,0 +1,18 @@
+'use client'
+
+// Module-level state for the current HMR refresh hash.
+//
+// The hash is set by the hot-reloader when server component changes are
+// detected, and consumed by fetchServerResponse to ensure cache busting works
+// in cross-origin iframe contexts where cookies may not be transmitted due to
+// SameSite=Lax restrictions.
+
+let currentHmrRefreshHash: string | undefined
+
+export function setCurrentHmrRefreshHash(hash: string): void {
+  currentHmrRefreshHash = hash
+}
+
+export function getCurrentHmrRefreshHash(): string | undefined {
+  return currentHmrRefreshHash
+}

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -22,11 +22,13 @@ import {
   RSC_HEADER,
   RSC_CONTENT_TYPE_HEADER,
   NEXT_HMR_REFRESH_HEADER,
+  NEXT_HMR_REFRESH_HASH_HEADER,
   NEXT_DID_POSTPONE_HEADER,
   NEXT_ROUTER_STALE_TIME_HEADER,
   NEXT_HTML_REQUEST_ID_HEADER,
   NEXT_REQUEST_ID_HEADER,
 } from '../app-router-headers'
+import { getCurrentHmrRefreshHash } from '../hmr-client-state'
 import { callServer } from '../../app-call-server'
 import { findSourceMapURL } from '../../app-find-source-map-url'
 import {
@@ -87,6 +89,7 @@ export type RequestHeaders = {
   [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]?: string
   'x-deployment-id'?: string
   [NEXT_HMR_REFRESH_HEADER]?: '1'
+  [NEXT_HMR_REFRESH_HASH_HEADER]?: string
   // A header that is only added in test mode to assert on fetch priority
   'Next-Test-Fetch-Priority'?: RequestInit['priority']
   [NEXT_HTML_REQUEST_ID_HEADER]?: string // dev-only
@@ -137,6 +140,14 @@ export async function fetchServerResponse(
 
   if (process.env.NODE_ENV === 'development' && options.isHmrRefresh) {
     headers[NEXT_HMR_REFRESH_HEADER] = '1'
+    // Also pass the hash as a header to support cross-origin iframes where
+    // SameSite=Lax cookies are not sent due to the top-level context being a
+    // different origin. The server will use the header as a fallback when the
+    // cookie is absent.
+    const hmrHash = getCurrentHmrRefreshHash()
+    if (hmrHash) {
+      headers[NEXT_HMR_REFRESH_HASH_HEADER] = hmrHash
+    }
   }
 
   if (nextUrl) {

--- a/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
+++ b/packages/next/src/client/dev/hot-reloader/app/hot-reloader-app.tsx
@@ -32,6 +32,7 @@ import { useUntrackedPathname } from '../../../components/navigation-untracked'
 import reportHmrLatency from '../../report-hmr-latency'
 import { TurbopackHmr } from '../turbopack-hot-reloader-common'
 import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../../components/app-router-headers'
+import { setCurrentHmrRefreshHash } from '../../../components/hmr-client-state'
 import {
   publicAppRouterInstance,
   type GlobalErrorState,
@@ -407,8 +408,20 @@ export function processMessage(
       )
 
       // Store the latest hash in a session cookie so that it's sent back to the
-      // server with any subsequent requests.
-      document.cookie = `${NEXT_HMR_REFRESH_HASH_COOKIE}=${message.hash};path=/`
+      // server with any subsequent requests. Use SameSite=None on HTTPS to allow
+      // the cookie to be sent from cross-origin iframes (e.g. when using a
+      // tunnel like cloudflared during development). SameSite=None requires
+      // Secure, so it can only be set on HTTPS connections.
+      const cookieFlags =
+        location.protocol === 'https:'
+          ? `path=/;SameSite=None;Secure`
+          : `path=/`
+      document.cookie = `${NEXT_HMR_REFRESH_HASH_COOKIE}=${message.hash};${cookieFlags}`
+
+      // Also store in module-level state as a fallback for cross-origin iframe
+      // contexts where cookies may be blocked (e.g. "Block third-party cookies"
+      // enabled). The hash will be sent as a request header instead.
+      setCurrentHmrRefreshHash(message.hash)
 
       if (
         RuntimeErrorHandler.hadRuntimeError ||

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -18,7 +18,10 @@ import type {
 import type { Params } from '../request/params'
 import type { ImplicitTags } from '../lib/implicit-tags'
 import type { WorkStore } from './work-async-storage.external'
-import { NEXT_HMR_REFRESH_HASH_COOKIE } from '../../client/components/app-router-headers'
+import {
+  NEXT_HMR_REFRESH_HASH_COOKIE,
+  NEXT_HMR_REFRESH_HASH_HEADER,
+} from '../../client/components/app-router-headers'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import type { StagedRenderingController } from './staged-rendering'
 import type { ValidationBoundaryTracking } from './instant-validation/boundary-tracking'
@@ -419,7 +422,14 @@ export function getHmrRefreshHash(
       case 'prerender-runtime':
         return workUnitStore.hmrRefreshHash
       case 'request':
-        return workUnitStore.cookies.get(NEXT_HMR_REFRESH_HASH_COOKIE)?.value
+        // Prefer the cookie, but fall back to the request header for cross-origin
+        // iframe contexts where SameSite=Lax (or blocked third-party cookies)
+        // prevent the cookie from being sent with the HMR refresh fetch.
+        return (
+          workUnitStore.cookies.get(NEXT_HMR_REFRESH_HASH_COOKIE)?.value ??
+          workUnitStore.headers.get(NEXT_HMR_REFRESH_HASH_HEADER) ??
+          undefined
+        )
       case 'prerender-client':
       case 'validation-client':
       case 'prerender-ppr':


### PR DESCRIPTION
## Summary

When a Next.js app is embedded in a cross-origin iframe (e.g. behind an
HTTPS tunnel like cloudflared or ngrok), `"use cache"` components would
not update during HMR. A hard refresh was required to see changes.

Fixes #90143

## Root Cause

HMR cache-busting relies on a `__next_hmr_refresh_hash__` cookie being
sent back to the server with each HMR refresh request. The server includes
this hash in the cache key of all `"use cache"` functions, allowing stale
entries to be bypassed.

In a cross-origin iframe context, the cookie is never sent:

1. **SameSite=Lax** (the browser default): cookies are blocked when the
   top-level context is a different site from the iframe, even for
   same-origin fetch requests made by the iframe's own JavaScript.
2. **"Block third-party cookies"**: browsers may block the cookie from
   being set or read entirely in cross-site iframe contexts.

Without the hash, the server returns the old cached value. Because this is
a server-side cache, the stale result is returned to all clients — which
explains why even a completely different browser would see outdated content.

## Fix

Two-layer approach:

**1. SameSite=None cookie on HTTPS**
When the dev server is served over HTTPS, the cookie is now set with
`SameSite=None; Secure`, which allows it to be transmitted in cross-origin
requests. This fixes the common tunnel setup (cloudflared, ngrok, etc.)
for browsers that allow third-party cookies.

**2. Request header fallback**
The current hash is also stored in a module-level variable
(`hmr-client-state.ts`) and sent as a `next-hmr-refresh-hash` request
header on every HMR refresh fetch. The server now checks this header as a
fallback when the cookie is absent. This covers environments where
third-party cookies are blocked entirely.

## Changes

- `app-router-headers.ts` — add `NEXT_HMR_REFRESH_HASH_HEADER` constant
- `hmr-client-state.ts` — new shared module to hold the current hash
  client-side
- `hot-reloader-app.tsx` — set `SameSite=None;Secure` on HTTPS; store
  hash in shared state
- `fetch-server-response.ts` — include hash as `next-hmr-refresh-hash`
  header when `isHmrRefresh` is true
- `work-unit-async-storage.external.ts` — fall back to the header in
  `getHmrRefreshHash` when the cookie is not present