### PR TITLE
Add unstable_wrapSegmentsWithSuspense flag and instant-suite coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,26 @@ pnpm build   # Sets up outputs for dependent packages (Turborepo dedupes if unch
 
 **When NOT to use NEXT_SKIP_ISOLATE:** Drop it when testing module resolution changes (new require() paths, new exports from entry-base.ts, edge route imports). Without isolation, the test uses local dist/ directly, hiding resolution failures that occur when Next.js is packed as a real npm package.
 
+### Worktree Validation Flow
+
+When bootstrapping or validating changes in a new worktree, run this sequence:
+
+```bash
+# 1) Install dependencies in the worktree
+pnpm i
+
+# 2) Build core Next.js outputs required by tests
+pnpm --filter=next build
+
+# 3) Run targeted app-dir e2e coverage in both dev bundlers
+pnpm test-dev-turbo test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+pnpm test-dev-webpack test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+
+# 4) Run the same suite in start mode for both bundlers
+pnpm test-start-turbo test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+pnpm test-start-webpack test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+```
+
 ## Bundler Selection
 
 Turbopack is the default bundler for both `next dev` and `next build`. To force webpack:

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -722,6 +722,9 @@ export async function handler(
             ),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
             authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
+            unstable_wrapSegmentsWithSuspense: Boolean(
+              nextConfig.experimental.unstable_wrapSegmentsWithSuspense
+            ),
             clientTraceMetadata:
               nextConfig.experimental.clientTraceMetadata || ([] as any),
             clientParamParsingOrigins:

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -510,6 +510,9 @@ async function exportAppImpl(
       optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
+      unstable_wrapSegmentsWithSuspense: Boolean(
+        nextConfig.experimental.unstable_wrapSegmentsWithSuspense
+      ),
       maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
         nextConfig.experimental.maxPostponedStateSize
       ),

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -119,6 +119,7 @@ async function createComponentTreeInternal(
     componentMod: {
       createElement,
       Fragment,
+      Suspense,
       SegmentViewNode,
       HTTPAccessFallbackBoundary,
       LayoutRouter,
@@ -1082,11 +1083,15 @@ async function createComponentTreeInternal(
             segmentNode
           )
         : segmentNode
+    const maybeWrappedSegmentNode =
+      experimental.unstable_wrapSegmentsWithSuspense === true
+        ? createElement(Suspense, { fallback: null }, wrappedSegmentNode)
+        : wrappedSegmentNode
 
     // For layouts we just render the component
     return createSeedData(
       ctx,
-      wrappedSegmentNode,
+      maybeWrappedSegmentNode,
       parallelRouteCacheNodeSeedData,
       loadingData,
       isPossiblyPartialResponse,

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -13,7 +13,7 @@ export {
 export { prerender } from 'react-server-dom-webpack/static'
 
 // TODO: Just re-export `* as ReactServer`
-export { captureOwnerStack, createElement, Fragment } from 'react'
+export { captureOwnerStack, createElement, Fragment, Suspense } from 'react'
 
 export {
   default as LayoutRouter,

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -161,6 +161,7 @@ export interface RenderOptsPartial {
     optimisticRouting: boolean
     inlineCss: boolean
     authInterrupts: boolean
+    unstable_wrapSegmentsWithSuspense?: boolean
 
     /**
      * The maximum size (in bytes) of the postponed state body for PPR resume

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -574,6 +574,9 @@ export default abstract class Server<
           this.nextConfig.experimental.optimisticRouting ?? false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,
+        unstable_wrapSegmentsWithSuspense: Boolean(
+          this.nextConfig.experimental.unstable_wrapSegmentsWithSuspense
+        ),
         maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
           this.nextConfig.experimental.maxPostponedStateSize
         ),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -239,6 +239,7 @@ export const experimentalSchema = {
   externalMiddlewareRewritesResolve: z.boolean().optional(),
   externalProxyRewritesResolve: z.boolean().optional(),
   exposeTestingApiInProductionBuild: z.boolean().optional(),
+  unstable_wrapSegmentsWithSuspense: z.boolean().optional(),
   fallbackNodePolyfills: z.literal(false).optional(),
   fetchCacheKeyPrefix: z.string().optional(),
   forceSwcTransforms: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -394,6 +394,12 @@ export interface ExperimentalConfig {
    * Do not enable in user-facing production deployments.
    */
   exposeTestingApiInProductionBuild?: boolean
+  /**
+   * Wraps app-router layout segments in `Suspense` with a `null` fallback.
+   * This can be used to avoid static-shell validation failures for blocking
+   * page-level I/O under statically-prefetched layouts.
+   */
+  unstable_wrapSegmentsWithSuspense?: boolean
   extensionAlias?: Record<string, any>
   allowedRevalidateHeaderKeys?: string[]
   fetchCacheKeyPrefix?: string
@@ -1694,6 +1700,7 @@ export const defaultConfig = Object.freeze({
     transitionIndicator: false,
     gestureTransition: false,
     inlineCss: false,
+    unstable_wrapSegmentsWithSuspense: false,
     useCache: undefined,
     slowModuleDetection: undefined,
     globalNotFound: false,
@@ -1805,6 +1812,7 @@ export interface NextConfigRuntime {
     | 'maxPostponedStateSize'
     | 'devCacheControlNoCache'
     | 'exposeTestingApiInProductionBuild'
+    | 'unstable_wrapSegmentsWithSuspense'
   > & {
     // Pick on @internal fields generates invalid .d.ts files
     /** @internal */
@@ -1869,6 +1877,7 @@ export function getNextConfigRuntime(
         maxPostponedStateSize: ex.maxPostponedStateSize,
         devCacheControlNoCache: ex.devCacheControlNoCache,
         exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
+        unstable_wrapSegmentsWithSuspense: ex.unstable_wrapSegmentsWithSuspense,
 
         trustHostHeader: ex.trustHostHeader,
         isExperimentalCompile: ex.isExperimentalCompile,

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/page.tsx
@@ -8,6 +8,12 @@ export default function HomePage() {
         Go to target page
       </Link>
       <Link
+        href="/static-prefetch-blocking"
+        id="link-to-static-prefetch-blocking"
+      >
+        Go to static prefetch blocking page
+      </Link>
+      <Link
         href="/runtime-prefetch-target?myParam=testValue"
         id="link-to-runtime-prefetch"
       >

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/static-prefetch-blocking/layout.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/static-prefetch-blocking/layout.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react'
+
+export const unstable_instant = { prefetch: 'static' as const }
+
+export default function StaticPrefetchBlockingLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return children
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/static-prefetch-blocking/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/static-prefetch-blocking/page.tsx
@@ -1,0 +1,7 @@
+import { connection } from 'next/server'
+
+export default async function StaticPrefetchBlockingPage() {
+  await connection()
+
+  return <p data-testid="hello-world">hello world</p>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -108,6 +108,22 @@ describe('instant-navigation-testing-api', () => {
     )
   })
 
+  it('does not reveal blocking page content inside instant scope under static prefetch', async () => {
+    const page = await openPage('/')
+
+    await instant(page, async () => {
+      await page.click('#link-to-static-prefetch-blocking')
+      await page.waitForURL(/\/static-prefetch-blocking\/?$/)
+
+      const helloWorld = page.locator('[data-testid="hello-world"]')
+      expect(await helloWorld.count()).toBe(0)
+    })
+
+    const helloWorld = page.locator('[data-testid="hello-world"]')
+    await helloWorld.waitFor({ state: 'visible' })
+    expect(await helloWorld.textContent()).toContain('hello world')
+  })
+
   it('renders runtime-prefetched content instantly during navigation', async () => {
     const page = await openPage('/')
 

--- a/test/e2e/app-dir/instant-navigation-testing-api/next.config.js
+++ b/test/e2e/app-dir/instant-navigation-testing-api/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
   experimental: {
     // Enable the testing API in production builds for these tests
     exposeTestingApiInProductionBuild: true,
+    unstable_wrapSegmentsWithSuspense: true,
   },
 }
 


### PR DESCRIPTION
### Summary
- add the new `experimental.unstable_wrapSegmentsWithSuspense` option throughout config, render plumbing, and layout tree construction so layouts can be wrapped in `<Suspense fallback={null}>`
- wire the option through app-page, base server, and export render paths while leaving page rendering unchanged
- extend the instant-navigation e2e fixture to enable the flag, introduce a blocking page under a static-prefetch layout, and assert its content appears outside the `instant()` block

### Testing
- Not run (not requested)

Follow the following format:

### Why?

<Explain why we are making the changes>

### How?

<Explain how we did the changes>