### PR TITLE
[instant] Don't add debug stack to random `unstable_instant` exports

### DIFF
--- a/crates/next-core/src/next_shared/transforms/next_debug_instant_stack.rs
+++ b/crates/next-core/src/next_shared/transforms/next_debug_instant_stack.rs
@@ -28,8 +28,8 @@ struct NextDebugInstantStack {}
 #[async_trait]
 impl CustomTransformer for NextDebugInstantStack {
     #[tracing::instrument(level = tracing::Level::TRACE, name = "debug_instant_stack", skip_all)]
-    async fn transform(&self, program: &mut Program, _ctx: &TransformContext<'_>) -> Result<()> {
-        program.mutate(debug_instant_stack());
+    async fn transform(&self, program: &mut Program, ctx: &TransformContext<'_>) -> Result<()> {
+        program.mutate(debug_instant_stack(ctx.file_path_str.to_string()));
         Ok(())
     }
 }

--- a/crates/next-custom-transforms/src/chain_transforms.rs
+++ b/crates/next-custom-transforms/src/chain_transforms.rs
@@ -136,6 +136,7 @@ where
     C: Clone + Comments + 'a,
 {
     let file_path_str = file.name.to_string();
+    let file_path_for_instant_stack = file_path_str.clone();
 
     #[cfg(target_arch = "wasm32")]
     let relay_plugin = noop_pass();
@@ -347,7 +348,9 @@ where
                 crate::transforms::debug_fn_name::debug_fn_name(),
                 opts.debug_function_name,
             ),
-            crate::transforms::debug_instant_stack::debug_instant_stack(),
+            crate::transforms::debug_instant_stack::debug_instant_stack(
+                file_path_for_instant_stack,
+            ),
             visit_mut_pass(crate::transforms::pure::pure_magic(comments.clone())),
             Optional::new(
                 linter(lint_codemod_comments(comments)),

--- a/crates/next-custom-transforms/src/transforms/debug_instant_stack.rs
+++ b/crates/next-custom-transforms/src/transforms/debug_instant_stack.rs
@@ -1,3 +1,5 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
 use swc_core::{
     common::{Span, Spanned},
     ecma::{
@@ -7,13 +9,19 @@ use swc_core::{
     quote,
 };
 
-pub fn debug_instant_stack() -> impl Pass {
+/// Only apply to page/layout segment files.
+static PAGE_OR_LAYOUT_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"[\\/](page|layout|default)\.(ts|js)x?$").unwrap());
+
+pub fn debug_instant_stack(filepath: String) -> impl Pass {
     fold_pass(DebugInstantStack {
+        filepath,
         instant_export_span: None,
     })
 }
 
 struct DebugInstantStack {
+    filepath: String,
     instant_export_span: Option<Span>,
 }
 
@@ -66,6 +74,10 @@ fn find_var_init_span(items: &[ModuleItem], local_name: &str) -> Option<Span> {
 
 impl Fold for DebugInstantStack {
     fn fold_module_items(&mut self, items: Vec<ModuleItem>) -> Vec<ModuleItem> {
+        if !PAGE_OR_LAYOUT_RE.is_match(&self.filepath) {
+            return items;
+        }
+
         for item in &items {
             match item {
                 // `export const unstable_instant = ...`

--- a/crates/next-custom-transforms/tests/fixture.rs
+++ b/crates/next-custom-transforms/tests/fixture.rs
@@ -876,7 +876,7 @@ fn test_debug_instant_stack(input: PathBuf) {
 
     test_fixture(
         syntax(),
-        &|_| debug_instant_stack(),
+        &|_| debug_instant_stack("app/page.js".to_string()),
         &input,
         &output,
         FixtureTestConfig {

--- a/test/e2e/app-dir/instant-validation-causes/app/not-actual-instant/config.ts
+++ b/test/e2e/app-dir/instant-validation-causes/app/not-actual-instant/config.ts
@@ -1,0 +1,1 @@
+export const unstable_instant = false

--- a/test/e2e/app-dir/instant-validation-causes/app/not-actual-instant/page.tsx
+++ b/test/e2e/app-dir/instant-validation-causes/app/not-actual-instant/page.tsx
@@ -1,0 +1,5 @@
+import * as config from './config'
+
+export default function NotActualInstantConfig() {
+  return <pre data-testid="config">{JSON.stringify(config)}</pre>
+}

--- a/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
+++ b/test/e2e/app-dir/instant-validation-causes/instant-validation-causes.test.ts
@@ -266,4 +266,12 @@ describe('instant validation causes', () => {
      }
     `)
   })
+
+  it('does not add an instant stack for random unstable_instant exports', async () => {
+    const browser = await next.browser('/not-actual-instant')
+    const config = await browser.waitForElementByCss('[data-testid="config"]')
+    expect(await config.innerText()).toBe(
+      JSON.stringify({ unstable_instant: false })
+    )
+  })
 })


### PR DESCRIPTION
Instead of just limiting the transform to any file within the app dir, we now restrict it to any page, default, or layout file in the app dir. This avoids having the transform applied to random modules. The inserted value would not have been used by anything.