### PR TITLE
[test] Improve fetch timeout error stack for `act`

### DIFF
--- a/test/lib/router-act.ts
+++ b/test/lib/router-act.ts
@@ -224,9 +224,18 @@ export function createRouterAct(
             // but it should not affect the timing of when requests reach the
             // server; we pass the request to the server the immediately.
             result: (async () => {
-              const originalResponse = await page.request.fetch(request, {
-                maxRedirects: 0,
-              })
+              let originalResponse: Playwright.APIResponse
+              try {
+                originalResponse = await page.request.fetch(request, {
+                  maxRedirects: 0,
+                })
+              } catch (fetchError) {
+                error.message =
+                  fetchError instanceof Error
+                    ? fetchError.message
+                    : String(fetchError)
+                throw error
+              }
 
               // WORKAROUND:
               // intercepting responses with 'Transfer-Encoding: chunked' (used for streaming)


### PR DESCRIPTION
Before:

```
    apiRequestContext.fetch: Request timed out after 30000ms
    Call log:
      - → GET http://localhost:55200/refetch-on-new-base-tree/a?_rsc=1u5ob
      -   <snip>

      225 |             // server; we pass the request to the server the immediately.
      226 |             result: (async () => {
    > 227 |               const originalResponse = await page.request.fetch(request, {
          |                                                           ^
      228 |                 maxRedirects: 0,
      229 |               })
      230 |

      at fetch (lib/router-act.ts:227:59)
      at lib/router-act.ts:245:13
      at routeHandler (lib/router-act.ts:257:7)
```

After:

```
    apiRequestContext.fetch: Request timed out after 30000ms
    Call log:
      - → GET http://localhost:61662/refetch-on-new-base-tree/a?_rsc=1u5ob
      -   <snip>

      264 |
      265 |     // Reveal the links to trigger prefetches
    > 266 |     await act(async () => {
          |           ^
      267 |       await linkALinkVisibilityToggle.click()
      268 |       await linkBLinkVisibilityToggle.click()
      269 |     }, [

      at Object.act (e2e/app-dir/segment-cache/revalidation/segment-cache-revalidation.test.ts:266:11)
```

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
