### PR TITLE
Assert cache value in node middleware tests

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1717,6 +1717,13 @@ export default class NextNodeServer extends BaseServer<
         request: requestData,
         useCache: true,
         onWarning: params.onWarning,
+        incrementalCache:
+          (globalThis as any).__incrementalCache ||
+          getRequestMeta(params.request, 'incrementalCache'),
+        serverComponentsHmrCache: getRequestMeta(
+          params.request,
+          'serverComponentsHmrCache'
+        ),
         deploymentId: this.deploymentId,
       })
     }

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -209,6 +209,7 @@ export async function adapter(
     // leverage the shared instance if not we need
     // to create a fresh cache instance each time
     !(globalThis as any).__incrementalCacheShared &&
+    !(globalThis as any).__incrementalCache &&
     (params as any).IncrementalCache
   ) {
     ;(globalThis as any).__incrementalCache = new (

--- a/packages/next/src/server/web/adapter.ts
+++ b/packages/next/src/server/web/adapter.ts
@@ -35,7 +35,7 @@ import { CloseController } from './web-on-close'
 import { getEdgePreviewProps } from './get-edge-preview-props'
 import { getBuiltinRequestContext } from '../after/builtin-request-context'
 import { getImplicitTags } from '../lib/implicit-tags'
-import { setRequestMeta } from '../request-meta'
+import { getRequestMeta, setRequestMeta } from '../request-meta'
 
 export class NextRequestHint extends NextRequest {
   sourcePage: string
@@ -204,12 +204,16 @@ export async function adapter(
     })
   }
 
+  const requestMinimalMode = getRequestMeta(request, 'minimalMode') === true
+
   if (
     // If we are inside of the next start sandbox
     // leverage the shared instance if not we need
-    // to create a fresh cache instance each time
+    // to create a fresh cache instance each time.
+    // In minimal mode we also avoid reusing a non-shared global cache
+    // as it can contain stale request-derived state.
     !(globalThis as any).__incrementalCacheShared &&
-    !(globalThis as any).__incrementalCache &&
+    (requestMinimalMode || !(globalThis as any).__incrementalCache) &&
     (params as any).IncrementalCache
   ) {
     ;(globalThis as any).__incrementalCache = new (

--- a/test/e2e/app-dir/app-middleware-proxy/app-middleware-proxy.test.ts
+++ b/test/e2e/app-dir/app-middleware-proxy/app-middleware-proxy.test.ts
@@ -137,11 +137,21 @@ describe('app-dir with proxy', () => {
   })
 
   it('should support unstable_cache in proxy', async () => {
-    const res = await next.fetch('/unstable-cache')
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({
-      value: expect.any(String),
-    })
+    const readValue = async () => {
+      const res = await next.fetch('/unstable-cache')
+      expect(res.status).toBe(200)
+      const payload = await res.json()
+      expect(payload).toEqual({
+        value: expect.any(String),
+      })
+      return payload.value
+    }
+
+    await retry(async () => {
+      const value = await readValue()
+      expect(await readValue()).toBe(value)
+      expect(await readValue()).toBe(value)
+    }, 10000)
   })
 
   it('should be possible to modify cookies & read them in an RSC in a single request', async () => {

--- a/test/e2e/app-dir/app-middleware/app-middleware.test.ts
+++ b/test/e2e/app-dir/app-middleware/app-middleware.test.ts
@@ -138,11 +138,21 @@ describe('app-dir with middleware', () => {
   })
 
   it('should support unstable_cache in middleware', async () => {
-    const res = await next.fetch('/unstable-cache')
-    expect(res.status).toBe(200)
-    expect(await res.json()).toEqual({
-      value: expect.any(String),
-    })
+    const readValue = async () => {
+      const res = await next.fetch('/unstable-cache')
+      expect(res.status).toBe(200)
+      const payload = await res.json()
+      expect(payload).toEqual({
+        value: expect.any(String),
+      })
+      return payload.value
+    }
+
+    await retry(async () => {
+      const value = await readValue()
+      expect(await readValue()).toBe(value)
+      expect(await readValue()).toBe(value)
+    }, 10000)
   })
 
   it('should be possible to modify cookies & read them in an RSC in a single request', async () => {


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/89980 this ensures the cache is actually able to be leveraged across requests accounting for eventual consistency in a distributed environment. 