### PR TITLE
Cached Navigations: Serve cached segments instantly on repeat visits

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1070,5 +1070,6 @@
   "1069": "Invariant: cache entry \"%s\" not found in dir \"%s\"",
   "1070": "image of size %s could not be tracked by lru cache",
   "1071": "toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase",
-  "1072": "Missing segment data: <head>"
+  "1072": "Missing segment data: <head>",
+  "1073": "Expected static stage body to be available"
 }

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1098,6 +1098,26 @@ export async function handler(
             ? getFallbackRouteParams(normalizedSrcPage, routeModule)
             : null
 
+      // For staged dynamic rendering (cached navigations), pass the fallback
+      // params via request meta so the RequestStore knows which params to defer
+      // to the runtime stage. We don't pass them as fallbackRouteParams because
+      // that would replace actual param values with opaque placeholders during
+      // segment resolution.
+      if (
+        isProduction &&
+        nextConfig.cacheComponents &&
+        !isPrerendered &&
+        prerenderInfo?.fallbackRouteParams
+      ) {
+        const fallbackParams = createOpaqueFallbackRouteParams(
+          prerenderInfo.fallbackRouteParams
+        )
+
+        if (fallbackParams) {
+          addRequestMeta(req, 'fallbackParams', fallbackParams)
+        }
+      }
+
       // Perform the render.
       return doRender({
         span,

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -512,18 +512,18 @@ function createFromNextFetch<T>(
 }
 
 async function decodeStaticStageResponse(
-  staticByteCountPromise: Promise<number>,
-  staticBodyPromise: Promise<ReadableStream<Uint8Array> | null>,
+  staticStageByteLengthPromise: Promise<number>,
+  staticStageBodyPromise: Promise<ReadableStream<Uint8Array> | null>,
   requestHeaders: RequestHeaders
 ): Promise<NavigationFlightResponse> {
-  const [staticByteCount, staticBody] = await Promise.all([
-    staticByteCountPromise,
-    staticBodyPromise,
+  const [byteLength, staticBody] = await Promise.all([
+    staticStageByteLengthPromise,
+    staticStageBodyPromise,
   ])
   if (staticBody === null) {
     throw new InvariantError('Expected static stage body to be available')
   }
-  const truncatedStream = truncateStream(staticBody, staticByteCount)
+  const truncatedStream = truncateStream(staticBody, byteLength)
   return createFromNextReadableStream<NavigationFlightResponse>(
     truncatedStream,
     requestHeaders,
@@ -533,10 +533,10 @@ async function decodeStaticStageResponse(
 
 function truncateStream(
   stream: ReadableStream<Uint8Array>,
-  maxBytes: number
+  byteLength: number
 ): ReadableStream<Uint8Array> {
   const reader = stream.getReader()
-  let remaining = maxBytes
+  let remaining = byteLength
 
   return new ReadableStream({
     async pull(controller) {

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -7,6 +7,7 @@ import {
   createFromFetch as createFromFetchBrowser,
 } from 'react-server-dom-webpack/client'
 
+import { InvariantError } from '../../../shared/lib/invariant-error'
 import type {
   FlightRouterState,
   NavigationFlightResponse,
@@ -70,6 +71,7 @@ type SpaFetchServerResponseResult = {
   prerendered: boolean
   postponed: boolean
   staleTime: number
+  staticStageResponse: Promise<NavigationFlightResponse> | null
   debugInfo: Array<any> | null
 }
 
@@ -222,7 +224,7 @@ export async function fetchServerResponse(
       ).waitForWebpackRuntimeHotUpdate()
     }
 
-    let flightResponsePromise = res.flightResponse
+    let flightResponsePromise = res.flightResponsePromise
     if (flightResponsePromise === null) {
       // Typically, `createFetch` would have already started decoding the
       // Flight response. If it hasn't, though, we need to decode it now.
@@ -252,6 +254,20 @@ export async function fetchServerResponse(
       return doMpaNavigation(normalizedFlightData)
     }
 
+    // If the server included a static stage byte count, decode the static
+    // stage from the cloned response body to seed the segment cache.
+    let staticStageResponse: Promise<NavigationFlightResponse> | null = null
+    if (flightResponse.l !== undefined && res.staticStageBodyPromise !== null) {
+      staticStageResponse = decodeStaticStageResponse(
+        flightResponse.l,
+        res.staticStageBodyPromise,
+        headers
+      )
+    } else if (res.staticStageBodyPromise !== null) {
+      // No static stage byte count — cancel the unused clone.
+      res.staticStageBodyPromise.then((body) => body?.cancel())
+    }
+
     return {
       flightData: normalizedFlightData,
       canonicalUrl: canonicalUrl,
@@ -267,6 +283,7 @@ export async function fetchServerResponse(
       prerendered: flightResponse.S,
       postponed,
       staleTime,
+      staticStageResponse,
       debugInfo: flightResponsePromise._debugInfo ?? null,
     }
   } catch (err) {
@@ -296,7 +313,8 @@ export type RSCResponse<T> = {
   body: ReadableStream<Uint8Array> | null
   status: number
   url: string
-  flightResponse: (Promise<T> & { _debugInfo?: Array<any> }) | null
+  flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
+  staticStageBodyPromise: Promise<ReadableStream<Uint8Array> | null> | null
 }
 
 export async function createFetch<T>(
@@ -345,6 +363,15 @@ export async function createFetch<T>(
   let fetchUrl = new URL(url)
   setCacheBustingSearchParam(fetchUrl, headers)
   let fetchPromise = fetch(fetchUrl, fetchOptions)
+
+  // When cache components is enabled, clone the response before Flight
+  // consumes the body, so we can later truncate the clone to extract the
+  // static stage for caching.
+  let staticStageBodyPromise: Promise<ReadableStream<Uint8Array> | null> | null =
+    process.env.__NEXT_CACHE_COMPONENTS
+      ? fetchPromise.then((response) => response.clone().body)
+      : null
+
   // Immediately pass the fetch promise to the Flight client so that the debug
   // info includes the latency from the client to the server. The internal timer
   // in React starts as soon as `createFromFetch` is called.
@@ -413,6 +440,9 @@ export async function createFetch<T>(
       fetchUrl = new URL(responseUrl)
       setCacheBustingSearchParam(fetchUrl, headers)
       fetchPromise = fetch(fetchUrl, fetchOptions)
+      if (process.env.__NEXT_CACHE_COMPONENTS) {
+        staticStageBodyPromise = fetchPromise.then((r) => r.clone().body)
+      }
       flightResponsePromise = shouldImmediatelyDecode
         ? createFromNextFetch<T>(fetchPromise, headers)
         : null
@@ -447,7 +477,9 @@ export async function createFetch<T>(
     // This is the exact promise returned by `createFromFetch`. It contains
     // debug information that we need to transfer to any derived promises that
     // are later rendered by React.
-    flightResponse: flightResponsePromise,
+    flightResponsePromise: flightResponsePromise,
+
+    staticStageBodyPromise: staticStageBodyPromise,
   }
 
   return rscResponse
@@ -474,5 +506,63 @@ function createFromNextFetch<T>(
     callServer,
     findSourceMapURL,
     debugChannel: createDebugChannel && createDebugChannel(requestHeaders),
+  })
+}
+
+async function decodeStaticStageResponse(
+  staticByteCountPromise: Promise<number>,
+  staticBodyPromise: Promise<ReadableStream<Uint8Array> | null>,
+  requestHeaders: RequestHeaders
+): Promise<NavigationFlightResponse> {
+  const [staticByteCount, staticBody] = await Promise.all([
+    staticByteCountPromise,
+    staticBodyPromise,
+  ])
+  if (staticBody === null) {
+    throw new InvariantError('Expected static stage body to be available')
+  }
+  const truncatedStream = truncateStream(staticBody, staticByteCount)
+  return createFromNextReadableStream<NavigationFlightResponse>(
+    truncatedStream,
+    requestHeaders,
+    { allowPartialStream: true }
+  )
+}
+
+function truncateStream(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number
+): ReadableStream<Uint8Array> {
+  const reader = stream.getReader()
+  let remaining = maxBytes
+
+  return new ReadableStream({
+    async pull(controller) {
+      if (remaining <= 0) {
+        reader.cancel()
+        controller.close()
+        return
+      }
+
+      const { done, value } = await reader.read()
+
+      if (done) {
+        controller.close()
+        return
+      }
+
+      if (value.byteLength <= remaining) {
+        controller.enqueue(value)
+        remaining -= value.byteLength
+      } else {
+        controller.enqueue(value.subarray(0, remaining))
+        remaining = 0
+        reader.cancel()
+        controller.close()
+      }
+    },
+    cancel() {
+      reader.cancel()
+    },
   })
 }

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -72,6 +72,7 @@ type SpaFetchServerResponseResult = {
   postponed: boolean
   staleTime: number
   staticStageResponse: Promise<NavigationFlightResponse> | null
+  responseHeaders: Headers
   debugInfo: Array<any> | null
 }
 
@@ -284,6 +285,7 @@ export async function fetchServerResponse(
       postponed,
       staleTime,
       staticStageResponse,
+      responseHeaders: res.headers,
       debugInfo: flightResponsePromise._debugInfo ?? null,
     }
   } catch (err) {

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1550,6 +1550,7 @@ async function fetchMissingDynamicData(
     if (routeCacheEntry !== null && result.staticStageResponse !== null) {
       writeStaticStageResponseIntoCache(
         result.staticStageResponse,
+        result.responseHeaders,
         routeCacheEntry
       )
     }

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -34,6 +34,7 @@ import {
   waitForSegmentCacheEntry,
   markRouteEntryAsDynamicRewrite,
   invalidateRouteCacheEntries,
+  processStaticStageResponse,
   writeStaticStageResponseIntoCache,
   EntryStatus,
 } from '../segment-cache/cache'
@@ -1548,10 +1549,21 @@ async function fetchMissingDynamicData(
     }
 
     if (routeCacheEntry !== null && result.staticStageResponse !== null) {
-      writeStaticStageResponseIntoCache(
-        result.staticStageResponse,
-        result.responseHeaders,
-        routeCacheEntry
+      const now = Date.now()
+      processStaticStageResponse(now, result.staticStageResponse).then(
+        ({ serverData, headVaryParams, staleAt }) =>
+          writeStaticStageResponseIntoCache(
+            now,
+            serverData,
+            result.responseHeaders,
+            headVaryParams,
+            staleAt,
+            routeCacheEntry
+          ),
+        () => {
+          // The static stage processing failed. Not fatal — the navigation
+          // completed normally, we just won't write into the cache.
+        }
       )
     }
 

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -34,6 +34,7 @@ import {
   waitForSegmentCacheEntry,
   markRouteEntryAsDynamicRewrite,
   invalidateRouteCacheEntries,
+  writeStaticStageResponseIntoCache,
   EntryStatus,
 } from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
@@ -1248,7 +1249,8 @@ export function spawnDynamicRequests(
     dynamicRequestTree,
     primaryUrl,
     nextUrl,
-    freshnessPolicy
+    freshnessPolicy,
+    routeCacheEntry
   )
 
   const separateRefreshUrls = accumulation.separateRefreshUrls
@@ -1299,7 +1301,8 @@ export function spawnDynamicRequests(
             // if a refresh fails due to a mismatch, it will trigger a
             // hard refresh.
             nextUrl,
-            freshnessPolicy
+            freshnessPolicy,
+            routeCacheEntry
           )
         )
       }
@@ -1507,7 +1510,8 @@ async function fetchMissingDynamicData(
   dynamicRequestTree: FlightRouterState,
   url: URL,
   nextUrl: string | null,
-  freshnessPolicy: FreshnessPolicy
+  freshnessPolicy: FreshnessPolicy,
+  routeCacheEntry: FulfilledRouteCacheEntry | null
 ): Promise<{
   exitStatus: NavigationTaskExitStatus
   url: URL
@@ -1541,6 +1545,13 @@ async function fetchMissingDynamicData(
     // UI state.
     if (process.env.__NEXT_EXPOSE_TESTING_API) {
       await waitForNavigationLock()
+    }
+
+    if (routeCacheEntry !== null && result.staticStageResponse !== null) {
+      writeStaticStageResponseIntoCache(
+        result.staticStageResponse,
+        routeCacheEntry
+      )
     }
 
     const didReceiveUnknownParallelRoute = writeDynamicDataIntoNavigationTask(

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2687,48 +2687,61 @@ async function getStaleAt(
   return now + STATIC_STALETIME_MS
 }
 
+type ProcessedStaticStageResponse = {
+  readonly serverData: NavigationFlightResponse
+  readonly headVaryParams: VaryParams | null
+  readonly staleAt: number
+}
+
+/**
+ * Resolves a static stage response promise and computes derived values
+ * (stale time, vary params). Callers should `.then()` the result into
+ * `writeStaticStageResponseIntoCache`.
+ */
+export async function processStaticStageResponse(
+  now: number,
+  staticStageResponse: Promise<NavigationFlightResponse>
+): Promise<ProcessedStaticStageResponse> {
+  const serverData = await staticStageResponse
+  const staleAt = await getStaleAt(now, serverData)
+
+  const headVaryParams =
+    serverData.h !== null ? readVaryParams(serverData.h) : null
+
+  return { serverData, headVaryParams, staleAt }
+}
+
 /**
  * Writes the static stage of a dynamic navigation response into the segment
- * cache. Awaits the decoded static stage response, reads its stale time, and
- * writes the segment data.
+ * cache.
  */
-export async function writeStaticStageResponseIntoCache(
-  staticStageResponse: Promise<NavigationFlightResponse>,
+export function writeStaticStageResponseIntoCache(
+  now: number,
+  serverData: NavigationFlightResponse,
   responseHeaders: Headers,
+  headVaryParams: VaryParams | null,
+  staleAt: number,
   route: FulfilledRouteCacheEntry
-): Promise<void> {
-  try {
-    const serverData = await staticStageResponse
-    const now = Date.now()
-    const staleAt = await getStaleAt(now, serverData)
+): void {
+  // All segments are partial — the static stage needs a dynamic fetch to fill
+  // in runtime/dynamic content within their subtrees.
+  const isResponsePartial = true
 
-    const headVaryParams =
-      serverData.h !== null ? readVaryParams(serverData.h) : null
+  // The static stage corresponds to the default prefetching strategy for
+  // Cache Components (FetchStrategy.PPR).
+  const fetchStrategy = FetchStrategy.PPR
 
-    // The truncated stream contains only the static stage, so all segments are
-    // partial — they need a dynamic fetch to fill in runtime/dynamic content
-    // within their subtrees.
-    const isResponsePartial = true
-
-    // The static stage corresponds to the default prefetching strategy for
-    // Cache Components (FetchStrategy.PPR).
-    const fetchStrategy = FetchStrategy.PPR
-
-    writeDynamicRenderResponseIntoCache(
-      now,
-      fetchStrategy,
-      responseHeaders,
-      serverData,
-      isResponsePartial,
-      headVaryParams,
-      staleAt,
-      route,
-      null // spawnedEntries — no pre-created entries; will create or upsert
-    )
-  } catch {
-    // The static stage decode failed. This is not fatal — the navigation
-    // still completed normally, we just won't write into the cache.
-  }
+  writeDynamicRenderResponseIntoCache(
+    now,
+    fetchStrategy,
+    responseHeaders,
+    serverData,
+    isResponsePartial,
+    headVaryParams,
+    staleAt,
+    route,
+    null // spawnedEntries — no pre-created entries; will create or upsert
+  )
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2266,6 +2266,8 @@ export function writeDynamicRenderResponseIntoCache(
 
   const flightDatas = normalizeFlightData(serverData.f)
   if (typeof flightDatas === 'string') {
+    // This means navigating to this route will result in an MPA navigation.
+    // TODO: We should cache this, too, so that the MPA navigation is immediate.
     return null
   }
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -974,6 +974,48 @@ export function attemptToFulfillDynamicSegmentFromBFCache(
   return null
 }
 
+/**
+ * Attempts to replace an existing segment cache entry with data from the
+ * bfcache. Unlike `attemptToFulfillDynamicSegmentFromBFCache` (which fills an
+ * empty entry), this creates a new entry and upserts it, so it works even when
+ * the segment is already fulfilled.
+ */
+export function attemptToUpgradeSegmentFromBFCache(
+  now: number,
+  tree: RouteTree
+): FulfilledSegmentCacheEntry | null {
+  const varyPath = tree.varyPath
+  const adjustedCurrentTime = now - STATIC_STALETIME_MS + DYNAMIC_STALETIME_MS
+  const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
+    adjustedCurrentTime,
+    varyPath
+  )
+  if (bfcacheEntry !== null) {
+    const requestedAt = bfcacheEntry.staleAt - DYNAMIC_STALETIME_MS
+    const dynamicPrefetchStaleAt = requestedAt + STATIC_STALETIME_MS
+    const pendingSegment = upgradeToPendingSegment(
+      createDetachedSegmentCacheEntry(now),
+      FetchStrategy.Full
+    )
+    const isPartial = false
+    const newEntry = fulfillSegmentCacheEntry(
+      pendingSegment,
+      bfcacheEntry.rsc,
+      dynamicPrefetchStaleAt,
+      isPartial
+    )
+    const segmentVaryPath = getSegmentVaryPathForRequest(
+      FetchStrategy.Full,
+      tree
+    )
+    const upserted = upsertSegmentEntry(now, segmentVaryPath, newEntry)
+    if (upserted !== null && upserted.status === EntryStatus.Fulfilled) {
+      return upserted
+    }
+  }
+  return null
+}
+
 function pingBlockedTasks(entry: {
   blockedTasks: Set<PrefetchTask> | null
 }): void {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2246,7 +2246,7 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.LoadingBoundary
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
-  headers: Headers | undefined,
+  responseHeaders: Headers,
   serverData: NavigationFlightResponse,
   isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
@@ -2254,7 +2254,9 @@ export function writeDynamicRenderResponseIntoCache(
   route: FulfilledRouteCacheEntry,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
 ): Array<FulfilledSegmentCacheEntry> | null {
-  const buildId = headers?.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
+  const buildId =
+    responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
+
   if (buildId !== getNavigationBuildId()) {
     // The server build does not match the client. Treat as a 404. During
     // an actual navigation, the router will trigger an MPA navigation.
@@ -2689,6 +2691,7 @@ async function getStaleAt(
  */
 export async function writeStaticStageResponseIntoCache(
   staticStageResponse: Promise<NavigationFlightResponse>,
+  responseHeaders: Headers,
   route: FulfilledRouteCacheEntry
 ): Promise<void> {
   try {
@@ -2712,7 +2715,7 @@ export async function writeStaticStageResponseIntoCache(
     writeDynamicRenderResponseIntoCache(
       now,
       fetchStrategy,
-      undefined, // headers — build ID already verified by fetchServerResponse
+      responseHeaders,
       serverData,
       isResponsePartial,
       headVaryParams,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2244,6 +2244,7 @@ export function writeDynamicRenderResponseIntoCache(
   now: number,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
+    | FetchStrategy.PPR
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
   responseHeaders: Headers,
@@ -2345,6 +2346,7 @@ function writeSeedDataIntoCache(
   now: number,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
+    | FetchStrategy.PPR
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
   tree: RouteTree,
@@ -2404,6 +2406,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   now: number,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
+    | FetchStrategy.PPR
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
   rsc: React.ReactNode,
@@ -2707,10 +2710,9 @@ export async function writeStaticStageResponseIntoCache(
     // within their subtrees.
     const isResponsePartial = true
 
-    // The static stage contains only cached/static content — no runtime or
-    // dynamic data. This is the least specific fetch strategy, so a subsequent
-    // runtime prefetch or full navigation can replace it.
-    const fetchStrategy = FetchStrategy.LoadingBoundary
+    // The static stage corresponds to the default prefetching strategy for
+    // Cache Components (FetchStrategy.PPR).
+    const fetchStrategy = FetchStrategy.PPR
 
     writeDynamicRenderResponseIntoCache(
       now,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -1511,7 +1511,6 @@ export function convertRouteTreeToFlightRouterState(
 
 export async function fetchRouteOnCacheMiss(
   entry: PendingRouteCacheEntry,
-  task: PrefetchTask,
   key: RouteCacheKey
 ): Promise<PrefetchSubtaskResult<null> | null> {
   // This function is allowed to use async/await because it contains the actual
@@ -1755,7 +1754,6 @@ export async function fetchRouteOnCacheMiss(
           : null
       writeDynamicTreeResponseIntoCache(
         Date.now(),
-        task,
         // The non-PPR response format is what we'd get if we prefetched these segments
         // using the LoadingBoundary fetch strategy, so mark their cache entries accordingly.
         FetchStrategy.LoadingBoundary,
@@ -2071,9 +2069,8 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // in the LRU as more data comes in.
     fulfilledEntries = writeDynamicRenderResponseIntoCache(
       now,
-      task,
       fetchStrategy,
-      response as RSCResponse<NavigationFlightResponse>,
+      response.headers,
       serverData,
       isResponsePartial,
       headVaryParams,
@@ -2093,7 +2090,6 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
 
 function writeDynamicTreeResponseIntoCache(
   now: number,
-  task: PrefetchTask,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
     | FetchStrategy.PPRRuntime
@@ -2176,9 +2172,8 @@ function writeDynamicTreeResponseIntoCache(
   // remove the "client-only" option. Then, we can delete this function call.
   writeDynamicRenderResponseIntoCache(
     now,
-    task,
     fetchStrategy,
-    response,
+    response.headers,
     serverData,
     isResponsePartial,
     headVaryParams,
@@ -2203,14 +2198,13 @@ function rejectSegmentEntriesIfStillPending(
   return fulfilledEntries
 }
 
-function writeDynamicRenderResponseIntoCache(
+export function writeDynamicRenderResponseIntoCache(
   now: number,
-  task: PrefetchTask,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
-  response: RSCResponse<NavigationFlightResponse>,
+  headers: Headers | undefined,
   serverData: NavigationFlightResponse,
   isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
@@ -2218,10 +2212,8 @@ function writeDynamicRenderResponseIntoCache(
   route: FulfilledRouteCacheEntry,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
 ): Array<FulfilledSegmentCacheEntry> | null {
-  if (
-    (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b) !==
-    getNavigationBuildId()
-  ) {
+  const buildId = headers?.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
+  if (buildId !== getNavigationBuildId()) {
     // The server build does not match the client. Treat as a 404. During
     // an actual navigation, the router will trigger an MPA navigation.
     if (spawnedEntries !== null) {
@@ -2232,8 +2224,6 @@ function writeDynamicRenderResponseIntoCache(
 
   const flightDatas = normalizeFlightData(serverData.f)
   if (typeof flightDatas === 'string') {
-    // This means navigating to this route will result in an MPA navigation.
-    // TODO: We should cache this, too, so that the MPA navigation is immediate.
     return null
   }
 
@@ -2263,7 +2253,6 @@ function writeDynamicRenderResponseIntoCache(
 
       writeSeedDataIntoCache(
         now,
-        task,
         fetchStrategy,
         tree,
         staleAt,
@@ -2308,7 +2297,6 @@ function writeDynamicRenderResponseIntoCache(
 
 function writeSeedDataIntoCache(
   now: number,
-  task: PrefetchTask,
   fetchStrategy:
     | FetchStrategy.LoadingBoundary
     | FetchStrategy.PPRRuntime
@@ -2354,7 +2342,6 @@ function writeSeedDataIntoCache(
       if (childSeedData !== null && childSeedData !== undefined) {
         writeSeedDataIntoCache(
           now,
-          task,
           fetchStrategy,
           childTree,
           staleAt,
@@ -2617,7 +2604,7 @@ function getStaleAtFromHeader(
 async function getStaleAt(
   now: number,
   serverData: NavigationFlightResponse,
-  response: RSCResponse<unknown>
+  response?: RSCResponse<unknown>
 ): Promise<number> {
   if (serverData.s !== undefined) {
     // Iterate the async iterable and take the last yielded value. The server
@@ -2644,7 +2631,55 @@ async function getStaleAt(
     }
   }
 
-  return getStaleAtFromHeader(now, response)
+  if (response !== undefined) {
+    return getStaleAtFromHeader(now, response)
+  }
+
+  return now + STATIC_STALETIME_MS
+}
+
+/**
+ * Writes the static stage of a dynamic navigation response into the segment
+ * cache. Awaits the decoded static stage response, reads its stale time, and
+ * writes the segment data.
+ */
+export async function writeStaticStageResponseIntoCache(
+  staticStageResponse: Promise<NavigationFlightResponse>,
+  route: FulfilledRouteCacheEntry
+): Promise<void> {
+  try {
+    const serverData = await staticStageResponse
+    const now = Date.now()
+    const staleAt = await getStaleAt(now, serverData)
+
+    const headVaryParams =
+      serverData.h !== null ? readVaryParams(serverData.h) : null
+
+    // The truncated stream contains only the static stage, so all segments are
+    // partial — they need a dynamic fetch to fill in runtime/dynamic content
+    // within their subtrees.
+    const isResponsePartial = true
+
+    // The static stage contains only cached/static content — no runtime or
+    // dynamic data. This is the least specific fetch strategy, so a subsequent
+    // runtime prefetch or full navigation can replace it.
+    const fetchStrategy = FetchStrategy.LoadingBoundary
+
+    writeDynamicRenderResponseIntoCache(
+      now,
+      fetchStrategy,
+      undefined, // headers — build ID already verified by fetchServerResponse
+      serverData,
+      isResponsePartial,
+      headVaryParams,
+      staleAt,
+      route,
+      null // spawnedEntries — no pre-created entries; will create or upsert
+    )
+  } catch {
+    // The static stage decode failed. This is not fatal — the navigation
+    // still completed normally, we just won't write into the cache.
+  }
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -19,6 +19,7 @@ import {
   readRouteCacheEntry,
   deprecated_requestOptimisticRouteCacheEntry,
   convertRootFlightRouterStateToRouteTree,
+  writeStaticStageResponseIntoCache,
   type RouteTree,
   type FulfilledRouteCacheEntry,
 } from './cache'
@@ -368,6 +369,7 @@ async function navigateToUnknownRoute(
     renderedSearch,
     couldBeIntercepted,
     prerendered,
+    staticStageResponse,
     debugInfo,
   } = result
 
@@ -387,7 +389,7 @@ async function navigateToUnknownRoute(
   // retrying after a tree mismatch (see dispatchRetryDueToTreeMismatch).
   const metadataVaryPath = navigationSeed.metadataVaryPath
   if (metadataVaryPath !== null) {
-    discoverKnownRoute(
+    const fulfilledRoute = discoverKnownRoute(
       now,
       url.pathname,
       nextUrl,
@@ -399,6 +401,12 @@ async function navigateToUnknownRoute(
       prerendered,
       false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
     )
+
+    // Write the static stage of the response into the segment cache so
+    // that subsequent navigations can serve cached static segments instantly.
+    if (staticStageResponse !== null) {
+      writeStaticStageResponseIntoCache(staticStageResponse, fulfilledRoute)
+    }
   }
 
   return navigateToKnownRoute(

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -370,6 +370,7 @@ async function navigateToUnknownRoute(
     couldBeIntercepted,
     prerendered,
     staticStageResponse,
+    responseHeaders,
     debugInfo,
   } = result
 
@@ -405,7 +406,11 @@ async function navigateToUnknownRoute(
     // Write the static stage of the response into the segment cache so
     // that subsequent navigations can serve cached static segments instantly.
     if (staticStageResponse !== null) {
-      writeStaticStageResponseIntoCache(staticStageResponse, fulfilledRoute)
+      writeStaticStageResponseIntoCache(
+        staticStageResponse,
+        responseHeaders,
+        fulfilledRoute
+      )
     }
   }
 

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -19,6 +19,7 @@ import {
   readRouteCacheEntry,
   deprecated_requestOptimisticRouteCacheEntry,
   convertRootFlightRouterStateToRouteTree,
+  processStaticStageResponse,
   writeStaticStageResponseIntoCache,
   type RouteTree,
   type FulfilledRouteCacheEntry,
@@ -406,10 +407,20 @@ async function navigateToUnknownRoute(
     // Write the static stage of the response into the segment cache so
     // that subsequent navigations can serve cached static segments instantly.
     if (staticStageResponse !== null) {
-      writeStaticStageResponseIntoCache(
-        staticStageResponse,
-        responseHeaders,
-        fulfilledRoute
+      processStaticStageResponse(now, staticStageResponse).then(
+        ({ serverData, headVaryParams, staleAt }) =>
+          writeStaticStageResponseIntoCache(
+            now,
+            serverData,
+            responseHeaders,
+            headVaryParams,
+            staleAt,
+            fulfilledRoute
+          ),
+        () => {
+          // The static stage processing failed. Not fatal — the navigation
+          // completed normally, we just won't write into the cache.
+        }
       )
     }
   }

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -26,6 +26,7 @@ import {
   overwriteRevalidatingSegmentCacheEntry,
   canNewFetchStrategyProvideMoreContent,
   attemptToFulfillDynamicSegmentFromBFCache,
+  attemptToUpgradeSegmentFromBFCache,
 } from './cache'
 import { getSegmentVaryPathForRequest, type SegmentVaryPath } from './vary-path'
 import type { RouteCacheKey } from './cache-key'
@@ -1347,11 +1348,22 @@ function pingRouteTreeAndIncludeDynamicData(
           fetchStrategy
         )
       ) {
-        // The cached segment contains dynamic holes, and was prefetched using a less specific strategy than the current one.
-        // This means we're in one of these cases:
+        // The cached segment contains dynamic holes, and was prefetched using a
+        // less specific strategy than the current one. This means we're in one
+        // of these cases:
         //   - we have a static prefetch, and we're doing a runtime prefetch
-        //   - we have a static or runtime prefetch, and we're doing a Full prefetch (or a navigation).
-        // In either case, we need to include it in the request to get a more specific (or full) version.
+        //   - we have a static or runtime prefetch, and we're doing a Full
+        //     prefetch (or a navigation).
+        // In either case, we need to include it in the request to get a more
+        // specific (or full) version. However, if there's a non-stale bfcache
+        // entry from a previous navigation, prefer that over making a new
+        // request.
+        if (fetchStrategy === FetchStrategy.Full) {
+          const fulfilled = attemptToUpgradeSegmentFromBFCache(now, tree)
+          if (fulfilled !== null) {
+            break
+          }
+        }
         spawnedSegment = pingFullSegmentRevalidation(now, tree, fetchStrategy)
       }
       break

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -621,7 +621,7 @@ function pingRoute(now: number, task: PrefetchTask): PrefetchTaskExitStatus {
         if (background(task)) {
           routeWithoutSearch.status = EntryStatus.Pending
           spawnPrefetchSubtask(
-            fetchRouteOnCacheMiss(routeWithoutSearch, task, keyWithoutSearch)
+            fetchRouteOnCacheMiss(routeWithoutSearch, keyWithoutSearch)
           )
         }
         break
@@ -663,7 +663,7 @@ function pingRootRouteTree(
       // behavior if PPR is disabled for a route (via the incremental opt-in).
       //
       // Those cases will be handled here.
-      spawnPrefetchSubtask(fetchRouteOnCacheMiss(route, task, task.key))
+      spawnPrefetchSubtask(fetchRouteOnCacheMiss(route, task.key))
 
       // If the request takes longer than a minute, a subsequent request should
       // retry instead of waiting for this one. When the response is received,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -7,6 +7,7 @@ import type {
   FlightRouterState,
   CacheNodeSeedData,
   RSCPayload,
+  NavigationFlightResponse,
   FlightData,
   InitialRSCPayload,
   FlightDataPath,
@@ -304,14 +305,9 @@ function maybeAppendBuildIdToRSCPayload<T extends RSCPayload>(
   if (!ctx.sharedContext.deploymentId) {
     // When using the build id, we need to initialize the id on initial page load, so a build id
     // header wouldn't be enough.
-    return {
-      ...payload,
-      b: ctx.sharedContext.buildId,
-    }
-  } else {
-    // We rely on a response header
-    return payload
+    payload.b = ctx.sharedContext.buildId
   }
+  return payload
 }
 
 interface ParseRequestHeadersOptions {
@@ -510,6 +506,7 @@ async function generateDynamicRSCPayload(
     actionResult?: ActionResult
     skipPageRendering?: boolean
     staleTimeIterable?: AsyncIterable<number>
+    staticStageByteLengthPromise?: Promise<number>
   }
 ): Promise<RSCPayload> {
   // Flight data that is going to be passed to the browser.
@@ -630,19 +627,23 @@ async function generateDynamicRSCPayload(
   }
 
   // Otherwise, it's a regular RSC response.
-  const baseResponse = maybeAppendBuildIdToRSCPayload(ctx, {
-    f: flightData,
-    q: getRenderedSearch(query),
-    i: !!couldBeIntercepted,
-    S: workStore.isStaticGeneration,
-    h: getMetadataVaryParamsThenable(),
-  })
+  const baseResponse: NavigationFlightResponse = maybeAppendBuildIdToRSCPayload(
+    ctx,
+    {
+      f: flightData,
+      q: getRenderedSearch(query),
+      i: !!couldBeIntercepted,
+      S: workStore.isStaticGeneration,
+      h: getMetadataVaryParamsThenable(),
+    }
+  )
 
   if (options?.staleTimeIterable !== undefined) {
-    return {
-      ...baseResponse,
-      s: options.staleTimeIterable,
-    }
+    baseResponse.s = options.staleTimeIterable
+  }
+
+  if (options?.staticStageByteLengthPromise !== undefined) {
+    baseResponse.l = options.staticStageByteLengthPromise
   }
 
   return baseResponse
@@ -740,6 +741,107 @@ async function generateDynamicFlightRenderResult(
   )
 }
 
+/**
+ * Production-only staged dynamic flight render for cache components. Uses
+ * staged rendering to separate static (RDC-backed) from runtime/dynamic
+ * content.
+ */
+async function generateStagedDynamicFlightRenderResult(
+  req: BaseNextRequest,
+  ctx: AppRenderContext,
+  requestStore: RequestStore
+): Promise<RenderResult> {
+  const { componentMod, workStore, renderOpts } = ctx
+  const { renderToReadableStream } = componentMod
+  const { onInstrumentationRequestError, experimental } = renderOpts
+
+  function onFlightDataRenderError(err: DigestedError, silenceLog: boolean) {
+    return onInstrumentationRequestError?.(
+      err,
+      req,
+      createErrorContext(ctx, 'react-server-components-payload'),
+      silenceLog
+    )
+  }
+
+  const onError = createReactServerErrorHandler(
+    false,
+    false,
+    workStore.reactServerErrorsByDigest,
+    onFlightDataRenderError
+  )
+
+  const selectStaleTime = createSelectStaleTime(experimental)
+  const staleTimeIterable = new StaleTimeIterable()
+
+  const stageController = new StagedRenderingController()
+
+  // Initialize stale time tracking on the request store.
+  requestStore.stale = INFINITE_CACHE
+  requestStore.stagedRendering = stageController
+  requestStore.asyncApiPromises = createAsyncApiPromisesInDev(
+    stageController,
+    requestStore.cookies,
+    requestStore.mutableCookies,
+    requestStore.headers
+  )
+
+  trackStaleTime(
+    requestStore as { stale: number },
+    staleTimeIterable,
+    selectStaleTime
+  )
+
+  // Deferred promise for the static stage byte length. Flight serializes the
+  // resolved value into the stream so the client knows where the static
+  // prefix ends.
+  let resolveStaticStageByteLength: (count: number) => void
+  const staticStageByteLengthPromise = new Promise<number>((resolve) => {
+    resolveStaticStageByteLength = resolve
+  })
+
+  const rscPayload = await workUnitAsyncStorage.run(
+    requestStore,
+    generateDynamicRSCPayload,
+    ctx,
+    { staleTimeIterable, staticStageByteLengthPromise }
+  )
+
+  const { clientModules } = getClientReferenceManifest()
+
+  const flightReadableStream = await runInSequentialTasks(
+    () => {
+      stageController.advanceStage(RenderStage.Static)
+
+      const stream = workUnitAsyncStorage.run(
+        requestStore,
+        renderToReadableStream,
+        rscPayload,
+        clientModules,
+        { onError, filterStackFrame }
+      )
+
+      const [dynamicStream, staticStream] = stream.tee()
+
+      countStaticStageBytes(staticStream, stageController).then(
+        resolveStaticStageByteLength
+      )
+
+      return dynamicStream
+    },
+    () => {
+      finishStaleTimeTracking(staleTimeIterable)
+    },
+    () => {
+      stageController.advanceStage(RenderStage.Dynamic)
+    }
+  )
+
+  return new FlightRenderResult(flightReadableStream, {
+    fetchMetrics: workStore.fetchMetrics,
+  })
+}
+
 type RenderToReadableStreamServerOptions = NonNullable<
   Parameters<
     (typeof import('react-server-dom-webpack/server.node'))['renderToReadableStream']
@@ -821,7 +923,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
   ctx: AppRenderContext,
   initialRequestStore: RequestStore,
   createRequestStore: (() => RequestStore) | undefined,
-  devFallbackParams: OpaqueFallbackRouteParams | null
+  fallbackParams: OpaqueFallbackRouteParams | null
 ): Promise<RenderResult> {
   const {
     htmlRequestId,
@@ -944,7 +1046,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
         runtimeStageEndTime,
         ctx,
         finalRequestStore,
-        devFallbackParams,
+        fallbackParams,
         validationDebugChannelClient
       )
     } else {
@@ -2150,7 +2252,7 @@ async function renderToHTMLOrFlightImpl(
       null
 
     const rootParams = getRootParams(loaderTree, ctx.getDynamicParamFromSegment)
-    const devFallbackParams = getRequestMeta(req, 'devFallbackParams') || null
+    const fallbackParams = getRequestMeta(req, 'fallbackParams') || null
 
     const createRequestStore = createRequestStoreForRender.bind(
       null,
@@ -2164,7 +2266,7 @@ async function renderToHTMLOrFlightImpl(
       isHmrRefresh,
       serverComponentsHmrCache,
       renderResumeDataCache,
-      devFallbackParams
+      fallbackParams
     )
     const requestStore = createRequestStore()
 
@@ -2200,8 +2302,10 @@ async function renderToHTMLOrFlightImpl(
             ctx,
             requestStore,
             createRequestStore,
-            devFallbackParams
+            fallbackParams
           )
+        } else if (cacheComponents) {
+          return generateStagedDynamicFlightRenderResult(req, ctx, requestStore)
         } else {
           return generateDynamicFlightRenderResult(req, ctx, requestStore)
         }
@@ -2239,7 +2343,7 @@ async function renderToHTMLOrFlightImpl(
             postponedState,
             metadata,
             undefined, // Prevent restartable-render behavior in dev + Cache Components mode
-            devFallbackParams
+            fallbackParams
           )
 
           return new RenderResult(stream, {
@@ -2281,7 +2385,7 @@ async function renderToHTMLOrFlightImpl(
       // and we currently we don't copy changes over when creating a new store,
       // so the restarted render wouldn't be correct.
       didExecuteServerAction ? undefined : createRequestStore,
-      devFallbackParams
+      fallbackParams
     )
 
     // Invalid dynamic usages should only error the request in development.
@@ -2488,7 +2592,7 @@ async function renderToStream(
   postponedState: PostponedState | null,
   metadata: AppPageRenderResultMetadata,
   createRequestStore: (() => RequestStore) | undefined,
-  devFallbackParams: OpaqueFallbackRouteParams | null
+  fallbackParams: OpaqueFallbackRouteParams | null
 ): Promise<ReadableStream<Uint8Array>> {
   /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   const {
@@ -2721,7 +2825,7 @@ async function renderToStream(
             runtimeStageEndTime,
             ctx,
             finalRequestStore,
-            devFallbackParams,
+            fallbackParams,
             validationDebugChannelClient
           )
 
@@ -3467,6 +3571,29 @@ async function accumulateStreamChunks(
   }
 
   return { staticChunks, runtimeChunks, dynamicChunks }
+}
+
+async function countStaticStageBytes(
+  stream: ReadableStream<Uint8Array>,
+  stageController: StagedRenderingController
+): Promise<number> {
+  let byteLength = 0
+  const reader = stream.getReader()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+    if (stageController.currentStage <= RenderStage.Static) {
+      byteLength += value.byteLength
+    } else {
+      reader.cancel()
+      break
+    }
+  }
+
+  return byteLength
 }
 
 function createAsyncApiPromisesInDev(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3580,6 +3580,10 @@ async function countStaticStageBytes(
   let byteLength = 0
   const reader = stream.getReader()
 
+  stageController.waitForStage(RenderStage.EarlyRuntime).then(() => {
+    reader.cancel()
+  })
+
   while (true) {
     const { done, value } = await reader.read()
     if (done) {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -830,7 +830,10 @@ async function generateStagedDynamicFlightRenderResult(
       return dynamicStream
     },
     () => {
-      finishStaleTimeTracking(staleTimeIterable)
+      // This is a separate task that doesn't advance a stage. It forces
+      // draining the microtask queue so that the stale time iterable is closed
+      // before we advance to the dynamic stage.
+      void finishStaleTimeTracking(staleTimeIterable)
     },
     () => {
       stageController.advanceStage(RenderStage.Dynamic)
@@ -3580,7 +3583,7 @@ async function countStaticStageBytes(
   let byteLength = 0
   const reader = stream.getReader()
 
-  stageController.waitForStage(RenderStage.EarlyRuntime).then(() => {
+  stageController.onStage(RenderStage.EarlyRuntime, () => {
     reader.cancel()
   })
 

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -69,16 +69,18 @@ export interface RequestStore extends CommonWorkUnitStore {
    */
   renderResumeDataCache: RenderResumeDataCache | null
 
-  // DEV-only
-  usedDynamic?: boolean
-  devFallbackParams?: OpaqueFallbackRouteParams | null
+  stale?: number
   stagedRendering?: StagedRenderingController | null
-  asyncApiPromises?: DevAsyncApiPromises
+  asyncApiPromises?: AsyncApiPromises
   cacheSignal?: CacheSignal | null
   prerenderResumeDataCache?: PrerenderResumeDataCache | null
+  fallbackParams?: OpaqueFallbackRouteParams | null
+
+  // DEV-only
+  usedDynamic?: boolean
 }
 
-type DevAsyncApiPromises = {
+export type AsyncApiPromises = {
   cookies: Promise<ReadonlyRequestCookies>
   earlyCookies: Promise<ReadonlyRequestCookies>
 

--- a/packages/next/src/server/async-storage/request-store.ts
+++ b/packages/next/src/server/async-storage/request-store.ts
@@ -116,7 +116,7 @@ export function createRequestStoreForRender(
   isHmrRefresh: RequestContext['isHmrRefresh'],
   serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
   renderResumeDataCache: RenderResumeDataCache | null,
-  devFallbackParams: OpaqueFallbackRouteParams | null
+  fallbackParams: OpaqueFallbackRouteParams | null
 ): RequestStore {
   return createRequestStoreImpl(
     // Pages start in render phase by default
@@ -131,7 +131,7 @@ export function createRequestStoreForRender(
     previewProps,
     isHmrRefresh,
     serverComponentsHmrCache,
-    devFallbackParams
+    fallbackParams
   )
 }
 
@@ -171,7 +171,7 @@ function createRequestStoreImpl(
   previewProps: WrapperRenderOpts['previewProps'],
   isHmrRefresh: RequestContext['isHmrRefresh'],
   serverComponentsHmrCache: RequestContext['serverComponentsHmrCache'],
-  devFallbackParams: OpaqueFallbackRouteParams | null | undefined
+  fallbackParams: OpaqueFallbackRouteParams | null | undefined
 ): RequestStore {
   function defaultOnUpdateCookies(cookies: string[]) {
     if (res) {
@@ -263,7 +263,7 @@ function createRequestStoreImpl(
     serverComponentsHmrCache:
       serverComponentsHmrCache ||
       (globalThis as any).__serverComponentsHmrCache,
-    devFallbackParams,
+    fallbackParams,
   }
 }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2360,7 +2360,7 @@ export default abstract class Server<
           if (smallestFallbackRouteParams) {
             addRequestMeta(
               req,
-              'devFallbackParams',
+              'fallbackParams',
               createOpaqueFallbackRouteParams(smallestFallbackRouteParams)!
             )
           }

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -852,9 +852,9 @@ export default class DevServer extends Server {
           }
 
           // Since generateStaticParams run on the background, when accessing the
-          // devFallbackParams during the render, it is still set to the previous
+          // fallbackParams during the render, it is still set to the previous
           // result from the cache. Therefore when the result has changed, re-render
-          // the Server Component to sync the devFallbackParams with the new result.
+          // the Server Component to sync the fallbackParams with the new result.
           if (
             isAppPath &&
             this.nextConfig.cacheComponents &&

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -277,9 +277,10 @@ export interface RequestMeta {
   minimalMode?: boolean
 
   /**
-   * DEV only: The fallback params that should be used when validating prerenders during dev
+   * The fallback params for this route. In dev, used for validating prerenders.
+   * In production, used to defer params resolution during staged rendering.
    */
-  devFallbackParams?: OpaqueFallbackRouteParams
+  fallbackParams?: OpaqueFallbackRouteParams
 
   /**
    * DEV only: Request timings in process.hrtime.bigint()

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -123,6 +123,8 @@ export function connection(): Promise<void> {
               workUnitStore,
               RenderStage.Dynamic
             )
+          } else if (workUnitStore.asyncApiPromises) {
+            return workUnitStore.asyncApiPromises.connection
           } else {
             return Promise.resolve(undefined)
           }

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -130,6 +130,17 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
               underlyingCookies,
               workStore?.route
             )
+          } else if (workUnitStore.asyncApiPromises) {
+            const early = isInEarlyRenderStage(workUnitStore)
+            if (underlyingCookies === workUnitStore.mutableCookies) {
+              return early
+                ? workUnitStore.asyncApiPromises.earlyMutableCookies
+                : workUnitStore.asyncApiPromises.mutableCookies
+            } else {
+              return early
+                ? workUnitStore.asyncApiPromises.earlyCookies
+                : workUnitStore.asyncApiPromises.cookies
+            }
           } else {
             return makeUntrackedCookies(underlyingCookies)
           }

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -146,6 +146,10 @@ export function headers(): Promise<ReadonlyHeaders> {
               workStore?.route,
               workUnitStore
             )
+          } else if (workUnitStore.asyncApiPromises) {
+            return isInEarlyRenderStage(workUnitStore)
+              ? workUnitStore.asyncApiPromises.earlyHeaders
+              : workUnitStore.asyncApiPromises.headers
           } else {
             return makeUntrackedHeaders(workUnitStore.headers)
           }

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -84,12 +84,12 @@ export function createParamsFromClient(
           // Semantically we only need the dev tracking when running in `next dev`
           // but since you would never use next dev with production NODE_ENV we use this
           // as a proxy so we can statically exclude this code from production builds.
-          const devFallbackParams = workUnitStore.devFallbackParams
+          const fallbackParams = workUnitStore.fallbackParams
           // Client params are not runtime prefetchable
           const isRuntimePrefetchable = false
           return createRenderParamsInDev(
             underlyingParams,
-            devFallbackParams,
+            fallbackParams,
             workStore,
             workUnitStore,
             isRuntimePrefetchable
@@ -169,12 +169,12 @@ export function createServerParamsForRoute(
           // Semantically we only need the dev tracking when running in `next dev`
           // but since you would never use next dev with production NODE_ENV we use this
           // as a proxy so we can statically exclude this code from production builds.
-          const devFallbackParams = workUnitStore.devFallbackParams
+          const fallbackParams = workUnitStore.fallbackParams
           // Route params are not runtime prefetchable
           const isRuntimePrefetchable = false
           return createRenderParamsInDev(
             underlyingParams,
-            devFallbackParams,
+            fallbackParams,
             workStore,
             workUnitStore,
             isRuntimePrefetchable
@@ -235,14 +235,23 @@ export function createServerParamsForServerSegment(
           // Semantically we only need the dev tracking when running in `next dev`
           // but since you would never use next dev with production NODE_ENV we use this
           // as a proxy so we can statically exclude this code from production builds.
-          const devFallbackParams = workUnitStore.devFallbackParams
+          const fallbackParams = workUnitStore.fallbackParams
           return createRenderParamsInDev(
             underlyingParams,
-            devFallbackParams,
+            fallbackParams,
             workStore,
             workUnitStore,
             isRuntimePrefetchable
           )
+        } else if (
+          workUnitStore.asyncApiPromises &&
+          hasFallbackRouteParams(underlyingParams, workUnitStore.fallbackParams)
+        ) {
+          return (
+            isRuntimePrefetchable
+              ? workUnitStore.asyncApiPromises.earlySharedParamsParent
+              : workUnitStore.asyncApiPromises.sharedParamsParent
+          ).then(() => underlyingParams)
         } else {
           return createRenderParamsInProd(underlyingParams)
         }
@@ -398,30 +407,34 @@ function createRuntimePrerenderParams(
   return stagedRendering.waitForStage(stage).then(() => result)
 }
 
+function hasFallbackRouteParams(
+  underlyingParams: Params,
+  fallbackParams: OpaqueFallbackRouteParams | null | undefined
+): boolean {
+  if (fallbackParams) {
+    for (let key in underlyingParams) {
+      if (fallbackParams.has(key)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
 function createRenderParamsInProd(underlyingParams: Params): Promise<Params> {
   return makeUntrackedParams(underlyingParams)
 }
 
 function createRenderParamsInDev(
   underlyingParams: Params,
-  devFallbackParams: OpaqueFallbackRouteParams | null | undefined,
+  fallbackParams: OpaqueFallbackRouteParams | null | undefined,
   workStore: WorkStore,
   requestStore: RequestStore,
   isRuntimePrefetchable: boolean
 ): Promise<Params> {
-  let hasFallbackParams = false
-  if (devFallbackParams) {
-    for (let key in underlyingParams) {
-      if (devFallbackParams.has(key)) {
-        hasFallbackParams = true
-        break
-      }
-    }
-  }
-
   return makeDynamicallyTrackedParamsWithDevWarnings(
     underlyingParams,
-    hasFallbackParams,
+    hasFallbackRouteParams(underlyingParams, fallbackParams),
     workStore,
     requestStore,
     isRuntimePrefetchable

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -265,6 +265,12 @@ function createRenderSearchParams(
         requestStore,
         isRuntimePrefetchable
       )
+    } else if (requestStore.asyncApiPromises) {
+      return (
+        isRuntimePrefetchable
+          ? requestStore.asyncApiPromises.earlySharedSearchParamsParent
+          : requestStore.asyncApiPromises.sharedSearchParamsParent
+      ).then(() => underlyingSearchParams)
     } else {
       return makeUntrackedSearchParams(underlyingSearchParams)
     }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -352,6 +352,15 @@ function propagateCacheLifeAndTagsToRevalidateStore(
   }
 }
 
+function propagateCacheStaleTimeToRequestStore(
+  requestStore: RequestStore,
+  entry: CacheEntry
+): void {
+  if (requestStore.stale !== undefined && requestStore.stale > entry.stale) {
+    requestStore.stale = entry.stale
+  }
+}
+
 function propagateCacheLifeAndTags(
   cacheContext: CacheContext,
   entry: CacheEntry
@@ -366,6 +375,11 @@ function propagateCacheLifeAndTags(
         )
         break
       case 'request':
+        propagateCacheStaleTimeToRequestStore(
+          cacheContext.outerWorkUnitStore,
+          entry
+        )
+        break
       case undefined:
         break
       default:
@@ -385,6 +399,11 @@ function propagateCacheLifeAndTags(
         )
         break
       case 'request':
+        propagateCacheStaleTimeToRequestStore(
+          cacheContext.outerWorkUnitStore,
+          entry
+        )
+        break
       case 'unstable-cache':
       case undefined:
         break

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -278,6 +278,8 @@ export type NavigationFlightResponse = {
   i: boolean
   /** staleTime - Only present in dynamic runtime prefetch responses. */
   s?: AsyncIterable<number>
+  /** staticStageByteLength - Resolves when the static stage ends. */
+  l?: Promise<number>
   /** headVaryParams */
   h: VaryParamsThenable | null
 }

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -257,6 +257,7 @@
       "test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts",
       "test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts",
       "test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts",
+      "test/e2e/app-dir/segment-cache/force-stale/force-stale.test.ts",
       "test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts",
       "test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts",

--- a/test/cache-components-tests-manifest.json
+++ b/test/cache-components-tests-manifest.json
@@ -257,7 +257,6 @@
       "test/e2e/app-dir/segment-cache/conflicting-routes/conflicting-routes.test.ts",
       "test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts",
       "test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts",
-      "test/e2e/app-dir/segment-cache/force-stale/force-stale.test.ts",
       "test/e2e/app-dir/segment-cache/incremental-opt-in/segment-cache-incremental-opt-in.test.ts",
       "test/e2e/app-dir/segment-cache/memory-pressure/segment-cache-memory-pressure.test.ts",
       "test/e2e/app-dir/segment-cache/prefetch-scheduling/prefetch-scheduling.test.ts",

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/fully-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/fully-static/page.tsx
@@ -1,0 +1,15 @@
+import { cacheLife } from 'next/cache'
+
+export default async function Page() {
+  return (
+    <main>
+      <CachedContent />
+    </main>
+  )
+}
+
+async function CachedContent() {
+  'use cache'
+  cacheLife({ stale: 120 })
+  return <p id="cached-content">Cached content</p>
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/layout.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <nav>
+          <Link href="/">Home</Link>
+        </nav>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/page.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <h2>
+        Links with <code>prefetch=false</code>
+      </h2>
+      <ul>
+        <li>
+          <Link href="/partially-static" prefetch={false}>
+            Go to partially static page
+          </Link>
+        </li>
+        <li>
+          <Link href="/fully-static" prefetch={false}>
+            Go to fully static page
+          </Link>
+        </li>
+        <li>
+          <Link href="/with-static-params/foo" prefetch={false}>
+            Go to page with static params
+          </Link>
+        </li>
+        <li>
+          <Link href="/with-fallback-params/foo" prefetch={false}>
+            Go to page with fallback params
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/partially-static/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/partially-static/page.tsx
@@ -1,0 +1,79 @@
+import { cacheLife } from 'next/cache'
+import { cookies, headers } from 'next/headers'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  return (
+    <main>
+      <CachedContent />
+      <div id="search-params-boundary">
+        <Suspense fallback={<p>Loading search params...</p>}>
+          <SearchParamsContent searchParams={searchParams} />
+        </Suspense>
+      </div>
+      <div id="cookies-boundary">
+        <Suspense fallback={<p>Loading cookies...</p>}>
+          <CookiesContent />
+        </Suspense>
+      </div>
+      <div id="headers-boundary">
+        <Suspense fallback={<p>Loading headers...</p>}>
+          <HeadersContent />
+        </Suspense>
+      </div>
+      <div id="connection-boundary">
+        <Suspense fallback={<p>Loading connection...</p>}>
+          <ConnectionContent />
+        </Suspense>
+      </div>
+    </main>
+  )
+}
+
+async function CachedContent() {
+  'use cache'
+  cacheLife({ stale: 120 })
+  return <p id="cached-content">Cached content</p>
+}
+
+async function SearchParamsContent({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  return <p>Search params: {q ?? 'none'}</p>
+}
+
+async function CookiesContent() {
+  const cookieStore = await cookies()
+  const value = cookieStore.get('testCookie')?.value ?? 'none'
+  const timestamp = await getShortLivedCachedTimestamp()
+  return (
+    <p>
+      Cookie: {value}, Cached at: {timestamp}
+    </p>
+  )
+}
+
+async function getShortLivedCachedTimestamp() {
+  'use cache'
+  cacheLife({ stale: 30 })
+  return Date.now()
+}
+
+async function HeadersContent() {
+  const headerStore = await headers()
+  const value = headerStore.get('x-test-header') ?? 'none'
+  return <p>Header: {value}</p>
+}
+
+async function ConnectionContent() {
+  await connection()
+  return <p>Dynamic content</p>
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/with-fallback-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/with-fallback-params/[slug]/page.tsx
@@ -1,0 +1,48 @@
+import { cacheLife } from 'next/cache'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <main>
+      <CachedContent />
+      <div id="params-boundary">
+        <Suspense fallback={<p>Loading params...</p>}>
+          <ParamsContent params={params} />
+        </Suspense>
+      </div>
+      <div id="connection-boundary">
+        <Suspense fallback={<p>Loading connection...</p>}>
+          <ConnectionContent />
+        </Suspense>
+      </div>
+    </main>
+  )
+}
+
+async function CachedContent() {
+  'use cache'
+  cacheLife({ stale: 120 })
+  return <p id="cached-content">Cached content</p>
+}
+
+async function ParamsContent({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  // When the param is a fallback param (not in generateStaticParams), the
+  // await is deferred to the runtime stage, so this content won't appear
+  // in the static stage.
+  const { slug } = await params
+  return <p>Param: {slug}</p>
+}
+
+async function ConnectionContent() {
+  await connection()
+  return <p>Dynamic content</p>
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/with-static-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/with-static-params/[slug]/page.tsx
@@ -1,0 +1,37 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+export async function generateStaticParams() {
+  return [{ slug: 'foo' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return (
+    <main>
+      <CachedContent />
+      <div id="params">
+        <p>Param: {slug}</p>
+      </div>
+      <div id="connection-boundary">
+        <Suspense fallback={<p>Loading connection...</p>}>
+          <ConnectionContent />
+        </Suspense>
+      </div>
+    </main>
+  )
+}
+
+async function CachedContent() {
+  'use cache'
+  return <p id="cached-content">Cached content</p>
+}
+
+async function ConnectionContent() {
+  await connection()
+  return <p>Dynamic content</p>
+}

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -184,6 +184,99 @@ describe('cached navigations', () => {
     }
   )
 
+  it('caches static segments when navigating to a known route without a prefetch', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+    await page.clock.install()
+
+    // First navigation — seeds the route cache (stale after 5 min) and
+    // segment cache (stale after 120s, from cacheLife({ stale: 120 })).
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/partially-static"]').click()
+      },
+      { includes: 'Dynamic content' }
+    )
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+
+    // Navigate back to home
+    await browser.back()
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    // Fast-forward past the segment cache stale time (120s) but under the
+    // route cache stale time (5 min). Segment entries are now expired, but
+    // the route is still known.
+    await page.clock.fastForward(130_000)
+
+    // Second navigation — the route is known but all segment entries have
+    // expired, so nothing is served from the cache. The server responds
+    // with fresh data including a static stage, which is written into the
+    // segment cache for future navigations.
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/partially-static"]').click()
+      },
+      { includes: 'Dynamic content' }
+    )
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+
+    // Navigate back to home again
+    await browser.back()
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    // Fast-forward 60s — well under the 120s stale time that the segment
+    // entries would have if the second navigation had cached them.
+    await page.clock.fastForward(60_000)
+
+    // Third navigation — block the dynamic request to test whether cached
+    // static segments are available.
+    await act(async () => {
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/partially-static"]').click()
+        },
+        {
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+
+      // The second navigation wrote the static stage into the segment
+      // cache. These entries are still fresh (60s < 120s) so the cached
+      // content is visible while the dynamic request is pending.
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+
+      expect(await browser.elementById('connection-boundary').text()).toBe(
+        'Loading connection...'
+      )
+    })
+
+    // After unblocking, all content should be visible
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+  })
+
   it('includes static params in the cached static stage', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -1,0 +1,315 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('cached navigations', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('is skipped', () => {})
+    return
+  }
+
+  it('serves cached static segments instantly on the second navigation', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+    await page.clock.install()
+
+    // First navigation — full dynamic request, no prefetch
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/partially-static"]').click()
+      },
+      { includes: 'Dynamic content' }
+    )
+
+    // Verify all content is visible
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(
+      await browser.elementById('search-params-boundary').text()
+    ).toContain('Search params:')
+    expect(await browser.elementById('cookies-boundary').text()).toContain(
+      'Cookie:'
+    )
+    expect(await browser.elementById('headers-boundary').text()).toContain(
+      'Header:'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+
+    // Navigate back to home
+    await browser.back()
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    // Fast-forward time past the short-lived runtime cache's stale time (30s)
+    // but under the static cache's stale time (120s). If the stale time sent to
+    // the client incorrectly used the runtime cache's value, the cached
+    // segments would have expired and the second navigation wouldn't be
+    // instant.
+    await page.clock.fastForward(60_000)
+
+    // Second navigation — cached static data should show immediately
+    await act(async () => {
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/partially-static"]').click()
+        },
+        {
+          // Block the dynamic request. The cached/prefetchable content
+          // should still be visible even though the dynamic data hasn't
+          // arrived yet.
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+
+      // The static/cached part should be visible while the dynamic
+      // request is still blocked
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+
+      // Runtime and dynamic content should show Suspense fallbacks
+      expect(await browser.elementById('search-params-boundary').text()).toBe(
+        'Loading search params...'
+      )
+      expect(await browser.elementById('cookies-boundary').text()).toBe(
+        'Loading cookies...'
+      )
+      expect(await browser.elementById('headers-boundary').text()).toBe(
+        'Loading headers...'
+      )
+      expect(await browser.elementById('connection-boundary').text()).toBe(
+        'Loading connection...'
+      )
+    })
+
+    // After unblocking, all content should be visible
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(
+      await browser.elementById('search-params-boundary').text()
+    ).toContain('Search params:')
+    expect(await browser.elementById('cookies-boundary').text()).toContain(
+      'Cookie:'
+    )
+    expect(await browser.elementById('headers-boundary').text()).toContain(
+      'Header:'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+
+    // Navigate back to home again
+    await browser.back()
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    // Fast-forward past the static cache's stale time (120s). The cached
+    // segments should now be expired, so the third navigation should NOT
+    // show cached content instantly — it should block on the full response.
+    await page.clock.fastForward(120_000)
+
+    // Third navigation — cache is stale, no cached content should be shown
+    await act(async () => {
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/partially-static"]').click()
+        },
+        {
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+
+      // With stale cache, nothing from the target page should be visible
+      // while the request is blocked — not even the cached content.
+      const mainText = await (await browser.elementByCss('main')).innerText()
+      expect(mainText).not.toContain('Cached content')
+    })
+
+    // After unblocking, all content should be visible
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+  })
+
+  // TODO: To be implemented.
+  it.failing(
+    'serves a fully static page without any requests on the second navigation',
+    async () => {
+      let page: Playwright.Page
+      const browser = await next.browser('/', {
+        beforePageLoad(p: Playwright.Page) {
+          page = p
+        },
+      })
+      const act = createRouterAct(page)
+
+      // First navigation — full request, no prefetch
+      await act(
+        async () => {
+          await browser.elementByCss('a[href="/fully-static"]').click()
+        },
+        { includes: 'Cached content' }
+      )
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+
+      // Navigate back to home
+      await browser.back()
+      expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+      // Second navigation — fully cached, should not issue any requests
+      await act(async () => {
+        await browser.elementByCss('a[href="/fully-static"]').click()
+      }, 'no-requests')
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+    }
+  )
+
+  it('includes static params in the cached static stage', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+    await page.clock.install()
+
+    // First navigation
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/with-static-params/foo"]').click()
+      },
+      { includes: 'Dynamic content' }
+    )
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('params').text()).toContain('Param: foo')
+
+    // Navigate back
+    await browser.back()
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    await page.clock.fastForward(60_000)
+
+    // Second navigation — params are static, so they should be included in
+    // the cached static stage and visible while the dynamic request is blocked
+    await act(async () => {
+      await act(
+        async () => {
+          await browser
+            .elementByCss('a[href="/with-static-params/foo"]')
+            .click()
+        },
+        {
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+      // Static params should be visible — they resolve during the static stage
+      expect(await browser.elementById('params').text()).toContain('Param: foo')
+      // Dynamic content should show Suspense fallback
+      expect(await browser.elementById('connection-boundary').text()).toBe(
+        'Loading connection...'
+      )
+    })
+
+    // After unblocking, dynamic content should be visible
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+  })
+
+  it('defers fallback params to the runtime stage', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+    await page.clock.install()
+
+    // First navigation — "foo" is not in generateStaticParams, so it's a
+    // fallback param
+    await act(
+      async () => {
+        await browser
+          .elementByCss('a[href="/with-fallback-params/foo"]')
+          .click()
+      },
+      { includes: 'Dynamic content' }
+    )
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+    expect(await browser.elementById('params-boundary').text()).toContain(
+      'Param: foo'
+    )
+
+    // Navigate back
+    await browser.back()
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    await page.clock.fastForward(60_000)
+
+    // Second navigation — fallback params are deferred to the runtime stage,
+    // so they should NOT be visible while the dynamic request is blocked
+    await act(async () => {
+      await act(
+        async () => {
+          await browser
+            .elementByCss('a[href="/with-fallback-params/foo"]')
+            .click()
+        },
+        {
+          includes: 'Dynamic content',
+          block: true,
+        }
+      )
+
+      expect(await browser.elementById('cached-content').text()).toContain(
+        'Cached content'
+      )
+      // Fallback params should show Suspense fallback — deferred to runtime
+      expect(await browser.elementById('params-boundary').text()).toBe(
+        'Loading params...'
+      )
+      expect(await browser.elementById('connection-boundary').text()).toBe(
+        'Loading connection...'
+      )
+    })
+
+    // After unblocking, all content should be visible
+    expect(await browser.elementById('params-boundary').text()).toContain(
+      'Param: foo'
+    )
+    expect(await browser.elementById('connection-boundary').text()).toContain(
+      'Dynamic content'
+    )
+  })
+})

--- a/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/next.config.ts
@@ -1,0 +1,11 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  productionBrowserSourceMaps: true,
+  experimental: {
+    exposeTestingApiInProductionBuild: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/segment-cache/force-stale/next.config.js
+++ b/test/e2e/app-dir/segment-cache/force-stale/next.config.js
@@ -2,6 +2,7 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
+  cacheComponents: true,
   productionBrowserSourceMaps: true,
 }
 

--- a/test/e2e/app-dir/segment-cache/force-stale/next.config.js
+++ b/test/e2e/app-dir/segment-cache/force-stale/next.config.js
@@ -2,7 +2,6 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
-  cacheComponents: true,
   productionBrowserSourceMaps: true,
 }
 


### PR DESCRIPTION
When navigating to a dynamic (or partially static) page with Cache Components, the server now uses staged rendering to separate the static portion (backed by the Resume Data Cache) from the dynamic portion (runtime APIs like `cookies`, `headers`, `connection`, or uncached I/O). The static stage byte length is embedded in the RSC payload so the client can extract it.

On the client, the first navigation clones the response stream, truncates it to the static stage byte length, decodes it as a partial Flight response, and writes the result into the segment cache. Subsequent navigations find these cached segments and display them instantly while fetching only the dynamic data from the server.

Server-side changes:
- Add `generateStagedDynamicFlightRenderResult` with `StaleTimeIterable`, byte counting via tee'd stream, and stage-separated rendering
- Enable `asyncApiPromises` checks in production for `cookies`, `headers`, `connection`, `searchParams`, and `params`
- Propagate stale time to `RequestStore` for Cache Components
- Thread `fallbackParams` from prerender manifest to production renders
- Rename `devFallbackParams` → `fallbackParams` (now used in both dev/prod)

Client-side changes:
- Clone response in `fetchServerResponse`, truncate to static byte length, decode with `allowPartialStream`
- Write static stage into segment cache via `writeStaticStageResponseIntoCache`
- Use `getFulfilledRouteVaryPath` in `writeRouteIntoCache` for `Fallback` keying
- Refactor `writeDynamicRenderResponseIntoCache` (remove dead `task` param, accept `headers` directly)

In follow-ups we'll also handle fully static pages, as well as extracting static segment data from the initial load.