### PR TITLE
fix: Correct AppType parameter to apply to component props instead of pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -30,8 +30,8 @@ export type DocumentType = NextComponentType<
 
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
-  P,
-  AppPropsType<any, P>
+  any,
+  AppPropsType<any> & P
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
## Summary

Fixes the AppType<P> generic type so that P correctly extends the component props instead of being incorrectly applied to pageProps.

## Problem

The AppType<P> generic parameter was incorrectly applied to InitialProps (the second parameter of NextComponentType), which caused P to be applied to pageProps.

## Changes

Changed AppType definition to move P to the Props parameter (third parameter), so it correctly extends the component props via & P.

Fixes #42846