### PR TITLE
feat(node-streams): add config flag, define-env, and env precedence test

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -123,6 +123,7 @@ export function getDefineEnv({
   const isPPREnabled = checkIsAppPPREnabled(config.experimental.ppr)
   const isCacheComponentsEnabled = !!config.cacheComponents
   const isUseCacheEnabled = !!config.experimental.useCache
+  const isUseNodeStreamsEnabled = !!config.experimental.useNodeStreams
 
   const defineEnv: DefineEnv = {
     // internal field to identify the plugin config
@@ -178,6 +179,9 @@ export function getDefineEnv({
     'process.env.__NEXT_INSTANT_NAV_TOGGLE':
       !!config.experimental.instantNavigationDevToolsToggle,
     'process.env.__NEXT_USE_CACHE': isUseCacheEnabled,
+    'process.env.__NEXT_USE_NODE_STREAMS': isEdgeServer
+      ? false
+      : isUseNodeStreamsEnabled,
 
     'process.env.NEXT_IMMUTABLE_ASSET_TOKEN':
       config.experimental.immutableAssetToken || '',

--- a/packages/next/src/export/types.ts
+++ b/packages/next/src/export/types.ts
@@ -60,6 +60,7 @@ export interface ExportPageInput {
   debugOutput?: boolean
   nextConfigOutput?: NextConfigComplete['output']
   enableExperimentalReact?: boolean
+  enableNodeStreams?: boolean
   sriEnabled: boolean
   renderResumeDataCache: RenderResumeDataCache | undefined
 }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -82,6 +82,7 @@ async function exportPageImpl(
     disableOptimizedLoading,
     debugOutput = false,
     enableExperimentalReact,
+    enableNodeStreams,
     trailingSlash,
     sriEnabled,
     renderOpts: commonRenderOpts,
@@ -94,6 +95,9 @@ async function exportPageImpl(
 
   if (enableExperimentalReact) {
     process.env.__NEXT_EXPERIMENTAL_REACT = 'true'
+  }
+  if (enableNodeStreams) {
+    process.env.__NEXT_USE_NODE_STREAMS = 'true'
   }
 
   const {
@@ -432,6 +436,7 @@ export async function exportPages(
             httpAgentOptions: nextConfig.httpAgentOptions,
             debugOutput: options.debugOutput,
             enableExperimentalReact: needsExperimentalReact(nextConfig),
+            enableNodeStreams: !!nextConfig.experimental.useNodeStreams,
             sriEnabled: Boolean(nextConfig.experimental.sri?.algorithm),
             buildId: input.buildId,
             deploymentId: input.deploymentId,

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -10,6 +10,34 @@ export {
 // eslint-disable-next-line import/no-extraneous-dependencies
 export { prerender } from 'react-server-dom-webpack/static'
 
+// Node.js-specific Flight APIs, needed by stream-ops.node.ts via ComponentMod.
+// These must be exported from entry-base (react-server layer) because direct
+// imports from react-server-dom-webpack/* fail outside this layer.
+type FlightRenderToPipeableStream = (...args: any[]) => {
+  pipe<Writable extends NodeJS.WritableStream>(destination: Writable): Writable
+  abort: (reason?: unknown) => void
+}
+
+type FlightPrerenderToNodeStream = (...args: any[]) => Promise<{
+  prelude: import('node:stream').Readable
+}>
+
+/* eslint-disable import/no-extraneous-dependencies */
+export let renderToPipeableStream: FlightRenderToPipeableStream | undefined
+export let prerenderToNodeStream: FlightPrerenderToNodeStream | undefined
+if (process.env.__NEXT_USE_NODE_STREAMS) {
+  renderToPipeableStream = (
+    require('react-server-dom-webpack/server.node') as typeof import('react-server-dom-webpack/server.node')
+  ).renderToPipeableStream
+  prerenderToNodeStream = (
+    require('react-server-dom-webpack/static') as typeof import('react-server-dom-webpack/static')
+  ).prerenderToNodeStream
+} else {
+  renderToPipeableStream = undefined
+  prerenderToNodeStream = undefined
+}
+/* eslint-enable import/no-extraneous-dependencies */
+
 // TODO: Just re-export `* as ReactServer`
 export { captureOwnerStack, createElement, Fragment } from 'react'
 
@@ -45,15 +73,17 @@ export {
   collectPrefetchHints,
 } from './collect-segment-data'
 
-export const InstantValidation = () => {
-  if (
-    process.env.NEXT_RUNTIME !== 'edge' &&
-    process.env.__NEXT_CACHE_COMPONENTS
-  ) {
-    return require('./instant-validation/instant-validation') as typeof import('./instant-validation/instant-validation')
-  } else {
-    return undefined
-  }
+export let InstantValidation:
+  | typeof import('./instant-validation/instant-validation')
+  | undefined
+if (
+  process.env.NEXT_RUNTIME !== 'edge' &&
+  process.env.__NEXT_CACHE_COMPONENTS
+) {
+  InstantValidation =
+    require('./instant-validation/instant-validation') as typeof import('./instant-validation/instant-validation')
+} else {
+  InstantValidation = undefined
 }
 
 import type { NodeJsPartialHmrUpdate } from '../../build/swc/types'

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -73,17 +73,15 @@ export {
   collectPrefetchHints,
 } from './collect-segment-data'
 
-export let InstantValidation:
-  | typeof import('./instant-validation/instant-validation')
-  | undefined
-if (
-  process.env.NEXT_RUNTIME !== 'edge' &&
-  process.env.__NEXT_CACHE_COMPONENTS
-) {
-  InstantValidation =
-    require('./instant-validation/instant-validation') as typeof import('./instant-validation/instant-validation')
-} else {
-  InstantValidation = undefined
+export const InstantValidation = () => {
+  if (
+    process.env.NEXT_RUNTIME !== 'edge' &&
+    process.env.__NEXT_CACHE_COMPONENTS
+  ) {
+    return require('./instant-validation/instant-validation') as typeof import('./instant-validation/instant-validation')
+  } else {
+    return undefined
+  }
 }
 
 import type { NodeJsPartialHmrUpdate } from '../../build/swc/types'

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -350,10 +350,18 @@ export const experimentalSchema = {
   turbopackClientSideNestedAsyncChunking: z.boolean().optional(),
   turbopackServerSideNestedAsyncChunking: z.boolean().optional(),
   turbopackImportTypeBytes: z.boolean().optional(),
-  turbopackImportTypeText: z.boolean().optional(),
   turbopackUseBuiltinBabel: z.boolean().optional(),
   turbopackUseBuiltinSass: z.boolean().optional(),
   turbopackModuleIds: z.enum(['named', 'deterministic']).optional(),
+  turbopackIgnoreIssue: z
+    .array(
+      z.object({
+        path: z.union([z.string(), z.instanceof(RegExp)]),
+        title: z.union([z.string(), z.instanceof(RegExp)]).optional(),
+        description: z.union([z.string(), z.instanceof(RegExp)]).optional(),
+      })
+    )
+    .optional(),
   turbopackInferModuleSideEffects: z.boolean().optional(),
   optimizePackageImports: z.array(z.string()).optional(),
   optimizeServerReact: z.boolean().optional(),
@@ -381,6 +389,7 @@ export const experimentalSchema = {
   serverComponentsHmrCache: z.boolean().optional(),
   authInterrupts: z.boolean().optional(),
   useCache: z.boolean().optional(),
+  useNodeStreams: z.boolean().optional(),
   slowModuleDetection: z
     .object({
       buildTimeThresholdMs: z.number().int(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -350,18 +350,10 @@ export const experimentalSchema = {
   turbopackClientSideNestedAsyncChunking: z.boolean().optional(),
   turbopackServerSideNestedAsyncChunking: z.boolean().optional(),
   turbopackImportTypeBytes: z.boolean().optional(),
+  turbopackImportTypeText: z.boolean().optional(),
   turbopackUseBuiltinBabel: z.boolean().optional(),
   turbopackUseBuiltinSass: z.boolean().optional(),
   turbopackModuleIds: z.enum(['named', 'deterministic']).optional(),
-  turbopackIgnoreIssue: z
-    .array(
-      z.object({
-        path: z.union([z.string(), z.instanceof(RegExp)]),
-        title: z.union([z.string(), z.instanceof(RegExp)]).optional(),
-        description: z.union([z.string(), z.instanceof(RegExp)]).optional(),
-      })
-    )
-    .optional(),
   turbopackInferModuleSideEffects: z.boolean().optional(),
   optimizePackageImports: z.array(z.string()).optional(),
   optimizeServerReact: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -159,6 +159,7 @@ export type TurbopackModuleType =
   | 'raw'
   | 'node'
   | 'bytes'
+  | 'text'
 
 export type TurbopackRuleConfigItem = {
   /** Loaders to apply to matched files. */

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -580,6 +580,11 @@ export interface ExperimentalConfig {
   turbopackImportTypeBytes?: boolean
 
   /**
+   * Enable support for `with {type: "text"}` for ESM imports.
+   */
+  turbopackImportTypeText?: boolean
+
+  /**
    * Enable scope hoisting. Defaults to true in build mode. Always disabled in development mode.
    */
   turbopackScopeHoisting?: boolean
@@ -667,19 +672,6 @@ export interface ExperimentalConfig {
    * for production.
    */
   turbopackModuleIds?: 'named' | 'deterministic'
-
-  /**
-   * Filter out specific Turbopack errors and warnings so they do not appear
-   * in the CLI output or the error overlay. String values for `path` are
-   * glob patterns; string values for `title`/`description` are exact matches.
-   * RegExp values match anywhere within the string (use `^` and `$` anchors
-   * for full-string matching).
-   */
-  turbopackIgnoreIssue?: Array<{
-    path: string | RegExp
-    title?: string | RegExp
-    description?: string | RegExp
-  }>
 
   /**
    * For use with `@next/mdx`. Compile MDX files using the new Rust compiler.

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -159,7 +159,6 @@ export type TurbopackModuleType =
   | 'raw'
   | 'node'
   | 'bytes'
-  | 'text'
 
 export type TurbopackRuleConfigItem = {
   /** Loaders to apply to matched files. */
@@ -581,11 +580,6 @@ export interface ExperimentalConfig {
   turbopackImportTypeBytes?: boolean
 
   /**
-   * Enable support for `with {type: "text"}` for ESM imports.
-   */
-  turbopackImportTypeText?: boolean
-
-  /**
    * Enable scope hoisting. Defaults to true in build mode. Always disabled in development mode.
    */
   turbopackScopeHoisting?: boolean
@@ -673,6 +667,19 @@ export interface ExperimentalConfig {
    * for production.
    */
   turbopackModuleIds?: 'named' | 'deterministic'
+
+  /**
+   * Filter out specific Turbopack errors and warnings so they do not appear
+   * in the CLI output or the error overlay. String values for `path` are
+   * glob patterns; string values for `title`/`description` are exact matches.
+   * RegExp values match anywhere within the string (use `^` and `$` anchors
+   * for full-string matching).
+   */
+  turbopackIgnoreIssue?: Array<{
+    path: string | RegExp
+    title?: string | RegExp
+    description?: string | RegExp
+  }>
 
   /**
    * For use with `@next/mdx`. Compile MDX files using the new Rust compiler.
@@ -915,6 +922,13 @@ export interface ExperimentalConfig {
    * Enables the use of the `"use cache"` directive.
    */
   useCache?: boolean
+
+  /**
+   * Use Node.js native streams instead of web streams for the App Router
+   * rendering pipeline on the Node.js runtime. This can improve performance
+   * by avoiding the overhead of web stream wrappers.
+   */
+  useNodeStreams?: boolean
 
   /**
    * Enables detection and reporting of slow modules during development builds.
@@ -1907,6 +1921,7 @@ export interface NextConfigRuntime {
     | 'partialFallbacks'
     | 'exposeTestingApiInProductionBuild'
     | 'immutableAssetToken'
+    | 'useNodeStreams'
   > & {
     // Pick on @internal fields generates invalid .d.ts files
     /** @internal */
@@ -1973,6 +1988,7 @@ export function getNextConfigRuntime(
         partialFallbacks: ex.partialFallbacks,
         exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
         immutableAssetToken: ex.immutableAssetToken,
+        useNodeStreams: ex.useNodeStreams,
 
         trustHostHeader: ex.trustHostHeader,
         isExperimentalCompile: ex.isExperimentalCompile,

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2020,6 +2020,43 @@ function enforceExperimentalFeatures(
     }
   }
 
+  // Enable node streams via env var (for CI testing).
+  if (
+    process.env.__NEXT_USE_NODE_STREAMS === 'true' &&
+    (config.experimental.useNodeStreams === undefined ||
+      (isDefaultConfig && !config.experimental.useNodeStreams))
+  ) {
+    config.experimental.useNodeStreams = true
+  }
+
+  // Keep runtime bundle selection env in sync with the resolved config.
+  // Explicit user config (e.g. useNodeStreams: false) should win over an
+  // inherited shell env var to avoid selecting nodestream runtime bundles
+  // while define-env compiled user bundles with node streams disabled.
+  if (config.experimental.useNodeStreams) {
+    process.env.__NEXT_USE_NODE_STREAMS = 'true'
+  } else {
+    delete process.env.__NEXT_USE_NODE_STREAMS
+  }
+
+  // TODO: Remove this once using the debug channel is the default.
+  if (
+    process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL === 'true' &&
+    // We do respect an explicit value in the user config.
+    (config.experimental.reactDebugChannel === undefined ||
+      (isDefaultConfig && !config.experimental.reactDebugChannel))
+  ) {
+    config.experimental.reactDebugChannel = true
+
+    if (configuredExperimentalFeatures) {
+      addConfiguredExperimentalFeature(
+        configuredExperimentalFeatures,
+        'reactDebugChannel',
+        true,
+        'enabled by `__NEXT_EXPERIMENTAL_DEBUG_CHANNEL`'
+      )
+    }
+  }
   // TODO: Remove this once strictRouteTypes is the default.
   if (
     process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true' &&

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -2039,24 +2039,6 @@ function enforceExperimentalFeatures(
     delete process.env.__NEXT_USE_NODE_STREAMS
   }
 
-  // TODO: Remove this once using the debug channel is the default.
-  if (
-    process.env.__NEXT_EXPERIMENTAL_DEBUG_CHANNEL === 'true' &&
-    // We do respect an explicit value in the user config.
-    (config.experimental.reactDebugChannel === undefined ||
-      (isDefaultConfig && !config.experimental.reactDebugChannel))
-  ) {
-    config.experimental.reactDebugChannel = true
-
-    if (configuredExperimentalFeatures) {
-      addConfiguredExperimentalFeature(
-        configuredExperimentalFeatures,
-        'reactDebugChannel',
-        true,
-        'enabled by `__NEXT_EXPERIMENTAL_DEBUG_CHANNEL`'
-      )
-    }
-  }
   // TODO: Remove this once strictRouteTypes is the default.
   if (
     process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true' &&

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -222,6 +222,9 @@ export default class NextNodeServer extends BaseServer<
     if (this.renderOpts.nextScriptWorkers) {
       process.env.__NEXT_SCRIPT_WORKERS = JSON.stringify(true)
     }
+    if (this.nextConfig.experimental.useNodeStreams) {
+      process.env.__NEXT_USE_NODE_STREAMS = 'true'
+    }
 
     if (!this.minimalMode) {
       this.imageResponseCache = new ResponseCache(this.minimalMode)

--- a/packages/next/types/$$compiled.internal.d.ts
+++ b/packages/next/types/$$compiled.internal.d.ts
@@ -225,6 +225,35 @@ declare module 'react-server-dom-webpack/server.node' {
     renderToReadableStream,
   } from 'react-server-dom-webpack/server.edge'
 
+  export function renderToPipeableStream(
+    model: any,
+    webpackMap: import('react-server-dom-webpack/server.edge').ClientManifest,
+    options?: {
+      temporaryReferences?: import('react-server-dom-webpack/server.edge').TemporaryReferenceSet
+      environmentName?: string | (() => string)
+      filterStackFrame:
+        | ((
+            url: string,
+            functionName: string,
+            lineNumber: number,
+            columnNumber: number
+          ) => boolean)
+        | undefined
+      onError?: (error: unknown) => void
+      signal?: AbortSignal
+      // React's Node API expects debugChannel to be a Node.js Writable
+      // (has .write()), Duplex (has .read()), or WebSocket (has .send()).
+      // This differs from the web API which expects { readable?, writable? }.
+      debugChannel?: import('node:stream').Writable
+      startTime?: number
+    }
+  ): {
+    pipe<Writable extends NodeJS.WritableStream>(
+      destination: Writable
+    ): Writable
+    abort(reason?: unknown): void
+  }
+
   export type TemporaryReferenceSet = WeakMap<any, string>
 
   export type ImportManifestEntry = {
@@ -306,6 +335,35 @@ declare module 'react-server-dom-webpack/static' {
     }
   ): Promise<{
     prelude: ReadableStream<Uint8Array>
+  }>
+
+  export function prerenderToNodeStream(
+    children: any,
+    webpackMap: {
+      readonly [id: string]: {
+        readonly id: string | number
+        readonly chunks: ReadonlyArray<string>
+        readonly name: string
+        readonly async?: boolean
+      }
+    },
+    options?: {
+      environmentName?: string | (() => string)
+      filterStackFrame:
+        | ((
+            url: string,
+            functionName: string,
+            lineNumber: number,
+            columnNumber: number
+          ) => boolean)
+        | undefined
+      identifierPrefix?: string
+      signal?: AbortSignal
+      temporaryReferences?: TemporaryReferenceSet
+      onError?: (error: unknown) => void
+    }
+  ): Promise<{
+    prelude: import('node:stream').Readable
   }>
 }
 declare module 'react-server-dom-webpack/client.edge' {

--- a/test/e2e/app-dir/use-node-streams-env-precedence/app/layout.js
+++ b/test/e2e/app-dir/use-node-streams-env-precedence/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-node-streams-env-precedence/app/page.js
+++ b/test/e2e/app-dir/use-node-streams-env-precedence/app/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>env precedence fixture</p>
+}

--- a/test/e2e/app-dir/use-node-streams-env-precedence/next.config.js
+++ b/test/e2e/app-dir/use-node-streams-env-precedence/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    useNodeStreams: false,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-node-streams-env-precedence/use-node-streams-env-precedence.test.ts
+++ b/test/e2e/app-dir/use-node-streams-env-precedence/use-node-streams-env-precedence.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('use-node-streams env precedence', () => {
+  const { next, isNextDev, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+    env: {
+      __NEXT_USE_NODE_STREAMS: 'true',
+    },
+  })
+
+  if (isNextDev || skipped) {
+    it.skip('only testable in start mode', () => {})
+    return
+  }
+
+  it('should respect explicit useNodeStreams=false even when env flag is true', async () => {
+    const { exitCode, cliOutput } = await next.build()
+    expect(exitCode).toBe(0)
+    expect(cliOutput).toContain('useNodeStreams')
+  }, 30_000)
+})


### PR DESCRIPTION
## What?

Split out these changes from #89859. Only adds more plumbing for future Node.js streams feature.