### PR TITLE
[test] Only auto-retry individual e2e tests in CI

### DIFF
--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -126,7 +126,9 @@ if (!e2eGlobal.__NEXT_E2E_TEST_CONFIG_PATCHED__) {
       global.test = wrapJestTestFn(global.test) as jest.It
     }
 
-    jest.retryTimes(1)
+    if (process.env.CI) {
+      jest.retryTimes(1)
+    }
   }
 
   e2eGlobal.__NEXT_E2E_TEST_CONFIG_PATCHED__ = true


### PR DESCRIPTION
The per-test `jest.retryTimes(1)` added in #89929 is useful for CI resilience & performance but produces confusing logs and adds unnecessary wait time when investigating test failures locally.

We're now only enabling the retry when running in CI so that local runs fail fast on the first attempt.