### PR TITLE
docs: use PageProps helper in metadata

### DIFF
--- a/docs/01-app/01-getting-started/14-metadata-and-og-images.mdx
+++ b/docs/01-app/01-getting-started/14-metadata-and-og-images.mdx
@@ -74,7 +74,7 @@ You can use [`generateMetadata`](/docs/app/api-reference/functions/generate-meta
 import type { Metadata, ResolvingMetadata } from 'next'
 
 export async function generateMetadata(
-  { params, searchParams }: PageProps<'blog/[slug]'>,
+  { params, searchParams }: PageProps<'/blog/[slug]'>,
   parent: ResolvingMetadata
 ): Promise<Metadata> {
   const { slug } = await params
@@ -90,7 +90,10 @@ export async function generateMetadata(
   }
 }
 
-export default function Page({ params, searchParams }: PageProps<'blog/[slug]'>) {}
+export default function Page({
+  params,
+  searchParams,
+}: PageProps<'/blog/[slug]'>) {}
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher

--- a/docs/01-app/01-getting-started/14-metadata-and-og-images.mdx
+++ b/docs/01-app/01-getting-started/14-metadata-and-og-images.mdx
@@ -73,16 +73,11 @@ You can use [`generateMetadata`](/docs/app/api-reference/functions/generate-meta
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 import type { Metadata, ResolvingMetadata } from 'next'
 
-type Props = {
-  params: Promise<{ slug: string }>
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
-}
-
 export async function generateMetadata(
-  { params, searchParams }: Props,
+  { params, searchParams }: PageProps<'blog/[slug]'>,
   parent: ResolvingMetadata
 ): Promise<Metadata> {
-  const slug = (await params).slug
+  const { slug } = await params
 
   // fetch post information
   const post = await fetch(`https://api.vercel.app/blog/${slug}`).then((res) =>
@@ -95,7 +90,7 @@ export async function generateMetadata(
   }
 }
 
-export default function Page({ params, searchParams }: Props) {}
+export default function Page({ params, searchParams }: PageProps<'blog/[slug]'>) {}
 ```
 
 ```jsx filename="app/blog/[slug]/page.js" switcher


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->

Enforces the use of page props helper : https://nextjs.org/docs/app/api-reference/file-conventions/page#page-props-helper
