### PR TITLE
fix: handle file:// URLs in cacheHandler for ESM configs

### DIFF
--- a/packages/next/src/build/collect-build-traces.ts
+++ b/packages/next/src/build/collect-build-traces.ts
@@ -10,6 +10,7 @@ import {
 } from './webpack/plugins/next-trace-entrypoints-plugin'
 
 import path from 'path'
+import { fileURLToPath } from 'url'
 import fs from 'fs/promises'
 import { nonNullable } from '../lib/non-nullable'
 import * as ciEnvironment from '../server/ci-info'
@@ -147,11 +148,14 @@ export async function collectBuildTraces({
       // ensure we trace any dependencies needed for custom
       // incremental cache handler
       if (cacheHandler) {
+        const resolvedCacheHandler = cacheHandler.startsWith('file://')
+          ? fileURLToPath(cacheHandler)
+          : cacheHandler
         sharedEntriesSet.push(
           require.resolve(
-            path.isAbsolute(cacheHandler)
-              ? cacheHandler
-              : path.join(dir, cacheHandler)
+            path.isAbsolute(resolvedCacheHandler)
+              ? resolvedCacheHandler
+              : path.join(dir, resolvedCacheHandler)
           )
         )
       }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { pathToFileURL } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 import { arch, platform } from 'os'
 import { platformArchTriples } from 'next/dist/compiled/@napi-rs/triples'
 import * as Log from '../output/log'
@@ -926,14 +926,19 @@ function bindingToApi(
       }
     }
 
-    // cacheHandler can be an absolute path, we need it to be relative for turbopack.
+    // cacheHandler can be an absolute path or a file:// URL (from import.meta.resolve()
+    // in ESM configs), we need it to be relative for turbopack.
     if (nextConfigSerializable.cacheHandler) {
+      const resolvedCacheHandler =
+        nextConfigSerializable.cacheHandler.startsWith('file://')
+          ? fileURLToPath(nextConfigSerializable.cacheHandler)
+          : nextConfigSerializable.cacheHandler
       nextConfigSerializable.cacheHandler =
         './' +
         normalizePathOnWindows(
-          path.isAbsolute(nextConfigSerializable.cacheHandler)
-            ? path.relative(projectPath, nextConfigSerializable.cacheHandler)
-            : nextConfigSerializable.cacheHandler
+          path.isAbsolute(resolvedCacheHandler)
+            ? path.relative(projectPath, resolvedCacheHandler)
+            : resolvedCacheHandler
         )
     }
     if (nextConfigSerializable.cacheHandlers) {
@@ -942,15 +947,20 @@ function bindingToApi(
           nextConfigSerializable.cacheHandlers as Record<string, string>
         )
           .filter(([_, value]) => value != null)
-          .map(([key, value]) => [
-            key,
-            './' +
-              normalizePathOnWindows(
-                path.isAbsolute(value)
-                  ? path.relative(projectPath, value)
-                  : value
-              ),
-          ])
+          .map(([key, value]) => {
+            const resolved = value.startsWith('file://')
+              ? fileURLToPath(value)
+              : value
+            return [
+              key,
+              './' +
+                normalizePathOnWindows(
+                  path.isAbsolute(resolved)
+                    ? path.relative(projectPath, resolved)
+                    : resolved
+                ),
+            ]
+          })
       )
     }
 

--- a/packages/next/src/lib/format-dynamic-import-path.ts
+++ b/packages/next/src/lib/format-dynamic-import-path.ts
@@ -7,9 +7,15 @@ import { pathToFileURL } from 'url'
  * When an absolute Windows path is passed to it, it interprets the beginning of the path as a protocol (`C:`).
  * Therefore, it is important to always construct a complete path.
  * @param dir File directory
- * @param filePath Absolute or relative path
+ * @param filePath Absolute or relative path, or a file:// URL
  */
 export const formatDynamicImportPath = (dir: string, filePath: string) => {
+  // If the path is already a file:// URL (e.g. from import.meta.resolve()
+  // in ESM configs), it's already a valid URL for dynamic import.
+  if (filePath.startsWith('file://')) {
+    return filePath
+  }
+
   const absoluteFilePath = path.isAbsolute(filePath)
     ? filePath
     : path.join(dir, filePath)

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs'
 import { basename, extname, join, relative, isAbsolute, resolve } from 'path'
-import { pathToFileURL } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 import findUp from 'next/dist/compiled/find-up'
 import * as Log from '../build/output/log'
 import * as ciEnvironment from '../server/ci-info'
@@ -1253,7 +1253,10 @@ function assignDefaultsAndValidate(
           }
         )[key]
 
-        if (handlerPath && !existsSync(handlerPath)) {
+        const resolvedHandlerPath = handlerPath?.startsWith('file://')
+          ? fileURLToPath(handlerPath)
+          : handlerPath
+        if (resolvedHandlerPath && !existsSync(resolvedHandlerPath)) {
           invalidHandlerItems.push({
             key,
             reason: `cache handler path provided does not exist, received ${handlerPath}`,

--- a/test/unit/format-dynamic-import-path.test.ts
+++ b/test/unit/format-dynamic-import-path.test.ts
@@ -1,0 +1,40 @@
+/* eslint-env jest */
+import { formatDynamicImportPath } from 'next/dist/lib/format-dynamic-import-path'
+import path from 'path'
+import { pathToFileURL } from 'url'
+
+describe('formatDynamicImportPath', () => {
+  it('should handle relative paths', () => {
+    const result = formatDynamicImportPath(
+      '/project/.next',
+      './cache-handler.js'
+    )
+    expect(result).toBe(
+      pathToFileURL(
+        path.join('/project/.next', './cache-handler.js')
+      ).toString()
+    )
+  })
+
+  it('should handle absolute paths', () => {
+    const result = formatDynamicImportPath(
+      '/project/.next',
+      '/absolute/path/cache-handler.js'
+    )
+    expect(result).toBe(
+      pathToFileURL('/absolute/path/cache-handler.js').toString()
+    )
+  })
+
+  it('should pass through file:// URLs unchanged', () => {
+    const fileUrl = 'file:///absolute/path/cache-handler.js'
+    const result = formatDynamicImportPath('/project/.next', fileUrl)
+    expect(result).toBe(fileUrl)
+  })
+
+  it('should pass through file:// URLs from import.meta.resolve()', () => {
+    const fileUrl = pathToFileURL('/project/cache-handler.mjs').toString()
+    const result = formatDynamicImportPath('/project/.next', fileUrl)
+    expect(result).toBe(fileUrl)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #73796

When using `"type": "module"` in `package.json`, `import.meta.resolve()` returns `file:///...` URLs instead of filesystem paths. The `cacheHandler` config option accepts these values, but several internal code paths used `path.isAbsolute()` checks that don't recognize `file://` protocol URLs, causing broken path concatenation (e.g., `.next/file:/path/to/handler.js`) and `ERR_MODULE_NOT_FOUND` errors.

## Changes

- **`packages/next/src/lib/format-dynamic-import-path.ts`**: Short-circuit for `file://` URLs since they're already valid import URLs — no need to convert to path and back.

- **`packages/next/src/build/collect-build-traces.ts`**: Convert `file://` URLs to filesystem paths via `fileURLToPath()` before `path.isAbsolute()` check during build tracing.

- **`packages/next/src/build/swc/index.ts`**: Convert `file://` URLs to filesystem paths for both `cacheHandler` and `cacheHandlers` config values before making them relative for Turbopack.

- **`test/unit/format-dynamic-import-path.test.ts`**: Added unit tests covering relative paths, absolute paths, and `file://` URL inputs.

## How to Reproduce

1. Create a Next.js project with `"type": "module"` in `package.json`
2. In `next.config.js`, set `cacheHandler: import.meta.resolve('./cache-handler.mjs')`
3. Run `next build` → `ERR_MODULE_NOT_FOUND` because the path becomes `.next/file:/absolute/path/to/cache-handler.mjs`

Reproduction repo from issue: https://github.com/hdodov/test-nextjs/tree/cache-handler-not-working

## Disclosure

This PR was authored with the assistance of Claude (LLM) to help understand the codebase and structure the implementation and description.