### PR TITLE
[ci] Always upload Turborepo summary artifact

### DIFF
--- a/.github/workflows/build_reusable.yml
+++ b/.github/workflows/build_reusable.yml
@@ -324,7 +324,8 @@ jobs:
         if: ${{ always() }}
         run: rm -f /tmp/package-lock.json
 
-      - name: Upload artifact
+      - name: Upload Turborepo summary
+        if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: turbo-run-summary-${{ steps.var.outputs.input_step_key }}


### PR DESCRIPTION
A bad cache could lead to failure which was previously not debuggable since we only uploaded the summary on passing jobs.

Now we always upload the summary (if it exists) allowing to debug fauly Turborepo caches.

## Test plan

- [x] CI was so nice and flaked producing a failed job uploading Turborepo summary: https://github.com/vercel/next.js/actions/runs/22356425285/job/64697373237?pr=90441