### PR TITLE
Always render metadata with Suspense regardless of streaming mode

### DIFF
--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -40,7 +40,6 @@ export function createMetadataComponents({
   metadataContext,
   interpolatedParams,
   errorType,
-  serveStreamingMetadata,
 }: {
   tree: LoaderTree
   pathname: string
@@ -48,7 +47,6 @@ export function createMetadataComponents({
   metadataContext: MetadataContext
   interpolatedParams: Params
   errorType?: MetadataErrorType | 'redirect'
-  serveStreamingMetadata: boolean
 }): {
   Viewport: React.ComponentType
   Metadata: React.ComponentType
@@ -126,16 +124,6 @@ export function createMetadataComponents({
   Metadata.displayName = 'Next.Metadata'
 
   function MetadataWrapper() {
-    // TODO: We shouldn't change what we render based on whether we are streaming or not.
-    // If we aren't streaming we should just block the response until we have resolved the
-    // metadata.
-    if (!serveStreamingMetadata) {
-      return (
-        <MetadataBoundary>
-          <Metadata />
-        </MetadataBoundary>
-      )
-    }
     return (
       <div hidden>
         <MetadataBoundary>
@@ -160,12 +148,6 @@ export function createMetadataComponents({
       getResolvedViewport(tree, searchParams, interpolatedParams, errorType),
     ]).then(() => null)
 
-    // TODO: We shouldn't change what we render based on whether we are streaming or not.
-    // If we aren't streaming we should just block the response until we have resolved the
-    // metadata.
-    if (!serveStreamingMetadata) {
-      return <OutletBoundary>{pendingOutlet}</OutletBoundary>
-    }
     return (
       <OutletBoundary>
         <Suspense name="Next.MetadataOutlet">{pendingOutlet}</Suspense>

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -531,8 +531,6 @@ async function generateDynamicRSCPayload(
     url,
   } = ctx
 
-  const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
-
   if (!options?.skipPageRendering) {
     const preloadCallbacks: PreloadCallbacks = []
 
@@ -550,7 +548,6 @@ async function generateDynamicRSCPayload(
       pathname: url.pathname,
       metadataContext: createMetadataContext(ctx.renderOpts),
       interpolatedParams: ctx.interpolatedParams,
-      serveStreamingMetadata,
     })
 
     const rscHead = createElement(
@@ -1428,7 +1425,6 @@ async function getRSCPayload(
     getDynamicParamFromSegment,
     query
   )
-  const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
   const hasGlobalNotFound = !!tree[2]['global-not-found']
 
   const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
@@ -1443,7 +1439,6 @@ async function getRSCPayload(
     pathname: url.pathname,
     metadataContext: createMetadataContext(ctx.renderOpts),
     interpolatedParams: ctx.interpolatedParams,
-    serveStreamingMetadata,
   })
 
   const preloadCallbacks: PreloadCallbacks = []
@@ -1555,7 +1550,6 @@ async function getErrorRSCPayload(
     workStore,
   } = ctx
 
-  const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
   const { Viewport, Metadata } = createMetadataComponents({
     tree,
     parsedQuery: query,
@@ -1563,7 +1557,6 @@ async function getErrorRSCPayload(
     metadataContext: createMetadataContext(ctx.renderOpts),
     errorType,
     interpolatedParams: ctx.interpolatedParams,
-    serveStreamingMetadata: serveStreamingMetadata,
   })
 
   const initialHead = createElement(


### PR DESCRIPTION
Metadata rendering previously changed its component tree structure based on serveStreamingMetadata — wrapping in Suspense for streaming responses but rendering synchronously for bots. This is unnecessary because bot responses already block on allReady before sending any bytes, so the Suspense boundaries resolve before the response starts regardless. Removing this conditional eliminates serveStreamingMetadata from the metadata closure.