### PR TITLE
[Instant] export "Instant" config type

### DIFF
--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -46,10 +46,8 @@ const InstantConfigSchema = z.union([
   z.literal(false),
 ])
 
-export type InstantConfig = InstantConfigStatic | InstantConfigRuntime | false
-export type InstantConfigForTypeCheckInternal =
-  | __GenericInstantConfig
-  | InstantConfig
+export type Instant = InstantConfigStatic | InstantConfigRuntime | false
+export type InstantConfigForTypeCheckInternal = __GenericInstantConfig | Instant
 // the __GenericPrefetch type is used to avoid type widening issues with
 // our choice to make exports the medium for programming a Next.js application
 // With exports the type is controlled by the module and all we can do is assert on it
@@ -233,7 +231,7 @@ export type AppSegmentConfig = {
   /**
    * How this segment should be prefetched.
    */
-  unstable_instant?: InstantConfig
+  unstable_instant?: Instant
 
   /**
    * The preferred region for the page.

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -29,7 +29,7 @@ import { parseLoaderTree } from '../../../shared/lib/router/utils/parse-loader-t
 import type { GetDynamicParamFromSegment } from '../app-render'
 import type {
   AppSegmentConfig,
-  InstantConfig,
+  Instant,
 } from '../../../build/segment-config/app/app-segment-config'
 import { Readable } from 'node:stream'
 import {
@@ -84,7 +84,7 @@ export type RouteTree = {
   module: null | {
     type: 'layout' | 'page'
     // TODO(instant-validation): We should know if a layout segment is shared
-    instantConfig: InstantConfig | null
+    instantConfig: Instant | null
     conventionPath: string
   }
 

--- a/packages/next/src/types.ts
+++ b/packages/next/src/types.ts
@@ -40,6 +40,8 @@ export type {
   ResolvedViewport,
 } from './lib/metadata/types/metadata-interface'
 
+export type { Instant } from './build/segment-config/app/app-segment-config'
+
 export type { Instrumentation } from './server/instrumentation/types'
 
 /**


### PR DESCRIPTION
We forgot to export a type for the `unstable_instant` config. This works now

```tsx
import type { Instant } from 'next'
export const unstable_instant: Instant = { ... }
```