### PR TITLE
Turbopack: Add line numbers to debug info in release-with-assertions profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,12 +269,12 @@ opt-level = "s"
 [profile.release.package.miette]
 opt-level = "s"
 
-
 # Use a custom profile for CI where many tests are performance sensitive but we still want the additional validation of debug-assertions
 [profile.release-with-assertions]
 inherits = "release"
 debug-assertions = true
 overflow-checks = true
+debug = "line-tables-only"
 
 [profile.release-with-debug]
 inherits = "release"


### PR DESCRIPTION
We use this profile in CI. Without debug symbols, we only get the line/column number of the panic, and we don't get line numbers in the whole backtrace: https://github.com/vercel/next.js/runs/64337217556#step:35:474

This can be difficult if the function in the backtrace that you care about is large.

This enables just enough debugging info in this profile for us to get line numbers in the backtrace.

https://doc.rust-lang.org/cargo/reference/profiles.html#debug