### PR TITLE
Add trace spans for turbopack persistence in .next/trace

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2129,6 +2129,7 @@ pub fn project_compilation_events_subscribe(
             obj.set_named_property("typeName", event.type_name())?;
             obj.set_named_property("severity", event.severity().to_string())?;
             obj.set_named_property("message", event.message())?;
+            obj.set_named_property("eventJson", event.to_json())?;
 
             let external = env.create_external(event, None);
             obj.set_named_property("eventData", external)?;

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -266,6 +266,7 @@ export type CompilationEvent = {
   typeName: string
   message: string
   severity: string
+  eventJson: string
   eventData: any
 }
 

--- a/packages/next/src/build/turbopack-analyze/index.ts
+++ b/packages/next/src/build/turbopack-analyze/index.ts
@@ -7,6 +7,7 @@ import { createDefineEnv, loadBindings } from '../swc'
 import { isCI } from '../../server/ci-info'
 import { backgroundLogCompilationEvents } from '../../shared/lib/turbopack/compilation-events'
 import { getSupportedBrowsers } from '../get-supported-browsers'
+import { trace } from '../../trace'
 import { normalizePath } from '../../lib/normalize-path'
 import { PHASE_PRODUCTION_BUILD } from '../../shared/lib/constants'
 
@@ -100,7 +101,9 @@ export async function turbopackAnalyze(
   )
 
   try {
-    backgroundLogCompilationEvents(project)
+    const analyzeEventsSpan = trace('turbopack-analyze-events')
+    analyzeEventsSpan.stop()
+    backgroundLogCompilationEvents(project, { parentSpan: analyzeEventsSpan })
 
     await project.writeAnalyzeData(analyzeContext.appDirOnly)
 

--- a/packages/next/src/build/turbopack-analyze/index.ts
+++ b/packages/next/src/build/turbopack-analyze/index.ts
@@ -102,6 +102,8 @@ export async function turbopackAnalyze(
 
   try {
     const analyzeEventsSpan = trace('turbopack-analyze-events')
+    // Stop immediately: this span is only used as a parent for
+    // manualTraceChild calls which carry their own timestamps.
     analyzeEventsSpan.stop()
     backgroundLogCompilationEvents(project, { parentSpan: analyzeEventsSpan })
 

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -15,7 +15,13 @@ import { PHASE_PRODUCTION_BUILD } from '../../shared/lib/constants'
 import loadConfig from '../../server/config'
 import { hasCustomExportOutput } from '../../export/utils'
 import { Telemetry } from '../../telemetry/storage'
-import { setGlobal } from '../../trace'
+import {
+  setGlobal,
+  trace,
+  initializeTraceState,
+  getTraceEvents,
+} from '../../trace'
+import type { TraceState } from '../../trace'
 import { isCI } from '../../server/ci-info'
 import { backgroundLogCompilationEvents } from '../../shared/lib/turbopack/compilation-events'
 import { getSupportedBrowsers } from '../get-supported-browsers'
@@ -141,7 +147,11 @@ export async function turbopackBuild(): Promise<{
       : undefined
   )
   try {
-    backgroundLogCompilationEvents(project)
+    const buildEventsSpan = trace('turbopack-build-events')
+    buildEventsSpan.stop()
+    backgroundLogCompilationEvents(project, {
+      parentSpan: buildEventsSpan,
+    })
 
     // Write an empty file in a known location to signal this was built with Turbopack
     await fs.writeFile(path.join(distDir, 'turbopack'), '')
@@ -269,11 +279,15 @@ export async function turbopackBuild(): Promise<{
 let shutdownPromise: Promise<void> | undefined
 export async function workerMain(workerData: {
   buildContext: typeof NextBuildContext
+  traceState: TraceState & { shouldSaveTraceEvents: boolean }
 }): Promise<
-  Omit<Awaited<ReturnType<typeof turbopackBuild>>, 'shutdownPromise'>
+  Omit<Awaited<ReturnType<typeof turbopackBuild>>, 'shutdownPromise'> & {
+    debugTraceEvents?: ReturnType<typeof getTraceEvents>
+  }
 > {
   // setup new build context from the serialized data passed from the parent
   Object.assign(NextBuildContext, workerData.buildContext)
+  initializeTraceState(workerData.traceState)
 
   /// load the config because it's not serializable
   const config = await loadConfig(
@@ -308,9 +322,14 @@ export async function workerMain(workerData: {
       duration,
     } = await turbopackBuild()
     shutdownPromise = resultShutdownPromise
+    // Wait for shutdown to complete so that all compilation events
+    // (e.g. persistence trace spans) have been processed before we
+    // collect the saved trace events.
+    await shutdownPromise
     return {
       buildTraceContext,
       duration,
+      debugTraceEvents: getTraceEvents(),
     }
   } finally {
     // Always flush telemetry before worker exits (waits for async operations like setTimeout in debug mode)

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -148,6 +148,8 @@ export async function turbopackBuild(): Promise<{
   )
   try {
     const buildEventsSpan = trace('turbopack-build-events')
+    // Stop immediately: this span is only used as a parent for
+    // manualTraceChild calls which carry their own timestamps.
     buildEventsSpan.stop()
     backgroundLogCompilationEvents(project, {
       parentSpan: buildEventsSpan,

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -2,10 +2,12 @@ import path from 'path'
 
 import { Worker } from '../../lib/worker'
 import { NextBuildContext } from '../build-context'
+import { exportTraceState, recordTraceEvents } from '../../trace'
 
 async function turbopackBuildWithWorker(): ReturnType<
   typeof import('./impl').turbopackBuild
 > {
+  const nextBuildSpan = NextBuildContext.nextBuildSpan!
   try {
     const worker = new Worker(path.join(__dirname, 'impl.js'), {
       exposedMethods: ['workerMain', 'waitForShutdown'],
@@ -28,14 +30,24 @@ async function turbopackBuildWithWorker(): ReturnType<
       },
     }) as Worker & typeof import('./impl')
     const {
-      nextBuildSpan,
+      nextBuildSpan: _nextBuildSpan,
       // Config is not serializable and is loaded in the worker.
       config: _config,
       ...prunedBuildContext
     } = NextBuildContext
-    const { buildTraceContext, duration } = await worker.workerMain({
-      buildContext: prunedBuildContext,
-    })
+    const { buildTraceContext, duration, debugTraceEvents } =
+      await worker.workerMain({
+        buildContext: prunedBuildContext,
+        traceState: {
+          ...exportTraceState(),
+          defaultParentSpanId: nextBuildSpan.getId(),
+          shouldSaveTraceEvents: true,
+        },
+      })
+
+    if (debugTraceEvents) {
+      recordTraceEvents(debugTraceEvents)
+    }
 
     return {
       // destroy worker when Turbopack has shutdown so it's not sticking around using memory

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -35,12 +35,7 @@ import {
 import os from 'os'
 import { once } from 'node:events'
 import { clearTimeout } from 'timers'
-import {
-  flushAllTraces,
-  trace,
-  initializeTraceState,
-  exportTraceState,
-} from '../trace'
+import { trace, initializeTraceState, exportTraceState } from '../trace'
 import { traceId } from '../trace/shared'
 import { Bundler, parseBundlerArgs } from '../lib/bundler'
 
@@ -105,7 +100,6 @@ const handleSessionStop = async (signal: NodeJS.Signals | number | null) => {
   }
 
   sessionSpan.stop()
-  await flushAllTraces({ end: true })
 
   try {
     const { eventCliSessionStopped } =

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -424,7 +424,9 @@ export async function createHotReloaderTurbopack(
       'StartupCacheInvalidationEvent',
       'TimingEvent',
       'SlowFilesystemEvent',
+      'TraceEvent',
     ],
+    parentSpan: hotReloaderSpan,
   })
   setBundlerFindSourceMapImplementation(
     getSourceMapFromTurbopack.bind(null, project, projectPath)

--- a/packages/next/src/server/dev/turbopack-utils.ts
+++ b/packages/next/src/server/dev/turbopack-utils.ts
@@ -86,11 +86,7 @@ export function processTopLevelIssues(
   }
 }
 
-const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
-
-export function msToNs(ms: number): bigint {
-  return BigInt(Math.floor(ms)) * MILLISECONDS_IN_NANOSECOND
-}
+export { msToNs } from '../../shared/lib/turbopack/compilation-events'
 
 export type ChangeSubscriptions = Map<
   EntryKey,

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -3,10 +3,8 @@ import * as Log from '../../../build/output/log'
 import { flushAllTraces, type Span } from '../../../trace'
 import { traceMemoryUsage } from '../../../lib/memory/trace'
 
-// Also defined in server/dev/turbopack-utils.ts — duplicated here to avoid
-// a dependency from shared/lib/ into server/dev/.
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
-function msToNs(ms: number): bigint {
+export function msToNs(ms: number): bigint {
   return BigInt(Math.floor(ms)) * MILLISECONDS_IN_NANOSECOND
 }
 

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -3,8 +3,9 @@ import * as Log from '../../../build/output/log'
 import { flushAllTraces, type Span } from '../../../trace'
 import { traceMemoryUsage } from '../../../lib/memory/trace'
 
+// Also defined in server/dev/turbopack-utils.ts — duplicated here to avoid
+// a dependency from shared/lib/ into server/dev/.
 const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
-
 function msToNs(ms: number): bigint {
   return BigInt(Math.floor(ms)) * MILLISECONDS_IN_NANOSECOND
 }

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -1,22 +1,57 @@
 import type { Project } from '../../../build/swc/types'
 import * as Log from '../../../build/output/log'
+import { flushAllTraces, type Span } from '../../../trace'
+import { traceMemoryUsage } from '../../../lib/memory/trace'
+
+const MILLISECONDS_IN_NANOSECOND = BigInt(1_000_000)
+
+function msToNs(ms: number): bigint {
+  return BigInt(Math.floor(ms)) * MILLISECONDS_IN_NANOSECOND
+}
 
 /**
  * Subscribes to compilation events for `project` and prints them using the
  * `Log` library.
+ *
+ * When `parentSpan` is provided, `TraceEvent` compilation events are recorded
+ * as trace spans in the `.next/trace` file.
  *
  * The `signal` argument is partially implemented. The abort may not happen until the next
  * compilation event arrives.
  */
 export function backgroundLogCompilationEvents(
   project: Project,
-  { eventTypes, signal }: { eventTypes?: string[]; signal?: AbortSignal } = {}
-) {
-  ;(async function () {
+  {
+    eventTypes,
+    signal,
+    parentSpan,
+  }: { eventTypes?: string[]; signal?: AbortSignal; parentSpan?: Span } = {}
+): Promise<void> {
+  const promise = (async function () {
     for await (const event of project.compilationEventsSubscribe(eventTypes)) {
       if (signal?.aborted) {
         return
       }
+
+      // Record TraceEvent compilation events as trace spans in .next/trace.
+      if (parentSpan && event.typeName === 'TraceEvent' && event.eventJson) {
+        try {
+          const data = JSON.parse(event.eventJson)
+          parentSpan.manualTraceChild(
+            data.name,
+            msToNs(data.startTimeMs),
+            msToNs(data.endTimeMs),
+            Object.fromEntries(data.attributes ?? [])
+          )
+          traceMemoryUsage(data.name, parentSpan)
+          // We flush after each event to make sure it makes it to disk.  These events are rare and
+          // tend to happen at the very end of a build so to make sure they are logged we need to
+          // flush.
+          flushAllTraces()
+        } catch {}
+        continue // don't log these events, they just go to the trace file
+      }
+
       switch (event.severity) {
         case 'EVENT':
           Log.event(event.message)
@@ -41,4 +76,7 @@ export function backgroundLogCompilationEvents(
       }
     }
   })()
+  // Prevent unhandled rejection if the subscription errors after the project shuts down.
+  promise.catch(() => {})
+  return promise
 }

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -46,7 +46,8 @@ export function backgroundLogCompilationEvents(
           // We flush after each event to make sure it makes it to disk.  These events are rare and
           // tend to happen at the very end of a build so to make sure they are logged we need to
           // flush.
-          flushAllTraces()
+          // NOTE: in a `next build` environment where we are reporting events to the parent thread, this is a no-op.
+          await flushAllTraces()
         } catch {}
         continue // don't log these events, they just go to the trace file
       }

--- a/packages/next/src/trace/report/to-json-build.ts
+++ b/packages/next/src/trace/report/to-json-build.ts
@@ -1,78 +1,6 @@
-import { traceGlobals, traceId } from '../shared'
-import fs from 'fs'
-import path from 'path'
-import {
-  PHASE_DEVELOPMENT_SERVER,
-  PHASE_PRODUCTION_BUILD,
-} from '../../shared/lib/constants'
-import type { TraceEvent } from '../types'
-import { batcher } from './to-json'
-
-let writeStream: RotatingWriteStream
-let batch: ReturnType<typeof batcher> | undefined
-
-const writeStreamOptions = {
-  flags: 'a',
-  encoding: 'utf8' as const,
-}
-class RotatingWriteStream {
-  file: string
-  writeStream!: fs.WriteStream
-  size: number
-  sizeLimit: number
-  private rotatePromise: Promise<void> | undefined
-  private drainPromise: Promise<void> | undefined
-  constructor(file: string, sizeLimit: number) {
-    this.file = file
-    this.size = 0
-    this.sizeLimit = sizeLimit
-    this.createWriteStream()
-  }
-  private createWriteStream() {
-    this.writeStream = fs.createWriteStream(this.file, writeStreamOptions)
-  }
-  // Recreate the file
-  private async rotate() {
-    await this.end()
-    try {
-      fs.unlinkSync(this.file)
-    } catch (err: any) {
-      // It's fine if the file does not exist yet
-      if (err.code !== 'ENOENT') {
-        throw err
-      }
-    }
-    this.size = 0
-    this.createWriteStream()
-    this.rotatePromise = undefined
-  }
-  async write(data: string): Promise<void> {
-    if (this.rotatePromise) await this.rotatePromise
-
-    this.size += data.length
-    if (this.size > this.sizeLimit) {
-      await (this.rotatePromise = this.rotate())
-    }
-
-    if (!this.writeStream.write(data, 'utf8')) {
-      if (this.drainPromise === undefined) {
-        this.drainPromise = new Promise<void>((resolve, _reject) => {
-          this.writeStream.once('drain', () => {
-            this.drainPromise = undefined
-            resolve()
-          })
-        })
-      }
-      await this.drainPromise
-    }
-  }
-
-  end(): Promise<void> {
-    return new Promise((resolve) => {
-      this.writeStream.end(resolve)
-    })
-  }
-}
+import { traceGlobals } from '../shared'
+import { PHASE_PRODUCTION_BUILD } from '../../shared/lib/constants'
+import { createJsonReporter } from './to-json'
 
 const allowlistedEvents = new Set([
   'next-build',
@@ -89,58 +17,11 @@ const allowlistedEvents = new Set([
   'telemetry-flush',
 ])
 
-function reportToJsonBuild(event: TraceEvent) {
-  if (!allowlistedEvents.has(event.name)) {
-    return
-  }
-
-  const distDir = traceGlobals.get('distDir')
-  const phase = traceGlobals.get('phase')
-  if (!distDir || !phase) {
-    return
-  }
-
-  // Only report in production builds
-  if (phase !== PHASE_PRODUCTION_BUILD) {
-    return
-  }
-
-  if (!batch) {
-    batch = batcher(async (events: TraceEvent[]) => {
-      if (!writeStream) {
-        await fs.promises.mkdir(distDir, { recursive: true })
-        const file = path.join(distDir, 'trace-build')
-        writeStream = new RotatingWriteStream(
-          file,
-          // Development is limited to 50MB, production is unlimited
-          phase === PHASE_DEVELOPMENT_SERVER ? 52428800 : Infinity
-        )
-      }
-      const eventsJson = JSON.stringify(events)
-      try {
-        await writeStream.write(eventsJson + '\n')
-      } catch (err) {
-        console.log(err)
-      }
-    })
-  }
-
-  batch.report({
-    ...event,
-    traceId,
-  })
-}
-
-export default {
-  flushAll: (opts?: { end: boolean }) =>
-    batch
-      ? batch.flushAll().then(() => {
-          const phase = traceGlobals.get('phase')
-          // Only end writeStream when manually flushing in production
-          if (opts?.end || phase !== PHASE_DEVELOPMENT_SERVER) {
-            return writeStream.end()
-          }
-        })
-      : undefined,
-  report: reportToJsonBuild,
-}
+export default createJsonReporter({
+  filename: 'trace-build',
+  sizeLimit: Infinity,
+  filter: (event) => {
+    const phase = traceGlobals.get('phase')
+    return phase === PHASE_PRODUCTION_BUILD && allowlistedEvents.has(event.name)
+  },
+})

--- a/packages/next/src/trace/report/to-json.ts
+++ b/packages/next/src/trace/report/to-json.ts
@@ -3,6 +3,7 @@ import fs from 'fs'
 import path from 'path'
 import { PHASE_DEVELOPMENT_SERVER } from '../../shared/lib/constants'
 import type { TraceEvent } from '../types'
+import type { Reporter } from './types'
 
 // Batch events as zipkin allows for multiple events to be sent in one go
 export function batcher(reportEvents: (evts: TraceEvent[]) => Promise<void>) {
@@ -30,9 +31,6 @@ export function batcher(reportEvents: (evts: TraceEvent[]) => Promise<void>) {
     },
   }
 }
-
-let writeStream: RotatingWriteStream
-let batch: ReturnType<typeof batcher> | undefined
 
 const writeStreamOptions = {
   flags: 'a',
@@ -97,49 +95,69 @@ class RotatingWriteStream {
   }
 }
 
-function reportToJson(event: TraceEvent) {
-  const distDir = traceGlobals.get('distDir')
-  const phase = traceGlobals.get('phase')
-  if (!distDir || !phase) {
-    return
-  }
+export function createJsonReporter(options: {
+  filename: string
+  sizeLimit: number | ((phase: string) => number)
+  filter?: (event: TraceEvent) => boolean
+}): Reporter {
+  let writeStream: RotatingWriteStream
+  let batch: ReturnType<typeof batcher> | undefined
 
-  if (!batch) {
-    batch = batcher(async (events: TraceEvent[]) => {
-      if (!writeStream) {
-        await fs.promises.mkdir(distDir, { recursive: true })
-        const file = path.join(distDir, 'trace')
-        writeStream = new RotatingWriteStream(
-          file,
-          // Development is limited to 50MB, production is unlimited
-          phase === PHASE_DEVELOPMENT_SERVER ? 52428800 : Infinity
-        )
-      }
-      const eventsJson = JSON.stringify(events)
-      try {
-        await writeStream.write(eventsJson + '\n')
-      } catch (err) {
-        console.log(err)
-      }
+  function report(event: TraceEvent) {
+    if (options.filter && !options.filter(event)) {
+      return
+    }
+
+    const distDir = traceGlobals.get('distDir')
+    const phase = traceGlobals.get('phase')
+    if (!distDir || !phase) {
+      return
+    }
+
+    if (!batch) {
+      batch = batcher(async (events: TraceEvent[]) => {
+        if (!writeStream) {
+          await fs.promises.mkdir(distDir, { recursive: true })
+          const file = path.join(distDir, options.filename)
+          const limit =
+            typeof options.sizeLimit === 'function'
+              ? options.sizeLimit(phase)
+              : options.sizeLimit
+          writeStream = new RotatingWriteStream(file, limit)
+        }
+        const eventsJson = JSON.stringify(events)
+        try {
+          await writeStream.write(eventsJson + '\n')
+        } catch (err) {
+          console.log(err)
+        }
+      })
+    }
+
+    batch.report({
+      ...event,
+      traceId,
     })
   }
 
-  batch.report({
-    ...event,
-    traceId,
-  })
+  return {
+    flushAll: (opts?: { end: boolean }) =>
+      batch
+        ? batch.flushAll().then(() => {
+            const phase = traceGlobals.get('phase')
+            // Only end writeStream when manually flushing in production
+            if (opts?.end || phase !== PHASE_DEVELOPMENT_SERVER) {
+              return writeStream.end()
+            }
+          })
+        : undefined,
+    report,
+  }
 }
 
-export default {
-  flushAll: (opts?: { end: boolean }) =>
-    batch
-      ? batch.flushAll().then(() => {
-          const phase = traceGlobals.get('phase')
-          // Only end writeStream when manually flushing in production
-          if (opts?.end || phase !== PHASE_DEVELOPMENT_SERVER) {
-            return writeStream.end()
-          }
-        })
-      : undefined,
-  report: reportToJson,
-}
+export default createJsonReporter({
+  filename: 'trace',
+  sizeLimit: (phase) =>
+    // Development is limited to 50MB, production is unlimited
+    phase === PHASE_DEVELOPMENT_SERVER ? 52428800 : Infinity,
+})

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -2,7 +2,24 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import fs from 'fs/promises'
+import { readFileSync, existsSync } from 'fs'
 import path from 'path'
+import type { TraceEvent } from 'next/dist/trace'
+
+function parseTraceFile(tracePath: string): TraceEvent[] {
+  const traceContent = readFileSync(tracePath, 'utf8')
+  const traceLines = traceContent
+    .trim()
+    .split('\n')
+    .filter((line) => line.trim())
+
+  const allEvents: TraceEvent[] = []
+  for (const line of traceLines) {
+    const events = JSON.parse(line) as TraceEvent[]
+    allEvents.push(...events)
+  }
+  return allEvents
+}
 
 async function getDirectorySize(dirPath: string): Promise<number> {
   try {
@@ -402,6 +419,44 @@ for (const cacheEnabled of [false, true]) {
           }
         },
         200000
+      )
+    }
+
+    if (cacheEnabled) {
+      ;(process.env.IS_TURBOPACK_TEST ? it : it.skip)(
+        'should emit turbopack-persistence trace spans',
+        async () => {
+          // Trigger a page load so persistence has data to write
+          const browser = await next.browser('/')
+          expect(await browser.elementByCss('main').text()).toMatch(
+            /Timestamp = \d+$/
+          )
+          await browser.close()
+
+          // Wait for persistence to write to disk
+          await stop()
+
+          const traceDir = isNextDev ? '.next/dev' : '.next'
+          const tracePath = path.join(next.testDir, traceDir, 'trace')
+          expect(existsSync(tracePath)).toBe(true)
+
+          const events = parseTraceFile(tracePath)
+          const persistenceEvents = events.filter(
+            (e) => e.name === 'turbopack-persistence'
+          )
+
+          expect(persistenceEvents.length).toBeGreaterThan(0)
+
+          // Verify the persistence event has the expected attributes
+          const event = persistenceEvents[0]
+          expect(event.duration).toBeGreaterThanOrEqual(0)
+          expect(event.tags).toBeDefined()
+          const tags = event.tags as Record<string, unknown>
+          expect(tags.reason).toBeDefined()
+          expect(typeof tags.snapshot_duration_ms).toBe('number')
+          expect(typeof tags.persist_duration_ms).toBe('number')
+          expect(typeof tags.task_count).toBe('number')
+        }
       )
     }
   })

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1374,6 +1374,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let wall_start_ms = wall_start
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap_or_default()
+            // as_millis_f64 is not stable yet
             .as_secs_f64()
             * 1000.0;
         let wall_end_ms = wall_start_ms + elapsed.as_secs_f64() * 1000.0;

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1007,6 +1007,9 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason)
                 .entered();
         let start = Instant::now();
+        // SystemTime for wall-clock timestamps in trace events (milliseconds
+        // since epoch). Instant is monotonic but has no defined epoch, so it
+        // can't be used for cross-process trace correlation.
         let wall_start = SystemTime::now();
         debug_assert!(self.should_persist());
 

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -14,6 +14,7 @@ use std::{
         Arc, LazyLock,
         atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
+    time::SystemTime,
 };
 
 use anyhow::{Context, Result, bail};
@@ -36,7 +37,7 @@ use turbo_tasks::{
         VerificationMode,
     },
     event::{Event, EventDescription, EventListener},
-    message_queue::TimingEvent,
+    message_queue::{TimingEvent, TraceEvent},
     registry::get_value_type,
     scope::scope_and_block,
     task_statistics::TaskStatisticsApi,
@@ -1006,6 +1007,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
             tracing::trace_span!(parent: parent_span.clone(), "snapshot", reason = reason)
                 .entered();
         let start = Instant::now();
+        let wall_start = SystemTime::now();
         debug_assert!(self.should_persist());
 
         let suspended_operations;
@@ -1228,11 +1230,14 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         swap_retain(&mut persisted_task_cache_log, |shard| !shard.is_empty());
 
         drop(snapshot_span);
+        let snapshot_duration = start.elapsed();
+        let task_count = task_snapshots.len();
 
         if persisted_task_cache_log.is_empty() && task_snapshots.is_empty() {
             return Some((snapshot_time, false));
         }
 
+        let persist_start = Instant::now();
         let _span = tracing::info_span!(parent: parent_span, "persist", reason = reason).entered();
         {
             if let Err(err) = self.backing_storage.save_snapshot(
@@ -1354,6 +1359,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
 
         let elapsed = start.elapsed();
+        let persist_duration = persist_start.elapsed();
         // avoid spamming the event queue with information about fast operations
         if elapsed > Duration::from_secs(10) {
             turbo_tasks.send_compilation_event(Arc::new(TimingEvent::new(
@@ -1361,6 +1367,30 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 elapsed,
             )));
         }
+
+        let wall_start_ms = wall_start
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64()
+            * 1000.0;
+        let wall_end_ms = wall_start_ms + elapsed.as_secs_f64() * 1000.0;
+        turbo_tasks.send_compilation_event(Arc::new(TraceEvent::new(
+            "turbopack-persistence",
+            wall_start_ms,
+            wall_end_ms,
+            vec![
+                ("reason", serde_json::Value::from(reason)),
+                (
+                    "snapshot_duration_ms",
+                    serde_json::Value::from(snapshot_duration.as_secs_f64() * 1000.0),
+                ),
+                (
+                    "persist_duration_ms",
+                    serde_json::Value::from(persist_duration.as_secs_f64() * 1000.0),
+                ),
+                ("task_count", serde_json::Value::from(task_count)),
+            ],
+        )));
 
         Some((snapshot_time, true))
     }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -3,7 +3,7 @@ use std::{
     path::PathBuf,
     sync::Arc,
     thread::available_parallelism,
-    time::{Duration, Instant},
+    time::{Duration, Instant, SystemTime},
 };
 
 use anyhow::{Ok, Result};
@@ -12,7 +12,11 @@ use smallvec::SmallVec;
 use turbo_persistence::{
     ArcBytes, CompactConfig, DbConfig, KeyBase, StoreKey, TurboPersistence, ValueBuffer,
 };
-use turbo_tasks::{JoinHandle, message_queue::TimingEvent, spawn, turbo_tasks};
+use turbo_tasks::{
+    JoinHandle,
+    message_queue::{TimingEvent, TraceEvent},
+    spawn, turbo_tasks,
+};
 
 use crate::database::{
     key_value_database::{KeySpace, KeyValueDatabase},
@@ -169,6 +173,7 @@ fn do_compact(
     max_merge_segment_count: usize,
 ) -> Result<()> {
     let start = Instant::now();
+    let wall_start = SystemTime::now();
     // Compact the database with the given max merge segment count
     let ran = db.compact(&CompactConfig {
         max_merge_segment_count,
@@ -181,6 +186,18 @@ fn do_compact(
             turbo_tasks()
                 .send_compilation_event(Arc::new(TimingEvent::new(message.to_string(), elapsed)));
         }
+        let wall_start_ms = wall_start
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs_f64()
+            * 1000.0;
+        let wall_end_ms = wall_start_ms + elapsed.as_secs_f64() * 1000.0;
+        turbo_tasks().send_compilation_event(Arc::new(TraceEvent::new(
+            "turbopack-compaction",
+            wall_start_ms,
+            wall_end_ms,
+            vec![],
+        )));
     }
     Ok(())
 }

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -173,8 +173,9 @@ fn do_compact(
     max_merge_segment_count: usize,
 ) -> Result<()> {
     let start = Instant::now();
+    // SystemTime for wall-clock timestamps in trace events (Instant has no
+    // defined epoch so it can't be used for cross-process trace correlation).
     let wall_start = SystemTime::now();
-    // Compact the database with the given max merge segment count
     let ran = db.compact(&CompactConfig {
         max_merge_segment_count,
         ..COMPACT_CONFIG

--- a/turbopack/crates/turbo-tasks/src/message_queue.rs
+++ b/turbopack/crates/turbo-tasks/src/message_queue.rs
@@ -236,6 +236,52 @@ impl CompilationEvent for DiagnosticEvent {
     }
 }
 
+/// A generic trace event that carries a name, wall-clock timing, and arbitrary attributes.
+/// Forwarded as a `CompilationEvent` to the JS side for inclusion in `.next/trace`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TraceEvent {
+    pub name: &'static str,
+    pub start_time_ms: f64,
+    pub end_time_ms: f64,
+    pub attributes: Vec<(&'static str, serde_json::Value)>,
+}
+
+impl TraceEvent {
+    pub fn new(
+        name: &'static str,
+        start_time_ms: f64,
+        end_time_ms: f64,
+        attributes: Vec<(&'static str, serde_json::Value)>,
+    ) -> Self {
+        Self {
+            name,
+            start_time_ms,
+            end_time_ms,
+            attributes,
+        }
+    }
+}
+
+impl CompilationEvent for TraceEvent {
+    fn type_name(&self) -> &'static str {
+        "TraceEvent"
+    }
+
+    fn severity(&self) -> Severity {
+        Severity::Event
+    }
+
+    fn message(&self) -> String {
+        let duration_ms = self.end_time_ms - self.start_time_ms;
+        format!("{} in {:.0}ms", self.name, duration_ms)
+    }
+
+    fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

- Add a generic `TraceEvent` compilation event type that carries a name, wall-clock timing, and arbitrary attributes
- Emit `TraceEvent` from Turbopack's Rust backend for cache persistence and compaction operations
- Expose `eventJson` on compilation events through the NAPI bridge
- Record `turbopack-persistence` and `turbopack-compaction` trace spans in `.next/trace` with memory usage snapshots, in both dev and build workflows

## Details

Turbopack persistence and compaction operations were invisible in `.next/trace`. The only signal was a console log for operations exceeding 10s.

A new generic `TraceEvent` type replaces the need for per-operation event structs. It carries a name, start/end wall-clock timestamps, and a `Vec` of key-value attributes. On the JS side, `backgroundLogCompilationEvents` handles all `TraceEvent`s with a single code path — creating trace spans via `manualTraceChild` and recording memory usage snapshots. Adding new traced operations requires only a few lines of Rust and zero JS changes.

At @bgw's suggestion, I considered integrating as a `tracing_subscriber::Layer` to automatically forward spans to the compilation event system, but this ended up requiring quite a bit of code (a new subscriber, 'target' impl, span lifecycle management, new crate dependencies) for what is currently just 2 events, and we don't really anticipate adding more.

## Test plan

- [x] Integration test in `test/e2e/filesystem-cache` verifying `turbopack-persistence` spans exist with correct attributes
- [x] `pnpm test-dev-turbo test/e2e/filesystem-cache`
- [x] `pnpm test-start-turbo test/e2e/filesystem-cache`