### PR TITLE
Remove MetadataContext type and construct isStaticMetadataRouteFile inside resolveMetadata

### DIFF
--- a/packages/next/src/lib/metadata/metadata-context.tsx
+++ b/packages/next/src/lib/metadata/metadata-context.tsx
@@ -1,7 +1,0 @@
-import type { MetadataContext } from './types/resolvers'
-
-export function createMetadataContext(): MetadataContext {
-  return {
-    isStaticMetadataRouteFile: false,
-  }
-}

--- a/packages/next/src/lib/metadata/metadata.tsx
+++ b/packages/next/src/lib/metadata/metadata.tsx
@@ -13,7 +13,6 @@ import type {
   ResolvedViewport,
 } from './types/metadata-interface'
 import { isHTTPAccessFallbackError } from '../../client/components/http-access-fallback/http-access-fallback'
-import type { MetadataContext } from './types/resolvers'
 import { createServerSearchParamsForMetadata } from '../../server/request/search-params'
 import { createServerPathnameForMetadata } from '../../server/request/pathname'
 import { isPostpone } from '../../server/lib/router-utils/is-postpone'
@@ -42,7 +41,6 @@ export function createMetadataComponents({
   tree,
   pathname,
   parsedQuery,
-  metadataContext,
   interpolatedParams,
   errorType,
   serveStreamingMetadata,
@@ -51,7 +49,6 @@ export function createMetadataComponents({
   tree: LoaderTree
   pathname: string
   parsedQuery: SearchParams
-  metadataContext: MetadataContext
   interpolatedParams: Params
   errorType?: MetadataErrorType | 'redirect'
   serveStreamingMetadata: boolean
@@ -137,7 +134,6 @@ export function createMetadataComponents({
       pathnameForMetadata,
       searchParams,
       interpolatedParams,
-      metadataContext,
       isRuntimePrefetchable,
       errorType
     ).catch((metadataErr) => {
@@ -153,7 +149,6 @@ export function createMetadataComponents({
           pathnameForMetadata,
           searchParams,
           interpolatedParams,
-          metadataContext,
           isRuntimePrefetchable
         ).catch(() => null)
       }
@@ -194,7 +189,6 @@ export function createMetadataComponents({
         pathnameForMetadata,
         searchParams,
         interpolatedParams,
-        metadataContext,
         isRuntimePrefetchable,
         errorType
       ),
@@ -234,7 +228,6 @@ async function getResolvedMetadataImpl(
   pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
-  metadataContext: MetadataContext,
   isRuntimePrefetchable: boolean,
   errorType?: MetadataErrorType | 'redirect'
 ): Promise<React.ReactNode> {
@@ -244,7 +237,6 @@ async function getResolvedMetadataImpl(
     pathname,
     searchParams,
     interpolatedParams,
-    metadataContext,
     isRuntimePrefetchable,
     errorConvention
   )
@@ -256,7 +248,6 @@ async function getNotFoundMetadataImpl(
   pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
-  metadataContext: MetadataContext,
   isRuntimePrefetchable: boolean
 ): Promise<React.ReactNode> {
   const notFoundErrorConvention = 'not-found'
@@ -265,7 +256,6 @@ async function getNotFoundMetadataImpl(
     pathname,
     searchParams,
     interpolatedParams,
-    metadataContext,
     isRuntimePrefetchable,
     notFoundErrorConvention
   )
@@ -311,7 +301,6 @@ async function renderMetadata(
   pathname: Promise<string>,
   searchParams: Promise<ParsedUrlQuery>,
   interpolatedParams: Params,
-  metadataContext: MetadataContext,
   isRuntimePrefetchable: boolean,
   errorConvention?: MetadataErrorType
 ) {
@@ -321,7 +310,6 @@ async function renderMetadata(
     searchParams,
     errorConvention,
     interpolatedParams,
-    metadataContext,
     isRuntimePrefetchable
   )
   return <>{createMetadataElements(resolvedMetadata)}</>

--- a/packages/next/src/lib/metadata/resolve-metadata.test.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.test.ts
@@ -20,9 +20,7 @@ function accumulateMetadata(metadataItems: MetadataItems) {
   ])
   const route = '/test'
   const pathname = Promise.resolve('/test')
-  return originAccumulateMetadata(route, fullMetadataItems, pathname, {
-    isStaticMetadataRouteFile: false,
-  })
+  return originAccumulateMetadata(route, fullMetadataItems, pathname, false)
 }
 
 function accumulateViewport(viewportExports: Viewport[]) {

--- a/packages/next/src/lib/metadata/resolve-metadata.ts
+++ b/packages/next/src/lib/metadata/resolve-metadata.ts
@@ -12,7 +12,6 @@ import { getSegmentParam } from '../../shared/lib/router/utils/get-segment-param
 import type { Twitter } from './types/twitter-types'
 import type { OpenGraph } from './types/opengraph-types'
 import type { AppDirModules } from '../../build/webpack/loaders/next-app-loader'
-import type { MetadataContext } from './types/resolvers'
 import type { LoaderTree } from '../../server/lib/app-dir-module'
 import type {
   AbsoluteTemplateString,
@@ -162,7 +161,6 @@ async function mergeStaticMetadata(
   source: Metadata | null,
   target: ResolvedMetadata,
   staticFilesMetadata: StaticMetadata,
-  metadataContext: MetadataContext,
   titleTemplates: TitleTemplates,
   leafSegmentStaticIcons: StaticIcons,
   pathname: Promise<string>
@@ -181,10 +179,11 @@ async function mergeStaticMetadata(
 
   // file based metadata is specified and current level metadata twitter.images is not specified
   if (twitter && !source?.twitter?.hasOwnProperty('images')) {
+    const isStaticFile = true
     const resolvedTwitter = resolveTwitter(
       { ...target.twitter, images: twitter } as Twitter,
       metadataBase,
-      { ...metadataContext, isStaticMetadataRouteFile: true },
+      isStaticFile,
       titleTemplates.twitter
     )
     target.twitter = convertUrlsToStrings(resolvedTwitter)
@@ -192,11 +191,12 @@ async function mergeStaticMetadata(
 
   // file based metadata is specified and current level metadata openGraph.images is not specified
   if (openGraph && !source?.openGraph?.hasOwnProperty('images')) {
+    const isStaticFile = true
     const resolvedOpenGraph = await resolveOpenGraph(
       { ...target.openGraph, images: openGraph } as OpenGraph,
       metadataBase,
       pathname,
-      { ...metadataContext, isStaticMetadataRouteFile: true },
+      isStaticFile,
       titleTemplates.openGraph
     )
     target.openGraph = convertUrlsToStrings(resolvedOpenGraph)
@@ -219,7 +219,7 @@ async function mergeMetadata(
     resolvedMetadata,
     staticFilesMetadata,
     titleTemplates,
-    metadataContext,
+    isStaticMetadataRouteFile,
     buildState,
     leafSegmentStaticIcons,
   }: {
@@ -227,7 +227,7 @@ async function mergeMetadata(
     resolvedMetadata: ResolvedMetadata
     staticFilesMetadata: StaticMetadata
     titleTemplates: TitleTemplates
-    metadataContext: MetadataContext
+    isStaticMetadataRouteFile: boolean
     buildState: BuildState
     leafSegmentStaticIcons: StaticIcons
   }
@@ -253,12 +253,7 @@ async function mergeMetadata(
       }
       case 'alternates': {
         newResolvedMetadata.alternates = convertUrlsToStrings(
-          await resolveAlternates(
-            metadata.alternates,
-            metadataBase,
-            pathname,
-            metadataContext
-          )
+          await resolveAlternates(metadata.alternates, metadataBase, pathname)
         )
         break
       }
@@ -268,7 +263,7 @@ async function mergeMetadata(
             metadata.openGraph,
             metadataBase,
             pathname,
-            metadataContext,
+            isStaticMetadataRouteFile,
             titleTemplates.openGraph
           )
         )
@@ -279,7 +274,7 @@ async function mergeMetadata(
           resolveTwitter(
             metadata.twitter,
             metadataBase,
-            metadataContext,
+            isStaticMetadataRouteFile,
             titleTemplates.twitter
           )
         )
@@ -331,8 +326,7 @@ async function mergeMetadata(
         newResolvedMetadata[key] = await resolveItunes(
           metadata.itunes,
           metadataBase,
-          pathname,
-          metadataContext
+          pathname
         )
         break
       }
@@ -340,8 +334,7 @@ async function mergeMetadata(
         newResolvedMetadata.pagination = await resolvePagination(
           metadata.pagination,
           metadataBase,
-          pathname,
-          metadataContext
+          pathname
         )
         break
       }
@@ -439,7 +432,6 @@ async function mergeMetadata(
     metadata,
     newResolvedMetadata,
     staticFilesMetadata,
-    metadataContext,
     titleTemplates,
     leafSegmentStaticIcons,
     pathname
@@ -938,7 +930,7 @@ function postProcessMetadata(
   metadata: ResolvedMetadata,
   favicon: any,
   titleTemplates: TitleTemplates,
-  metadataContext: MetadataContext
+  isStaticMetadataRouteFile: boolean
 ): ResolvedMetadata {
   const { openGraph, twitter } = metadata
 
@@ -971,7 +963,7 @@ function postProcessMetadata(
       const partialTwitter = resolveTwitter(
         autoFillProps,
         normalizeMetadataBase(metadata.metadataBase),
-        metadataContext,
+        isStaticMetadataRouteFile,
         titleTemplates.twitter
       )
       if (metadata.twitter) {
@@ -1114,7 +1106,7 @@ export async function accumulateMetadata(
   route: string,
   metadataItems: MetadataItems,
   pathname: Promise<string>,
-  metadataContext: MetadataContext
+  isStaticMetadataRouteFile: boolean
 ): Promise<ResolvedMetadata> {
   let resolvedMetadata = createDefaultMetadata()
 
@@ -1173,7 +1165,7 @@ export async function accumulateMetadata(
     resolvedMetadata = await mergeMetadata(route, pathname, {
       resolvedMetadata,
       metadata,
-      metadataContext,
+      isStaticMetadataRouteFile,
       staticFilesMetadata,
       titleTemplates,
       buildState,
@@ -1220,7 +1212,7 @@ export async function accumulateMetadata(
     resolvedMetadata,
     favicon,
     titleTemplates,
-    metadataContext
+    isStaticMetadataRouteFile
   )
 }
 
@@ -1267,7 +1259,6 @@ export async function resolveMetadata(
   searchParams: Promise<ParsedUrlQuery>,
   errorConvention: MetadataErrorType | undefined,
   interpolatedParams: Params,
-  metadataContext: MetadataContext,
   isRuntimePrefetchable: boolean
 ): Promise<ResolvedMetadata> {
   const metadataItems = await resolveMetadataItems(
@@ -1281,11 +1272,15 @@ export async function resolveMetadata(
   if (!workStore) {
     throw new InvariantError('Expected workStore to be initialized')
   }
+  // isStaticMetadataRouteFile is always false from external callers.
+  // mergeStaticMetadata overrides it to true internally when processing
+  // static metadata route files (opengraph-image, twitter-image, etc.).
+  const isStaticMetadataRouteFile = false
   return accumulateMetadata(
     workStore.route,
     metadataItems,
     pathname,
-    metadataContext
+    isStaticMetadataRouteFile
   )
 }
 

--- a/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
@@ -8,7 +8,6 @@ import type { ResolvedVerification } from '../types/metadata-types'
 import type {
   FieldResolver,
   AsyncFieldResolverExtraArgs,
-  MetadataContext,
 } from '../types/resolvers'
 import { resolveAsArrayOrUndefined } from '../generate/utils'
 import {
@@ -19,8 +18,7 @@ import {
 function resolveAlternateUrl(
   url: string | URL,
   metadataBase: MetadataBaseURL,
-  pathname: string,
-  metadataContext: MetadataContext
+  pathname: string
 ) {
   // If alter native url is an URL instance,
   // we treat it as a URL base and resolve with current pathname
@@ -31,12 +29,7 @@ function resolveAlternateUrl(
     )
     url = newUrl
   }
-  return resolveAbsoluteUrlWithPathname(
-    url,
-    metadataBase,
-    pathname,
-    metadataContext
-  )
+  return resolveAbsoluteUrlWithPathname(url, metadataBase, pathname)
 }
 
 export const resolveThemeColor: FieldResolver<'themeColor', Viewport> = (
@@ -67,8 +60,7 @@ async function resolveUrlValuesOfObject(
     | null
     | undefined,
   metadataBase: MetadataBaseURL,
-  pathname: Promise<string>,
-  metadataContext: MetadataContext
+  pathname: Promise<string>
 ): Promise<null | Record<string, AlternateLinkDescriptor[]>> {
   if (!obj) return null
 
@@ -78,24 +70,14 @@ async function resolveUrlValuesOfObject(
       const pathnameForUrl = await pathname
       result[key] = [
         {
-          url: resolveAlternateUrl(
-            value,
-            metadataBase,
-            pathnameForUrl,
-            metadataContext
-          ),
+          url: resolveAlternateUrl(value, metadataBase, pathnameForUrl),
         },
       ]
     } else if (value && value.length) {
       result[key] = []
       const pathnameForUrl = await pathname
       value.forEach((item, index) => {
-        const url = resolveAlternateUrl(
-          item.url,
-          metadataBase,
-          pathnameForUrl,
-          metadataContext
-        )
+        const url = resolveAlternateUrl(item.url, metadataBase, pathnameForUrl)
         result[key][index] = {
           url,
           title: item.title,
@@ -109,8 +91,7 @@ async function resolveUrlValuesOfObject(
 async function resolveCanonicalUrl(
   urlOrDescriptor: string | URL | null | AlternateLinkDescriptor | undefined,
   metadataBase: MetadataBaseURL,
-  pathname: Promise<string>,
-  metadataContext: MetadataContext
+  pathname: Promise<string>
 ): Promise<null | AlternateLinkDescriptor> {
   if (!urlOrDescriptor) return null
 
@@ -123,44 +104,35 @@ async function resolveCanonicalUrl(
 
   // Return string url because structureClone can't handle URL instance
   return {
-    url: resolveAlternateUrl(
-      url,
-      metadataBase,
-      pathnameForUrl,
-      metadataContext
-    ),
+    url: resolveAlternateUrl(url, metadataBase, pathnameForUrl),
   }
 }
 
 export const resolveAlternates: AsyncFieldResolverExtraArgs<
   'alternates',
-  [MetadataBaseURL, Promise<string>, MetadataContext]
-> = async (alternates, metadataBase, pathname, context) => {
+  [MetadataBaseURL, Promise<string>]
+> = async (alternates, metadataBase, pathname) => {
   if (!alternates) return null
 
   const canonical = await resolveCanonicalUrl(
     alternates.canonical,
     metadataBase,
-    pathname,
-    context
+    pathname
   )
   const languages = await resolveUrlValuesOfObject(
     alternates.languages,
     metadataBase,
-    pathname,
-    context
+    pathname
   )
   const media = await resolveUrlValuesOfObject(
     alternates.media,
     metadataBase,
-    pathname,
-    context
+    pathname
   )
   const types = await resolveUrlValuesOfObject(
     alternates.types,
     metadataBase,
-    pathname,
-    context
+    pathname
   )
 
   return {
@@ -274,18 +246,13 @@ export const resolveAppLinks: FieldResolver<'appLinks'> = (appLinks) => {
 
 export const resolveItunes: AsyncFieldResolverExtraArgs<
   'itunes',
-  [MetadataBaseURL, Promise<string>, MetadataContext]
-> = async (itunes, metadataBase, pathname, context) => {
+  [MetadataBaseURL, Promise<string>]
+> = async (itunes, metadataBase, pathname) => {
   if (!itunes) return null
   return {
     appId: itunes.appId,
     appArgument: itunes.appArgument
-      ? resolveAlternateUrl(
-          itunes.appArgument,
-          metadataBase,
-          await pathname,
-          context
-        )
+      ? resolveAlternateUrl(itunes.appArgument, metadataBase, await pathname)
       : undefined,
   }
 }
@@ -300,24 +267,14 @@ export const resolveFacebook: FieldResolver<'facebook'> = (facebook) => {
 
 export const resolvePagination: AsyncFieldResolverExtraArgs<
   'pagination',
-  [MetadataBaseURL, Promise<string>, MetadataContext]
-> = async (pagination, metadataBase, pathname, context) => {
+  [MetadataBaseURL, Promise<string>]
+> = async (pagination, metadataBase, pathname) => {
   return {
     previous: pagination?.previous
-      ? resolveAlternateUrl(
-          pagination.previous,
-          metadataBase,
-          await pathname,
-          context
-        )
+      ? resolveAlternateUrl(pagination.previous, metadataBase, await pathname)
       : null,
     next: pagination?.next
-      ? resolveAlternateUrl(
-          pagination.next,
-          metadataBase,
-          await pathname,
-          context
-        )
+      ? resolveAlternateUrl(pagination.next, metadataBase, await pathname)
       : null,
   }
 }

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.test.ts
@@ -51,9 +51,7 @@ describe('resolveOpenGraph', () => {
         { type: 'article', authors: '' },
         null,
         pathname,
-        {
-          isStaticMetadataRouteFile: false,
-        },
+        false,
         ''
       )
     ).toEqual({
@@ -74,9 +72,7 @@ describe('resolveOpenGraph', () => {
         { type: 'article', authors: null },
         null,
         pathname,
-        {
-          isStaticMetadataRouteFile: false,
-        },
+        false,
         ''
       )
     ).toEqual({

--- a/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-opengraph.ts
@@ -7,7 +7,6 @@ import type {
 import type {
   FieldResolverExtraArgs,
   AsyncFieldResolverExtraArgs,
-  MetadataContext,
 } from '../types/resolvers'
 import type { ResolvedTwitterMetadata, Twitter } from '../types/twitter-types'
 import { resolveArray, resolveAsArrayOrUndefined } from '../generate/utils'
@@ -160,12 +159,12 @@ function getFieldsByOgType(ogType: OpenGraphType | undefined) {
 
 export const resolveOpenGraph: AsyncFieldResolverExtraArgs<
   'openGraph',
-  [MetadataBaseURL, Promise<string>, MetadataContext, string | null]
+  [MetadataBaseURL, Promise<string>, boolean, string | null]
 > = async (
   openGraph,
   metadataBase,
   pathname,
-  metadataContext,
+  isStaticMetadataRouteFile,
   titleTemplate
 ) => {
   if (!openGraph) return null
@@ -184,7 +183,7 @@ export const resolveOpenGraph: AsyncFieldResolverExtraArgs<
     target.images = resolveImages(
       og.images,
       metadataBase,
-      metadataContext.isStaticMetadataRouteFile
+      isStaticMetadataRouteFile
     )
   }
 
@@ -198,8 +197,7 @@ export const resolveOpenGraph: AsyncFieldResolverExtraArgs<
     ? resolveAbsoluteUrlWithPathname(
         openGraph.url,
         metadataBase,
-        await pathname,
-        metadataContext
+        await pathname
       )
     : null
 
@@ -216,8 +214,8 @@ const TwitterBasicInfoKeys = [
 
 export const resolveTwitter: FieldResolverExtraArgs<
   'twitter',
-  [MetadataBaseURL, MetadataContext, string | null]
-> = (twitter, metadataBase, metadataContext, titleTemplate) => {
+  [MetadataBaseURL, boolean, string | null]
+> = (twitter, metadataBase, isStaticMetadataRouteFile, titleTemplate) => {
   if (!twitter) return null
   let card = 'card' in twitter ? twitter.card : undefined
   const resolved = {
@@ -231,7 +229,7 @@ export const resolveTwitter: FieldResolverExtraArgs<
   resolved.images = resolveImages(
     twitter.images,
     metadataBase,
-    metadataContext.isStaticMetadataRouteFile
+    isStaticMetadataRouteFile
   )
 
   card = card || (resolved.images?.length ? 'summary_large_image' : 'summary')

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.test.ts
@@ -52,16 +52,13 @@ describe('resolveAbsoluteUrlWithPathname', () => {
   describe('trailingSlash is false', () => {
     const metadataBase = new URL('https://example.com/')
     const pathname = '/'
-    const opts = {
-      isStaticMetadataRouteFile: false,
-    }
 
     beforeEach(() => {
       setNextInvariantsForTest({ trailingSlash: false })
     })
 
     const resolver = (url: string | URL) =>
-      resolveAbsoluteUrlWithPathname(url, metadataBase, pathname, opts)
+      resolveAbsoluteUrlWithPathname(url, metadataBase, pathname)
     it('should resolve absolute internal url', () => {
       expect(resolver('https://example.com/foo')).toBe(
         'https://example.com/foo'
@@ -78,16 +75,13 @@ describe('resolveAbsoluteUrlWithPathname', () => {
   describe('trailingSlash is true', () => {
     const metadataBase = new URL('https://example.com/')
     const pathname = '/'
-    const opts = {
-      isStaticMetadataRouteFile: false,
-    }
 
     beforeEach(() => {
       setNextInvariantsForTest({ trailingSlash: true })
     })
 
     const resolver = (url: string | URL) =>
-      resolveAbsoluteUrlWithPathname(url, metadataBase, pathname, opts)
+      resolveAbsoluteUrlWithPathname(url, metadataBase, pathname)
     it('should add trailing slash to relative url', () => {
       expect(resolver('/foo')).toBe('https://example.com/foo/')
     })

--- a/packages/next/src/lib/metadata/resolvers/resolve-url.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-url.ts
@@ -1,5 +1,4 @@
 import path from '../../../shared/lib/isomorphic/path'
-import type { MetadataContext } from '../types/resolvers'
 
 export type MetadataBaseURL = URL | null
 
@@ -103,8 +102,7 @@ function isFilePattern(pathname: string): boolean {
 function resolveAbsoluteUrlWithPathname(
   url: string | URL,
   metadataBase: MetadataBaseURL,
-  pathname: string,
-  _metadataContext: MetadataContext
+  pathname: string
 ): string {
   // Resolve url with pathname that always starts with `/`
   url = resolveRelativeUrl(url, pathname)

--- a/packages/next/src/lib/metadata/types/resolvers.ts
+++ b/packages/next/src/lib/metadata/types/resolvers.ts
@@ -19,7 +19,3 @@ export type AsyncFieldResolverExtraArgs<
   Data = Metadata,
   ResolvedData = ResolvedMetadataWithURLs,
 > = (T: Data[Key], ...args: ExtraArgs) => Promise<ResolvedData[Key]>
-
-export type MetadataContext = {
-  isStaticMetadataRouteFile: boolean
-}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -57,7 +57,6 @@ import {
   NEXT_REQUEST_ID_HEADER,
   NEXT_HTML_REQUEST_ID_HEADER,
 } from '../../client/components/app-router-headers'
-import { createMetadataContext } from '../../lib/metadata/metadata-context'
 import { createRequestStoreForRender } from '../async-storage/request-store'
 import { createWorkStore } from '../async-storage/work-store'
 import {
@@ -551,7 +550,6 @@ async function generateDynamicRSCPayload(
       tree: loaderTree,
       parsedQuery: query,
       pathname: url.pathname,
-      metadataContext: createMetadataContext(),
       interpolatedParams: ctx.interpolatedParams,
       serveStreamingMetadata,
       isRuntimePrefetchable: metadataIsRuntimePrefetchable,
@@ -1449,7 +1447,6 @@ async function getRSCPayload(
     errorType: is404 && !hasGlobalNotFound ? 'not-found' : undefined,
     parsedQuery: query,
     pathname: url.pathname,
-    metadataContext: createMetadataContext(),
     interpolatedParams: ctx.interpolatedParams,
     serveStreamingMetadata,
     isRuntimePrefetchable: metadataIsRuntimePrefetchable,
@@ -1571,7 +1568,6 @@ async function getErrorRSCPayload(
     tree,
     parsedQuery: query,
     pathname: url.pathname,
-    metadataContext: createMetadataContext(),
     errorType,
     interpolatedParams: ctx.interpolatedParams,
     serveStreamingMetadata: serveStreamingMetadata,


### PR DESCRIPTION
Stacked on #90270

MetadataContext was a single-field object ({ isStaticMetadataRouteFile: boolean }) that was threaded from createMetadataComponents through the entire metadata resolution chain — six layers of function calls deep — even though every external caller always passed false. The only place that ever set it to true was mergeStaticMetadata, internally.

Instead of threading a constant through the closure and across the call stack, resolveMetadata now constructs the default false value internally. The field is replaced with a plain boolean parameter that only appears in functions that actually distinguish between static and non-static metadata routes.

Deletes metadata-context.tsx and the MetadataContext type.