### PR TITLE
[test] Deflake `typed-routes-validator` using `tsc`

### DIFF
--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -53,7 +53,7 @@ describe('typed-routes-validator', () => {
           const routesDts = await next.readFile(
             `${getDistDir()}/types/routes.d.ts`
           )
-          expect(routesDts).toContain("AppRoutes = '/'")
+          expect(routesDts).toContain('AppRoutes = "/"')
         })
       }
 

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -43,11 +43,17 @@ describe('typed-routes-validator', () => {
     }
     try {
       if (isNextDev) {
-        // In dev mode, next-env.d.ts is generated asynchronously after the
-        // server starts. Wait for it before running tsc.
+        // In dev mode, next-env.d.ts and the route type definitions it
+        // references (.next/types/routes.d.ts) are generated asynchronously
+        // after the server starts. Wait for both files to be ready with
+        // actual route data before running tsc.
         await retry(async () => {
-          const content = await next.readFile('next-env.d.ts')
-          expect(content).toContain('reference types="next"')
+          const envDts = await next.readFile('next-env.d.ts')
+          expect(envDts).toContain('reference types="next"')
+          const routesDts = await next.readFile(
+            `${getDistDir()}/types/routes.d.ts`
+          )
+          expect(routesDts).toContain("AppRoutes = '/'")
         })
       }
 

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -42,12 +42,14 @@ describe('typed-routes-validator', () => {
       await next.build()
     }
     try {
-      // Wait for next-env.d.ts to be written; in dev mode this is generated
-      // asynchronously after the server starts.
-      await retry(async () => {
-        const content = await next.readFile('next-env.d.ts')
-        expect(content).toContain('reference types="next"')
-      })
+      if (isNextDev) {
+        // In dev mode, next-env.d.ts is generated asynchronously after the
+        // server starts. Wait for it before running tsc.
+        await retry(async () => {
+          const content = await next.readFile('next-env.d.ts')
+          expect(content).toContain('reference types="next"')
+        })
+      }
 
       const { stdout, stderr } = await execa('pnpm', ['tsc', '--noEmit'], {
         cwd: next.testDir,

--- a/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
+++ b/test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts
@@ -1,6 +1,6 @@
 import execa from 'execa'
 import { nextTestSetup } from 'e2e-utils'
-import { getDistDir } from 'next-test-utils'
+import { getDistDir, retry } from 'next-test-utils'
 
 const strictRouteTypes =
   process.env.__NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES === 'true'
@@ -42,6 +42,13 @@ describe('typed-routes-validator', () => {
       await next.build()
     }
     try {
+      // Wait for next-env.d.ts to be written; in dev mode this is generated
+      // asynchronously after the server starts.
+      await retry(async () => {
+        const content = await next.readFile('next-env.d.ts')
+        expect(content).toContain('reference types="next"')
+      })
+
       const { stdout, stderr } = await execa('pnpm', ['tsc', '--noEmit'], {
         cwd: next.testDir,
         reject: false,


### PR DESCRIPTION
We need to wait for `next-env.d.ts` to be written. Creation of that file is not blocking dev-server startup.

Fixes 
```
FAIL webpack test/e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts (11.107 s)
  typed-routes-validator
    ✓ should generate route validation correctly (5878 ms)
    ✕ should have passing tsc after the server generated types (2379 ms)

  ● typed-routes-validator › should have passing tsc after the server generated types

    expect(received).toEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 2

      Object {
        "stderr": "",
    -   "stdout": "",
    +   "stdout": "app/layout.tsx(1,37): error TS2304: Cannot find name 'LayoutProps'.
    + app/page.tsx(1,37): error TS2304: Cannot find name 'PageProps'.",
      }

      48 |       })
      49 |
    > 50 |       expect({ stdout, stderr }).toEqual({
         |                                  ^
      51 |         stdout: '',
      52 |         stderr: '',
      53 |       })

      at Object.toEqual (e2e/app-dir/typed-routes-validator/typed-routes-validator.test.ts:50:34)
```
-- https://github.com/vercel/next.js/actions/runs/22358627319/job/64710613953