### PR TITLE
Fix params leaking into instant navigation shell in dev

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -926,9 +926,10 @@ export async function handler(
               ? createOpaqueFallbackRouteParams(
                   prerenderInfo.fallbackRouteParams
                 )
-              : // Otherwise, if we're debugging the fallback shell, then we
-                // have to manually generate the fallback route params.
-                isDebugFallbackShell
+              : // Otherwise, if we're debugging the fallback shell or the
+                // static shell, then we have to manually generate the
+                // fallback route params.
+                isDebugFallbackShell || isDebugStaticShell
                 ? getFallbackRouteParams(normalizedSrcPage, routeModule)
                 : null
 
@@ -1090,9 +1091,10 @@ export async function handler(
         prerenderInfo?.fallbackRouteParams &&
         getRequestMeta(req, 'renderFallbackShell')
           ? createOpaqueFallbackRouteParams(prerenderInfo.fallbackRouteParams)
-          : // Otherwise, if we're debugging the fallback shell, then we have to
-            // manually generate the fallback route params.
-            isDebugFallbackShell
+          : // Otherwise, if we're debugging the fallback shell or the static
+            // shell, then we have to manually generate the fallback route
+            // params.
+            isDebugFallbackShell || isDebugStaticShell
             ? getFallbackRouteParams(normalizedSrcPage, routeModule)
             : null
 

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -844,9 +844,13 @@ async function tryNavigateUsingTestingAPIPrefetch(
       )
     }
 
-    // Prefetch failed - fall through to normal unknown route path. This is fine
-    // because the lock will still be held, and waitForNavigationLockIfActive()
-    // in the dynamic data path will block until the lock is released.
+    // Prefetch failed. Wait for the lock to be released before falling
+    // through to the normal navigation path. This prevents runtime data
+    // from leaking into the shell while the lock is held — the navigation
+    // blocks until the instant scope ends, then proceeds normally.
+    const { waitForNavigationLockIfActive } =
+      require('./navigation-testing-lock') as typeof import('./navigation-testing-lock')
+    await waitForNavigationLockIfActive()
     return null
   }
   return null

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/cookies-page/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/cookies-page/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export default function CookiesPage() {
+  return (
+    <div>
+      <h1 data-testid="cookies-page-title">Cookies Page</h1>
+      <Suspense
+        fallback={<div data-testid="cookies-fallback">Loading cookies...</div>}
+      >
+        <CookieContent />
+      </Suspense>
+    </div>
+  )
+}
+
+async function CookieContent() {
+  const cookieStore = await cookies()
+  const testCookie = cookieStore.get('testCookie')
+
+  return (
+    <div data-testid="cookie-value">
+      testCookie: {testCookie?.value ?? 'not set'}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/dynamic-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/dynamic-params/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { Suspense } from 'react'
+
+export default function DynamicParamsPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <div>
+      <h1 data-testid="dynamic-params-title">Dynamic Params Page</h1>
+      <Suspense
+        fallback={<div data-testid="params-fallback">Loading params...</div>}
+      >
+        <ParamContent params={params} />
+      </Suspense>
+    </div>
+  )
+}
+
+async function ParamContent({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+
+  return <div data-testid="param-value">slug: {slug}</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/page.tsx
@@ -20,9 +20,27 @@ export default function HomePage() {
       >
         Go to full prefetch target
       </Link>
+      <Link href="/cookies-page" id="link-to-cookies-page">
+        Go to cookies page
+      </Link>
+      <Link href="/dynamic-params/hello" id="link-to-dynamic-params">
+        Go to dynamic params page
+      </Link>
+      <Link href="/search-params-page?foo=bar" id="link-to-search-params">
+        Go to search params page
+      </Link>
       {/* Plain anchor for MPA navigation testing (bypasses client-side routing) */}
       <a href="/target-page" id="plain-link-to-target">
         Go to target page (MPA)
+      </a>
+      <a href="/cookies-page" id="plain-link-to-cookies-page">
+        Go to cookies page (MPA)
+      </a>
+      <a href="/dynamic-params/hello" id="plain-link-to-dynamic-params">
+        Go to dynamic params page (MPA)
+      </a>
+      <a href="/search-params-page?foo=bar" id="plain-link-to-search-params">
+        Go to search params page (MPA)
       </a>
     </div>
   )

--- a/test/e2e/app-dir/instant-navigation-testing-api/app/search-params-page/page.tsx
+++ b/test/e2e/app-dir/instant-navigation-testing-api/app/search-params-page/page.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from 'react'
+
+type SearchParams = { [key: string]: string | string[] | undefined }
+
+export default function SearchParamsPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  return (
+    <div>
+      <h1 data-testid="search-params-title">Search Params Page</h1>
+      <Suspense
+        fallback={
+          <div data-testid="search-params-fallback">
+            Loading search params...
+          </div>
+        }
+      >
+        <SearchParamContent searchParams={searchParams} />
+      </Suspense>
+    </div>
+  )
+}
+
+async function SearchParamContent({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>
+}) {
+  const params = await searchParams
+  const foo = params.foo
+
+  return <div data-testid="search-param-content">foo: {foo ?? 'not set'}</div>
+}

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -26,7 +26,7 @@ import { nextTestSetup } from 'e2e-utils'
 import type * as Playwright from 'playwright'
 
 describe('instant-navigation-testing-api', () => {
-  const { next } = nextTestSetup({
+  const { next, isNextDev } = nextTestSetup({
     files: __dirname,
     // Skip deployment tests because the exposeTestingApiInProductionBuild flag
     // doesn't exist in the production version of Next.js yet
@@ -314,6 +314,246 @@ describe('instant-navigation-testing-api', () => {
     expect(await dynamicContent.textContent()).toContain(
       'Dynamic content loaded'
     )
+  })
+
+  // Verifies that runtime params (cookies, dynamic route params, search
+  // params) are excluded from the instant navigation shell. The shell should
+  // only contain static content — runtime param values should be blocked
+  // behind a Suspense boundary until the instant lock is released.
+  //
+  // Each test route reads a different runtime param inside a <Suspense>
+  // boundary without opting into `unstable_instant: { prefetch: 'runtime' }`.
+  // During the instant scope, the static page title should be visible and the
+  // Suspense fallback should be shown, but the resolved param value should
+  // NOT be present.
+  describe('runtime params are excluded from instant shell', () => {
+    it('does not include cookie values in instant shell during client navigation', async () => {
+      const page = await openPage('/')
+
+      // Set a test cookie
+      await page.evaluate(() => {
+        document.cookie = 'testCookie=hello; path=/'
+      })
+
+      await instant(page, async () => {
+        await page.click('#link-to-cookies-page')
+
+        // Static page title is visible
+        const title = page.locator('[data-testid="cookies-page-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // Suspense fallback is visible
+        const fallback = page.locator('[data-testid="cookies-fallback"]')
+        await fallback.waitFor({ state: 'visible' })
+
+        // Cookie value is NOT in the shell
+        const cookieValue = page.locator('[data-testid="cookie-value"]')
+        expect(await cookieValue.count()).toBe(0)
+      })
+
+      // After exiting instant scope, cookie value streams in
+      const cookieValue = page.locator('[data-testid="cookie-value"]')
+      await cookieValue.waitFor({ state: 'visible' })
+      expect(await cookieValue.textContent()).toContain('testCookie: hello')
+    })
+
+    // Bug (dev-only, SPA): In dev, segment data is only populated during
+    // static prerendering, which doesn't run for dynamic routes. The
+    // segment prefetch handler returns 204, so
+    // tryNavigateUsingTestingAPIPrefetch fails and the client falls back
+    // to navigateToUnknownRoute — a full RSC request that returns the
+    // entire page (shell + resolved params) in a single stream. The
+    // instant lock never gets a chance to separate them.
+    ;(isNextDev ? it.failing : it)(
+      'does not include dynamic param values in instant shell during client navigation',
+      async () => {
+        const page = await openPage('/')
+
+        await instant(page, async () => {
+          await page.click('#link-to-dynamic-params')
+
+          // Static page title is visible
+          const title = page.locator('[data-testid="dynamic-params-title"]')
+          await title.waitFor({ state: 'visible' })
+
+          // Suspense fallback is visible (shorter timeout since in dev mode
+          // this fails immediately — the param value is already rendered)
+          const fallback = page.locator('[data-testid="params-fallback"]')
+          await fallback.waitFor({ state: 'visible', timeout: 5000 })
+
+          // Param value is NOT in the shell
+          const paramValue = page.locator('[data-testid="param-value"]')
+          expect(await paramValue.count()).toBe(0) // eslint-disable-line jest/no-standalone-expect
+        })
+
+        // After exiting instant scope, param value streams in
+        const paramValue = page.locator('[data-testid="param-value"]')
+        await paramValue.waitFor({ state: 'visible' })
+        expect(await paramValue.textContent()).toContain('slug: hello') // eslint-disable-line jest/no-standalone-expect
+      }
+    )
+
+    it('does not include search param values in instant shell during client navigation', async () => {
+      const page = await openPage('/')
+
+      await instant(page, async () => {
+        await page.click('#link-to-search-params')
+
+        // Static page title is visible
+        const title = page.locator('[data-testid="search-params-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // Suspense fallback is visible
+        const fallback = page.locator('[data-testid="search-params-fallback"]')
+        await fallback.waitFor({ state: 'visible' })
+
+        // Search param content is NOT in the shell
+        const searchParamContent = page.locator(
+          '[data-testid="search-param-content"]'
+        )
+        expect(await searchParamContent.count()).toBe(0)
+      })
+
+      // After exiting instant scope, search param content streams in
+      const searchParamContent = page.locator(
+        '[data-testid="search-param-content"]'
+      )
+      await searchParamContent.waitFor({ state: 'visible' })
+      expect(await searchParamContent.textContent()).toContain('foo: bar')
+    })
+
+    it('does not include cookie values in instant shell during page load', async () => {
+      const page = await openPage('/')
+
+      // Set a test cookie
+      await page.evaluate(() => {
+        document.cookie = 'testCookie=hello; path=/'
+      })
+
+      await instant(page, async () => {
+        await page.click('#plain-link-to-cookies-page')
+
+        // Static page title is visible
+        const title = page.locator('[data-testid="cookies-page-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // Suspense fallback is visible
+        const fallback = page.locator('[data-testid="cookies-fallback"]')
+        await fallback.waitFor({ state: 'visible' })
+
+        // Cookie value is NOT in the shell
+        const cookieValue = page.locator('[data-testid="cookie-value"]')
+        expect(await cookieValue.count()).toBe(0)
+      })
+
+      // After exiting instant scope, cookie value streams in
+      const cookieValue = page.locator('[data-testid="cookie-value"]')
+      await cookieValue.waitFor({ state: 'visible', timeout: 10000 })
+      expect(await cookieValue.textContent()).toContain('testCookie: hello')
+    })
+
+    // Bug (dev-only, MPA): When the instant lock cookie is set during a
+    // full page load, the server forces the page through the prerender
+    // path (isDebugStaticShell). cookies(), searchParams, and
+    // connection() all return hanging promises unconditionally during a
+    // prerender, so they correctly suspend. But params only suspends if
+    // fallbackRouteParams is set — and it's null in the
+    // isDebugStaticShell path (only isDebugFallbackShell populates it).
+    // So params resolve immediately with actual values and get baked
+    // into the HTML.
+    ;(isNextDev ? it.failing : it)(
+      'does not include dynamic param values in instant shell during page load',
+      async () => {
+        const page = await openPage('/')
+
+        await instant(page, async () => {
+          await page.click('#plain-link-to-dynamic-params')
+
+          // Static page title is visible
+          const title = page.locator('[data-testid="dynamic-params-title"]')
+          await title.waitFor({ state: 'visible' })
+
+          // Suspense fallback is visible (shorter timeout — see SPA test)
+          const fallback = page.locator('[data-testid="params-fallback"]')
+          await fallback.waitFor({ state: 'visible', timeout: 5000 })
+
+          // Param value is NOT in the shell
+          const paramValue = page.locator('[data-testid="param-value"]')
+          expect(await paramValue.count()).toBe(0) // eslint-disable-line jest/no-standalone-expect
+        })
+
+        // After exiting instant scope, param value streams in
+        const paramValue = page.locator('[data-testid="param-value"]')
+        await paramValue.waitFor({ state: 'visible', timeout: 10000 })
+        expect(await paramValue.textContent()).toContain('slug: hello') // eslint-disable-line jest/no-standalone-expect
+      }
+    )
+
+    it('does not include search param values in instant shell during page load', async () => {
+      const page = await openPage('/')
+
+      await instant(page, async () => {
+        await page.click('#plain-link-to-search-params')
+
+        // Static page title is visible
+        const title = page.locator('[data-testid="search-params-title"]')
+        await title.waitFor({ state: 'visible' })
+
+        // Suspense fallback is visible
+        const fallback = page.locator('[data-testid="search-params-fallback"]')
+        await fallback.waitFor({ state: 'visible' })
+
+        // Search param content is NOT in the shell
+        const searchParamContent = page.locator(
+          '[data-testid="search-param-content"]'
+        )
+        expect(await searchParamContent.count()).toBe(0)
+      })
+
+      // After exiting instant scope, search param content streams in
+      const searchParamContent = page.locator(
+        '[data-testid="search-param-content"]'
+      )
+      await searchParamContent.waitFor({ state: 'visible', timeout: 10000 })
+      expect(await searchParamContent.textContent()).toContain('foo: bar')
+    })
+  })
+
+  // In dev mode, hover/intent-based prefetches should not send requests
+  // that produce stale segment data. If a hover prefetch caches the route
+  // with resolved runtime data before the instant lock is acquired, params
+  // will leak into the shell when instant mode is later enabled.
+  it('does not leak runtime data from hover prefetch into instant shell', async () => {
+    const page = await openPage('/')
+
+    // Hover over the dynamic params link to trigger an intent prefetch
+    await page.hover('#link-to-dynamic-params')
+
+    // Wait for the prefetch to complete
+    await page.waitForTimeout(3000)
+
+    // Now enable instant mode and navigate
+    await instant(page, async () => {
+      await page.click('#link-to-dynamic-params')
+
+      // Static page title is visible
+      const title = page.locator('[data-testid="dynamic-params-title"]')
+      await title.waitFor({ state: 'visible' })
+
+      // Suspense fallback is visible
+      const fallback = page.locator('[data-testid="params-fallback"]')
+      await fallback.waitFor({ state: 'visible' })
+
+      // Param value is NOT in the shell — even though a hover prefetch
+      // ran before the instant lock was acquired
+      const paramValue = page.locator('[data-testid="param-value"]')
+      expect(await paramValue.count()).toBe(0)
+    })
+
+    // After exiting instant scope, param value streams in
+    const paramValue = page.locator('[data-testid="param-value"]')
+    await paramValue.waitFor({ state: 'visible' })
+    expect(await paramValue.textContent()).toContain('slug: hello')
   })
 
   it('subsequent navigations after instant scope are not locked', async () => {

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -26,7 +26,7 @@ import { nextTestSetup } from 'e2e-utils'
 import type * as Playwright from 'playwright'
 
 describe('instant-navigation-testing-api', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     // Skip deployment tests because the exposeTestingApiInProductionBuild flag
     // doesn't exist in the production version of Next.js yet
@@ -357,41 +357,30 @@ describe('instant-navigation-testing-api', () => {
       expect(await cookieValue.textContent()).toContain('testCookie: hello')
     })
 
-    // Bug (dev-only, SPA): In dev, segment data is only populated during
-    // static prerendering, which doesn't run for dynamic routes. The
-    // segment prefetch handler returns 204, so
-    // tryNavigateUsingTestingAPIPrefetch fails and the client falls back
-    // to navigateToUnknownRoute — a full RSC request that returns the
-    // entire page (shell + resolved params) in a single stream. The
-    // instant lock never gets a chance to separate them.
-    ;(isNextDev ? it.failing : it)(
-      'does not include dynamic param values in instant shell during client navigation',
-      async () => {
-        const page = await openPage('/')
+    it('does not include dynamic param values in instant shell during client navigation', async () => {
+      const page = await openPage('/')
 
-        await instant(page, async () => {
-          await page.click('#link-to-dynamic-params')
+      await instant(page, async () => {
+        await page.click('#link-to-dynamic-params')
 
-          // Static page title is visible
-          const title = page.locator('[data-testid="dynamic-params-title"]')
-          await title.waitFor({ state: 'visible' })
+        // Static page title is visible
+        const title = page.locator('[data-testid="dynamic-params-title"]')
+        await title.waitFor({ state: 'visible' })
 
-          // Suspense fallback is visible (shorter timeout since in dev mode
-          // this fails immediately — the param value is already rendered)
-          const fallback = page.locator('[data-testid="params-fallback"]')
-          await fallback.waitFor({ state: 'visible', timeout: 5000 })
+        // Suspense fallback is visible
+        const fallback = page.locator('[data-testid="params-fallback"]')
+        await fallback.waitFor({ state: 'visible' })
 
-          // Param value is NOT in the shell
-          const paramValue = page.locator('[data-testid="param-value"]')
-          expect(await paramValue.count()).toBe(0) // eslint-disable-line jest/no-standalone-expect
-        })
-
-        // After exiting instant scope, param value streams in
+        // Param value is NOT in the shell
         const paramValue = page.locator('[data-testid="param-value"]')
-        await paramValue.waitFor({ state: 'visible' })
-        expect(await paramValue.textContent()).toContain('slug: hello') // eslint-disable-line jest/no-standalone-expect
-      }
-    )
+        expect(await paramValue.count()).toBe(0)
+      })
+
+      // After exiting instant scope, param value streams in
+      const paramValue = page.locator('[data-testid="param-value"]')
+      await paramValue.waitFor({ state: 'visible' })
+      expect(await paramValue.textContent()).toContain('slug: hello')
+    })
 
     it('does not include search param values in instant shell during client navigation', async () => {
       const page = await openPage('/')
@@ -452,42 +441,30 @@ describe('instant-navigation-testing-api', () => {
       expect(await cookieValue.textContent()).toContain('testCookie: hello')
     })
 
-    // Bug (dev-only, MPA): When the instant lock cookie is set during a
-    // full page load, the server forces the page through the prerender
-    // path (isDebugStaticShell). cookies(), searchParams, and
-    // connection() all return hanging promises unconditionally during a
-    // prerender, so they correctly suspend. But params only suspends if
-    // fallbackRouteParams is set — and it's null in the
-    // isDebugStaticShell path (only isDebugFallbackShell populates it).
-    // So params resolve immediately with actual values and get baked
-    // into the HTML.
-    ;(isNextDev ? it.failing : it)(
-      'does not include dynamic param values in instant shell during page load',
-      async () => {
-        const page = await openPage('/')
+    it('does not include dynamic param values in instant shell during page load', async () => {
+      const page = await openPage('/')
 
-        await instant(page, async () => {
-          await page.click('#plain-link-to-dynamic-params')
+      await instant(page, async () => {
+        await page.click('#plain-link-to-dynamic-params')
 
-          // Static page title is visible
-          const title = page.locator('[data-testid="dynamic-params-title"]')
-          await title.waitFor({ state: 'visible' })
+        // Static page title is visible
+        const title = page.locator('[data-testid="dynamic-params-title"]')
+        await title.waitFor({ state: 'visible' })
 
-          // Suspense fallback is visible (shorter timeout — see SPA test)
-          const fallback = page.locator('[data-testid="params-fallback"]')
-          await fallback.waitFor({ state: 'visible', timeout: 5000 })
+        // Suspense fallback is visible
+        const fallback = page.locator('[data-testid="params-fallback"]')
+        await fallback.waitFor({ state: 'visible' })
 
-          // Param value is NOT in the shell
-          const paramValue = page.locator('[data-testid="param-value"]')
-          expect(await paramValue.count()).toBe(0) // eslint-disable-line jest/no-standalone-expect
-        })
-
-        // After exiting instant scope, param value streams in
+        // Param value is NOT in the shell
         const paramValue = page.locator('[data-testid="param-value"]')
-        await paramValue.waitFor({ state: 'visible', timeout: 10000 })
-        expect(await paramValue.textContent()).toContain('slug: hello') // eslint-disable-line jest/no-standalone-expect
-      }
-    )
+        expect(await paramValue.count()).toBe(0)
+      })
+
+      // After exiting instant scope, param value streams in
+      const paramValue = page.locator('[data-testid="param-value"]')
+      await paramValue.waitFor({ state: 'visible', timeout: 10000 })
+      expect(await paramValue.textContent()).toContain('slug: hello')
+    })
 
     it('does not include search param values in instant shell during page load', async () => {
       const page = await openPage('/')


### PR DESCRIPTION
Populate `fallbackRouteParams` in the `isDebugStaticShell` prerender path so that params suspend correctly during instant navigation shell rendering in dev mode.

When the instant lock is active, the server forces pages through the prerender path (`isDebugStaticShell`). During a prerender, `cookies()`, `searchParams`, and `connection()` all return hanging promises unconditionally, but params only suspends if `fallbackRouteParams` is set. Previously, only `isDebugFallbackShell` populated it — now `isDebugStaticShell` does too.

This fixes both the MPA and SPA cases: the MPA HTML shell no longer contains resolved param values, and the SPA segment prefetch data no longer includes them either.

Also adds a safety net: if the prefetch fails while the instant lock is held, the navigation waits for the lock to be released before falling through, preventing silent data leakage from future bugs.

## Test plan

- `pnpm test-start-turbo test/e2e/app-dir/instant-navigation-testing-api/` — 16/16 pass
- `pnpm test-dev-turbo test/e2e/app-dir/instant-navigation-testing-api/` — 16/16 pass
- Manual verification via DevTools toggle: shell shows title + fallback, params are blocked until lock is released