### PR TITLE
[ci] Crash if next-swc could not be loaded when `NEXT_TEST_NATIVE_DIR` is specified

### DIFF
--- a/apps/bundle-analyzer/package.json
+++ b/apps/bundle-analyzer/package.json
@@ -3,10 +3,10 @@
   "version": "16.0.2-canary.16",
   "private": true,
   "scripts": {
-    "build": "cross-env NEXT_TEST_NATIVE_DIR=no next build --no-mangling",
-    "dev": "cross-env NEXT_TEST_NATIVE_DIR=no next dev",
+    "build": "cross-env NEXT_TEST_NATIVE_DIR= next build --no-mangling",
+    "dev": "cross-env NEXT_TEST_NATIVE_DIR= next dev",
     "lint": "eslint .",
-    "start": "cross-env NEXT_TEST_NATIVE_DIR=no next start"
+    "start": "cross-env NEXT_TEST_NATIVE_DIR= next start"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.4",

--- a/apps/bundle-analyzer/package.json
+++ b/apps/bundle-analyzer/package.json
@@ -3,10 +3,10 @@
   "version": "16.0.2-canary.16",
   "private": true,
   "scripts": {
-    "build": "cross-env NEXT_TEST_NATIVE_DIR= next build --no-mangling",
-    "dev": "cross-env NEXT_TEST_NATIVE_DIR= next dev",
+    "build": "cross-env NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL=true NEXT_TEST_NATIVE_DIR=no next build --no-mangling",
+    "dev": "cross-env NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL=true NEXT_TEST_NATIVE_DIR=no next dev",
     "lint": "eslint .",
-    "start": "cross-env NEXT_TEST_NATIVE_DIR= next start"
+    "start": "cross-env NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL=true NEXT_TEST_NATIVE_DIR=no next start"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "1.1.4",

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1070,6 +1070,5 @@
   "1069": "Invariant: cache entry \"%s\" not found in dir \"%s\"",
   "1070": "image of size %s could not be tracked by lru cache",
   "1071": "toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase",
-  "1072": "Missing segment data: <head>",
-  "1073": "Failed to load native bindings from '%s'"
+  "1072": "Missing segment data: <head>"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1070,5 +1070,6 @@
   "1069": "Invariant: cache entry \"%s\" not found in dir \"%s\"",
   "1070": "image of size %s could not be tracked by lru cache",
   "1071": "toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase",
-  "1072": "Missing segment data: <head>"
+  "1072": "Missing segment data: <head>",
+  "1073": "Failed to load native bindings from '%s'"
 }

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1483,7 +1483,7 @@ function loadNative(importPath?: string) {
           `Failed to load triple ${triple.platformArchABI}: ${e.message ?? e}`
         )
       }
-    } else {
+    } else if (process.env.NEXT_TEST_NATIVE_IGNORE_LOCAL_INSTALL !== 'true') {
       try {
         bindings = require(
           `@next/swc/native/next-swc.${triple.platformArchABI}.node`

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1496,10 +1496,7 @@ function loadNative(importPath?: string) {
 
   if (!bindings) {
     if (NEXT_TEST_NATIVE_DIR) {
-      throw new AggregateError(
-        attempts,
-        `Failed to load native bindings from '${NEXT_TEST_NATIVE_DIR}'`
-      )
+      throw attempts
     }
 
     for (const triple of triples) {

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1463,7 +1463,8 @@ function loadNative(importPath?: string) {
     ? require(__INTERNAL_CUSTOM_TURBOPACK_BINDINGS)
     : null
   let bindings: RawBindings = customBindings
-  let attempts: any[] = []
+  // callers expect that if loadNative throws, it's an array of strings.
+  let attempts: string[] = []
 
   const NEXT_TEST_NATIVE_DIR = process.env.NEXT_TEST_NATIVE_DIR
   for (const triple of triples) {
@@ -1477,7 +1478,11 @@ function loadNative(importPath?: string) {
           'next-swc build: local built @next/swc from NEXT_TEST_NATIVE_DIR'
         )
         break
-      } catch (e) {}
+      } catch (e: any) {
+        attempts.push(
+          `Failed to load triple ${triple.platformArchABI}: ${e.message ?? e}`
+        )
+      }
     } else {
       try {
         bindings = require(
@@ -1490,6 +1495,13 @@ function loadNative(importPath?: string) {
   }
 
   if (!bindings) {
+    if (NEXT_TEST_NATIVE_DIR) {
+      throw new AggregateError(
+        attempts,
+        `Failed to load native bindings from '${NEXT_TEST_NATIVE_DIR}'`
+      )
+    }
+
     for (const triple of triples) {
       let pkg = importPath
         ? path.join(


### PR DESCRIPTION
It's never valid to fall back to downloading next-swc if `NEXT_TEST_NATIVE_DIR` is specified. If we built locally, we want to use that version.

E.g. https://github.com/vercel/next.js/actions/runs/22315397194/job/64568286425 fails silently and then falls back to downloading 15.x which is completely wrong.

There's probably a better fallback but CI should always use the binary built (or restored from cache) for a specific workflow.