### PR TITLE
[turbopack] Reduce memory usage during compaction

### DIFF
--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -19,28 +19,22 @@ pub fn decompress_into_arc(
          zero-copy mmap path"
     );
 
-    // We directly allocate the buffer in an Arc to avoid copying it into an Arc and avoiding
-    // double indirection. This is a dynamically sized arc.
-    let buffer: Arc<[MaybeUninit<u8>]> = Arc::new_zeroed_slice(uncompressed_length as usize);
-    // Assume that the buffer is initialized.
-    let buffer = Arc::into_raw(buffer);
-    // Safety: Assuming that the buffer is initialized is safe because we just created it as
-    // zeroed slice and u8 doesn't require initialization.
-    let mut buffer = unsafe { Arc::from_raw(buffer as *mut [u8]) };
-    // Safety: We know that the buffer is not shared yet.
-    let decompressed = unsafe { Arc::get_mut_unchecked(&mut buffer) };
-    let bytes_writes = if let Some(dict) = compression_dictionary {
-        // Safety: decompress_with_dict will only write to `decompressed` and not read from it.
+    // Allocate directly into an Arc to avoid a copy. The buffer is uninitialized;
+    // decompression will overwrite it completely (verified by the assert below).
+    let buffer: Arc<[MaybeUninit<u8>]> = Arc::new_uninit_slice(uncompressed_length as usize);
+    // Safety: decompression will fully initialize the buffer we verify with an assert
+    let mut buffer = unsafe { buffer.assume_init() };
+    // We just created this Arc so refcount is 1; get_mut always succeeds.
+    let decompressed = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
+    let bytes_written = if let Some(dict) = compression_dictionary {
         decompress_with_dict(block, decompressed, dict)?
     } else {
-        // Safety: decompress will only write to `decompressed` and not read from it.
         decompress(block, decompressed)?
     };
     assert_eq!(
-        bytes_writes, uncompressed_length as usize,
+        bytes_written, uncompressed_length as usize,
         "Decompressed length does not match expected length"
     );
-    // Safety: The buffer is now fully initialized and can be used.
     Ok(buffer)
 }
 

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -35,7 +35,7 @@ use crate::{
     meta_file_builder::MetaFileBuilder,
     parallel_scheduler::ParallelScheduler,
     sst_filter::SstFilter,
-    static_sorted_file::{BlockCache, SstLookupResult},
+    static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile},
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
     value_block_count_tracker::ValueBlockCountTracker,
     write_batch::{FinishResult, WriteBatch},
@@ -780,6 +780,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             );
         }
 
+        // Free block caches and SST mmaps before compaction. The block caches
+        // are not used during compaction (we iterate uncached), and any cached
+        // SST mmaps would use MADV_RANDOM which is wrong for sequential scans.
+        // Clearing them upfront frees memory for the merge work.
+        self.clear_cache();
+
         let mut sequence_number;
         let mut new_meta_files = Vec::new();
         let mut new_sst_files = Vec::new();
@@ -887,8 +893,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             sst_by_family[sst.range.family as usize].push(sst);
         }
 
-        let key_block_cache = &self.key_block_cache;
-        let value_block_cache = &self.value_block_cache;
         let path = &self.path;
 
         let log_mutex = Mutex::new(());
@@ -916,22 +920,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             })
             .collect::<Vec<_>>();
 
-        let mut used_key_hashes = [(); FAMILIES].map(|_| Vec::new());
-
-        {
-            for &(family, ..) in merge_jobs.iter() {
-                used_key_hashes[family].extend(
-                    meta_files
-                        .iter()
-                        .filter(|m| m.family() == family as u32)
-                        .filter_map(|meta_file| {
-                            meta_file.deserialize_used_key_hashes_amqf().transpose()
-                        })
-                        .collect::<Result<Vec<_>>>()?,
-                );
-            }
-        }
-
         let result = self
             .parallel_scheduler
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(
@@ -948,6 +936,41 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             keys_written: 0,
                         });
                     }
+
+                    // Deserialize and merge used key hash filters per-family into
+                    // a single filter. This avoids O(entries × N) filter probes
+                    // during the merge loop. Empty filters (from commits with no
+                    // reads) are discarded.
+                    let used_key_hashes: Option<qfilter::Filter> = {
+                        let filters: Vec<qfilter::Filter> = meta_files
+                            .iter()
+                            .filter(|m| m.family() == family)
+                            .filter_map(|meta_file| {
+                                meta_file.deserialize_used_key_hashes_amqf().transpose()
+                            })
+                            .collect::<Result<Vec<_>>>()?
+                            .into_iter()
+                            .filter(|amqf| !amqf.is_empty())
+                            .collect();
+                        if filters.is_empty() {
+                            None
+                        } else if filters.len() == 1 {
+                            // Just directly use the single item
+                            filters.into_iter().next()
+                        } else {
+                            let total_len: u64 = filters.iter().map(|f| f.len()).sum();
+                            let mut merged =
+                                qfilter::Filter::with_fingerprint_size(total_len, u64::BITS as u8)
+                                    .expect("Failed to create merged AMQF filter");
+                            for filter in &filters {
+                                merged
+                                    .merge(false, filter)
+                                    .expect("Failed to merge AMQF filters");
+                            }
+                            merged.shrink_to_fit();
+                            Some(merged)
+                        }
+                    };
 
                     // Later we will remove the merged files
                     let sst_seq_numbers_to_delete = merge_jobs
@@ -1002,9 +1025,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     });
                                 }
 
-                                fn create_sst_file<'l, S: ParallelScheduler>(
+                                fn create_sst_file<S: ParallelScheduler>(
                                     parallel_scheduler: &S,
-                                    entries: &[LookupEntry<'l>],
+                                    entries: &[LookupEntry],
                                     total_key_size: usize,
                                     path: &Path,
                                     seq: u32,
@@ -1024,16 +1047,20 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     Ok((seq, file, meta))
                                 }
 
-                                // Iterate all SST files
+                                // Open SST files independently for compaction.
+                                // Uses MADV_SEQUENTIAL for better OS page management
+                                // and avoids caching mmaps on MetaEntry's OnceLock.
                                 let iters = indicies
                                     .iter()
                                     .map(|&index| {
                                         let meta_index = ssts_with_ranges[index].meta_index;
                                         let index_in_meta = ssts_with_ranges[index].index_in_meta;
-                                        let meta = &meta_files[meta_index];
-                                        meta.entry(index_in_meta)
-                                            .sst(meta)?
-                                            .iter(key_block_cache, value_block_cache)
+                                        let entry = meta_files[meta_index].entry(index_in_meta);
+                                        StaticSortedFile::open_for_compaction(
+                                            path,
+                                            entry.sst_metadata(),
+                                        )?
+                                        .try_into_iter()
                                     })
                                     .collect::<Result<Vec<_>>>()?;
 
@@ -1045,18 +1072,34 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
                                 let mut keys_written = 0;
 
-                                let mut current: Option<LookupEntry<'_>> = None;
+                                let mut current: Option<LookupEntry> = None;
 
                                 #[derive(Default)]
-                                struct Collector<'l> {
-                                    entries: Vec<LookupEntry<'l>>,
+                                struct Collector {
+                                    entries: Vec<LookupEntry>,
                                     total_key_size: usize,
                                     total_value_size: usize,
                                     value_block_tracker: ValueBlockCountTracker,
-                                    last_entries: Vec<LookupEntry<'l>>,
+                                    last_entries: Vec<LookupEntry>,
                                     last_entries_total_key_size: usize,
                                     new_sst_files:
                                         Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
+                                }
+                                impl Collector {
+                                    fn is_full(&self) -> bool {
+                                        self.total_key_size + self.total_value_size
+                                            > DATA_THRESHOLD_PER_COMPACTED_FILE
+                                            || self.entries.len() >= MAX_ENTRIES_PER_COMPACTED_FILE
+                                            || self.value_block_tracker.is_full()
+                                    }
+
+                                    fn is_half_full(&self) -> bool {
+                                        self.total_key_size + self.total_value_size
+                                            > DATA_THRESHOLD_PER_COMPACTED_FILE / 2
+                                            || self.entries.len()
+                                                >= MAX_ENTRIES_PER_COMPACTED_FILE / 2
+                                            || self.value_block_tracker.is_half_full()
+                                    }
                                 }
                                 let mut used_collector = Collector::default();
                                 let mut unused_collector = Collector::default();
@@ -1067,9 +1110,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     if let Some(current) = current.take() {
                                         if current.key != entry.key {
                                             let is_used =
-                                                used_key_hashes[family as usize].iter().any(
-                                                    |amqf| amqf.contains_fingerprint(current.hash),
-                                                );
+                                                used_key_hashes.as_ref().is_some_and(|amqf| {
+                                                    amqf.contains_fingerprint(current.hash)
+                                                });
                                             let collector = if is_used {
                                                 &mut used_collector
                                             } else {
@@ -1086,12 +1129,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                                 .value_block_tracker
                                                 .track(is_medium, small_size);
 
-                                            if collector.total_key_size + collector.total_value_size
-                                                > DATA_THRESHOLD_PER_COMPACTED_FILE
-                                                || collector.entries.len()
-                                                    >= MAX_ENTRIES_PER_COMPACTED_FILE
-                                                || collector.value_block_tracker.is_full()
-                                            {
+                                            if collector.is_full() {
                                                 let selected_total_key_size =
                                                     collector.last_entries_total_key_size;
                                                 swap(
@@ -1129,6 +1167,31 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             }
 
                                             collector.entries.push(current);
+
+                                            // Early flush: once entries is past 50%
+                                            // of any limit, the final file won't be
+                                            // undersized, so flush last_entries to
+                                            // reduce peak memory.
+                                            if !collector.last_entries.is_empty()
+                                                && collector.is_half_full()
+                                            {
+                                                let seq = sequence_number
+                                                    .fetch_add(1, Ordering::SeqCst)
+                                                    + 1;
+                                                keys_written += collector.last_entries.len() as u64;
+                                                let mut flags = MetaEntryFlags::default();
+                                                flags.set_cold(!is_used);
+                                                collector.new_sst_files.push(create_sst_file(
+                                                    &self.parallel_scheduler,
+                                                    &collector.last_entries,
+                                                    collector.last_entries_total_key_size,
+                                                    path,
+                                                    seq,
+                                                    flags,
+                                                )?);
+                                                collector.last_entries.clear();
+                                                collector.last_entries_total_key_size = 0;
+                                            }
                                         } else {
                                             // Override value
                                             // TODO delete blob file
@@ -1137,9 +1200,9 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     current = Some(entry);
                                 }
                                 if let Some(entry) = current {
-                                    let is_used = used_key_hashes[family as usize]
-                                        .iter()
-                                        .any(|amqf| amqf.contains_fingerprint(entry.hash));
+                                    let is_used = used_key_hashes
+                                        .as_ref()
+                                        .is_some_and(|amqf| amqf.contains_fingerprint(entry.hash));
                                     let collector = if is_used {
                                         &mut used_collector
                                     } else {

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(once_cell_try)]
-#![feature(get_mut_unchecked)]
 #![feature(sync_unsafe_cell)]
 #![feature(iter_collect_into)]
 

--- a/turbopack/crates/turbo-persistence/src/lookup_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/lookup_entry.rs
@@ -17,17 +17,17 @@ pub enum LookupValue {
 }
 
 /// A value from a SST file lookup.
-pub enum LazyLookupValue<'l> {
+pub enum LazyLookupValue {
     /// A LookupValue
     Eager(LookupValue),
     /// A medium sized value that is still compressed.
     Medium {
         uncompressed_size: u32,
-        block: &'l [u8],
+        block: ArcBytes,
     },
 }
 
-impl LazyLookupValue<'_> {
+impl LazyLookupValue {
     /// Returns the size of the value in the SST file.
     pub fn uncompressed_size_in_sst(&self) -> usize {
         match self {
@@ -74,16 +74,16 @@ impl LazyLookupValue<'_> {
 }
 
 /// An entry from a SST file lookup.
-pub struct LookupEntry<'l> {
+pub struct LookupEntry {
     /// The hash of the key.
     pub hash: u64,
     /// The key.
     pub key: ArcBytes,
     /// The value.
-    pub value: LazyLookupValue<'l>,
+    pub value: LazyLookupValue,
 }
 
-impl Entry for LookupEntry<'_> {
+impl Entry for LookupEntry {
     fn key_hash(&self) -> u64 {
         self.hash
     }
@@ -116,7 +116,7 @@ impl Entry for LookupEntry<'_> {
                 block,
             } => EntryValue::MediumRaw {
                 uncompressed_size: *uncompressed_size,
-                block,
+                block: block.as_ref(),
             },
         }
     }

--- a/turbopack/crates/turbo-persistence/src/merge_iter.rs
+++ b/turbopack/crates/turbo-persistence/src/merge_iter.rs
@@ -6,27 +6,30 @@ use crate::lookup_entry::LookupEntry;
 
 /// An active iterator that is being merged. It has peeked the next element and can be compared
 /// according to that element. The `order` is used when multiple iterators have the same key.
-struct ActiveIterator<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> {
+///
+/// Boxed so that BinaryHeap sift operations only move a pointer (8 bytes) instead of the full
+/// struct (~312 bytes for StaticSortedFileIter), which is significant with 128 iterators.
+struct ActiveIterator<T: Iterator<Item = Result<LookupEntry>>> {
     iter: T,
     order: usize,
-    entry: LookupEntry<'l>,
+    entry: LookupEntry,
 }
 
-impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> PartialEq for ActiveIterator<'l, T> {
+impl<T: Iterator<Item = Result<LookupEntry>>> PartialEq for Box<ActiveIterator<T>> {
     fn eq(&self, other: &Self) -> bool {
         self.entry.hash == other.entry.hash && *self.entry.key == *other.entry.key
     }
 }
 
-impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> Eq for ActiveIterator<'l, T> {}
+impl<T: Iterator<Item = Result<LookupEntry>>> Eq for Box<ActiveIterator<T>> {}
 
-impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> PartialOrd for ActiveIterator<'l, T> {
+impl<T: Iterator<Item = Result<LookupEntry>>> PartialOrd for Box<ActiveIterator<T>> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> Ord for ActiveIterator<'l, T> {
+impl<T: Iterator<Item = Result<LookupEntry>>> Ord for Box<ActiveIterator<T>> {
     fn cmp(&self, other: &Self) -> Ordering {
         self.entry
             .hash
@@ -39,41 +42,34 @@ impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> Ord for ActiveIterator<'l,
 
 /// An iterator that merges multiple sorted iterators into a single sorted iterator. Internal it
 /// uses an heap of iterators to iterate them in order.
-pub struct MergeIter<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> {
-    heap: BinaryHeap<ActiveIterator<'l, T>>,
+pub struct MergeIter<T: Iterator<Item = Result<LookupEntry>>> {
+    heap: BinaryHeap<Box<ActiveIterator<T>>>,
 }
 
-impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> MergeIter<'l, T> {
+impl<T: Iterator<Item = Result<LookupEntry>>> MergeIter<T> {
     pub fn new(iters: impl Iterator<Item = T>) -> Result<Self> {
         let mut heap = BinaryHeap::new();
         for (order, mut iter) in iters.enumerate() {
             if let Some(entry) = iter.next() {
                 let entry = entry?;
-                heap.push(ActiveIterator { iter, order, entry });
+                heap.push(Box::new(ActiveIterator { iter, order, entry }));
             }
         }
         Ok(Self { heap })
     }
 }
 
-impl<'l, T: Iterator<Item = Result<LookupEntry<'l>>>> Iterator for MergeIter<'l, T> {
-    type Item = Result<LookupEntry<'l>>;
+impl<T: Iterator<Item = Result<LookupEntry>>> Iterator for MergeIter<T> {
+    type Item = Result<LookupEntry>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let ActiveIterator {
-            mut iter,
-            order,
-            entry,
-        } = self.heap.pop()?;
-        match iter.next() {
-            None => {}
+        let mut active = self.heap.pop()?;
+        let entry = match active.iter.next() {
+            None => return Some(Ok(active.entry)),
             Some(Err(e)) => return Some(Err(e)),
-            Some(Ok(next)) => self.heap.push(ActiveIterator {
-                iter,
-                order,
-                entry: next,
-            }),
-        }
+            Some(Ok(next)) => std::mem::replace(&mut active.entry, next),
+        };
+        self.heap.push(active);
         Some(Ok(entry))
     }
 }

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -129,7 +129,7 @@ impl MetaEntry {
 
     pub fn sst(&self, meta: &MetaFile) -> Result<&StaticSortedFile> {
         self.sst.get_or_try_init(|| {
-            StaticSortedFile::open(&meta.db_path, self.sst_data.clone()).with_context(|| {
+            StaticSortedFile::open(&meta.db_path, self.sst_data).with_context(|| {
                 format!(
                     "Unable to open static sorted file referenced from {:08}.meta",
                     meta.sequence_number()
@@ -161,6 +161,12 @@ impl MetaEntry {
 
     pub fn block_count(&self) -> u16 {
         self.sst_data.block_count
+    }
+
+    /// Returns the SST metadata needed to open the file independently.
+    /// Used during compaction to avoid caching mmaps on the MetaEntry.
+    pub fn sst_metadata(&self) -> StaticSortedFileMetaData {
+        self.sst_data
     }
 }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -79,7 +79,45 @@ impl quick_cache::Weighter<(u32, u16), ArcBytes> for BlockWeighter {
 pub type BlockCache =
     quick_cache::sync::Cache<(u32, u16), ArcBytes, BlockWeighter, BuildHasherDefault<FxHasher>>;
 
-#[derive(Clone, Debug)]
+/// Trait abstracting value block caching for `handle_key_match`.
+///
+/// Implemented by `&BlockCache` (global shared cache for lookups) and
+/// `&mut Option<(u16, ArcBytes)>` (lightweight single-entry cache for
+/// sequential iteration).
+trait ValueBlockCache {
+    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes>;
+}
+
+impl ValueBlockCache for &BlockCache {
+    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes> {
+        let this = &sst;
+        let block = match self.get_value_or_guard(&(this.meta.sequence_number, block_index), None) {
+            GuardResult::Value(block) => block,
+            GuardResult::Guard(guard) => {
+                let block = this.read_small_value_block(block_index)?;
+                let _ = guard.insert(block.clone());
+                block
+            }
+            GuardResult::Timeout => unreachable!(),
+        };
+        Ok(block)
+    }
+}
+
+impl ValueBlockCache for &mut Option<(u16, ArcBytes)> {
+    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes> {
+        if let Some((idx, block)) = self.as_ref()
+            && *idx == block_index
+        {
+            return Ok(block.clone());
+        }
+        let block = sst.read_small_value_block(block_index)?;
+        *self = Some((block_index, block.clone()));
+        Ok(block)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 pub struct StaticSortedFileMetaData {
     /// The sequence number of this file.
     pub sequence_number: u32,
@@ -123,16 +161,31 @@ impl StaticSortedFile {
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
-        Self::open_internal(path, meta)
+        Self::open_internal(path, meta, false)
             .with_context(|| format!("Unable to open static sorted file {filename}"))
     }
 
-    fn open_internal(path: PathBuf, meta: StaticSortedFileMetaData) -> Result<Self> {
+    /// Opens an SST file for compaction. Uses MADV_SEQUENTIAL instead of MADV_RANDOM,
+    /// since compaction reads blocks sequentially and benefits from OS read-ahead
+    /// and page reclamation.
+    pub fn open_for_compaction(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
+        let filename = format!("{:08}.sst", meta.sequence_number);
+        let path = db_path.join(&filename);
+        Self::open_internal(path, meta, true)
+            .with_context(|| format!("Unable to open static sorted file {filename}"))
+    }
+
+    fn open_internal(
+        path: PathBuf,
+        meta: StaticSortedFileMetaData,
+        sequential: bool,
+    ) -> Result<Self> {
         let mmap = unsafe { Mmap::map(&File::open(&path)?)? };
         #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Random)?;
-        #[cfg(unix)]
-        {
+        if sequential {
+            mmap.advise(memmap2::Advice::Sequential)?;
+        } else {
+            mmap.advise(memmap2::Advice::Random)?;
             let offset = meta.block_offsets_start(mmap.len());
             let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
         }
@@ -143,20 +196,18 @@ impl StaticSortedFile {
         Ok(file)
     }
 
-    /// Iterate over all entries in this file in sorted order.
-    pub fn iter<'l>(
-        &'l self,
-        key_block_cache: &'l BlockCache,
-        value_block_cache: &'l BlockCache,
-    ) -> Result<StaticSortedFileIter<'l>> {
+    /// Consume this file and return an iterator over all entries in sorted order.
+    /// The iterator takes ownership of the SST file, so the mmap and its pages
+    /// are freed when the iterator is dropped.
+    pub fn try_into_iter(self) -> Result<StaticSortedFileIter> {
+        let block_count = self.meta.block_count;
         let mut iter = StaticSortedFileIter {
             this: self,
-            key_block_cache,
-            value_block_cache,
             stack: Vec::new(),
             current_key_block: None,
+            value_block_cache: None,
         };
-        iter.enter_block(self.meta.block_count - 1)?;
+        iter.enter_block(block_count - 1)?;
         Ok(iter)
     }
 
@@ -290,15 +341,15 @@ impl StaticSortedFile {
         ty: u8,
         mut val: &[u8],
         key_block_arc: &ArcBytes,
-        value_block_cache: &BlockCache,
+        value_block_cache: impl ValueBlockCache,
     ) -> Result<LookupValue> {
         Ok(match ty {
             KEY_BLOCK_ENTRY_TYPE_SMALL => {
                 let block = val.read_u16::<BE>()?;
                 let size = val.read_u16::<BE>()? as usize;
                 let position = val.read_u32::<BE>()? as usize;
-                let value = self
-                    .get_small_value_block(block, value_block_cache)?
+                let value = value_block_cache
+                    .get_or_read(self, block)?
                     .slice(position..position + size);
                 LookupValue::Slice { value }
             }
@@ -340,25 +391,6 @@ impl StaticSortedFile {
         )
     }
 
-    /// Gets a value block from the cache or reads it from the file.
-    fn get_small_value_block(
-        &self,
-        block: u16,
-        value_block_cache: &BlockCache,
-    ) -> Result<ArcBytes> {
-        let block =
-            match value_block_cache.get_value_or_guard(&(self.meta.sequence_number, block), None) {
-                GuardResult::Value(block) => block,
-                GuardResult::Guard(guard) => {
-                    let block = self.read_small_value_block(block)?;
-                    let _ = guard.insert(block.clone());
-                    block
-                }
-                GuardResult::Timeout => unreachable!(),
-            };
-        Ok(block)
-    }
-
     /// Reads a key block from the file.
     fn read_key_block(&self, block_index: u16) -> Result<ArcBytes> {
         self.read_block(
@@ -386,12 +418,11 @@ impl StaticSortedFile {
         compression_dictionary: Option<&[u8]>,
         long_term: bool,
     ) -> Result<ArcBytes> {
-        let (uncompressed_length, block) = self.get_raw_block(block_index)?;
+        let (uncompressed_length, block) = self.get_raw_block_slice(block_index)?;
 
-        // 0 means the block was not compressed, just return the slice into the mmap
+        // 0 means the block was not compressed, return the mmap-backed ArcBytes directly
         if uncompressed_length == 0 {
-            // SAFETY: get_raw_block only returns reference into the mmap.
-            return Ok(unsafe { ArcBytes::from_mmap(self.mmap.clone(), block) });
+            return Ok(self.mmap_slice_to_arc_bytes(block));
         }
 
         // Advise Sequential only here: we're about to linearly scan the block
@@ -414,8 +445,23 @@ impl StaticSortedFile {
         Ok(ArcBytes::from(buffer))
     }
 
-    /// Gets the slice of the compressed block from the memory mapped file.
-    fn get_raw_block(&self, block_index: u16) -> Result<(u32, &[u8])> {
+    /// Returns `(uncompressed_length, block_data)` as an owned `ArcBytes` backed by
+    /// the mmap. Only use this when the block data needs to outlive the current borrow
+    /// (e.g. medium values stored in `LookupEntry`).
+    fn get_raw_block(&self, block_index: u16) -> Result<(u32, ArcBytes)> {
+        let (uncompressed_length, block) = self.get_raw_block_slice(block_index)?;
+        Ok((uncompressed_length, self.mmap_slice_to_arc_bytes(block)))
+    }
+
+    /// Promotes a mmap subslice to an owned `ArcBytes`. This clones the `Arc<Mmap>`.
+    fn mmap_slice_to_arc_bytes(&self, subslice: &[u8]) -> ArcBytes {
+        // SAFETY: callers guarantee subslice points into self.mmap.
+        unsafe { ArcBytes::from_mmap(self.mmap.clone(), subslice) }
+    }
+
+    /// Gets the raw block slice directly from the memory mapped file, without
+    /// cloning the `Arc<Mmap>`. The returned slice borrows from the mmap.
+    fn get_raw_block_slice(&self, block_index: u16) -> Result<(u32, &[u8])> {
         #[cfg(feature = "strict_checks")]
         if block_index >= self.meta.block_count {
             bail!(
@@ -471,13 +517,15 @@ impl StaticSortedFile {
 }
 
 /// An iterator over all entries in a SST file in sorted order.
-pub struct StaticSortedFileIter<'l> {
-    this: &'l StaticSortedFile,
-    key_block_cache: &'l BlockCache,
-    value_block_cache: &'l BlockCache,
+pub struct StaticSortedFileIter {
+    this: StaticSortedFile,
 
     stack: Vec<CurrentIndexBlock>,
     current_key_block: Option<CurrentKeyBlock>,
+    /// Single-entry value block cache. Within a key block, entries reference
+    /// value blocks sequentially and don't revisit earlier blocks, so caching
+    /// just the current one avoids redundant decompression.
+    value_block_cache: Option<(u16, ArcBytes)>,
 }
 
 struct CurrentKeyBlock {
@@ -494,18 +542,18 @@ struct CurrentIndexBlock {
     index: usize,
 }
 
-impl<'l> Iterator for StaticSortedFileIter<'l> {
-    type Item = Result<LookupEntry<'l>>;
+impl Iterator for StaticSortedFileIter {
+    type Item = Result<LookupEntry>;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.next_internal().transpose()
     }
 }
 
-impl<'l> StaticSortedFileIter<'l> {
+impl StaticSortedFileIter {
     /// Enters a block at the given index.
     fn enter_block(&mut self, block_index: u16) -> Result<()> {
-        let block_arc = self.this.get_key_block(block_index, self.key_block_cache)?;
+        let block_arc = self.this.read_key_block(block_index)?;
         let mut block = &*block_arc;
         let block_type = block.read_u8()?;
         match block_type {
@@ -542,7 +590,7 @@ impl<'l> StaticSortedFileIter<'l> {
     }
 
     /// Gets the next entry in the file and moves the cursor.
-    fn next_internal(&mut self) -> Result<Option<LookupEntry<'l>>> {
+    fn next_internal(&mut self) -> Result<Option<LookupEntry>> {
         loop {
             if let Some(CurrentKeyBlock {
                 offsets,
@@ -569,9 +617,12 @@ impl<'l> StaticSortedFileIter<'l> {
                         block,
                     }
                 } else {
-                    let value =
-                        self.this
-                            .handle_key_match(ty, val, &entries, self.value_block_cache)?;
+                    let value = self.this.handle_key_match(
+                        ty,
+                        val,
+                        &entries,
+                        &mut self.value_block_cache,
+                    )?;
                     LazyLookupValue::Eager(value)
                 };
                 let entry = LookupEntry {

--- a/turbopack/crates/turbo-persistence/src/value_block_count_tracker.rs
+++ b/turbopack/crates/turbo-persistence/src/value_block_count_tracker.rs
@@ -33,6 +33,12 @@ impl ValueBlockCountTracker {
             >= MAX_VALUE_BLOCK_COUNT
     }
 
+    /// Returns true if the tracked value block count has reached half of the maximum.
+    pub fn is_half_full(&self) -> bool {
+        self.value_block_count + (self.current_small_value_block_size > 0) as usize
+            >= MAX_VALUE_BLOCK_COUNT / 2
+    }
+
     /// Reset the tracker to empty.
     pub fn reset(&mut self) {
         self.value_block_count = 0;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1271,7 +1271,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 persisted_task_cache_log,
                 task_snapshots,
             ) {
-                println!("Persisting failed: {err:?}");
+                eprintln!("Persisting failed: {err:?}");
                 return None;
             }
             #[cfg(feature = "print_cache_item_size")]


### PR DESCRIPTION
### What?

Optimizes memory usage, I/O patterns, and CPU efficiency during database compaction by:

* clearing block caches and SST mmaps before compaction starts
* opening SST files independently with madvise(SEQUENTIAL) for compaction
* making the SST iterator own the file so mmaps are dropped as as soon as the iterator is are consumed
* moving used-key-hash filter deserialization into per-family scope, 
    * also mering AMQF filters into a single pre-sized filter per family, reducing used-key classification from O(N filters) to O(1) per entry
* flushing entries early once collectors reach 50% capacity to reduce peak overhead while still avoiding small files
* adding a lightweight single-entry value block cache on the iterator (replacing the global `BlockCache` for sequential scans, this reaps all the benefits while not accumulating too many blocks that will never be visited again)
* boxing MergeIter heap elements so BinaryHeap sifts swap 8-byte pointers instead of ~312-byte structs

### Why?

Database compaction was consuming excessive memory by maintaining block caches and memory-mapped files that weren't needed during the sequential merge operations. The existing approach used random access patterns optimized for lookups, but compaction performs sequential scans that benefit from different memory management strategies.

Profiling revealed two additional CPU bottlenecks:
1. **AMQF query overhead (44% of compaction time):** With 128 commits, `compact_internal` iterated all 128 AMQF filters per entry (16M entries × 128 filters = ~2B probes). Most filters were empty in write-only workloads but still deserialized. Filtering empty filters and merging the rest into a single filter eliminates this entirely.
2. **MergeIter heap sift overhead (21% inclusive):** `ActiveIterator<StaticSortedFileIter>` is ~312 bytes. BinaryHeap sifts moved these large structs at each level (log2(128) = 7 levels per pop/push). Boxing reduces each swap to 8 bytes, cutting MergeIter inclusive time from 21% to 12%.

### Performance results

Compaction benchmark (16Mi entries, 128 commits):

| Scenario | Before | After | Improvement |
|---|---|---|---|
| Partial compaction | 6.79s | 3.71s | -45% |
| Full compaction | 8.07s | 3.79s | -53% |