### PR TITLE
fix(examples): remove deprecated url.parse from with-http2

### DIFF
--- a/examples/with-http2/server.js
+++ b/examples/with-http2/server.js
@@ -1,6 +1,5 @@
 const next = require("next");
 const http2 = require("node:http2");
-const { parse } = require("node:url");
 const fs = require("node:fs");
 
 const port = parseInt(process.env.PORT, 10) || 3000;
@@ -21,8 +20,7 @@ const handler = app.getRequestHandler();
 app.prepare().then(() => {
   server.on("error", (err) => console.error(err));
   server.on("request", (req, res) => {
-    const parsedUrl = parse(req.url, true);
-    handler(req, res, parsedUrl);
+    handler(req, res);
   });
   server.listen(port);
 


### PR DESCRIPTION
## What this PR does

Removes the deprecated Node.js `url.parse()` API call from the `examples/with-http2/server.js` file.

## Why this change is needed

- Node.js has deprecated the legacy URL API (`url.parse()`)
- The deprecation warning appears when running this example
- The `parsedUrl` parameter is optional for `RequestHandler`

## Changes made

- Removed `const { parse } = require("node:url")`
- Removed `const parsedUrl = parse(req.url, true)`
- Simplified `handler(req, res, parsedUrl)` to `handler(req, res)`

Related to #86951