### PR TITLE
Throw when `unstable_instant` is used in Client Component

### DIFF
--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -118,6 +118,9 @@ pub struct NextSegmentConfig {
     #[turbo_tasks(trace_ignore)]
     #[bincode(with_serde)]
     pub generate_static_params: Option<Span>,
+    #[turbo_tasks(trace_ignore)]
+    #[bincode(with_serde)]
+    pub unstable_instant: Option<Span>,
 }
 
 #[turbo_tasks::value_impl]
@@ -505,36 +508,52 @@ pub async fn parse_segment_config_from_source(
     )
     .await?;
 
-    if mode == ParseSegmentMode::App
-        && let Some(span) = config.generate_static_params
-        && module_ast
-            .body
-            .iter()
-            .take_while(|i| match i {
-                ModuleItem::Stmt(stmt) => stmt.directive_continue(),
-                ModuleItem::ModuleDecl(_) => false,
-            })
-            .filter_map(|i| i.as_stmt())
-            .any(|f| match f {
-                Stmt::Expr(ExprStmt { expr, .. }) => match &**expr {
-                    Expr::Lit(Lit::Str(Str { value, .. })) => value == "use client",
-                    _ => false,
-                },
+    let is_client_entry = module_ast
+        .body
+        .iter()
+        .take_while(|i| match i {
+            ModuleItem::Stmt(stmt) => stmt.directive_continue(),
+            ModuleItem::ModuleDecl(_) => false,
+        })
+        .filter_map(|i| i.as_stmt())
+        .any(|f| match f {
+            Stmt::Expr(ExprStmt { expr, .. }) => match &**expr {
+                Expr::Lit(Lit::Str(Str { value, .. })) => value == "use client",
                 _ => false,
-            })
-    {
-        invalid_config(
-            source,
-            "generateStaticParams",
-            span,
-            rcstr!(
-                "App pages cannot use both \"use client\" and export function \
-                 \"generateStaticParams()\"."
-            ),
-            None,
-            IssueSeverity::Error,
-        )
-        .await?;
+            },
+            _ => false,
+        });
+
+    if mode == ParseSegmentMode::App && is_client_entry {
+        if let Some(span) = config.generate_static_params {
+            invalid_config(
+                source,
+                "generateStaticParams",
+                span,
+                rcstr!(
+                    "App pages cannot use both \"use client\" and export function \
+                     \"generateStaticParams()\"."
+                ),
+                None,
+                IssueSeverity::Error,
+            )
+            .await?;
+        }
+
+        if let Some(span) = config.unstable_instant {
+            invalid_config(
+                source,
+                "unstable_instant",
+                span,
+                rcstr!(
+                    "App pages cannot use both \"use client\" and export const \
+                     \"unstable_instant\"."
+                ),
+                None,
+                IssueSeverity::Error,
+            )
+            .await?;
+        }
     }
 
     Ok(config.cell())
@@ -951,6 +970,9 @@ async fn parse_config_value(
         }
         "generateStaticParams" => {
             config.generate_static_params = Some(span);
+        }
+        "unstable_instant" => {
+            config.unstable_instant = Some(span);
         }
         _ => {}
     }

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -546,8 +546,9 @@ pub async fn parse_segment_config_from_source(
                 "unstable_instant",
                 span,
                 rcstr!(
-                    "App pages cannot use both \"use client\" and export const \
-                     \"unstable_instant\"."
+                    "App pages cannot export \"unstable_instant\" from a Client \
+                     Component module. To use this API, convert this module to a \
+                     Server Component by removing the \"use client\" directive."
                 ),
                 None,
                 IssueSeverity::Error,

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -546,9 +546,9 @@ pub async fn parse_segment_config_from_source(
                 "unstable_instant",
                 span,
                 rcstr!(
-                    "App pages cannot export \"unstable_instant\" from a Client \
-                     Component module. To use this API, convert this module to a \
-                     Server Component by removing the \"use client\" directive."
+                    "App pages cannot export \"unstable_instant\" from a Client Component module. \
+                     To use this API, convert this module to a Server Component by removing the \
+                     \"use client\" directive."
                 ),
                 None,
                 IssueSeverity::Error,

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1071,5 +1071,6 @@
   "1070": "image of size %s could not be tracked by lru cache",
   "1071": "toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase",
   "1072": "Missing segment data: <head>",
-  "1073": "Expected static stage body to be available"
+  "1073": "Expected static stage body to be available",
+  "1074": "Page \"%s\" cannot use both \"use client\" and export const \"unstable_instant\"."
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1072,5 +1072,6 @@
   "1071": "toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase",
   "1072": "Missing segment data: <head>",
   "1073": "Expected static stage body to be available",
-  "1074": "Page \"%s\" cannot use both \"use client\" and export const \"unstable_instant\"."
+  "1074": "Page \"%s\" cannot use both \"use client\" and export const \"unstable_instant\".",
+  "1075": "Page \"%s\" cannot export \"unstable_instant\" from a Client Component module. To use this API, convert this module to a Server Component by removing the \"use client\" directive."
 }

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -684,6 +684,13 @@ export async function getAppPageStaticInfo({
     )
   }
 
+  // Prevent use client and unstable_instant in the same file.
+  if (directives?.has('client') && 'unstable_instant' in config) {
+    throw new Error(
+      `Page "${page}" cannot use both "use client" and export const "unstable_instant".`
+    )
+  }
+
   if ('unstable_instant' in config && !nextConfig.cacheComponents) {
     throw new Error(
       `Page "${page}" cannot use \`export const unstable_instant = ...\` without enabling \`cacheComponents\`.`

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -687,7 +687,7 @@ export async function getAppPageStaticInfo({
   // Prevent use client and unstable_instant in the same file.
   if (directives?.has('client') && 'unstable_instant' in config) {
     throw new Error(
-      `Page "${page}" cannot use both "use client" and export const "unstable_instant".`
+      `Page "${page}" cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
     )
   }
 

--- a/test/e2e/app-dir-export/test/unstable-instant.test.ts
+++ b/test/e2e/app-dir-export/test/unstable-instant.test.ts
@@ -22,8 +22,8 @@ describe('app dir - with output export - unstable_instant', () => {
     )
 
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
-      ? `Next.js can't recognize the exported \`unstable_instant\` field in route. App pages cannot use both "use client" and export const "unstable_instant".`
-      : `Page "/client/page" cannot use both "use client" and export const "unstable_instant".`
+      ? `Next.js can't recognize the exported \`unstable_instant\` field in route. App pages cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
+      : `Page "/client/page" cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
 
     if (isNextDev) {
       await next.start().catch(() => {})

--- a/test/e2e/app-dir-export/test/unstable-instant.test.ts
+++ b/test/e2e/app-dir-export/test/unstable-instant.test.ts
@@ -1,0 +1,39 @@
+import { join } from 'path'
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('app dir - with output export - unstable_instant', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: join(__dirname, '..'),
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  it('should error when client component has unstable_instant', async () => {
+    await next.patchFile('app/client/page.js', (content) =>
+      content.replace(
+        `'use client'\n`,
+        `'use client'\n\nexport const unstable_instant = { prefetch: 'runtime', samples: [{}] }\n\n`
+      )
+    )
+
+    const expectedErrMsg = process.env.IS_TURBOPACK_TEST
+      ? `Next.js can't recognize the exported \`unstable_instant\` field in route. App pages cannot use both "use client" and export const "unstable_instant".`
+      : `Page "/client/page" cannot use both "use client" and export const "unstable_instant".`
+
+    if (isNextDev) {
+      await next.start().catch(() => {})
+      await next.browser('/client').catch(() => {})
+      await retry(async () => {
+        expect(next.cliOutput).toContain(expectedErrMsg)
+      })
+    } else {
+      const { cliOutput } = await next.build()
+      expect(cliOutput).toContain(expectedErrMsg)
+    }
+  })
+})

--- a/test/e2e/app-dir/instant-validation-client/app/layout.tsx
+++ b/test/e2e/app-dir/instant-validation-client/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/instant-validation-client/app/page.tsx
+++ b/test/e2e/app-dir/instant-validation-client/app/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Page() {
+  return <p>hello world</p>
+}
+
+export const unstable_instant = {
+  prefetch: 'static',
+}

--- a/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
+++ b/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
@@ -15,7 +15,7 @@ describe('app dir - instant-validation-client', () => {
   it('should error when a client component exports unstable_instant', async () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? `Next.js can't recognize the exported \`unstable_instant\` field in route. App pages cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
-      : `Page "/client/page" cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
+      : `Page "/page" cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
 
     if (isNextDev) {
       await next.start().catch(() => {})

--- a/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
+++ b/test/e2e/app-dir/instant-validation-client/instant-validation-client.test.ts
@@ -1,10 +1,9 @@
-import { join } from 'path'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
-describe('app dir - with output export - unstable_instant', () => {
+describe('app dir - instant-validation-client', () => {
   const { next, isNextDev, skipped } = nextTestSetup({
-    files: join(__dirname, '..'),
+    files: __dirname,
     skipDeployment: true,
     skipStart: true,
   })
@@ -13,21 +12,14 @@ describe('app dir - with output export - unstable_instant', () => {
     return
   }
 
-  it('should error when client component has unstable_instant', async () => {
-    await next.patchFile('app/client/page.js', (content) =>
-      content.replace(
-        `'use client'\n`,
-        `'use client'\n\nexport const unstable_instant = { prefetch: 'runtime', samples: [{}] }\n\n`
-      )
-    )
-
+  it('should error when a client component exports unstable_instant', async () => {
     const expectedErrMsg = process.env.IS_TURBOPACK_TEST
       ? `Next.js can't recognize the exported \`unstable_instant\` field in route. App pages cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
       : `Page "/client/page" cannot export "unstable_instant" from a Client Component module. To use this API, convert this module to a Server Component by removing the "use client" directive.`
 
     if (isNextDev) {
       await next.start().catch(() => {})
-      await next.browser('/client').catch(() => {})
+      await next.browser('/').catch(() => {})
       await retry(async () => {
         expect(next.cliOutput).toContain(expectedErrMsg)
       })

--- a/test/e2e/app-dir/instant-validation-client/next.config.ts
+++ b/test/e2e/app-dir/instant-validation-client/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+}
+
+export default nextConfig


### PR DESCRIPTION
The `unstable_instant` route segment config is not allowed in Client Components because the API mainly depends on prefetches, which Client Components aren't part of.

Closes NAR-774