### PR TITLE
test: unflake lru-disk-eviction on Windows

### DIFF
--- a/test/unit/image-optimizer/lru-disk-eviction.test.ts
+++ b/test/unit/image-optimizer/lru-disk-eviction.test.ts
@@ -44,7 +44,11 @@ async function initEntries(
 }
 
 async function rmEntry(cacheDir: string, cacheKey: string): Promise<void> {
-  await promises.rm(join(cacheDir, cacheKey), { recursive: true, force: true })
+  await promises.rm(join(cacheDir, cacheKey), {
+    recursive: true,
+    force: true,
+    maxRetries: 3,
+  })
 }
 
 describe('LRU disk eviction', () => {

--- a/test/unit/image-optimizer/lru-disk-eviction.test.ts
+++ b/test/unit/image-optimizer/lru-disk-eviction.test.ts
@@ -48,6 +48,7 @@ async function rmEntry(cacheDir: string, cacheKey: string): Promise<void> {
     recursive: true,
     force: true,
     maxRetries: 3,
+    retryDelay: 500,
   })
 }
 
@@ -61,7 +62,12 @@ describe('LRU disk eviction', () => {
 
   afterEach(async () => {
     resetDiskLRU()
-    await promises.rm(cacheDir, { recursive: true, force: true })
+    await promises.rm(cacheDir, {
+      recursive: true,
+      force: true,
+      maxRetries: 3,
+      retryDelay: 500,
+    })
   })
 
   it('should evict oldest entries on initialization', async () => {


### PR DESCRIPTION
```
FAIL Turbopack test/unit/image-optimizer/lru-disk-eviction.test.ts
  LRU disk eviction
    √ should evict oldest entries on initialization (133 ms)
    √ should evict old entries when new entries are set (124 ms)
    × should promote entries on get() to prevent eviction (8 ms)
    √ should return the same LRU instance on subsequent calls (1 ms)
    √ should deduplicate concurrent init calls (2 ms)
    √ should handle empty cache directory (2 ms)
    √ should handle non-existent cache directory (2 ms)

  ● LRU disk eviction › should promote entries on get() to prevent eviction

    EPERM: operation not permitted, rmdir 'C:\Users\ADMINI~1\AppData\Local\Temp\next-lru-test-dOXRaF\y'
```