### PR TITLE
Add PR tarball install note to stats comment

### DIFF
--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -973,6 +973,24 @@ function generateDiffsSection(result) {
   return content
 }
 
+function generatePrTarballSection(actionInfo) {
+  if (actionInfo.isRelease || !actionInfo.issueId) return ''
+
+  const prNumber = String(actionInfo.issueId).trim()
+  if (!/^\d+$/.test(prNumber)) return ''
+
+  return `<details>
+<summary><strong>📎 Tarball URL</strong></summary>
+
+\`\`\`
+next@https://vercel-packages.vercel.app/next/prs/${prNumber}/next
+\`\`\`
+
+</details>
+
+`
+}
+
 // ============================================================================
 // Main Export
 // ============================================================================
@@ -1033,6 +1051,8 @@ module.exports = async function addComment(
       comment += '<hr/>\n\n'
     }
   }
+
+  comment += generatePrTarballSection(actionInfo)
 
   // Save canary stats to history (only for releases, not PR comparisons)
   // This ensures we only track official canary metrics, not PR-specific data


### PR DESCRIPTION
### Why?

Make it easier for reviewers to test changes from a PR by showing the tarball install command directly in the next-stats-action comment.

### How?

Added `generatePrTarballSection()` to `add-comment.js` that appends a "Next.js Tarball from current PR" section to the stats comment with the install command:

```
next@https://vercel-packages.vercel.app/next/prs/<pr-number>/next
```

<img width="1790" height="680" alt="CleanShot 2026-02-21 at 16 48 28@2x" src="https://github.com/user-attachments/assets/8f5a1d84-da87-4a6f-a0a0-282cee490f23" />

The section is skipped for release PRs and only shown when a valid PR number is available.

### Testing Plan

- Verify the stats comment on this PR includes the tarball section