### PR TITLE
Fix route.replace crash with --debug-build-paths

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2183,7 +2183,10 @@ export default async function build(
                   for (const [originalPath, normalizedPath] of Object.entries(
                     appPathRoutes
                   )) {
-                    if (normalizedPath === page) {
+                    if (
+                      normalizedPath === page &&
+                      mappedAppPages[originalPath]
+                    ) {
                       pagePath = mappedAppPages[originalPath].replace(
                         /^private-next-app-dir/,
                         ''


### PR DESCRIPTION
## Summary

- Fixes `route.replace is not a function` error when running `next build --debug-build-paths` on projects with parallel routes

**Root cause:** Turbopack filters routes at the route level (e.g., `/parallel-test` includes all page entries), while JS route discovery filters at the file path level (e.g., only `app/parallel-test/page.tsx`). This causes the `appPathsManifest` to contain entries (like `/@sidebar/page`) that `mappedAppPages` doesn't have. The unguarded lookup at `mappedAppPages[originalPath].replace(...)` crashes on `undefined`.

**Fix:** Added a guard to skip manifest entries that don't exist in `mappedAppPages`.

## Test plan

- [x] Verified `next build --debug-build-paths 'app/parallel-test/**/page.tsx'` succeeds on test fixture
- [x] Verified other `--debug-build-paths` patterns still work (multi-page, pages-only, etc.)