### PR TITLE
Cached Navigations: Cache visited fully static pages in the segment cache

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1085,5 +1085,6 @@
   "1084": "Route \"%s\": Uncached data or \\`connection()\\` was accessed outside of \\`<Suspense>\\`. This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/blocking-route",
   "1085": "Route \"%s\": Runtime data such as \\`cookies()\\`, \\`headers()\\`, \\`params\\`, or \\`searchParams\\` was accessed inside \\`generateMetadata\\` or you have file-based metadata such as icons that depend on dynamic params segments. Except for this instance, the page would have been entirely prerenderable which may have been the intended behavior. See more info here: https://nextjs.org/docs/messages/next-prerender-dynamic-metadata",
   "1086": "Route \"%s\": %s This delays the entire page from rendering, resulting in a slow user experience. Learn more: https://nextjs.org/docs/messages/next-prerender-dynamic-viewport",
-  "1087": "Failed to parse \"%s\":\\n%s%s"
+  "1087": "Failed to parse \"%s\":\\n%s%s",
+  "1088": "Expected RSC navigation response to have a body"
 }

--- a/packages/next/src/client/app-index.tsx
+++ b/packages/next/src/client/app-index.tsx
@@ -326,6 +326,8 @@ export async function hydrate(
       initialRenderedSearch: initialRSCPayload.q,
       initialCouldBeIntercepted: initialRSCPayload.i,
       initialSupportsPerSegmentPrefetching: initialRSCPayload.S,
+      initialStaleTime: initialRSCPayload.s,
+      initialHeadVaryParams: initialRSCPayload.h,
       location: window.location,
     }),
     instrumentationHooks

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -10,7 +10,7 @@ import { createInitialCacheNodeForHydration } from './ppr-navigations'
 import {
   convertRootFlightRouterStateToRouteTree,
   getStaleAt,
-  writeStaticStageResponseIntoCache,
+  writeInitialFullyStaticResponseIntoCache,
 } from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
@@ -105,10 +105,9 @@ export function createInitialRouterState({
 
       getStaleAt(now, initialStaleTime)
         .then((staleAt) => {
-          writeStaticStageResponseIntoCache(
+          writeInitialFullyStaticResponseIntoCache(
             now,
             initialFlightData,
-            undefined, // buildId - used to check mismatch during navigation
             initialHeadVaryParams,
             staleAt,
             route

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -82,7 +82,7 @@ export function createInitialRouterState({
   // route learning nor segment cache state persists from SSR to client.
   if (location !== null && metadataVaryPath !== null) {
     // Learn the route pattern so we can predict it for future navigations.
-    const route = discoverKnownRoute(
+    discoverKnownRoute(
       Date.now(),
       location.pathname,
       null, // nextUrl — initial render is never an interception
@@ -109,7 +109,8 @@ export function createInitialRouterState({
             undefined, // buildId — not applicable for initial HTML
             initialHeadVaryParams,
             staleAt,
-            route,
+            initialTree,
+            initialRenderedSearch,
             false // isResponsePartial
           )
         })

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -9,7 +9,8 @@ import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
 import { createInitialCacheNodeForHydration } from './ppr-navigations'
 import {
   convertRootFlightRouterStateToRouteTree,
-  writeInitialSeedDataIntoCache,
+  getStaleAt,
+  writeStaticStageResponseIntoCache,
 } from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
@@ -100,14 +101,23 @@ export function createInitialRouterState({
       // Currently only fully static pages include initialStaleTime.
       route.isFullyStatic = true
 
-      writeInitialSeedDataIntoCache(
-        route,
-        initialRouteTree,
-        initialSeedData,
-        initialHead,
-        initialStaleTime,
-        initialHeadVaryParams
-      )
+      const now = Date.now()
+
+      getStaleAt(now, initialStaleTime)
+        .then((staleAt) => {
+          writeStaticStageResponseIntoCache(
+            now,
+            initialFlightData,
+            undefined, // buildId - used to check mismatch during navigation
+            initialHeadVaryParams,
+            staleAt,
+            route
+          )
+        })
+        .catch(() => {
+          // The static stage processing failed. Not fatal — the page
+          // rendered normally, we just won't write into the cache.
+        })
     }
   }
 

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -1,4 +1,5 @@
 import type { FlightDataPath } from '../../../shared/lib/app-router-types'
+import type { VaryParamsThenable } from '../../../shared/lib/segment-cache/vary-params-decoding'
 
 import { createHrefFromUrl } from './create-href-from-url'
 import { extractPathFromFlightRouterState } from './compute-changed-path'
@@ -6,7 +7,10 @@ import { extractPathFromFlightRouterState } from './compute-changed-path'
 import type { AppRouterState } from './router-reducer-types'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
 import { createInitialCacheNodeForHydration } from './ppr-navigations'
-import { convertRootFlightRouterStateToRouteTree } from '../segment-cache/cache'
+import {
+  convertRootFlightRouterStateToRouteTree,
+  writeInitialSeedDataIntoCache,
+} from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
 
@@ -17,6 +21,8 @@ export interface InitialRouterStateParameters {
   initialFlightData: FlightDataPath[]
   initialCouldBeIntercepted: boolean
   initialSupportsPerSegmentPrefetching: boolean
+  initialStaleTime: AsyncIterable<number> | undefined
+  initialHeadVaryParams: VaryParamsThenable | null
   location: Location | null
 }
 
@@ -27,6 +33,8 @@ export function createInitialRouterState({
   initialRenderedSearch,
   initialCouldBeIntercepted,
   initialSupportsPerSegmentPrefetching,
+  initialStaleTime,
+  initialHeadVaryParams,
   location,
 }: InitialRouterStateParameters): AppRouterState {
   // When initialized on the server, the canonical URL is provided as an array of parts.
@@ -51,7 +59,7 @@ export function createInitialRouterState({
         createHrefFromUrl(location)
       : initialCanonicalUrl
 
-  // Conver the initial FlightRouterState into the RouteTree type.
+  // Convert the initial FlightRouterState into the RouteTree type.
   // NOTE: The metadataVaryPath isn't used for anything currently because the
   // head is embedded into the CacheNode tree, but eventually we'll lift it out
   // and store it on the top-level state object.
@@ -69,11 +77,11 @@ export function createInitialRouterState({
     initialHead
   )
 
-  // Learn the route pattern so we can predict it for future navigations.
-  // Only do this in the browser (location !== null) since route learning
-  // state doesn't persist from SSR to client.
+  // The following only applies in the browser (location !== null) since neither
+  // route learning nor segment cache state persists from SSR to client.
   if (location !== null && metadataVaryPath !== null) {
-    discoverKnownRoute(
+    // Learn the route pattern so we can predict it for future navigations.
+    const route = discoverKnownRoute(
       Date.now(),
       location.pathname,
       null, // nextUrl — initial render is never an interception
@@ -85,6 +93,19 @@ export function createInitialRouterState({
       initialSupportsPerSegmentPrefetching,
       false // hasDynamicRewrite
     )
+
+    // Write the initial seed data into the segment cache so subsequent
+    // navigations to the initial page can serve cached segments instantly.
+    if (initialSeedData !== null && initialStaleTime !== undefined) {
+      writeInitialSeedDataIntoCache(
+        route,
+        initialRouteTree,
+        initialSeedData,
+        initialHead,
+        initialStaleTime,
+        initialHeadVaryParams
+      )
+    }
   }
 
   // NOTE: We intentionally don't check if any data needs to be fetched from the

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -97,6 +97,9 @@ export function createInitialRouterState({
     // Write the initial seed data into the segment cache so subsequent
     // navigations to the initial page can serve cached segments instantly.
     if (initialSeedData !== null && initialStaleTime !== undefined) {
+      // Currently only fully static pages include initialStaleTime.
+      route.isFullyStatic = true
+
       writeInitialSeedDataIntoCache(
         route,
         initialRouteTree,

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -14,6 +14,7 @@ import {
 } from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
+import { ResponseCompleteness } from './fetch-server-response'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
@@ -99,7 +100,6 @@ export function createInitialRouterState({
     // navigations to the initial page can serve cached segments instantly.
     if (initialSeedData !== null && initialStaleTime !== undefined) {
       // Currently only fully static pages include initialStaleTime.
-      const isResponsePartial = false
       const now = Date.now()
 
       getStaleAt(now, initialStaleTime)
@@ -111,7 +111,7 @@ export function createInitialRouterState({
             initialHeadVaryParams,
             staleAt,
             route,
-            isResponsePartial
+            ResponseCompleteness.Static
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -10,7 +10,7 @@ import { createInitialCacheNodeForHydration } from './ppr-navigations'
 import {
   convertRootFlightRouterStateToRouteTree,
   getStaleAt,
-  writeInitialFullyStaticResponseIntoCache,
+  writeStaticStageResponseIntoCache,
 } from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
@@ -99,18 +99,19 @@ export function createInitialRouterState({
     // navigations to the initial page can serve cached segments instantly.
     if (initialSeedData !== null && initialStaleTime !== undefined) {
       // Currently only fully static pages include initialStaleTime.
-      route.isFullyStatic = true
-
+      const isResponsePartial = false
       const now = Date.now()
 
       getStaleAt(now, initialStaleTime)
         .then((staleAt) => {
-          writeInitialFullyStaticResponseIntoCache(
+          writeStaticStageResponseIntoCache(
             now,
             initialFlightData,
+            undefined, // buildId — not applicable for initial HTML
             initialHeadVaryParams,
             staleAt,
-            route
+            route,
+            isResponsePartial
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -14,7 +14,6 @@ import {
 } from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
-import { ResponseCompleteness } from './fetch-server-response'
 
 export interface InitialRouterStateParameters {
   navigatedAt: number
@@ -111,7 +110,7 @@ export function createInitialRouterState({
             initialHeadVaryParams,
             staleAt,
             route,
-            ResponseCompleteness.Static
+            false // isResponsePartial
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -41,7 +41,8 @@ import type { NormalizedSearch } from '../segment-cache/cache-key'
 import { getDeploymentId } from '../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
-import { stripIsPartialByte } from '../segment-cache/cache'
+import { stripCompletenessMarker } from '../segment-cache/cache'
+import { ResponseCompletenessMarker } from '../../../shared/lib/app-router-types'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -320,18 +321,18 @@ export type RSCResponse<T> = {
 }
 
 type FetchResponseCacheData = {
-  isFullyStatic: boolean
+  completenessMarker: ResponseCompletenessMarker | null
   responseBodyClone: ReadableStream<Uint8Array>
 }
 
 /**
- * Strips the leading isPartial marker byte from an RSC navigation response and
- * clones the body for segment cache extraction.
+ * Strips the leading completeness marker byte from an RSC navigation response
+ * and clones the body for segment cache extraction.
  *
- * When cache components is enabled, the server may prepend a marker byte to the
- * response: '~' (0x7e) for partial, '#' (0x23) for complete. This must be
- * stripped before Flight decoding because it's not valid RSC data. The body is
- * cloned before Flight can consume it so the clone is available for later use.
+ * When cache components is enabled, the server prepends a completeness marker
+ * byte (see {@link ResponseCompletenessMarker}). This must be stripped before
+ * Flight decoding because it's not valid RSC data. The body is cloned before
+ * Flight can consume it so the clone is available for later use.
  *
  * When cache components is disabled, returns the original response with
  * cacheData: null.
@@ -347,7 +348,9 @@ async function processFetch(response: Response): Promise<{
       )
     }
 
-    const { stream, isFullyStatic } = await stripIsPartialByte(response.body)
+    const { stream, completenessMarker } = await stripCompletenessMarker(
+      response.body
+    )
     const [stream1, stream2] = stream.tee()
 
     const strippedResponse = new Response(stream1, {
@@ -361,7 +364,7 @@ async function processFetch(response: Response): Promise<{
 
     return {
       response: strippedResponse,
-      cacheData: { isFullyStatic, responseBodyClone: stream2 },
+      cacheData: { completenessMarker, responseBodyClone: stream2 },
     }
   }
 
@@ -382,7 +385,8 @@ async function resolveStaticStageData(
   flightResponse: NavigationFlightResponse,
   headers: RequestHeaders
 ): Promise<StaticStageData | null> {
-  const { isFullyStatic, responseBodyClone } = cacheData
+  const { completenessMarker, responseBodyClone } = cacheData
+  const isFullyStatic = completenessMarker === ResponseCompletenessMarker.Static
 
   if (isFullyStatic) {
     // Fully static — cache the entire decoded response as-is.

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -66,7 +66,7 @@ export interface FetchServerResponseOptions {
 
 export type StaticStageData = {
   readonly response: NavigationFlightResponse
-  readonly isResponsePartial: boolean
+  readonly isFullyStatic: boolean
 }
 
 type SpaFetchServerResponseResult = {
@@ -320,7 +320,7 @@ export type RSCResponse<T> = {
 }
 
 type FetchResponseCacheData = {
-  isResponsePartial: boolean
+  isFullyStatic: boolean
   responseBodyClone: ReadableStream<Uint8Array>
 }
 
@@ -347,9 +347,7 @@ async function processFetch(response: Response): Promise<{
       )
     }
 
-    const { stream, isResponsePartial } = await stripIsPartialByte(
-      response.body
-    )
+    const { stream, isFullyStatic } = await stripIsPartialByte(response.body)
 
     const strippedResponse = new Response(stream, {
       headers: response.headers,
@@ -363,7 +361,7 @@ async function processFetch(response: Response): Promise<{
     return {
       response: strippedResponse,
       cacheData: {
-        isResponsePartial,
+        isFullyStatic,
         responseBodyClone: strippedResponse.clone().body!,
       },
     }
@@ -376,10 +374,9 @@ async function processFetch(response: Response): Promise<{
  * Resolves the static stage response from the raw `processFetch` outputs and
  * the decoded flight response, for writing into the segment cache.
  *
- * - Not partial (fully static): use the decoded flight response as-is, no
- *   truncation needed.
- * - Partial + `l` field: truncate the body clone at the static stage byte
- *   boundary and decode.
+ * - Fully static: use the decoded flight response as-is, no truncation needed.
+ * - Not fully static + `l` field: truncate the body clone at the static stage
+ *   byte boundary and decode.
  * - Otherwise: no cache-worthy data.
  */
 async function resolveStaticStageData(
@@ -387,13 +384,13 @@ async function resolveStaticStageData(
   flightResponse: NavigationFlightResponse,
   headers: RequestHeaders
 ): Promise<StaticStageData | null> {
-  const { isResponsePartial, responseBodyClone } = cacheData
+  const { isFullyStatic, responseBodyClone } = cacheData
 
-  if (!isResponsePartial) {
+  if (isFullyStatic) {
     // Fully static — cache the entire decoded response as-is.
     responseBodyClone.cancel()
 
-    return { response: flightResponse, isResponsePartial }
+    return { response: flightResponse, isFullyStatic }
   }
 
   if (flightResponse.l !== undefined) {
@@ -412,11 +409,12 @@ async function resolveStaticStageData(
         { allowPartialStream: true }
       )
 
-    return { response, isResponsePartial }
+    return { response, isFullyStatic }
   }
 
   // No caching — cancel the unused clone.
   responseBodyClone.cancel()
+
   return null
 }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -65,9 +65,28 @@ export interface FetchServerResponseOptions {
   readonly isHmrRefresh?: boolean
 }
 
+/**
+ * Describes how complete a response is, affecting how segments and the head are
+ * written into the cache.
+ *
+ * - Partial: segments have dynamic holes that need a follow-up request.
+ * - Complete: all included segments are complete, but the response may not
+ *   include all segments for the route (based on the router state tree
+ *   sent with the request), and the head may still be partial (e.g.
+ *   LoadingBoundary prefetches, or runtime prefetches that completed for
+ *   a non-fully-static page).
+ * - Static: the server confirmed the entire response is fully static. Both
+ *   segments and the head are complete.
+ */
+export const enum ResponseCompleteness {
+  Partial,
+  Complete,
+  Static,
+}
+
 export type StaticStageData = {
   readonly response: NavigationFlightResponse
-  readonly isFullyStatic: boolean
+  readonly completeness: ResponseCompleteness
 }
 
 type SpaFetchServerResponseResult = {
@@ -391,13 +410,19 @@ async function resolveStaticStageData(
   headers: RequestHeaders
 ): Promise<StaticStageData | null> {
   const { completenessMarker, responseBodyClone } = cacheData
-  const isFullyStatic = completenessMarker === ResponseCompletenessMarker.Static
 
-  if (isFullyStatic) {
+  const completeness =
+    completenessMarker === ResponseCompletenessMarker.Static
+      ? ResponseCompleteness.Static
+      : completenessMarker === ResponseCompletenessMarker.Complete
+        ? ResponseCompleteness.Complete
+        : ResponseCompleteness.Partial
+
+  if (completeness === ResponseCompleteness.Static) {
     // Fully static — cache the entire decoded response as-is.
     responseBodyClone.cancel()
 
-    return { response: flightResponse, isFullyStatic }
+    return { response: flightResponse, completeness }
   }
 
   if (flightResponse.l !== undefined) {
@@ -416,7 +441,7 @@ async function resolveStaticStageData(
         { allowPartialStream: true }
       )
 
-    return { response, isFullyStatic }
+    return { response, completeness }
   }
 
   // No caching — cancel the unused clone.

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -41,8 +41,7 @@ import type { NormalizedSearch } from '../segment-cache/cache-key'
 import { getDeploymentId } from '../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
-import { stripCompletenessMarker } from '../segment-cache/cache'
-import { ResponseCompletenessMarker } from '../../../shared/lib/app-router-types'
+import { stripIsPartialByte } from '../segment-cache/cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -65,28 +64,9 @@ export interface FetchServerResponseOptions {
   readonly isHmrRefresh?: boolean
 }
 
-/**
- * Describes how complete a response is, affecting how segments and the head are
- * written into the cache.
- *
- * - Partial: segments have dynamic holes that need a follow-up request.
- * - Complete: all included segments are complete, but the response may not
- *   include all segments for the route (based on the router state tree
- *   sent with the request), and the head may still be partial (e.g.
- *   LoadingBoundary prefetches, or runtime prefetches that completed for
- *   a non-fully-static page).
- * - Static: the server confirmed the entire response is fully static. Both
- *   segments and the head are complete.
- */
-export const enum ResponseCompleteness {
-  Partial,
-  Complete,
-  Static,
-}
-
 export type StaticStageData = {
   readonly response: NavigationFlightResponse
-  readonly completeness: ResponseCompleteness
+  readonly isResponsePartial: boolean
 }
 
 type SpaFetchServerResponseResult = {
@@ -340,18 +320,18 @@ export type RSCResponse<T> = {
 }
 
 type FetchResponseCacheData = {
-  completenessMarker: ResponseCompletenessMarker | null
+  isResponsePartial: boolean
   responseBodyClone: ReadableStream<Uint8Array>
 }
 
 /**
- * Strips the leading completeness marker byte from an RSC navigation response
- * and clones the body for segment cache extraction.
+ * Strips the leading isPartial byte from an RSC navigation response and
+ * clones the body for segment cache extraction.
  *
- * When cache components is enabled, the server prepends a completeness marker
- * byte (see {@link ResponseCompletenessMarker}). This must be stripped before
- * Flight decoding because it's not valid RSC data. The body is cloned before
- * Flight can consume it so the clone is available for later use.
+ * When cache components is enabled, the server prepends a single byte:
+ * '~' (0x7e) for partial, '#' (0x23) for complete. This must be stripped
+ * before Flight decoding because it's not valid RSC data. The body is
+ * cloned before Flight can consume it so the clone is available for later use.
  *
  * When cache components is disabled, returns the original response with
  * cacheData: null.
@@ -367,9 +347,7 @@ export async function processFetch(response: Response): Promise<{
       )
     }
 
-    const { stream, completenessMarker } = await stripCompletenessMarker(
-      response.body
-    )
+    const { stream, isPartial } = await stripIsPartialByte(response.body)
     const [stream1, stream2] = stream.tee()
 
     const strippedResponse = new Response(stream1, {
@@ -388,7 +366,7 @@ export async function processFetch(response: Response): Promise<{
 
     return {
       response: strippedResponse,
-      cacheData: { completenessMarker, responseBodyClone: stream2 },
+      cacheData: { isResponsePartial: isPartial, responseBodyClone: stream2 },
     }
   }
 
@@ -409,20 +387,13 @@ async function resolveStaticStageData(
   flightResponse: NavigationFlightResponse,
   headers: RequestHeaders
 ): Promise<StaticStageData | null> {
-  const { completenessMarker, responseBodyClone } = cacheData
+  const { isResponsePartial, responseBodyClone } = cacheData
 
-  const completeness =
-    completenessMarker === ResponseCompletenessMarker.Static
-      ? ResponseCompleteness.Static
-      : completenessMarker === ResponseCompletenessMarker.Complete
-        ? ResponseCompleteness.Complete
-        : ResponseCompleteness.Partial
-
-  if (completeness === ResponseCompleteness.Static) {
+  if (!isResponsePartial) {
     // Fully static — cache the entire decoded response as-is.
     responseBodyClone.cancel()
 
-    return { response: flightResponse, completeness }
+    return { response: flightResponse, isResponsePartial: false }
   }
 
   if (flightResponse.l !== undefined) {
@@ -441,7 +412,7 @@ async function resolveStaticStageData(
         { allowPartialStream: true }
       )
 
-    return { response, completeness }
+    return { response, isResponsePartial: true }
   }
 
   // No caching — cancel the unused clone.

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -348,8 +348,9 @@ async function processFetch(response: Response): Promise<{
     }
 
     const { stream, isFullyStatic } = await stripIsPartialByte(response.body)
+    const [stream1, stream2] = stream.tee()
 
-    const strippedResponse = new Response(stream, {
+    const strippedResponse = new Response(stream1, {
       headers: response.headers,
       status: response.status,
       statusText: response.statusText,
@@ -360,10 +361,7 @@ async function processFetch(response: Response): Promise<{
 
     return {
       response: strippedResponse,
-      cacheData: {
-        isFullyStatic,
-        responseBodyClone: strippedResponse.clone().body!,
-      },
+      cacheData: { isFullyStatic, responseBodyClone: stream2 },
     }
   }
 

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -41,6 +41,7 @@ import type { NormalizedSearch } from '../segment-cache/cache-key'
 import { getDeploymentId } from '../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
+import { stripIsPartialByte } from '../segment-cache/cache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -63,6 +64,11 @@ export interface FetchServerResponseOptions {
   readonly isHmrRefresh?: boolean
 }
 
+export type StaticStageData = {
+  readonly response: NavigationFlightResponse
+  readonly isResponsePartial: boolean
+}
+
 type SpaFetchServerResponseResult = {
   flightData: NormalizedFlightData[]
   canonicalUrl: URL
@@ -71,7 +77,7 @@ type SpaFetchServerResponseResult = {
   supportsPerSegmentPrefetching: boolean
   postponed: boolean
   staleTime: number
-  staticStageResponse: Promise<NavigationFlightResponse> | null
+  staticStageData: StaticStageData | null
   responseHeaders: Headers
   debugInfo: Array<any> | null
 }
@@ -240,7 +246,10 @@ export async function fetchServerResponse(
         )
     }
 
-    const flightResponse = await flightResponsePromise
+    const [flightResponse, cacheData] = await Promise.all([
+      flightResponsePromise,
+      res.cacheData,
+    ])
 
     if (
       (res.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? flightResponse.b) !==
@@ -255,19 +264,10 @@ export async function fetchServerResponse(
       return doMpaNavigation(normalizedFlightData)
     }
 
-    // If the server included a static stage byte count, decode the static
-    // stage from the cloned response body to seed the segment cache.
-    let staticStageResponse: Promise<NavigationFlightResponse> | null = null
-    if (flightResponse.l !== undefined && res.staticStageBodyPromise !== null) {
-      staticStageResponse = decodeStaticStageResponse(
-        flightResponse.l,
-        res.staticStageBodyPromise,
-        headers
-      )
-    } else if (res.staticStageBodyPromise !== null) {
-      // No static stage byte count — cancel the unused clone.
-      res.staticStageBodyPromise.then((body) => body?.cancel())
-    }
+    const staticStageData =
+      cacheData !== null
+        ? await resolveStaticStageData(cacheData, flightResponse, headers)
+        : null
 
     return {
       flightData: normalizedFlightData,
@@ -284,7 +284,7 @@ export async function fetchServerResponse(
       supportsPerSegmentPrefetching: flightResponse.S,
       postponed,
       staleTime,
-      staticStageResponse,
+      staticStageData,
       responseHeaders: res.headers,
       debugInfo: flightResponsePromise._debugInfo ?? null,
     }
@@ -316,7 +316,108 @@ export type RSCResponse<T> = {
   status: number
   url: string
   flightResponsePromise: (Promise<T> & { _debugInfo?: Array<any> }) | null
-  staticStageBodyPromise: Promise<ReadableStream<Uint8Array> | null> | null
+  cacheData: Promise<FetchResponseCacheData | null>
+}
+
+type FetchResponseCacheData = {
+  isResponsePartial: boolean
+  responseBodyClone: ReadableStream<Uint8Array>
+}
+
+/**
+ * Strips the leading isPartial marker byte from an RSC navigation response and
+ * clones the body for segment cache extraction.
+ *
+ * When cache components is enabled, the server may prepend a marker byte to the
+ * response: '~' (0x7e) for partial, '#' (0x23) for complete. This must be
+ * stripped before Flight decoding because it's not valid RSC data. The body is
+ * cloned before Flight can consume it so the clone is available for later use.
+ *
+ * When cache components is disabled, returns the original response with
+ * cacheData: null.
+ */
+async function processFetch(response: Response): Promise<{
+  response: Response
+  cacheData: FetchResponseCacheData | null
+}> {
+  if (process.env.__NEXT_CACHE_COMPONENTS) {
+    if (!response.body) {
+      throw new InvariantError(
+        'Expected RSC navigation response to have a body'
+      )
+    }
+
+    const { stream, isResponsePartial } = await stripIsPartialByte(
+      response.body
+    )
+
+    const strippedResponse = new Response(stream, {
+      headers: response.headers,
+      status: response.status,
+      statusText: response.statusText,
+    })
+    // Setting the URL on the response is non-standard, but React DevTools rely
+    // on it to show the URL for Flight responses in the "suspended by" view.
+    Object.defineProperty(strippedResponse, 'url', { value: response.url })
+
+    return {
+      response: strippedResponse,
+      cacheData: {
+        isResponsePartial,
+        responseBodyClone: strippedResponse.clone().body!,
+      },
+    }
+  }
+
+  return { response, cacheData: null }
+}
+
+/**
+ * Resolves the static stage response from the raw `processFetch` outputs and
+ * the decoded flight response, for writing into the segment cache.
+ *
+ * - Not partial (fully static): use the decoded flight response as-is, no
+ *   truncation needed.
+ * - Partial + `l` field: truncate the body clone at the static stage byte
+ *   boundary and decode.
+ * - Otherwise: no cache-worthy data.
+ */
+async function resolveStaticStageData(
+  cacheData: FetchResponseCacheData,
+  flightResponse: NavigationFlightResponse,
+  headers: RequestHeaders
+): Promise<StaticStageData | null> {
+  const { isResponsePartial, responseBodyClone } = cacheData
+
+  if (!isResponsePartial) {
+    // Fully static — cache the entire decoded response as-is.
+    responseBodyClone.cancel()
+
+    return { response: flightResponse, isResponsePartial }
+  }
+
+  if (flightResponse.l !== undefined) {
+    // Partially static — truncate the body clone at the byte boundary.
+    const staticStageByteLength = await flightResponse.l
+
+    const truncatedStream = truncateStream(
+      responseBodyClone,
+      staticStageByteLength
+    )
+
+    const response =
+      await createFromNextReadableStream<NavigationFlightResponse>(
+        truncatedStream,
+        headers,
+        { allowPartialStream: true }
+      )
+
+    return { response, isResponsePartial }
+  }
+
+  // No caching — cancel the unused clone.
+  responseBodyClone.cancel()
+  return null
 }
 
 export async function createFetch<T>(
@@ -364,15 +465,8 @@ export async function createFetch<T>(
   // track them separately.
   let fetchUrl = new URL(url)
   setCacheBustingSearchParam(fetchUrl, headers)
-  let fetchPromise = fetch(fetchUrl, fetchOptions)
-
-  // When cache components is enabled, clone the response before Flight
-  // consumes the body, so we can later truncate the clone to extract the
-  // static stage for caching.
-  let staticStageBodyPromise: Promise<ReadableStream<Uint8Array> | null> | null =
-    process.env.__NEXT_CACHE_COMPONENTS
-      ? fetchPromise.then((response) => response.clone().body)
-      : null
+  let processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+  let fetchPromise = processed.then(({ response }) => response)
 
   // Immediately pass the fetch promise to the Flight client so that the debug
   // info includes the latency from the client to the server. The internal timer
@@ -441,10 +535,8 @@ export async function createFetch<T>(
       // TODO: We should abort the previous request.
       fetchUrl = new URL(responseUrl)
       setCacheBustingSearchParam(fetchUrl, headers)
-      fetchPromise = fetch(fetchUrl, fetchOptions)
-      if (process.env.__NEXT_CACHE_COMPONENTS) {
-        staticStageBodyPromise = fetchPromise.then((r) => r.clone().body)
-      }
+      processed = fetch(fetchUrl, fetchOptions).then(processFetch)
+      fetchPromise = processed.then(({ response }) => response)
       flightResponsePromise = shouldImmediatelyDecode
         ? createFromNextFetch<T>(fetchPromise, headers)
         : null
@@ -481,7 +573,7 @@ export async function createFetch<T>(
     // are later rendered by React.
     flightResponsePromise: flightResponsePromise,
 
-    staticStageBodyPromise: staticStageBodyPromise,
+    cacheData: processed.then(({ cacheData }) => cacheData),
   }
 
   return rscResponse
@@ -509,26 +601,6 @@ function createFromNextFetch<T>(
     findSourceMapURL,
     debugChannel: createDebugChannel && createDebugChannel(requestHeaders),
   })
-}
-
-async function decodeStaticStageResponse(
-  staticStageByteLengthPromise: Promise<number>,
-  staticStageBodyPromise: Promise<ReadableStream<Uint8Array> | null>,
-  requestHeaders: RequestHeaders
-): Promise<NavigationFlightResponse> {
-  const [byteLength, staticBody] = await Promise.all([
-    staticStageByteLengthPromise,
-    staticStageBodyPromise,
-  ])
-  if (staticBody === null) {
-    throw new InvariantError('Expected static stage body to be available')
-  }
-  const truncatedStream = truncateStream(staticBody, byteLength)
-  return createFromNextReadableStream<NavigationFlightResponse>(
-    truncatedStream,
-    requestHeaders,
-    { allowPartialStream: true }
-  )
 }
 
 function truncateStream(

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -337,7 +337,7 @@ type FetchResponseCacheData = {
  * When cache components is disabled, returns the original response with
  * cacheData: null.
  */
-async function processFetch(response: Response): Promise<{
+export async function processFetch(response: Response): Promise<{
   response: Response
   cacheData: FetchResponseCacheData | null
 }> {
@@ -358,9 +358,14 @@ async function processFetch(response: Response): Promise<{
       status: response.status,
       statusText: response.statusText,
     })
-    // Setting the URL on the response is non-standard, but React DevTools rely
-    // on it to show the URL for Flight responses in the "suspended by" view.
+
+    // The Response constructor doesn't preserve `url` or `redirected` from
+    // the original. We need both: `url` for React DevTools and `redirected`
+    // for the redirect replay logic below.
     Object.defineProperty(strippedResponse, 'url', { value: response.url })
+    Object.defineProperty(strippedResponse, 'redirected', {
+      value: response.redirected,
+    })
 
     return {
       response: strippedResponse,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -143,8 +143,7 @@ export function createInitialCacheNodeForHydration(
     null,
     null,
     false,
-    accumulation,
-    false
+    accumulation
   )
   return task
 }
@@ -190,8 +189,7 @@ export function startPPRNavigation(
   seedData: CacheNodeSeedData | null,
   seedHead: HeadData | null,
   isSamePageNavigation: boolean,
-  accumulation: NavigationRequestAccumulation,
-  isRouteFullyStatic: boolean = false
+  accumulation: NavigationRequestAccumulation
 ): NavigationTask | null {
   const didFindRootLayout = false
   const parentNeedsDynamicRequest = false
@@ -217,8 +215,7 @@ export function startPPRNavigation(
     parentNeedsDynamicRequest,
     oldRootRefreshState,
     parentRefreshState,
-    accumulation,
-    isRouteFullyStatic
+    accumulation
   )
 }
 
@@ -239,8 +236,7 @@ function updateCacheNodeOnNavigation(
   parentNeedsDynamicRequest: boolean,
   oldRootRefreshState: RefreshState,
   parentRefreshState: RefreshState | null,
-  accumulation: NavigationRequestAccumulation,
-  isRouteFullyStatic: boolean
+  accumulation: NavigationRequestAccumulation
 ): NavigationTask | null {
   // Check if this segment matches the one in the previous route.
   const oldSegment = oldRouterState[0]
@@ -302,8 +298,7 @@ function updateCacheNodeOnNavigation(
       parentSegmentPath,
       parentParallelRouteKey,
       parentNeedsDynamicRequest,
-      accumulation,
-      isRouteFullyStatic
+      accumulation
     )
   }
 
@@ -381,8 +376,7 @@ function updateCacheNodeOnNavigation(
       seedRsc,
       newMetadataVaryPath,
       seedHead,
-      freshness,
-      isRouteFullyStatic
+      freshness
     )
     newCacheNode = result.cacheNode
     needsDynamicRequest = result.needsDynamicRequest
@@ -509,8 +503,7 @@ function updateCacheNodeOnNavigation(
         parentNeedsDynamicRequest || needsDynamicRequest,
         oldRootRefreshState,
         refreshState,
-        accumulation,
-        isRouteFullyStatic
+        accumulation
       )
 
       if (taskChild === null) {
@@ -579,8 +572,7 @@ function createCacheNodeOnNavigation(
   parentSegmentPath: FlightSegmentPath | null,
   parentParallelRouteKey: string | null,
   parentNeedsDynamicRequest: boolean,
-  accumulation: NavigationRequestAccumulation,
-  isRouteFullyStatic: boolean
+  accumulation: NavigationRequestAccumulation
 ): NavigationTask {
   // Same traversal as updateCacheNodeNavigation, but simpler. We switch to this
   // path once we reach the part of the tree that was not in the previous route.
@@ -627,8 +619,7 @@ function createCacheNodeOnNavigation(
     seedRsc,
     newMetadataVaryPath,
     seedHead,
-    freshness,
-    isRouteFullyStatic
+    freshness
   )
   const newCacheNode = result.cacheNode
   const needsDynamicRequest = result.needsDynamicRequest
@@ -662,8 +653,7 @@ function createCacheNodeOnNavigation(
         segmentPath,
         parallelRouteKey,
         parentNeedsDynamicRequest || needsDynamicRequest,
-        accumulation,
-        isRouteFullyStatic
+        accumulation
       )
 
       taskChildren.set(parallelRouteKey, taskChild)
@@ -880,8 +870,7 @@ function createCacheNodeForSegment(
   seedRsc: React.ReactNode | null,
   metadataVaryPath: PageVaryPath | null,
   seedHead: HeadData | null,
-  freshness: FreshnessPolicy,
-  isRouteFullyStatic: boolean
+  freshness: FreshnessPolicy
 ): { cacheNode: CacheNode; needsDynamicRequest: boolean } {
   // Construct a new CacheNode using data from the BFCache, the client's
   // Segment Cache, or seeded from a server response.
@@ -1043,14 +1032,6 @@ function createCacheNodeForSegment(
     }
   }
 
-  // When the route is fully static and we have cached segment data,
-  // treat it as complete — no dynamic follow-up needed. If the cached
-  // data is null (stale, evicted, or failed), we fall through to the
-  // dynamic request path.
-  if (isRouteFullyStatic && cachedRsc !== null) {
-    isCachedRscPartial = false
-  }
-
   // Now combine the cached data with the seed data to determine what we can
   // render immediately, versus what needs to stream in later.
 
@@ -1138,13 +1119,6 @@ function createCacheNodeForSegment(
           }
         }
       }
-    }
-
-    // Same override as the segment check above: the server conservatively marks
-    // the head as partial, but for a fully static route with a cached head
-    // entry, no dynamic follow-up is needed.
-    if (isRouteFullyStatic && cachedHead !== null) {
-      isCachedHeadPartial = false
     }
 
     if (process.env.__NEXT_OPTIMISTIC_ROUTING && isCachedHeadPartial) {
@@ -1612,10 +1586,6 @@ async function fetchMissingDynamicData(
       const { response: staticStageResponse, isFullyStatic } =
         result.staticStageData
 
-      // Update the route entry so future navigations to this route can skip the
-      // dynamic follow-up when reading from the segment cache.
-      routeCacheEntry.isFullyStatic = isFullyStatic
-
       const now = Date.now()
 
       getStaleAt(now, staticStageResponse.s)
@@ -1630,7 +1600,8 @@ async function fetchMissingDynamicData(
             buildId,
             staticStageResponse.h,
             staleAt,
-            routeCacheEntry
+            routeCacheEntry,
+            !isFullyStatic
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1600,7 +1600,8 @@ async function fetchMissingDynamicData(
             buildId,
             staticStageResponse.h,
             staleAt,
-            routeCacheEntry,
+            dynamicRequestTree,
+            result.renderedSearch,
             isResponsePartial
           )
         })

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1581,13 +1581,14 @@ async function fetchMissingDynamicData(
       await waitForNavigationLock()
     }
 
-    if (routeCacheEntry !== null && result.staticStageResponse !== null) {
+    if (routeCacheEntry !== null && result.staticStageData !== null) {
       const now = Date.now()
-      processStaticStageResponse(now, result.staticStageResponse).then(
-        ({ serverData, headVaryParams, staleAt }) =>
+      const { staticStageData } = result
+      processStaticStageResponse(now, staticStageData.response).then(
+        ({ headVaryParams, staleAt }) =>
           writeStaticStageResponseIntoCache(
             now,
-            serverData,
+            staticStageData,
             result.responseHeaders,
             headVaryParams,
             staleAt,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1619,7 +1619,7 @@ async function fetchMissingDynamicData(
         ({ headVaryParams, staleAt }) =>
           writeStaticStageResponseIntoCache(
             now,
-            staticStageData,
+            staticStageData.response,
             result.responseHeaders,
             headVaryParams,
             staleAt,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -142,7 +142,8 @@ export function createInitialCacheNodeForHydration(
     null,
     null,
     false,
-    accumulation
+    accumulation,
+    false
   )
   return task
 }
@@ -188,7 +189,8 @@ export function startPPRNavigation(
   seedData: CacheNodeSeedData | null,
   seedHead: HeadData | null,
   isSamePageNavigation: boolean,
-  accumulation: NavigationRequestAccumulation
+  accumulation: NavigationRequestAccumulation,
+  isRouteFullyStatic: boolean = false
 ): NavigationTask | null {
   const didFindRootLayout = false
   const parentNeedsDynamicRequest = false
@@ -214,7 +216,8 @@ export function startPPRNavigation(
     parentNeedsDynamicRequest,
     oldRootRefreshState,
     parentRefreshState,
-    accumulation
+    accumulation,
+    isRouteFullyStatic
   )
 }
 
@@ -235,7 +238,8 @@ function updateCacheNodeOnNavigation(
   parentNeedsDynamicRequest: boolean,
   oldRootRefreshState: RefreshState,
   parentRefreshState: RefreshState | null,
-  accumulation: NavigationRequestAccumulation
+  accumulation: NavigationRequestAccumulation,
+  isRouteFullyStatic: boolean
 ): NavigationTask | null {
   // Check if this segment matches the one in the previous route.
   const oldSegment = oldRouterState[0]
@@ -297,7 +301,8 @@ function updateCacheNodeOnNavigation(
       parentSegmentPath,
       parentParallelRouteKey,
       parentNeedsDynamicRequest,
-      accumulation
+      accumulation,
+      isRouteFullyStatic
     )
   }
 
@@ -375,7 +380,8 @@ function updateCacheNodeOnNavigation(
       seedRsc,
       newMetadataVaryPath,
       seedHead,
-      freshness
+      freshness,
+      isRouteFullyStatic
     )
     newCacheNode = result.cacheNode
     needsDynamicRequest = result.needsDynamicRequest
@@ -502,7 +508,8 @@ function updateCacheNodeOnNavigation(
         parentNeedsDynamicRequest || needsDynamicRequest,
         oldRootRefreshState,
         refreshState,
-        accumulation
+        accumulation,
+        isRouteFullyStatic
       )
 
       if (taskChild === null) {
@@ -571,7 +578,8 @@ function createCacheNodeOnNavigation(
   parentSegmentPath: FlightSegmentPath | null,
   parentParallelRouteKey: string | null,
   parentNeedsDynamicRequest: boolean,
-  accumulation: NavigationRequestAccumulation
+  accumulation: NavigationRequestAccumulation,
+  isRouteFullyStatic: boolean
 ): NavigationTask {
   // Same traversal as updateCacheNodeNavigation, but simpler. We switch to this
   // path once we reach the part of the tree that was not in the previous route.
@@ -618,7 +626,8 @@ function createCacheNodeOnNavigation(
     seedRsc,
     newMetadataVaryPath,
     seedHead,
-    freshness
+    freshness,
+    isRouteFullyStatic
   )
   const newCacheNode = result.cacheNode
   const needsDynamicRequest = result.needsDynamicRequest
@@ -652,7 +661,8 @@ function createCacheNodeOnNavigation(
         segmentPath,
         parallelRouteKey,
         parentNeedsDynamicRequest || needsDynamicRequest,
-        accumulation
+        accumulation,
+        isRouteFullyStatic
       )
 
       taskChildren.set(parallelRouteKey, taskChild)
@@ -869,7 +879,8 @@ function createCacheNodeForSegment(
   seedRsc: React.ReactNode | null,
   metadataVaryPath: PageVaryPath | null,
   seedHead: HeadData | null,
-  freshness: FreshnessPolicy
+  freshness: FreshnessPolicy,
+  isRouteFullyStatic: boolean
 ): { cacheNode: CacheNode; needsDynamicRequest: boolean } {
   // Construct a new CacheNode using data from the BFCache, the client's
   // Segment Cache, or seeded from a server response.
@@ -1031,6 +1042,14 @@ function createCacheNodeForSegment(
     }
   }
 
+  // When the route is fully static and we have cached segment data,
+  // treat it as complete — no dynamic follow-up needed. If the cached
+  // data is null (stale, evicted, or failed), we fall through to the
+  // dynamic request path.
+  if (isRouteFullyStatic && cachedRsc !== null) {
+    isCachedRscPartial = false
+  }
+
   // Now combine the cached data with the seed data to determine what we can
   // render immediately, versus what needs to stream in later.
 
@@ -1118,6 +1137,13 @@ function createCacheNodeForSegment(
           }
         }
       }
+    }
+
+    // Same override as the segment check above: the server conservatively marks
+    // the head as partial, but for a fully static route with a cached head
+    // entry, no dynamic follow-up is needed.
+    if (isRouteFullyStatic && cachedHead !== null) {
+      isCachedHeadPartial = false
     }
 
     if (process.env.__NEXT_OPTIMISTIC_ROUTING && isCachedHeadPartial) {
@@ -1582,8 +1608,13 @@ async function fetchMissingDynamicData(
     }
 
     if (routeCacheEntry !== null && result.staticStageData !== null) {
+      // Update the route entry so future navigations to this route can skip the
+      // dynamic follow-up when reading from the segment cache.
+      routeCacheEntry.isFullyStatic = result.staticStageData.isFullyStatic
+
       const now = Date.now()
       const { staticStageData } = result
+
       processStaticStageResponse(now, staticStageData.response).then(
         ({ headVaryParams, staleAt }) =>
           writeStaticStageResponseIntoCache(

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1583,7 +1583,7 @@ async function fetchMissingDynamicData(
     }
 
     if (routeCacheEntry !== null && result.staticStageData !== null) {
-      const { response: staticStageResponse, isFullyStatic } =
+      const { response: staticStageResponse, completeness } =
         result.staticStageData
 
       const now = Date.now()
@@ -1601,7 +1601,7 @@ async function fetchMissingDynamicData(
             staticStageResponse.h,
             staleAt,
             routeCacheEntry,
-            !isFullyStatic
+            completeness
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1583,7 +1583,7 @@ async function fetchMissingDynamicData(
     }
 
     if (routeCacheEntry !== null && result.staticStageData !== null) {
-      const { response: staticStageResponse, completeness } =
+      const { response: staticStageResponse, isResponsePartial } =
         result.staticStageData
 
       const now = Date.now()
@@ -1601,7 +1601,7 @@ async function fetchMissingDynamicData(
             staticStageResponse.h,
             staleAt,
             routeCacheEntry,
-            completeness
+            isResponsePartial
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -35,11 +35,12 @@ import {
   waitForSegmentCacheEntry,
   markRouteEntryAsDynamicRewrite,
   invalidateRouteCacheEntries,
-  processStaticStageResponse,
+  getStaleAt,
   writeStaticStageResponseIntoCache,
   EntryStatus,
 } from '../segment-cache/cache'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
+import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
 import {
   getRenderedSearchFromVaryPath,
@@ -1608,28 +1609,34 @@ async function fetchMissingDynamicData(
     }
 
     if (routeCacheEntry !== null && result.staticStageData !== null) {
+      const { response: staticStageResponse, isFullyStatic } =
+        result.staticStageData
+
       // Update the route entry so future navigations to this route can skip the
       // dynamic follow-up when reading from the segment cache.
-      routeCacheEntry.isFullyStatic = result.staticStageData.isFullyStatic
+      routeCacheEntry.isFullyStatic = isFullyStatic
 
       const now = Date.now()
-      const { staticStageData } = result
 
-      processStaticStageResponse(now, staticStageData.response).then(
-        ({ headVaryParams, staleAt }) =>
+      getStaleAt(now, staticStageResponse.s)
+        .then((staleAt) => {
+          const buildId =
+            result.responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
+            staticStageResponse.b
+
           writeStaticStageResponseIntoCache(
             now,
-            staticStageData.response,
-            result.responseHeaders,
-            headVaryParams,
+            staticStageResponse.f,
+            buildId,
+            staticStageResponse.h,
             staleAt,
             routeCacheEntry
-          ),
-        () => {
+          )
+        })
+        .catch(() => {
           // The static stage processing failed. Not fatal — the navigation
           // completed normally, we just won't write into the cache.
-        }
-      )
+        })
     }
 
     const didReceiveUnknownParallelRoute = writeDynamicDataIntoNavigationTask(

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -64,6 +64,7 @@ import {
 } from '../../../../shared/lib/action-revalidation-kind'
 import { isExternalURL } from '../../app-router-utils'
 import { FreshnessPolicy } from '../ppr-navigations'
+import { processFetch } from '../fetch-server-response'
 import { invalidateBfCache } from '../../segment-cache/bfcache'
 
 const createFromFetch =
@@ -205,8 +206,15 @@ async function fetchServerAction(
   let couldBeIntercepted: boolean = false
 
   if (isRscResponse) {
+    // Server action redirect responses carry the Flight data of the redirect
+    // target, which may be prerendered with a completeness marker byte
+    // prepended. Strip it before passing to Flight.
+    const responsePromise = redirectLocation
+      ? processFetch(res).then(({ response: r }) => r)
+      : Promise.resolve(res)
+
     const response: ActionFlightResponse = await createFromFetch(
-      Promise.resolve(res),
+      responsePromise,
       {
         callServer,
         findSourceMapURL,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -7,7 +7,7 @@ import type {
 } from '../../../server/app-render/collect-segment-data'
 import type {
   CacheNodeSeedData,
-  HeadData,
+  FlightData,
   Segment as FlightRouterStateSegment,
 } from '../../../shared/lib/app-router-types'
 import {
@@ -2304,11 +2304,13 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
     // in the LRU as more data comes in.
+    const buildId =
+      response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
     fulfilledEntries = writeDynamicRenderResponseIntoCache(
       now,
       fetchStrategy,
-      response.headers,
-      serverData,
+      serverData.f,
+      buildId,
       isResponsePartial,
       headVaryParams,
       staleAt,
@@ -2407,11 +2409,13 @@ function writeDynamicTreeResponseIntoCache(
   // the page is fully static), the normal check is bypassed and the server
   // responds with the full page. This is a temporary situation until we can
   // remove the "client-only" option. Then, we can delete this function call.
+  const buildId =
+    response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
-    response.headers,
-    serverData,
+    serverData.f,
+    buildId,
     isResponsePartial,
     headVaryParams,
     getStaleAtFromHeader(now, response),
@@ -2442,18 +2446,15 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.PPR
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
-  responseHeaders: Headers,
-  serverData: NavigationFlightResponse,
+  flightData: FlightData,
+  buildId: string | undefined,
   isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
 ): Array<FulfilledSegmentCacheEntry> | null {
-  const buildId =
-    responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
-
-  if (buildId !== getNavigationBuildId()) {
+  if (buildId && buildId !== getNavigationBuildId()) {
     // The server build does not match the client. Treat as a 404. During
     // an actual navigation, the router will trigger an MPA navigation.
     if (spawnedEntries !== null) {
@@ -2462,15 +2463,15 @@ export function writeDynamicRenderResponseIntoCache(
     return null
   }
 
-  const flightDatas = normalizeFlightData(serverData.f)
+  const flightDatas = normalizeFlightData(flightData)
   if (typeof flightDatas === 'string') {
     // This means navigating to this route will result in an MPA navigation.
     // TODO: We should cache this, too, so that the MPA navigation is immediate.
     return null
   }
 
-  for (const flightData of flightDatas) {
-    const seedData = flightData.seedData
+  for (const flightDataEntry of flightDatas) {
+    const seedData = flightDataEntry.seedData
     if (seedData !== null) {
       // The data sent by the server represents only a subtree of the app. We
       // need to find the part of the task tree that matches the response.
@@ -2479,7 +2480,7 @@ export function writeDynamicRenderResponseIntoCache(
       // pattern of parallel route key and segment:
       //
       //   [string, Segment, string, Segment, string, Segment, ...]
-      const segmentPath = flightData.segmentPath
+      const segmentPath = flightDataEntry.segmentPath
       let tree = route.tree
       for (let i = 0; i < segmentPath.length; i += 2) {
         const parallelRouteKey: string = segmentPath[i]
@@ -2504,7 +2505,7 @@ export function writeDynamicRenderResponseIntoCache(
       )
     }
 
-    const head = flightData.head
+    const head = flightDataEntry.head
     if (head !== null) {
       // The server conservatively marks the head as partial whenever Cache
       // Components is enabled, even for fully static pages where the head is
@@ -2512,7 +2513,7 @@ export function writeDynamicRenderResponseIntoCache(
       // override this since the server confirmed no dynamic content exists.
       const isHeadPartial = route.isFullyStatic
         ? false
-        : flightData.isHeadPartial
+        : flightDataEntry.isHeadPartial
 
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
@@ -2865,7 +2866,7 @@ function getStaleAtFromHeader(
  * starts leaving async iterables hanging when the outer RSC stream is
  * aborted e.g. due to sync I/O (with unstable_allowPartialStream).
  */
-async function getStaleAt(
+export async function getStaleAt(
   now: number,
   staleTimeIterable: AsyncIterable<number> | undefined,
   response?: RSCResponse<unknown>
@@ -2895,40 +2896,17 @@ async function getStaleAt(
   return now + STATIC_STALETIME_MS
 }
 
-type ProcessedStaticStageResponse = {
-  readonly headVaryParams: VaryParams | null
-  readonly staleAt: number
-}
-
 /**
- * Computes derived values (stale time, vary params) from a static stage
- * response.
- */
-export async function processStaticStageResponse(
-  now: number,
-  serverData: NavigationFlightResponse
-): Promise<ProcessedStaticStageResponse> {
-  const staleAt = await getStaleAt(now, serverData.s)
-
-  const headVaryParams =
-    serverData.h !== null ? readVaryParams(serverData.h) : null
-
-  return { headVaryParams, staleAt }
-}
-
-/**
- * Writes the static stage of a dynamic navigation response into the segment
- * cache.
+ * Writes flight data into the segment cache as partial entries. The route-level
+ * `isFullyStatic` flag handles skipping the dynamic follow-up at read time.
  *
- * When the response is fully static, all segments and the head are cached as
- * complete entries. Otherwise, segments are marked as partial and need a
- * dynamic follow-up.
+ * Used for both navigation responses and initial HTML seed data.
  */
 export function writeStaticStageResponseIntoCache(
   now: number,
-  serverData: NavigationFlightResponse,
-  responseHeaders: Headers,
-  headVaryParams: VaryParams | null,
+  flightData: FlightData,
+  buildId: string | undefined,
+  headVaryParamsThenable: VaryParamsThenable | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry
 ): void {
@@ -2938,78 +2916,22 @@ export function writeStaticStageResponseIntoCache(
   const isResponsePartial = true
   const fetchStrategy = FetchStrategy.PPR
 
+  const headVaryParams =
+    headVaryParamsThenable !== null
+      ? readVaryParams(headVaryParamsThenable)
+      : null
+
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
-    responseHeaders,
-    serverData,
+    flightData,
+    buildId,
     isResponsePartial,
     headVaryParams,
     staleAt,
     route,
     null // spawnedEntries — no pre-created entries; will create or upsert
   )
-}
-
-/**
- * Writes the initial HTML RSC payload (seed data from hydration) into the
- * segment cache. This allows subsequent client-side navigations to serve cached
- * segments instantly instead of re-fetching them from the server.
- *
- * Called during createInitialRouterState when the server included a stale time
- * in the InitialRSCPayload (currently only for fully static prerendered pages
- * with Cache Components enabled).
- */
-export async function writeInitialSeedDataIntoCache(
-  route: FulfilledRouteCacheEntry,
-  routeTree: RouteTree,
-  seedData: CacheNodeSeedData,
-  head: HeadData,
-  staleTimeIterable: AsyncIterable<number>,
-  headVaryParamsThenable: VaryParamsThenable | null
-): Promise<void> {
-  const now = Date.now()
-  const staleAt = await getStaleAt(now, staleTimeIterable)
-
-  // We currently only reach this branch for fully static pages (where
-  // initialStaleTimeSeconds is set), so the head is never partial.
-  const isHeadPartial = false
-
-  // For fully static prerendered pages, all segments are complete.
-  const isResponsePartial = false
-
-  // Use Full fetch strategy since the initial HTML contains the complete
-  // render, not just a loading boundary prefix.
-  const fetchStrategy = FetchStrategy.Full
-
-  writeSeedDataIntoCache(
-    now,
-    fetchStrategy,
-    routeTree,
-    staleAt,
-    seedData,
-    isResponsePartial,
-    null // spawnedEntries — no pre-created entries; will create or upsert
-  )
-
-  // Write the head (metadata) into the cache.
-  if (head !== null) {
-    const headVaryParams =
-      headVaryParamsThenable !== null
-        ? readVaryParams(headVaryParamsThenable)
-        : null
-
-    fulfillEntrySpawnedByRuntimePrefetch(
-      now,
-      fetchStrategy,
-      head,
-      isHeadPartial,
-      staleAt,
-      headVaryParams,
-      route.metadata,
-      null // spawnedEntries
-    )
-  }
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -95,6 +95,7 @@ import type {
   NavigationFlightResponse,
 } from '../../../shared/lib/app-router-types'
 import {
+  type NormalizedFlightData,
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
 } from '../../flight-data-helpers'
@@ -103,14 +104,12 @@ import {
   STATIC_STALETIME_MS,
 } from '../router-reducer/reducers/navigate-reducer'
 import { pingVisibleLinks } from '../links'
-import {
-  DEFAULT_SEGMENT_KEY,
-  PAGE_SEGMENT_KEY,
-} from '../../../shared/lib/segment'
+import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 import { readFromBFCacheDuringRegularNavigation } from './bfcache'
 import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
+import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 
@@ -2287,15 +2286,25 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // in the LRU as more data comes in.
     const buildId =
       response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
+    const flightDatas = normalizeFlightData(serverData.f)
+    if (typeof flightDatas === 'string') {
+      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      return null
+    }
+    const navigationSeed = convertServerPatchToFullTree(
+      dynamicRequestTree,
+      flightDatas,
+      renderedSearch
+    )
     fulfilledEntries = writeDynamicRenderResponseIntoCache(
       now,
       fetchStrategy,
-      serverData.f,
+      flightDatas,
       buildId,
       isResponsePartial,
       headVaryParams,
       staleAt,
-      route,
+      navigationSeed,
       spawnedEntries
     )
 
@@ -2367,7 +2376,7 @@ function writeDynamicTreeResponseIntoCache(
     return
   }
 
-  const fulfilledEntry = discoverKnownRoute(
+  discoverKnownRoute(
     now,
     originalPathname,
     nextUrl,
@@ -2382,24 +2391,25 @@ function writeDynamicTreeResponseIntoCache(
 
   // If the server sent segment data as part of the response, we should write
   // it into the cache to prevent a second, redundant prefetch request.
-  //
-  // TODO: When `clientSegmentCache` is enabled, the server does not include
-  // segment data when responding to a route tree prefetch request. However,
-  // when `clientSegmentCache` is set to "client-only", and PPR is enabled (or
-  // the page is fully static), the normal check is bypassed and the server
-  // responds with the full page. This is a temporary situation until we can
-  // remove the "client-only" option. Then, we can delete this function call.
+  // TODO: This is a leftover branch from before Client Segment Cache was
+  // enabled everywhere. Tree prefetches should never include segment data.  We
+  // can delete it. Leaving for a subsequent PR.
+  const navigationSeed = convertServerPatchToFullTree(
+    flightRouterState,
+    normalizedFlightDataResult,
+    renderedSearch
+  )
   const buildId =
     response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
-    serverData.f,
+    normalizedFlightDataResult,
     buildId,
     isResponsePartial,
     headVaryParams,
     getStaleAtFromHeader(now, response),
-    fulfilledEntry,
+    navigationSeed,
     null
   )
 }
@@ -2426,12 +2436,12 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.PPR
     | FetchStrategy.PPRRuntime
     | FetchStrategy.Full,
-  flightData: FlightData,
+  flightDatas: NormalizedFlightData[],
   buildId: string | undefined,
   isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
   staleAt: number,
-  route: FulfilledRouteCacheEntry,
+  navigationSeed: NavigationSeed,
   spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
 ): Array<FulfilledSegmentCacheEntry> | null {
   if (buildId && buildId !== getNavigationBuildId()) {
@@ -2443,12 +2453,11 @@ export function writeDynamicRenderResponseIntoCache(
     return null
   }
 
-  const flightDatas = normalizeFlightData(flightData)
-  if (typeof flightDatas === 'string') {
-    // This means navigating to this route will result in an MPA navigation.
-    // TODO: We should cache this, too, so that the MPA navigation is immediate.
-    return null
-  }
+  const routeTree = navigationSeed.routeTree
+  const metadataTree =
+    navigationSeed.metadataVaryPath !== null
+      ? createMetadataRouteTree(navigationSeed.metadataVaryPath)
+      : null
 
   for (const flightDataEntry of flightDatas) {
     const seedData = flightDataEntry.seedData
@@ -2461,7 +2470,7 @@ export function writeDynamicRenderResponseIntoCache(
       //
       //   [string, Segment, string, Segment, string, Segment, ...]
       const segmentPath = flightDataEntry.segmentPath
-      let tree = route.tree
+      let tree = routeTree
       for (let i = 0; i < segmentPath.length; i += 2) {
         const parallelRouteKey: string = segmentPath[i]
         if (tree?.slots?.[parallelRouteKey] !== undefined) {
@@ -2486,7 +2495,7 @@ export function writeDynamicRenderResponseIntoCache(
     }
 
     const head = flightDataEntry.head
-    if (head !== null) {
+    if (head !== null && metadataTree !== null) {
       // When Cache Components is enabled, the server conservatively marks
       // the head as partial during static generation (isPossiblyPartialHead
       // in app-render.tsx), even for fully static pages where the head is
@@ -2509,7 +2518,7 @@ export function writeDynamicRenderResponseIntoCache(
         // For head entries, use the head-specific vary params passed as
         // parameter.
         headVaryParams,
-        route.metadata,
+        metadataTree,
         spawnedEntries
       )
     }
@@ -2578,30 +2587,6 @@ function writeSeedDataIntoCache(
       const childSeedData: CacheNodeSeedData | null | void =
         seedDataChildren[parallelRouteKey]
       if (childSeedData !== null && childSeedData !== undefined) {
-        // When the response is non-partial (fully static), skip writing default
-        // page segments. Default pages are fallback content for parallel route
-        // slots that don't have a matching page. Writing them as non-partial
-        // creates a cache entry whose key collides with the reused active
-        // segment's lookup during refresh. The refresh then uses the cached
-        // default content instead of fetching fresh data, replacing the
-        // previously active dynamic slot content with the static default page.
-        //
-        // We check two cases:
-        // 1. The child segment is directly "__DEFAULT__" (the `children`
-        //    parallel route of a layout that has no matching page).
-        // 2. The child is a "(slot)" virtual wrapper whose `children` slot is
-        //    "__DEFAULT__" (named parallel route slots like @navbar). The
-        //    "(slot)" wrapper is always exactly one level deep — it's inserted
-        //    by next-app-loader to process slot-level files before the actual
-        //    content segment.
-        if (
-          !isResponsePartial &&
-          (childTree.segment === DEFAULT_SEGMENT_KEY ||
-            childTree.slots?.['children']?.segment === DEFAULT_SEGMENT_KEY)
-        ) {
-          continue
-        }
-
         writeSeedDataIntoCache(
           now,
           fetchStrategy,
@@ -2918,7 +2903,8 @@ export function writeStaticStageResponseIntoCache(
   buildId: string | undefined,
   headVaryParamsThenable: VaryParamsThenable | null,
   staleAt: number,
-  route: FulfilledRouteCacheEntry,
+  baseTree: FlightRouterState,
+  renderedSearch: string,
   isResponsePartial: boolean
 ): void {
   const fetchStrategy = isResponsePartial
@@ -2930,15 +2916,24 @@ export function writeStaticStageResponseIntoCache(
       ? readVaryParams(headVaryParamsThenable)
       : null
 
+  const flightDatas = normalizeFlightData(flightData)
+  if (typeof flightDatas === 'string') {
+    return
+  }
+  const navigationSeed = convertServerPatchToFullTree(
+    baseTree,
+    flightDatas,
+    renderedSearch
+  )
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
-    flightData,
+    flightDatas,
     buildId,
     isResponsePartial,
     headVaryParams,
     staleAt,
-    route,
+    navigationSeed,
     null // spawnedEntries — no pre-created entries; will create or upsert
   )
 }

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -29,6 +29,7 @@ import {
 import {
   createFetch,
   createFromNextReadableStream,
+  ResponseCompleteness,
   type RSCResponse,
   type RequestHeaders,
 } from '../router-reducer/fetch-server-response'
@@ -2279,19 +2280,20 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const staleAt = await getStaleAt(now, serverData.s, response)
     const completenessMarker = cacheData?.completenessMarker ?? null
 
-    // PPRRuntime prefetches are partial when the server marks the response
-    // as '~' (Partial). Full/LoadingBoundary prefetches are always complete.
-    const isResponsePartial =
-      fetchStrategy === FetchStrategy.PPRRuntime &&
-      completenessMarker === ResponseCompletenessMarker.Partial
-
-    // A runtime prefetch may receive a statically generated response (with the
-    // Static completeness marker) for a fully static page. In that case the
-    // head is complete despite the server conservatively marking it as partial,
-    // so we override it.
-    const overrideHeadAsNonPartial =
-      fetchStrategy === FetchStrategy.PPRRuntime &&
-      completenessMarker === ResponseCompletenessMarker.Static
+    // Derive the completeness level from the fetch strategy and the server's
+    // completeness marker. For PPRRuntime prefetches, the marker distinguishes
+    // partial (~), complete (*), and fully static (#) responses. For
+    // Full/LoadingBoundary prefetches, segments are always complete but the
+    // head may still be partial (e.g. dynamic metadata behind a loading
+    // boundary), so we use Complete rather than FullyStatic.
+    const completeness: ResponseCompleteness =
+      fetchStrategy === FetchStrategy.PPRRuntime
+        ? completenessMarker === ResponseCompletenessMarker.Static
+          ? ResponseCompleteness.Static
+          : completenessMarker === ResponseCompletenessMarker.Partial
+            ? ResponseCompleteness.Partial
+            : ResponseCompleteness.Complete
+        : ResponseCompleteness.Complete
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -2303,12 +2305,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       fetchStrategy,
       serverData.f,
       buildId,
-      isResponsePartial,
+      completeness,
       headVaryParams,
       staleAt,
       route,
-      spawnedEntries,
-      overrideHeadAsNonPartial
+      spawnedEntries
     )
 
     // Return a promise that resolves when the network connection closes, so
@@ -2357,11 +2358,13 @@ function writeDynamicTreeResponseIntoCache(
 
   const flightRouterState = flightData.tree
   // If the response contains dynamic holes, then we must conservatively assume
-  // that any individual segment might contain dynamic holes, and also the
-  // head. If it did not contain dynamic holes, then we can assume every segment
-  // and the head is completely static.
-  const isResponsePartial =
+  // that any individual segment might contain dynamic holes, and also the head.
+  // If it did not contain dynamic holes, then we can assume every included
+  // segment and the head is completely static.
+  const completeness =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
+      ? ResponseCompleteness.Partial
+      : ResponseCompleteness.Complete
 
   // Convert the server-sent data into the RouteTree format used by the
   // client cache.
@@ -2409,12 +2412,11 @@ function writeDynamicTreeResponseIntoCache(
     fetchStrategy,
     serverData.f,
     buildId,
-    isResponsePartial,
+    completeness,
     headVaryParams,
     getStaleAtFromHeader(now, response),
     fulfilledEntry,
-    null,
-    false // overrideHeadAsNonPartial
+    null
   )
 }
 
@@ -2442,12 +2444,11 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.Full,
   flightData: FlightData,
   buildId: string | undefined,
-  isResponsePartial: boolean,
+  completeness: ResponseCompleteness,
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
-  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
-  overrideHeadAsNonPartial: boolean
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
 ): Array<FulfilledSegmentCacheEntry> | null {
   if (buildId && buildId !== getNavigationBuildId()) {
     // The server build does not match the client. Treat as a 404. During
@@ -2495,7 +2496,7 @@ export function writeDynamicRenderResponseIntoCache(
         tree,
         staleAt,
         seedData,
-        isResponsePartial,
+        completeness === ResponseCompleteness.Partial,
         spawnedEntries
       )
     }
@@ -2504,11 +2505,12 @@ export function writeDynamicRenderResponseIntoCache(
     if (head !== null) {
       // The server conservatively marks the head as partial whenever Cache
       // Components is enabled, even for fully static pages where the head is
-      // actually complete. The caller can override this when it knows the
-      // response is from a fully static prerender.
-      const isHeadPartial = overrideHeadAsNonPartial
-        ? false
-        : flightDataEntry.isHeadPartial
+      // actually complete. When the response is fully static, we can safely
+      // overrule this since the server confirmed no dynamic content exists.
+      const isHeadPartial =
+        completeness === ResponseCompleteness.Static
+          ? false
+          : flightDataEntry.isHeadPartial
 
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
@@ -2917,7 +2919,7 @@ export async function getStaleAt(
 
 /**
  * Writes the static stage of a navigation response into the segment cache.
- * When `isFullyStatic` is true, segments are written as non-partial with
+ * When `completeness` is `Static`, segments are written as non-partial with
  * `FetchStrategy.Full` so no dynamic follow-up is needed. Default segments
  * are skipped (by `writeSeedDataIntoCache`) to avoid caching fallback content
  * that would block refreshes from overwriting with dynamic data.
@@ -2929,11 +2931,12 @@ export function writeStaticStageResponseIntoCache(
   headVaryParamsThenable: VaryParamsThenable | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
-  isResponsePartial: boolean
+  completeness: ResponseCompleteness
 ): void {
-  const fetchStrategy = isResponsePartial
-    ? FetchStrategy.PPR
-    : FetchStrategy.Full
+  const fetchStrategy =
+    completeness === ResponseCompleteness.Static
+      ? FetchStrategy.Full
+      : FetchStrategy.PPR
 
   const headVaryParams =
     headVaryParamsThenable !== null
@@ -2945,12 +2948,11 @@ export function writeStaticStageResponseIntoCache(
     fetchStrategy,
     flightData,
     buildId,
-    isResponsePartial,
+    completeness,
     headVaryParams,
     staleAt,
     route,
-    null, // spawnedEntries — no pre-created entries; will create or upsert
-    !isResponsePartial // overrideHeadAsNonPartial
+    null // spawnedEntries — no pre-created entries; will create or upsert
   )
 }
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2275,10 +2275,13 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const now = Date.now()
     const staleAt = await getStaleAt(now, serverData.s, response)
 
-    // When cacheData is null (Cache Components disabled), default to false
-    // (non-partial). Full and LoadingBoundary prefetches cannot have holes —
-    // only PPRRuntime prefetches can be partial.
-    const isResponsePartial = cacheData?.isResponsePartial ?? false
+    // Only PPRRuntime prefetches can be partial — Full and LoadingBoundary
+    // prefetches are by definition complete. Use the marker-derived value from
+    // cacheData only for PPRRuntime; default to false otherwise.
+    const isResponsePartial =
+      fetchStrategy === FetchStrategy.PPRRuntime
+        ? (cacheData?.isResponsePartial ?? false)
+        : false
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2910,9 +2910,11 @@ export function writeStaticStageResponseIntoCache(
   staleAt: number,
   route: FulfilledRouteCacheEntry
 ): void {
-  // Always write segments as partial so that refreshes and other navigations
-  // can overwrite them. The route-level isFullyStatic flag handles skipping
-  // the dynamic follow-up at read time.
+  // Always write segments as partial, even for fully static routes. Writing as
+  // non-partial would prevent refreshes and shared parallel route slots from
+  // being overwritten on subsequent navigations. Instead, the route-level
+  // `isFullyStatic` flag is checked at read time (in
+  // `createCacheNodeForSegment`) to skip the dynamic follow-up request.
   const isResponsePartial = true
   const fetchStrategy = FetchStrategy.PPR
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -7,11 +7,13 @@ import type {
 } from '../../../server/app-render/collect-segment-data'
 import type {
   CacheNodeSeedData,
+  HeadData,
   Segment as FlightRouterStateSegment,
 } from '../../../shared/lib/app-router-types'
 import {
   readVaryParams,
   type VaryParams,
+  type VaryParamsThenable,
 } from '../../../shared/lib/segment-cache/vary-params-decoding'
 import {
   NEXT_DID_POSTPONE_HEADER,
@@ -2277,7 +2279,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
         : null
 
     const now = Date.now()
-    const staleAt = await getStaleAt(now, serverData, response)
+    const staleAt = await getStaleAt(now, serverData.s, response)
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -2823,24 +2825,28 @@ function getStaleAtFromHeader(
   return now + staleTimeMs
 }
 
+/**
+ * Reads the stale time from an async iterable or a response header and
+ * returns a staleAt timestamp.
+ *
+ * TODO: Buffer the response and then read the iterable values
+ * synchronously, similar to readVaryParams. This would avoid the need to
+ * make this async, and we could also use it in
+ * writeDynamicTreeResponseIntoCache. This will also be needed when React
+ * starts leaving async iterables hanging when the outer RSC stream is
+ * aborted e.g. due to sync I/O (with unstable_allowPartialStream).
+ */
 async function getStaleAt(
   now: number,
-  serverData: NavigationFlightResponse,
+  staleTimeIterable: AsyncIterable<number> | undefined,
   response?: RSCResponse<unknown>
 ): Promise<number> {
-  if (serverData.s !== undefined) {
+  if (staleTimeIterable !== undefined) {
     // Iterate the async iterable and take the last yielded value. The server
     // yields updated staleTime values during the render; the last one is the
     // final staleTime.
     let staleTimeSeconds: number | undefined
-
-    // TODO: Buffer the response and then read the iterable values
-    // synchronously, similar to readVaryParams. This would avoid the need to
-    // make getStaleAt async, and we could also use it in
-    // writeDynamicTreeResponseIntoCache. This will also be needed when React
-    // starts leaving async iterables hanging when the outer RSC stream is
-    // aborted e.g. due to sync I/O (with unstable_allowPartialStream).
-    for await (const value of serverData.s) {
+    for await (const value of staleTimeIterable) {
       staleTimeSeconds = value
     }
 
@@ -2876,7 +2882,7 @@ export async function processStaticStageResponse(
   staticStageResponse: Promise<NavigationFlightResponse>
 ): Promise<ProcessedStaticStageResponse> {
   const serverData = await staticStageResponse
-  const staleAt = await getStaleAt(now, serverData)
+  const staleAt = await getStaleAt(now, serverData.s)
 
   const headVaryParams =
     serverData.h !== null ? readVaryParams(serverData.h) : null
@@ -2915,6 +2921,68 @@ export function writeStaticStageResponseIntoCache(
     route,
     null // spawnedEntries — no pre-created entries; will create or upsert
   )
+}
+
+/**
+ * Writes the initial HTML RSC payload (seed data from hydration) into the
+ * segment cache. This allows subsequent client-side navigations to serve cached
+ * segments instantly instead of re-fetching them from the server.
+ *
+ * Called during createInitialRouterState when the server included a stale time
+ * in the InitialRSCPayload (currently only for fully static prerendered pages
+ * with Cache Components enabled).
+ */
+export async function writeInitialSeedDataIntoCache(
+  route: FulfilledRouteCacheEntry,
+  routeTree: RouteTree,
+  seedData: CacheNodeSeedData,
+  head: HeadData,
+  staleTimeIterable: AsyncIterable<number>,
+  headVaryParamsThenable: VaryParamsThenable | null
+): Promise<void> {
+  const now = Date.now()
+  const staleAt = await getStaleAt(now, staleTimeIterable)
+
+  // We currently only reach this branch for fully static pages (where
+  // initialStaleTimeSeconds is set), so the head is never partial.
+  const isHeadPartial = false
+
+  // For fully static prerendered pages, the entire payload is static — all
+  // segments are complete and don't need a dynamic follow-up request.
+  const isResponsePartial = false
+
+  // Use Full fetch strategy since the initial HTML contains the complete
+  // render, not just a loading boundary prefix.
+  const fetchStrategy = FetchStrategy.Full
+
+  writeSeedDataIntoCache(
+    now,
+    fetchStrategy,
+    routeTree,
+    staleAt,
+    seedData,
+    isResponsePartial,
+    null // spawnedEntries — no pre-created entries; will create or upsert
+  )
+
+  // Write the head (metadata) into the cache.
+  if (head !== null) {
+    const headVaryParams =
+      headVaryParamsThenable !== null
+        ? readVaryParams(headVaryParamsThenable)
+        : null
+
+    fulfillEntrySpawnedByRuntimePrefetch(
+      now,
+      fetchStrategy,
+      head,
+      isHeadPartial,
+      staleAt,
+      headVaryParams,
+      route.metadata,
+      null // spawnedEntries
+    )
+  }
 }
 
 /**

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2899,8 +2899,6 @@ export async function getStaleAt(
 /**
  * Writes flight data into the segment cache as partial entries. The route-level
  * `isFullyStatic` flag handles skipping the dynamic follow-up at read time.
- *
- * Used for both navigation responses and initial HTML seed data.
  */
 export function writeStaticStageResponseIntoCache(
   now: number,
@@ -2929,6 +2927,36 @@ export function writeStaticStageResponseIntoCache(
     flightData,
     buildId,
     isResponsePartial,
+    headVaryParams,
+    staleAt,
+    route,
+    null // spawnedEntries — no pre-created entries; will create or upsert
+  )
+}
+
+/**
+ * Writes flight data from the initial HTML into the segment cache as complete
+ * entries. Used for fully static pages where all segments are present and no
+ * dynamic follow-up is needed.
+ */
+export function writeInitialFullyStaticResponseIntoCache(
+  now: number,
+  flightData: FlightData,
+  headVaryParamsThenable: VaryParamsThenable | null,
+  staleAt: number,
+  route: FulfilledRouteCacheEntry
+): void {
+  const headVaryParams =
+    headVaryParamsThenable !== null
+      ? readVaryParams(headVaryParamsThenable)
+      : null
+
+  writeDynamicRenderResponseIntoCache(
+    now,
+    FetchStrategy.Full,
+    flightData,
+    undefined, // buildId — not applicable for initial HTML
+    false, // isResponsePartial — fully static, all segments are complete
     headVaryParams,
     staleAt,
     route,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -104,7 +104,10 @@ import {
   STATIC_STALETIME_MS,
 } from '../router-reducer/reducers/navigate-reducer'
 import { pingVisibleLinks } from '../links'
-import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
+import {
+  DEFAULT_SEGMENT_KEY,
+  PAGE_SEGMENT_KEY,
+} from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 import { readFromBFCacheDuringRegularNavigation } from './bfcache'
@@ -226,16 +229,6 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
-  // When true, the server marked this route as fully static (marker byte
-  // '#', ResponseCompletenessMarker.Static). Segment cache entries from
-  // writeStaticStageResponseIntoCache may be marked as partial, but at
-  // navigation read time we can skip the dynamic follow-up request because
-  // the prerendered response contains all the data.
-  //
-  // Runtime prefetches use a separate marker ('*',
-  // ResponseCompletenessMarker.Complete) for complete responses that are NOT
-  // fully static — those do not set this flag.
-  isFullyStatic: boolean
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
   // to a different route structure (e.g., /foo was rewritten to /bar). Since
@@ -677,7 +670,6 @@ export function deprecated_requestOptimisticRouteCacheEntry(
     couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
     supportsPerSegmentPrefetching:
       routeWithNoSearchParams.supportsPerSegmentPrefetching,
-    isFullyStatic: routeWithNoSearchParams.isFullyStatic,
     hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
 
     // Override the rendered search with the optimistic value.
@@ -1092,7 +1084,6 @@ export function fulfillRouteCacheEntry(
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
-  fulfilledEntry.isFullyStatic = false
   fulfilledEntry.hasDynamicRewrite = false
   pingBlockedTasks(entry)
   return fulfilledEntry
@@ -2288,13 +2279,6 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const staleAt = await getStaleAt(now, serverData.s, response)
     const completenessMarker = cacheData?.completenessMarker ?? null
 
-    // Update the route entry based on the server's completeness marker.
-    // Only '#' (Static) means the route is fully static — '*' (Complete)
-    // means the included segments are complete but the route may have other
-    // segments not included in this response.
-    route.isFullyStatic =
-      completenessMarker === ResponseCompletenessMarker.Static
-
     // PPRRuntime prefetches are partial when the server marks the response
     // as '~' (Partial). Full/LoadingBoundary prefetches are always complete.
     const isResponsePartial =
@@ -2509,11 +2493,11 @@ export function writeDynamicRenderResponseIntoCache(
     if (head !== null) {
       // The server conservatively marks the head as partial whenever Cache
       // Components is enabled, even for fully static pages where the head is
-      // actually complete. When the route is fully static, we can safely
+      // actually complete. When the response is non-partial, we can safely
       // override this since the server confirmed no dynamic content exists.
-      const isHeadPartial = route.isFullyStatic
-        ? false
-        : flightDataEntry.isHeadPartial
+      const isHeadPartial = isResponsePartial
+        ? flightDataEntry.isHeadPartial
+        : false
 
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
@@ -2593,6 +2577,30 @@ function writeSeedDataIntoCache(
       const childSeedData: CacheNodeSeedData | null | void =
         seedDataChildren[parallelRouteKey]
       if (childSeedData !== null && childSeedData !== undefined) {
+        // When the response is non-partial (fully static), skip writing default
+        // page segments. Default pages are fallback content for parallel route
+        // slots that don't have a matching page. Writing them as non-partial
+        // creates a cache entry whose key collides with the reused active
+        // segment's lookup during refresh. The refresh then uses the cached
+        // default content instead of fetching fresh data, replacing the
+        // previously active dynamic slot content with the static default page.
+        //
+        // We check two cases:
+        // 1. The child segment is directly "__DEFAULT__" (the `children`
+        //    parallel route of a layout that has no matching page).
+        // 2. The child is a "(slot)" virtual wrapper whose `children` slot is
+        //    "__DEFAULT__" (named parallel route slots like @navbar). The
+        //    "(slot)" wrapper is always exactly one level deep — it's inserted
+        //    by next-app-loader to process slot-level files before the actual
+        //    content segment.
+        if (
+          !isResponsePartial &&
+          (childTree.segment === DEFAULT_SEGMENT_KEY ||
+            childTree.slots?.['children']?.segment === DEFAULT_SEGMENT_KEY)
+        ) {
+          continue
+        }
+
         writeSeedDataIntoCache(
           now,
           fetchStrategy,
@@ -2897,8 +2905,11 @@ export async function getStaleAt(
 }
 
 /**
- * Writes flight data into the segment cache as partial entries. The route-level
- * `isFullyStatic` flag handles skipping the dynamic follow-up at read time.
+ * Writes the static stage of a navigation response into the segment cache.
+ * When `isFullyStatic` is true, segments are written as non-partial with
+ * `FetchStrategy.Full` so no dynamic follow-up is needed. Default segments
+ * are skipped (by `writeSeedDataIntoCache`) to avoid caching fallback content
+ * that would block refreshes from overwriting with dynamic data.
  */
 export function writeStaticStageResponseIntoCache(
   now: number,
@@ -2906,15 +2917,12 @@ export function writeStaticStageResponseIntoCache(
   buildId: string | undefined,
   headVaryParamsThenable: VaryParamsThenable | null,
   staleAt: number,
-  route: FulfilledRouteCacheEntry
+  route: FulfilledRouteCacheEntry,
+  isResponsePartial: boolean
 ): void {
-  // Always write segments as partial, even for fully static routes. Writing as
-  // non-partial would prevent refreshes and shared parallel route slots from
-  // being overwritten on subsequent navigations. Instead, the route-level
-  // `isFullyStatic` flag is checked at read time (in
-  // `createCacheNodeForSegment`) to skip the dynamic follow-up request.
-  const isResponsePartial = true
-  const fetchStrategy = FetchStrategy.PPR
+  const fetchStrategy = isResponsePartial
+    ? FetchStrategy.PPR
+    : FetchStrategy.Full
 
   const headVaryParams =
     headVaryParamsThenable !== null
@@ -2927,36 +2935,6 @@ export function writeStaticStageResponseIntoCache(
     flightData,
     buildId,
     isResponsePartial,
-    headVaryParams,
-    staleAt,
-    route,
-    null // spawnedEntries — no pre-created entries; will create or upsert
-  )
-}
-
-/**
- * Writes flight data from the initial HTML into the segment cache as complete
- * entries. Used for fully static pages where all segments are present and no
- * dynamic follow-up is needed.
- */
-export function writeInitialFullyStaticResponseIntoCache(
-  now: number,
-  flightData: FlightData,
-  headVaryParamsThenable: VaryParamsThenable | null,
-  staleAt: number,
-  route: FulfilledRouteCacheEntry
-): void {
-  const headVaryParams =
-    headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
-      : null
-
-  writeDynamicRenderResponseIntoCache(
-    now,
-    FetchStrategy.Full,
-    flightData,
-    undefined, // buildId — not applicable for initial HTML
-    false, // isResponsePartial — fully static, all segments are complete
     headVaryParams,
     staleAt,
     route,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -31,7 +31,6 @@ import {
   createFromNextReadableStream,
   type RSCResponse,
   type RequestHeaders,
-  type StaticStageData,
 } from '../router-reducer/fetch-server-response'
 import {
   pingPrefetchTask,
@@ -2282,17 +2281,15 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const now = Date.now()
     const staleAt = await getStaleAt(now, serverData.s, response)
 
-    // Determine completeness based on fetch strategy and marker byte:
-    // - PPRRuntime + isFullyStatic: FullyStatic — overrides the server's
-    //   conservative isHeadPartial flag (see writeDynamicRenderResponseIntoCache)
-    // - PPRRuntime + !isFullyStatic: Partial — segments may have dynamic holes
-    // - Full/LoadingBoundary: Complete — always a complete response
-    const completeness =
-      fetchStrategy === FetchStrategy.PPRRuntime
-        ? cacheData?.isFullyStatic
-          ? ResponseCompleteness.FullyStatic
-          : ResponseCompleteness.Partial
-        : ResponseCompleteness.Complete
+    // Update the route entry with whether the response is fully static, based
+    // on the server's marker byte.
+    route.isFullyStatic = cacheData?.isFullyStatic ?? false
+
+    // PPRRuntime prefetches are partial (segments may have dynamic holes)
+    // unless the response is fully static. Full/LoadingBoundary prefetches are
+    // always complete.
+    const isResponsePartial =
+      fetchStrategy === FetchStrategy.PPRRuntime && !route.isFullyStatic
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -2302,12 +2299,13 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       fetchStrategy,
       response.headers,
       serverData,
-      completeness,
+      isResponsePartial,
       headVaryParams,
       staleAt,
       route,
       spawnedEntries
     )
+
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
     return { value: null, closed: closed.promise }
@@ -2357,10 +2355,8 @@ function writeDynamicTreeResponseIntoCache(
   // that any individual segment might contain dynamic holes, and also the
   // head. If it did not contain dynamic holes, then we can assume every segment
   // and the head is completely static.
-  const completeness =
+  const isResponsePartial =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
-      ? ResponseCompleteness.Partial
-      : ResponseCompleteness.Complete
 
   // Convert the server-sent data into the RouteTree format used by the
   // client cache.
@@ -2406,7 +2402,7 @@ function writeDynamicTreeResponseIntoCache(
     fetchStrategy,
     response.headers,
     serverData,
-    completeness,
+    isResponsePartial,
     headVaryParams,
     getStaleAtFromHeader(now, response),
     fulfilledEntry,
@@ -2429,24 +2425,6 @@ function rejectSegmentEntriesIfStillPending(
   return fulfilledEntries
 }
 
-/**
- * Describes how complete a cached response is. This determines both the segment
- * partiality and whether the server's isHeadPartial flag can be overridden.
- *
- * - `Partial`: Segments may contain dynamic holes and need a dynamic follow-up
- *   request to fill in runtime content.
- * - `Complete`: All segments are complete, but the head (metadata) may still be
- *   partial per the server's flag.
- * - `FullyStatic`: The server explicitly marked the response as fully static
- *   (marker byte '#'). Both segments and head are complete — no dynamic
- *   follow-up needed.
- */
-export const enum ResponseCompleteness {
-  Partial = 0,
-  Complete = 1,
-  FullyStatic = 2,
-}
-
 export function writeDynamicRenderResponseIntoCache(
   now: number,
   fetchStrategy:
@@ -2456,7 +2434,7 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.Full,
   responseHeaders: Headers,
   serverData: NavigationFlightResponse,
-  completeness: ResponseCompleteness,
+  isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
@@ -2511,23 +2489,20 @@ export function writeDynamicRenderResponseIntoCache(
         tree,
         staleAt,
         seedData,
-        completeness,
+        isResponsePartial,
         spawnedEntries
       )
     }
 
     const head = flightData.head
     if (head !== null) {
-      // The server conservatively marks the head as partial whenever PPR is
-      // enabled, even for fully static pages where the head is actually
-      // complete (see isPossiblyPartialHead in app-render.tsx and the hardcoded
-      // `true` in walk-tree-with-flight-router-state.tsx). When the response is
-      // fully static (marker byte '#'), we can safely override this since the
-      // server confirmed no dynamic content exists.
-      const isHeadPartial =
-        completeness === ResponseCompleteness.FullyStatic
-          ? false
-          : flightData.isHeadPartial
+      // The server conservatively marks the head as partial whenever Cache
+      // Components is enabled, even for fully static pages where the head is
+      // actually complete. When the route is fully static, we can safely
+      // override this since the server confirmed no dynamic content exists.
+      const isHeadPartial = route.isFullyStatic
+        ? false
+        : flightData.isHeadPartial
 
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
@@ -2571,7 +2546,7 @@ function writeSeedDataIntoCache(
   tree: RouteTree,
   staleAt: number,
   seedData: CacheNodeSeedData,
-  completeness: ResponseCompleteness,
+  isResponsePartial: boolean,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -2580,8 +2555,7 @@ function writeSeedDataIntoCache(
   // This function is used to write the result of a runtime server request
   // (CacheNodeSeedData) into the prefetch cache.
   const rsc = seedData[0]
-  const isPartial =
-    rsc === null || completeness === ResponseCompleteness.Partial
+  const isPartial = rsc === null || isResponsePartial
   const varyParamsThenable = seedData[4]
   // Each segment carries its own vary params thenable in the seed data. The
   // thenable resolves to the set of params the segment accessed during render.
@@ -2614,7 +2588,7 @@ function writeSeedDataIntoCache(
           childTree,
           staleAt,
           childSeedData,
-          completeness,
+          isResponsePartial,
           entriesOwnedByCurrentTask
         )
       }
@@ -2942,28 +2916,24 @@ export async function processStaticStageResponse(
  */
 export function writeStaticStageResponseIntoCache(
   now: number,
-  staticStageData: StaticStageData,
+  serverData: NavigationFlightResponse,
   responseHeaders: Headers,
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry
 ): void {
-  const { response: serverData } = staticStageData
-
-  // Always write segments as partial. The isFullyStatic flag from the marker
-  // byte is a route-level signal that's checked at read time (in
-  // createCacheNodeForSegment) to skip the dynamic follow-up. Writing as
-  // partial here preserves correct behavior for refreshes and other
-  // navigations that may need to overwrite these segments.
-  const completeness = ResponseCompleteness.Partial
-  const fetchStrategy = FetchStrategy.LoadingBoundary
+  // Always write segments as partial so that refreshes and other navigations
+  // can overwrite them. The route-level isFullyStatic flag handles skipping
+  // the dynamic follow-up at read time.
+  const isResponsePartial = true
+  const fetchStrategy = FetchStrategy.PPR
 
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
     responseHeaders,
     serverData,
-    completeness,
+    isResponsePartial,
     headVaryParams,
     staleAt,
     route,
@@ -2995,9 +2965,8 @@ export async function writeInitialSeedDataIntoCache(
   // initialStaleTimeSeconds is set), so the head is never partial.
   const isHeadPartial = false
 
-  // For fully static prerendered pages, the entire payload is static — all
-  // segments are complete and don't need a dynamic follow-up request.
-  const completeness = ResponseCompleteness.FullyStatic
+  // For fully static prerendered pages, all segments are complete.
+  const isResponsePartial = false
 
   // Use Full fetch strategy since the initial HTML contains the complete
   // render, not just a loading boundary prefix.
@@ -3009,7 +2978,7 @@ export async function writeInitialSeedDataIntoCache(
     routeTree,
     staleAt,
     seedData,
-    completeness,
+    isResponsePartial,
     null // spawnedEntries — no pre-created entries; will create or upsert
   )
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -226,6 +226,11 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
+  // When true, the server explicitly marked this route as fully static
+  // (marker byte '#'). The segment cache entries may be marked as partial,
+  // but at navigation read time we can skip the dynamic follow-up request
+  // because the prerendered response contains all the data.
+  isFullyStatic: boolean
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
   // to a different route structure (e.g., /foo was rewritten to /bar). Since
@@ -667,6 +672,7 @@ export function deprecated_requestOptimisticRouteCacheEntry(
     couldBeIntercepted: routeWithNoSearchParams.couldBeIntercepted,
     supportsPerSegmentPrefetching:
       routeWithNoSearchParams.supportsPerSegmentPrefetching,
+    isFullyStatic: routeWithNoSearchParams.isFullyStatic,
     hasDynamicRewrite: routeWithNoSearchParams.hasDynamicRewrite,
 
     // Override the rendered search with the optimistic value.
@@ -1081,6 +1087,7 @@ export function fulfillRouteCacheEntry(
   fulfilledEntry.canonicalUrl = canonicalUrl
   fulfilledEntry.renderedSearch = renderedSearch
   fulfilledEntry.supportsPerSegmentPrefetching = supportsPerSegmentPrefetching
+  fulfilledEntry.isFullyStatic = false
   fulfilledEntry.hasDynamicRewrite = false
   pingBlockedTasks(entry)
   return fulfilledEntry
@@ -2275,10 +2282,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const now = Date.now()
     const staleAt = await getStaleAt(now, serverData.s, response)
 
-    // Determine completeness: PPRRuntime prefetches use the marker-derived
-    // value from cacheData. Full and LoadingBoundary prefetches are always
-    // complete (segments non-partial), but we use Complete rather than
-    // FullyStatic because the head may still be partial.
+    // Determine completeness based on fetch strategy and marker byte:
+    // - PPRRuntime + isFullyStatic: FullyStatic — overrides the server's
+    //   conservative isHeadPartial flag (see writeDynamicRenderResponseIntoCache)
+    // - PPRRuntime + !isFullyStatic: Partial — segments may have dynamic holes
+    // - Full/LoadingBoundary: Complete — always a complete response
     const completeness =
       fetchStrategy === FetchStrategy.PPRRuntime
         ? cacheData?.isFullyStatic
@@ -2940,13 +2948,15 @@ export function writeStaticStageResponseIntoCache(
   staleAt: number,
   route: FulfilledRouteCacheEntry
 ): void {
-  const { response: serverData, isFullyStatic } = staticStageData
+  const { response: serverData } = staticStageData
 
-  const completeness = isFullyStatic
-    ? ResponseCompleteness.FullyStatic
-    : ResponseCompleteness.Partial
-
-  const fetchStrategy = isFullyStatic ? FetchStrategy.Full : FetchStrategy.PPR
+  // Always write segments as partial. The isFullyStatic flag from the marker
+  // byte is a route-level signal that's checked at read time (in
+  // createCacheNodeForSegment) to skip the dynamic follow-up. Writing as
+  // partial here preserves correct behavior for refreshes and other
+  // navigations that may need to overwrite these segments.
+  const completeness = ResponseCompleteness.Partial
+  const fetchStrategy = FetchStrategy.LoadingBoundary
 
   writeDynamicRenderResponseIntoCache(
     now,

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2275,13 +2275,16 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const now = Date.now()
     const staleAt = await getStaleAt(now, serverData.s, response)
 
-    // Only PPRRuntime prefetches can be partial — Full and LoadingBoundary
-    // prefetches are by definition complete. Use the marker-derived value from
-    // cacheData only for PPRRuntime; default to false otherwise.
-    const isResponsePartial =
+    // Determine completeness: PPRRuntime prefetches use the marker-derived
+    // value from cacheData. Full and LoadingBoundary prefetches are always
+    // complete (segments non-partial), but we use Complete rather than
+    // FullyStatic because the head may still be partial.
+    const completeness =
       fetchStrategy === FetchStrategy.PPRRuntime
-        ? (cacheData?.isResponsePartial ?? false)
-        : false
+        ? cacheData?.isFullyStatic
+          ? ResponseCompleteness.FullyStatic
+          : ResponseCompleteness.Partial
+        : ResponseCompleteness.Complete
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -2291,7 +2294,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       fetchStrategy,
       response.headers,
       serverData,
-      isResponsePartial,
+      completeness,
       headVaryParams,
       staleAt,
       route,
@@ -2346,8 +2349,10 @@ function writeDynamicTreeResponseIntoCache(
   // that any individual segment might contain dynamic holes, and also the
   // head. If it did not contain dynamic holes, then we can assume every segment
   // and the head is completely static.
-  const isResponsePartial =
+  const completeness =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
+      ? ResponseCompleteness.Partial
+      : ResponseCompleteness.Complete
 
   // Convert the server-sent data into the RouteTree format used by the
   // client cache.
@@ -2393,7 +2398,7 @@ function writeDynamicTreeResponseIntoCache(
     fetchStrategy,
     response.headers,
     serverData,
-    isResponsePartial,
+    completeness,
     headVaryParams,
     getStaleAtFromHeader(now, response),
     fulfilledEntry,
@@ -2416,6 +2421,24 @@ function rejectSegmentEntriesIfStillPending(
   return fulfilledEntries
 }
 
+/**
+ * Describes how complete a cached response is. This determines both the segment
+ * partiality and whether the server's isHeadPartial flag can be overridden.
+ *
+ * - `Partial`: Segments may contain dynamic holes and need a dynamic follow-up
+ *   request to fill in runtime content.
+ * - `Complete`: All segments are complete, but the head (metadata) may still be
+ *   partial per the server's flag.
+ * - `FullyStatic`: The server explicitly marked the response as fully static
+ *   (marker byte '#'). Both segments and head are complete — no dynamic
+ *   follow-up needed.
+ */
+export const enum ResponseCompleteness {
+  Partial = 0,
+  Complete = 1,
+  FullyStatic = 2,
+}
+
 export function writeDynamicRenderResponseIntoCache(
   now: number,
   fetchStrategy:
@@ -2425,7 +2448,7 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.Full,
   responseHeaders: Headers,
   serverData: NavigationFlightResponse,
-  isResponsePartial: boolean,
+  completeness: ResponseCompleteness,
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
@@ -2480,7 +2503,7 @@ export function writeDynamicRenderResponseIntoCache(
         tree,
         staleAt,
         seedData,
-        isResponsePartial,
+        completeness,
         spawnedEntries
       )
     }
@@ -2489,9 +2512,14 @@ export function writeDynamicRenderResponseIntoCache(
     if (head !== null) {
       // The server conservatively marks the head as partial whenever PPR is
       // enabled, even for fully static pages where the head is actually
-      // complete. When we know the entire response is fully static, we can
-      // safely override this.
-      const isHeadPartial = isResponsePartial && flightData.isHeadPartial
+      // complete (see isPossiblyPartialHead in app-render.tsx and the hardcoded
+      // `true` in walk-tree-with-flight-router-state.tsx). When the response is
+      // fully static (marker byte '#'), we can safely override this since the
+      // server confirmed no dynamic content exists.
+      const isHeadPartial =
+        completeness === ResponseCompleteness.FullyStatic
+          ? false
+          : flightData.isHeadPartial
 
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
@@ -2535,7 +2563,7 @@ function writeSeedDataIntoCache(
   tree: RouteTree,
   staleAt: number,
   seedData: CacheNodeSeedData,
-  isResponsePartial: boolean,
+  completeness: ResponseCompleteness,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -2544,7 +2572,8 @@ function writeSeedDataIntoCache(
   // This function is used to write the result of a runtime server request
   // (CacheNodeSeedData) into the prefetch cache.
   const rsc = seedData[0]
-  const isPartial = rsc === null || isResponsePartial
+  const isPartial =
+    rsc === null || completeness === ResponseCompleteness.Partial
   const varyParamsThenable = seedData[4]
   // Each segment carries its own vary params thenable in the seed data. The
   // thenable resolves to the set of params the segment accessed during render.
@@ -2577,7 +2606,7 @@ function writeSeedDataIntoCache(
           childTree,
           staleAt,
           childSeedData,
-          isResponsePartial,
+          completeness,
           entriesOwnedByCurrentTask
         )
       }
@@ -2899,10 +2928,9 @@ export async function processStaticStageResponse(
  * Writes the static stage of a dynamic navigation response into the segment
  * cache.
  *
- * When isResponsePartial is false, the response represents a fully static
- * page — all segments are cached as complete entries that don't need a dynamic
- * follow-up request. When true, the response contains only the static stage
- * and segments are marked as partial.
+ * When the response is fully static, all segments and the head are cached as
+ * complete entries. Otherwise, segments are marked as partial and need a
+ * dynamic follow-up.
  */
 export function writeStaticStageResponseIntoCache(
   now: number,
@@ -2912,18 +2940,20 @@ export function writeStaticStageResponseIntoCache(
   staleAt: number,
   route: FulfilledRouteCacheEntry
 ): void {
-  const { response: serverData, isResponsePartial } = staticStageData
+  const { response: serverData, isFullyStatic } = staticStageData
 
-  const fetchStrategy = isResponsePartial
-    ? FetchStrategy.PPR
-    : FetchStrategy.Full
+  const completeness = isFullyStatic
+    ? ResponseCompleteness.FullyStatic
+    : ResponseCompleteness.Partial
+
+  const fetchStrategy = isFullyStatic ? FetchStrategy.Full : FetchStrategy.PPR
 
   writeDynamicRenderResponseIntoCache(
     now,
     fetchStrategy,
     responseHeaders,
     serverData,
-    isResponsePartial,
+    completeness,
     headVaryParams,
     staleAt,
     route,
@@ -2957,7 +2987,7 @@ export async function writeInitialSeedDataIntoCache(
 
   // For fully static prerendered pages, the entire payload is static — all
   // segments are complete and don't need a dynamic follow-up request.
-  const isResponsePartial = false
+  const completeness = ResponseCompleteness.FullyStatic
 
   // Use Full fetch strategy since the initial HTML contains the complete
   // render, not just a loading boundary prefix.
@@ -2969,7 +2999,7 @@ export async function writeInitialSeedDataIntoCache(
     routeTree,
     staleAt,
     seedData,
-    isResponsePartial,
+    completeness,
     null // spawnedEntries — no pre-created entries; will create or upsert
   )
 
@@ -2999,12 +3029,12 @@ export async function writeInitialSeedDataIntoCache(
  * it is stripped. If the first byte is not a recognized marker, the stream is
  * returned intact.
  *
- * Returns `isResponsePartial`:
- * - `true` when the marker is '~' (partial), or when no marker is found.
+ * Returns `isFullyStatic`:
+ * - `true` only when the marker is '#' (complete), meaning the server
+ *   explicitly marked the response as fully static.
+ * - `false` when the marker is '~' (partial), or when no marker is found.
  *   This is the conservative default — unknown means "assume dynamic
  *   follow-up is needed".
- * - `false` only when the marker is '#' (complete), meaning the server
- *   explicitly marked the response as fully static.
  *
  * This is safe because the marker bytes (0x7e '~', 0x23 '#') cannot appear as
  * the first byte of a valid RSC Flight response. Flight rows start with either
@@ -3015,23 +3045,23 @@ export async function stripIsPartialByte(
   stream: ReadableStream<Uint8Array>
 ): Promise<{
   stream: ReadableStream<Uint8Array>
-  isResponsePartial: boolean
+  isFullyStatic: boolean
 }> {
   const reader = stream.getReader()
   const { done, value } = await reader.read()
   if (done || !value || value.byteLength === 0) {
     return {
       stream: new ReadableStream({ start: (c) => c.close() }),
-      isResponsePartial: true,
+      isFullyStatic: false,
     }
   }
 
   const firstByte = value[0]
   // '~' (0x7e) = partial, '#' (0x23) = complete
   const hasMarker = firstByte === 0x7e || firstByte === 0x23
-  // Only '#' (complete) is non-partial. Everything else — including
-  // no marker — defaults to partial as the conservative choice.
-  const isResponsePartial = firstByte !== 0x23
+  // Only '#' (complete) means fully static. Everything else — including
+  // no marker — defaults to not fully static as the conservative choice.
+  const isFullyStatic = firstByte === 0x23
 
   const remainder = hasMarker
     ? value.byteLength > 1
@@ -3040,7 +3070,7 @@ export async function stripIsPartialByte(
     : value
 
   return {
-    isResponsePartial,
+    isFullyStatic,
     stream: new ReadableStream<Uint8Array>({
       start(controller) {
         if (remainder) {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2299,7 +2299,8 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       headVaryParams,
       staleAt,
       route,
-      spawnedEntries
+      spawnedEntries,
+      false // overrideHeadAsNonPartial
     )
 
     // Return a promise that resolves when the network connection closes, so
@@ -2404,7 +2405,8 @@ function writeDynamicTreeResponseIntoCache(
     headVaryParams,
     getStaleAtFromHeader(now, response),
     fulfilledEntry,
-    null
+    null,
+    false // overrideHeadAsNonPartial
   )
 }
 
@@ -2436,7 +2438,8 @@ export function writeDynamicRenderResponseIntoCache(
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
-  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
+  overrideHeadAsNonPartial: boolean
 ): Array<FulfilledSegmentCacheEntry> | null {
   if (buildId && buildId !== getNavigationBuildId()) {
     // The server build does not match the client. Treat as a 404. During
@@ -2493,11 +2496,11 @@ export function writeDynamicRenderResponseIntoCache(
     if (head !== null) {
       // The server conservatively marks the head as partial whenever Cache
       // Components is enabled, even for fully static pages where the head is
-      // actually complete. When the response is non-partial, we can safely
-      // override this since the server confirmed no dynamic content exists.
-      const isHeadPartial = isResponsePartial
-        ? flightDataEntry.isHeadPartial
-        : false
+      // actually complete. The caller can override this when it knows the
+      // response is from a fully static prerender.
+      const isHeadPartial = overrideHeadAsNonPartial
+        ? false
+        : flightDataEntry.isHeadPartial
 
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
@@ -2938,7 +2941,8 @@ export function writeStaticStageResponseIntoCache(
     headVaryParams,
     staleAt,
     route,
-    null // spawnedEntries — no pre-created entries; will create or upsert
+    null, // spawnedEntries — no pre-created entries; will create or upsert
+    !isResponsePartial // overrideHeadAsNonPartial
   )
 }
 

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -29,7 +29,6 @@ import {
 import {
   createFetch,
   createFromNextReadableStream,
-  ResponseCompleteness,
   type RSCResponse,
   type RequestHeaders,
 } from '../router-reducer/fetch-server-response'
@@ -95,7 +94,6 @@ import type {
   FlightRouterState,
   NavigationFlightResponse,
 } from '../../../shared/lib/app-router-types'
-import { ResponseCompletenessMarker } from '../../../shared/lib/app-router-types'
 import {
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -2278,22 +2276,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
 
     const now = Date.now()
     const staleAt = await getStaleAt(now, serverData.s, response)
-    const completenessMarker = cacheData?.completenessMarker ?? null
-
-    // Derive the completeness level from the fetch strategy and the server's
-    // completeness marker. For PPRRuntime prefetches, the marker distinguishes
-    // partial (~), complete (*), and fully static (#) responses. For
-    // Full/LoadingBoundary prefetches, segments are always complete but the
-    // head may still be partial (e.g. dynamic metadata behind a loading
-    // boundary), so we use Complete rather than FullyStatic.
-    const completeness: ResponseCompleteness =
-      fetchStrategy === FetchStrategy.PPRRuntime
-        ? completenessMarker === ResponseCompletenessMarker.Static
-          ? ResponseCompleteness.Static
-          : completenessMarker === ResponseCompletenessMarker.Partial
-            ? ResponseCompleteness.Partial
-            : ResponseCompleteness.Complete
-        : ResponseCompleteness.Complete
+    // PPRRuntime prefetches are partial when the server marks the response
+    // as '~' (Partial). Full/LoadingBoundary prefetches are always complete.
+    const isResponsePartial =
+      fetchStrategy === FetchStrategy.PPRRuntime &&
+      (cacheData?.isResponsePartial ?? false)
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -2305,7 +2292,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       fetchStrategy,
       serverData.f,
       buildId,
-      completeness,
+      isResponsePartial,
       headVaryParams,
       staleAt,
       route,
@@ -2357,14 +2344,11 @@ function writeDynamicTreeResponseIntoCache(
   }
 
   const flightRouterState = flightData.tree
-  // If the response contains dynamic holes, then we must conservatively assume
-  // that any individual segment might contain dynamic holes, and also the head.
-  // If it did not contain dynamic holes, then we can assume every included
-  // segment and the head is completely static.
-  const completeness =
+  // If the response was postponed, segments may contain dynamic holes.
+  // The head has its own partiality flag (flightDataEntry.isHeadPartial)
+  // which is handled separately in writeDynamicRenderResponseIntoCache.
+  const isResponsePartial =
     response.headers.get(NEXT_DID_POSTPONE_HEADER) === '1'
-      ? ResponseCompleteness.Partial
-      : ResponseCompleteness.Complete
 
   // Convert the server-sent data into the RouteTree format used by the
   // client cache.
@@ -2412,7 +2396,7 @@ function writeDynamicTreeResponseIntoCache(
     fetchStrategy,
     serverData.f,
     buildId,
-    completeness,
+    isResponsePartial,
     headVaryParams,
     getStaleAtFromHeader(now, response),
     fulfilledEntry,
@@ -2444,7 +2428,7 @@ export function writeDynamicRenderResponseIntoCache(
     | FetchStrategy.Full,
   flightData: FlightData,
   buildId: string | undefined,
-  completeness: ResponseCompleteness,
+  isResponsePartial: boolean,
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
@@ -2496,19 +2480,23 @@ export function writeDynamicRenderResponseIntoCache(
         tree,
         staleAt,
         seedData,
-        completeness === ResponseCompleteness.Partial,
+        isResponsePartial,
         spawnedEntries
       )
     }
 
     const head = flightDataEntry.head
     if (head !== null) {
-      // The server conservatively marks the head as partial whenever Cache
-      // Components is enabled, even for fully static pages where the head is
-      // actually complete. When the response is fully static, we can safely
-      // overrule this since the server confirmed no dynamic content exists.
+      // When Cache Components is enabled, the server conservatively marks
+      // the head as partial during static generation (isPossiblyPartialHead
+      // in app-render.tsx), even for fully static pages where the head is
+      // actually complete. When the response is non-partial, we override
+      // this since the server confirmed no dynamic content exists.
+      //
+      // Without Cache Components, the server always sends the correct
+      // isHeadPartial value, so no override is needed.
       const isHeadPartial =
-        completeness === ResponseCompleteness.Static
+        !isResponsePartial && process.env.__NEXT_CACHE_COMPONENTS
           ? false
           : flightDataEntry.isHeadPartial
 
@@ -2919,7 +2907,7 @@ export async function getStaleAt(
 
 /**
  * Writes the static stage of a navigation response into the segment cache.
- * When `completeness` is `Static`, segments are written as non-partial with
+ * When `isResponsePartial` is false, segments are written as non-partial with
  * `FetchStrategy.Full` so no dynamic follow-up is needed. Default segments
  * are skipped (by `writeSeedDataIntoCache`) to avoid caching fallback content
  * that would block refreshes from overwriting with dynamic data.
@@ -2931,12 +2919,11 @@ export function writeStaticStageResponseIntoCache(
   headVaryParamsThenable: VaryParamsThenable | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry,
-  completeness: ResponseCompleteness
+  isResponsePartial: boolean
 ): void {
-  const fetchStrategy =
-    completeness === ResponseCompleteness.Static
-      ? FetchStrategy.Full
-      : FetchStrategy.PPR
+  const fetchStrategy = isResponsePartial
+    ? FetchStrategy.PPR
+    : FetchStrategy.Full
 
   const headVaryParams =
     headVaryParamsThenable !== null
@@ -2948,7 +2935,7 @@ export function writeStaticStageResponseIntoCache(
     fetchStrategy,
     flightData,
     buildId,
-    completeness,
+    isResponsePartial,
     headVaryParams,
     staleAt,
     route,
@@ -2957,54 +2944,42 @@ export function writeStaticStageResponseIntoCache(
 }
 
 /**
- * Strips the leading completeness marker byte from an RSC response stream.
+ * Strips the leading isPartial byte from an RSC response stream.
  *
- * The server prepends one of three marker bytes:
- * - '#' (0x23) = fully static prerender — all segments present.
- * - '*' (0x2a) = complete runtime prefetch — included segments are complete,
- *   but the response may not include all segments for the route.
- * - '~' (0x7e) = partial — contains dynamic holes that need a follow-up.
+ * The server prepends a single byte: '~' (0x7e) for partial, '#' (0x23) for
+ * complete. These bytes cannot appear as the first byte of a valid RSC Flight
+ * response (Flight rows start with a hex digit or ':').
  *
  * If the first byte is not a recognized marker, the stream is returned intact
  * and the response is conservatively treated as partial.
- *
- * These marker bytes cannot appear as the first byte of a valid RSC Flight
- * response. Flight rows start with either a row ID (a hex character) or
- * ':' (0x3a) for hint and debug chunks. Neither overlaps with the markers.
  */
-export async function stripCompletenessMarker(
+export async function stripIsPartialByte(
   stream: ReadableStream<Uint8Array>
-): Promise<{
-  stream: ReadableStream<Uint8Array>
-  completenessMarker: ResponseCompletenessMarker | null
-}> {
+): Promise<{ stream: ReadableStream<Uint8Array>; isPartial: boolean }> {
   const reader = stream.getReader()
   const { done, value } = await reader.read()
   if (done || !value || value.byteLength === 0) {
     return {
       stream: new ReadableStream({ start: (c) => c.close() }),
-      completenessMarker: null,
+      isPartial: true,
     }
   }
 
   const firstByte = value[0]
+  // '#' (0x23) = complete, '~' (0x7e) = partial.
+  // Only '#' explicitly means non-partial. Everything else (including
+  // unrecognized bytes) is conservatively treated as partial.
+  const hasMarker = firstByte === 0x23 || firstByte === 0x7e
+  const isPartial = firstByte !== 0x23
 
-  const completenessMarker: ResponseCompletenessMarker | null =
-    firstByte === ResponseCompletenessMarker.Static ||
-    firstByte === ResponseCompletenessMarker.Complete ||
-    firstByte === ResponseCompletenessMarker.Partial
-      ? firstByte
+  const remainder = hasMarker
+    ? value.byteLength > 1
+      ? value.subarray(1)
       : null
-
-  const remainder =
-    completenessMarker !== null
-      ? value.byteLength > 1
-        ? value.subarray(1)
-        : null
-      : value
+    : value
 
   return {
-    completenessMarker,
+    isPartial,
     stream: new ReadableStream<Uint8Array>({
       start(controller) {
         if (remainder) {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2285,6 +2285,14 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       fetchStrategy === FetchStrategy.PPRRuntime &&
       completenessMarker === ResponseCompletenessMarker.Partial
 
+    // A runtime prefetch may receive a statically generated response (with the
+    // Static completeness marker) for a fully static page. In that case the
+    // head is complete despite the server conservatively marking it as partial,
+    // so we override it.
+    const overrideHeadAsNonPartial =
+      fetchStrategy === FetchStrategy.PPRRuntime &&
+      completenessMarker === ResponseCompletenessMarker.Static
+
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
     // in the LRU as more data comes in.
@@ -2300,7 +2308,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       staleAt,
       route,
       spawnedEntries,
-      false // overrideHeadAsNonPartial
+      overrideHeadAsNonPartial
     )
 
     // Return a promise that resolves when the network connection closes, so

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -94,6 +94,7 @@ import type {
   FlightRouterState,
   NavigationFlightResponse,
 } from '../../../shared/lib/app-router-types'
+import { ResponseCompletenessMarker } from '../../../shared/lib/app-router-types'
 import {
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
@@ -225,10 +226,15 @@ export type FulfilledRouteCacheEntry = RouteCacheEntryShared & {
   tree: RouteTree
   metadata: RouteTree
   supportsPerSegmentPrefetching: boolean
-  // When true, the server explicitly marked this route as fully static
-  // (marker byte '#'). The segment cache entries may be marked as partial,
-  // but at navigation read time we can skip the dynamic follow-up request
-  // because the prerendered response contains all the data.
+  // When true, the server marked this route as fully static (marker byte
+  // '#', ResponseCompletenessMarker.Static). Segment cache entries from
+  // writeStaticStageResponseIntoCache may be marked as partial, but at
+  // navigation read time we can skip the dynamic follow-up request because
+  // the prerendered response contains all the data.
+  //
+  // Runtime prefetches use a separate marker ('*',
+  // ResponseCompletenessMarker.Complete) for complete responses that are NOT
+  // fully static — those do not set this flag.
   isFullyStatic: boolean
   // When true, this entry should not be used as a template for route
   // prediction. Set when we discover that the URL was rewritten by middleware
@@ -2280,16 +2286,20 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
 
     const now = Date.now()
     const staleAt = await getStaleAt(now, serverData.s, response)
+    const completenessMarker = cacheData?.completenessMarker ?? null
 
-    // Update the route entry with whether the response is fully static, based
-    // on the server's marker byte.
-    route.isFullyStatic = cacheData?.isFullyStatic ?? false
+    // Update the route entry based on the server's completeness marker.
+    // Only '#' (Static) means the route is fully static — '*' (Complete)
+    // means the included segments are complete but the route may have other
+    // segments not included in this response.
+    route.isFullyStatic =
+      completenessMarker === ResponseCompletenessMarker.Static
 
-    // PPRRuntime prefetches are partial (segments may have dynamic holes)
-    // unless the response is fully static. Full/LoadingBoundary prefetches are
-    // always complete.
+    // PPRRuntime prefetches are partial when the server marks the response
+    // as '~' (Partial). Full/LoadingBoundary prefetches are always complete.
     const isResponsePartial =
-      fetchStrategy === FetchStrategy.PPRRuntime && !route.isFullyStatic
+      fetchStrategy === FetchStrategy.PPRRuntime &&
+      completenessMarker === ResponseCompletenessMarker.Partial
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -3003,53 +3013,54 @@ export async function writeInitialSeedDataIntoCache(
 }
 
 /**
- * Checks for and strips the leading marker byte from an RSC response stream.
- * If the first byte is a recognized marker ('~' for partial, '#' for complete),
- * it is stripped. If the first byte is not a recognized marker, the stream is
- * returned intact.
+ * Strips the leading completeness marker byte from an RSC response stream.
  *
- * Returns `isFullyStatic`:
- * - `true` only when the marker is '#' (complete), meaning the server
- *   explicitly marked the response as fully static.
- * - `false` when the marker is '~' (partial), or when no marker is found.
- *   This is the conservative default — unknown means "assume dynamic
- *   follow-up is needed".
+ * The server prepends one of three marker bytes:
+ * - '#' (0x23) = fully static prerender — all segments present.
+ * - '*' (0x2a) = complete runtime prefetch — included segments are complete,
+ *   but the response may not include all segments for the route.
+ * - '~' (0x7e) = partial — contains dynamic holes that need a follow-up.
  *
- * This is safe because the marker bytes (0x7e '~', 0x23 '#') cannot appear as
- * the first byte of a valid RSC Flight response. Flight rows start with either
- * a row ID (a hex character) or ':' (0x3a) for hint and debug chunks. Neither
- * overlaps with the marker bytes.
+ * If the first byte is not a recognized marker, the stream is returned intact
+ * and the response is conservatively treated as partial.
+ *
+ * These marker bytes cannot appear as the first byte of a valid RSC Flight
+ * response. Flight rows start with either a row ID (a hex character) or
+ * ':' (0x3a) for hint and debug chunks. Neither overlaps with the markers.
  */
-export async function stripIsPartialByte(
+export async function stripCompletenessMarker(
   stream: ReadableStream<Uint8Array>
 ): Promise<{
   stream: ReadableStream<Uint8Array>
-  isFullyStatic: boolean
+  completenessMarker: ResponseCompletenessMarker | null
 }> {
   const reader = stream.getReader()
   const { done, value } = await reader.read()
   if (done || !value || value.byteLength === 0) {
     return {
       stream: new ReadableStream({ start: (c) => c.close() }),
-      isFullyStatic: false,
+      completenessMarker: null,
     }
   }
 
   const firstByte = value[0]
-  // '~' (0x7e) = partial, '#' (0x23) = complete
-  const hasMarker = firstByte === 0x7e || firstByte === 0x23
-  // Only '#' (complete) means fully static. Everything else — including
-  // no marker — defaults to not fully static as the conservative choice.
-  const isFullyStatic = firstByte === 0x23
 
-  const remainder = hasMarker
-    ? value.byteLength > 1
-      ? value.subarray(1)
+  const completenessMarker: ResponseCompletenessMarker | null =
+    firstByte === ResponseCompletenessMarker.Static ||
+    firstByte === ResponseCompletenessMarker.Complete ||
+    firstByte === ResponseCompletenessMarker.Partial
+      ? firstByte
       : null
-    : value
+
+  const remainder =
+    completenessMarker !== null
+      ? value.byteLength > 1
+        ? value.subarray(1)
+        : null
+      : value
 
   return {
-    isFullyStatic,
+    completenessMarker,
     stream: new ReadableStream<Uint8Array>({
       start(controller) {
         if (remainder) {

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -31,6 +31,7 @@ import {
   createFromNextReadableStream,
   type RSCResponse,
   type RequestHeaders,
+  type StaticStageData,
 } from '../router-reducer/fetch-server-response'
 import {
   pingPrefetchTask,
@@ -2234,19 +2235,9 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     // Track when the network connection closes.
     const closed = createPromiseWithResolvers<void>()
 
-    let isResponsePartial = false
-    let responseBody = response.body
-    // For runtime prefetches, strip the leading isPartial byte before passing
-    // the stream to Flight.
-    if (fetchStrategy === FetchStrategy.PPRRuntime) {
-      const stripped = await stripIsPartialByte(responseBody)
-      isResponsePartial = stripped.isPartial
-      responseBody = stripped.stream
-    }
-
     let fulfilledEntries: Array<FulfilledSegmentCacheEntry> | null = null
     const prefetchStream = createPrefetchResponseStream(
-      responseBody,
+      response.body,
       closed.resolve,
       function onResponseSizeUpdate(totalBytesReceivedSoFar) {
         // When processing a dynamic response, we don't know how large each
@@ -2263,12 +2254,15 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
         }
       }
     )
-    const serverData =
-      await createFromNextReadableStream<NavigationFlightResponse>(
+
+    const [serverData, cacheData] = await Promise.all([
+      createFromNextReadableStream<NavigationFlightResponse>(
         prefetchStream,
         headers,
         { allowPartialStream: true }
-      )
+      ),
+      response.cacheData,
+    ])
 
     // Read head vary params synchronously. Individual segments carry their
     // own thenables in CacheNodeSeedData.
@@ -2280,6 +2274,11 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
 
     const now = Date.now()
     const staleAt = await getStaleAt(now, serverData.s, response)
+
+    // When cacheData is null (Cache Components disabled), default to false
+    // (non-partial). Full and LoadingBoundary prefetches cannot have holes —
+    // only PPRRuntime prefetches can be partial.
+    const isResponsePartial = cacheData?.isResponsePartial ?? false
 
     // Aside from writing the data into the cache, this function also returns
     // the entries that were fulfilled, so we can streamingly update their sizes
@@ -2295,7 +2294,6 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       route,
       spawnedEntries
     )
-
     // Return a promise that resolves when the network connection closes, so
     // the scheduler can track the number of concurrent network connections.
     return { value: null, closed: closed.promise }
@@ -2486,13 +2484,20 @@ export function writeDynamicRenderResponseIntoCache(
 
     const head = flightData.head
     if (head !== null) {
-      // For head entries, use the head-specific vary params passed as parameter.
+      // The server conservatively marks the head as partial whenever PPR is
+      // enabled, even for fully static pages where the head is actually
+      // complete. When we know the entire response is fully static, we can
+      // safely override this.
+      const isHeadPartial = isResponsePartial && flightData.isHeadPartial
+
       fulfillEntrySpawnedByRuntimePrefetch(
         now,
         fetchStrategy,
         head,
-        flightData.isHeadPartial,
+        isHeadPartial,
         staleAt,
+        // For head entries, use the head-specific vary params passed as
+        // parameter.
         headVaryParams,
         route.metadata,
         spawnedEntries
@@ -2867,48 +2872,48 @@ async function getStaleAt(
 }
 
 type ProcessedStaticStageResponse = {
-  readonly serverData: NavigationFlightResponse
   readonly headVaryParams: VaryParams | null
   readonly staleAt: number
 }
 
 /**
- * Resolves a static stage response promise and computes derived values
- * (stale time, vary params). Callers should `.then()` the result into
- * `writeStaticStageResponseIntoCache`.
+ * Computes derived values (stale time, vary params) from a static stage
+ * response.
  */
 export async function processStaticStageResponse(
   now: number,
-  staticStageResponse: Promise<NavigationFlightResponse>
+  serverData: NavigationFlightResponse
 ): Promise<ProcessedStaticStageResponse> {
-  const serverData = await staticStageResponse
   const staleAt = await getStaleAt(now, serverData.s)
 
   const headVaryParams =
     serverData.h !== null ? readVaryParams(serverData.h) : null
 
-  return { serverData, headVaryParams, staleAt }
+  return { headVaryParams, staleAt }
 }
 
 /**
  * Writes the static stage of a dynamic navigation response into the segment
  * cache.
+ *
+ * When isResponsePartial is false, the response represents a fully static
+ * page — all segments are cached as complete entries that don't need a dynamic
+ * follow-up request. When true, the response contains only the static stage
+ * and segments are marked as partial.
  */
 export function writeStaticStageResponseIntoCache(
   now: number,
-  serverData: NavigationFlightResponse,
+  staticStageData: StaticStageData,
   responseHeaders: Headers,
   headVaryParams: VaryParams | null,
   staleAt: number,
   route: FulfilledRouteCacheEntry
 ): void {
-  // All segments are partial — the static stage needs a dynamic fetch to fill
-  // in runtime/dynamic content within their subtrees.
-  const isResponsePartial = true
+  const { response: serverData, isResponsePartial } = staticStageData
 
-  // The static stage corresponds to the default prefetching strategy for
-  // Cache Components (FetchStrategy.PPR).
-  const fetchStrategy = FetchStrategy.PPR
+  const fetchStrategy = isResponsePartial
+    ? FetchStrategy.PPR
+    : FetchStrategy.Full
 
   writeDynamicRenderResponseIntoCache(
     now,
@@ -2986,34 +2991,44 @@ export async function writeInitialSeedDataIntoCache(
 }
 
 /**
- * Checks for and strips the leading isPartial byte from a runtime prefetch
- * response stream. If the first byte is a recognized marker ('~' for partial,
- * '#' for complete), it is stripped and isPartial is set accordingly. If the
- * first byte is not a recognized marker (e.g. for static responses that were
- * not generated by the runtime prefetch codepath), the stream is returned
- * intact with isPartial set to false.
+ * Checks for and strips the leading marker byte from an RSC response stream.
+ * If the first byte is a recognized marker ('~' for partial, '#' for complete),
+ * it is stripped. If the first byte is not a recognized marker, the stream is
+ * returned intact.
+ *
+ * Returns `isResponsePartial`:
+ * - `true` when the marker is '~' (partial), or when no marker is found.
+ *   This is the conservative default — unknown means "assume dynamic
+ *   follow-up is needed".
+ * - `false` only when the marker is '#' (complete), meaning the server
+ *   explicitly marked the response as fully static.
  *
  * This is safe because the marker bytes (0x7e '~', 0x23 '#') cannot appear as
  * the first byte of a valid RSC Flight response. Flight rows start with either
  * a row ID (a hex character) or ':' (0x3a) for hint and debug chunks. Neither
  * overlaps with the marker bytes.
  */
-async function stripIsPartialByte(
+export async function stripIsPartialByte(
   stream: ReadableStream<Uint8Array>
-): Promise<{ stream: ReadableStream<Uint8Array>; isPartial: boolean }> {
+): Promise<{
+  stream: ReadableStream<Uint8Array>
+  isResponsePartial: boolean
+}> {
   const reader = stream.getReader()
   const { done, value } = await reader.read()
   if (done || !value || value.byteLength === 0) {
     return {
       stream: new ReadableStream({ start: (c) => c.close() }),
-      isPartial: false,
+      isResponsePartial: true,
     }
   }
 
   const firstByte = value[0]
   // '~' (0x7e) = partial, '#' (0x23) = complete
   const hasMarker = firstByte === 0x7e || firstByte === 0x23
-  const isPartial = firstByte === 0x7e
+  // Only '#' (complete) is non-partial. Everything else — including
+  // no marker — defaults to partial as the conservative choice.
+  const isResponsePartial = firstByte !== 0x23
 
   const remainder = hasMarker
     ? value.byteLength > 1
@@ -3022,7 +3037,7 @@ async function stripIsPartialByte(
     : value
 
   return {
-    isPartial,
+    isResponsePartial,
     stream: new ReadableStream<Uint8Array>({
       start(controller) {
         if (remainder) {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -371,7 +371,7 @@ async function navigateToUnknownRoute(
     renderedSearch,
     couldBeIntercepted,
     supportsPerSegmentPrefetching,
-    staticStageResponse,
+    staticStageData,
     responseHeaders,
     debugInfo,
   } = result
@@ -407,12 +407,12 @@ async function navigateToUnknownRoute(
 
     // Write the static stage of the response into the segment cache so
     // that subsequent navigations can serve cached static segments instantly.
-    if (staticStageResponse !== null) {
-      processStaticStageResponse(now, staticStageResponse).then(
-        ({ serverData, headVaryParams, staleAt }) =>
+    if (staticStageData !== null) {
+      processStaticStageResponse(now, staticStageData.response).then(
+        ({ headVaryParams, staleAt }) =>
           writeStaticStageResponseIntoCache(
             now,
-            serverData,
+            staticStageData,
             responseHeaders,
             headVaryParams,
             staleAt,

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -407,7 +407,7 @@ async function navigateToUnknownRoute(
     )
 
     if (staticStageData !== null) {
-      const { response: staticStageResponse, isFullyStatic } = staticStageData
+      const { response: staticStageResponse, completeness } = staticStageData
 
       // Write the static stage of the response into the segment cache so that
       // subsequent navigations can serve cached static segments instantly.
@@ -424,7 +424,7 @@ async function navigateToUnknownRoute(
             staticStageResponse.h,
             staleAt,
             fulfilledRoute,
-            !isFullyStatic
+            completeness
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -14,12 +14,13 @@ import {
   type NavigationRequestAccumulation,
 } from '../router-reducer/ppr-navigations'
 import { createHrefFromUrl } from '../router-reducer/create-href-from-url'
+import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import {
   EntryStatus,
   readRouteCacheEntry,
   deprecated_requestOptimisticRouteCacheEntry,
   convertRootFlightRouterStateToRouteTree,
-  processStaticStageResponse,
+  getStaleAt,
   writeStaticStageResponseIntoCache,
   type RouteTree,
   type FulfilledRouteCacheEntry,
@@ -407,27 +408,33 @@ async function navigateToUnknownRoute(
     )
 
     if (staticStageData !== null) {
+      const { response: staticStageResponse, isFullyStatic } = staticStageData
+
       // Store whether the response is fully static on the route entry. This is
       // checked at navigation read time to skip the dynamic follow-up request.
-      fulfilledRoute.isFullyStatic = staticStageData.isFullyStatic
+      fulfilledRoute.isFullyStatic = isFullyStatic
 
       // Write the static stage of the response into the segment cache so that
       // subsequent navigations can serve cached static segments instantly.
-      processStaticStageResponse(now, staticStageData.response).then(
-        ({ headVaryParams, staleAt }) =>
+      getStaleAt(now, staticStageResponse.s)
+        .then((staleAt) => {
+          const buildId =
+            responseHeaders.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
+            staticStageResponse.b
+
           writeStaticStageResponseIntoCache(
             now,
-            staticStageData.response,
-            responseHeaders,
-            headVaryParams,
+            staticStageResponse.f,
+            buildId,
+            staticStageResponse.h,
             staleAt,
             fulfilledRoute
-          ),
-        () => {
+          )
+        })
+        .catch(() => {
           // The static stage processing failed. Not fatal — the navigation
           // completed normally, we just won't write into the cache.
-        }
-      )
+        })
     }
   }
 

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -204,8 +204,7 @@ export function navigateToKnownRoute(
     navigationSeed.data,
     navigationSeed.head,
     isSamePageNavigation,
-    accumulation,
-    routeCacheEntry?.isFullyStatic ?? false
+    accumulation
   )
   if (task !== null) {
     if (freshnessPolicy !== FreshnessPolicy.Gesture) {
@@ -410,10 +409,6 @@ async function navigateToUnknownRoute(
     if (staticStageData !== null) {
       const { response: staticStageResponse, isFullyStatic } = staticStageData
 
-      // Store whether the response is fully static on the route entry. This is
-      // checked at navigation read time to skip the dynamic follow-up request.
-      fulfilledRoute.isFullyStatic = isFullyStatic
-
       // Write the static stage of the response into the segment cache so that
       // subsequent navigations can serve cached static segments instantly.
       getStaleAt(now, staticStageResponse.s)
@@ -428,7 +423,8 @@ async function navigateToUnknownRoute(
             buildId,
             staticStageResponse.h,
             staleAt,
-            fulfilledRoute
+            fulfilledRoute,
+            !isFullyStatic
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -407,7 +407,8 @@ async function navigateToUnknownRoute(
     )
 
     if (staticStageData !== null) {
-      const { response: staticStageResponse, completeness } = staticStageData
+      const { response: staticStageResponse, isResponsePartial } =
+        staticStageData
 
       // Write the static stage of the response into the segment cache so that
       // subsequent navigations can serve cached static segments instantly.
@@ -424,7 +425,7 @@ async function navigateToUnknownRoute(
             staticStageResponse.h,
             staleAt,
             fulfilledRoute,
-            completeness
+            isResponsePartial
           )
         })
         .catch(() => {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -393,7 +393,7 @@ async function navigateToUnknownRoute(
   // retrying after a tree mismatch (see dispatchRetryDueToTreeMismatch).
   const metadataVaryPath = navigationSeed.metadataVaryPath
   if (metadataVaryPath !== null) {
-    const fulfilledRoute = discoverKnownRoute(
+    discoverKnownRoute(
       now,
       url.pathname,
       nextUrl,
@@ -424,7 +424,8 @@ async function navigateToUnknownRoute(
             buildId,
             staticStageResponse.h,
             staleAt,
-            fulfilledRoute,
+            currentFlightRouterState,
+            renderedSearch,
             isResponsePartial
           )
         })

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -417,7 +417,7 @@ async function navigateToUnknownRoute(
         ({ headVaryParams, staleAt }) =>
           writeStaticStageResponseIntoCache(
             now,
-            staticStageData,
+            staticStageData.response,
             responseHeaders,
             headVaryParams,
             staleAt,

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -203,7 +203,8 @@ export function navigateToKnownRoute(
     navigationSeed.data,
     navigationSeed.head,
     isSamePageNavigation,
-    accumulation
+    accumulation,
+    routeCacheEntry?.isFullyStatic ?? false
   )
   if (task !== null) {
     if (freshnessPolicy !== FreshnessPolicy.Gesture) {
@@ -405,9 +406,13 @@ async function navigateToUnknownRoute(
       false // hasDynamicRewrite - not a retry, rewrite detection happens during traversal
     )
 
-    // Write the static stage of the response into the segment cache so
-    // that subsequent navigations can serve cached static segments instantly.
     if (staticStageData !== null) {
+      // Store whether the response is fully static on the route entry. This is
+      // checked at navigation read time to skip the dynamic follow-up request.
+      fulfilledRoute.isFullyStatic = staticStageData.isFullyStatic
+
+      // Write the static stage of the response into the segment cache so that
+      // subsequent navigations can serve cached static segments instantly.
       processStaticStageResponse(now, staticStageData.response).then(
         ({ headVaryParams, staleAt }) =>
           writeStaticStageResponseIntoCache(

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -558,6 +558,7 @@ export function matchKnownRoute(
     metadata: reifiedMetadata,
     couldBeIntercepted: pattern.couldBeIntercepted,
     supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
+    isFullyStatic: false,
     hasDynamicRewrite: false,
     renderedSearch: search,
     ref: null,

--- a/packages/next/src/client/components/segment-cache/optimistic-routes.ts
+++ b/packages/next/src/client/components/segment-cache/optimistic-routes.ts
@@ -558,7 +558,6 @@ export function matchKnownRoute(
     metadata: reifiedMetadata,
     couldBeIntercepted: pattern.couldBeIntercepted,
     supportsPerSegmentPrefetching: pattern.supportsPerSegmentPrefetching,
-    isFullyStatic: false,
     hasDynamicRewrite: false,
     renderedSearch: search,
     ref: null,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -12,7 +12,6 @@ import type {
   InitialRSCPayload,
   FlightDataPath,
 } from '../../shared/lib/app-router-types'
-import { ResponseCompletenessMarker } from '../../shared/lib/app-router-types'
 import type { Readable } from 'node:stream'
 import {
   workAsyncStorage,
@@ -1314,14 +1313,20 @@ async function prospectiveRuntimeServerPrerender(
   }
 }
 
-function prependCompletenessMarker(
+/**
+ * Prepends a single ASCII byte to the stream indicating whether the response
+ * is partial (contains dynamic holes): '~' (0x7e) for partial, '#' (0x23)
+ * for complete.
+ */
+function prependIsPartialByte(
   stream: ReadableStream<Uint8Array>,
-  completenessMarker: ResponseCompletenessMarker
+  isPartial: boolean
 ): ReadableStream<Uint8Array> {
+  const byte = new Uint8Array([isPartial ? 0x7e : 0x23])
   return stream.pipeThrough(
     new TransformStream({
       start(controller) {
-        controller.enqueue(new Uint8Array([completenessMarker]))
+        controller.enqueue(byte)
       },
     })
   )
@@ -1451,12 +1456,7 @@ async function finalRuntimeServerPrerender(
     }
   )
 
-  result.prelude = prependCompletenessMarker(
-    result.prelude,
-    serverIsDynamic
-      ? ResponseCompletenessMarker.Partial
-      : ResponseCompletenessMarker.Complete
-  )
+  result.prelude = prependIsPartialByte(result.prelude, serverIsDynamic)
 
   return {
     result,
@@ -5371,12 +5371,7 @@ async function prerenderToStream(
       })
 
       metadata.flightData = await streamToBuffer(
-        prependCompletenessMarker(
-          reactServerResult.asStream(),
-          serverIsDynamic
-            ? ResponseCompletenessMarker.Partial
-            : ResponseCompletenessMarker.Static
-        )
+        prependIsPartialByte(reactServerResult.asStream(), serverIsDynamic)
       )
 
       // collectSegmentData needs the raw flight data without the marker byte.

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1828,6 +1828,8 @@ function App<T>({
     initialRenderedSearch: response.q,
     initialCouldBeIntercepted: response.i,
     initialSupportsPerSegmentPrefetching: response.S,
+    initialStaleTime: undefined,
+    initialHeadVaryParams: null,
     // location is not initialized in the SSR render
     // it's set to window.location during hydration
     location: null,
@@ -1893,6 +1895,8 @@ function ErrorApp<T>({
     initialRenderedSearch: response.q,
     initialCouldBeIntercepted: response.i,
     initialSupportsPerSegmentPrefetching: response.S,
+    initialStaleTime: undefined,
+    initialHeadVaryParams: null,
     // location is not initialized in the SSR render
     // it's set to window.location during hydration
     location: null,
@@ -5139,6 +5143,9 @@ async function prerenderToStream(
         res.statusCode === 404
       )
 
+      const staleTimeIterable = new StaleTimeIterable()
+      finalAttemptRSCPayload.s = staleTimeIterable
+
       const serverDynamicTracking = createDynamicTrackingState(
         isDebugDynamicAccesses
       )
@@ -5166,6 +5173,12 @@ async function prerenderToStream(
         varyParamsAccumulator,
       })
 
+      trackStaleTime(
+        finalServerPrerenderStore,
+        staleTimeIterable,
+        selectStaleTime
+      )
+
       let prerenderIsPending = true
       const finalRSCPrerenderOptions = {
         filterStackFrame,
@@ -5175,18 +5188,20 @@ async function prerenderToStream(
         signal: finalServerReactController.signal,
       }
       const finalRSCAbortCallback = async () => {
-        // Now that the prerendering is complete, we know which vary
-        // params were used to compute the response. Resolve the vary
-        // params thenable so it can be sent to the client. The timing
-        // here is important: the thenable was included in the Flight
-        // payload, but it can only be serialized at the very end, after
-        // all the components have finished.
+        // Now that the prerendering is complete, we know the final stale
+        // time and vary params. Close the stale time iterable and resolve
+        // the vary params thenable so Flight can serialize their values
+        // into the stream. The timing here is important: both were
+        // included in the Flight payload, but they can only be serialized
+        // at the very end, after all the components have finished.
         //
-        // We resolve the accumulator directly here instead of reading from
-        // the work unit store because this callback runs in a separate
-        // task (via setTimeout) and may not have access to the async
-        // storage context.
-        await finishAccumulatingVaryParams(varyParamsAccumulator)
+        // We resolve these directly here instead of reading from the work
+        // unit store because this callback runs in a separate task (via
+        // setTimeout) and may not have access to the async storage context.
+        await Promise.all([
+          finishStaleTimeTracking(staleTimeIterable),
+          finishAccumulatingVaryParams(varyParamsAccumulator),
+        ])
 
         if (finalServerReactController.signal.aborted) {
           // If the server controller is already aborted we must have called something

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5372,7 +5372,8 @@ async function prerenderToStream(
       })
 
       const flightData = await streamToBuffer(reactServerResult.asStream())
-      metadata.flightData = flightData
+      const isPartialMarker = Buffer.from([serverIsDynamic ? 0x7e : 0x23])
+      metadata.flightData = Buffer.concat([isPartialMarker, flightData])
       metadata.segmentData = await collectSegmentData(
         flightData,
         finalServerPrerenderStore,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -12,6 +12,7 @@ import type {
   InitialRSCPayload,
   FlightDataPath,
 } from '../../shared/lib/app-router-types'
+import { ResponseCompletenessMarker } from '../../shared/lib/app-router-types'
 import type { Readable } from 'node:stream'
 import {
   workAsyncStorage,
@@ -1313,20 +1314,14 @@ async function prospectiveRuntimeServerPrerender(
   }
 }
 
-/**
- * Prepends a single ASCII byte to the stream indicating whether the response
- * is partial (contains dynamic holes): '~' (0x7e) for partial, '#' (0x23)
- * for complete.
- */
-function prependIsPartialByte(
+function prependCompletenessMarker(
   stream: ReadableStream<Uint8Array>,
-  isPartial: boolean
+  completenessMarker: ResponseCompletenessMarker
 ): ReadableStream<Uint8Array> {
-  const byte = new Uint8Array([isPartial ? 0x7e : 0x23])
   return stream.pipeThrough(
     new TransformStream({
       start(controller) {
-        controller.enqueue(byte)
+        controller.enqueue(new Uint8Array([completenessMarker]))
       },
     })
   )
@@ -1456,8 +1451,12 @@ async function finalRuntimeServerPrerender(
     }
   )
 
-  // Prepend a byte indicating whether the response contains dynamic holes.
-  result.prelude = prependIsPartialByte(result.prelude, serverIsDynamic)
+  result.prelude = prependCompletenessMarker(
+    result.prelude,
+    serverIsDynamic
+      ? ResponseCompletenessMarker.Partial
+      : ResponseCompletenessMarker.Complete
+  )
 
   return {
     result,
@@ -5371,9 +5370,17 @@ async function prerenderToStream(
         tracingMetadata: tracingMetadata,
       })
 
-      const flightData = await streamToBuffer(reactServerResult.asStream())
-      const isPartialMarker = Buffer.from([serverIsDynamic ? 0x7e : 0x23])
-      metadata.flightData = Buffer.concat([isPartialMarker, flightData])
+      metadata.flightData = await streamToBuffer(
+        prependCompletenessMarker(
+          reactServerResult.asStream(),
+          serverIsDynamic
+            ? ResponseCompletenessMarker.Partial
+            : ResponseCompletenessMarker.Static
+        )
+      )
+
+      // collectSegmentData needs the raw flight data without the marker byte.
+      const flightData = metadata.flightData.subarray(1)
       metadata.segmentData = await collectSegmentData(
         flightData,
         finalServerPrerenderStore,

--- a/packages/next/src/server/app-render/stale-time.ts
+++ b/packages/next/src/server/app-render/stale-time.ts
@@ -14,6 +14,7 @@ import { INFINITE_CACHE } from '../../lib/constants'
 export class StaleTimeIterable {
   private _resolve: ((result: IteratorResult<number>) => void) | null = null
   private _done = false
+  private _buffer: number[] = []
 
   /** The last value passed to `update()`. */
   public currentValue: number = 0
@@ -24,6 +25,8 @@ export class StaleTimeIterable {
     if (this._resolve) {
       this._resolve({ value, done: false })
       this._resolve = null
+    } else {
+      this._buffer.push(value)
     }
   }
 
@@ -39,6 +42,9 @@ export class StaleTimeIterable {
   [Symbol.asyncIterator](): AsyncIterator<number> {
     return {
       next: () => {
+        if (this._buffer.length > 0) {
+          return Promise.resolve({ value: this._buffer.shift()!, done: false })
+        }
         if (this._done) {
           return Promise.resolve({ value: undefined, done: true })
         }

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -262,6 +262,8 @@ export type InitialRSCPayload = {
    * headVaryParams - vary params for the head (metadata) of the response.
    */
   h: VaryParamsThenable | null
+  /** staleTime in seconds - Only present when Cache Components is enabled. */
+  s?: AsyncIterable<number>
 }
 
 // Response from `createFromFetch` for normal rendering

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -169,25 +169,6 @@ export const enum PrefetchHint {
 }
 
 /**
- * Completeness markers prepended to RSC Flight streams/buffers by the server
- * and stripped by the client before Flight decoding.
- *
- * These byte values cannot appear as the first byte of a valid RSC Flight
- * response. Flight rows start with either a row ID (a hex character) or
- * ':' (0x3a) for hint and debug chunks. Neither overlaps with the markers.
- */
-export const enum ResponseCompletenessMarker {
-  /** '#' — fully static prerender. All segments present; safe to skip
-   *  dynamic follow-up entirely. */
-  Static = 0x23,
-  /** '*' — complete runtime prefetch. Included segments are complete, but
-   *  the response may not include all segments for the route. */
-  Complete = 0x2a,
-  /** '~' — partial. Contains dynamic holes that need a follow-up. */
-  Partial = 0x7e,
-}
-
-/**
  * Individual Flight response path
  */
 export type FlightSegmentPath =

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -169,6 +169,25 @@ export const enum PrefetchHint {
 }
 
 /**
+ * Completeness markers prepended to RSC Flight streams/buffers by the server
+ * and stripped by the client before Flight decoding.
+ *
+ * These byte values cannot appear as the first byte of a valid RSC Flight
+ * response. Flight rows start with either a row ID (a hex character) or
+ * ':' (0x3a) for hint and debug chunks. Neither overlaps with the markers.
+ */
+export const enum ResponseCompletenessMarker {
+  /** '#' — fully static prerender. All segments present; safe to skip
+   *  dynamic follow-up entirely. */
+  Static = 0x23,
+  /** '*' — complete runtime prefetch. Included segments are complete, but
+   *  the response may not include all segments for the route. */
+  Complete = 0x2a,
+  /** '~' — partial. Contains dynamic holes that need a follow-up. */
+  Partial = 0x7e,
+}
+
+/**
  * Individual Flight response path
  */
 export type FlightSegmentPath =

--- a/test/e2e/app-dir/segment-cache/cached-navigations/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/app/layout.tsx
@@ -6,7 +6,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html>
       <body>
         <nav>
-          <Link href="/">Home</Link>
+          <Link href="/" prefetch={false}>
+            Home
+          </Link>
         </nav>
         {children}
       </body>

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -147,42 +147,38 @@ describe('cached navigations', () => {
     )
   })
 
-  // TODO: To be implemented.
-  it.failing(
-    'serves a fully static page without any requests on the second navigation',
-    async () => {
-      let page: Playwright.Page
-      const browser = await next.browser('/', {
-        beforePageLoad(p: Playwright.Page) {
-          page = p
-        },
-      })
-      const act = createRouterAct(page)
+  it('serves a fully static page without any requests on the second navigation', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
 
-      // First navigation — full request, no prefetch
-      await act(
-        async () => {
-          await browser.elementByCss('a[href="/fully-static"]').click()
-        },
-        { includes: 'Cached content' }
-      )
-      expect(await browser.elementById('cached-content').text()).toContain(
-        'Cached content'
-      )
-
-      // Navigate back to home
-      await browser.back()
-      expect(await browser.elementByCss('h1').text()).toBe('Home')
-
-      // Second navigation — fully cached, should not issue any requests
-      await act(async () => {
+    // First navigation — full request, no prefetch
+    await act(
+      async () => {
         await browser.elementByCss('a[href="/fully-static"]').click()
-      }, 'no-requests')
-      expect(await browser.elementById('cached-content').text()).toContain(
-        'Cached content'
-      )
-    }
-  )
+      },
+      { includes: 'Cached content' }
+    )
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+
+    // Navigate back to home
+    await browser.back()
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    // Second navigation — fully cached, should not issue any requests
+    await act(async () => {
+      await browser.elementByCss('a[href="/fully-static"]').click()
+    }, 'no-requests')
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+  })
 
   it('caches static segments when navigating to a known route without a prefetch', async () => {
     let page: Playwright.Page
@@ -443,13 +439,9 @@ describe('cached navigations', () => {
     )
 
     // Navigate back to home again
-    await act(
-      async () => {
-        await browser.elementByCss('a[href="/"]').click()
-      },
-      // TODO: Should be `no-requests` when fully static pages are handled.
-      { includes: 'Home' }
-    )
+    await act(async () => {
+      await browser.elementByCss('a[href="/"]').click()
+    }, 'no-requests')
     expect(await browser.elementByCss('h1').text()).toBe('Home')
 
     // Fast-forward past the stale time (120s from cacheLife({ stale: 120 })).

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -15,12 +15,12 @@ describe('cached navigations', () => {
   it('serves cached static segments instantly on the second navigation', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
-      beforePageLoad(p: Playwright.Page) {
+      async beforePageLoad(p: Playwright.Page) {
         page = p
+        await page.clock.install()
       },
     })
     const act = createRouterAct(page)
-    await page.clock.install()
 
     // First navigation — full dynamic request, no prefetch
     await act(
@@ -187,12 +187,12 @@ describe('cached navigations', () => {
   it('caches static segments when navigating to a known route without a prefetch', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
-      beforePageLoad(p: Playwright.Page) {
+      async beforePageLoad(p: Playwright.Page) {
         page = p
+        await page.clock.install()
       },
     })
     const act = createRouterAct(page)
-    await page.clock.install()
 
     // First navigation — seeds the route cache (stale after 5 min) and
     // segment cache (stale after 120s, from cacheLife({ stale: 120 })).
@@ -280,12 +280,12 @@ describe('cached navigations', () => {
   it('includes static params in the cached static stage', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
-      beforePageLoad(p: Playwright.Page) {
+      async beforePageLoad(p: Playwright.Page) {
         page = p
+        await page.clock.install()
       },
     })
     const act = createRouterAct(page)
-    await page.clock.install()
 
     // First navigation
     await act(
@@ -340,12 +340,12 @@ describe('cached navigations', () => {
   it('defers fallback params to the runtime stage', async () => {
     let page: Playwright.Page
     const browser = await next.browser('/', {
-      beforePageLoad(p: Playwright.Page) {
+      async beforePageLoad(p: Playwright.Page) {
         page = p
+        await page.clock.install()
       },
     })
     const act = createRouterAct(page)
-    await page.clock.install()
 
     // First navigation — "foo" is not in generateStaticParams, so it's a
     // fallback param
@@ -412,22 +412,25 @@ describe('cached navigations', () => {
     // navigation. The RSC payload is inlined in the HTML and contains only
     // static (cached) content.
     const browser = await next.browser('/fully-static', {
-      beforePageLoad(p: Playwright.Page) {
+      async beforePageLoad(p: Playwright.Page) {
         page = p
+        await page.clock.install()
       },
     })
     const act = createRouterAct(page)
-    await page.clock.install()
 
     // Verify the page rendered fully via HTML
     expect(await browser.elementById('cached-content').text()).toContain(
       'Cached content'
     )
 
-    // Navigate to home (no server requests — home is in the BFCache)
-    await act(async () => {
-      await browser.elementByCss('a[href="/"]').click()
-    }, 'no-requests')
+    // Navigate to home
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/"]').click()
+      },
+      { includes: 'Home' }
+    )
     expect(await browser.elementByCss('h1').text()).toBe('Home')
 
     // Navigate back to /fully-static. Since it was fully static and cached
@@ -440,9 +443,13 @@ describe('cached navigations', () => {
     )
 
     // Navigate back to home again
-    await act(async () => {
-      await browser.elementByCss('a[href="/"]').click()
-    }, 'no-requests')
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/"]').click()
+      },
+      // TODO: Should be `no-requests` when fully static pages are handled.
+      { includes: 'Home' }
+    )
     expect(await browser.elementByCss('h1').text()).toBe('Home')
 
     // Fast-forward past the stale time (120s from cacheLife({ stale: 120 })).

--- a/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
+++ b/test/e2e/app-dir/segment-cache/cached-navigations/cached-navigations.test.ts
@@ -405,4 +405,62 @@ describe('cached navigations', () => {
       'Dynamic content'
     )
   })
+
+  it('caches a fully static page from the initial HTML for subsequent navigations', async () => {
+    let page: Playwright.Page
+    // Start directly at /fully-static — full HTML load, not a client-side
+    // navigation. The RSC payload is inlined in the HTML and contains only
+    // static (cached) content.
+    const browser = await next.browser('/fully-static', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+    await page.clock.install()
+
+    // Verify the page rendered fully via HTML
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+
+    // Navigate to home (no server requests — home is in the BFCache)
+    await act(async () => {
+      await browser.elementByCss('a[href="/"]').click()
+    }, 'no-requests')
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    // Navigate back to /fully-static. Since it was fully static and cached
+    // during the initial HTML load, no server requests should be needed.
+    await act(async () => {
+      await browser.elementByCss('a[href="/fully-static"]').click()
+    }, 'no-requests')
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+
+    // Navigate back to home again
+    await act(async () => {
+      await browser.elementByCss('a[href="/"]').click()
+    }, 'no-requests')
+    expect(await browser.elementByCss('h1').text()).toBe('Home')
+
+    // Fast-forward past the stale time (120s from cacheLife({ stale: 120 })).
+    // Using 180s to stay well under the 300s default — if we accidentally
+    // used the default instead of the collected stale time, this would
+    // not expire and the test would fail.
+    await page.clock.fastForward(180_000)
+
+    // Navigate to /fully-static again — cache is stale, so a server
+    // request should be required.
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/fully-static"]').click()
+      },
+      { includes: 'Cached content' }
+    )
+    expect(await browser.elementById('cached-content').text()).toContain(
+      'Cached content'
+    )
+  })
 })

--- a/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
+++ b/test/e2e/app-dir/segment-cache/refresh/segment-cache-refresh.test.ts
@@ -138,4 +138,54 @@ describe('segment cache (refresh)', () => {
       expect(await docsPage.textContent()).toBe('Static docs page')
     }, 'no-requests')
   })
+
+  it('re-navigation to a fully static page does not overwrite dynamic slots with default content', async () => {
+    // Load the main Dashboard page. The @navbar slot renders dynamic content
+    // (connection() + randomUUID()), but the @main slot is static.
+    let page: Playwright.Page
+    const browser = await next.browser('/dashboard', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Navigate to the Analytics page. This is a fully static page (both the
+    // @main/analytics slot and the @navbar/default slot are static), so the
+    // server responds with a Static completeness marker. The client writes
+    // all segments into the segment cache.
+    await act(async () => {
+      const toggleAnalyticsLink = await browser.elementByCss(
+        'input[data-link-accordion="/dashboard/analytics"]'
+      )
+      await toggleAnalyticsLink.click()
+      const link = await browser.elementByCss('a[href="/dashboard/analytics"]')
+      await link.click()
+    })
+
+    // Navigate back to the Dashboard page.
+    await act(async () => {
+      const toggleDashboardLink = await browser.elementByCss(
+        'input[data-link-accordion="/dashboard"]'
+      )
+      await toggleDashboardLink.click()
+      const link = await browser.elementByCss('a[href="/dashboard"]')
+      await link.click()
+    })
+
+    // Navigate to the Analytics page again. Since it's fully static and was
+    // already visited, this should be served entirely from the segment cache
+    // without any server requests.
+    await act(async () => {
+      const link = await browser.elementByCss('a[href="/dashboard/analytics"]')
+      await link.click()
+    }, 'no-requests')
+
+    // Verify the navbar still shows the dynamic content from the original
+    // /dashboard render, not the static @navbar/default.tsx content.
+    const navbarDynamicRenderCounter = await browser.elementById(
+      'navbar-dynamic-render-counter'
+    )
+    expect(await navbarDynamicRenderCounter.textContent()).toBe('0')
+  })
 })


### PR DESCRIPTION
When a fully static page is loaded (via initial HTML or client-side navigation), the segments are now written into the segment cache so subsequent navigations can be served entirely from cache without server requests.

Initial HTML: The RSC payload inlined in the HTML is written during hydration via `getStaleAt` + `writeStaticStageResponseIntoCache` with `isResponsePartial: false`, using `FetchStrategy.Full` since all segments are present. A `StaleTimeIterable` (`s` field) is included in the `InitialRSCPayload` during the Cache Components prerender path to provide the stale time.

Navigation: The `isResponsePartial` flag from the prepended byte (stripped by `processFetch`) is now also used to determine how segments from `writeStaticStageResponseIntoCache` are cached. For fully static routes (`isResponsePartial: false`), segments are written as non-partial so no dynamic follow-up is needed.

The route tree used for cache writes is now always derived from the Flight data itself (via `convertServerPatchToFullTree`), rather than from a pre-existing route cache entry. This guarantees the tree stays in sync with the response and avoids key mismatches between the static stage tree and the per-segment prefetch tree for parallel route slots.

When writing the head into the cache, `isHeadPartial` from the server is overridden to `false` for non-partial responses, but only when Cache Components is enabled. This corrects the server's conservative `isPossiblyPartialHead` marking during static generation. Without Cache Components, the server already sends the correct value. Responses without a recognized marker byte (e.g. regular navigations that don't go through the prerender path) are conservatively treated as partial.

Partially static pages (where the static stage needs to be extracted via byte-level truncation of the initial HTML Flight stream) will be handled in a follow-up.