### PR TITLE
ci: declare explicit least-privilege permissions in automation workflows

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -5,6 +5,8 @@ on:
     # This runs every day 20 minutes before midnight: https://crontab.guru/#40_23_*_*_*
     - cron: '40 23 * * *'
 
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue_wrong_template.yml
+++ b/.github/workflows/issue_wrong_template.yml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   close:
     if: github.event.label.name == 'please use the correct issue template'

--- a/.github/workflows/popular.yml
+++ b/.github/workflows/popular.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 10 * * 1' # Every Monday at 10AM UTC (6AM EST)
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
 jobs:
   run:
     if: github.repository_owner == 'vercel'

--- a/.github/workflows/pull_request_stats.yml
+++ b/.github/workflows/pull_request_stats.yml
@@ -7,6 +7,9 @@ on:
 
 name: Generate Stats
 
+permissions:
+  contents: read
+
 concurrency:
   # Keep cancel-on-update behavior for PRs, but allow canary pushes to run independently.
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}

--- a/.github/workflows/setup-nextjs-build.yml
+++ b/.github/workflows/setup-nextjs-build.yml
@@ -13,6 +13,9 @@ on:
         description: 'version of Node.js to use'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build_nextjs:
     name: Build Next.js for the turbopack integration test

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -13,6 +13,9 @@ on:
 
 name: Test examples
 
+permissions:
+  contents: read
+
 jobs:
   testExamples:
     # Don't execute using cron on forks

--- a/.github/workflows/upload-tests-manifest.yml
+++ b/.github/workflows/upload-tests-manifest.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - 'test/*-manifest.json'
 
+permissions:
+  contents: read
+
 jobs:
   upload_test_results:
     name: Upload test results


### PR DESCRIPTION
## Summary\nAdd explicit token permissions to selected workflows currently relying on implicit defaults:\n\n- `.github/workflows/issue_stale.yml`\n- `.github/workflows/issue_wrong_template.yml`\n- `.github/workflows/popular.yml`\n- `.github/workflows/pull_request_stats.yml`\n- `.github/workflows/setup-nextjs-build.yml`\n- `.github/workflows/test_examples.yml`\n- `.github/workflows/upload-tests-manifest.yml`\n\n## Permission choices\n- Tokenless stale handler (uses dedicated secret token): `permissions: {}`\n- Issue automation using default token: `contents: read` + `issues: write`\n- Read-only CI/reporting workflows: `contents: read`\n- Repo analytics workflow: `contents: read`, `issues: read`, `pull-requests: read`\n\n## Why\nThis reduces reliance on broad default token scopes and makes each workflow’s intended access explicit and auditable.\n\n## Notes\n- configuration-only changes\n- no test/build logic changes\n