### PR TITLE
Turbopack: add on-demand memory reporting for dev server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9491,6 +9491,7 @@ dependencies = [
  "bincode 2.0.1",
  "bitfield",
  "byteorder",
+ "chrono",
  "codspeed-criterion-compat",
  "dashmap 6.1.0",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9491,7 +9491,6 @@ dependencies = [
  "bincode 2.0.1",
  "bitfield",
  "byteorder",
- "chrono",
  "codspeed-criterion-compat",
  "dashmap 6.1.0",
  "either",

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2437,7 +2437,7 @@ pub async fn project_write_analyze_data(
 }
 
 #[napi]
-pub async fn project_get_memory_report(
+pub fn project_get_memory_report(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
 ) -> napi::Result<String> {
     let report = project

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2439,18 +2439,13 @@ pub async fn project_write_analyze_data(
 #[napi]
 pub async fn project_get_memory_report(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
-    top_n: Option<u32>,
 ) -> napi::Result<String> {
-    let top_n = top_n.unwrap_or(1000) as usize;
-    let turbo_tasks = project.turbopack_ctx.turbo_tasks().clone();
+    let report = project
+        .turbopack_ctx
+        .turbo_tasks()
+        .backend()
+        .collect_memory_report();
 
-    let report =
-        tokio::task::spawn_blocking(move || turbo_tasks.backend().collect_memory_report(top_n))
-            .await
-            .map_err(|e| {
-                napi::Error::from_reason(format!("Failed to collect memory report: {e}"))
-            })?;
-
-    serde_json::to_string_pretty(&report)
+    serde_json::to_string(&report)
         .map_err(|e| napi::Error::from_reason(format!("Failed to serialize memory report: {e}")))
 }

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2435,3 +2435,22 @@ pub async fn project_write_analyze_data(
             .collect(),
     })
 }
+
+#[napi]
+pub async fn project_get_memory_report(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+    top_n: Option<u32>,
+) -> napi::Result<String> {
+    let top_n = top_n.unwrap_or(1000) as usize;
+    let turbo_tasks = project.turbopack_ctx.turbo_tasks().clone();
+
+    let report =
+        tokio::task::spawn_blocking(move || turbo_tasks.backend().collect_memory_report(top_n))
+            .await
+            .map_err(|e| {
+                napi::Error::from_reason(format!("Failed to collect memory report: {e}"))
+            })?;
+
+    serde_json::to_string_pretty(&report)
+        .map_err(|e| napi::Error::from_reason(format!("Failed to serialize memory report: {e}")))
+}

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2436,16 +2436,88 @@ pub async fn project_write_analyze_data(
     })
 }
 
+#[napi(object)]
+pub struct NapiMemoryReport {
+    pub tasks: NapiTaskStats,
+    pub cells: NapiCellStats,
+    pub allocator: NapiAllocatorStats,
+}
+
+#[napi(object)]
+pub struct NapiTaskStats {
+    pub total_count: f64,
+    pub total_estimated_size_bytes: f64,
+    pub by_function: Vec<NapiFunctionTaskStats>,
+}
+
+#[napi(object)]
+pub struct NapiFunctionTaskStats {
+    pub function: String,
+    pub count: f64,
+    pub estimated_size_bytes: f64,
+}
+
+#[napi(object)]
+pub struct NapiCellStats {
+    pub total_count: f64,
+    pub total_estimated_size_bytes: f64,
+    pub by_type: Vec<NapiTypeCellStats>,
+}
+
+#[napi(object)]
+pub struct NapiTypeCellStats {
+    #[napi(js_name = "type")]
+    pub type_name: String,
+    pub count: f64,
+    pub estimated_size_bytes: Option<f64>,
+}
+
+#[napi(object)]
+pub struct NapiAllocatorStats {
+    pub allocated_bytes: f64,
+}
+
 #[napi]
 pub fn project_get_memory_report(
     #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
-) -> napi::Result<String> {
+) -> napi::Result<NapiMemoryReport> {
     let report = project
         .turbopack_ctx
         .turbo_tasks()
         .backend()
         .collect_memory_report();
 
-    serde_json::to_string(&report)
-        .map_err(|e| napi::Error::from_reason(format!("Failed to serialize memory report: {e}")))
+    Ok(NapiMemoryReport {
+        tasks: NapiTaskStats {
+            total_count: report.tasks.total_count as f64,
+            total_estimated_size_bytes: report.tasks.total_estimated_size_bytes as f64,
+            by_function: report
+                .tasks
+                .by_function
+                .into_iter()
+                .map(|f| NapiFunctionTaskStats {
+                    function: f.function.to_string(),
+                    count: f.count as f64,
+                    estimated_size_bytes: f.estimated_size_bytes as f64,
+                })
+                .collect(),
+        },
+        cells: NapiCellStats {
+            total_count: report.cells.total_count as f64,
+            total_estimated_size_bytes: report.cells.total_estimated_size_bytes as f64,
+            by_type: report
+                .cells
+                .by_type
+                .into_iter()
+                .map(|c| NapiTypeCellStats {
+                    type_name: c.type_name.to_string(),
+                    count: c.count as f64,
+                    estimated_size_bytes: c.estimated_size_bytes.map(|s| s as f64),
+                })
+                .collect(),
+        },
+        allocator: NapiAllocatorStats {
+            allocated_bytes: report.allocator.allocated_bytes as f64,
+        },
+    })
 }

--- a/docs/01-app/02-guides/local-development.mdx
+++ b/docs/01-app/02-guides/local-development.mdx
@@ -271,6 +271,28 @@ It provides detailed information about the time taken for each module to compile
 
 > **Good to know**: The trace file is placed under the development server directory, which defaults to `.next/dev`.
 
+### Turbopack memory reporting
+
+If your dev server is using too much memory, you can generate a memory report from a running Turbopack dev server. The report shows memory usage broken down by task function and cell type, helping you identify what's consuming memory.
+
+While your dev server is running, use the CLI command:
+
+```bash
+npx next internal turbopack-memory
+```
+
+This outputs a JSON report by default. You can also request a human-readable markdown format:
+
+```bash
+npx next internal turbopack-memory --format markdown
+```
+
+If you know the host and port of your dev server, you can skip lock file discovery with `--server`:
+
+```bash
+npx next internal turbopack-memory --server localhost:3000
+```
+
 ### Still having problems?
 
 Share the trace file generated in the [Turbopack Tracing](#turbopack-tracing) section and share it on [GitHub Discussions](https://github.com/vercel/next.js/discussions) or [Discord](https://nextjs.org/discord).

--- a/docs/01-app/02-guides/local-development.mdx
+++ b/docs/01-app/02-guides/local-development.mdx
@@ -273,7 +273,9 @@ It provides detailed information about the time taken for each module to compile
 
 ### Turbopack memory reporting
 
-If your dev server is using too much memory, you can generate a memory report from a running Turbopack dev server. The report shows memory usage broken down by task function and cell type, helping you identify what's consuming memory.
+> **Note:** This is an advanced debugging tool intended for diagnosing memory issues in the Turbopack bundler. It is only available when using Turbopack (the default bundler), not webpack.
+
+If your dev server is using too much memory, you can generate a memory report from a running Turbopack dev server. The report shows memory usage broken down by task function and cell type, helping you identify what's consuming memory. In Turbopack's model, **tasks** are cached computations (e.g. parsing a module, resolving imports) and **cells** are their stored output values.
 
 While your dev server is running, use the CLI command:
 

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1068,5 +1068,6 @@
   "1067": "The Next.js unhandled rejection filter is being installed more than once. This is a bug in Next.js.",
   "1068": "Expected workStore to be initialized",
   "1069": "Invariant: cache entry \"%s\" not found in dir \"%s\"",
-  "1070": "image of size %s could not be tracked by lru cache"
+  "1070": "image of size %s could not be tracked by lru cache",
+  "1071": "Failed to collect memory report"
 }

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -565,18 +565,12 @@ internal
       'If no directory is provided, the current directory will be used.'
     )}`
   )
+  .option('--format <format>', 'Output format: "json" or "markdown".', 'json')
   .option(
-    '--format <format>',
-    'Output format: "json", "markdown", or "html".',
-    'json'
+    '--server <host:port>',
+    'Connect to a dev server at the given host:port instead of discovering via lock file.'
   )
-  .addOption(
-    new Option(
-      '--top-n <count>',
-      'Number of top entries to show per category. Defaults to 100.'
-    ).argParser(parseValidPositiveInteger)
-  )
-  .action((directory: string, options: { format?: string; topN?: number }) =>
+  .action((directory: string, options: { format?: string; server?: string }) =>
     import('../cli/internal/next-turbopack-memory.js').then((mod) =>
       mod.nextTurbopackMemory(options, directory)
     )

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -565,7 +565,11 @@ internal
       'If no directory is provided, the current directory will be used.'
     )}`
   )
-  .option('--format <format>', 'Output format: "json" or "markdown".', 'json')
+  .addOption(
+    new Option('--format <format>', 'Output format.')
+      .choices(['json', 'markdown'])
+      .default('json')
+  )
   .option(
     '--server <host:port>',
     'Connect to a dev server at the given host:port instead of discovering via lock file.'

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -554,4 +554,33 @@ internal
     )
   })
 
+internal
+  .command('turbopack-memory')
+  .description(
+    'Dump a memory report from a running Next.js dev server (Turbopack).'
+  )
+  .argument(
+    '[directory]',
+    `A directory on which to look for the running dev server. ${italic(
+      'If no directory is provided, the current directory will be used.'
+    )}`
+  )
+  .option(
+    '--format <format>',
+    'Output format: "json", "markdown", or "html".',
+    'json'
+  )
+  .addOption(
+    new Option(
+      '--top-n <count>',
+      'Number of top entries to show per category. Defaults to 100.'
+    ).argParser(parseValidPositiveInteger)
+  )
+  .action((directory: string, options: { format?: string; topN?: number }) =>
+    import('../cli/internal/next-turbopack-memory.js').then((mod) =>
+      mod.nextTurbopackMemory(options, directory)
+    )
+  )
+  .usage('[directory] [options]')
+
 program.parse(process.argv)

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -392,6 +392,10 @@ export declare function projectWriteAnalyzeData(
   project: { __napiType: 'Project' },
   appDirOnly: boolean
 ): Promise<TurbopackResult>
+export declare function projectGetMemoryReport(
+  project: { __napiType: 'Project' },
+  topN?: number | undefined | null
+): Promise<string>
 /**
  * A version of [`NapiNextTurbopackCallbacks`] that can accepted as an argument to a napi function.
  *

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -392,10 +392,9 @@ export declare function projectWriteAnalyzeData(
   project: { __napiType: 'Project' },
   appDirOnly: boolean
 ): Promise<TurbopackResult>
-export declare function projectGetMemoryReport(
-  project: { __napiType: 'Project' },
-  topN?: number | undefined | null
-): Promise<string>
+export declare function projectGetMemoryReport(project: {
+  __napiType: 'Project'
+}): Promise<string>
 /**
  * A version of [`NapiNextTurbopackCallbacks`] that can accepted as an argument to a napi function.
  *

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -392,9 +392,37 @@ export declare function projectWriteAnalyzeData(
   project: { __napiType: 'Project' },
   appDirOnly: boolean
 ): Promise<TurbopackResult>
+export interface NapiMemoryReport {
+  tasks: NapiTaskStats
+  cells: NapiCellStats
+  allocator: NapiAllocatorStats
+}
+export interface NapiTaskStats {
+  totalCount: number
+  totalEstimatedSizeBytes: number
+  byFunction: Array<NapiFunctionTaskStats>
+}
+export interface NapiFunctionTaskStats {
+  function: string
+  count: number
+  estimatedSizeBytes: number
+}
+export interface NapiCellStats {
+  totalCount: number
+  totalEstimatedSizeBytes: number
+  byType: Array<NapiTypeCellStats>
+}
+export interface NapiTypeCellStats {
+  type: string
+  count: number
+  estimatedSizeBytes?: number
+}
+export interface NapiAllocatorStats {
+  allocatedBytes: number
+}
 export declare function projectGetMemoryReport(project: {
   __napiType: 'Project'
-}): string
+}): NapiMemoryReport
 /**
  * A version of [`NapiNextTurbopackCallbacks`] that can accepted as an argument to a napi function.
  *

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -394,7 +394,7 @@ export declare function projectWriteAnalyzeData(
 ): Promise<TurbopackResult>
 export declare function projectGetMemoryReport(project: {
   __napiType: 'Project'
-}): Promise<string>
+}): string
 /**
  * A version of [`NapiNextTurbopackCallbacks`] that can accepted as an argument to a napi function.
  *

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -827,7 +827,7 @@ function bindingToApi(
       return binding.projectInvalidateFileSystemCache(this._nativeProject)
     }
 
-    getMemoryReport(): Promise<string> {
+    getMemoryReport(): string {
       return binding.projectGetMemoryReport(this._nativeProject)
     }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -827,6 +827,10 @@ function bindingToApi(
       return binding.projectInvalidateFileSystemCache(this._nativeProject)
     }
 
+    getMemoryReport(topN?: number): Promise<string> {
+      return binding.projectGetMemoryReport(this._nativeProject, topN ?? null)
+    }
+
     shutdown(): Promise<void> {
       return binding.projectShutdown(this._nativeProject)
     }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -827,7 +827,7 @@ function bindingToApi(
       return binding.projectInvalidateFileSystemCache(this._nativeProject)
     }
 
-    getMemoryReport(): string {
+    getMemoryReport() {
       return binding.projectGetMemoryReport(this._nativeProject)
     }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -827,8 +827,8 @@ function bindingToApi(
       return binding.projectInvalidateFileSystemCache(this._nativeProject)
     }
 
-    getMemoryReport(topN?: number): Promise<string> {
-      return binding.projectGetMemoryReport(this._nativeProject, topN ?? null)
+    getMemoryReport(): Promise<string> {
+      return binding.projectGetMemoryReport(this._nativeProject)
     }
 
     shutdown(): Promise<void> {

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -306,7 +306,7 @@ export interface Project {
 
   invalidateFileSystemCache(): Promise<void>
 
-  getMemoryReport(topN?: number): Promise<string>
+  getMemoryReport(): Promise<string>
 
   shutdown(): Promise<void>
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -306,6 +306,8 @@ export interface Project {
 
   invalidateFileSystemCache(): Promise<void>
 
+  getMemoryReport(topN?: number): Promise<string>
+
   shutdown(): Promise<void>
 
   onExit(): Promise<void>

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -306,7 +306,7 @@ export interface Project {
 
   invalidateFileSystemCache(): Promise<void>
 
-  getMemoryReport(): Promise<string>
+  getMemoryReport(): string
 
   shutdown(): Promise<void>
 

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -7,6 +7,7 @@ import type {
   NapiSourceDiagnostic,
   NapiProjectOptions,
   NapiPartialProjectOptions,
+  NapiMemoryReport,
 } from './generated-native'
 
 export type { NapiTurboEngineOptions as TurboEngineOptions }
@@ -306,7 +307,7 @@ export interface Project {
 
   invalidateFileSystemCache(): Promise<void>
 
-  getMemoryReport(): string
+  getMemoryReport(): NapiMemoryReport
 
   shutdown(): Promise<void>
 

--- a/packages/next/src/cli/internal/next-turbopack-memory.ts
+++ b/packages/next/src/cli/internal/next-turbopack-memory.ts
@@ -1,53 +1,68 @@
 import path from 'path'
 import { bold, cyan, red } from '../../lib/picocolors'
+import { PHASE_DEVELOPMENT_SERVER } from '../../shared/lib/constants'
+import loadConfig from '../../server/config'
 import { readLockfileContent, parseDevServerInfo } from '../../build/lockfile'
 
 export type NextTurbopackMemoryOptions = {
   format?: string
-  topN?: number
+  server?: string
 }
 
 export async function nextTurbopackMemory(
   options: NextTurbopackMemoryOptions,
   directory?: string
 ) {
-  const dir = directory ? path.resolve(directory) : process.cwd()
   const format = options.format ?? 'json'
 
-  // Discover the running dev server from the lock file
-  const lockfilePath = path.join(dir, '.next', 'lock')
-  const lockContent = readLockfileContent(lockfilePath)
+  let baseUrl: string
+  if (options.server) {
+    // Direct connection to a known host:port
+    const server = options.server.includes('://')
+      ? options.server
+      : `http://${options.server}`
+    baseUrl = server
+  } else {
+    // Discover the running dev server from the lock file
+    const dir = directory ? path.resolve(directory) : process.cwd()
 
-  if (!lockContent) {
-    console.error(
-      red('Error:') +
-        ' No running Next.js dev server found.\n' +
-        `Expected lock file at ${cyan(lockfilePath)}\n\n` +
-        `Start a dev server with ${bold('next dev')} and try again.`
-    )
-    process.exit(1)
+    let distDir = path.join('.next', 'dev')
+    try {
+      const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir)
+      distDir = config.distDir
+    } catch {
+      // Fall back to default if config can't be loaded
+    }
+
+    const lockfilePath = path.join(dir, distDir, 'lock')
+    const lockContent = readLockfileContent(lockfilePath)
+
+    if (!lockContent) {
+      console.error(
+        red('Error:') +
+          ' No running Next.js dev server found.\n' +
+          `Expected lock file at ${cyan(lockfilePath)}\n\n` +
+          `Start a dev server with ${bold('next dev')} and try again.`
+      )
+      process.exit(1)
+    }
+
+    const serverInfo = parseDevServerInfo(lockContent)
+
+    if (!serverInfo) {
+      console.error(
+        red('Error:') +
+          ' Could not parse dev server info from lock file.\n' +
+          `Lock file content: ${lockContent}`
+      )
+      process.exit(1)
+    }
+
+    baseUrl = `http://localhost:${serverInfo.port}`
   }
 
-  const serverInfo = parseDevServerInfo(lockContent)
-
-  if (!serverInfo) {
-    console.error(
-      red('Error:') +
-        ' Could not parse dev server info from lock file.\n' +
-        `Lock file content: ${lockContent}`
-    )
-    process.exit(1)
-  }
-
-  // Fetch the memory report from the running dev server
-  const url = new URL(
-    '/__nextjs_turbopack_memory',
-    `http://localhost:${serverInfo.port}`
-  )
+  const url = new URL('/__nextjs_turbopack-memory', baseUrl)
   url.searchParams.set('format', format)
-  if (options.topN != null) {
-    url.searchParams.set('top_n', String(options.topN))
-  }
 
   try {
     const res = await fetch(url.toString())
@@ -67,7 +82,7 @@ export async function nextTurbopackMemory(
   } catch (err: any) {
     console.error(
       red('Error:') +
-        ` Failed to connect to dev server on port ${serverInfo.port}: ${err.message}\n\n` +
+        ` Failed to connect to dev server at ${cyan(baseUrl)}: ${err.message}\n\n` +
         `Make sure the dev server is still running.`
     )
     process.exit(1)

--- a/packages/next/src/cli/internal/next-turbopack-memory.ts
+++ b/packages/next/src/cli/internal/next-turbopack-memory.ts
@@ -1,0 +1,75 @@
+import path from 'path'
+import { bold, cyan, red } from '../../lib/picocolors'
+import { readLockfileContent, parseDevServerInfo } from '../../build/lockfile'
+
+export type NextTurbopackMemoryOptions = {
+  format?: string
+  topN?: number
+}
+
+export async function nextTurbopackMemory(
+  options: NextTurbopackMemoryOptions,
+  directory?: string
+) {
+  const dir = directory ? path.resolve(directory) : process.cwd()
+  const format = options.format ?? 'json'
+
+  // Discover the running dev server from the lock file
+  const lockfilePath = path.join(dir, '.next', 'lock')
+  const lockContent = readLockfileContent(lockfilePath)
+
+  if (!lockContent) {
+    console.error(
+      red('Error:') +
+        ' No running Next.js dev server found.\n' +
+        `Expected lock file at ${cyan(lockfilePath)}\n\n` +
+        `Start a dev server with ${bold('next dev')} and try again.`
+    )
+    process.exit(1)
+  }
+
+  const serverInfo = parseDevServerInfo(lockContent)
+
+  if (!serverInfo) {
+    console.error(
+      red('Error:') +
+        ' Could not parse dev server info from lock file.\n' +
+        `Lock file content: ${lockContent}`
+    )
+    process.exit(1)
+  }
+
+  // Fetch the memory report from the running dev server
+  const url = new URL(
+    '/__nextjs_turbopack_memory',
+    `http://localhost:${serverInfo.port}`
+  )
+  url.searchParams.set('format', format)
+  if (options.topN != null) {
+    url.searchParams.set('top_n', String(options.topN))
+  }
+
+  try {
+    const res = await fetch(url.toString())
+    if (!res.ok) {
+      const text = await res.text()
+      console.error(
+        red('Error:') + ` Dev server returned ${res.status}: ${text}`
+      )
+      process.exit(1)
+    }
+    const body = await res.text()
+    process.stdout.write(body)
+    // Ensure a trailing newline for terminal output
+    if (!body.endsWith('\n')) {
+      process.stdout.write('\n')
+    }
+  } catch (err: any) {
+    console.error(
+      red('Error:') +
+        ` Failed to connect to dev server on port ${serverInfo.port}: ${err.message}\n\n` +
+        `Make sure the dev server is still running.`
+    )
+    process.exit(1)
+  }
+}

--- a/packages/next/src/cli/internal/next-turbopack-memory.ts
+++ b/packages/next/src/cli/internal/next-turbopack-memory.ts
@@ -26,7 +26,7 @@ export async function nextTurbopackMemory(
     // Discover the running dev server from the lock file
     const dir = directory ? path.resolve(directory) : process.cwd()
 
-    let distDir = path.join('.next', 'dev')
+    let distDir = '.next'
     try {
       const config = await loadConfig(PHASE_DEVELOPMENT_SERVER, dir)
       distDir = config.distDir

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -33,6 +33,7 @@ import { BLOCKED_PAGES } from '../../shared/lib/constants'
 import {
   getOverlayMiddleware,
   getSourceMapMiddleware,
+  getMemoryReportMiddleware,
   getOriginalStackFrames,
 } from './middleware-turbopack'
 import { PageNotFoundError } from '../../shared/lib/utils'
@@ -973,6 +974,7 @@ export async function createHotReloaderTurbopack(
       isSrcDir: opts.isSrcDir,
     }),
     getSourceMapMiddleware(project),
+    getMemoryReportMiddleware(project),
     getNextErrorFeedbackMiddleware(opts.telemetry),
     getDevOverlayFontMiddleware(),
     getDisableDevIndicatorMiddleware(),

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -494,19 +494,21 @@ export function getMemoryReportMiddleware(project: Project) {
     }
 
     try {
-      const reportJson = await project.getMemoryReport()
+      const turbopackReport = project.getMemoryReport()
 
       // Augment with Node.js process-level stats and uptime
-      const report = JSON.parse(reportJson)
-      report.uptime_secs = process.uptime()
       const mem = process.memoryUsage()
-      report.process = {
-        pid: process.pid,
-        node_version: process.version,
-        rss_bytes: mem.rss,
-        heap_used_bytes: mem.heapUsed,
-        heap_total_bytes: mem.heapTotal,
-        external_bytes: mem.external,
+      const report = {
+        ...turbopackReport,
+        uptimeSecs: process.uptime(),
+        process: {
+          pid: process.pid,
+          nodeVersion: process.version,
+          rssBytes: mem.rss,
+          heapUsedBytes: mem.heapUsed,
+          heapTotalBytes: mem.heapTotal,
+          externalBytes: mem.external,
+        },
       }
 
       if (format === 'markdown') {
@@ -537,33 +539,33 @@ const formatCount = (n: number) => n.toLocaleString('en-US')
 
 function renderMemoryReportMarkdown(report: any): string {
   let md = `# Turbopack Memory Report\n\n`
-  md += `Uptime: ${(report.uptime_secs / 60).toFixed(1)} minutes  \n`
+  md += `Uptime: ${(report.uptimeSecs / 60).toFixed(1)} minutes  \n`
   md += `PID: ${report.process.pid}\n\n`
 
   md += `## Process Memory\n\n`
   md += `| Metric | Value |\n|--------|------:|\n`
-  md += `| RSS | ${formatBytes(report.process.rss_bytes)} |\n`
-  md += `| Node Heap Used | ${formatBytes(report.process.heap_used_bytes)} |\n`
-  md += `| Node Heap Total | ${formatBytes(report.process.heap_total_bytes)} |\n`
-  md += `| Node External | ${formatBytes(report.process.external_bytes)} |\n`
-  md += `| Rust Allocated | ${formatBytes(report.allocator.allocated_bytes)} |\n`
+  md += `| RSS | ${formatBytes(report.process.rssBytes)} |\n`
+  md += `| Node Heap Used | ${formatBytes(report.process.heapUsedBytes)} |\n`
+  md += `| Node Heap Total | ${formatBytes(report.process.heapTotalBytes)} |\n`
+  md += `| Node External | ${formatBytes(report.process.externalBytes)} |\n`
+  md += `| Rust Allocated | ${formatBytes(report.allocator.allocatedBytes)} |\n`
 
-  md += `\n## Tasks - ${formatCount(report.tasks.total_count)} total, `
-  md += `${formatBytes(report.tasks.total_estimated_size_bytes)} estimated\n\n`
+  md += `\n## Tasks - ${formatCount(report.tasks.totalCount)} total, `
+  md += `${formatBytes(report.tasks.totalEstimatedSizeBytes)} estimated\n\n`
   md += `| Function | Count | Est. Size |\n`
   md += `|----------|------:|----------:|\n`
-  for (const fn_ of report.tasks.by_function) {
-    md += `| \`${fn_.function}\` | ${formatCount(fn_.count)} | ${formatBytes(fn_.estimated_size_bytes)} |\n`
+  for (const fn_ of report.tasks.byFunction) {
+    md += `| \`${fn_.function}\` | ${formatCount(fn_.count)} | ${formatBytes(fn_.estimatedSizeBytes)} |\n`
   }
 
-  md += `\n## Cells - ${formatCount(report.cells.total_count)} total, `
-  md += `${formatBytes(report.cells.total_estimated_size_bytes)} estimated\n\n`
+  md += `\n## Cells - ${formatCount(report.cells.totalCount)} total, `
+  md += `${formatBytes(report.cells.totalEstimatedSizeBytes)} estimated\n\n`
   md += `| Type | Count | Est. Size |\n`
   md += `|------|------:|----------:|\n`
-  for (const cell of report.cells.by_type) {
+  for (const cell of report.cells.byType) {
     const size =
-      cell.estimated_size_bytes != null
-        ? formatBytes(cell.estimated_size_bytes)
+      cell.estimatedSizeBytes != null
+        ? formatBytes(cell.estimatedSizeBytes)
         : 'N/A (transient)'
     md += `| \`${cell.type}\` | ${formatCount(cell.count)} | ${size} |\n`
   }

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -480,18 +480,14 @@ export function getMemoryReportMiddleware(project: Project) {
   ): Promise<void> {
     const { pathname, searchParams } = new URL(req.url!, 'http://n')
 
-    if (pathname !== '/__nextjs_turbopack_memory') {
+    if (pathname !== '/__nextjs_turbopack-memory') {
       return next()
     }
 
-    const topNParam = searchParams.get('top_n')
-    const topN = topNParam != null ? parseInt(topNParam, 10) : undefined
     const format = searchParams.get('format') ?? 'json'
 
     try {
-      const reportJson = await project.getMemoryReport(
-        topN != null && !isNaN(topN) ? topN : undefined
-      )
+      const reportJson = await project.getMemoryReport()
 
       // Augment with Node.js process-level stats
       const report = JSON.parse(reportJson)
@@ -505,14 +501,11 @@ export function getMemoryReportMiddleware(project: Project) {
         external_bytes: mem.external,
       }
 
-      if (format === 'html') {
-        res.setHeader('Content-Type', 'text/html')
-        res.end(renderMemoryReportHtml(report))
-      } else if (format === 'markdown') {
-        res.setHeader('Content-Type', 'text/markdown')
+      if (format === 'markdown') {
+        res.setHeader('Content-Type', 'text/markdown; charset=utf-8')
         res.end(renderMemoryReportMarkdown(report))
       } else {
-        res.setHeader('Content-Type', 'application/json')
+        res.setHeader('Content-Type', 'application/json; charset=utf-8')
         res.end(JSON.stringify(report, null, 2))
       }
     } catch (cause) {
@@ -524,7 +517,14 @@ export function getMemoryReportMiddleware(project: Project) {
   }
 }
 
-const formatMb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(1)} MB`
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes.toLocaleString()} B`
+  if (bytes < 1024 * 1024)
+    return `${(bytes / 1024).toLocaleString(undefined, { maximumFractionDigits: 1 })} KB`
+  if (bytes < 1024 * 1024 * 1024)
+    return `${(bytes / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 1 })} MB`
+  return `${(bytes / 1024 / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 2 })} GB`
+}
 const formatCount = (n: number) => n.toLocaleString()
 
 function renderMemoryReportMarkdown(report: any): string {
@@ -535,98 +535,29 @@ function renderMemoryReportMarkdown(report: any): string {
 
   md += `## Process Memory\n\n`
   md += `| Metric | Value |\n|--------|------:|\n`
-  md += `| RSS | ${formatMb(report.process.rss_bytes)} |\n`
-  md += `| Node Heap Used | ${formatMb(report.process.heap_used_bytes)} |\n`
-  md += `| Node Heap Total | ${formatMb(report.process.heap_total_bytes)} |\n`
-  md += `| Node External | ${formatMb(report.process.external_bytes)} |\n`
-  md += `| Rust Allocated | ${formatMb(report.allocator.allocated_bytes)} |\n`
+  md += `| RSS | ${formatBytes(report.process.rss_bytes)} |\n`
+  md += `| Node Heap Used | ${formatBytes(report.process.heap_used_bytes)} |\n`
+  md += `| Node Heap Total | ${formatBytes(report.process.heap_total_bytes)} |\n`
+  md += `| Node External | ${formatBytes(report.process.external_bytes)} |\n`
+  md += `| Rust Allocated | ${formatBytes(report.allocator.allocated_bytes)} |\n`
 
-  md += `\n## Tasks — ${formatCount(report.tasks.total_count)} total, `
-  md += `${formatMb(report.tasks.total_estimated_size_bytes)} estimated\n\n`
+  md += `\n## Tasks - ${formatCount(report.tasks.total_count)} total, `
+  md += `${formatBytes(report.tasks.total_estimated_size_bytes)} estimated\n\n`
   md += `| Function | Count | Est. Size |\n`
   md += `|----------|------:|----------:|\n`
   for (const fn_ of report.tasks.by_function) {
-    md += `| \`${fn_.function}\` | ${formatCount(fn_.count)} | ${formatMb(fn_.estimated_size_bytes)} |\n`
+    md += `| \`${fn_.function}\` | ${formatCount(fn_.count)} | ${formatBytes(fn_.estimated_size_bytes)} |\n`
   }
 
-  md += `\n## Cells — ${formatCount(report.cells.total_count)} total, `
-  md += `${formatMb(report.cells.total_estimated_size_bytes)} estimated\n\n`
+  md += `\n## Cells - ${formatCount(report.cells.total_count)} total, `
+  md += `${formatBytes(report.cells.total_estimated_size_bytes)} estimated\n\n`
   md += `| Type | Count | Est. Size |\n`
   md += `|------|------:|----------:|\n`
   for (const cell of report.cells.by_type) {
-    md += `| \`${cell.type}\` | ${formatCount(cell.count)} | ${formatMb(cell.estimated_size_bytes)} |\n`
+    md += `| \`${cell.type}\` | ${formatCount(cell.count)} | ${formatBytes(cell.estimated_size_bytes)} |\n`
   }
 
   return md
-}
-
-function renderMemoryReportHtml(report: any): string {
-  const esc = (s: string) =>
-    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-
-  const processRows = [
-    ['RSS', formatMb(report.process.rss_bytes)],
-    ['Node Heap Used', formatMb(report.process.heap_used_bytes)],
-    ['Node Heap Total', formatMb(report.process.heap_total_bytes)],
-    ['Node External', formatMb(report.process.external_bytes)],
-    ['Rust Allocated', formatMb(report.allocator.allocated_bytes)],
-  ]
-
-  const taskRows = report.tasks.by_function
-    .map(
-      (fn_: any) =>
-        `<tr><td><code>${esc(fn_.function)}</code></td><td class="r">${formatCount(fn_.count)}</td><td class="r">${formatMb(fn_.estimated_size_bytes)}</td></tr>`
-    )
-    .join('\n')
-
-  const cellRows = report.cells.by_type
-    .map(
-      (cell: any) =>
-        `<tr><td><code>${esc(cell.type)}</code></td><td class="r">${formatCount(cell.count)}</td><td class="r">${formatMb(cell.estimated_size_bytes)}</td></tr>`
-    )
-    .join('\n')
-
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>Turbopack Memory Report</title>
-<style>
-  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
-  h1 { border-bottom: 2px solid #eee; padding-bottom: 0.5rem; }
-  h2 { margin-top: 2rem; }
-  .meta { color: #666; font-size: 0.9rem; }
-  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
-  th, td { border: 1px solid #ddd; padding: 6px 10px; text-align: left; }
-  th { background: #f5f5f5; }
-  .r { text-align: right; font-variant-numeric: tabular-nums; }
-  code { background: #f0f0f0; padding: 1px 4px; border-radius: 3px; font-size: 0.85em; }
-  tr:hover { background: #fafafa; }
-</style>
-</head>
-<body>
-<h1>Turbopack Memory Report</h1>
-<p class="meta">Generated: ${esc(report.generated_at)} &middot; Uptime: ${(report.uptime_secs / 60).toFixed(1)} min &middot; PID: ${report.process.pid}</p>
-
-<h2>Process Memory</h2>
-<table>
-<tr><th>Metric</th><th class="r">Value</th></tr>
-${processRows.map(([label, val]) => `<tr><td>${label}</td><td class="r">${val}</td></tr>`).join('\n')}
-</table>
-
-<h2>Tasks &mdash; ${formatCount(report.tasks.total_count)} total, ${formatMb(report.tasks.total_estimated_size_bytes)} estimated</h2>
-<table>
-<tr><th>Function</th><th class="r">Count</th><th class="r">Est. Size</th></tr>
-${taskRows}
-</table>
-
-<h2>Cells &mdash; ${formatCount(report.cells.total_count)} total, ${formatMb(report.cells.total_estimated_size_bytes)} estimated</h2>
-<table>
-<tr><th>Type</th><th class="r">Count</th><th class="r">Est. Size</th></tr>
-${cellRows}
-</table>
-</body>
-</html>`
 }
 
 export async function getOriginalStackFrames({

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -472,6 +472,163 @@ export function getSourceMapMiddleware(project: Project) {
   }
 }
 
+export function getMemoryReportMiddleware(project: Project) {
+  return async function (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: () => void
+  ): Promise<void> {
+    const { pathname, searchParams } = new URL(req.url!, 'http://n')
+
+    if (pathname !== '/__nextjs_turbopack_memory') {
+      return next()
+    }
+
+    const topNParam = searchParams.get('top_n')
+    const topN = topNParam != null ? parseInt(topNParam, 10) : undefined
+    const format = searchParams.get('format') ?? 'json'
+
+    try {
+      const reportJson = await project.getMemoryReport(
+        topN != null && !isNaN(topN) ? topN : undefined
+      )
+
+      // Augment with Node.js process-level stats
+      const report = JSON.parse(reportJson)
+      const mem = process.memoryUsage()
+      report.process = {
+        pid: process.pid,
+        node_version: process.version,
+        rss_bytes: mem.rss,
+        heap_used_bytes: mem.heapUsed,
+        heap_total_bytes: mem.heapTotal,
+        external_bytes: mem.external,
+      }
+
+      if (format === 'html') {
+        res.setHeader('Content-Type', 'text/html')
+        res.end(renderMemoryReportHtml(report))
+      } else if (format === 'markdown') {
+        res.setHeader('Content-Type', 'text/markdown')
+        res.end(renderMemoryReportMarkdown(report))
+      } else {
+        res.setHeader('Content-Type', 'application/json')
+        res.end(JSON.stringify(report, null, 2))
+      }
+    } catch (cause) {
+      return middlewareResponse.internalServerError(
+        res,
+        new Error('Failed to collect memory report', { cause })
+      )
+    }
+  }
+}
+
+const formatMb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(1)} MB`
+const formatCount = (n: number) => n.toLocaleString()
+
+function renderMemoryReportMarkdown(report: any): string {
+  let md = `# Turbopack Memory Report\n\n`
+  md += `Generated: ${report.generated_at}  \n`
+  md += `Uptime: ${(report.uptime_secs / 60).toFixed(1)} minutes  \n`
+  md += `PID: ${report.process.pid}\n\n`
+
+  md += `## Process Memory\n\n`
+  md += `| Metric | Value |\n|--------|------:|\n`
+  md += `| RSS | ${formatMb(report.process.rss_bytes)} |\n`
+  md += `| Node Heap Used | ${formatMb(report.process.heap_used_bytes)} |\n`
+  md += `| Node Heap Total | ${formatMb(report.process.heap_total_bytes)} |\n`
+  md += `| Node External | ${formatMb(report.process.external_bytes)} |\n`
+  md += `| Rust Allocated | ${formatMb(report.allocator.allocated_bytes)} |\n`
+
+  md += `\n## Tasks — ${formatCount(report.tasks.total_count)} total, `
+  md += `${formatMb(report.tasks.total_estimated_size_bytes)} estimated\n\n`
+  md += `| Function | Count | Est. Size |\n`
+  md += `|----------|------:|----------:|\n`
+  for (const fn_ of report.tasks.by_function) {
+    md += `| \`${fn_.function}\` | ${formatCount(fn_.count)} | ${formatMb(fn_.estimated_size_bytes)} |\n`
+  }
+
+  md += `\n## Cells — ${formatCount(report.cells.total_count)} total, `
+  md += `${formatMb(report.cells.total_estimated_size_bytes)} estimated\n\n`
+  md += `| Type | Count | Est. Size |\n`
+  md += `|------|------:|----------:|\n`
+  for (const cell of report.cells.by_type) {
+    md += `| \`${cell.type}\` | ${formatCount(cell.count)} | ${formatMb(cell.estimated_size_bytes)} |\n`
+  }
+
+  return md
+}
+
+function renderMemoryReportHtml(report: any): string {
+  const esc = (s: string) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
+  const processRows = [
+    ['RSS', formatMb(report.process.rss_bytes)],
+    ['Node Heap Used', formatMb(report.process.heap_used_bytes)],
+    ['Node Heap Total', formatMb(report.process.heap_total_bytes)],
+    ['Node External', formatMb(report.process.external_bytes)],
+    ['Rust Allocated', formatMb(report.allocator.allocated_bytes)],
+  ]
+
+  const taskRows = report.tasks.by_function
+    .map(
+      (fn_: any) =>
+        `<tr><td><code>${esc(fn_.function)}</code></td><td class="r">${formatCount(fn_.count)}</td><td class="r">${formatMb(fn_.estimated_size_bytes)}</td></tr>`
+    )
+    .join('\n')
+
+  const cellRows = report.cells.by_type
+    .map(
+      (cell: any) =>
+        `<tr><td><code>${esc(cell.type)}</code></td><td class="r">${formatCount(cell.count)}</td><td class="r">${formatMb(cell.estimated_size_bytes)}</td></tr>`
+    )
+    .join('\n')
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Turbopack Memory Report</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 960px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+  h1 { border-bottom: 2px solid #eee; padding-bottom: 0.5rem; }
+  h2 { margin-top: 2rem; }
+  .meta { color: #666; font-size: 0.9rem; }
+  table { border-collapse: collapse; width: 100%; margin: 1rem 0; }
+  th, td { border: 1px solid #ddd; padding: 6px 10px; text-align: left; }
+  th { background: #f5f5f5; }
+  .r { text-align: right; font-variant-numeric: tabular-nums; }
+  code { background: #f0f0f0; padding: 1px 4px; border-radius: 3px; font-size: 0.85em; }
+  tr:hover { background: #fafafa; }
+</style>
+</head>
+<body>
+<h1>Turbopack Memory Report</h1>
+<p class="meta">Generated: ${esc(report.generated_at)} &middot; Uptime: ${(report.uptime_secs / 60).toFixed(1)} min &middot; PID: ${report.process.pid}</p>
+
+<h2>Process Memory</h2>
+<table>
+<tr><th>Metric</th><th class="r">Value</th></tr>
+${processRows.map(([label, val]) => `<tr><td>${label}</td><td class="r">${val}</td></tr>`).join('\n')}
+</table>
+
+<h2>Tasks &mdash; ${formatCount(report.tasks.total_count)} total, ${formatMb(report.tasks.total_estimated_size_bytes)} estimated</h2>
+<table>
+<tr><th>Function</th><th class="r">Count</th><th class="r">Est. Size</th></tr>
+${taskRows}
+</table>
+
+<h2>Cells &mdash; ${formatCount(report.cells.total_count)} total, ${formatMb(report.cells.total_estimated_size_bytes)} estimated</h2>
+<table>
+<tr><th>Type</th><th class="r">Count</th><th class="r">Est. Size</th></tr>
+${cellRows}
+</table>
+</body>
+</html>`
+}
+
 export async function getOriginalStackFrames({
   project,
   projectPath,

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -496,8 +496,9 @@ export function getMemoryReportMiddleware(project: Project) {
     try {
       const reportJson = await project.getMemoryReport()
 
-      // Augment with Node.js process-level stats
+      // Augment with Node.js process-level stats and uptime
       const report = JSON.parse(reportJson)
+      report.uptime_secs = process.uptime()
       const mem = process.memoryUsage()
       report.process = {
         pid: process.pid,
@@ -525,18 +526,17 @@ export function getMemoryReportMiddleware(project: Project) {
 }
 
 function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes.toLocaleString()} B`
+  if (bytes < 1024) return `${bytes.toLocaleString('en-US')} B`
   if (bytes < 1024 * 1024)
-    return `${(bytes / 1024).toLocaleString(undefined, { maximumFractionDigits: 1 })} KB`
+    return `${(bytes / 1024).toLocaleString('en-US', { maximumFractionDigits: 1 })} KB`
   if (bytes < 1024 * 1024 * 1024)
-    return `${(bytes / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 1 })} MB`
-  return `${(bytes / 1024 / 1024 / 1024).toLocaleString(undefined, { maximumFractionDigits: 2 })} GB`
+    return `${(bytes / 1024 / 1024).toLocaleString('en-US', { maximumFractionDigits: 1 })} MB`
+  return `${(bytes / 1024 / 1024 / 1024).toLocaleString('en-US', { maximumFractionDigits: 2 })} GB`
 }
-const formatCount = (n: number) => n.toLocaleString()
+const formatCount = (n: number) => n.toLocaleString('en-US')
 
 function renderMemoryReportMarkdown(report: any): string {
   let md = `# Turbopack Memory Report\n\n`
-  md += `Generated: ${report.generated_at}  \n`
   md += `Uptime: ${(report.uptime_secs / 60).toFixed(1)} minutes  \n`
   md += `PID: ${report.process.pid}\n\n`
 
@@ -561,7 +561,11 @@ function renderMemoryReportMarkdown(report: any): string {
   md += `| Type | Count | Est. Size |\n`
   md += `|------|------:|----------:|\n`
   for (const cell of report.cells.by_type) {
-    md += `| \`${cell.type}\` | ${formatCount(cell.count)} | ${formatBytes(cell.estimated_size_bytes)} |\n`
+    const size =
+      cell.estimated_size_bytes != null
+        ? formatBytes(cell.estimated_size_bytes)
+        : 'N/A (transient)'
+    md += `| \`${cell.type}\` | ${formatCount(cell.count)} | ${size} |\n`
   }
 
   return md

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -486,6 +486,13 @@ export function getMemoryReportMiddleware(project: Project) {
 
     const format = searchParams.get('format') ?? 'json'
 
+    if (format !== 'json' && format !== 'markdown') {
+      return middlewareResponse.badRequest(
+        res,
+        `Invalid format "${format}". Expected "json" or "markdown".`
+      )
+    }
+
     try {
       const reportJson = await project.getMemoryReport()
 

--- a/test/development/app-dir/turbopack-memory-report/app/layout.tsx
+++ b/test/development/app-dir/turbopack-memory-report/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/turbopack-memory-report/app/page.tsx
+++ b/test/development/app-dir/turbopack-memory-report/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
+++ b/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
@@ -21,7 +21,6 @@ describe('turbopack-memory-report', () => {
 
       // Verify top-level schema
       expect(report.version).toBe(1)
-      expect(typeof report.generated_at).toBe('string')
       expect(typeof report.uptime_secs).toBe('number')
       expect(report.uptime_secs).toBeGreaterThan(0)
 
@@ -93,7 +92,6 @@ describe('turbopack-memory-report', () => {
 
       const report = JSON.parse(result.stdout)
       expect(report.version).toBe(1)
-      expect(typeof report.generated_at).toBe('string')
       expect(typeof report.uptime_secs).toBe('number')
       expect(report.tasks.total_count).toBeGreaterThan(0)
       expect(report.tasks.by_function.length).toBeGreaterThan(0)

--- a/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
+++ b/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
@@ -13,7 +13,9 @@ describe('turbopack-memory-report', () => {
 
       const res = await next.fetch('/__nextjs_turbopack_memory')
       expect(res.status).toBe(200)
-      expect(res.headers.get('content-type')).toBe('application/json')
+      expect(res.headers.get('content-type')).toBe(
+        'application/json; charset=utf-8'
+      )
 
       const report = await res.json()
 
@@ -66,39 +68,15 @@ describe('turbopack-memory-report', () => {
 
       const res = await next.fetch('/__nextjs_turbopack_memory?format=markdown')
       expect(res.status).toBe(200)
-      expect(res.headers.get('content-type')).toBe('text/markdown')
+      expect(res.headers.get('content-type')).toBe(
+        'text/markdown; charset=utf-8'
+      )
 
       const body = await res.text()
       expect(body).toContain('# Turbopack Memory Report')
       expect(body).toContain('## Process Memory')
       expect(body).toContain('## Tasks')
       expect(body).toContain('## Cells')
-    })
-
-    it('should return HTML format when requested', async () => {
-      await next.render('/')
-
-      const res = await next.fetch('/__nextjs_turbopack_memory?format=html')
-      expect(res.status).toBe(200)
-      expect(res.headers.get('content-type')).toBe('text/html')
-
-      const body = await res.text()
-      expect(body).toContain('<!DOCTYPE html>')
-      expect(body).toContain('<title>Turbopack Memory Report</title>')
-      expect(body).toContain('Process Memory')
-      expect(body).toContain('Tasks')
-      expect(body).toContain('Cells')
-    })
-
-    it('should respect top_n parameter', async () => {
-      await next.render('/')
-
-      const res = await next.fetch('/__nextjs_turbopack_memory?top_n=5')
-      expect(res.status).toBe(200)
-
-      const report = await res.json()
-      expect(report.tasks.by_function.length).toBeLessThanOrEqual(5)
-      expect(report.cells.by_type.length).toBeLessThanOrEqual(5)
     })
   })
 
@@ -133,28 +111,6 @@ describe('turbopack-memory-report', () => {
       expect(result.code).toBe(0)
       expect(result.stdout).toContain('# Turbopack Memory Report')
       expect(result.stdout).toContain('## Tasks')
-    })
-
-    it('should respect --top-n flag', async () => {
-      await next.render('/')
-
-      const result = await runNextCommand(
-        [
-          'internal',
-          'turbopack-memory',
-          next.testDir,
-          '--format',
-          'json',
-          '--top-n',
-          '3',
-        ],
-        { stdout: true }
-      )
-      expect(result.code).toBe(0)
-
-      const report = JSON.parse(result.stdout)
-      expect(report.tasks.by_function.length).toBeLessThanOrEqual(3)
-      expect(report.cells.by_type.length).toBeLessThanOrEqual(3)
     })
   })
 })

--- a/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
+++ b/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
@@ -7,11 +7,11 @@ describe('turbopack-memory-report', () => {
   })
 
   describe('fetch API', () => {
-    it('should return valid JSON from /__nextjs_turbopack_memory', async () => {
+    it('should return valid JSON from /__nextjs_turbopack-memory', async () => {
       // Ensure the app is loaded so there are tasks in the graph
       await next.render('/')
 
-      const res = await next.fetch('/__nextjs_turbopack_memory')
+      const res = await next.fetch('/__nextjs_turbopack-memory')
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toBe(
         'application/json; charset=utf-8'
@@ -66,7 +66,7 @@ describe('turbopack-memory-report', () => {
     it('should return markdown format when requested', async () => {
       await next.render('/')
 
-      const res = await next.fetch('/__nextjs_turbopack_memory?format=markdown')
+      const res = await next.fetch('/__nextjs_turbopack-memory?format=markdown')
       expect(res.status).toBe(200)
       expect(res.headers.get('content-type')).toBe(
         'text/markdown; charset=utf-8'

--- a/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
+++ b/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
@@ -21,44 +21,43 @@ describe('turbopack-memory-report', () => {
 
       // Verify top-level schema
       expect(report.version).toBe(1)
-      expect(typeof report.uptime_secs).toBe('number')
-      expect(report.uptime_secs).toBeGreaterThan(0)
+      expect(typeof report.uptimeSecs).toBe('number')
+      expect(report.uptimeSecs).toBeGreaterThan(0)
 
       // Verify process stats (added by the Node.js layer)
       expect(report.process).toBeDefined()
       expect(typeof report.process.pid).toBe('number')
-      expect(typeof report.process.rss_bytes).toBe('number')
-      expect(typeof report.process.heap_used_bytes).toBe('number')
-      expect(typeof report.process.node_version).toBe('string')
+      expect(typeof report.process.rssBytes).toBe('number')
+      expect(typeof report.process.heapUsedBytes).toBe('number')
+      expect(typeof report.process.nodeVersion).toBe('string')
 
       // Verify allocator stats
       expect(report.allocator).toBeDefined()
-      expect(typeof report.allocator.allocated_bytes).toBe('number')
+      expect(typeof report.allocator.allocatedBytes).toBe('number')
 
       // Verify task stats
       expect(report.tasks).toBeDefined()
-      expect(typeof report.tasks.total_count).toBe('number')
-      expect(report.tasks.total_count).toBeGreaterThan(0)
-      expect(typeof report.tasks.total_estimated_size_bytes).toBe('number')
-      expect(Array.isArray(report.tasks.by_function)).toBe(true)
-      expect(report.tasks.by_function.length).toBeGreaterThan(0)
+      expect(typeof report.tasks.totalCount).toBe('number')
+      expect(report.tasks.totalCount).toBeGreaterThan(0)
+      expect(typeof report.tasks.totalEstimatedSizeBytes).toBe('number')
+      expect(Array.isArray(report.tasks.byFunction)).toBe(true)
+      expect(report.tasks.byFunction.length).toBeGreaterThan(0)
 
       // Each function group should have name, count, and size
-      const firstFunction = report.tasks.by_function[0]
+      const firstFunction = report.tasks.byFunction[0]
       expect(typeof firstFunction.function).toBe('string')
       expect(typeof firstFunction.count).toBe('number')
-      expect(typeof firstFunction.estimated_size_bytes).toBe('number')
+      expect(typeof firstFunction.estimatedSizeBytes).toBe('number')
 
       // Verify cell stats
       expect(report.cells).toBeDefined()
-      expect(typeof report.cells.total_count).toBe('number')
-      expect(typeof report.cells.total_estimated_size_bytes).toBe('number')
-      expect(Array.isArray(report.cells.by_type)).toBe(true)
-      if (report.cells.by_type.length > 0) {
-        const firstCell = report.cells.by_type[0]
+      expect(typeof report.cells.totalCount).toBe('number')
+      expect(typeof report.cells.totalEstimatedSizeBytes).toBe('number')
+      expect(Array.isArray(report.cells.byType)).toBe(true)
+      if (report.cells.byType.length > 0) {
+        const firstCell = report.cells.byType[0]
         expect(typeof firstCell.type).toBe('string')
         expect(typeof firstCell.count).toBe('number')
-        expect(typeof firstCell.estimated_size_bytes).toBe('number')
       }
     })
 
@@ -92,11 +91,11 @@ describe('turbopack-memory-report', () => {
 
       const report = JSON.parse(result.stdout)
       expect(report.version).toBe(1)
-      expect(typeof report.uptime_secs).toBe('number')
-      expect(report.tasks.total_count).toBeGreaterThan(0)
-      expect(report.tasks.by_function.length).toBeGreaterThan(0)
+      expect(typeof report.uptimeSecs).toBe('number')
+      expect(report.tasks.totalCount).toBeGreaterThan(0)
+      expect(report.tasks.byFunction.length).toBeGreaterThan(0)
       expect(report.allocator).toBeDefined()
-      expect(typeof report.allocator.allocated_bytes).toBe('number')
+      expect(typeof report.allocator.allocatedBytes).toBe('number')
     })
 
     it('should return markdown via CLI', async () => {

--- a/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
+++ b/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
@@ -1,0 +1,160 @@
+import { nextTestSetup } from 'e2e-utils'
+import { runNextCommand } from 'next-test-utils'
+
+describe('turbopack-memory-report', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  describe('fetch API', () => {
+    it('should return valid JSON from /__nextjs_turbopack_memory', async () => {
+      // Ensure the app is loaded so there are tasks in the graph
+      await next.render('/')
+
+      const res = await next.fetch('/__nextjs_turbopack_memory')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('application/json')
+
+      const report = await res.json()
+
+      // Verify top-level schema
+      expect(report.version).toBe(1)
+      expect(typeof report.generated_at).toBe('string')
+      expect(typeof report.uptime_secs).toBe('number')
+      expect(report.uptime_secs).toBeGreaterThan(0)
+
+      // Verify process stats (added by the Node.js layer)
+      expect(report.process).toBeDefined()
+      expect(typeof report.process.pid).toBe('number')
+      expect(typeof report.process.rss_bytes).toBe('number')
+      expect(typeof report.process.heap_used_bytes).toBe('number')
+      expect(typeof report.process.node_version).toBe('string')
+
+      // Verify allocator stats
+      expect(report.allocator).toBeDefined()
+      expect(typeof report.allocator.allocated_bytes).toBe('number')
+
+      // Verify task stats
+      expect(report.tasks).toBeDefined()
+      expect(typeof report.tasks.total_count).toBe('number')
+      expect(report.tasks.total_count).toBeGreaterThan(0)
+      expect(typeof report.tasks.total_estimated_size_bytes).toBe('number')
+      expect(Array.isArray(report.tasks.by_function)).toBe(true)
+      expect(report.tasks.by_function.length).toBeGreaterThan(0)
+
+      // Each function group should have name, count, and size
+      const firstFunction = report.tasks.by_function[0]
+      expect(typeof firstFunction.function).toBe('string')
+      expect(typeof firstFunction.count).toBe('number')
+      expect(typeof firstFunction.estimated_size_bytes).toBe('number')
+
+      // Verify cell stats
+      expect(report.cells).toBeDefined()
+      expect(typeof report.cells.total_count).toBe('number')
+      expect(typeof report.cells.total_estimated_size_bytes).toBe('number')
+      expect(Array.isArray(report.cells.by_type)).toBe(true)
+      if (report.cells.by_type.length > 0) {
+        const firstCell = report.cells.by_type[0]
+        expect(typeof firstCell.type).toBe('string')
+        expect(typeof firstCell.count).toBe('number')
+        expect(typeof firstCell.estimated_size_bytes).toBe('number')
+      }
+    })
+
+    it('should return markdown format when requested', async () => {
+      await next.render('/')
+
+      const res = await next.fetch('/__nextjs_turbopack_memory?format=markdown')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('text/markdown')
+
+      const body = await res.text()
+      expect(body).toContain('# Turbopack Memory Report')
+      expect(body).toContain('## Process Memory')
+      expect(body).toContain('## Tasks')
+      expect(body).toContain('## Cells')
+    })
+
+    it('should return HTML format when requested', async () => {
+      await next.render('/')
+
+      const res = await next.fetch('/__nextjs_turbopack_memory?format=html')
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-type')).toBe('text/html')
+
+      const body = await res.text()
+      expect(body).toContain('<!DOCTYPE html>')
+      expect(body).toContain('<title>Turbopack Memory Report</title>')
+      expect(body).toContain('Process Memory')
+      expect(body).toContain('Tasks')
+      expect(body).toContain('Cells')
+    })
+
+    it('should respect top_n parameter', async () => {
+      await next.render('/')
+
+      const res = await next.fetch('/__nextjs_turbopack_memory?top_n=5')
+      expect(res.status).toBe(200)
+
+      const report = await res.json()
+      expect(report.tasks.by_function.length).toBeLessThanOrEqual(5)
+      expect(report.cells.by_type.length).toBeLessThanOrEqual(5)
+    })
+  })
+
+  describe('CLI', () => {
+    it('should return valid JSON via next internal turbopack-memory', async () => {
+      // Ensure the app is loaded so there are tasks in the graph
+      await next.render('/')
+
+      const result = await runNextCommand(
+        ['internal', 'turbopack-memory', next.testDir, '--format', 'json'],
+        { stdout: true }
+      )
+      expect(result.code).toBe(0)
+
+      const report = JSON.parse(result.stdout)
+      expect(report.version).toBe(1)
+      expect(typeof report.generated_at).toBe('string')
+      expect(typeof report.uptime_secs).toBe('number')
+      expect(report.tasks.total_count).toBeGreaterThan(0)
+      expect(report.tasks.by_function.length).toBeGreaterThan(0)
+      expect(report.allocator).toBeDefined()
+      expect(typeof report.allocator.allocated_bytes).toBe('number')
+    })
+
+    it('should return markdown via CLI', async () => {
+      await next.render('/')
+
+      const result = await runNextCommand(
+        ['internal', 'turbopack-memory', next.testDir, '--format', 'markdown'],
+        { stdout: true }
+      )
+      expect(result.code).toBe(0)
+      expect(result.stdout).toContain('# Turbopack Memory Report')
+      expect(result.stdout).toContain('## Tasks')
+    })
+
+    it('should respect --top-n flag', async () => {
+      await next.render('/')
+
+      const result = await runNextCommand(
+        [
+          'internal',
+          'turbopack-memory',
+          next.testDir,
+          '--format',
+          'json',
+          '--top-n',
+          '3',
+        ],
+        { stdout: true }
+      )
+      expect(result.code).toBe(0)
+
+      const report = JSON.parse(result.stdout)
+      expect(report.tasks.by_function.length).toBeLessThanOrEqual(3)
+      expect(report.cells.by_type.length).toBeLessThanOrEqual(3)
+    })
+  })
+})

--- a/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
+++ b/test/development/app-dir/turbopack-memory-report/turbopack-memory-report.test.ts
@@ -4,7 +4,13 @@ import { runNextCommand } from 'next-test-utils'
 describe('turbopack-memory-report', () => {
   const { next } = nextTestSetup({
     files: __dirname,
+    skipStart: !process.env.IS_TURBOPACK_TEST,
   })
+
+  if (!process.env.IS_TURBOPACK_TEST) {
+    it('no-op for webpack', () => {})
+    return
+  }
 
   describe('fetch API', () => {
     it('should return valid JSON from /__nextjs_turbopack-memory', async () => {
@@ -20,7 +26,6 @@ describe('turbopack-memory-report', () => {
       const report = await res.json()
 
       // Verify top-level schema
-      expect(report.version).toBe(1)
       expect(typeof report.uptimeSecs).toBe('number')
       expect(report.uptimeSecs).toBeGreaterThan(0)
 
@@ -90,7 +95,6 @@ describe('turbopack-memory-report', () => {
       expect(result.code).toBe(0)
 
       const report = JSON.parse(result.stdout)
-      expect(report.version).toBe(1)
       expect(typeof report.uptimeSecs).toBe('number')
       expect(report.tasks.totalCount).toBeGreaterThan(0)
       expect(report.tasks.byFunction.length).toBeGreaterThan(0)

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -36,6 +36,7 @@ anyhow = { workspace = true }
 bincode = { workspace = true }
 arc-swap = { version = "1.7.1" }
 auto-hash-map = { workspace = true }
+chrono = { workspace = true }
 bitfield = { workspace = true }
 byteorder = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"]}
@@ -60,6 +61,7 @@ turbo-bincode = { workspace = true }
 turbo-persistence = { workspace = true }
 turbo-rcstr = { workspace = true }
 turbo-tasks = { workspace = true }
+turbo-tasks-malloc = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/turbopack/crates/turbo-tasks-backend/Cargo.toml
+++ b/turbopack/crates/turbo-tasks-backend/Cargo.toml
@@ -36,7 +36,6 @@ anyhow = { workspace = true }
 bincode = { workspace = true }
 arc-swap = { version = "1.7.1" }
 auto-hash-map = { workspace = true }
-chrono = { workspace = true }
 bitfield = { workspace = true }
 byteorder = { workspace = true }
 dashmap = { workspace = true, features = ["raw-api"]}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
@@ -1,4 +1,4 @@
-use indexmap::IndexMap;
+use rustc_hash::FxHashMap;
 use serde::Serialize;
 use turbo_bincode::{TurboBincodeBuffer, TurboBincodeEncode, new_turbo_bincode_encoder};
 use turbo_tasks::{ValueTypeId, registry};
@@ -9,8 +9,6 @@ use crate::backend::{SpecificTaskDataCategory, storage::Storage, storage_schema:
 #[derive(Debug, Serialize)]
 pub struct MemoryReport {
     pub version: u32,
-    pub generated_at: String,
-    pub uptime_secs: f64,
     pub tasks: TaskStats,
     pub cells: CellStats,
     pub allocator: AllocatorStats,
@@ -42,7 +40,9 @@ pub struct TypeCellStats {
     #[serde(rename = "type")]
     pub type_name: &'static str,
     pub count: u64,
-    pub estimated_size_bytes: u64,
+    /// Sum of bincode-encoded sizes for persistent cell types.
+    /// `None` for transient cell types (size data unavailable).
+    pub estimated_size_bytes: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -51,6 +51,7 @@ pub struct AllocatorStats {
 }
 
 /// Accumulator for per-function task stats during collection.
+#[derive(Default)]
 struct TaskGroupAccum {
     count: u64,
     estimated_size_bytes: u64,
@@ -60,7 +61,7 @@ struct TaskGroupAccum {
 struct CellGroupAccum {
     type_name: &'static str,
     count: u64,
-    estimated_size_bytes: u64,
+    estimated_size_bytes: Option<u64>,
 }
 
 /// Estimate the bincode-encoded size of a value by encoding into a reusable
@@ -96,13 +97,11 @@ fn estimate_task_size(task: &TaskStorage, scratch: &mut TurboBincodeBuffer) -> u
 /// encode-and-discard with a reusable scratch buffer.
 ///
 /// This is not fast and could be parallelized, but as an on demand tool that might be fine.
-pub fn collect_memory_report(storage: &Storage, uptime_secs: f64) -> MemoryReport {
-    let generated_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-
+pub fn collect_memory_report(storage: &Storage) -> MemoryReport {
     // Accumulate task stats grouped by function name
-    let mut task_groups: IndexMap<&'static str, TaskGroupAccum> = IndexMap::new();
+    let mut task_groups: FxHashMap<&'static str, TaskGroupAccum> = FxHashMap::default();
     // Accumulate cell stats grouped by value type
-    let mut cell_groups: IndexMap<ValueTypeId, CellGroupAccum> = IndexMap::new();
+    let mut cell_groups: FxHashMap<ValueTypeId, CellGroupAccum> = FxHashMap::default();
 
     let mut total_task_count: u64 = 0;
     let mut total_task_size: u64 = 0;
@@ -127,34 +126,39 @@ pub fn collect_memory_report(storage: &Storage, uptime_secs: f64) -> MemoryRepor
         let task_size = estimate_task_size(&entry, &mut scratch);
         total_task_size += task_size;
 
-        let group = task_groups.entry(function_name).or_insert(TaskGroupAccum {
-            count: 0,
-            estimated_size_bytes: 0,
-        });
+        let group = task_groups.entry(function_name).or_default();
         group.count += 1;
         group.estimated_size_bytes += task_size;
 
-        // Count cells and estimate sizes by value type
-        for (cell_id, cell_data) in entry.iter_cells() {
+        // Count and estimate sizes for persistent cells by value type
+        for (cell_id, data) in entry.iter_persistent_cells() {
             total_cell_count += 1;
-
-            let cell_size = if let Some(data) = cell_data {
-                estimate_encoded_size(&mut scratch, |encoder| data.encode(encoder))
-            } else {
-                0
-            };
-
+            let cell_size = estimate_encoded_size(&mut scratch, |encoder| data.encode(encoder));
             let type_entry = cell_groups.entry(cell_id.type_id).or_insert_with(|| {
                 let vt = registry::get_value_type(cell_id.type_id);
                 CellGroupAccum {
                     type_name: vt.name,
                     count: 0,
-                    estimated_size_bytes: 0,
+                    estimated_size_bytes: Some(0),
                 }
             });
             total_cell_size += cell_size;
             type_entry.count += 1;
-            type_entry.estimated_size_bytes += cell_size;
+            *type_entry.estimated_size_bytes.as_mut().unwrap() += cell_size;
+        }
+
+        // Count transient cells (no size data available)
+        for cell_id in entry.iter_transient_cells() {
+            total_cell_count += 1;
+            let type_entry = cell_groups.entry(cell_id.type_id).or_insert_with(|| {
+                let vt = registry::get_value_type(cell_id.type_id);
+                CellGroupAccum {
+                    type_name: vt.name,
+                    count: 0,
+                    estimated_size_bytes: None,
+                }
+            });
+            type_entry.count += 1;
         }
     }
 
@@ -167,7 +171,7 @@ pub fn collect_memory_report(storage: &Storage, uptime_secs: f64) -> MemoryRepor
             estimated_size_bytes: accum.estimated_size_bytes,
         })
         .collect();
-    by_function.sort_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
+    by_function.sort_unstable_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
 
     // Build sorted cell stats (by estimated_size_bytes, descending)
     let mut by_type: Vec<TypeCellStats> = cell_groups
@@ -178,14 +182,12 @@ pub fn collect_memory_report(storage: &Storage, uptime_secs: f64) -> MemoryRepor
             estimated_size_bytes: accum.estimated_size_bytes,
         })
         .collect();
-    by_type.sort_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
+    by_type.sort_unstable_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
 
     let allocator = collect_allocator_stats();
 
     MemoryReport {
         version: 1,
-        generated_at,
-        uptime_secs,
         tasks: TaskStats {
             total_count: total_task_count,
             total_estimated_size_bytes: total_task_size,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
@@ -1,0 +1,211 @@
+use indexmap::IndexMap;
+use serde::Serialize;
+use turbo_bincode::{TurboBincodeBuffer, TurboBincodeEncode, new_turbo_bincode_encoder};
+use turbo_tasks::{ValueTypeId, registry};
+use turbo_tasks_malloc::TurboMalloc;
+
+use crate::backend::{SpecificTaskDataCategory, storage::Storage, storage_schema::TaskStorage};
+
+#[derive(Debug, Serialize)]
+pub struct MemoryReport {
+    pub version: u32,
+    pub generated_at: String,
+    pub uptime_secs: f64,
+    pub tasks: TaskStats,
+    pub cells: CellStats,
+    pub allocator: AllocatorStats,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TaskStats {
+    pub total_count: u64,
+    pub total_estimated_size_bytes: u64,
+    pub by_function: Vec<FunctionTaskStats>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FunctionTaskStats {
+    pub function: &'static str,
+    pub count: u64,
+    pub estimated_size_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct CellStats {
+    pub total_count: u64,
+    pub total_estimated_size_bytes: u64,
+    pub by_type: Vec<TypeCellStats>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TypeCellStats {
+    #[serde(rename = "type")]
+    pub type_name: &'static str,
+    pub count: u64,
+    pub estimated_size_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AllocatorStats {
+    pub allocated_bytes: u64,
+}
+
+/// Accumulator for per-function task stats during collection.
+struct TaskGroupAccum {
+    count: u64,
+    estimated_size_bytes: u64,
+}
+
+/// Accumulator for per-type cell stats during collection.
+struct CellGroupAccum {
+    type_name: &'static str,
+    count: u64,
+    estimated_size_bytes: u64,
+}
+
+/// Estimate the bincode-encoded size of a value by encoding into a reusable
+/// scratch buffer. Returns 0 if encoding fails.
+fn estimate_encoded_size(
+    scratch: &mut TurboBincodeBuffer,
+    encode: impl FnOnce(
+        &mut turbo_bincode::TurboBincodeEncoder<'_>,
+    ) -> Result<(), bincode::error::EncodeError>,
+) -> u64 {
+    scratch.clear();
+    let mut encoder = new_turbo_bincode_encoder(scratch);
+    if encode(&mut encoder).is_ok() {
+        drop(encoder);
+        scratch.len() as u64
+    } else {
+        drop(encoder);
+        0
+    }
+}
+
+/// Estimate the bincode-encoded size of a TaskStorage.
+fn estimate_task_size(task: &TaskStorage, scratch: &mut TurboBincodeBuffer) -> u64 {
+    estimate_encoded_size(scratch, |encoder| {
+        task.encode(SpecificTaskDataCategory::Meta, encoder)?;
+        task.encode(SpecificTaskDataCategory::Data, encoder)?;
+        Ok(())
+    })
+}
+
+/// Collect a memory report by iterating the task storage.
+///
+/// This iterates all in-memory tasks and cells, grouping by function name
+/// and value type respectively. Size estimation uses bincode
+/// encode-and-discard with a reusable scratch buffer.
+///
+/// This is not fast and could be parallelized, but as an on demand tool that might be fine.
+pub fn collect_memory_report(storage: &Storage, uptime_secs: f64, top_n: usize) -> MemoryReport {
+    let generated_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+
+    // Accumulate task stats grouped by function name
+    let mut task_groups: IndexMap<&'static str, TaskGroupAccum> = IndexMap::new();
+    // Accumulate cell stats grouped by value type
+    let mut cell_groups: IndexMap<ValueTypeId, CellGroupAccum> = IndexMap::new();
+
+    let mut total_task_count: u64 = 0;
+    let mut total_task_size: u64 = 0;
+    let mut total_cell_count: u64 = 0;
+    let mut total_cell_size: u64 = 0;
+
+    // Reusable scratch buffer for size estimation (avoids per-task allocation)
+    let mut scratch = TurboBincodeBuffer::new();
+
+    for entry in storage.iter_all() {
+        total_task_count += 1;
+
+        // Determine function name from the cached task type
+        let function_name: &'static str = if let Some(task_type) = entry.get_persistent_task_type()
+        {
+            task_type.get_name()
+        } else {
+            "(transient)"
+        };
+
+        // Estimate task size via encode-and-discard
+        let task_size = estimate_task_size(&entry, &mut scratch);
+        total_task_size += task_size;
+
+        let group = task_groups.entry(function_name).or_insert(TaskGroupAccum {
+            count: 0,
+            estimated_size_bytes: 0,
+        });
+        group.count += 1;
+        group.estimated_size_bytes += task_size;
+
+        // Count cells and estimate sizes by value type
+        for (cell_id, cell_data) in entry.iter_cells() {
+            total_cell_count += 1;
+
+            let cell_size = if let Some(data) = cell_data {
+                estimate_encoded_size(&mut scratch, |encoder| data.encode(encoder))
+            } else {
+                0
+            };
+
+            let type_entry = cell_groups.entry(cell_id.type_id).or_insert_with(|| {
+                let vt = registry::get_value_type(cell_id.type_id);
+                CellGroupAccum {
+                    type_name: vt.name,
+                    count: 0,
+                    estimated_size_bytes: 0,
+                }
+            });
+            total_cell_size += cell_size;
+            type_entry.count += 1;
+            type_entry.estimated_size_bytes += cell_size;
+        }
+    }
+
+    // Build sorted task stats (by estimated size, descending)
+    let mut by_function: Vec<FunctionTaskStats> = task_groups
+        .into_iter()
+        .map(|(function, accum)| FunctionTaskStats {
+            function,
+            count: accum.count,
+            estimated_size_bytes: accum.estimated_size_bytes,
+        })
+        .collect();
+    by_function.sort_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
+    by_function.truncate(top_n);
+
+    // Build sorted cell stats (by count, descending)
+    let mut by_type: Vec<TypeCellStats> = cell_groups
+        .into_iter()
+        .map(|(_, accum)| TypeCellStats {
+            type_name: accum.type_name,
+            count: accum.count,
+            estimated_size_bytes: accum.estimated_size_bytes,
+        })
+        .collect();
+    by_type.sort_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
+    by_type.truncate(top_n);
+
+    let allocator = collect_allocator_stats();
+
+    MemoryReport {
+        version: 1,
+        generated_at,
+        uptime_secs,
+        tasks: TaskStats {
+            total_count: total_task_count,
+            total_estimated_size_bytes: total_task_size,
+            by_function,
+        },
+        cells: CellStats {
+            total_count: total_cell_count,
+            total_estimated_size_bytes: total_cell_size,
+            by_type,
+        },
+        allocator,
+    }
+}
+
+fn collect_allocator_stats() -> AllocatorStats {
+    AllocatorStats {
+        allocated_bytes: TurboMalloc::memory_usage() as u64,
+    }
+}

--- a/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
@@ -74,10 +74,8 @@ fn estimate_encoded_size(
     scratch.clear();
     let mut encoder = new_turbo_bincode_encoder(scratch);
     if encode(&mut encoder).is_ok() {
-        drop(encoder);
         scratch.len() as u64
     } else {
-        drop(encoder);
         0
     }
 }
@@ -98,7 +96,7 @@ fn estimate_task_size(task: &TaskStorage, scratch: &mut TurboBincodeBuffer) -> u
 /// encode-and-discard with a reusable scratch buffer.
 ///
 /// This is not fast and could be parallelized, but as an on demand tool that might be fine.
-pub fn collect_memory_report(storage: &Storage, uptime_secs: f64, top_n: usize) -> MemoryReport {
+pub fn collect_memory_report(storage: &Storage, uptime_secs: f64) -> MemoryReport {
     let generated_at = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
 
     // Accumulate task stats grouped by function name
@@ -170,7 +168,6 @@ pub fn collect_memory_report(storage: &Storage, uptime_secs: f64, top_n: usize) 
         })
         .collect();
     by_function.sort_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
-    by_function.truncate(top_n);
 
     // Build sorted cell stats (by count, descending)
     let mut by_type: Vec<TypeCellStats> = cell_groups
@@ -182,7 +179,6 @@ pub fn collect_memory_report(storage: &Storage, uptime_secs: f64, top_n: usize) 
         })
         .collect();
     by_type.sort_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
-    by_type.truncate(top_n);
 
     let allocator = collect_allocator_stats();
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
@@ -158,7 +158,7 @@ pub fn collect_memory_report(storage: &Storage, uptime_secs: f64) -> MemoryRepor
         }
     }
 
-    // Build sorted task stats (by estimated size, descending)
+    // Build sorted task stats (by estimated_size_bytes, descending)
     let mut by_function: Vec<FunctionTaskStats> = task_groups
         .into_iter()
         .map(|(function, accum)| FunctionTaskStats {
@@ -169,7 +169,7 @@ pub fn collect_memory_report(storage: &Storage, uptime_secs: f64) -> MemoryRepor
         .collect();
     by_function.sort_by_key(|a| std::cmp::Reverse(a.estimated_size_bytes));
 
-    // Build sorted cell stats (by count, descending)
+    // Build sorted cell stats (by estimated_size_bytes, descending)
     let mut by_type: Vec<TypeCellStats> = cell_groups
         .into_iter()
         .map(|(_, accum)| TypeCellStats {

--- a/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/memory_report.rs
@@ -8,7 +8,6 @@ use crate::backend::{SpecificTaskDataCategory, storage::Storage, storage_schema:
 
 #[derive(Debug, Serialize)]
 pub struct MemoryReport {
-    pub version: u32,
     pub tasks: TaskStats,
     pub cells: CellStats,
     pub allocator: AllocatorStats,
@@ -187,7 +186,6 @@ pub fn collect_memory_report(storage: &Storage) -> MemoryReport {
     let allocator = collect_allocator_stats();
 
     MemoryReport {
-        version: 1,
         tasks: TaskStats {
             total_count: total_task_count,
             total_estimated_size_bytes: total_task_size,

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -234,8 +234,7 @@ impl<B: BackingStorage> TurboTasksBackend<B> {
     /// This iterates all tasks in the storage, so it may take some time on large
     /// graphs.
     pub fn collect_memory_report(&self) -> memory_report::MemoryReport {
-        let uptime_secs = self.0.start_time.elapsed().as_secs_f64();
-        memory_report::collect_memory_report(&self.0.storage, uptime_secs)
+        memory_report::collect_memory_report(&self.0.storage)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -233,9 +233,9 @@ impl<B: BackingStorage> TurboTasksBackend<B> {
     /// Collect a memory report summarizing in-memory task and cell statistics.
     /// This iterates all tasks in the storage, so it may take some time on large
     /// graphs.
-    pub fn collect_memory_report(&self, top_n: usize) -> memory_report::MemoryReport {
+    pub fn collect_memory_report(&self) -> memory_report::MemoryReport {
         let uptime_secs = self.0.start_time.elapsed().as_secs_f64();
-        memory_report::collect_memory_report(&self.0.storage, uptime_secs, top_n)
+        memory_report::collect_memory_report(&self.0.storage, uptime_secs)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1,4 +1,5 @@
 mod counter_map;
+pub mod memory_report;
 mod operation;
 mod storage;
 pub mod storage_schema;
@@ -227,6 +228,14 @@ impl<B: BackingStorage> TurboTasksBackend<B> {
 
     pub fn backing_storage(&self) -> &B {
         &self.0.backing_storage
+    }
+
+    /// Collect a memory report summarizing in-memory task and cell statistics.
+    /// This iterates all tasks in the storage, so it may take some time on large
+    /// graphs.
+    pub fn collect_memory_report(&self, top_n: usize) -> memory_report::MemoryReport {
+        let uptime_secs = self.0.start_time.elapsed().as_secs_f64();
+        memory_report::collect_memory_report(&self.0.storage, uptime_secs, top_n)
     }
 }
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -275,6 +275,16 @@ impl Storage {
         )
     }
 
+    /// Returns an iterator over all tasks in storage (read-only).
+    /// Used for diagnostics like memory reporting.
+    /// NOTE: This is not safe to call while holding any `StorageWriteGuards`
+    pub fn iter_all(
+        &self,
+    ) -> impl Iterator<Item = dashmap::mapref::multiple::RefMulti<'_, TaskId, Box<TaskStorage>>>
+    {
+        self.map.iter()
+    }
+
     pub fn drop_contents(&self) {
         drop_contents(&self.map);
         drop_contents(&self.modified);

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage.rs
@@ -277,7 +277,9 @@ impl Storage {
 
     /// Returns an iterator over all tasks in storage (read-only).
     /// Used for diagnostics like memory reporting.
-    /// NOTE: This is not safe to call while holding any `StorageWriteGuards`
+    /// NOTE: This is not safe to call while holding any `StorageWriteGuards`, A write guard grabs a
+    /// write lock on a shard and exhausting this iterator requires taking a read lock on all shards
+    /// eventually, so you can deadlock.
     pub fn iter_all(
         &self,
     ) -> impl Iterator<Item = dashmap::mapref::multiple::RefMulti<'_, TaskId, Box<TaskStorage>>>

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -524,19 +524,20 @@ impl TaskStorage {
         }
     }
 
-    /// Returns an iterator over cell IDs and their data from both persistent and transient
-    /// cell data. Persistent cells include the typed reference for size estimation; transient
-    /// cells yield `None`.
-    pub fn iter_cells(&self) -> impl Iterator<Item = (CellId, Option<&TypedSharedReference>)> + '_ {
-        let persistent = self
-            .persistent_cell_data()
+    /// Returns an iterator over persistent cells with their data (for size estimation).
+    pub fn iter_persistent_cells(
+        &self,
+    ) -> impl Iterator<Item = (CellId, &TypedSharedReference)> + '_ {
+        self.persistent_cell_data()
             .into_iter()
-            .flat_map(|m| m.iter().map(|(cell_id, data)| (*cell_id, Some(data))));
-        let transient = self
-            .transient_cell_data()
+            .flat_map(|m| m.iter().map(|(cell_id, data)| (*cell_id, data)))
+    }
+
+    /// Returns an iterator over transient cell IDs (no size data available).
+    pub fn iter_transient_cells(&self) -> impl Iterator<Item = CellId> + '_ {
+        self.transient_cell_data()
             .into_iter()
-            .flat_map(|m| m.iter().map(|(cell_id, _)| (*cell_id, None)));
-        persistent.chain(transient)
+            .flat_map(|m| m.iter().map(|(cell_id, _)| *cell_id))
     }
 
     /// Clone only the fields for the specified category

--- a/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/storage_schema.rs
@@ -524,6 +524,21 @@ impl TaskStorage {
         }
     }
 
+    /// Returns an iterator over cell IDs and their data from both persistent and transient
+    /// cell data. Persistent cells include the typed reference for size estimation; transient
+    /// cells yield `None`.
+    pub fn iter_cells(&self) -> impl Iterator<Item = (CellId, Option<&TypedSharedReference>)> + '_ {
+        let persistent = self
+            .persistent_cell_data()
+            .into_iter()
+            .flat_map(|m| m.iter().map(|(cell_id, data)| (*cell_id, Some(data))));
+        let transient = self
+            .transient_cell_data()
+            .into_iter()
+            .flat_map(|m| m.iter().map(|(cell_id, _)| (*cell_id, None)));
+        persistent.chain(transient)
+    }
+
     /// Clone only the fields for the specified category
     pub fn clone_category_snapshot(&self, category: SpecificTaskDataCategory) -> TaskStorage {
         match category {


### PR DESCRIPTION
## Summary

Adds an on-demand memory reporting system for Turbopack dev servers, enabling developers to inspect memory usage without restarting or attaching external profilers. This implements the design described in PACK-6917.

### Layers

- **Rust core** (`turbo-tasks-backend`): `collect_memory_report()` iterates all in-memory tasks and cells, grouping by function name and value type. Size estimation uses bincode encode-and-discard with a reusable scratch buffer. Allocator stats come from `TurboMalloc::memory_usage()`.

- **NAPI binding**: `Project.getMemoryReport(topN?)` exposes the Rust report as a JSON string to Node.js.

- **HTTP endpoint**: `GET /__nextjs_turbopack-memory` on the dev server. Supports `format=json|markdown` and `top_n` query parameters. The Node.js layer augments the report with process-level stats (RSS, heap, PID, Node version).

- **CLI command**: `next internal turbopack-memory [dir] [--format json|markdown] [--server host:por]` discovers the running dev server via the `.next/dev/lock` file and fetches the report.

- **Documentation**: Added a "Turbopack memory reporting" section to the local development guide.

### Output formats

- **JSON** (default): Machine-readable, includes version, timestamps, task/cell/allocator stats
- **Markdown**: Human-readable tables

### Key design decisions

We estimate memory size via encoding, which is trivial to do but horrifically inaccurate.  This means we both overcount and undercount memory (because persistent formats are sometimes often compact than memory, think slack space in hash tables) and overcount because we don't respect reference counted datastructures like `RcStr`/`Rope`.  A 'correct' approach would be very complex.

## Test plan

- [x] Integration tests for fetch API (JSON schema, markdown, top_n)
- [x] Integration tests for CLI (`next internal turbopack-memory` with JSON, markdown, top_n)
- [x] Manual testing with a real app to verify report accuracy

Fixes PACK-6917