### PR TITLE
[turbopack] Remove obsolete is_internal field 

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2127,7 +2127,6 @@ pub fn project_compilation_events_subscribe(
 )]
 pub struct StackFrame {
     pub is_server: bool,
-    pub is_internal: Option<bool>,
     pub is_ignored: Option<bool>,
     pub original_file: Option<RcStr>,
     pub file: RcStr,
@@ -2258,7 +2257,7 @@ pub async fn project_trace_source_operation(
 
     let project_root_uri =
         uri_from_file(container.project().project_root_path().owned().await?, None).await? + "/";
-    let (file, original_file, is_internal) =
+    let (file, original_file) =
         if let Some(source_file) = original_file.strip_prefix(&project_root_uri) {
             // Client code uses file://
             (
@@ -2268,7 +2267,6 @@ pub async fn project_trace_source_operation(
                         .trim_start_matches("./"),
                 ),
                 Some(RcStr::from(source_file)),
-                false,
             )
         } else if let Some(source_file) = original_file.strip_prefix(&*SOURCE_MAP_PREFIX_PROJECT) {
             // Server code uses turbopack:///[project]
@@ -2283,12 +2281,10 @@ pub async fn project_trace_source_operation(
                     .trim_start_matches("./"),
                 ),
                 Some(RcStr::from(source_file)),
-                false,
             )
         } else if let Some(source_file) = original_file.strip_prefix(&*SOURCE_MAP_PREFIX) {
-            // All other code like turbopack:///[turbopack] is internal code
             // TODO(veil): Should the protocol be preserved?
-            (RcStr::from(source_file), None, true)
+            (RcStr::from(source_file), None)
         } else {
             bail!(
                 "Original file ({}) outside project ({})",
@@ -2304,7 +2300,6 @@ pub async fn project_trace_source_operation(
         line,
         column,
         is_server: frame.is_server,
-        is_internal: Some(is_internal),
         is_ignored: Some(is_ignored),
     })))
 }

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -362,7 +362,6 @@ export declare function projectCompilationEventsSubscribe(
 ): void
 export interface StackFrame {
   isServer: boolean
-  isInternal?: boolean
   isIgnored?: boolean
   originalFile?: RcStr
   file: RcStr

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -229,7 +229,6 @@ export interface HmrChunkNames {
 /** @see https://github.com/vercel/next.js/blob/415cd74b9a220b6f50da64da68c13043e9b02995/crates/next-napi-bindings/src/next_api/project.rs#L824-L833 */
 export interface TurbopackStackFrame {
   isServer: boolean
-  isInternal?: boolean
   isIgnored?: boolean
   file: string
   originalFile?: string

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -89,9 +89,7 @@ async function batchedTraceSource(
   const ignored =
     // Check the sourcemap's ignoreList (e.g. from 3rd party packages)
     !!sourceFrame.isIgnored ||
-    shouldIgnorePath(originalFile ?? sourceFrame.file) ||
-    // isInternal means resource starts with turbopack:///[turbopack]
-    !!sourceFrame.isInternal
+    shouldIgnorePath(originalFile ?? sourceFrame.file)
   if (originalFile && !ignored) {
     let sourcePromise = currentSourcesByFile.get(originalFile)
     if (!sourcePromise) {


### PR DESCRIPTION
We've switched to using `ignoreList` in sourcemaps instead.