### PR TITLE
Remove workStore from params/searchParams/pathname function signatures

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1065,5 +1065,6 @@
   "1064": "createServerParamsForRoute should not be called in client contexts.",
   "1065": "createServerPathnameForMetadata should not be called in client contexts.",
   "1066": "createServerSearchParamsForServerPage should not be called in a client validation.",
-  "1067": "The Next.js unhandled rejection filter is being installed more than once. This is a bug in Next.js."
+  "1067": "The Next.js unhandled rejection filter is being installed more than once. This is a bug in Next.js.",
+  "1068": "Expected workStore to be initialized"
 }

--- a/packages/next/src/client/components/client-page.tsx
+++ b/packages/next/src/client/components/client-page.tsx
@@ -1,8 +1,6 @@
 'use client'
 
 import type { ParsedUrlQuery } from 'querystring'
-import { InvariantError } from '../../shared/lib/invariant-error'
-
 import type { Params } from '../../server/request/params'
 import { LayoutRouterContext } from '../../shared/lib/app-router-context.shared-runtime'
 import { use } from 'react'
@@ -49,27 +47,16 @@ export function ClientPageRoot({
   }
 
   if (typeof window === 'undefined') {
-    const { workAsyncStorage } =
-      require('../../server/app-render/work-async-storage.external') as typeof import('../../server/app-render/work-async-storage.external')
-
     let clientSearchParams: Promise<ParsedUrlQuery>
     let clientParams: Promise<Params>
-    // We are going to instrument the searchParams prop with tracking for the
-    // appropriate context. We wrap differently in prerendering vs rendering
-    const store = workAsyncStorage.getStore()
-    if (!store) {
-      throw new InvariantError(
-        'Expected workStore to exist when handling searchParams in a client Page.'
-      )
-    }
 
     const { createSearchParamsFromClient } =
       require('../../server/request/search-params') as typeof import('../../server/request/search-params')
-    clientSearchParams = createSearchParamsFromClient(searchParams, store)
+    clientSearchParams = createSearchParamsFromClient(searchParams)
 
     const { createParamsFromClient } =
       require('../../server/request/params') as typeof import('../../server/request/params')
-    clientParams = createParamsFromClient(params, store)
+    clientParams = createParamsFromClient(params)
 
     return <Component params={clientParams} searchParams={clientSearchParams} />
   } else {

--- a/packages/next/src/client/components/client-segment.tsx
+++ b/packages/next/src/client/components/client-segment.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-import { InvariantError } from '../../shared/lib/invariant-error'
-
 import type { Params } from '../../server/request/params'
 import { LayoutRouterContext } from '../../shared/lib/app-router-context.shared-runtime'
 import { use } from 'react'
@@ -38,22 +36,9 @@ export function ClientSegmentRoot({
   }
 
   if (typeof window === 'undefined') {
-    const { workAsyncStorage } =
-      require('../../server/app-render/work-async-storage.external') as typeof import('../../server/app-render/work-async-storage.external')
-
-    let clientParams: Promise<Params>
-    // We are going to instrument the searchParams prop with tracking for the
-    // appropriate context. We wrap differently in prerendering vs rendering
-    const store = workAsyncStorage.getStore()
-    if (!store) {
-      throw new InvariantError(
-        'Expected workStore to exist when handling params in a client segment such as a Layout or Template.'
-      )
-    }
-
     const { createParamsFromClient } =
       require('../../server/request/params') as typeof import('../../server/request/params')
-    clientParams = createParamsFromClient(params, store)
+    const clientParams: Promise<Params> = createParamsFromClient(params)
 
     return <Component {...slots} params={clientParams} />
   } else {

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -57,14 +57,8 @@ export function createMetadataComponents({
   Metadata: React.ComponentType
   MetadataOutlet: React.ComponentType
 } {
-  const searchParams = createServerSearchParamsForMetadata(
-    parsedQuery,
-    workStore
-  )
-  const pathnameForMetadata = createServerPathnameForMetadata(
-    pathname,
-    workStore
-  )
+  const searchParams = createServerSearchParamsForMetadata(parsedQuery)
+  const pathnameForMetadata = createServerPathnameForMetadata(pathname)
 
   async function Viewport() {
     const tags = await getResolvedViewport(

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -758,7 +758,7 @@ async function resolveMetadataItemsImpl(
     }
   }
 
-  const params = createServerParamsForMetadata(currentParams, workStore)
+  const params = createServerParamsForMetadata(currentParams)
   const props: SegmentProps = isPage ? { params, searchParams } : { params }
 
   await collectMetadata({
@@ -854,7 +854,7 @@ async function resolveViewportItemsImpl(
     }
   }
 
-  const params = createServerParamsForMetadata(currentParams, workStore)
+  const params = createServerParamsForMetadata(currentParams)
 
   let layerProps: LayoutProps | PageProps
   if (isPage) {

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -784,8 +784,7 @@ async function createComponentTreeInternal(
       } else if (isStaticGeneration) {
         const promiseOfParams =
           createPrerenderParamsForClientSegment(currentParams)
-        const promiseOfSearchParams =
-          createPrerenderSearchParamsForClientPage(workStore)
+        const promiseOfSearchParams = createPrerenderSearchParamsForClientPage()
         pageElement = createElement(ClientPageRoot, {
           Component: PageComponent,
           serverProvidedParams: {
@@ -809,7 +808,6 @@ async function createComponentTreeInternal(
       // their usage in case the current render mode tracks dynamic API usage.
       const params = createServerParamsForServerSegment(
         currentParams,
-        workStore,
         varyParamsAccumulator,
         isRuntimePrefetchable
       )
@@ -819,7 +817,6 @@ async function createComponentTreeInternal(
       // usage.
       let searchParams = createServerSearchParamsForServerPage(
         query,
-        workStore,
         varyParamsAccumulator,
         isRuntimePrefetchable
       )
@@ -993,7 +990,6 @@ async function createComponentTreeInternal(
     } else {
       const params = createServerParamsForServerSegment(
         currentParams,
-        workStore,
         varyParamsAccumulator,
         isRuntimePrefetchable
       )

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -42,9 +42,12 @@ export type ParamValue = string | Array<string> | undefined
 export type Params = Record<string, ParamValue>
 
 export function createParamsFromClient(
-  underlyingParams: Params,
-  workStore: WorkStore
+  underlyingParams: Params
 ): Promise<Params> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -105,13 +108,11 @@ export function createParamsFromClient(
 const metadataIsRuntimePrefetchable = false
 export type CreateServerParamsForMetadata = typeof createServerParamsForMetadata
 export function createServerParamsForMetadata(
-  underlyingParams: Params,
-  workStore: WorkStore
+  underlyingParams: Params
 ): Promise<Params> {
   const metadataVaryParamsAccumulator = getMetadataVaryParamsAccumulator()
   return createServerParamsForServerSegment(
     underlyingParams,
-    workStore,
     metadataVaryParamsAccumulator,
     metadataIsRuntimePrefetchable
   )
@@ -120,9 +121,12 @@ export function createServerParamsForMetadata(
 // routes always runs in RSC context so it is equivalent to a Server Page Component
 export function createServerParamsForRoute(
   underlyingParams: Params,
-  workStore: WorkStore,
   varyParamsAccumulator: VaryParamsAccumulator | null = null
 ): Promise<Params> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -183,10 +187,13 @@ export function createServerParamsForRoute(
 
 export function createServerParamsForServerSegment(
   underlyingParams: Params,
-  workStore: WorkStore,
   varyParamsAccumulator: VaryParamsAccumulator | null,
   isRuntimePrefetchable: boolean
 ): Promise<Params> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -1,4 +1,7 @@
-import type { WorkStore } from '../app-render/work-async-storage.external'
+import {
+  workAsyncStorage,
+  type WorkStore,
+} from '../app-render/work-async-storage.external'
 
 import {
   postponeWithTracking,
@@ -19,9 +22,12 @@ import {
 import { InvariantError } from '../../shared/lib/invariant-error'
 
 export function createServerPathnameForMetadata(
-  underlyingPathname: string,
-  workStore: WorkStore
+  underlyingPathname: string
 ): Promise<string> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -1,4 +1,7 @@
-import type { WorkStore } from '../app-render/work-async-storage.external'
+import {
+  workAsyncStorage,
+  type WorkStore,
+} from '../app-render/work-async-storage.external'
 import type { VaryParamsAccumulator } from '../app-render/vary-params'
 import {
   createVaryingSearchParams,
@@ -42,9 +45,12 @@ import { RenderStage } from '../app-render/staged-rendering'
 export type SearchParams = { [key: string]: string | string[] | undefined }
 
 export function createSearchParamsFromClient(
-  underlyingSearchParams: SearchParams,
-  workStore: WorkStore
+  underlyingSearchParams: SearchParams
 ): Promise<SearchParams> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -86,13 +92,11 @@ export function createSearchParamsFromClient(
 // TODO: metadata should inherit the runtime prefetchability of the page segment
 const metadataIsRuntimePrefetchable = false
 export function createServerSearchParamsForMetadata(
-  underlyingSearchParams: SearchParams,
-  workStore: WorkStore
+  underlyingSearchParams: SearchParams
 ): Promise<SearchParams> {
   const metadataVaryParamsAccumulator = getMetadataVaryParamsAccumulator()
   return createServerSearchParamsForServerPage(
     underlyingSearchParams,
-    workStore,
     metadataVaryParamsAccumulator,
     metadataIsRuntimePrefetchable
   )
@@ -100,10 +104,13 @@ export function createServerSearchParamsForMetadata(
 
 export function createServerSearchParamsForServerPage(
   underlyingSearchParams: SearchParams,
-  workStore: WorkStore,
   varyParamsAccumulator: VaryParamsAccumulator | null,
   isRuntimePrefetchable: boolean
 ): Promise<SearchParams> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   const workUnitStore = workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
@@ -143,9 +150,11 @@ export function createServerSearchParamsForServerPage(
   throwInvariantForMissingStore()
 }
 
-export function createPrerenderSearchParamsForClientPage(
-  workStore: WorkStore
-): Promise<SearchParams> {
+export function createPrerenderSearchParamsForClientPage(): Promise<SearchParams> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   if (workStore.forceStatic) {
     // When using forceStatic we override all other logic and always just return an empty
     // dictionary object.
@@ -381,9 +390,11 @@ function makeErroringSearchParams(
  * error on access, because accessing searchParams inside of `"use cache"` is
  * not allowed.
  */
-export function makeErroringSearchParamsForUseCache(
-  workStore: WorkStore
-): Promise<SearchParams> {
+export function makeErroringSearchParamsForUseCache(): Promise<SearchParams> {
+  const workStore = workAsyncStorage.getStore()
+  if (!workStore) {
+    throw new InvariantError('Expected workStore to be initialized')
+  }
   const cachedSearchParams = CachedSearchParamsForUseCache.get(workStore)
   if (cachedSearchParams) {
     return cachedSearchParams

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -323,10 +323,7 @@ export class AppRouteRouteModule extends RouteModule<
 
     const handlerContext: AppRouteHandlerFnContext = {
       params: context.params
-        ? createServerParamsForRoute(
-            parsedUrlQueryToParams(context.params),
-            workStore
-          )
+        ? createServerParamsForRoute(parsedUrlQueryToParams(context.params))
         : undefined,
     }
 

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -1139,7 +1139,7 @@ export async function cache(
               // using a hanging promise for search params. For cached pages
               // that do access them, which is an invalid dynamic usage, we
               // need to ensure that an error is shown.
-              makeErroringSearchParamsForUseCache(workStore),
+              makeErroringSearchParamsForUseCache(),
           },
           ...otherInnerArgs,
         ]),

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -225,7 +225,7 @@ describe('build-output-prerender', () => {
           expect(getPrerenderOutput(next.cliOutput)).toMatchInlineSnapshot(`
            "Error: Route "/client" used \`new Date()\` inside a Client Component without a Suspense boundary above it. See more info here: https://nextjs.org/docs/messages/next-prerender-current-time-client
                at Page (webpack:///app/client/page.tsx:4:28)
-               at ClientPageRoot (webpack:///src/client/components/client-page.tsx:74:12)
+               at ClientPageRoot (webpack:///src/client/components/client-page.tsx:61:12)
              2 |
              3 | export default function Page() {
            > 4 |   return <p>Current time: {new Date().toISOString()}</p>


### PR DESCRIPTION
 `workStore` is a request-scoped value available via `workAsyncStorage.getStore()` anywhere during rendering. Threading it as an explicit parameter was originally done to enforce that these functions are only callable within a valid work scope, but
   we already throw InvariantErrors when the store is missing in many other places. Reading it from async storage is more idiomatic and removes a parameter that every caller had to forward without ever varying. This is a step toward making
  metadata components renderable directly without a factory closure that captures workStore.