### PR TITLE
[turbopack] Consider `ignoreList` of 3rd party sourcemaps in Redbox

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2128,6 +2128,7 @@ pub fn project_compilation_events_subscribe(
 pub struct StackFrame {
     pub is_server: bool,
     pub is_internal: Option<bool>,
+    pub is_ignored: Option<bool>,
     pub original_file: Option<RcStr>,
     pub file: RcStr,
     /// 1-indexed, unlike source map tokens
@@ -2235,7 +2236,7 @@ pub async fn project_trace_source_operation(
         frame.column.unwrap_or(1).saturating_sub(1),
     );
 
-    let (original_file, line, column, method_name) = match token {
+    let (original_file, line, column, method_name, is_ignored) = match token {
         Token::Original(token) => (
             match urlencoding::decode(&token.original_file)? {
                 Cow::Borrowed(_) => token.original_file,
@@ -2245,12 +2246,13 @@ pub async fn project_trace_source_operation(
             Some(token.original_line + 1),
             Some(token.original_column + 1),
             token.name,
+            token.is_ignored,
         ),
         Token::Synthetic(token) => {
             let Some(original_file) = token.guessed_original_file else {
                 return Ok(Vc::cell(None));
             };
-            (original_file, None, None, None)
+            (original_file, None, None, None, false)
         }
     };
 
@@ -2303,6 +2305,7 @@ pub async fn project_trace_source_operation(
         column,
         is_server: frame.is_server,
         is_internal: Some(is_internal),
+        is_ignored: Some(is_ignored),
     })))
 }
 

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -363,6 +363,7 @@ export declare function projectCompilationEventsSubscribe(
 export interface StackFrame {
   isServer: boolean
   isInternal?: boolean
+  isIgnored?: boolean
   originalFile?: RcStr
   file: RcStr
   /** 1-indexed, unlike source map tokens */

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -230,6 +230,7 @@ export interface HmrChunkNames {
 export interface TurbopackStackFrame {
   isServer: boolean
   isInternal?: boolean
+  isIgnored?: boolean
   file: string
   originalFile?: string
   /** 1-indexed, unlike source map tokens */

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -87,6 +87,8 @@ async function batchedTraceSource(
 
   // Don't look up source for node_modules or internals. These can often be large bundled files.
   const ignored =
+    // Check the sourcemap's ignoreList (e.g. from 3rd party packages)
+    !!sourceFrame.isIgnored ||
     shouldIgnorePath(originalFile ?? sourceFrame.file) ||
     // isInternal means resource starts with turbopack:///[turbopack]
     !!sourceFrame.isInternal
@@ -104,7 +106,6 @@ async function batchedTraceSource(
     source = await sourcePromise
   }
 
-  // TODO: get ignoredList from turbopack source map
   const ignorableFrame: IgnorableStackFrame = {
     file: sourceFrame.file,
     line1: sourceFrame.line ?? null,

--- a/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
+++ b/test/e2e/app-dir/server-source-maps/server-source-maps.test.ts
@@ -318,7 +318,6 @@ describe('app-dir - server source maps', () => {
       )
       if (isTurbopack) {
         // TODO(veil): Turbopack errors because it thinks the sources are not part of the project.
-        // TODO(veil-NDX-910): Turbopack's sourcemap loader drops `ignoreList` in browser sourcemaps.
         await expect(browser).toDisplayCollapsedRedbox(`
          {
            "description": "ssr-error-log-ignore-listed",
@@ -330,7 +329,6 @@ describe('app-dir - server source maps', () => {
            "stack": [
              "logError app/ssr-error-log-ignore-listed/page.js (9:17)",
              "runWithInternalIgnored app/ssr-error-log-ignore-listed/page.js (19:13)",
-             "runInternalIgnored internal-pkg/ignored.ts (6:10)",
              "runWithExternalSourceMapped app/ssr-error-log-ignore-listed/page.js (18:29)",
              "runWithExternal app/ssr-error-log-ignore-listed/page.js (17:32)",
              "runWithInternalSourceMapped app/ssr-error-log-ignore-listed/page.js (16:18)",

--- a/turbopack/crates/turbopack-core/src/source_map/mod.rs
+++ b/turbopack/crates/turbopack-core/src/source_map/mod.rs
@@ -129,6 +129,8 @@ pub struct OriginalToken {
     pub original_line: u32,
     pub original_column: u32,
     pub name: Option<RcStr>,
+    /// Whether this token's source is in the sourcemap's `ignoreList`.
+    pub is_ignored: bool,
 }
 
 impl Token {
@@ -159,6 +161,7 @@ impl Token {
                 original_line: t.original_line,
                 original_column: t.original_column,
                 name: t.name.clone(),
+                is_ignored: t.is_ignored,
             }),
             Self::Synthetic(t) => Self::Synthetic(SyntheticToken {
                 generated_line: t.generated_line + line_offset,
@@ -187,6 +190,10 @@ impl From<swc_sourcemap::Token<'_>> for Token {
                 original_line: t.get_src_line(),
                 original_column: t.get_src_col(),
                 name: t.get_name().cloned().map(RcStr::from),
+                // Set to false initially; will be updated by
+                // lookup_token_and_source_internal which has access to the full
+                // source map's ignoreList.
+                is_ignored: false,
             })
         } else {
             Token::Synthetic(SyntheticToken {
@@ -546,22 +553,32 @@ impl SourceMap {
                 *guessed_original_file = Some(RcStr::from(source));
             }
 
-            if need_source_content
-                && content.is_none()
-                && let Some(map) = map.as_regular_source_map()
-            {
-                content = tok.and_then(|tok| {
-                    let src_id = tok.get_src_id();
+            // Check ignoreList and resolve source content using the regular
+            // (possibly flattened) source map. For Index maps,
+            // SourceMapIndex::flatten() correctly transfers ignoreList entries
+            // from each section into the flattened map.
+            if let Some(flat_map) = map.as_regular_source_map() {
+                if let Token::Original(ref mut orig) = token
+                    && let Some(source_name) = tok.and_then(|t| t.get_source().cloned())
+                    && let Some(idx) = flat_map.sources().position(|s| *s == *source_name)
+                {
+                    orig.is_ignored = flat_map.ignore_list().any(|id| *id == idx as u32);
+                }
 
-                    let name = map.get_source(src_id);
-                    let content = map.get_source_contents(src_id);
+                if need_source_content && content.is_none() {
+                    content = tok.and_then(|tok| {
+                        let src_id = tok.get_src_id();
 
-                    let (name, content) = name.zip(content)?;
-                    Some(sourcemap_content_source(
-                        name.clone().into(),
-                        content.clone().into(),
-                    ))
-                });
+                        let name = flat_map.get_source(src_id);
+                        let content = flat_map.get_source_contents(src_id);
+
+                        let (name, content) = name.zip(content)?;
+                        Some(sourcemap_content_source(
+                            name.clone().into(),
+                            content.clone().into(),
+                        ))
+                    });
+                }
             }
 
             token

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -222,6 +222,8 @@ pub fn generate_js_source_map<'a>(
         // TODO: Make this more efficient
         map.adjust_mappings(new_mappings);
 
+        // TODO: Enable this when we have a way to handle the ignore list
+        // add_default_ignore_list(&mut map);
         let map = map.into_raw_sourcemap();
         let result = serde_json::to_vec(&map)?;
         Ok(Rope::from(result))

--- a/turbopack/crates/turbopack-ecmascript/src/parse.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/parse.rs
@@ -222,8 +222,6 @@ pub fn generate_js_source_map<'a>(
         // TODO: Make this more efficient
         map.adjust_mappings(new_mappings);
 
-        // TODO: Enable this when we have a way to handle the ignore list
-        // add_default_ignore_list(&mut map);
         let map = map.into_raw_sourcemap();
         let result = serde_json::to_vec(&map)?;
         Ok(Rope::from(result))


### PR DESCRIPTION
Fixes https://linear.app/vercel/issue/NEXT-4412 for Turbopack
Fixes https://linear.app/vercel/issue/NEXT-4389

Turbopacks `traceSource` only pattern matched the `sources` to determine if something is ignore-listed. However, sources could look like 1st party code and should be ignore-listed. E.g. library code in monorepos tends to be symlinked so its realpath won't appear in `node_modules`.

There's a related missing feature to configure Next.js to also ignore-list more sources beyond pattern matching for `node_modules`. That requires a bit more consideration and doesn't contradict this work though.