### PR TITLE
[ci] Stop linting auto-generated next-swc typings

### DIFF
--- a/.config/eslintignore.mjs
+++ b/.config/eslintignore.mjs
@@ -48,6 +48,7 @@ export default globalIgnores([
   'test/development/basic/hmr/components/parse-error.js',
   'test/development/mcp-server/fixtures/default-template/app/build-error/page.tsx',
   'test/production/debug-build-path/fixtures/with-compile-error/app/broken/page.tsx',
+  'packages/next-swc/native/index.d.ts',
   'packages/next-swc/docs/assets/**/*',
   'test/e2e/app-dir/server-source-maps/fixtures/default/internal-pkg/sourcemapped.js',
   'test/e2e/app-dir/server-source-maps/fixtures/default/external-pkg/sourcemapped.js',


### PR DESCRIPTION
This is an auto-generated file. The eslint-disable just sometimes lead to `--report-unused-disable-directive` throwing which isn't actionable. Now we ignore it entirely.