### PR TITLE
test: Cleanup and refactoring

### DIFF
--- a/test/integration/next-image-legacy/base-path/test/index.test.ts
+++ b/test/integration/next-image-legacy/base-path/test/index.test.ts
@@ -20,17 +20,15 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-async function hasImageMatchingUrl(browser, url) {
-  const links = await browser.elementsByCss('img')
-  let foundMatch = false
-  for (const link of links) {
-    const src = await link.getAttribute('src')
-    if (new URL(src, `http://localhost:${appPort}`).toString() === url) {
-      foundMatch = true
-      break
-    }
-  }
-  return foundMatch
+async function getImageUrls(browser) {
+  return await Promise.all(
+    (await browser.elementsByCss('img')).map(async (link) =>
+      new URL(
+        await link.getAttribute('src'),
+        `http://localhost:${appPort}`
+      ).toString()
+    )
+  )
 }
 
 async function getComputed(browser, id, prop) {
@@ -76,12 +74,9 @@ function runTests(mode) {
         return 'result-correct'
       }, /result-correct/)
 
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75`
-        )
-      ).toBe(true)
+      expect(await getImageUrls(browser)).toContain(
+        `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75`
+      )
     } finally {
       await browser.close()
     }

--- a/test/integration/next-image-legacy/default/test/index.test.ts
+++ b/test/integration/next-image-legacy/default/test/index.test.ts
@@ -25,19 +25,16 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-async function hasImageMatchingUrl(browser, url) {
-  const links = await browser.elementsByCss('img')
-  let foundMatch = false
-  for (const link of links) {
-    const src = await link.getAttribute('src')
-    if (new URL(src, `http://localhost:${appPort}`).toString() === url) {
-      foundMatch = true
-      break
-    }
-  }
-  return foundMatch
+async function getImageUrls(browser) {
+  return await Promise.all(
+    (await browser.elementsByCss('img')).map(async (link) =>
+      new URL(
+        await link.getAttribute('src'),
+        `http://localhost:${appPort}`
+      ).toString()
+    )
+  )
 }
-
 async function getComputed(browser, id, prop) {
   const val = await browser.eval(`document.getElementById('${id}').${prop}`)
   if (typeof val === 'number') {
@@ -89,12 +86,9 @@ function runTests(mode) {
         return 'result-correct'
       }, /result-correct/)
 
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
-        )
-      ).toBe(true)
+      expect(await getImageUrls(browser)).toContain(
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+      )
     } finally {
       if (browser) {
         await browser.close()
@@ -1444,30 +1438,17 @@ function runTests(mode) {
         return 'result-correct'
       }, /result-correct/)
 
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
-        )
-      ).toBe(false)
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/_next/image?url=%2Ftest.png&w=828&q=75`
-        )
-      ).toBe(true)
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/test.svg`
-        )
-      ).toBe(true)
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/_next/image?url=%2Ftest.webp&w=828&q=75`
-        )
-      ).toBe(false)
+      const imageUrls = await getImageUrls(browser)
+      expect(imageUrls).not.toContain(
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+      )
+      expect(imageUrls).toContain(
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.png&w=828&q=75`
+      )
+      expect(imageUrls).toContain(`http://localhost:${appPort}/test.svg`)
+      expect(imageUrls).not.toContain(
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.webp&w=828&q=75`
+      )
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -27,19 +27,16 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-async function hasImageMatchingUrl(browser, url) {
-  const links = await browser.elementsByCss('img')
-  let foundMatch = false
-  for (const link of links) {
-    const src = await link.getAttribute('src')
-    if (new URL(src, `http://localhost:${appPort}`).toString() === url) {
-      foundMatch = true
-      break
-    }
-  }
-  return foundMatch
+async function getImageUrls(browser) {
+  return await Promise.all(
+    (await browser.elementsByCss('img')).map(async (link) =>
+      new URL(
+        await link.getAttribute('src'),
+        `http://localhost:${appPort}`
+      ).toString()
+    )
+  )
 }
-
 async function getComputed(browser, id, prop) {
   const val = await browser.eval(`document.getElementById('${id}').${prop}`)
   if (typeof val === 'number') {
@@ -91,12 +88,9 @@ function runTests(mode: 'dev' | 'server') {
         return 'result-correct'
       }, /result-correct/)
 
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
-        )
-      ).toBe(true)
+      expect(await getImageUrls(browser)).toContain(
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+      )
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/next-image-new/base-path/test/index.test.ts
+++ b/test/integration/next-image-new/base-path/test/index.test.ts
@@ -20,17 +20,15 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-async function hasImageMatchingUrl(browser, url) {
-  const links = await browser.elementsByCss('img')
-  let foundMatch = false
-  for (const link of links) {
-    const src = await link.getAttribute('src')
-    if (new URL(src, `http://localhost:${appPort}`).toString() === url) {
-      foundMatch = true
-      break
-    }
-  }
-  return foundMatch
+async function getImageUrls(browser) {
+  return await Promise.all(
+    (await browser.elementsByCss('img')).map(async (link) =>
+      new URL(
+        await link.getAttribute('src'),
+        `http://localhost:${appPort}`
+      ).toString()
+    )
+  )
 }
 
 async function getComputed(browser, id, prop) {
@@ -70,12 +68,9 @@ function runTests(mode) {
         return 'result-correct'
       }, /result-correct/)
 
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75`
-        )
-      ).toBe(true)
+      expect(await getImageUrls(browser)).toContain(
+        `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75`
+      )
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -29,17 +29,15 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-async function hasImageMatchingUrl(browser, url) {
-  const links = await browser.elementsByCss('img')
-  let foundMatch = false
-  for (const link of links) {
-    const src = await link.getAttribute('src')
-    if (new URL(src, `http://localhost:${appPort}`).toString() === url) {
-      foundMatch = true
-      break
-    }
-  }
-  return foundMatch
+async function getImageUrls(browser) {
+  return await Promise.all(
+    (await browser.elementsByCss('img')).map(async (link) =>
+      new URL(
+        await link.getAttribute('src'),
+        `http://localhost:${appPort}`
+      ).toString()
+    )
+  )
 }
 
 async function getComputed(browser, id, prop) {
@@ -93,12 +91,9 @@ function runTests(mode) {
         return 'result-correct'
       }, /result-correct/)
 
-      expect(
-        await hasImageMatchingUrl(
-          browser,
-          `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
-        )
-      ).toBe(true)
+      expect(await getImageUrls(browser)).toContain(
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+      )
     } finally {
       if (browser) {
         await browser.close()

--- a/test/integration/repeated-slashes/test/index.test.ts
+++ b/test/integration/repeated-slashes/test/index.test.ts
@@ -411,24 +411,11 @@ function runTests({ isDev = false, isExport = false, isPages404 = false }) {
 }
 
 describe('404 handling', () => {
-  let nextOpts = {}
-  beforeAll(async () => {
-    const hasLocalNext = fs.existsSync(join(appDir, 'node_modules/next'))
-
-    if (hasLocalNext) {
-      nextOpts = {
-        nextBin: join(appDir, 'node_modules/next/dist/bin/next'),
-        cwd: appDir,
-      }
-      console.log('Using next options', nextOpts)
-    }
-  })
-
   const devStartAndExport = (isPages404) => {
     describe('next dev', () => {
       beforeAll(async () => {
         appPort = await findPort()
-        app = await launchApp(appDir, appPort, nextOpts)
+        app = await launchApp(appDir, appPort)
 
         // prebuild pages
         await renderViaHTTP(appPort, '/')
@@ -446,21 +433,19 @@ describe('404 handling', () => {
       () => {
         describe('next start', () => {
           beforeAll(async () => {
-            await nextBuild(appDir, [], nextOpts)
+            await nextBuild(appDir)
             appPort = await findPort()
-            app = await nextStart(appDir, appPort, nextOpts)
+            app = await nextStart(appDir, appPort)
           })
           afterAll(() => killApp(app))
-
           runTests({
             isPages404,
           })
         })
-
         describe('next export', () => {
           beforeAll(async () => {
             nextConfig.write(`module.exports = { output: 'export' }`)
-            await nextBuild(appDir, [], nextOpts)
+            await nextBuild(appDir)
             app = await startStaticServer(outdir, join(outdir, '404.html'))
             appPort = app.address().port
           })
@@ -468,7 +453,6 @@ describe('404 handling', () => {
             await stopApp(app)
             nextConfig.restore()
           })
-
           runTests({
             isPages404,
             isExport: true,
@@ -483,17 +467,14 @@ describe('404 handling', () => {
   })
 
   describe('pages/404', () => {
-    ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
-      'production mode',
-      () => {
-        const pagesErr = join(appDir, 'pages/_error.js')
-        const pages404 = join(appDir, 'pages/404.js')
+    const pagesErr = join(appDir, 'pages/_error.js')
+    const pages404 = join(appDir, 'pages/404.js')
 
-        beforeAll(async () => {
-          await fs.move(pagesErr, pagesErr + '.bak')
-          await fs.writeFile(
-            pages404,
-            `
+    beforeAll(async () => {
+      await fs.move(pagesErr, pagesErr + '.bak')
+      await fs.writeFile(
+        pages404,
+        `
           if (typeof window !== 'undefined') {
             window.errorLoad = true
           }
@@ -501,16 +482,13 @@ describe('404 handling', () => {
             return <p id='error'>custom 404</p>
           }
         `
-          )
-          await nextBuild(appDir, [], nextOpts)
-        })
-        afterAll(async () => {
-          await fs.move(pagesErr + '.bak', pagesErr)
-          await fs.remove(pages404)
-        })
+      )
+    })
+    afterAll(async () => {
+      await fs.move(pagesErr + '.bak', pagesErr)
+      await fs.remove(pages404)
+    })
 
-        devStartAndExport(true)
-      }
-    )
+    devStartAndExport(true)
   })
 })


### PR DESCRIPTION
- `expect(hasImageMatchingUrl(browser, "...")).toBe(true)` has very bad error messages if the assertion fails
- there was a `(process.env.TURBOPACK_DEV ? describe.skip : describe)('production mode',` around a dev test