### PR TITLE
Enable `experimental.reactDebugChannel` by default

### DIFF
--- a/.claude/commands/pr-status.md
+++ b/.claude/commands/pr-status.md
@@ -99,7 +99,7 @@ Analyze PR status including CI failures and review comments.
    - `IS_WEBPACK_TEST=1` forces webpack (turbopack is default locally)
    - `NEXT_SKIP_ISOLATE=1` skips packing next.js into a separate project (hides module resolution failures)
    - Feature flags like `__NEXT_USE_NODE_STREAMS=true`, `__NEXT_CACHE_COMPONENTS=true` change build-time DefinePlugin replacements
-   - Example: a failure in "test node streams prod" needs `IS_WEBPACK_TEST=1 __NEXT_USE_NODE_STREAMS=true __NEXT_CACHE_COMPONENTS=true __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true NEXT_TEST_MODE=start`
+   - Example: a failure in "test node streams prod" needs `IS_WEBPACK_TEST=1 __NEXT_USE_NODE_STREAMS=true __NEXT_CACHE_COMPONENTS=true NEXT_TEST_MODE=start`
    - Never use `NEXT_SKIP_ISOLATE=1` when verifying module resolution or build-time compilation fixes
 
 9. The script automatically checks the last 3 main branch CI runs for known flaky tests. Check the **"Known Flaky Tests"** section in index.md and the `flaky-tests.json` file. Tests listed there also fail on main and are likely pre-existing flakes, not caused by the PR. Mark them as **FLAKY (pre-existing)** in your summary table. Use `--skip-flaky-check` to skip this step if it's too slow.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -707,7 +707,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
-        export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json,test/cache-components-tests-manifest.json"
         export NEXT_E2E_TEST_TIMEOUT=240000
         export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }}
@@ -948,7 +947,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
-        export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export IS_WEBPACK_TEST=1
 
@@ -972,7 +970,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
-        export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=dev
         export IS_WEBPACK_TEST=1
@@ -998,7 +995,6 @@ jobs:
       afterBuild: |
         export __NEXT_CACHE_COMPONENTS=true
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
-        export __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/cache-components-tests-manifest.json"
         export NEXT_TEST_MODE=start
         export IS_WEBPACK_TEST=1

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "with-rspack": "cross-env NEXT_RSPACK=1 NEXT_TEST_USE_RSPACK=1",
     "with-turbo": "cross-env IS_TURBOPACK_TEST=1",
     "with-webpack": "cross-env IS_WEBPACK_TEST=1",
-    "with-experimental": "cross-env __NEXT_CACHE_COMPONENTS=true __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true __NEXT_EXPERIMENTAL_DEBUG_CHANNEL=true"
+    "with-experimental": "cross-env __NEXT_CACHE_COMPONENTS=true __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true"
   },
   "devDependencies": {
     "@actions/core": "1.10.1",

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1692,7 +1692,7 @@ export const defaultConfig = Object.freeze({
       static: 300,
     },
     allowDevelopmentBuild: undefined,
-    reactDebugChannel: false,
+    reactDebugChannel: true,
     staticGenerationRetryCount: undefined,
     serverComponentsHmrCache: true,
     staticGenerationMaxConcurrency: 8,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -1932,25 +1932,6 @@ function enforceExperimentalFeatures(
     }
   }
 
-  // TODO: Remove this once using the debug channel is the default.
-  if (
-    process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL === 'true' &&
-    // We do respect an explicit value in the user config.
-    (config.experimental.reactDebugChannel === undefined ||
-      (isDefaultConfig && !config.experimental.reactDebugChannel))
-  ) {
-    config.experimental.reactDebugChannel = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'reactDebugChannel',
-        true,
-        'enabled by `__NEXT_EXPERIMENTAL_DEBUG_CHANNEL`'
-      )
-    }
-  }
-
   // TODO: Remove this once strictRouteTypes is the default.
   if (
     process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true' &&

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -343,7 +343,7 @@ describe(`Terminal Logging (${bundlerName})`, () => {
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>
                        <RedirectBoundary>
                          <RedirectErrorBoundary router={{...}}>
-                           <InnerLayoutRouter url="/hydration..." tree={[...]} params={{}} cacheNode={{rsc:<Fragment>, ...}} ...>
+                           <InnerLayoutRouter url="/hydration..." tree={[...]} params={{}} cacheNode={{rsc:{...}, ...}} ...>
                              <SegmentViewNode type="page" pagePath="hydration-...">
                                <SegmentTrieNode>
                                <ClientPageRoot Component={function Page} serverProvidedParams={{...}}>

--- a/test/e2e/legacy-link-behavior/app/about/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/about/page.tsx
@@ -5,7 +5,7 @@ export default function Page() {
     <>
       <h1 id="about-page">About Page</h1>
       <Link href="/" legacyBehavior>
-        <a>Home</a>
+        Home
       </Link>
     </>
   )

--- a/test/e2e/legacy-link-behavior/app/page.tsx
+++ b/test/e2e/legacy-link-behavior/app/page.tsx
@@ -5,7 +5,7 @@ export default function Page() {
     <>
       <h1>Home Page</h1>
       <Link href="/about" legacyBehavior>
-        <a>About</a>
+        About
       </Link>
     </>
   )

--- a/test/e2e/legacy-link-behavior/index.test.ts
+++ b/test/e2e/legacy-link-behavior/index.test.ts
@@ -2,11 +2,6 @@ import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
 describe('Link with legacyBehavior', () => {
-  if (process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL) {
-    it('should skip debug mode test', () => {})
-    return
-  }
-
   const { next, isNextDev, skipped } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,

--- a/test/e2e/legacy-link-behavior/validations.console.test.ts
+++ b/test/e2e/legacy-link-behavior/validations.console.test.ts
@@ -114,31 +114,29 @@ describe('Validations for <Link legacyBehavior>', () => {
         }
       })
 
-      if (!process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL) {
-        it('does not warn or throw if you pass a client component', async () => {
-          const browser = await next.browser(
-            '/validations/rsc-that-renders-link/client'
-          )
+      it('does not warn or throw if you pass a client component', async () => {
+        const browser = await next.browser(
+          '/validations/rsc-that-renders-link/client'
+        )
 
-          if (isNextDev) {
-            await waitForNoRedbox(browser)
-          } else {
-            expect(newConsoleOutput()).toEqual('')
-          }
-        })
+        if (isNextDev) {
+          await waitForNoRedbox(browser)
+        } else {
+          expect(newConsoleOutput()).toEqual('')
+        }
+      })
 
-        it('does not warn or throw if you pass a server component into a client component', async () => {
-          const browser = await next.browser(
-            '/validations/rsc-that-renders-link/client-with-rsc-child'
-          )
+      it('does not warn or throw if you pass a server component into a client component', async () => {
+        const browser = await next.browser(
+          '/validations/rsc-that-renders-link/client-with-rsc-child'
+        )
 
-          if (isNextDev) {
-            await waitForNoRedbox(browser)
-          } else {
-            expect(newConsoleOutput()).toEqual('')
-          }
-        })
-      }
+        if (isNextDev) {
+          await waitForNoRedbox(browser)
+        } else {
+          expect(newConsoleOutput()).toEqual('')
+        }
+      })
 
       it('warns if the child is a lazy component', async () => {
         const browser = await next.browser(
@@ -233,31 +231,29 @@ describe('Validations for <Link legacyBehavior>', () => {
         }
       })
 
-      if (!process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL) {
-        it('does not warn or throw if you pass a client component', async () => {
-          const browser = await next.browser(
-            '/validations/rsc-that-renders-client/client'
-          )
+      it('does not warn or throw if you pass a client component', async () => {
+        const browser = await next.browser(
+          '/validations/rsc-that-renders-client/client'
+        )
 
-          if (isNextDev) {
-            await waitForNoRedbox(browser)
-          } else {
-            expect(newConsoleOutput()).toEqual('')
-          }
-        })
+        if (isNextDev) {
+          await waitForNoRedbox(browser)
+        } else {
+          expect(newConsoleOutput()).toEqual('')
+        }
+      })
 
-        it('does not warn or throw if you pass a server component into a client component', async () => {
-          const browser = await next.browser(
-            '/validations/rsc-that-renders-client/client-with-rsc-child'
-          )
+      it('does not warn or throw if you pass a server component into a client component', async () => {
+        const browser = await next.browser(
+          '/validations/rsc-that-renders-client/client-with-rsc-child'
+        )
 
-          if (isNextDev) {
-            await waitForNoRedbox(browser)
-          } else {
-            expect(newConsoleOutput()).toEqual('')
-          }
-        })
-      }
+        if (isNextDev) {
+          await waitForNoRedbox(browser)
+        } else {
+          expect(newConsoleOutput()).toEqual('')
+        }
+      })
     })
   })
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -447,9 +447,7 @@ export class NextInstance {
           if (process.env.NEXT_PRIVATE_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER) {
             process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER = process.env.NEXT_PRIVATE_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER
           }
-          if (process.env.NEXT_PRIVATE_EXPERIMENTAL_DEBUG_CHANNEL) {
-            process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL = process.env.NEXT_PRIVATE_EXPERIMENTAL_DEBUG_CHANNEL
-          }
+
         `
           )
 

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -312,12 +312,6 @@ export class NextDeployInstance extends NextInstance {
         `NEXT_PRIVATE_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=${process.env.__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER}`
       )
     }
-    if (process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL) {
-      additionalEnv.push(
-        `NEXT_PRIVATE_EXPERIMENTAL_DEBUG_CHANNEL=${process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL}`
-      )
-    }
-
     if (process.env.IS_TURBOPACK_TEST) {
       additionalEnv.push(`IS_TURBOPACK_TEST=1`)
     }

--- a/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
+++ b/test/production/app-dir/build-output-prerender/build-output-prerender.test.ts
@@ -21,24 +21,21 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)"
             `)
           }
         } else {
@@ -119,7 +116,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
@@ -132,7 +128,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -145,7 +140,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -271,24 +265,21 @@ describe('build-output-prerender', () => {
              "▲ Next.js x.y.z (Turbopack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)"
             `)
           } else if (isRspack) {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (Rspack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)"
             `)
           } else {
             expect(getPreambleOutput(next.cliOutput)).toMatchInlineSnapshot(`
              "▲ Next.js x.y.z (webpack)
              - Cache Components enabled
              - Experiments (use with caution):
-               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)"
+               ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)"
             `)
           }
         } else {
@@ -335,7 +326,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)
                ⨯ turbopackMinify (disabled by \`--debug-prerender\`)"
             `)
@@ -348,7 +338,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)
@@ -361,7 +350,6 @@ describe('build-output-prerender', () => {
                ✓ allowDevelopmentBuild (enabled by \`--debug-prerender\`)
                ✓ appNewScrollHandler (enabled by \`__NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER\`)
                ⨯ prerenderEarlyExit (disabled by \`--debug-prerender\`)
-               ✓ reactDebugChannel (enabled by \`__NEXT_EXPERIMENTAL_DEBUG_CHANNEL\`)
                ⨯ serverMinification (disabled by \`--debug-prerender\`)
                ✓ serverSourceMaps (enabled by \`--debug-prerender\`)"
             `)


### PR DESCRIPTION
Switches the default value of `experimental.reactDebugChannel` to `true`.

The flag has been rolled out internally. Keeping the flag in as a quick workaround in case larger adoption reveals new bugs.