### PR TITLE
[DO NOT MERGE] Enable server HMR by default for testing

### DIFF
--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -314,10 +314,6 @@ program
     'Path to a HTTPS certificate authority file.'
   )
   .option(
-    '--experimental-server-fast-refresh',
-    'Enable experimental server-side Fast Refresh.'
-  )
-  .option(
     '--experimental-upload-trace, <traceUrl>',
     'Reports a subset of the debugging trace to a remote HTTP URL. Includes sensitive data.'
   )

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -60,7 +60,6 @@ export type NextDevOptions = {
   experimentalUploadTrace?: string
   experimentalNextConfigStripTypes?: boolean
   experimentalCpuProf?: boolean
-  experimentalServerFastRefresh?: boolean
 }
 
 type PortSource = 'cli' | 'default' | 'env'
@@ -255,7 +254,6 @@ const nextDev = async (
 
   const enabledFeatures = Object.fromEntries(
     Object.entries({
-      experimentalServerFastRefresh: options.experimentalServerFastRefresh,
       experimentalCpuProf: options.experimentalCpuProf,
     }).filter(([_, value]) => value)
   )
@@ -275,7 +273,6 @@ const nextDev = async (
     allowRetry,
     isDev: true,
     hostname: host,
-    experimentalServerFastRefresh: options.experimentalServerFastRefresh,
   }
 
   const startServerPath = require.resolve('../server/lib/start-server')

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -595,10 +595,7 @@ export async function createHotReloaderTurbopack(
     // Server HMR only applies to App Router.
     // Pages Router uses Node's require(), root entries (middleware/instrumentation)
     // use the edge runtime.
-    const usesServerHmr =
-      experimentalServerFastRefresh &&
-      entryType === 'app' &&
-      writtenEndpoint.type !== 'edge'
+    const usesServerHmr = entryType === 'app' && writtenEndpoint.type !== 'edge'
 
     for (const file of serverPaths) {
       clearModuleContext(file)

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -307,8 +307,7 @@ export async function createHotReloaderTurbopack(
   serverFields: ServerFields,
   distDir: string,
   resetFetch: () => void,
-  lockfile: Lockfile | undefined,
-  experimentalServerFastRefresh?: boolean
+  lockfile: Lockfile | undefined
 ): Promise<NextJsHotReloaderInterface> {
   const dev = true
   const buildId = 'development'
@@ -1819,32 +1818,30 @@ export async function createHotReloaderTurbopack(
     process.exit(1)
   })
 
-  if (experimentalServerFastRefresh) {
-    serverHmrSubscriptions = setupServerHmr(project, {
-      clear: async () => {
-        // Clear Node's require cache of all Turbopack-built modules
-        for (const chunkPath of serverHmrSubscriptions?.keys() ?? []) {
-          deleteCache(join(distDir, chunkPath))
-        }
+  serverHmrSubscriptions = setupServerHmr(project, {
+    clear: async () => {
+      // Clear Node's require cache of all Turbopack-built modules
+      for (const chunkPath of serverHmrSubscriptions?.keys() ?? []) {
+        deleteCache(join(distDir, chunkPath))
+      }
 
-        // Clear Turbopack's runtime caches
-        if (typeof __next__clear_chunk_cache__ === 'function') {
-          __next__clear_chunk_cache__()
-        }
+      // Clear Turbopack's runtime caches
+      if (typeof __next__clear_chunk_cache__ === 'function') {
+        __next__clear_chunk_cache__()
+      }
 
-        // Clear all edge contexts
-        await clearAllModuleContexts()
+      // Clear all edge contexts
+      await clearAllModuleContexts()
 
-        resetFetch()
+      resetFetch()
 
-        // Tell browsers to refetch RSC (soft refresh, not full page reload)
-        hotReloader.send({
-          type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
-          hash: String(++hmrHash),
-        })
-      },
-    })
-  }
+      // Tell browsers to refetch RSC (soft refresh, not full page reload)
+      hotReloader.send({
+        type: HMR_MESSAGE_SENT_TO_BROWSER.SERVER_COMPONENT_CHANGES,
+        hash: String(++hmrHash),
+      })
+    },
+  })
 
   return hotReloader
 }

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -90,7 +90,6 @@ export async function initialize(opts: {
   keepAliveTimeout?: number
   customServer?: boolean
   experimentalHttpsServer?: boolean
-  experimentalServerFastRefresh?: boolean
   startServerSpan?: Span
   quiet?: boolean
 }): Promise<ServerInitResult> {
@@ -179,7 +178,6 @@ export async function initialize(opts: {
         port: opts.port,
         onDevServerCleanup: opts.onDevServerCleanup,
         resetFetch,
-        experimentalServerFastRefresh: opts.experimentalServerFastRefresh,
       })
     )
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -114,7 +114,6 @@ export type SetupOpts = {
   port: number
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
   resetFetch: () => void
-  experimentalServerFastRefresh?: boolean
 }
 
 export interface DevRoutesManifest {
@@ -237,8 +236,7 @@ async function startWatcher(
           serverFields,
           distDir,
           resetFetch,
-          lockfile,
-          opts.experimentalServerFastRefresh
+          lockfile
         )
       })()
     : await (async () => {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -129,7 +129,6 @@ export interface StartServerOptions {
   keepAliveTimeout?: number
   // this is dev-server only
   selfSignedCertificate?: SelfSignedCertificate
-  experimentalServerFastRefresh?: boolean
 }
 
 export async function getRequestHandlers({
@@ -142,7 +141,6 @@ export async function getRequestHandlers({
   minimalMode,
   keepAliveTimeout,
   experimentalHttpsServer,
-  experimentalServerFastRefresh,
   quiet,
 }: {
   dir: string
@@ -154,7 +152,6 @@ export async function getRequestHandlers({
   minimalMode?: boolean
   keepAliveTimeout?: number
   experimentalHttpsServer?: boolean
-  experimentalServerFastRefresh?: boolean
   quiet?: boolean
 }): ReturnType<typeof initialize> {
   return initialize({
@@ -167,7 +164,6 @@ export async function getRequestHandlers({
     server,
     keepAliveTimeout,
     experimentalHttpsServer,
-    experimentalServerFastRefresh,
     startServerSpan,
     quiet,
   })
@@ -188,7 +184,6 @@ export async function startServer(
     allowRetry,
     keepAliveTimeout,
     selfSignedCertificate,
-    experimentalServerFastRefresh,
   } = serverOptions
   let { port } = serverOptions
 
@@ -489,7 +484,6 @@ export async function startServer(
           minimalMode,
           keepAliveTimeout,
           experimentalHttpsServer: !!selfSignedCertificate,
-          experimentalServerFastRefresh,
         })
         requestHandler = initResult.requestHandler
         upgradeHandler = initResult.upgradeHandler

--- a/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
+++ b/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
@@ -47,7 +47,6 @@ function parseTraceFile(tracePath: string): TraceStructure {
 describe('enabled features in trace', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    startArgs: ['--experimental-server-fast-refresh'],
   })
 
   if (!isNextDev) {

--- a/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
+++ b/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
@@ -75,9 +75,9 @@ describe('enabled features in trace', () => {
 
     const startDevServerEvent = startDevServerEvents![0]
     expect(startDevServerEvent.tags).toBeDefined()
-    expect(
-      startDevServerEvent.tags!['feature.experimentalServerFastRefresh']
-    ).toBe(true)
+    // expect(
+    //   startDevServerEvent.tags!['feature.experimentalServerFastRefresh']
+    // ).toBe(true)
   })
 
   it('should denormalize inherited enabled features during upload', async () => {
@@ -139,14 +139,14 @@ describe('enabled features in trace', () => {
 
     // Both should have inherited feature.experimentalServerFastRefresh from their parent
     expect(compilePathEvent).toBeDefined()
-    expect(compilePathEvent.tags['feature.experimentalServerFastRefresh']).toBe(
-      true
-    )
+    // expect(compilePathEvent.tags['feature.experimentalServerFastRefresh']).toBe(
+    //   true
+    // )
 
     expect(renderPathEvent).toBeDefined()
-    expect(renderPathEvent.tags['feature.experimentalServerFastRefresh']).toBe(
-      true
-    )
+    // expect(renderPathEvent.tags['feature.experimentalServerFastRefresh']).toBe(
+    //   true
+    // )
   })
 })
 

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -4,7 +4,6 @@ import { retry } from 'next-test-utils'
 describe('server-hmr', () => {
   const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
-    startArgs: ['--experimental-server-fast-refresh'],
   })
 
   // Server HMR is a Turbopack-only feature, only available in dev mode


### PR DESCRIPTION
Do not merge this. This PR currently exists only so that we can run the e2e test suite with server hmr applied.
