### PR TITLE
[ci] resolve Vercel build error by configuring pnpm-workspace.yaml for pnpm v10+

### DIFF
--- a/packages/create-next-app/templates/index.ts
+++ b/packages/create-next-app/templates/index.ts
@@ -330,6 +330,8 @@ export const installTemplate = async ({
     const pnpmMajorVersion = getPnpmMajorVersion();
     if (pnpmMajorVersion === null || pnpmMajorVersion >= 10) {
       const pnpmWorkspaceYaml = [
+        "packages:",
+        "  - .",
         "ignoredBuiltDependencies:",
         // Sharp has prebuilt binaries for the platforms next-swc has binaries.
         // If it needs to build binaries from source, next-swc wouldn't work either.


### PR DESCRIPTION
Vercel Build Logs:

> ...
> Using pnpm@9.x based on project creation date
> To use pnpm@10.x, manually opt in using corepack (https://vercel.com/docs/deployments/configure-a-build#corepack)
> Installing dependencies...
>  ERROR  packages field missing or empty
> For help, run: pnpm help install
> Error: Command "pnpm install" exited with 1

@eps1lon Do you think it's okay to do this ?