### PR TITLE
[ci] Fix input cache keys for tasks referencing `rust-toolchain`

### DIFF
--- a/packages/next-swc/turbo.json
+++ b/packages/next-swc/turbo.json
@@ -10,7 +10,7 @@
         "../../Cargo.toml",
         "../../Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": [
@@ -27,7 +27,7 @@
         "../../Cargo.toml",
         "../../Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["native/*.node", "native/index.d.ts"]
@@ -40,7 +40,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["native/*.node", "native/index.d.ts"]
@@ -53,7 +53,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["native/*.node", "native/index.d.ts"]
@@ -66,7 +66,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["native/*.node", "native/index.d.ts"]
@@ -79,7 +79,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["native/*.node", "native/index.d.ts"]
@@ -92,7 +92,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["../../crates/wasm/pkg/*"]
@@ -105,7 +105,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["native/*"]
@@ -118,7 +118,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "env": ["CI"],
       "outputs": ["native/*.node", "native/index.d.ts"]
@@ -134,7 +134,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ],
       "cache": false
     },
@@ -146,7 +146,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ]
     },
     "rust-check-napi": {
@@ -157,7 +157,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ]
     },
     "test-cargo-unit": {
@@ -168,7 +168,7 @@
         "../../**/Cargo.toml",
         "../../**/Cargo.lock",
         "../../.github/workflows/build_and_deploy.yml",
-        "../../rust-toolchain"
+        "../../rust-toolchain.toml"
       ]
     }
   }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 # if you update this, also update `.devcontainer/rust/devcontainer-feature.json`
+# if you move the file, also update any turbo.json inputs that references it.
 [toolchain]
 channel = "nightly-2026-02-18"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
`rust-toolchain` was moved to `rust-toolchain.toml` in https://github.com/vercel/next.js/pull/62176 without updating Turborepo cache key inputs.

Now we reference the actual file again in Turborepo tasks ensuring the right cache is used.

Doesn't fix native caching for Windows entirely:
- [build-native-windows: cache miss, executing `453c41ba10e2ac1e`](https://github.com/vercel/next.js/actions/runs/22357230271/job/64700231380?pr=90442#step:26:48)
- [test integration windows: cache hit, replaying logs `1ab8567fd0128112`](https://github.com/vercel/next.js/actions/runs/22357230271/job/64702528760?pr=90442)
- [test prod windows: cache hit, replaying logs `453c41ba10e2ac1e`](https://github.com/vercel/next.js/actions/runs/22357230271/job/64702528725?pr=90442#step:26:48)

I would expect the same cache key everywhere.