### PR TITLE
docs: Remove incorrect prop from the example

### DIFF
--- a/docs/01-app/01-getting-started/03-layouts-and-pages.mdx
+++ b/docs/01-app/01-getting-started/03-layouts-and-pages.mdx
@@ -290,7 +290,7 @@ For example, to generate a list of blog posts, import `<Link>` from `next/link` 
 ```tsx filename="app/ui/post.tsx" highlight={1,10} switcher
 import Link from 'next/link'
 
-export default async function Post({ post }) {
+export default async function Post() {
   const posts = await getPosts()
 
   return (


### PR DESCRIPTION
current example should not need `post` prop:
```ts
import Link from 'next/link'
 
export default async function Post({ post }) {
  const posts = await getPosts()
 
  return (
    <ul>
      {posts.map((post) => (
        <li key={post.slug}>
          <Link href={`/blog/${post.slug}`}>{post.title}</Link>
        </li>
      ))}
    </ul>
  )
}
```