### PR TITLE
Run test/e2e/url/url.test.ts in deploy mode

### DIFF
--- a/test/e2e/url/url.test.ts
+++ b/test/e2e/url/url.test.ts
@@ -17,7 +17,6 @@ describe(`Handle new URL asset references`, () => {
       // rely on skew protection when deployed
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
     },
-    skipDeployment: true,
   })
 
   if (skipped) {


### PR DESCRIPTION
A weird failure:
```
FAIL webpack test/e2e/url/url.test.ts (99.304 s)
  ● Handle new URL asset references › pages router › should respond on API

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

      Object {
        "imported": "/_next/static/media/vercel.HASH.png",
    -   "size": 30079,
    +   "size": "ENOENT: no such file or directory, open '/var/task/.next/server/chunks/static/media/vercel.HASH.png'",
        "url": StringMatching /file:.*\/.next(\/dev)?\/server\/.*\/vercel.HASH.png$/,
      }

      175 |       const json = JSON.parse(stripVercelPngHash(data))
      176 |
    > 177 |       expect(json).toEqual({
          |                    ^
      178 |         imported: clientUrl,
      179 |         url: serverFileRegex,
      180 |         size: 30079,

      at Object.toEqual (e2e/url/url.test.ts:177:20)
```