### PR TITLE
docs: clarify that next upgrade is for 16.1.x+

### DIFF
--- a/docs/01-app/01-getting-started/18-upgrading.mdx
+++ b/docs/01-app/01-getting-started/18-upgrading.mdx
@@ -30,7 +30,7 @@ yarn next upgrade
 bunx next upgrade
 ```
 
-Next.js 15 and earlier do not support the `upgrade` command and need to use a separate package instead:
+Versions before Next.js 16.1.0 do not support the `upgrade` command and need to use a separate package instead:
 
 ```bash filename="Terminal"
 npx @next/codemod@canary upgrade latest

--- a/docs/01-app/03-api-reference/06-cli/next.mdx
+++ b/docs/01-app/03-api-reference/06-cli/next.mdx
@@ -409,6 +409,7 @@ The generated `.cpuprofile` files can be opened in Chrome DevTools (Performance 
 
 | Version   | Changes                                                                         |
 | --------- | ------------------------------------------------------------------------------- |
+| `v16.1.0` | Add the `next upgrade` command                                                  |
 | `v16.1.0` | Add the `next experimental-analyze` command                                     |
 | `v16.0.0` | The JS bundle size metrics have been removed from `next build`                  |
 | `v15.5.0` | Add the `next typegen` command                                                  |


### PR DESCRIPTION
Closes: https://github.com/vercel/next.js/issues/90425