### PR TITLE
fix(examples): remove deprecated url.parse from custom-server

### DIFF
--- a/examples/custom-server/server.ts
+++ b/examples/custom-server/server.ts
@@ -1,5 +1,4 @@
 import { createServer } from "http";
-import { parse } from "url";
 import next from "next";
 
 const port = parseInt(process.env.PORT || "3000", 10);
@@ -9,8 +8,7 @@ const handle = app.getRequestHandler();
 
 app.prepare().then(() => {
   createServer((req, res) => {
-    const parsedUrl = parse(req.url!, true);
-    handle(req, res, parsedUrl);
+    handle(req, res);
   }).listen(port);
 
   console.log(


### PR DESCRIPTION
## What this PR does

   Removes the deprecated Node.js `url.parse()` API call from the `examples/custom-server/server.ts` file.

   ## Why this change is needed

   - Node.js has deprecated the legacy URL API (`url.parse()`)
   - The deprecation warning appears when running this example
   - The `parsedUrl` parameter is optional for `RequestHandler`

   ## Changes made

   - Removed `import { parse } from 'url'`
   - Removed `const parsedUrl = parse(req.url!, true)`
   - Simplified `handle(req, res, parsedUrl)` to `handle(req, res)`

   Related to #86951