### PR TITLE
Add @next/playwright package with instant() testing helper

### DIFF
--- a/packages/next-playwright/README.md
+++ b/packages/next-playwright/README.md
@@ -1,0 +1,107 @@
+# @next/playwright
+
+> - **Status:** Experimental. This API is not yet stable.
+> - **Requires:** [Cache Components](https://nextjs.org/docs) to be enabled.
+
+Playwright helpers for testing Next.js applications.
+
+## Instant Navigation Testing
+
+An **instant navigation** commits immediately without waiting for data fetching.
+The cached shell — including any Suspense loading boundaries — renders right
+away, and dynamic data streams in afterward. The shell is the instant part, not
+the full page.
+
+`instant()` lets you test whether a route achieves this. While the callback is
+active, navigations render only cached and prefetched content. Dynamic data is
+deferred until the callback returns. This lets you make deterministic assertions
+against the shell without race conditions.
+
+The tool assumes a warm cache: all prefetches have completed and all cacheable
+data is available. This way you're testing whether the route is *structured
+correctly* for instant navigation, independent of network timing. If content you
+expected to be cached is missing inside the callback, it points to a problem — a
+missing `use cache` directive, a misplaced Suspense boundary, or a similar gap.
+
+### Examples
+
+**Loading shell appears instantly** (dynamic content behind a Suspense boundary):
+
+```ts
+import { instant } from '@next/playwright'
+
+test('shows loading shell during navigation', async ({ page }) => {
+  await page.goto('/')
+
+  await instant(page, async () => {
+    await page.click('a[href="/dashboard"]')
+
+    // The loading shell is visible — dynamic data is deferred
+    await expect(page.locator('[data-testid="loading"]')).toBeVisible()
+  })
+
+  // After instant() returns, dynamic data streams in normally
+  await expect(page.locator('[data-testid="content"]')).toBeVisible()
+})
+```
+
+**Fully instant navigation** (all content is cached):
+
+```ts
+test('navigates to profile instantly', async ({ page }) => {
+  await page.goto('/')
+
+  await instant(page, async () => {
+    await page.click('a[href="/profile"]')
+
+    // All content renders immediately
+    await expect(page.locator('[data-testid="profile-name"]')).toBeVisible()
+    await expect(page.locator('[data-testid="profile-bio"]')).toBeVisible()
+  })
+})
+```
+
+### Enabling in production builds
+
+In development (`next dev`), the testing API is available by default. In
+production builds, it is disabled unless you explicitly opt in:
+
+```js
+// next.config.js
+module.exports = {
+  experimental: {
+    exposeTestingApiInProductionBuild: true,
+  },
+}
+```
+
+This is not meant to be deployed to live production sites. Only enable it in
+controlled testing environments like preview deployments or CI.
+
+## How it works
+
+`instant()` sets a cookie that tells Next.js to serve only cached data during
+navigations. While the cookie is active:
+
+- **Client-side navigations**: The router renders only what is available in the
+  prefetch cache. Dynamic data is deferred until the cookie is cleared.
+- **Server renders (initial load, reload, MPA navigation)**: The server responds
+  with only the static shell, without any per-request dynamic data.
+
+When the callback completes, the cookie is cleared and normal behavior resumes.
+
+## Design
+
+The layering between this package and Next.js is intentionally very thin. This
+serves as a reference implementation that other testing frameworks and dev tools
+can replicate with minimal effort. The entire mechanism is a single cookie:
+
+```ts
+// Set the cookie to enter instant mode
+document.cookie = 'next-instant-navigation-testing=1; path=/'
+
+// ... run assertions ...
+
+// Clear the cookie to resume normal behavior
+document.cookie = 'next-instant-navigation-testing=; path=/; max-age=0'
+```

--- a/packages/next-playwright/package.json
+++ b/packages/next-playwright/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@next/playwright",
+  "version": "16.2.0-canary.59",
+  "private": true,
+  "repository": {
+    "url": "vercel/next.js",
+    "directory": "packages/next-playwright"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "license": "MIT",
+  "scripts": {
+    "build": "node ../../scripts/rm.mjs dist && tsc -d -p tsconfig.json",
+    "prepublishOnly": "cd ../../ && turbo run build",
+    "dev": "tsc -d -w -p tsconfig.json",
+    "typescript": "tsec --noEmit -p tsconfig.json"
+  },
+  "devDependencies": {
+    "typescript": "5.9.2"
+  }
+}

--- a/packages/next-playwright/src/index.ts
+++ b/packages/next-playwright/src/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Minimal interface for Playwright's Page. We use a structural type rather than
+ * importing from a specific Playwright package so this works with any version
+ * of playwright, playwright-core, or @playwright/test.
+ */
+interface PlaywrightPage {
+  evaluate<R, Arg>(pageFunction: (arg: Arg) => R, arg: Arg): Promise<R>
+}
+
+const INSTANT_COOKIE = 'next-instant-navigation-testing'
+
+/**
+ * Runs a function with instant navigation enabled. Within this scope,
+ * navigations render the prefetched UI immediately and wait for the
+ * callback to complete before streaming in dynamic data.
+ *
+ * Uses the cookie-based protocol: setting the cookie acquires the
+ * navigation lock (via CookieStore change event), and clearing it
+ * releases the lock.
+ */
+export async function instant<T>(
+  page: PlaywrightPage,
+  fn: () => Promise<T>
+): Promise<T> {
+  // Acquire the lock by setting the cookie from within the page context.
+  // This triggers the CookieStore change event in navigation-testing-lock.ts,
+  // which acquires the in-memory navigation lock.
+  await page.evaluate((name) => {
+    document.cookie = name + '=1; path=/'
+  }, INSTANT_COOKIE)
+  try {
+    return await fn()
+  } finally {
+    // Release the lock by clearing the cookie. For SPA navigations, this
+    // triggers the CookieStore change event which resolves the in-memory
+    // lock. For MPA navigations (reload, plain anchor), the listener in
+    // app-bootstrap.ts triggers a page reload to fetch dynamic data.
+    await page.evaluate((name) => {
+      document.cookie = name + '=; path=/; max-age=0'
+    }, INSTANT_COOKIE)
+  }
+}

--- a/packages/next-playwright/tsconfig.json
+++ b/packages/next-playwright/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "esModuleInterop": true,
+    "target": "es2019",
+    "outDir": "dist",
+    "module": "commonjs",
+    "rootDir": "src",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -296,7 +296,7 @@ importers:
         version: 5.2.1(eslint@9.37.0(jiti@2.5.1))
       eslint-plugin-import:
         specifier: 2.31.0
-        version: 2.31.0(eslint@9.37.0(jiti@2.5.1))
+        version: 2.31.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1))
       eslint-plugin-jest:
         specifier: 27.6.3
         version: 27.6.3(eslint@9.37.0(jiti@2.5.1))(jest@29.7.0(@types/node@20.17.6(patch_hash=rvl3vkomen3tospgr67bzubfyu))(babel-plugin-macros@3.1.0))(typescript@5.9.2)
@@ -760,7 +760,7 @@ importers:
         version: 9.37.0(jiti@2.5.1)
       eslint-config-next:
         specifier: canary
-        version: link:../../packages/eslint-config-next
+        version: 16.2.0-canary.60(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
       tailwindcss:
         specifier: 4.1.13
         version: 4.1.13
@@ -1868,6 +1868,12 @@ importers:
         specifier: ^0.7.0
         version: 0.7.3
 
+  packages/next-playwright:
+    devDependencies:
+      typescript:
+        specifier: 5.9.2
+        version: 5.9.2
+
   packages/next-plugin-storybook: {}
 
   packages/next-polyfill-module:
@@ -2893,6 +2899,7 @@ packages:
   '@base-ui-components/react@1.0.0-beta.2':
     resolution: {integrity: sha512-jfAUfSgXvsfr8mQi7r/6gLG8U1Ybr77NN8WK5IXXM0c/hBvFDBtvUfwDJACV0gXiYbSKpA+dRzZz01V1tULobA==}
     engines: {node: '>=14.0.0'}
+    deprecated: Package was renamed to @base-ui/react
     peerDependencies:
       '@types/react': 19.2.10
       react: 19.3.0-canary-ab18f33d-20260220
@@ -2903,6 +2910,7 @@ packages:
 
   '@base-ui-components/utils@0.1.0':
     resolution: {integrity: sha512-9+uaWyF1o/PgXqHLJnC81IIG0HlV3o9eFCQ5hWZDMx5NHrFk0rrwqEFGQOB8lti/rnbxNPi+kYYw1D4e8xSn/Q==}
+    deprecated: Package was renamed to @base-ui/utils
     peerDependencies:
       '@types/react': 19.2.10
       react: 19.3.0-canary-ab18f33d-20260220
@@ -4403,6 +4411,9 @@ packages:
 
   '@next/env@16.0.8':
     resolution: {integrity: sha512-xP4WrQZuj9MdmLJy3eWFHepo+R3vznsMSS8Dy3wdA7FKpjCiesQ6DxZvdGziQisj0tEtCgBKJzjcAc4yZOgLEQ==}
+
+  '@next/eslint-plugin-next@16.2.0-canary.60':
+    resolution: {integrity: sha512-x4HfpWmd82hRuhlu0hbgrV/iIhBgY0uMruG4uT8G2baGXwBzR/0pi0rzGDNQHZYc4Vcr8jdDn8eG418N8uPJLw==}
 
   '@next/rspack-binding-android-arm-eabi@1.0.2':
     resolution: {integrity: sha512-ayoNrm5Z9xYIHdYfhUSvzPzNXRunMXx5B6Bonch9pJBfyC/3tUlcqVlI5+1HS+H4euWtPMeGqe8bARjQ71J/ug==}
@@ -7095,6 +7106,7 @@ packages:
   '@vercel/kv@3.0.0':
     resolution: {integrity: sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==}
     engines: {node: '>=14.6'}
+    deprecated: 'Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis'
 
   '@vercel/ncc@0.34.0':
     resolution: {integrity: sha512-G9h5ZLBJ/V57Ou9vz5hI8pda/YQX5HQszCs3AmIus3XzsmRn/0Ptic5otD3xVST8QLKk7AMk7AqpsyQGN7MZ9A==}
@@ -9917,6 +9929,15 @@ packages:
     resolution: {integrity: sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==}
     engines: {node: '>=6.0'}
     hasBin: true
+
+  eslint-config-next@16.2.0-canary.60:
+    resolution: {integrity: sha512-Fsm6naMhtIOTcqkWdr4X/lORgfjpupIdudktoMg3yh15Eh8LLb0YaYxb3Ri1G1V4HB6GlK6oFQqe19Xc3DNAaw==}
+    peerDependencies:
+      eslint: '>=9.0.0'
+      typescript: '>=3.3.1'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   eslint-formatter-codeframe@7.32.1:
     resolution: {integrity: sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==}
@@ -17289,7 +17310,7 @@ packages:
   superagent@3.8.3:
     resolution: {integrity: sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==}
     engines: {node: '>= 4.0'}
-    deprecated: Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net
+    deprecated: Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.
 
   superstruct@1.0.3:
     resolution: {integrity: sha512-8iTn3oSS8nRGn+C2pgXSKPI3jmpm6FExNazNpjvqS6ZUJQCej3PUXEKM8NjHBOs54ExM+LPW/FBRhymrdcCiSg==}
@@ -17412,11 +17433,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   taskr@1.1.0:
     resolution: {integrity: sha512-jELUxxTfAxR6ZRFV6S/8LRcNg/GnlhS/4x2WZjGDkfle9Bk+M/e8LutMy3GVeUcp1cJc8Oy/uuroqbDePLHunQ==}
@@ -21607,6 +21629,10 @@ snapshots:
   '@next/env@15.5.8': {}
 
   '@next/env@16.0.8': {}
+
+  '@next/eslint-plugin-next@16.2.0-canary.60':
+    dependencies:
+      fast-glob: 3.3.1
 
   '@next/rspack-binding-android-arm-eabi@1.0.2':
     optional: true
@@ -27910,6 +27936,26 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-config-next@16.2.0-canary.60(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2):
+    dependencies:
+      '@next/eslint-plugin-next': 16.2.0-canary.60
+      eslint: 9.37.0(jiti@2.5.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-react: 7.37.0(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-react-hooks: 7.0.0(eslint@9.37.0(jiti@2.5.1))
+      globals: 16.4.0
+      typescript-eslint: 8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - '@typescript-eslint/parser'
+      - eslint-import-resolver-webpack
+      - eslint-plugin-import-x
+      - supports-color
+
   eslint-formatter-codeframe@7.32.1:
     dependencies:
       '@babel/code-frame': 7.12.11
@@ -27920,6 +27966,22 @@ snapshots:
       debug: 3.2.7
       is-core-module: 2.16.1
       resolve: 1.22.10
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.0
+      eslint: 9.37.0(jiti@2.5.1)
+      get-tsconfig: 4.12.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
+      eslint-plugin-import-x: 4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -27960,12 +28022,24 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
       eslint: 9.37.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
+      eslint: 9.37.0(jiti@2.5.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -28004,7 +28078,7 @@ snapshots:
       - typescript
     optional: true
 
-  eslint-plugin-import@2.31.0(eslint@9.37.0(jiti@2.5.1)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -28015,7 +28089,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.37.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.37.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -28026,6 +28100,37 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
+
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)):
+    dependencies:
+      '@rtsao/scc': 1.1.0
+      array-includes: 3.1.9
+      array.prototype.findlastindex: 1.2.6
+      array.prototype.flat: 1.3.3
+      array.prototype.flatmap: 1.3.3
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 9.37.0(jiti@2.5.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import-x@4.3.1(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1)))(eslint@9.37.0(jiti@2.5.1))
+      hasown: 2.0.2
+      is-core-module: 2.16.1
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.8
+      object.groupby: 1.0.3
+      object.values: 1.2.1
+      semver: 6.3.1
+      string.prototype.trimend: 1.0.9
+      tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.5.1))(typescript@5.9.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
+++ b/test/e2e/app-dir/instant-navigation-testing-api/instant-navigation-testing-api.test.ts
@@ -23,6 +23,7 @@
  */
 
 import { nextTestSetup } from 'e2e-utils'
+import { instant } from '@next/playwright'
 import type * as Playwright from 'playwright'
 
 describe('instant-navigation-testing-api', () => {
@@ -49,40 +50,6 @@ describe('instant-navigation-testing-api', () => {
       },
     })
     return page!
-  }
-
-  const INSTANT_COOKIE = 'next-instant-navigation-testing'
-
-  /**
-   * Runs a function with instant navigation enabled. Within this scope,
-   * navigations render the prefetched UI immediately and wait for the
-   * callback to complete before streaming in dynamic data.
-   *
-   * Uses the cookie-based protocol: setting the cookie acquires the
-   * navigation lock (via CookieStore change event), and clearing it
-   * releases the lock.
-   */
-  async function instant<T>(
-    page: Playwright.Page,
-    fn: () => Promise<T>
-  ): Promise<T> {
-    // Acquire the lock by setting the cookie from within the page context.
-    // This triggers the CookieStore change event in navigation-testing-lock.ts,
-    // which acquires the in-memory navigation lock.
-    await page.evaluate((name) => {
-      document.cookie = name + '=1; path=/'
-    }, INSTANT_COOKIE)
-    try {
-      return await fn()
-    } finally {
-      // Release the lock by clearing the cookie. For SPA navigations, this
-      // triggers the CookieStore change event which resolves the in-memory
-      // lock. For MPA navigations (reload, plain anchor), the listener in
-      // app-bootstrap.ts triggers a page reload to fetch dynamic data.
-      await page.evaluate((name) => {
-        document.cookie = name + '=; path=/; max-age=0'
-      }, INSTANT_COOKIE)
-    }
   }
 
   it('renders prefetched loading shell instantly during navigation', async () => {
@@ -178,12 +145,10 @@ describe('instant-navigation-testing-api', () => {
     })
 
     await instant(page, async () => {
-      // Attempt to acquire the lock again by changing the cookie value.
-      // The CookieStore change event fires, and the handler detects that
-      // the lock is already held, logging an error.
-      await page.evaluate((name) => {
-        document.cookie = name + '=nested; path=/'
-      }, INSTANT_COOKIE)
+      // Attempt to acquire the lock again by nesting instant() calls.
+      // The inner call sets the cookie again, and the handler detects
+      // that the lock is already held, logging an error.
+      await instant(page, async () => {})
       const msg = await consolePromise
       expect(msg.text()).toContain('already acquired')
     })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
       "e2e-utils/*": ["./test/lib/e2e-utils/*"],
       "test-data-service/*": ["./test/lib/test-data-service/*"],
       "test-log": ["./test/lib/test-log"],
-      "router-act": ["./test/lib/router-act"]
+      "router-act": ["./test/lib/router-act"],
+      "@next/playwright": ["./packages/next-playwright/src/index.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
Extract the instant navigation testing API into a standalone @next/playwright package. The instant() helper lets Playwright tests assert on prefetched/cached UI by deferring dynamic data during navigations — similar to throttling the network in DevTools.

The package is private: true for now. The goal is to get the scaffolding ready so we can flip it to public when the API is ready to ship.

The existing inline implementation in the instant navigation test file is replaced with an import from @next/playwright. The nested scope test now exercises actual nested instant() calls rather than manipulating the cookie directly.

The protocol is intentionally minimal (a single cookie) so that other testing frameworks and dev tools can replicate the behavior with minimal effort.