### PR TITLE
[test] Include error code in Redbox snapshot

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -1558,6 +1558,7 @@ describe('ReactRefreshLogBox app', () => {
       if (isRspack) {
         await expect({ browser, next }).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "module error",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -1577,6 +1578,7 @@ describe('ReactRefreshLogBox app', () => {
       } else if (!isTurbopack) {
         await expect({ browser, next }).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "module error",
            "environmentLabel": null,
            "label": "Runtime Error",

--- a/test/development/acceptance-app/hydration-error.test.ts
+++ b/test/development/acceptance-app/hydration-error.test.ts
@@ -139,6 +139,7 @@ describe('Error overlay for hydration errors in App router', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
+         "code": "E394",
          "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -175,6 +176,7 @@ describe('Error overlay for hydration errors in App router', () => {
     } else {
       await expect(browser).toDisplayCollapsedRedbox(`
        {
+         "code": "E394",
          "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -336,6 +338,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      [
        {
+         "code": "E394",
          "componentStack": "...
          <Next.js Internal Component>
            <Next.js Internal Component>
@@ -408,6 +411,7 @@ describe('Error overlay for hydration errors in App router', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "code": "E394",
        "componentStack": "...
          <Next.js Internal Component>
            <Next.js Internal Component>
@@ -503,6 +507,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      [
        {
+         "code": "E394",
          "componentStack": "...
          <Next.js Internal Component>
            <Next.js Internal Component>
@@ -560,6 +565,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      [
        {
+         "code": "E394",
          "componentStack": "...
          <Next.js Internal Component>
            <Next.js Internal Component>
@@ -618,6 +624,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      [
        {
+         "code": "E394",
          "componentStack": "...
          <Next.js Internal Component>
            <Next.js Internal Component>
@@ -675,6 +682,7 @@ describe('Error overlay for hydration errors in App router', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      [
        {
+         "code": "E394",
          "componentStack": "...
          <Next.js Internal Component>
            <Next.js Internal Component>
@@ -711,6 +719,7 @@ describe('Error overlay for hydration errors in App router', () => {
          ],
        },
        {
+         "code": "E394",
          "description": "<p> cannot contain a nested <p>.
      See this log for the ancestor stack trace.",
          "environmentLabel": null,
@@ -753,6 +762,7 @@ describe('Error overlay for hydration errors in App router', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        [
          {
+           "code": "E394",
            "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
            "environmentLabel": null,
            "label": "Console Error",
@@ -764,6 +774,7 @@ describe('Error overlay for hydration errors in App router', () => {
            ],
          },
          {
+           "code": "E394",
            "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -799,6 +810,7 @@ describe('Error overlay for hydration errors in App router', () => {
            ],
          },
          {
+           "code": "E394",
            "description": "<html> cannot contain a nested <script>.
        See this log for the ancestor stack trace.",
            "environmentLabel": null,
@@ -817,6 +829,7 @@ describe('Error overlay for hydration errors in App router', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        [
          {
+           "code": "E394",
            "description": "Cannot render a sync or defer <script> outside the main document without knowing its order. Try adding async="" or moving it into the root <head> tag.",
            "environmentLabel": null,
            "label": "Console Error",
@@ -828,6 +841,7 @@ describe('Error overlay for hydration errors in App router', () => {
            ],
          },
          {
+           "code": "E394",
            "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -861,6 +875,7 @@ describe('Error overlay for hydration errors in App router', () => {
            ],
          },
          {
+           "code": "E394",
            "description": "<html> cannot contain a nested <script>.
        See this log for the ancestor stack trace.",
            "environmentLabel": null,

--- a/test/development/acceptance-app/rsc-runtime-errors.test.ts
+++ b/test/development/acceptance-app/rsc-runtime-errors.test.ts
@@ -53,6 +53,7 @@ describe('Error overlay - RSC runtime errors', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E251",
        "description": "\`cookies\` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -19,6 +19,7 @@ describe('ReactRefreshLogBox _app _document', () => {
     const { browser, session } = sandbox
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E394",
        "description": "The default export is not a React Component in page: "/_app"",
        "environmentLabel": null,
        "label": "Runtime Error",
@@ -48,6 +49,7 @@ describe('ReactRefreshLogBox _app _document', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E394",
        "description": "The default export is not a React Component in page: "/_document"",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -159,6 +159,7 @@ describe('ReactRefreshLogBox', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -176,6 +177,7 @@ describe('ReactRefreshLogBox', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -202,6 +204,7 @@ describe('ReactRefreshLogBox', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "no",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -1106,6 +1109,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "{"a":1,"b":"x"}",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1155,6 +1159,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "class Hello {
        }",
          "environmentLabel": null,
@@ -1202,6 +1207,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "string error",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1248,6 +1254,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "A null error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1403,6 +1410,7 @@ describe('ReactRefreshLogBox', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "anonymous error!",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1419,6 +1427,7 @@ describe('ReactRefreshLogBox', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "anonymous error!",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -1460,6 +1469,7 @@ describe('ReactRefreshLogBox', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E394",
        "description": "Invalid URL",
        "environmentLabel": null,
        "label": "Runtime TypeError",

--- a/test/development/acceptance/ReactRefreshRegression.test.ts
+++ b/test/development/acceptance/ReactRefreshRegression.test.ts
@@ -284,6 +284,7 @@ describe('ReactRefreshRegression', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "boom",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -298,6 +299,7 @@ describe('ReactRefreshRegression', () => {
     } else if (isRspack) {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "boom",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -312,6 +314,7 @@ describe('ReactRefreshRegression', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "boom",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
+++ b/test/development/app-dir/capture-console-error-owner-stack/capture-console-error-owner-stack.test.ts
@@ -12,6 +12,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "code": "E394",
        "description": "trigger an console <error>",
        "environmentLabel": null,
        "label": "Console Error",
@@ -32,6 +33,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "code": "E394",
        "description": "trigger an console.error in render",
        "environmentLabel": null,
        "label": "Console Error",
@@ -50,6 +52,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "code": "E394",
        "description": "trigger an console.error in render",
        "environmentLabel": null,
        "label": "Console Error",
@@ -68,6 +71,7 @@ describe('app-dir - capture-console-error-owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "code": "E394",
        "description": "ssr console error:client",
        "environmentLabel": null,
        "label": "Console Error",

--- a/test/development/app-dir/dynamic-error-trace/index.test.ts
+++ b/test/development/app-dir/dynamic-error-trace/index.test.ts
@@ -13,6 +13,7 @@ describe('app dir - dynamic error trace', () => {
     // TODO(veil): Where is the stackframe for app/page.js?
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E828",
        "description": "Route / with \`dynamic = "error"\` couldn't be rendered statically because it used \`headers()\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
        "environmentLabel": "Server",
        "label": "Runtime Error",

--- a/test/development/app-dir/error-overlay/async-client-component/async-client-component.test.ts
+++ b/test/development/app-dir/error-overlay/async-client-component/async-client-component.test.ts
@@ -17,6 +17,7 @@ describe('app-dir - async-client-component', () => {
     await expect(browser).toDisplayCollapsedRedbox(`
      [
        {
+         "code": "E394",
          "description": "<Page> is an async Client Component. Only Server Components can be async at the moment. This error is often caused by accidentally adding \`'use client'\` to a module that was originally written for the server.",
          "environmentLabel": null,
          "label": "Console Error",
@@ -24,6 +25,7 @@ describe('app-dir - async-client-component', () => {
          "stack": [],
        },
        {
+         "code": "E394",
          "description": "A component was suspended by an uncached promise. Creating promises inside a Client Component or hook is not yet supported, except via a Suspense-compatible library or framework.",
          "environmentLabel": null,
          "label": "Console Error",

--- a/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
+++ b/test/development/app-dir/hydration-error-count/hydration-error-count.test.ts
@@ -12,6 +12,7 @@ describe('hydration-error-count', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        [
          {
+           "code": "E394",
            "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -61,6 +62,7 @@ describe('hydration-error-count', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        [
          {
+           "code": "E394",
            "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -192,6 +194,7 @@ describe('hydration-error-count', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        [
          {
+           "code": "E394",
            "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -262,6 +265,7 @@ describe('hydration-error-count', () => {
       await expect(browser).toDisplayCollapsedRedbox(`
        [
          {
+           "code": "E394",
            "componentStack": "...
            <Next.js Internal Component>
              <Next.js Internal Component>
@@ -337,6 +341,7 @@ describe('hydration-error-count', () => {
     await expect(browser).toDisplayRedbox(`
      [
        {
+         "code": "E394",
          "componentStack": "...
          <Next.js Internal Component>
            <Next.js Internal Component>

--- a/test/development/app-dir/missing-required-html-tags/index.test.ts
+++ b/test/development/app-dir/missing-required-html-tags/index.test.ts
@@ -32,6 +32,7 @@ describe('app-dir - missing required html tags', () => {
     await waitForRedbox(browser)
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E394",
        "description": "Missing <html> and <body> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,
@@ -57,6 +58,7 @@ describe('app-dir - missing required html tags', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E394",
        "description": "Missing <html> and <body> tags in the root layout.
      Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
        "environmentLabel": null,
@@ -77,15 +79,16 @@ describe('app-dir - missing required html tags', () => {
 
     await retry(() =>
       expect(browser).toDisplayRedbox(`
-     {
-       "description": "Missing <html> tags in the root layout.
-     Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
-       "environmentLabel": null,
-       "label": "Runtime Error",
-       "source": null,
-       "stack": [],
-     }
-    `)
+       {
+         "code": "E394",
+         "description": "Missing <html> tags in the root layout.
+       Read more at https://nextjs.org/docs/messages/missing-root-layout-tags",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": null,
+         "stack": [],
+       }
+      `)
     )
 
     reloaded = false

--- a/test/development/app-dir/owner-stack/owner-stack.test.ts
+++ b/test/development/app-dir/owner-stack/owner-stack.test.ts
@@ -160,6 +160,7 @@ describe('app-dir - owner-stack', () => {
 
     await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "code": "E394",
        "description": "string in rejected promise",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
+++ b/test/development/app-dir/serialize-circular-error/serialize-circular-error.test.ts
@@ -10,6 +10,7 @@ describe('serialize-circular-error', () => {
 
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E394",
        "description": "An error occurred but serializing the error message failed.",
        "environmentLabel": "Server",
        "label": "Runtime Error",
@@ -29,6 +30,7 @@ describe('serialize-circular-error', () => {
     // TODO: Format arbitrary messages in Redbox
     await expect(browser).toDisplayRedbox(`
      {
+       "code": "E394",
        "description": "[object Object]",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
+++ b/test/development/app-dir/server-navigation-error/server-navigation-error.test.ts
@@ -11,6 +11,7 @@ describe('server-navigation-error', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Next.js navigation API is not allowed to be used in Pages Router.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -29,6 +30,7 @@ describe('server-navigation-error', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Next.js navigation API is not allowed to be used in Pages Router.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -51,6 +53,7 @@ describe('server-navigation-error', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Next.js navigation API is not allowed to be used in Middleware.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -69,6 +72,7 @@ describe('server-navigation-error', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Next.js navigation API is not allowed to be used in Middleware.",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
+++ b/test/development/app-dir/ssr-only-error/ssr-only-error.test.ts
@@ -12,6 +12,7 @@ describe('ssr-only-error', () => {
     // TODO(veil): Missing Owner Stack (NDX-905)
     await expect(browser).toDisplayCollapsedRedbox(`
      {
+       "code": "E394",
        "description": "SSR only error",
        "environmentLabel": null,
        "label": "Runtime Error",

--- a/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
+++ b/test/development/basic/gssp-ssr-change-reloading/test/index.test.ts
@@ -278,6 +278,7 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Additional keys were returned from \`getStaticProps\`. Properties intended for your component must be nested under the \`props\` key, e.g.:
 
        	return { props: { title: 'My Title', content: '...' } }
@@ -319,6 +320,7 @@ describe('GS(S)P Server-Side Change Reloading', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "custom oops",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -58,6 +58,7 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "boom",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -72,6 +73,7 @@ describe('middleware - development errors', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "boom",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -86,6 +88,7 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "boom",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -224,6 +227,7 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "test is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
@@ -240,6 +244,7 @@ describe('middleware - development errors', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "test is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
@@ -255,6 +260,7 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "test is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
@@ -328,6 +334,7 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -342,6 +349,7 @@ describe('middleware - development errors', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -365,6 +373,7 @@ describe('middleware - development errors', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "booooom!",
            "environmentLabel": null,
            "label": "Runtime Error",

--- a/test/development/pages-dir/client-navigation/index.test.ts
+++ b/test/development/pages-dir/client-navigation/index.test.ts
@@ -30,6 +30,7 @@ describe('Client Navigation', () => {
       await browser.elementByCss('#empty-props').click()
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E1025",
          "description": ""EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/development/pages-dir/client-navigation/rendering.test.ts
+++ b/test/development/pages-dir/client-navigation/rendering.test.ts
@@ -130,6 +130,7 @@ describe('Client Navigation rendering', () => {
       if (isReact18 && isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -142,6 +143,7 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "Circular structure in "getInitialProps" result of page "/circular-json-error". https://nextjs.org/docs/messages/circular-structure",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -160,6 +162,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": ""InstanceInitialPropsPage.getInitialProps()" is defined as an instance method - visit https://nextjs.org/docs/messages/get-initial-props-as-an-instance-method for more information.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -174,6 +177,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": ""EmptyInitialPropsPage.getInitialProps()" should resolve to an object. But found "null" instead.",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -217,6 +221,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "The default export is not a React Component in page: "/no-default-export"",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -232,6 +237,7 @@ describe('Client Navigation rendering', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "This is an expected error",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -246,6 +252,7 @@ describe('Client Navigation rendering', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "This is an expected error",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -260,6 +267,7 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "This is an expected error",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -283,6 +291,7 @@ describe('Client Navigation rendering', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "aa is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
@@ -298,6 +307,7 @@ describe('Client Navigation rendering', () => {
       } else if (isRspack) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "aa is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
@@ -321,6 +331,7 @@ describe('Client Navigation rendering', () => {
       } else {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "aa is not defined",
            "environmentLabel": null,
            "label": "Runtime ReferenceError",
@@ -447,6 +458,7 @@ describe('Client Navigation rendering', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "An undefined error was thrown, see here for more info: https://nextjs.org/docs/messages/threw-undefined",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/use-cache.test.ts
@@ -16,6 +16,7 @@ describe('app-root-param-getters - cache - at runtime', () => {
       const browser = await next.browser('/en/us/use-cache')
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E1012",
          "description": "Route /[lang]/[locale]/use-cache used \`import('next/root-params').lang()\` inside \`"use cache"\` or \`unstable_cache\`. Support for this API inside cache scopes is planned for a future version of Next.js.",
          "environmentLabel": "Cache",
          "label": "Runtime Error",
@@ -33,6 +34,7 @@ describe('app-root-param-getters - cache - at runtime', () => {
       const browser = await next.browser('/en/us/unstable_cache')
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E1012",
          "description": "Route /[lang]/[locale]/unstable_cache used \`import('next/root-params').lang()\` inside \`"use cache"\` or \`unstable_cache\`. Support for this API inside cache scopes is planned for a future version of Next.js.",
          "environmentLabel": "Server",
          "label": "Runtime Error",

--- a/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
+++ b/test/e2e/app-dir/cache-components-allow-otel-spans/cache-components-allow-otel-spans.test.ts
@@ -1,6 +1,6 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
 
-describe('hello-world', () => {
+describe('cache-components OTEL spans', () => {
   const { next, isTurbopack } = nextTestSetup({
     files: __dirname,
     dependencies: require('./package.json').dependencies,
@@ -15,6 +15,7 @@ describe('hello-world', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
          {
+           "code": "E394",
            "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
            "environmentLabel": "Cache",
            "label": "Console Error",
@@ -30,20 +31,21 @@ describe('hello-world', () => {
         `)
       } else {
         await expect(browser).toDisplayCollapsedRedbox(`
-                {
-                  "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
-                  "environmentLabel": "Cache",
-                  "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
-                > 26 |     return tracer.startActiveSpan('span-active-span', fn)
-                     |                   ^",
-                  "stack": [
-                    "eval app/traced-work.tsx (26:19)",
-                    "Inner app/traced-work.tsx (97:26)",
-                    "Page <anonymous>",
-                  ],
-                }
-              `)
+         {
+           "code": "E394",
+           "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
+           "environmentLabel": "Cache",
+           "label": "Console Error",
+           "source": "app/traced-work.tsx (26:19) @ eval
+         > 26 |     return tracer.startActiveSpan('span-active-span', fn)
+              |                   ^",
+           "stack": [
+             "eval app/traced-work.tsx (26:19)",
+             "Inner app/traced-work.tsx (97:26)",
+             "Page <anonymous>",
+           ],
+         }
+        `)
       }
 
       // Ideally we would assert the cached/loading status of each test case in dev but there are bugs with warmup renders that make this racey
@@ -63,6 +65,7 @@ describe('hello-world', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
          {
+           "code": "E394",
            "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
            "environmentLabel": "Cache",
            "label": "Console Error",
@@ -78,20 +81,21 @@ describe('hello-world', () => {
         `)
       } else {
         await expect(browser).toDisplayCollapsedRedbox(`
-                {
-                  "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
-                  "environmentLabel": "Cache",
-                  "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
-                > 26 |     return tracer.startActiveSpan('span-active-span', fn)
-                     |                   ^",
-                  "stack": [
-                    "eval app/traced-work.tsx (26:19)",
-                    "Inner app/traced-work.tsx (97:26)",
-                    "Page <anonymous>",
-                  ],
-                }
-              `)
+         {
+           "code": "E394",
+           "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
+           "environmentLabel": "Cache",
+           "label": "Console Error",
+           "source": "app/traced-work.tsx (26:19) @ eval
+         > 26 |     return tracer.startActiveSpan('span-active-span', fn)
+              |                   ^",
+           "stack": [
+             "eval app/traced-work.tsx (26:19)",
+             "Inner app/traced-work.tsx (97:26)",
+             "Page <anonymous>",
+           ],
+         }
+        `)
       }
 
       // Ideally we would assert the cached/loading status of each test case in dev but there are bugs with warmup renders that make this racey
@@ -110,6 +114,7 @@ describe('hello-world', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
          {
+           "code": "E394",
            "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
            "environmentLabel": "Prerender",
            "label": "Console Error",
@@ -126,21 +131,22 @@ describe('hello-world', () => {
         `)
       } else {
         await expect(browser).toDisplayCollapsedRedbox(`
-                {
-                  "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
-                  "environmentLabel": "Prerender",
-                  "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
-                > 26 |     return tracer.startActiveSpan('span-active-span', fn)
-                     |                   ^",
-                  "stack": [
-                    "eval app/traced-work.tsx (26:19)",
-                    "Inner app/traced-work.tsx (97:26)",
-                    "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
-                    "Page app/[slug]/server/page.tsx (29:7)",
-                  ],
-                }
-              `)
+         {
+           "code": "E394",
+           "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
+           "environmentLabel": "Prerender",
+           "label": "Console Error",
+           "source": "app/traced-work.tsx (26:19) @ eval
+         > 26 |     return tracer.startActiveSpan('span-active-span', fn)
+              |                   ^",
+           "stack": [
+             "eval app/traced-work.tsx (26:19)",
+             "Inner app/traced-work.tsx (97:26)",
+             "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
+             "Page app/[slug]/server/page.tsx (29:7)",
+           ],
+         }
+        `)
       }
 
       // Ideally we would assert the cached/loading status of each test case in dev but there are bugs with warmup renders that make this racey
@@ -160,6 +166,7 @@ describe('hello-world', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayCollapsedRedbox(`
          {
+           "code": "E394",
            "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
            "environmentLabel": "Prerender",
            "label": "Console Error",
@@ -176,21 +183,22 @@ describe('hello-world', () => {
         `)
       } else {
         await expect(browser).toDisplayCollapsedRedbox(`
-                {
-                  "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
-                  "environmentLabel": "Prerender",
-                  "label": "Console Error",
-                  "source": "app/traced-work.tsx (26:19) @ eval
-                > 26 |     return tracer.startActiveSpan('span-active-span', fn)
-                     |                   ^",
-                  "stack": [
-                    "eval app/traced-work.tsx (26:19)",
-                    "Inner app/traced-work.tsx (97:26)",
-                    "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
-                    "Page app/[slug]/server/page.tsx (29:7)",
-                  ],
-                }
-              `)
+         {
+           "code": "E394",
+           "description": "A Cache Function (\`use cache\`) was passed to startActiveSpan which means it will receive a Span argument with a possibly random ID on every invocation leading to cache misses. Provide a wrapping function around the Cache Function that does not forward the Span argument to avoid this issue.",
+           "environmentLabel": "Prerender",
+           "label": "Console Error",
+           "source": "app/traced-work.tsx (26:19) @ eval
+         > 26 |     return tracer.startActiveSpan('span-active-span', fn)
+              |                   ^",
+           "stack": [
+             "eval app/traced-work.tsx (26:19)",
+             "Inner app/traced-work.tsx (97:26)",
+             "CachedInnerTraceActiveSpan app/traced-work.tsx (104:9)",
+             "Page app/[slug]/server/page.tsx (29:7)",
+           ],
+         }
+        `)
       }
 
       // Ideally we would assert the cached/loading status of each test case in dev but there are bugs with warmup renders that make this racey

--- a/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-errors/cache-components-errors.test.ts
@@ -1027,6 +1027,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayCollapsedRedbox(`
              {
+               "code": "E394",
                "description": "A searchParam property was accessed directly with \`searchParams.foo\`. \`searchParams\` is a Promise and must be unwrapped with \`React.use()\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
                "environmentLabel": null,
                "label": "Console Error",
@@ -1123,6 +1124,7 @@ describe('Cache Components Errors', () => {
               await expect(browser).toDisplayRedbox(`
                [
                  {
+                   "code": "E394",
                    "description": "Route "/sync-cookies" used \`cookies().get\`. \`cookies()\` returns a Promise and must be unwrapped with \`await\` or \`React.use()\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
                    "environmentLabel": "Prerender",
                    "label": "Console Error",
@@ -1135,6 +1137,7 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
+                   "code": "E394",
                    "description": "(0 , next_headers__rspack_import_1.cookies)(...).get is not a function",
                    "environmentLabel": "Prerender",
                    "label": "Runtime TypeError",
@@ -1303,6 +1306,7 @@ describe('Cache Components Errors', () => {
               await expect(browser).toDisplayRedbox(`
                [
                  {
+                   "code": "E394",
                    "description": "Route "/sync-cookies-runtime" used \`cookies().get\`. \`cookies()\` returns a Promise and must be unwrapped with \`await\` or \`React.use()\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
                    "environmentLabel": "Server",
                    "label": "Console Error",
@@ -1315,6 +1319,7 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
+                   "code": "E394",
                    "description": "(0 , next_headers__rspack_import_1.cookies)(...).get is not a function",
                    "environmentLabel": "Server",
                    "label": "Runtime TypeError",
@@ -1457,6 +1462,7 @@ describe('Cache Components Errors', () => {
               await expect(browser).toDisplayRedbox(`
                [
                  {
+                   "code": "E394",
                    "description": "Route "/sync-headers" used \`headers().get\`. \`headers()\` returns a Promise and must be unwrapped with \`await\` or \`React.use()\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
                    "environmentLabel": "Prerender",
                    "label": "Console Error",
@@ -1469,6 +1475,7 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
+                   "code": "E394",
                    "description": "(0 , next_headers__rspack_import_1.headers)(...).get is not a function",
                    "environmentLabel": "Prerender",
                    "label": "Runtime TypeError",
@@ -1637,6 +1644,7 @@ describe('Cache Components Errors', () => {
               await expect(browser).toDisplayRedbox(`
                [
                  {
+                   "code": "E394",
                    "description": "Route "/sync-headers-runtime" used \`headers().get\`. \`headers()\` returns a Promise and must be unwrapped with \`await\` or \`React.use()\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
                    "environmentLabel": "Server",
                    "label": "Console Error",
@@ -1649,6 +1657,7 @@ describe('Cache Components Errors', () => {
                    ],
                  },
                  {
+                   "code": "E394",
                    "description": "(0 , next_headers__rspack_import_1.headers)(...).get is not a function",
                    "environmentLabel": "Server",
                    "label": "Runtime TypeError",
@@ -1713,6 +1722,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayCollapsedRedbox(`
                {
+                 "code": "E394",
                  "description": "A param property was accessed directly with \`params.slug\`. \`params\` is a Promise and must be unwrapped with \`React.use()\` before accessing its properties. Learn more: https://nextjs.org/docs/messages/sync-dynamic-apis",
                  "environmentLabel": null,
                  "label": "Console Error",
@@ -2182,6 +2192,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": "Route /use-cache-cookies used \`cookies()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -2287,6 +2298,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": "Route /use-cache-draft-mode used "draftMode().enable()" inside "use cache". The enabled status of \`draftMode()\` can be read in caches but you must not enable or disable \`draftMode()\` inside a cache. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -2391,6 +2403,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": "Route /use-cache-headers used \`headers()\` inside "use cache". Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -2763,6 +2776,7 @@ describe('Cache Components Errors', () => {
 
               await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": "A "use cache" with short \`expire\` (under 5 minutes) is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer \`"use cache"\` to choose whether it should be prerendered (with longer \`expire\`) or remain dynamic (with short \`expire\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3137,6 +3151,7 @@ describe('Cache Components Errors', () => {
 
               await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": "A "use cache" with zero \`revalidate\` is nested inside another "use cache" that has no explicit \`cacheLife\`, which is not allowed during prerendering. Add \`cacheLife()\` to the outer \`"use cache"\` to choose whether it should be prerendered (with non-zero \`revalidate\`) or remain dynamic (with zero \`revalidate\`). Read more: https://nextjs.org/docs/messages/nested-use-cache-no-explicit-cachelife",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3519,6 +3534,7 @@ describe('Cache Components Errors', () => {
             if (isTurbopack) {
               await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": ""use cache: private" must not be used within \`unstable_cache()\`.",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3534,6 +3550,7 @@ describe('Cache Components Errors', () => {
             } else {
               await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": ""use cache: private" must not be used within \`unstable_cache()\`.",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3645,6 +3662,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayRedbox(`
                {
+                 "code": "E394",
                  "description": ""use cache: private" must not be used within "use cache". It can only be nested inside of another "use cache: private".",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -3909,6 +3927,7 @@ describe('Cache Components Errors', () => {
 
             await expect(browser).toDisplayCollapsedRedbox(`
                {
+                 "code": "E394",
                  "description": "Route /use-cache-private-connection used \`connection()\` inside "use cache: private". The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual navigation request, but caches must be able to be produced before a navigation request, so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
                  "environmentLabel": null,
                  "label": "Runtime Error",
@@ -5842,6 +5861,7 @@ describe('Cache Components Errors', () => {
           await expect(browser).toDisplayCollapsedRedbox(`
            [
              {
+               "code": "E394",
                "description": "BOOM",
                "environmentLabel": "Prerender",
                "label": "Console Error",
@@ -5851,6 +5871,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
+               "code": "E394",
                "description": "⨯ "unhandledRejection:" "BOOM"",
                "environmentLabel": "Prerender",
                "label": "Console Error",
@@ -5860,6 +5881,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
+               "code": "E394",
                "description": "⨯ "unhandledRejection: " "BOOM"",
                "environmentLabel": "Prerender",
                "label": "Console Error",
@@ -5869,6 +5891,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
+               "code": "E394",
                "description": "BAM",
                "environmentLabel": "Server",
                "label": "Console Error",
@@ -5878,6 +5901,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
+               "code": "E394",
                "description": "⨯ "unhandledRejection:" "BAM"",
                "environmentLabel": "Server",
                "label": "Console Error",
@@ -5887,6 +5911,7 @@ describe('Cache Components Errors', () => {
                ],
              },
              {
+               "code": "E394",
                "description": "⨯ "unhandledRejection: " "BAM"",
                "environmentLabel": "Server",
                "label": "Console Error",

--- a/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
+++ b/test/e2e/app-dir/dynamic-data/dynamic-data.test.ts
@@ -178,6 +178,7 @@ describe('dynamic-data with dynamic = "error"', () => {
       try {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E849",
            "description": "Route /cookies with \`dynamic = "error"\` couldn't be rendered statically because it used \`cookies()\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
            "environmentLabel": "Server",
            "label": "Runtime Error",
@@ -197,6 +198,7 @@ describe('dynamic-data with dynamic = "error"', () => {
       try {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E847",
            "description": "Route /connection with \`dynamic = "error"\` couldn't be rendered statically because it used \`connection()\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
            "environmentLabel": "Server",
            "label": "Runtime Error",
@@ -216,6 +218,7 @@ describe('dynamic-data with dynamic = "error"', () => {
       try {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E828",
            "description": "Route /headers with \`dynamic = "error"\` couldn't be rendered statically because it used \`headers()\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
            "environmentLabel": "Server",
            "label": "Runtime Error",
@@ -235,6 +238,7 @@ describe('dynamic-data with dynamic = "error"', () => {
       try {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E543",
            "description": "Route /search with \`dynamic = "error"\` couldn't be rendered statically because it used \`searchParams.then\`. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering",
            "environmentLabel": "Server",
            "label": "Runtime Error",
@@ -307,6 +311,7 @@ describe('dynamic-data inside cache scope', () => {
       try {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E846",
            "description": "Route /cookies used \`cookies()\` inside a function cached with \`unstable_cache()\`. Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`cookies()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
            "environmentLabel": "Server",
            "label": "Runtime Error",
@@ -327,6 +332,7 @@ describe('dynamic-data inside cache scope', () => {
       try {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E840",
            "description": "Route /connection used \`connection()\` inside a function cached with \`unstable_cache()\`. The \`connection()\` function is used to indicate the subsequent code must only run when there is an actual Request, but caches must be able to be produced before a Request so this function is not allowed in this scope. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
            "environmentLabel": "Server",
            "label": "Runtime Error",
@@ -347,6 +353,7 @@ describe('dynamic-data inside cache scope', () => {
       try {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E838",
            "description": "Route /headers used \`headers()\` inside a function cached with \`unstable_cache()\`. Accessing Dynamic data sources inside a cache scope is not supported. If you need this data inside a cached function use \`headers()\` outside of the cached function and pass the required dynamic data in as an argument. See more info here: https://nextjs.org/docs/app/api-reference/functions/unstable_cache",
            "environmentLabel": "Server",
            "label": "Runtime Error",

--- a/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
+++ b/test/e2e/app-dir/dynamic-href/dynamic-href.test.ts
@@ -20,6 +20,7 @@ describe('dynamic-href', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E267",
          "description": "Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -56,6 +57,7 @@ describe('dynamic-href', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E267",
          "description": "Dynamic href \`/object/[slug]\` found in <Link> while using the \`/app\` router, this is not supported. Read more: https://nextjs.org/docs/messages/app-dir-dynamic-href",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/app-dir/not-found-default/index.test.ts
+++ b/test/e2e/app-dir/not-found-default/index.test.ts
@@ -20,6 +20,7 @@ describe('app dir - not found with default 404 page', () => {
       // TODO: Either allow or include original stack
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E192",
          "description": "notFound() is not allowed to use in root layout",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -51,6 +52,7 @@ describe('app dir - not found with default 404 page', () => {
       // TODO: Either allow or include original stack
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E192",
          "description": "notFound() is not allowed to use in root layout",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
+++ b/test/e2e/app-dir/undefined-default-export/undefined-default-export.test.ts
@@ -14,6 +14,7 @@ describe('Undefined default export', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "The default export is not a React Component in "/specific-path/1/page"",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -28,6 +29,7 @@ describe('Undefined default export', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "The default export is not a React Component in "/specific-path/2/layout"",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -42,6 +44,7 @@ describe('Undefined default export', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "The default export is not a React Component in "/will-not-found/not-found"",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
+++ b/test/e2e/app-dir/use-cache-search-params/use-cache-search-params.test.ts
@@ -136,6 +136,7 @@ describe('use-cache-search-params', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Route /search-params-used-generate-metadata used \`searchParams\` inside "use cache". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \`searchParams\` outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
          "environmentLabel": null,
          "label": "Runtime Error",
@@ -156,6 +157,7 @@ describe('use-cache-search-params', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Route /search-params-used-generate-viewport used \`searchParams\` inside "use cache". Accessing dynamic request data inside a cache scope is not supported. If you need some search params inside a cached function await \`searchParams\` outside of the cached function and pass only the required search params as arguments to the cached function. See more info here: https://nextjs.org/docs/messages/next-request-in-use-cache",
          "environmentLabel": null,
          "label": "Runtime Error",

--- a/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
+++ b/test/e2e/fetch-failures-have-good-stack-traces-in-edge-runtime/fetch-failures-have-good-stack-traces-in-edge-runtime.test.ts
@@ -47,6 +47,7 @@ describe('fetch failures have good stack traces in edge runtime', () => {
         // eslint-disable-next-line jest/no-standalone-expect
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E394",
            "description": "fetch failed",
            "environmentLabel": null,
            "label": "Runtime TypeError",

--- a/test/e2e/legacy-link-behavior/validations.console.test.ts
+++ b/test/e2e/legacy-link-behavior/validations.console.test.ts
@@ -30,6 +30,7 @@ describe('Validations for <Link legacyBehavior>', () => {
           await expect(browser).toDisplayCollapsedRedbox(`
            [
              {
+               "code": "E394",
                "description": "Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag.",
                "environmentLabel": "Prerender",
                "label": "Console Error",
@@ -41,6 +42,7 @@ describe('Validations for <Link legacyBehavior>', () => {
                ],
              },
              {
+               "code": "E394",
                "description": "\`legacyBehavior\` is deprecated and will be removed in a future release. A codemod is available to upgrade your components:
 
            npx @next/codemod@latest new-link .
@@ -74,6 +76,7 @@ describe('Validations for <Link legacyBehavior>', () => {
           await expect(browser).toDisplayRedbox(`
            [
              {
+               "code": "E394",
                "description": "Using a Server Component as a direct child of \`<Link legacyBehavior>\` is not supported. If you need legacyBehavior, wrap your Server Component in a Client Component that renders the Link's \`<a>\` tag.",
                "environmentLabel": "Prerender",
                "label": "Console Error",
@@ -85,6 +88,7 @@ describe('Validations for <Link legacyBehavior>', () => {
                ],
              },
              {
+               "code": "E863",
                "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
                "environmentLabel": null,
                "label": "Runtime Error",
@@ -145,6 +149,7 @@ describe('Validations for <Link legacyBehavior>', () => {
           await expect(browser).toDisplayRedbox(`
            [
              {
+               "code": "E394",
                "description": "Using a Lazy Component as a direct child of \`<Link legacyBehavior>\` from a Server Component is not supported. If you need legacyBehavior, wrap your Lazy Component in a Client Component that renders the Link's \`<a>\` tag.",
                "environmentLabel": "Prerender",
                "label": "Console Error",
@@ -156,6 +161,7 @@ describe('Validations for <Link legacyBehavior>', () => {
                ],
              },
              {
+               "code": "E863",
                "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
                "environmentLabel": null,
                "label": "Runtime Error",
@@ -201,18 +207,19 @@ describe('Validations for <Link legacyBehavior>', () => {
 
         if (isNextDev) {
           await expect(browser).toDisplayRedbox(`
-            {
-              "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
-              "environmentLabel": null,
-              "label": "Runtime Error",
-              "source": "app/validations/rsc-that-renders-client/client-link.tsx (7:10) @ ClientLink
-            > 7 |   return <Link legacyBehavior passHref {...props} />
-                |          ^",
-              "stack": [
-                "ClientLink app/validations/rsc-that-renders-client/client-link.tsx (7:10)",
-                "Page app/validations/rsc-that-renders-client/asynchronous/page.tsx (7:7)",
-              ],
-            }
+           {
+             "code": "E863",
+             "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
+             "environmentLabel": null,
+             "label": "Runtime Error",
+             "source": "app/validations/rsc-that-renders-client/client-link.tsx (7:10) @ ClientLink
+           > 7 |   return <Link legacyBehavior passHref {...props} />
+               |          ^",
+             "stack": [
+               "ClientLink app/validations/rsc-that-renders-client/client-link.tsx (7:10)",
+               "Page app/validations/rsc-that-renders-client/asynchronous/page.tsx (7:7)",
+             ],
+           }
           `)
         } else {
           const output = getContentBetween({
@@ -261,6 +268,7 @@ describe('Validations for <Link legacyBehavior>', () => {
       if (isNextDev) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E320",
            "description": "No children were passed to <Link> with \`href\` of \`/about\` but one child is required https://nextjs.org/docs/messages/link-no-children",
            "environmentLabel": null,
            "label": "Runtime Error",
@@ -292,6 +300,7 @@ describe('Validations for <Link legacyBehavior>', () => {
       if (isNextDev) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E266",
            "description": "Multiple children were passed to <Link> with \`href\` of \`/about\` but only one child is supported https://nextjs.org/docs/messages/link-multiple-children 
          Open your browser's console to view the Component stack trace.",
            "environmentLabel": null,
@@ -332,6 +341,7 @@ describe('Validations for <Link legacyBehavior>', () => {
       if (isNextDev) {
         await expect(browser).toDisplayRedbox(`
          {
+           "code": "E863",
            "description": "\`<Link legacyBehavior>\` received a direct child that is either a Server Component, or JSX that was loaded with React.lazy(). This is not supported. Either remove legacyBehavior, or make the direct child a Client Component that renders the Link's \`<a>\` tag.",
            "environmentLabel": null,
            "label": "Runtime Error",

--- a/test/e2e/new-link-behavior/child-a-tag-error.test.ts
+++ b/test/e2e/new-link-behavior/child-a-tag-error.test.ts
@@ -31,6 +31,7 @@ describe('New Link Behavior with <a> child', () => {
       )
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E394",
          "description": "Invalid <Link> with <a> child. Please remove <a> or use <Link legacyBehavior>.
        Learn more: https://nextjs.org/docs/messages/invalid-new-link-with-extra-anchor",
          "environmentLabel": null,

--- a/test/e2e/next-link-errors/next-link-errors.test.ts
+++ b/test/e2e/next-link-errors/next-link-errors.test.ts
@@ -15,6 +15,7 @@ describe('next-link', () => {
     if (isNextDev) {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E319",
          "description": "Failed prop type: The prop \`href\` expects a \`string\` or \`object\` in \`<Link>\`, but got \`undefined\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,
@@ -40,6 +41,7 @@ describe('next-link', () => {
     if (isNextDev) {
       await expect(browser).toDisplayRedbox(`
        {
+         "code": "E319",
          "description": "Failed prop type: The prop \`prefetch\` expects a \`boolean | "auto"\` in \`<Link>\`, but got \`string\` instead.
        Open your browser's console to view the Component stack trace.",
          "environmentLabel": null,

--- a/test/integration/server-side-dev-errors/test/index.test.ts
+++ b/test/integration/server-side-dev-errors/test/index.test.ts
@@ -84,17 +84,18 @@ describe('server-side dev errors', () => {
       )
 
       await expect(browser).toDisplayRedbox(`
-        {
-          "description": "missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime ReferenceError",
-          "source": "pages/gsp.js (6:3) @ getStaticProps
-        > 6 |   missingVar;return {
-            |   ^",
-          "stack": [
-            "getStaticProps pages/gsp.js (6:3)",
-          ],
-        }
+       {
+         "code": "E394",
+         "description": "missingVar is not defined",
+         "environmentLabel": null,
+         "label": "Runtime ReferenceError",
+         "source": "pages/gsp.js (6:3) @ getStaticProps
+       > 6 |   missingVar;return {
+           |   ^",
+         "stack": [
+           "getStaticProps pages/gsp.js (6:3)",
+         ],
+       }
       `)
 
       await fs.writeFile(gspPage, content, { flush: true })
@@ -134,17 +135,18 @@ describe('server-side dev errors', () => {
       )
 
       await expect(browser).toDisplayRedbox(`
-        {
-          "description": "missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime ReferenceError",
-          "source": "pages/gssp.js (6:3) @ getServerSideProps
-        > 6 |   missingVar;return {
-            |   ^",
-          "stack": [
-            "getServerSideProps pages/gssp.js (6:3)",
-          ],
-        }
+       {
+         "code": "E394",
+         "description": "missingVar is not defined",
+         "environmentLabel": null,
+         "label": "Runtime ReferenceError",
+         "source": "pages/gssp.js (6:3) @ getServerSideProps
+       > 6 |   missingVar;return {
+           |   ^",
+         "stack": [
+           "getServerSideProps pages/gssp.js (6:3)",
+         ],
+       }
       `)
 
       await fs.writeFile(gsspPage, content)
@@ -184,17 +186,18 @@ describe('server-side dev errors', () => {
       )
 
       await expect(browser).toDisplayRedbox(`
-        {
-          "description": "missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime ReferenceError",
-          "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
-        > 6 |   missingVar;return {
-            |   ^",
-          "stack": [
-            "getServerSideProps pages/blog/[slug].js (6:3)",
-          ],
-        }
+       {
+         "code": "E394",
+         "description": "missingVar is not defined",
+         "environmentLabel": null,
+         "label": "Runtime ReferenceError",
+         "source": "pages/blog/[slug].js (6:3) @ getServerSideProps
+       > 6 |   missingVar;return {
+           |   ^",
+         "stack": [
+           "getServerSideProps pages/blog/[slug].js (6:3)",
+         ],
+       }
       `)
 
       await fs.writeFile(dynamicGsspPage, content)
@@ -244,17 +247,18 @@ describe('server-side dev errors', () => {
       }
 
       await expect(browser).toDisplayRedbox(`
-        {
-          "description": "missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime ReferenceError",
-          "source": "pages/api/hello.js (2:3) @ handler
-        > 2 |   missingVar;res.status(200).json({ hello: 'world' })
-            |   ^",
-          "stack": [
-            "handler pages/api/hello.js (2:3)",
-          ],
-        }
+       {
+         "code": "E394",
+         "description": "missingVar is not defined",
+         "environmentLabel": null,
+         "label": "Runtime ReferenceError",
+         "source": "pages/api/hello.js (2:3) @ handler
+       > 2 |   missingVar;res.status(200).json({ hello: 'world' })
+           |   ^",
+         "stack": [
+           "handler pages/api/hello.js (2:3)",
+         ],
+       }
       `)
 
       await fs.writeFile(apiPage, content, { flush: true })
@@ -310,17 +314,18 @@ describe('server-side dev errors', () => {
       }
 
       await expect(browser).toDisplayRedbox(`
-        {
-          "description": "missingVar is not defined",
-          "environmentLabel": null,
-          "label": "Runtime ReferenceError",
-          "source": "pages/api/blog/[slug].js (2:3) @ handler
-        > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
-            |   ^",
-          "stack": [
-            "handler pages/api/blog/[slug].js (2:3)",
-          ],
-        }
+       {
+         "code": "E394",
+         "description": "missingVar is not defined",
+         "environmentLabel": null,
+         "label": "Runtime ReferenceError",
+         "source": "pages/api/blog/[slug].js (2:3) @ handler
+       > 2 |   missingVar;res.status(200).json({ slug: req.query.slug })
+           |   ^",
+         "stack": [
+           "handler pages/api/blog/[slug].js (2:3)",
+         ],
+       }
       `)
 
       await fs.writeFile(dynamicApiPage, content, { flush: true })

--- a/test/lib/add-redbox-matchers.ts
+++ b/test/lib/add-redbox-matchers.ts
@@ -7,6 +7,7 @@ import {
   getRedboxComponentStack,
   getRedboxDescription,
   getRedboxEnvironmentLabel,
+  getRedboxErrorCode,
   getRedboxSource,
   getRedboxLabel,
   getRedboxTotalErrorCount,
@@ -86,6 +87,7 @@ export interface ErrorSnapshot {
   description?: string
   componentStack?: string
   cause?: SanitizedCauseEntry[]
+  code?: string
   source: string | null
   stack: string[] | null
 }
@@ -191,6 +193,7 @@ async function createErrorSnapshot(
     stack,
     componentStack,
     cause,
+    code,
   ] = await Promise.all([
     includeLabel ? getRedboxLabel(browser) : null,
     getRedboxEnvironmentLabel(browser),
@@ -199,6 +202,7 @@ async function createErrorSnapshot(
     getRedboxCallStack(browser),
     getRedboxComponentStack(browser),
     getRedboxCause(browser),
+    getRedboxErrorCode(browser),
   ])
 
   // We don't need to test the codeframe logic everywhere.
@@ -251,6 +255,10 @@ async function createErrorSnapshot(
   // so we hide them from the snapshots unless they are present.
   if (componentStack !== null) {
     snapshot.componentStack = componentStack
+  }
+
+  if (code !== null) {
+    snapshot.code = code
   }
 
   // Error.cause chain is only relevant when present.

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -1193,6 +1193,22 @@ export function getRedboxDescription(
   })
 }
 
+export function getRedboxErrorCode(
+  browser: Playwright
+): Promise<string | null> {
+  return browser.eval(() => {
+    const portal = [].slice
+      .call(document.querySelectorAll('nextjs-portal'))
+      .find((p) => p.shadowRoot.querySelector('[data-nextjs-dialog-header]'))
+    const root = portal.shadowRoot
+    return (
+      root
+        .querySelector('[data-nextjs-error-code]')
+        ?.getAttribute('data-nextjs-error-code') ?? null
+    )
+  })
+}
+
 export function getRedboxDescriptionWarning(
   browser: Playwright
 ): Promise<string | null> {


### PR DESCRIPTION
The code is relevant for user feedback. Its absence indicates no user feedback can be provided.

Opus 4.6 confirmed all rspack branches were updated.