### PR TITLE
Node.js streams: First pass

### DIFF
--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -1,9 +1,9 @@
 import type { Readable } from 'node:stream'
 import { InvariantError } from '../../shared/lib/invariant-error'
 
-export type StreamLike = ReadableStream<Uint8Array> | Readable
+export type AnyStream = ReadableStream<Uint8Array> | Readable
 
-function isWebStream(stream: StreamLike): stream is ReadableStream<Uint8Array> {
+function isWebStream(stream: AnyStream): stream is ReadableStream<Uint8Array> {
   return typeof (stream as ReadableStream).tee === 'function'
 }
 
@@ -12,13 +12,13 @@ function isWebStream(stream: StreamLike): stream is ReadableStream<Uint8Array> {
 // has not yet implemented a concept of resume. For now we will simulate a paused connection by wrapping the stream
 // in one that doesn't close even when the underlying is complete.
 export class ReactServerResult {
-  private _stream: null | StreamLike
+  private _stream: null | AnyStream
 
-  constructor(stream: StreamLike) {
+  constructor(stream: AnyStream) {
     this._stream = stream
   }
 
-  tee(): StreamLike {
+  tee(): AnyStream {
     if (this._stream === null) {
       throw new Error(
         'Cannot tee a ReactServerResult that has already been consumed'
@@ -47,7 +47,7 @@ export class ReactServerResult {
     return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
   }
 
-  consume(): StreamLike {
+  consume(): AnyStream {
     if (this._stream === null) {
       throw new Error(
         'Cannot consume a ReactServerResult that has already been consumed'
@@ -80,7 +80,7 @@ export async function createReactServerPrerenderResult(
 }
 
 export async function createReactServerPrerenderResultFromRender(
-  underlying: StreamLike
+  underlying: AnyStream
 ): Promise<ReactServerPrerenderResult> {
   const chunks: Array<Uint8Array> = []
 

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -95,15 +95,9 @@ export async function createReactServerPrerenderResultFromRender(
       }
     }
   } else {
-    // Node.js Readable stream
-    const readable: Readable = underlying
-    await new Promise<void>((resolve, reject) => {
-      readable.on('data', (chunk: Buffer | Uint8Array) => {
-        chunks.push(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk))
-      })
-      readable.on('end', resolve)
-      readable.on('error', reject)
-    })
+    for await (const chunk of underlying) {
+      chunks.push(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk))
+    }
   }
 
   return new ReactServerPrerenderResult(chunks)

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -35,9 +35,9 @@ export class ReactServerResult {
       Readable = (require('node:stream') as typeof import('node:stream'))
         .Readable
     } else {
-      Readable = __non_webpack_require__(
-        'node:stream'
-      ) as typeof import('node:stream').Readable
+      Readable = (
+        __non_webpack_require__('node:stream') as typeof import('node:stream')
+      ).Readable
     }
     const webStream = Readable.toWeb(this._stream) as ReadableStream<Uint8Array>
     const tee = webStream.tee()

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -31,26 +31,28 @@ export class ReactServerResult {
     }
 
     if (process.env.TURBOPACK) {
-      // Node.js Readable: pipe to two PassThrough streams
-      const { PassThrough } =
+      const { Readable } =
         require('node:stream') as typeof import('node:stream')
-      const pt1 = new PassThrough()
-      const pt2 = new PassThrough()
-      this._stream.pipe(pt1)
-      this._stream.pipe(pt2)
-      this._stream = pt1
-      return pt2
+      const webStream = Readable.toWeb(
+        this._stream
+      ) as ReadableStream<Uint8Array>
+      const tee = webStream.tee()
+      this._stream = Readable.fromWeb(
+        tee[0] as import('stream/web').ReadableStream
+      )
+      return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
     } else {
-      // Node.js Readable: pipe to two PassThrough streams
-      const { PassThrough } = __non_webpack_require__(
+      const { Readable } = __non_webpack_require__(
         'node:stream'
       ) as typeof import('node:stream')
-      const pt1 = new PassThrough()
-      const pt2 = new PassThrough()
-      this._stream.pipe(pt1)
-      this._stream.pipe(pt2)
-      this._stream = pt1
-      return pt2
+      const webStream = Readable.toWeb(
+        this._stream
+      ) as ReadableStream<Uint8Array>
+      const tee = webStream.tee()
+      this._stream = Readable.fromWeb(
+        tee[0] as import('stream/web').ReadableStream
+      )
+      return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
     }
   }
 

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -29,15 +29,29 @@ export class ReactServerResult {
       this._stream = tee[0]
       return tee[1]
     }
-    // Node.js Readable: pipe to two PassThrough streams
-    const { PassThrough } =
-      require('node:stream') as typeof import('node:stream')
-    const pt1 = new PassThrough()
-    const pt2 = new PassThrough()
-    this._stream.pipe(pt1)
-    this._stream.pipe(pt2)
-    this._stream = pt1
-    return pt2
+
+    if (process.env.TURBOPACK) {
+      // Node.js Readable: pipe to two PassThrough streams
+      const { PassThrough } =
+        require('node:stream') as typeof import('node:stream')
+      const pt1 = new PassThrough()
+      const pt2 = new PassThrough()
+      this._stream.pipe(pt1)
+      this._stream.pipe(pt2)
+      this._stream = pt1
+      return pt2
+    } else {
+      // Node.js Readable: pipe to two PassThrough streams
+      const { PassThrough } = __non_webpack_require__(
+        'node:stream'
+      ) as typeof import('node:stream')
+      const pt1 = new PassThrough()
+      const pt2 = new PassThrough()
+      this._stream.pipe(pt1)
+      this._stream.pipe(pt2)
+      this._stream = pt1
+      return pt2
+    }
   }
 
   consume(): StreamLike {

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -30,30 +30,21 @@ export class ReactServerResult {
       return tee[1]
     }
 
+    let Readable: typeof import('node:stream').Readable
     if (process.env.TURBOPACK) {
-      const { Readable } =
-        require('node:stream') as typeof import('node:stream')
-      const webStream = Readable.toWeb(
-        this._stream
-      ) as ReadableStream<Uint8Array>
-      const tee = webStream.tee()
-      this._stream = Readable.fromWeb(
-        tee[0] as import('stream/web').ReadableStream
-      )
-      return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
+      Readable = (require('node:stream') as typeof import('node:stream'))
+        .Readable
     } else {
-      const { Readable } = __non_webpack_require__(
+      Readable = __non_webpack_require__(
         'node:stream'
-      ) as typeof import('node:stream')
-      const webStream = Readable.toWeb(
-        this._stream
-      ) as ReadableStream<Uint8Array>
-      const tee = webStream.tee()
-      this._stream = Readable.fromWeb(
-        tee[0] as import('stream/web').ReadableStream
-      )
-      return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
+      ) as typeof import('node:stream').Readable
     }
+    const webStream = Readable.toWeb(this._stream) as ReadableStream<Uint8Array>
+    const tee = webStream.tee()
+    this._stream = Readable.fromWeb(
+      tee[0] as import('stream/web').ReadableStream
+    )
+    return Readable.fromWeb(tee[1] as import('stream/web').ReadableStream)
   }
 
   consume(): StreamLike {

--- a/packages/next/src/server/app-render/app-render-prerender-utils.ts
+++ b/packages/next/src/server/app-render/app-render-prerender-utils.ts
@@ -1,28 +1,46 @@
+import type { Readable } from 'node:stream'
 import { InvariantError } from '../../shared/lib/invariant-error'
+
+export type StreamLike = ReadableStream<Uint8Array> | Readable
+
+function isWebStream(stream: StreamLike): stream is ReadableStream<Uint8Array> {
+  return typeof (stream as ReadableStream).tee === 'function'
+}
 
 // React's RSC prerender function will emit an incomplete flight stream when using `prerender`. If the connection
 // closes then whatever hanging chunks exist will be errored. This is because prerender (an experimental feature)
 // has not yet implemented a concept of resume. For now we will simulate a paused connection by wrapping the stream
 // in one that doesn't close even when the underlying is complete.
 export class ReactServerResult {
-  private _stream: null | ReadableStream<Uint8Array>
+  private _stream: null | StreamLike
 
-  constructor(stream: ReadableStream<Uint8Array>) {
+  constructor(stream: StreamLike) {
     this._stream = stream
   }
 
-  tee() {
+  tee(): StreamLike {
     if (this._stream === null) {
       throw new Error(
         'Cannot tee a ReactServerResult that has already been consumed'
       )
     }
-    const tee = this._stream.tee()
-    this._stream = tee[0]
-    return tee[1]
+    if (isWebStream(this._stream)) {
+      const tee = this._stream.tee()
+      this._stream = tee[0]
+      return tee[1]
+    }
+    // Node.js Readable: pipe to two PassThrough streams
+    const { PassThrough } =
+      require('node:stream') as typeof import('node:stream')
+    const pt1 = new PassThrough()
+    const pt2 = new PassThrough()
+    this._stream.pipe(pt1)
+    this._stream.pipe(pt2)
+    this._stream = pt1
+    return pt2
   }
 
-  consume() {
+  consume(): StreamLike {
     if (this._stream === null) {
       throw new Error(
         'Cannot consume a ReactServerResult that has already been consumed'
@@ -55,18 +73,32 @@ export async function createReactServerPrerenderResult(
 }
 
 export async function createReactServerPrerenderResultFromRender(
-  underlying: ReadableStream<Uint8Array>
+  underlying: StreamLike
 ): Promise<ReactServerPrerenderResult> {
   const chunks: Array<Uint8Array> = []
-  const reader = underlying.getReader()
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) {
-      break
-    } else {
-      chunks.push(value)
+
+  if (isWebStream(underlying)) {
+    const reader = underlying.getReader()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) {
+        break
+      } else {
+        chunks.push(value)
+      }
     }
+  } else {
+    // Node.js Readable stream
+    const readable: Readable = underlying
+    await new Promise<void>((resolve, reject) => {
+      readable.on('data', (chunk: Buffer | Uint8Array) => {
+        chunks.push(chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk))
+      })
+      readable.on('end', resolve)
+      readable.on('error', reject)
+    })
   }
+
   return new ReactServerPrerenderResult(chunks)
 }
 export class ReactServerPrerenderResult {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -3701,14 +3701,21 @@ async function renderWithRestartOnCacheMissInDev(
       startTime = performance.now() + performance.timeOrigin
 
       const streamPair = teeStream(
-        renderToFlightStream(ComponentMod, initialRscPayload, clientModules, {
-          onError,
-          environmentName,
-          startTime,
-          filterStackFrame,
-          debugChannel: debugChannel?.serverSide,
-          signal: initialReactController.signal,
-        })
+        workUnitAsyncStorage.run(
+          requestStore,
+          renderToFlightStream,
+          ComponentMod,
+          initialRscPayload,
+          clientModules,
+          {
+            onError,
+            environmentName,
+            startTime,
+            filterStackFrame,
+            debugChannel: debugChannel?.serverSide,
+            signal: initialReactController.signal,
+          }
+        )
       )
 
       // If we abort the render, we want to reject the stage-dependent promises as well.
@@ -3861,13 +3868,20 @@ async function renderWithRestartOnCacheMissInDev(
       startTime = performance.now() + performance.timeOrigin
 
       const streamPair = teeStream(
-        renderToFlightStream(ComponentMod, finalRscPayload, clientModules, {
-          onError,
-          environmentName,
-          startTime,
-          filterStackFrame,
-          debugChannel: debugChannel?.serverSide,
-        })
+        workUnitAsyncStorage.run(
+          requestStore,
+          renderToFlightStream,
+          ComponentMod,
+          finalRscPayload,
+          clientModules,
+          {
+            onError,
+            environmentName,
+            startTime,
+            filterStackFrame,
+            debugChannel: debugChannel?.serverSide,
+          }
+        )
       )
 
       return {

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6545,7 +6545,9 @@ async function prerenderToStream(
           // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
           // so we can set all the postponed boundaries to client render mode before we store the HTML response
           const foreverStream = createPendingStream()
-          const resumePrelude = await resumeAndAbort(
+          const resumePrelude = await workUnitAsyncStorage.run(
+            finalServerPrerenderStore,
+            resumeAndAbort,
             // eslint-disable-next-line @next/internal/no-ambiguous-jsx
             <App
               reactServerStream={foreverStream}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -57,7 +57,10 @@ import {
   getClientPrerender,
   processPrelude as processPreludeOp,
   createDocumentClosingStream,
+  teeStream,
+  toReadableStream,
 } from './stream-ops'
+import type { AnyStream } from './stream-ops'
 import { stripInternalQueries } from '../internal-utils'
 import {
   NEXT_HMR_REFRESH_HEADER,
@@ -1184,7 +1187,7 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
   }
 
   let debugChannel: DebugChannelPair | undefined
-  let stream: ReadableStream<Uint8Array>
+  let stream: AnyStream
 
   if (
     // We only do this flow if we can safely recreate the store from scratch
@@ -2131,7 +2134,7 @@ function ErrorApp<T>({
 // certain object shape. The generic type is not used directly in the type so it
 // requires a disabling of the eslint rule disallowing unused vars
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export type BinaryStreamOf<T> = ReadableStream<Uint8Array>
+export type BinaryStreamOf<T> = AnyStream
 
 /**
  * Extracted to a separate function to prevent V8 from retaining the entire
@@ -2859,7 +2862,7 @@ async function renderToStream(
   metadata: AppPageRenderResultMetadata,
   createRequestStore: (() => RequestStore) | undefined,
   fallbackParams: OpaqueFallbackRouteParams | null
-): Promise<ReadableStream<Uint8Array>> {
+): Promise<AnyStream> {
   /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   const {
     assetPrefix,
@@ -3697,23 +3700,16 @@ async function renderWithRestartOnCacheMissInDev(
       initialStageController.advanceStage(RenderStage.EarlyStatic)
       startTime = performance.now() + performance.timeOrigin
 
-      const streamPair = workUnitAsyncStorage
-        .run(
-          requestStore,
-          renderToFlightStream,
-          ComponentMod,
-          initialRscPayload,
-          clientModules,
-          {
-            onError,
-            environmentName,
-            startTime,
-            filterStackFrame,
-            debugChannel: debugChannel?.serverSide,
-            signal: initialReactController.signal,
-          }
-        )
-        .tee()
+      const streamPair = teeStream(
+        renderToFlightStream(ComponentMod, initialRscPayload, clientModules, {
+          onError,
+          environmentName,
+          startTime,
+          filterStackFrame,
+          debugChannel: debugChannel?.serverSide,
+          signal: initialReactController.signal,
+        })
+      )
 
       // If we abort the render, we want to reject the stage-dependent promises as well.
       // Note that we want to install this listener after the render is started
@@ -3729,7 +3725,7 @@ async function renderWithRestartOnCacheMissInDev(
 
       const stream = streamPair[0]
       const accumulatedChunksPromise = accumulateStreamChunks(
-        streamPair[1],
+        toReadableStream(streamPair[1]),
         initialStageController,
         initialDataController.signal
       )
@@ -3738,7 +3734,11 @@ async function renderWithRestartOnCacheMissInDev(
         'abort',
         () => {
           accumulatedChunksPromise.catch(() => {})
-          stream.cancel()
+          if (stream instanceof ReadableStream) {
+            stream.cancel()
+          } else {
+            stream.destroy()
+          }
         },
         { once: true }
       )
@@ -3860,27 +3860,20 @@ async function renderWithRestartOnCacheMissInDev(
       finalStageController.advanceStage(RenderStage.EarlyStatic)
       startTime = performance.now() + performance.timeOrigin
 
-      const streamPair = workUnitAsyncStorage
-        .run(
-          requestStore,
-          renderToFlightStream,
-          ComponentMod,
-          finalRscPayload,
-          clientModules,
-          {
-            onError,
-            environmentName,
-            startTime,
-            filterStackFrame,
-            debugChannel: debugChannel?.serverSide,
-          }
-        )
-        .tee()
+      const streamPair = teeStream(
+        renderToFlightStream(ComponentMod, finalRscPayload, clientModules, {
+          onError,
+          environmentName,
+          startTime,
+          filterStackFrame,
+          debugChannel: debugChannel?.serverSide,
+        })
+      )
 
       return {
         stream: streamPair[0],
         accumulatedChunksPromise: accumulateStreamChunks(
-          streamPair[1],
+          toReadableStream(streamPair[1]),
           finalStageController,
           null
         ),
@@ -4148,7 +4141,7 @@ async function logMessagesAndSendErrorsToBrowser(
       { filterStackFrame }
     )
 
-    sendErrorsToBrowser(errorsFlightStream, htmlRequestId)
+    sendErrorsToBrowser(toReadableStream(errorsFlightStream), htmlRequestId)
   }
 }
 
@@ -5675,7 +5668,7 @@ async function validateInstantConfigInBuildWithSample(
 }
 
 type PrerenderToStreamResult = {
-  stream: ReadableStream<Uint8Array>
+  stream: AnyStream
   digestErrorsMap: Map<string, DigestedError>
   ssrErrors: Array<unknown>
   dynamicAccess?: null | Array<DynamicAccess>
@@ -6533,7 +6526,7 @@ async function prerenderToStream(
           )
         }
 
-        let htmlStream: ReadableStream<Uint8Array> = prelude
+        let htmlStream: AnyStream = prelude
         if (postponed != null) {
           // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
           // so we can set all the postponed boundaries to client render mode before we store the HTML response

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4778,6 +4778,7 @@ async function validateInstantConfigs(
     stageEndTimes,
   } = await collectStagedSegmentData(
     ctx.componentMod,
+    renderToFlightStream,
     {
       [RenderStage.Static]: accumulatedChunks.staticChunks,
       [RenderStage.Runtime]: accumulatedChunks.runtimeChunks,
@@ -4854,6 +4855,7 @@ async function validateInstantConfigs(
     const { stream: serverStream, debugStream } =
       await createCombinedPayloadStream(
         ctx.componentMod,
+        renderToFlightStream,
         payloadResult.payload,
         extraChunksController,
         reactController.signal,

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1220,11 +1220,11 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     )
 
     if (shouldValidate) {
-      let validationDebugChannelClient: Readable | undefined = undefined
+      let validationDebugChannelClient: AnyStream | undefined = undefined
       if (returnedDebugChannel) {
         const [t1, t2] = teeStream(returnedDebugChannel.clientSide.readable)
         returnedDebugChannel.clientSide.readable = t1
-        validationDebugChannelClient = t2 as Readable
+        validationDebugChannelClient = t2
       }
       consoleAsyncStorage.run(
         { dim: true },
@@ -3080,11 +3080,11 @@ async function renderToStream(
             serverComponentsErrorHandler
           )
 
-          let validationDebugChannelClient: Readable | undefined = undefined
+          let validationDebugChannelClient: AnyStream | undefined = undefined
           if (returnedDebugChannel) {
             const [t1, t2] = teeStream(returnedDebugChannel.clientSide.readable)
             returnedDebugChannel.clientSide.readable = t1
-            validationDebugChannelClient = t2 as Readable
+            validationDebugChannelClient = t2
           }
 
           consoleAsyncStorage.run(
@@ -4263,7 +4263,7 @@ async function spawnStaticShellValidationInDevImpl(
   ctx: AppRenderContext,
   requestStore: RequestStore,
   fallbackRouteParams: OpaqueFallbackRouteParams | null,
-  debugChannelClient: Readable | undefined
+  debugChannelClient: AnyStream | undefined
 ): Promise<void> {
   const debug =
     process.env.NEXT_PRIVATE_DEBUG_VALIDATION === '1' ? console.log : undefined
@@ -4299,9 +4299,12 @@ async function spawnStaticShellValidationInDevImpl(
   let debugChunks: Uint8Array[] | null = null
   if (debugChannelClient) {
     debugChunks = []
-    debugChannelClient.on('data', (c) => {
-      debugChunks!.push(c)
-    })
+    const chunks = debugChunks
+    ;(async () => {
+      for await (const c of debugChannelClient as AsyncIterable<Uint8Array>) {
+        chunks.push(c)
+      }
+    })()
   }
 
   const accumulatedChunks = await accumulatedChunksPromise

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1222,9 +1222,9 @@ async function generateDynamicFlightRenderResultWithStagesInDev(
     if (shouldValidate) {
       let validationDebugChannelClient: Readable | undefined = undefined
       if (returnedDebugChannel) {
-        const [t1, t2] = returnedDebugChannel.clientSide.readable.tee()
+        const [t1, t2] = teeStream(returnedDebugChannel.clientSide.readable)
         returnedDebugChannel.clientSide.readable = t1
-        validationDebugChannelClient = nodeStreamFromReadableStream(t2)
+        validationDebugChannelClient = t2 as Readable
       }
       consoleAsyncStorage.run(
         { dim: true },
@@ -2026,7 +2026,7 @@ function App<T>({
 }: {
   /* eslint-disable @next/internal/no-ambiguous-jsx -- React Client */
   reactServerStream: Readable | BinaryStreamOf<T>
-  reactDebugStream: Readable | ReadableStream<Uint8Array> | undefined
+  reactDebugStream: AnyStream | undefined
   debugEndTime: number | undefined
   preinitScripts: () => void
   ServerInsertedHTMLProvider: ComponentType<{
@@ -3010,7 +3010,7 @@ async function renderToStream(
     )
 
     let reactServerResult: null | ReactServerResult = null
-    let reactDebugStream: ReadableStream<Uint8Array> | undefined
+    let reactDebugStream: AnyStream | undefined
 
     const setHeader = res.setHeader.bind(res)
     const appendHeader = res.appendHeader.bind(res)
@@ -3082,9 +3082,9 @@ async function renderToStream(
 
           let validationDebugChannelClient: Readable | undefined = undefined
           if (returnedDebugChannel) {
-            const [t1, t2] = returnedDebugChannel.clientSide.readable.tee()
+            const [t1, t2] = teeStream(returnedDebugChannel.clientSide.readable)
             returnedDebugChannel.clientSide.readable = t1
-            validationDebugChannelClient = nodeStreamFromReadableStream(t2)
+            validationDebugChannelClient = t2 as Readable
           }
 
           consoleAsyncStorage.run(
@@ -3127,8 +3127,9 @@ async function renderToStream(
         }
 
         if (debugChannel && setReactDebugChannel) {
-          const [readableSsr, readableBrowser] =
-            debugChannel.clientSide.readable.tee()
+          const [readableSsr, readableBrowser] = teeStream(
+            debugChannel.clientSide.readable
+          )
 
           reactDebugStream = readableSsr
 
@@ -3275,8 +3276,9 @@ async function renderToStream(
         const debugChannel = setReactDebugChannel && createDebugChannel()
 
         if (debugChannel) {
-          const [readableSsr, readableBrowser] =
-            debugChannel.clientSide.readable.tee()
+          const [readableSsr, readableBrowser] = teeStream(
+            debugChannel.clientSide.readable
+          )
 
           reactDebugStream = readableSsr
 
@@ -7388,31 +7390,4 @@ function WarnForBypassCachesInDev({ route }: { route: string }) {
     `Route ${route} is rendering with server caches disabled. For this navigation, Component Metadata in React DevTools will not accurately reflect what is statically prerenderable and runtime prefetchable. See more info here: https://nextjs.org/docs/messages/cache-bypass-in-dev`
   )
   return null
-}
-
-function nodeStreamFromReadableStream<T>(stream: ReadableStream<T>) {
-  if (process.env.NEXT_RUNTIME === 'edge') {
-    throw new InvariantError(
-      'nodeStreamFromReadableStream cannot be used in the edge runtime'
-    )
-  } else {
-    const reader = stream.getReader()
-
-    const { Readable } = require('node:stream') as typeof import('node:stream')
-
-    return new Readable({
-      read() {
-        reader
-          .read()
-          .then(({ done, value }) => {
-            if (done) {
-              this.push(null)
-            } else {
-              this.push(value)
-            }
-          })
-          .catch((err) => this.destroy(err))
-      },
-    })
-  }
 }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6884,7 +6884,7 @@ async function prerenderToStream(
           )
         }
 
-        let htmlStream: ReadableStream<Uint8Array> = prelude
+        let htmlStream: AnyStream = prelude
         if (postponed != null) {
           // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
           // so we can set all the postponed boundaries to client render mode before we store the HTML response

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4155,7 +4155,7 @@ async function logMessagesAndSendErrorsToBrowser(
       { filterStackFrame }
     )
 
-    sendErrorsToBrowser(toReadableStream(errorsFlightStream), htmlRequestId)
+    sendErrorsToBrowser(errorsFlightStream, htmlRequestId)
   }
 }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4299,10 +4299,9 @@ async function spawnStaticShellValidationInDevImpl(
   let debugChunks: Uint8Array[] | null = null
   if (debugChannelClient) {
     debugChunks = []
-    const chunks = debugChunks
     ;(async () => {
-      for await (const c of debugChannelClient as AsyncIterable<Uint8Array>) {
-        chunks.push(c)
+      for await (const c of debugChannelClient) {
+        debugChunks.push(c)
       }
     })()
   }

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6595,9 +6595,7 @@ async function prerenderToStream(
           // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
           // so we can set all the postponed boundaries to client render mode before we store the HTML response
           const foreverStream = createPendingStream()
-          const resumePrelude = await workUnitAsyncStorage.run(
-            finalServerPrerenderStore,
-            resumeAndAbort,
+          const resumePrelude = await resumeAndAbort(
             // eslint-disable-next-line @next/internal/no-ambiguous-jsx
             <App
               reactServerStream={foreverStream}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6597,7 +6597,9 @@ async function prerenderToStream(
           // We postponed but nothing dynamic was used. We resume the render now and immediately abort it
           // so we can set all the postponed boundaries to client render mode before we store the HTML response
           const foreverStream = createPendingStream()
-          const resumePrelude = await resumeAndAbort(
+          const resumePrelude = await workUnitAsyncStorage.run(
+            finalServerPrerenderStore,
+            resumeAndAbort,
             // eslint-disable-next-line @next/internal/no-ambiguous-jsx
             <App
               reactServerStream={foreverStream}

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -58,7 +58,6 @@ import {
   processPrelude as processPreludeOp,
   createDocumentClosingStream,
   teeStream,
-  toReadableStream,
 } from './stream-ops'
 import type { AnyStream } from './stream-ops'
 import { stripInternalQueries } from '../internal-utils'
@@ -3732,7 +3731,7 @@ async function renderWithRestartOnCacheMissInDev(
 
       const stream = streamPair[0]
       const accumulatedChunksPromise = accumulateStreamChunks(
-        toReadableStream(streamPair[1]),
+        streamPair[1],
         initialStageController,
         initialDataController.signal
       )
@@ -3887,7 +3886,7 @@ async function renderWithRestartOnCacheMissInDev(
       return {
         stream: streamPair[0],
         accumulatedChunksPromise: accumulateStreamChunks(
-          toReadableStream(streamPair[1]),
+          streamPair[1],
           finalStageController,
           null
         ),
@@ -3934,69 +3933,114 @@ interface AccumulatedStreamChunks {
 }
 
 async function accumulateStreamChunks(
-  stream: ReadableStream<Uint8Array>,
+  stream: AnyStream,
   stageController: StagedRenderingController,
   signal: AbortSignal | null
 ): Promise<AccumulatedStreamChunks> {
   const staticChunks: Array<Uint8Array> = []
   const runtimeChunks: Array<Uint8Array> = []
   const dynamicChunks: Array<Uint8Array> = []
-  const reader = stream.getReader()
 
-  let cancelled = false
-  function cancel() {
-    if (!cancelled) {
-      cancelled = true
-      reader.cancel()
-    }
-  }
+  if (stream instanceof ReadableStream) {
+    const reader = stream.getReader()
 
-  if (signal) {
-    signal.addEventListener('abort', cancel, { once: true })
-  }
-
-  try {
-    while (!cancelled) {
-      const { done, value } = await reader.read()
-      if (done) {
-        cancel()
-        break
-      }
-      switch (stageController.currentStage) {
-        case RenderStage.Before:
-          throw new InvariantError(
-            'Unexpected stream chunk while in Before stage'
-          )
-        case RenderStage.EarlyStatic:
-        case RenderStage.Static:
-          staticChunks.push(value)
-        // fall through
-        case RenderStage.EarlyRuntime:
-        case RenderStage.Runtime:
-          runtimeChunks.push(value)
-        // fall through
-        case RenderStage.Dynamic:
-          dynamicChunks.push(value)
-          break
-        case RenderStage.Abandoned:
-          // If the render was abandoned, we won't use the chunks,
-          // so there's no need to accumulate them
-          break
-        default:
-          stageController.currentStage satisfies never
-          break
+    let cancelled = false
+    function cancel() {
+      if (!cancelled) {
+        cancelled = true
+        reader.cancel()
       }
     }
-  } catch (err) {
-    // When we cancel the reader we may reject the read.
-    // Only swallow errors caused by our intentional cancel();
-    // re-throw unexpected errors to avoid silently returning partial data.
-    if (!cancelled) {
-      throw err
+
+    if (signal) {
+      signal.addEventListener('abort', cancel, { once: true })
+    }
+
+    try {
+      while (!cancelled) {
+        const { done, value } = await reader.read()
+        if (done) {
+          cancel()
+          break
+        }
+        accumulateChunk(
+          stageController,
+          staticChunks,
+          runtimeChunks,
+          dynamicChunks,
+          value
+        )
+      }
+    } catch (err) {
+      // When we cancel the reader we may reject the read.
+      // Only swallow errors caused by our intentional cancel();
+      // re-throw unexpected errors to avoid silently returning partial data.
+      if (!cancelled) {
+        throw err
+      }
+    }
+  } else {
+    const nodeStream = stream as Readable
+    let cancelled = false
+    function cancel() {
+      if (!cancelled) {
+        cancelled = true
+        nodeStream.destroy()
+      }
+    }
+
+    if (signal) {
+      signal.addEventListener('abort', cancel, { once: true })
+    }
+
+    try {
+      for await (const value of nodeStream) {
+        if (cancelled) break
+        accumulateChunk(
+          stageController,
+          staticChunks,
+          runtimeChunks,
+          dynamicChunks,
+          value
+        )
+      }
+    } catch (err) {
+      if (!cancelled) {
+        throw err
+      }
     }
   }
 
   return { staticChunks, runtimeChunks, dynamicChunks }
+}
+
+function accumulateChunk(
+  stageController: StagedRenderingController,
+  staticChunks: Array<Uint8Array>,
+  runtimeChunks: Array<Uint8Array>,
+  dynamicChunks: Array<Uint8Array>,
+  value: Uint8Array
+): void {
+  switch (stageController.currentStage) {
+    case RenderStage.Before:
+      throw new InvariantError('Unexpected stream chunk while in Before stage')
+    case RenderStage.EarlyStatic:
+    case RenderStage.Static:
+      staticChunks.push(value)
+    // fall through
+    case RenderStage.EarlyRuntime:
+    case RenderStage.Runtime:
+      runtimeChunks.push(value)
+    // fall through
+    case RenderStage.Dynamic:
+      dynamicChunks.push(value)
+      break
+    case RenderStage.Abandoned:
+      break
+    default:
+      stageController.currentStage satisfies never
+      break
+  }
 }
 
 async function countStaticStageBytes(

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -4778,6 +4778,7 @@ async function validateInstantConfigs(
     payload: initialRscPayload,
     stageEndTimes,
   } = await collectStagedSegmentData(
+    ctx.componentMod,
     {
       [RenderStage.Static]: accumulatedChunks.staticChunks,
       [RenderStage.Runtime]: accumulatedChunks.runtimeChunks,
@@ -4853,6 +4854,7 @@ async function validateInstantConfigs(
 
     const { stream: serverStream, debugStream } =
       await createCombinedPayloadStream(
+        ctx.componentMod,
         payloadResult.payload,
         extraChunksController,
         reactController.signal,

--- a/packages/next/src/server/app-render/debug-channel-server.node.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.node.ts
@@ -3,11 +3,11 @@
  * Loaded by debug-channel-server.ts when __NEXT_USE_NODE_STREAMS is enabled.
  */
 
-import { PassThrough, Readable } from 'node:stream'
+import { PassThrough, Readable, Writable } from 'node:stream'
 
 type NodeDebugChannelServer = {
   readable?: ReadableStream<Uint8Array>
-  writable: import('node:stream').Writable
+  writable: WritableStream<Uint8Array>
 }
 
 type NodeDebugChannelPair = {
@@ -30,10 +30,11 @@ export function createDebugChannel():
 export function createNodeDebugChannel(): NodeDebugChannelPair {
   const duplex = new PassThrough()
   const clientReadable = Readable.toWeb(duplex) as ReadableStream<Uint8Array>
+  const serverWritable = Writable.toWeb(duplex) as WritableStream<Uint8Array>
 
   return {
     serverSide: {
-      writable: duplex,
+      writable: serverWritable,
     },
     clientSide: { readable: clientReadable },
   }

--- a/packages/next/src/server/app-render/debug-channel-server.node.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.node.ts
@@ -3,16 +3,11 @@
  * Loaded by debug-channel-server.ts when __NEXT_USE_NODE_STREAMS is enabled.
  */
 
-import type { Writable as NodeWritable } from 'node:stream'
 import { PassThrough, Readable } from 'node:stream'
-
-import type { DebugChannelServer } from './debug-channel-server.web'
-
-type WebWritableStream = import('stream/web').WritableStream
 
 type NodeDebugChannelServer = {
   readable?: ReadableStream<Uint8Array>
-  writable: NodeWritable
+  writable: import('node:stream').Writable
 }
 
 type NodeDebugChannelPair = {
@@ -21,15 +16,6 @@ type NodeDebugChannelPair = {
     readable: ReadableStream<Uint8Array>
     writable?: WritableStream<Uint8Array>
   }
-}
-
-function isNodeWritable(value: unknown): value is NodeWritable {
-  return (
-    value !== null &&
-    typeof value === 'object' &&
-    typeof (value as { write?: unknown }).write === 'function' &&
-    typeof (value as { on?: unknown }).on === 'function'
-  )
 }
 
 export function createDebugChannel():
@@ -50,24 +36,5 @@ export function createNodeDebugChannel(): NodeDebugChannelPair {
       writable: duplex,
     },
     clientSide: { readable: clientReadable },
-  }
-}
-
-export function toNodeDebugChannel(
-  debugChannel: DebugChannelServer | NodeDebugChannelServer
-): NodeWritable {
-  const { writable } = debugChannel
-  if (isNodeWritable(writable)) {
-    return writable
-  }
-
-  if (process.env.TURBOPACK) {
-    const { Writable } = require('node:stream') as typeof import('node:stream')
-    return Writable.fromWeb(writable as WebWritableStream)
-  } else {
-    const { Writable } = __non_webpack_require__(
-      'node:stream'
-    ) as typeof import('node:stream')
-    return Writable.fromWeb(writable as WebWritableStream)
   }
 }

--- a/packages/next/src/server/app-render/debug-channel-server.node.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.node.ts
@@ -1,0 +1,73 @@
+/**
+ * Node debug channel implementation.
+ * Loaded by debug-channel-server.ts when __NEXT_USE_NODE_STREAMS is enabled.
+ */
+
+import type { Writable as NodeWritable } from 'node:stream'
+import { PassThrough, Readable } from 'node:stream'
+
+import type { DebugChannelServer } from './debug-channel-server.web'
+
+type WebWritableStream = import('stream/web').WritableStream
+
+type NodeDebugChannelServer = {
+  readable?: ReadableStream<Uint8Array>
+  writable: NodeWritable
+}
+
+type NodeDebugChannelPair = {
+  serverSide: NodeDebugChannelServer
+  clientSide: {
+    readable: ReadableStream<Uint8Array>
+    writable?: WritableStream<Uint8Array>
+  }
+}
+
+function isNodeWritable(value: unknown): value is NodeWritable {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as { write?: unknown }).write === 'function' &&
+    typeof (value as { on?: unknown }).on === 'function'
+  )
+}
+
+export function createDebugChannel():
+  | import('./debug-channel-server.web').DebugChannelPair
+  | undefined {
+  if (process.env.NODE_ENV === 'production') {
+    return undefined
+  }
+  return createNodeDebugChannel() as unknown as import('./debug-channel-server.web').DebugChannelPair
+}
+
+export function createNodeDebugChannel(): NodeDebugChannelPair {
+  const duplex = new PassThrough()
+  const clientReadable = Readable.toWeb(duplex) as ReadableStream<Uint8Array>
+
+  return {
+    serverSide: {
+      writable: duplex,
+    },
+    clientSide: { readable: clientReadable },
+  }
+}
+
+export function toNodeDebugChannel(
+  debugChannel: DebugChannelServer | NodeDebugChannelServer
+): NodeWritable {
+  const { writable } = debugChannel
+  if (isNodeWritable(writable)) {
+    return writable
+  }
+
+  if (process.env.TURBOPACK) {
+    const { Writable } = require('node:stream') as typeof import('node:stream')
+    return Writable.fromWeb(writable as WebWritableStream)
+  } else {
+    const { Writable } = __non_webpack_require__(
+      'node:stream'
+    ) as typeof import('node:stream')
+    return Writable.fromWeb(writable as WebWritableStream)
+  }
+}

--- a/packages/next/src/server/app-render/debug-channel-server.node.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.node.ts
@@ -3,7 +3,7 @@
  * Loaded by debug-channel-server.ts when __NEXT_USE_NODE_STREAMS is enabled.
  */
 
-import { PassThrough } from 'node:stream'
+import { PassThrough, Writable } from 'node:stream'
 import type { DebugChannelPair } from './debug-channel-server.web'
 
 export function createDebugChannel(): DebugChannelPair | undefined {
@@ -13,11 +13,25 @@ export function createDebugChannel(): DebugChannelPair | undefined {
   return createNodeDebugChannel()
 }
 
-export function createNodeDebugChannel(): DebugChannelPair {
-  const duplex = new PassThrough()
+function createNodeDebugChannel(): DebugChannelPair {
+  const readable = new PassThrough()
+
+  // Use a plain Writable instead of exposing the PassThrough directly.
+  // React's renderToPipeableStream detects .read() on the debugChannel and
+  // enters bidirectional mode, reading its own output back as commands.
+  const writable = new Writable({
+    write(chunk, _encoding, callback) {
+      readable.push(chunk)
+      callback()
+    },
+    final(callback) {
+      readable.push(null)
+      callback()
+    },
+  })
 
   return {
-    serverSide: duplex,
-    clientSide: { readable: duplex },
+    serverSide: writable,
+    clientSide: { readable },
   }
 }

--- a/packages/next/src/server/app-render/debug-channel-server.node.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.node.ts
@@ -3,39 +3,21 @@
  * Loaded by debug-channel-server.ts when __NEXT_USE_NODE_STREAMS is enabled.
  */
 
-import { PassThrough, Readable, Writable } from 'node:stream'
+import { PassThrough } from 'node:stream'
+import type { DebugChannelPair } from './debug-channel-server.web'
 
-type NodeDebugChannelServer = {
-  readable?: ReadableStream<Uint8Array>
-  writable: WritableStream<Uint8Array>
-}
-
-type NodeDebugChannelPair = {
-  serverSide: NodeDebugChannelServer
-  clientSide: {
-    readable: ReadableStream<Uint8Array>
-    writable?: WritableStream<Uint8Array>
-  }
-}
-
-export function createDebugChannel():
-  | import('./debug-channel-server.web').DebugChannelPair
-  | undefined {
+export function createDebugChannel(): DebugChannelPair | undefined {
   if (process.env.NODE_ENV === 'production') {
     return undefined
   }
-  return createNodeDebugChannel() as unknown as import('./debug-channel-server.web').DebugChannelPair
+  return createNodeDebugChannel()
 }
 
-export function createNodeDebugChannel(): NodeDebugChannelPair {
+export function createNodeDebugChannel(): DebugChannelPair {
   const duplex = new PassThrough()
-  const clientReadable = Readable.toWeb(duplex) as ReadableStream<Uint8Array>
-  const serverWritable = Writable.toWeb(duplex) as WritableStream<Uint8Array>
 
   return {
-    serverSide: {
-      writable: serverWritable,
-    },
-    clientSide: { readable: clientReadable },
+    serverSide: duplex,
+    clientSide: { readable: duplex },
   }
 }

--- a/packages/next/src/server/app-render/debug-channel-server.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.ts
@@ -1,15 +1,26 @@
 /**
  * Compile-time switcher for debug channel operations.
  *
- * Simple re-export from the web implementation.
- * A future change will add a conditional branch for node streams.
+ * When __NEXT_USE_NODE_STREAMS is true, uses a Node Writable-based channel.
+ * Otherwise, uses web WritableStream APIs.
  */
 export type {
   DebugChannelPair,
   DebugChannelServer,
 } from './debug-channel-server.web'
 
-export {
-  createDebugChannel,
-  toNodeDebugChannel,
-} from './debug-channel-server.web'
+type DebugChannelMod = {
+  createDebugChannel: typeof import('./debug-channel-server.web').createDebugChannel
+  toNodeDebugChannel: (...args: any[]) => import('node:stream').Writable
+}
+
+let _m: DebugChannelMod
+if (process.env.__NEXT_USE_NODE_STREAMS) {
+  _m =
+    require('./debug-channel-server.node') as typeof import('./debug-channel-server.node')
+} else {
+  _m = (require('./debug-channel-server.web') as typeof import('./debug-channel-server.web')) as DebugChannelMod
+}
+
+export const createDebugChannel = _m.createDebugChannel
+export const toNodeDebugChannel = _m.toNodeDebugChannel

--- a/packages/next/src/server/app-render/debug-channel-server.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.ts
@@ -1,8 +1,11 @@
 /**
  * Compile-time switcher for debug channel operations.
  *
- * When __NEXT_USE_NODE_STREAMS is true, uses a Node Writable-based channel.
+ * When __NEXT_USE_NODE_STREAMS is true, uses a Node PassThrough-based channel.
  * Otherwise, uses web WritableStream APIs.
+ *
+ * Both modules share the same DebugChannelPair type surface via AnyStream,
+ * matching the pattern used by stream-ops.ts.
  */
 export type {
   DebugChannelPair,
@@ -19,7 +22,7 @@ if (process.env.__NEXT_USE_NODE_STREAMS) {
     require('./debug-channel-server.node') as typeof import('./debug-channel-server.node')
 } else {
   _m =
-    require('./debug-channel-server.web') as typeof import('./debug-channel-server.web') as DebugChannelMod
+    require('./debug-channel-server.web') as typeof import('./debug-channel-server.web')
 }
 
 export const createDebugChannel = _m.createDebugChannel

--- a/packages/next/src/server/app-render/debug-channel-server.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.ts
@@ -11,7 +11,6 @@ export type {
 
 type DebugChannelMod = {
   createDebugChannel: typeof import('./debug-channel-server.web').createDebugChannel
-  toNodeDebugChannel: (...args: any[]) => import('node:stream').Writable
 }
 
 let _m: DebugChannelMod
@@ -19,8 +18,8 @@ if (process.env.__NEXT_USE_NODE_STREAMS) {
   _m =
     require('./debug-channel-server.node') as typeof import('./debug-channel-server.node')
 } else {
-  _m = (require('./debug-channel-server.web') as typeof import('./debug-channel-server.web')) as DebugChannelMod
+  _m =
+    require('./debug-channel-server.web') as typeof import('./debug-channel-server.web') as DebugChannelMod
 }
 
 export const createDebugChannel = _m.createDebugChannel
-export const toNodeDebugChannel = _m.toNodeDebugChannel

--- a/packages/next/src/server/app-render/debug-channel-server.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.ts
@@ -3,9 +3,6 @@
  *
  * When __NEXT_USE_NODE_STREAMS is true, uses a Node PassThrough-based channel.
  * Otherwise, uses web WritableStream APIs.
- *
- * Both modules share the same DebugChannelPair type surface via AnyStream,
- * matching the pattern used by stream-ops.ts.
  */
 export type {
   DebugChannelPair,

--- a/packages/next/src/server/app-render/debug-channel-server.web.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.web.ts
@@ -12,7 +12,7 @@ export type DebugChannelPair = {
 
 // Opaque: PassThrough on node, { writable: WritableStream } on web.
 // Each React render API handles its own variant.
- 
+
 export type DebugChannelServer = any
 
 type DebugChannelClient = {

--- a/packages/next/src/server/app-render/debug-channel-server.web.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.web.ts
@@ -3,20 +3,18 @@
  * Loaded by debug-channel-server.ts.
  */
 
-// Types defined inline for now; will move to debug-channel-server.node.ts later.
+import type { AnyStream } from './app-render-prerender-utils'
+
 export type DebugChannelPair = {
   serverSide: DebugChannelServer
   clientSide: DebugChannelClient
 }
 
-export type DebugChannelServer = {
-  readable?: ReadableStream<Uint8Array>
-  writable: WritableStream<Uint8Array>
-}
+ 
+export type DebugChannelServer = any
 
 type DebugChannelClient = {
-  readable: ReadableStream<Uint8Array>
-  writable?: WritableStream<Uint8Array>
+  readable: AnyStream
 }
 
 export function createDebugChannel(): DebugChannelPair | undefined {

--- a/packages/next/src/server/app-render/debug-channel-server.web.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.web.ts
@@ -52,15 +52,3 @@ export function createWebDebugChannel(): DebugChannelPair {
     clientSide: { readable: clientSideReadable },
   }
 }
-
-/**
- * toNodeDebugChannel is a no-op stub on the web path.
- * It should never be called in edge/web builds.
- */
-export function toNodeDebugChannel(
-  _webDebugChannel: DebugChannelServer
-): never {
-  throw new Error(
-    'toNodeDebugChannel cannot be used in edge/web runtime, this is a bug in the Next.js codebase'
-  )
-}

--- a/packages/next/src/server/app-render/debug-channel-server.web.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.web.ts
@@ -10,7 +10,6 @@ export type DebugChannelPair = {
   clientSide: DebugChannelClient
 }
 
- 
 export type DebugChannelServer = any
 
 type DebugChannelClient = {

--- a/packages/next/src/server/app-render/debug-channel-server.web.ts
+++ b/packages/next/src/server/app-render/debug-channel-server.web.ts
@@ -10,6 +10,9 @@ export type DebugChannelPair = {
   clientSide: DebugChannelClient
 }
 
+// Opaque: PassThrough on node, { writable: WritableStream } on web.
+// Each React render API handles its own variant.
+ 
 export type DebugChannelServer = any
 
 type DebugChannelClient = {

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,13 +1,13 @@
-import type { Readable } from 'node:stream'
 import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
 import RenderResult, { type RenderResultMetadata } from '../render-result'
+import type { AnyStream } from './stream-ops'
 
 /**
  * Flight Response is always set to RSC_CONTENT_TYPE_HEADER to ensure it does not get interpreted as HTML.
  */
 export class FlightRenderResult extends RenderResult {
   constructor(
-    response: string | ReadableStream<Uint8Array> | Readable,
+    response: string | AnyStream,
     metadata: RenderResultMetadata = {},
     waitUntil?: Promise<unknown>
   ) {

--- a/packages/next/src/server/app-render/flight-render-result.ts
+++ b/packages/next/src/server/app-render/flight-render-result.ts
@@ -1,3 +1,4 @@
+import type { Readable } from 'node:stream'
 import { RSC_CONTENT_TYPE_HEADER } from '../../client/components/app-router-headers'
 import RenderResult, { type RenderResultMetadata } from '../render-result'
 
@@ -6,7 +7,7 @@ import RenderResult, { type RenderResultMetadata } from '../render-result'
  */
 export class FlightRenderResult extends RenderResult {
   constructor(
-    response: string | ReadableStream<Uint8Array>,
+    response: string | ReadableStream<Uint8Array> | Readable,
     metadata: RenderResultMetadata = {},
     waitUntil?: Promise<unknown>
   ) {

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -42,7 +42,6 @@ import {
   createNodeStreamFromChunks,
 } from './stream-utils'
 import { createDebugChannel } from '../debug-channel-server'
-import { renderToFlightStream } from '../stream-ops'
 import type { FlightComponentMod } from '../stream-ops'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -204,8 +203,16 @@ export type StageEndTimes = {
  * Splits an existing staged stream (represented as arrays of chunks)
  * into separate staged streams (also in arrays-of-chunks form), one for each segment.
  * */
+type RenderToFlightStream = (
+  ComponentMod: FlightComponentMod,
+  payload: any,
+  clientModules: any,
+  opts: any
+) => AsyncIterable<Uint8Array>
+
 export async function collectStagedSegmentData(
   ComponentMod: FlightComponentMod,
+  renderFlightStream: RenderToFlightStream,
   fullPageChunks: StageChunks,
   fullPageDebugChunks: Uint8Array[] | null,
   startTime: number,
@@ -293,7 +300,7 @@ export async function collectStagedSegmentData(
       ? createDebugChannel()
       : undefined
 
-    const itemStream = renderToFlightStream(
+    const itemStream = renderFlightStream(
       ComponentMod,
       data,
       clientReferenceManifest.clientModules,
@@ -514,6 +521,7 @@ function writeChunk(
  * */
 export async function createCombinedPayloadStream(
   ComponentMod: FlightComponentMod,
+  renderFlightStream: RenderToFlightStream,
   payload: InitialRSCPayload,
   extraChunksAbortController: AbortController,
   renderSignal: AbortSignal,
@@ -534,7 +542,7 @@ export async function createCombinedPayloadStream(
 
   await runInSequentialTasks(
     () => {
-      const stream = renderToFlightStream(
+      const stream = renderFlightStream(
         ComponentMod,
         payload,
         clientReferenceManifest.clientModules,

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -342,8 +342,7 @@ export async function collectStagedSegmentData(
       // accumulate Debug chunks
       segmentDebugChannel &&
         (async () => {
-          for await (const chunk of segmentDebugChannel.clientSide
-            .readable as AsyncIterable<Uint8Array>) {
+          for await (const chunk of segmentDebugChannel.clientSide.readable) {
             cacheEntry.debugChunks!.push(chunk)
           }
         })(),

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -338,15 +338,14 @@ export async function collectStagedSegmentData(
     await Promise.all([
       // accumulate Flight chunks
       (async () => {
-        for await (const chunk of itemStream as AsyncIterable<Uint8Array>) {
+        for await (const chunk of itemStream) {
           writeChunk(cacheEntry.chunks, controller.currentStage, chunk)
         }
       })(),
       // accumulate Debug chunks
       segmentDebugChannel &&
         (async () => {
-          for await (const chunk of segmentDebugChannel.clientSide
-            .readable as AsyncIterable<Uint8Array>) {
+          for await (const chunk of segmentDebugChannel.clientSide.readable) {
             cacheEntry.debugChunks!.push(chunk)
           }
         })(),
@@ -579,7 +578,7 @@ export async function createCombinedPayloadStream(
       streamFinished = Promise.all([
         // Accumulate Flight chunks
         (async () => {
-          for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+          for await (const chunk of stream) {
             allChunks.push(chunk)
             if (isRenderable) {
               renderableChunks.push(chunk)
@@ -589,8 +588,7 @@ export async function createCombinedPayloadStream(
         // Accumulate debug chunks
         debugChannel &&
           (async () => {
-            for await (const chunk of debugChannel.clientSide
-              .readable as AsyncIterable<Uint8Array>) {
+            for await (const chunk of debugChannel.clientSide.readable) {
               debugChunks!.push(chunk)
             }
           })(),

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -342,7 +342,8 @@ export async function collectStagedSegmentData(
       // accumulate Debug chunks
       segmentDebugChannel &&
         (async () => {
-          for await (const chunk of segmentDebugChannel.clientSide.readable) {
+          for await (const chunk of segmentDebugChannel.clientSide
+            .readable as AsyncIterable<Uint8Array>) {
             cacheEntry.debugChunks!.push(chunk)
           }
         })(),

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -342,7 +342,8 @@ export async function collectStagedSegmentData(
       // accumulate Debug chunks
       segmentDebugChannel &&
         (async () => {
-          for await (const chunk of segmentDebugChannel.clientSide.readable.values()) {
+          for await (const chunk of segmentDebugChannel.clientSide
+            .readable as AsyncIterable<Uint8Array>) {
             cacheEntry.debugChunks!.push(chunk)
           }
         })(),
@@ -583,7 +584,8 @@ export async function createCombinedPayloadStream(
         // Accumulate debug chunks
         debugChannel &&
           (async () => {
-            for await (const chunk of debugChannel.clientSide.readable.values()) {
+            for await (const chunk of debugChannel.clientSide
+              .readable as AsyncIterable<Uint8Array>) {
               debugChunks!.push(chunk)
             }
           })(),

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -43,7 +43,7 @@ import {
 } from './stream-utils'
 import { createDebugChannel } from '../debug-channel-server'
 import { renderToFlightStream } from '../stream-ops'
-import type { AnyStream, FlightComponentMod } from '../stream-ops'
+import type { FlightComponentMod } from '../stream-ops'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createFromNodeStream } from 'react-server-dom-webpack/client'
@@ -293,7 +293,7 @@ export async function collectStagedSegmentData(
       ? createDebugChannel()
       : undefined
 
-    const itemStream: AnyStream = renderToFlightStream(
+    const itemStream = renderToFlightStream(
       ComponentMod,
       data,
       clientReferenceManifest.clientModules,
@@ -534,7 +534,7 @@ export async function createCombinedPayloadStream(
 
   await runInSequentialTasks(
     () => {
-      const stream: AnyStream = renderToFlightStream(
+      const stream = renderToFlightStream(
         ComponentMod,
         payload,
         clientReferenceManifest.clientModules,

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -42,10 +42,11 @@ import {
   createNodeStreamFromChunks,
 } from './stream-utils'
 import { createDebugChannel } from '../debug-channel-server'
+import { renderToFlightStream } from '../stream-ops'
+import type { AnyStream, FlightComponentMod } from '../stream-ops'
+
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createFromNodeStream } from 'react-server-dom-webpack/client'
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { renderToReadableStream } from 'react-server-dom-webpack/server'
 import {
   addSearchParamsIfPageSegment,
   isGroupSegment,
@@ -204,6 +205,7 @@ export type StageEndTimes = {
  * into separate staged streams (also in arrays-of-chunks form), one for each segment.
  * */
 export async function collectStagedSegmentData(
+  ComponentMod: FlightComponentMod,
   fullPageChunks: StageChunks,
   fullPageDebugChunks: Uint8Array[] | null,
   startTime: number,
@@ -291,7 +293,8 @@ export async function collectStagedSegmentData(
       ? createDebugChannel()
       : undefined
 
-    const itemStream = renderToReadableStream(
+    const itemStream: AnyStream = renderToFlightStream(
+      ComponentMod,
       data,
       clientReferenceManifest.clientModules,
       {
@@ -335,7 +338,7 @@ export async function collectStagedSegmentData(
     await Promise.all([
       // accumulate Flight chunks
       (async () => {
-        for await (const chunk of itemStream.values()) {
+        for await (const chunk of itemStream as AsyncIterable<Uint8Array>) {
           writeChunk(cacheEntry.chunks, controller.currentStage, chunk)
         }
       })(),
@@ -511,6 +514,7 @@ function writeChunk(
  * to provide extra debug info.
  * */
 export async function createCombinedPayloadStream(
+  ComponentMod: FlightComponentMod,
   payload: InitialRSCPayload,
   extraChunksAbortController: AbortController,
   renderSignal: AbortSignal,
@@ -531,7 +535,8 @@ export async function createCombinedPayloadStream(
 
   await runInSequentialTasks(
     () => {
-      const stream = renderToReadableStream(
+      const stream: AnyStream = renderToFlightStream(
+        ComponentMod,
         payload,
         clientReferenceManifest.clientModules,
         {
@@ -574,7 +579,7 @@ export async function createCombinedPayloadStream(
       streamFinished = Promise.all([
         // Accumulate Flight chunks
         (async () => {
-          for await (const chunk of stream.values()) {
+          for await (const chunk of stream as AsyncIterable<Uint8Array>) {
             allChunks.push(chunk)
             if (isRenderable) {
               renderableChunks.push(chunk)

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -2,7 +2,7 @@
  * Node.js stream operations for the rendering pipeline.
  * Loaded by stream-ops.ts when process.env.__NEXT_USE_NODE_STREAMS is true.
  *
- * AnyStream = StreamLike so the exported type surface matches stream-ops.web.ts,
+ * AnyStream = AnyStreamType so the exported type surface matches stream-ops.web.ts,
  * allowing the switcher to assign either module without casts.
  * Rendering uses pipeable APIs; continue functions wrap the existing web
  * transforms via Readable.fromWeb() on their output.
@@ -29,7 +29,7 @@ import {
   createRuntimePrefetchTransformStream,
 } from '../stream-utils/node-web-streams-helper'
 import { createInlinedDataReadableStream } from './use-flight-response'
-import type { StreamLike } from './app-render-prerender-utils'
+import type { AnyStream as AnyStreamType } from './app-render-prerender-utils'
 import { DetachedPromise } from '../../lib/detached-promise'
 import { getTracer } from '../lib/trace/tracer'
 import { AppRenderSpan } from '../lib/trace/constants'
@@ -53,7 +53,7 @@ export type {
 // AnyStream matches stream-ops.web.ts so both modules have the same type surface
 // ---------------------------------------------------------------------------
 
-export type AnyStream = StreamLike
+export type AnyStream = AnyStreamType
 
 export type FlightComponentMod = {
   renderToReadableStream: (
@@ -372,7 +372,7 @@ export async function streamToString(stream: AnyStream): Promise<string> {
 }
 
 export function createInlinedDataStream(
-  source: StreamLike,
+  source: AnyStream,
   nonce: string | undefined,
   formState: unknown | null
 ): AnyStream {

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -246,10 +246,14 @@ export async function continueFizzStream(
       ? readableToWeb(opts.inlinedDataStream)
       : undefined,
   }
-  const webResult = await webContinueFizzStream(
-    readableToWeb(renderStream) as ReactDOMServerReadableStream,
-    webOpts
-  )
+  // The web continueFizzStream reads renderStream.allReady from the stream
+  // object itself (ReactDOMServerReadableStream). A plain ReadableStream from
+  // readableToWeb() won't have that property, so we attach it from opts.
+  const webStream = readableToWeb(renderStream)
+  const fizzLike = Object.assign(webStream, {
+    allReady: opts.allReady ?? Promise.resolve(),
+  }) as ReactDOMServerReadableStream
+  const webResult = await webContinueFizzStream(fizzLike, webOpts)
   return webToReadable(webResult)
 }
 

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -437,9 +437,3 @@ export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
   const [s1, s2] = readableToWeb(stream).tee()
   return [webToReadable(s1), webToReadable(s2)]
 }
-
-export function toWebReadableStream(
-  stream: AnyStream
-): ReadableStream<Uint8Array> {
-  return readableToWeb(stream)
-}

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -438,7 +438,7 @@ export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
   return [webToReadable(s1), webToReadable(s2)]
 }
 
-export function toReadableStream(
+export function toWebReadableStream(
   stream: AnyStream
 ): ReadableStream<Uint8Array> {
   return readableToWeb(stream)

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -227,7 +227,7 @@ export async function resumeAndAbort(
     opts
   )
   pipeable.pipe(pt)
-  pipeable.abort()
+  pipeable.abort(opts?.signal?.reason)
   return pt
 }
 

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -2,7 +2,8 @@
  * Node.js stream operations for the rendering pipeline.
  * Loaded by stream-ops.ts when process.env.__NEXT_USE_NODE_STREAMS is true.
  *
- * AnyStream = Readable in this module.
+ * AnyStream = StreamLike so the exported type surface matches stream-ops.web.ts,
+ * allowing the switcher to assign either module without casts.
  * Rendering uses pipeable APIs; continue functions wrap the existing web
  * transforms via Readable.fromWeb() on their output.
  */
@@ -49,10 +50,10 @@ export type {
 } from './stream-ops.web'
 
 // ---------------------------------------------------------------------------
-// Override AnyStream and dependent types for Node path
+// AnyStream matches stream-ops.web.ts so both modules have the same type surface
 // ---------------------------------------------------------------------------
 
-export type AnyStream = Readable
+export type AnyStream = StreamLike
 
 export type FlightComponentMod = {
   renderToReadableStream: (
@@ -332,7 +333,7 @@ export function chainStreams(...streams: AnyStream[]): AnyStream {
       out.end()
       return
     }
-    const current = streams[i++]
+    const current = webToReadable(streams[i++])
     current.pipe(out, { end: false })
     current.on('end', pipeNext)
     current.on('error', (err) => out.destroy(err))
@@ -397,10 +398,11 @@ export function pipeRuntimePrefetchTransform(
 // ---------------------------------------------------------------------------
 
 export async function processPrelude(unprocessedPrelude: AnyStream) {
+  const readable = webToReadable(unprocessedPrelude)
   const pt1 = new PassThrough()
   const pt2 = new PassThrough()
-  ;(unprocessedPrelude as Readable).pipe(pt1)
-  ;(unprocessedPrelude as Readable).pipe(pt2)
+  readable.pipe(pt1)
+  readable.pipe(pt2)
 
   const firstChunk = await new Promise<Buffer | null>((resolve) => {
     pt2.once('data', (chunk: Buffer) => {
@@ -421,3 +423,18 @@ export function getServerPrerender(ComponentMod: {
 
 export const getClientPrerender: typeof import('react-dom/static').prerender =
   prerender
+
+export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
+  const readable = webToReadable(stream)
+  const pt1 = new PassThrough()
+  const pt2 = new PassThrough()
+  readable.pipe(pt1)
+  readable.pipe(pt2)
+  return [pt1, pt2]
+}
+
+export function toReadableStream(
+  stream: AnyStream
+): ReadableStream<Uint8Array> {
+  return readableToWeb(stream)
+}

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -402,21 +402,16 @@ export function pipeRuntimePrefetchTransform(
 // ---------------------------------------------------------------------------
 
 export async function processPrelude(unprocessedPrelude: AnyStream) {
-  const readable = webToReadable(unprocessedPrelude)
-  const pt1 = new PassThrough()
-  const pt2 = new PassThrough()
-  readable.pipe(pt1)
-  readable.pipe(pt2)
+  const [prelude, peek] = readableToWeb(unprocessedPrelude).tee()
 
-  const firstChunk = await new Promise<Buffer | null>((resolve) => {
-    pt2.once('data', (chunk: Buffer) => {
-      pt2.destroy()
-      resolve(chunk)
-    })
-    pt2.once('end', () => resolve(null))
-  })
+  const reader = peek.getReader()
+  const firstResult = await reader.read()
+  reader.cancel()
 
-  return { prelude: pt1 as AnyStream, preludeIsEmpty: firstChunk === null }
+  return {
+    prelude: webToReadable(prelude) as AnyStream,
+    preludeIsEmpty: firstResult.done === true,
+  }
 }
 
 export function getServerPrerender(ComponentMod: {
@@ -429,12 +424,8 @@ export const getClientPrerender: typeof import('react-dom/static').prerender =
   prerender
 
 export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
-  const readable = webToReadable(stream)
-  const pt1 = new PassThrough()
-  const pt2 = new PassThrough()
-  readable.pipe(pt1)
-  readable.pipe(pt2)
-  return [pt1, pt2]
+  const [s1, s2] = readableToWeb(stream).tee()
+  return [webToReadable(s1), webToReadable(s2)]
 }
 
 export function toReadableStream(

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -85,7 +85,7 @@ export type FizzStreamResult = {
 
 type WebReadableStream = import('stream/web').ReadableStream
 
-function readableToWeb(
+function nodeReadableToWebReadableStream(
   stream: Readable | ReadableStream<Uint8Array>
 ): ReadableStream<Uint8Array> {
   if (stream instanceof ReadableStream) {
@@ -243,13 +243,13 @@ export async function continueFizzStream(
   const webOpts = {
     ...opts,
     inlinedDataStream: opts.inlinedDataStream
-      ? readableToWeb(opts.inlinedDataStream)
+      ? nodeReadableToWebReadableStream(opts.inlinedDataStream)
       : undefined,
   }
   // The web continueFizzStream reads renderStream.allReady from the stream
   // object itself (ReactDOMServerReadableStream). A plain ReadableStream from
   // readableToWeb() won't have that property, so we attach it from opts.
-  const webStream = readableToWeb(renderStream)
+  const webStream = nodeReadableToWebReadableStream(renderStream)
   const fizzLike = Object.assign(webStream, {
     allReady: opts.allReady ?? Promise.resolve(),
   }) as ReactDOMServerReadableStream
@@ -262,10 +262,12 @@ export async function continueStaticPrerender(
   opts: import('./stream-ops.web').ContinueStaticPrerenderOptions
 ): Promise<AnyStream> {
   const webResult = await webContinueStaticPrerender(
-    readableToWeb(prerenderStream),
+    nodeReadableToWebReadableStream(prerenderStream),
     {
       ...opts,
-      inlinedDataStream: readableToWeb(opts.inlinedDataStream),
+      inlinedDataStream: nodeReadableToWebReadableStream(
+        opts.inlinedDataStream
+      ),
     }
   )
   return webToReadable(webResult)
@@ -280,7 +282,7 @@ export async function continueDynamicPrerender(
   }
 ): Promise<AnyStream> {
   const webResult = await webContinueDynamicPrerender(
-    readableToWeb(prerenderStream),
+    nodeReadableToWebReadableStream(prerenderStream),
     opts
   )
   return webToReadable(webResult)
@@ -291,10 +293,12 @@ export async function continueStaticFallbackPrerender(
   opts: import('./stream-ops.web').ContinueStaticPrerenderOptions
 ): Promise<AnyStream> {
   const webResult = await webContinueStaticFallbackPrerender(
-    readableToWeb(prerenderStream),
+    nodeReadableToWebReadableStream(prerenderStream),
     {
       ...opts,
-      inlinedDataStream: readableToWeb(opts.inlinedDataStream),
+      inlinedDataStream: nodeReadableToWebReadableStream(
+        opts.inlinedDataStream
+      ),
     }
   )
   return webToReadable(webResult)
@@ -305,10 +309,12 @@ export async function continueDynamicHTMLResume(
   opts: import('./stream-ops.web').ContinueDynamicHTMLResumeOptions
 ): Promise<AnyStream> {
   const webResult = await webContinueDynamicHTMLResume(
-    readableToWeb(renderStream),
+    nodeReadableToWebReadableStream(renderStream),
     {
       ...opts,
-      inlinedDataStream: readableToWeb(opts.inlinedDataStream),
+      inlinedDataStream: nodeReadableToWebReadableStream(
+        opts.inlinedDataStream
+      ),
     }
   )
   return webToReadable(webResult)
@@ -348,7 +354,7 @@ export function chainStreams(...streams: AnyStream[]): AnyStream {
 }
 
 export async function streamToBuffer(stream: AnyStream): Promise<Buffer> {
-  return webStreamToBuffer(readableToWeb(stream))
+  return webStreamToBuffer(nodeReadableToWebReadableStream(stream))
 }
 
 export async function streamToUint8Array(
@@ -362,7 +368,7 @@ export async function streamToUint8Array(
 }
 
 export async function streamToString(stream: AnyStream): Promise<string> {
-  return webStreamToString(readableToWeb(stream))
+  return webStreamToString(nodeReadableToWebReadableStream(stream))
 }
 
 export function createInlinedDataStream(
@@ -370,7 +376,7 @@ export function createInlinedDataStream(
   nonce: string | undefined,
   formState: unknown | null
 ): AnyStream {
-  const webSource = readableToWeb(source)
+  const webSource = nodeReadableToWebReadableStream(source)
   const webResult = createInlinedDataReadableStream(webSource, nonce, formState)
   return webToReadable(webResult)
 }
@@ -400,7 +406,7 @@ export function pipeRuntimePrefetchTransform(
   isPartial: boolean,
   staleTime: number
 ): AnyStream {
-  const webStream = readableToWeb(stream)
+  const webStream = nodeReadableToWebReadableStream(stream)
   const transformed = webStream.pipeThrough(
     createRuntimePrefetchTransformStream(sentinel, isPartial, staleTime)
   )
@@ -412,7 +418,8 @@ export function pipeRuntimePrefetchTransform(
 // ---------------------------------------------------------------------------
 
 export async function processPrelude(unprocessedPrelude: AnyStream) {
-  const [prelude, peek] = readableToWeb(unprocessedPrelude).tee()
+  const [prelude, peek] =
+    nodeReadableToWebReadableStream(unprocessedPrelude).tee()
 
   const reader = peek.getReader()
   const firstResult = await reader.read()
@@ -434,6 +441,6 @@ export const getClientPrerender: typeof import('react-dom/static').prerender =
   prerender
 
 export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
-  const [s1, s2] = readableToWeb(stream).tee()
+  const [s1, s2] = nodeReadableToWebReadableStream(stream).tee()
   return [webToReadable(s1), webToReadable(s2)]
 }

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -351,6 +351,16 @@ export async function streamToBuffer(stream: AnyStream): Promise<Buffer> {
   return webStreamToBuffer(readableToWeb(stream))
 }
 
+export async function streamToUint8Array(
+  stream: AnyStream
+): Promise<Uint8Array> {
+  const chunks: Buffer[] = []
+  for await (const chunk of webToReadable(stream)) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk)
+  }
+  return Buffer.concat(chunks)
+}
+
 export async function streamToString(stream: AnyStream): Promise<string> {
   return webStreamToString(readableToWeb(stream))
 }

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -30,10 +30,6 @@ import {
 } from '../stream-utils/node-web-streams-helper'
 import { createInlinedDataReadableStream } from './use-flight-response'
 import type { StreamLike } from './app-render-prerender-utils'
-import {
-  toNodeDebugChannel,
-  type DebugChannelServer,
-} from './debug-channel-server'
 import { DetachedPromise } from '../../lib/detached-promise'
 import { getTracer } from '../lib/trace/tracer'
 import { AppRenderSpan } from '../lib/trace/constants'
@@ -109,26 +105,6 @@ function webToReadable(
   return Readable.fromWeb(stream as WebReadableStream)
 }
 
-function normalizeNodeDebugChannel(options: any): any {
-  if (!options?.debugChannel) {
-    return options
-  }
-
-  const debugChannel = options.debugChannel as unknown
-  if (
-    typeof debugChannel === 'object' &&
-    debugChannel !== null &&
-    'writable' in debugChannel
-  ) {
-    return {
-      ...options,
-      debugChannel: toNodeDebugChannel(debugChannel as DebugChannelServer),
-    }
-  }
-
-  return options
-}
-
 // ---------------------------------------------------------------------------
 // Rendering functions (output Node Readable natively via PassThrough)
 // ---------------------------------------------------------------------------
@@ -144,9 +120,8 @@ export function renderToFlightStream(
 
   if (ComponentMod.renderToPipeableStream) {
     const pt = new PassThrough()
-    const nodeOptions = normalizeNodeDebugChannel(opts)
     const pipeable = run(() =>
-      ComponentMod.renderToPipeableStream!(payload, clientModules, nodeOptions)
+      ComponentMod.renderToPipeableStream!(payload, clientModules, opts)
     )
     pipeable.pipe(pt)
     return pt

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -30,6 +30,10 @@ import {
 } from '../stream-utils/node-web-streams-helper'
 import { createInlinedDataReadableStream } from './use-flight-response'
 import type { StreamLike } from './app-render-prerender-utils'
+import {
+  toNodeDebugChannel,
+  type DebugChannelServer,
+} from './debug-channel-server'
 import { DetachedPromise } from '../../lib/detached-promise'
 import { getTracer } from '../lib/trace/tracer'
 import { AppRenderSpan } from '../lib/trace/constants'
@@ -105,6 +109,26 @@ function webToReadable(
   return Readable.fromWeb(stream as WebReadableStream)
 }
 
+function normalizeNodeDebugChannel(options: any): any {
+  if (!options?.debugChannel) {
+    return options
+  }
+
+  const debugChannel = options.debugChannel as unknown
+  if (
+    typeof debugChannel === 'object' &&
+    debugChannel !== null &&
+    'writable' in debugChannel
+  ) {
+    return {
+      ...options,
+      debugChannel: toNodeDebugChannel(debugChannel as DebugChannelServer),
+    }
+  }
+
+  return options
+}
+
 // ---------------------------------------------------------------------------
 // Rendering functions (output Node Readable natively via PassThrough)
 // ---------------------------------------------------------------------------
@@ -120,8 +144,9 @@ export function renderToFlightStream(
 
   if (ComponentMod.renderToPipeableStream) {
     const pt = new PassThrough()
+    const nodeOptions = normalizeNodeDebugChannel(opts)
     const pipeable = run(() =>
-      ComponentMod.renderToPipeableStream!(payload, clientModules, opts)
+      ComponentMod.renderToPipeableStream!(payload, clientModules, nodeOptions)
     )
     pipeable.pipe(pt)
     return pt

--- a/packages/next/src/server/app-render/stream-ops.node.ts
+++ b/packages/next/src/server/app-render/stream-ops.node.ts
@@ -1,0 +1,423 @@
+/**
+ * Node.js stream operations for the rendering pipeline.
+ * Loaded by stream-ops.ts when process.env.__NEXT_USE_NODE_STREAMS is true.
+ *
+ * AnyStream = Readable in this module.
+ * Rendering uses pipeable APIs; continue functions wrap the existing web
+ * transforms via Readable.fromWeb() on their output.
+ */
+
+import type { PostponedState, PrerenderOptions } from 'react-dom/static'
+import {
+  renderToPipeableStream,
+  resumeToPipeableStream,
+} from 'react-dom/server'
+import { prerender } from 'react-dom/static'
+import { PassThrough, Readable } from 'node:stream'
+
+import type { ReactDOMServerReadableStream } from 'react-dom/server'
+import {
+  continueFizzStream as webContinueFizzStream,
+  continueStaticPrerender as webContinueStaticPrerender,
+  continueDynamicPrerender as webContinueDynamicPrerender,
+  continueStaticFallbackPrerender as webContinueStaticFallbackPrerender,
+  continueDynamicHTMLResume as webContinueDynamicHTMLResume,
+  streamToBuffer as webStreamToBuffer,
+  streamToString as webStreamToString,
+  createDocumentClosingStream as webCreateDocumentClosingStream,
+  createRuntimePrefetchTransformStream,
+} from '../stream-utils/node-web-streams-helper'
+import { createInlinedDataReadableStream } from './use-flight-response'
+import type { StreamLike } from './app-render-prerender-utils'
+import { DetachedPromise } from '../../lib/detached-promise'
+import { getTracer } from '../lib/trace/tracer'
+import { AppRenderSpan } from '../lib/trace/constants'
+
+// ---------------------------------------------------------------------------
+// Re-export shared types from the web module
+// ---------------------------------------------------------------------------
+
+export type {
+  ContinueStreamSharedOptions,
+  ContinueFizzStreamOptions,
+  ContinueStaticPrerenderOptions,
+  ContinueDynamicHTMLResumeOptions,
+  ServerPrerenderComponentMod,
+  FlightPayload,
+  FlightClientModules,
+  FlightRenderOptions,
+} from './stream-ops.web'
+
+// ---------------------------------------------------------------------------
+// Override AnyStream and dependent types for Node path
+// ---------------------------------------------------------------------------
+
+export type AnyStream = Readable
+
+export type FlightComponentMod = {
+  renderToReadableStream: (
+    model: any,
+    webpackMap: any,
+    options?: any
+  ) => ReadableStream<Uint8Array>
+  renderToPipeableStream?: (
+    model: any,
+    webpackMap: any,
+    options?: any
+  ) => {
+    pipe<Writable extends NodeJS.WritableStream>(
+      destination: Writable
+    ): Writable
+    abort(reason?: unknown): void
+  }
+}
+
+export type FizzStreamResult = {
+  stream: AnyStream
+  allReady: Promise<void>
+  abort?: (reason?: unknown) => void
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+type WebReadableStream = import('stream/web').ReadableStream
+
+function readableToWeb(
+  stream: Readable | ReadableStream<Uint8Array>
+): ReadableStream<Uint8Array> {
+  if (stream instanceof ReadableStream) {
+    return stream
+  }
+  // Readable.toWeb returns stream/web ReadableStream which is structurally
+  // identical to the global ReadableStream<Uint8Array>.
+  return Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>
+}
+
+function webToReadable(
+  stream: ReadableStream<Uint8Array> | Readable
+): Readable {
+  if (stream instanceof Readable) {
+    return stream
+  }
+  return Readable.fromWeb(stream as WebReadableStream)
+}
+
+// ---------------------------------------------------------------------------
+// Rendering functions (output Node Readable natively via PassThrough)
+// ---------------------------------------------------------------------------
+
+export function renderToFlightStream(
+  ComponentMod: FlightComponentMod,
+  payload: any,
+  clientModules: any,
+  opts: any,
+  runInContext?: <T>(fn: () => T) => T
+): AnyStream {
+  const run: <T>(fn: () => T) => T = runInContext ?? ((fn) => fn())
+
+  if (ComponentMod.renderToPipeableStream) {
+    const pt = new PassThrough()
+    const pipeable = run(() =>
+      ComponentMod.renderToPipeableStream!(payload, clientModules, opts)
+    )
+    pipeable.pipe(pt)
+    return pt
+  }
+
+  // Fallback: use web API and convert
+  const webStream = run(() =>
+    ComponentMod.renderToReadableStream(payload, clientModules, opts)
+  )
+  return webToReadable(webStream)
+}
+
+export async function renderToFizzStream(
+  element: React.ReactElement,
+  streamOptions: any,
+  runInContext?: <T>(fn: () => T) => T
+): Promise<FizzStreamResult> {
+  const run: <T>(fn: () => T) => T = runInContext ?? ((fn) => fn())
+
+  const pt = new PassThrough()
+  const shellReady = new DetachedPromise<void>()
+  const allReady = new DetachedPromise<void>()
+
+  // Node.js renderToPipeableStream passes a plain object to onHeaders,
+  // but callers expect a web Headers instance.
+  const originalOnHeaders = streamOptions?.onHeaders
+  const wrappedOnHeaders = originalOnHeaders
+    ? (headers: Record<string, string>) => {
+        originalOnHeaders(new Headers(headers))
+      }
+    : undefined
+
+  const pipeable = run(() =>
+    getTracer().trace(AppRenderSpan.renderToReadableStream, () =>
+      renderToPipeableStream(element, {
+        ...streamOptions,
+        onHeaders: wrappedOnHeaders,
+        onShellReady() {
+          streamOptions?.onShellReady?.()
+          pipeable.pipe(pt)
+          shellReady.resolve()
+        },
+        onShellError(error: unknown) {
+          streamOptions?.onShellError?.(error)
+          shellReady.reject(error)
+        },
+        onAllReady() {
+          streamOptions?.onAllReady?.()
+          allReady.resolve()
+        },
+        onError: streamOptions?.onError,
+      })
+    )
+  )
+
+  await shellReady.promise
+
+  return {
+    stream: pt,
+    allReady: allReady.promise,
+    abort: (reason?: unknown) => pipeable.abort(reason),
+  }
+}
+
+export async function resumeToFizzStream(
+  element: React.ReactElement,
+  postponedState: PostponedState,
+  streamOptions: any,
+  runInContext?: <T>(fn: () => T) => T
+): Promise<FizzStreamResult> {
+  const run: <T>(fn: () => T) => T = runInContext ?? ((fn) => fn())
+
+  const pt = new PassThrough()
+  const allReady = new DetachedPromise<void>()
+
+  const pipeable = await run(() =>
+    resumeToPipeableStream(element, postponedState, {
+      ...streamOptions,
+      onAllReady() {
+        streamOptions?.onAllReady?.()
+        allReady.resolve()
+      },
+    })
+  )
+  pipeable.pipe(pt)
+
+  return {
+    stream: pt,
+    allReady: allReady.promise,
+    abort: (reason?: unknown) => pipeable.abort(reason),
+  }
+}
+
+export async function resumeAndAbort(
+  element: React.ReactElement,
+  postponed: PostponedState | null,
+  opts: any
+): Promise<AnyStream> {
+  const pt = new PassThrough()
+  const pipeable = await resumeToPipeableStream(
+    element,
+    postponed as PostponedState,
+    opts
+  )
+  pipeable.pipe(pt)
+  pipeable.abort()
+  return pt
+}
+
+// ---------------------------------------------------------------------------
+// Continue function wrappers
+// Bridge Node Readable → web, apply existing web transforms, Readable.fromWeb()
+// ---------------------------------------------------------------------------
+
+export async function continueFizzStream(
+  renderStream: AnyStream,
+  opts: import('./stream-ops.web').ContinueFizzStreamOptions
+): Promise<AnyStream> {
+  const webOpts = {
+    ...opts,
+    inlinedDataStream: opts.inlinedDataStream
+      ? readableToWeb(opts.inlinedDataStream)
+      : undefined,
+  }
+  const webResult = await webContinueFizzStream(
+    readableToWeb(renderStream) as ReactDOMServerReadableStream,
+    webOpts
+  )
+  return webToReadable(webResult)
+}
+
+export async function continueStaticPrerender(
+  prerenderStream: AnyStream,
+  opts: import('./stream-ops.web').ContinueStaticPrerenderOptions
+): Promise<AnyStream> {
+  const webResult = await webContinueStaticPrerender(
+    readableToWeb(prerenderStream),
+    {
+      ...opts,
+      inlinedDataStream: readableToWeb(opts.inlinedDataStream),
+    }
+  )
+  return webToReadable(webResult)
+}
+
+export async function continueDynamicPrerender(
+  prerenderStream: AnyStream,
+  opts: {
+    getServerInsertedHTML: () => Promise<string>
+    getServerInsertedMetadata: () => Promise<string>
+    deploymentId: string | undefined
+  }
+): Promise<AnyStream> {
+  const webResult = await webContinueDynamicPrerender(
+    readableToWeb(prerenderStream),
+    opts
+  )
+  return webToReadable(webResult)
+}
+
+export async function continueStaticFallbackPrerender(
+  prerenderStream: AnyStream,
+  opts: import('./stream-ops.web').ContinueStaticPrerenderOptions
+): Promise<AnyStream> {
+  const webResult = await webContinueStaticFallbackPrerender(
+    readableToWeb(prerenderStream),
+    {
+      ...opts,
+      inlinedDataStream: readableToWeb(opts.inlinedDataStream),
+    }
+  )
+  return webToReadable(webResult)
+}
+
+export async function continueDynamicHTMLResume(
+  renderStream: AnyStream,
+  opts: import('./stream-ops.web').ContinueDynamicHTMLResumeOptions
+): Promise<AnyStream> {
+  const webResult = await webContinueDynamicHTMLResume(
+    readableToWeb(renderStream),
+    {
+      ...opts,
+      inlinedDataStream: readableToWeb(opts.inlinedDataStream),
+    }
+  )
+  return webToReadable(webResult)
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions (Node-native)
+// ---------------------------------------------------------------------------
+
+export function chainStreams(...streams: AnyStream[]): AnyStream {
+  if (streams.length === 0) {
+    const pt = new PassThrough()
+    pt.end()
+    return pt
+  }
+
+  if (streams.length === 1) {
+    return streams[0]
+  }
+
+  const out = new PassThrough()
+  let i = 0
+
+  function pipeNext() {
+    if (i >= streams.length) {
+      out.end()
+      return
+    }
+    const current = streams[i++]
+    current.pipe(out, { end: false })
+    current.on('end', pipeNext)
+    current.on('error', (err) => out.destroy(err))
+  }
+
+  pipeNext()
+  return out
+}
+
+export async function streamToBuffer(stream: AnyStream): Promise<Buffer> {
+  return webStreamToBuffer(readableToWeb(stream))
+}
+
+export async function streamToString(stream: AnyStream): Promise<string> {
+  return webStreamToString(readableToWeb(stream))
+}
+
+export function createInlinedDataStream(
+  source: StreamLike,
+  nonce: string | undefined,
+  formState: unknown | null
+): AnyStream {
+  const webSource = readableToWeb(source)
+  const webResult = createInlinedDataReadableStream(webSource, nonce, formState)
+  return webToReadable(webResult)
+}
+
+export function createPendingStream(): AnyStream {
+  return new PassThrough()
+}
+
+export function createDocumentClosingStream(): AnyStream {
+  const webStream = webCreateDocumentClosingStream()
+  return webToReadable(webStream)
+}
+
+export function createOnHeadersCallback(
+  appendHeader: (key: string, value: string) => void
+): NonNullable<PrerenderOptions['onHeaders']> {
+  return (headers: Headers) => {
+    headers.forEach((value, key) => {
+      appendHeader(key, value)
+    })
+  }
+}
+
+export function pipeRuntimePrefetchTransform(
+  stream: AnyStream,
+  sentinel: number,
+  isPartial: boolean,
+  staleTime: number
+): AnyStream {
+  const webStream = readableToWeb(stream)
+  const transformed = webStream.pipeThrough(
+    createRuntimePrefetchTransformStream(sentinel, isPartial, staleTime)
+  )
+  return webToReadable(transformed)
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports (no stream involvement, identical to web)
+// ---------------------------------------------------------------------------
+
+export async function processPrelude(unprocessedPrelude: AnyStream) {
+  const pt1 = new PassThrough()
+  const pt2 = new PassThrough()
+  ;(unprocessedPrelude as Readable).pipe(pt1)
+  ;(unprocessedPrelude as Readable).pipe(pt2)
+
+  const firstChunk = await new Promise<Buffer | null>((resolve) => {
+    pt2.once('data', (chunk: Buffer) => {
+      pt2.destroy()
+      resolve(chunk)
+    })
+    pt2.once('end', () => resolve(null))
+  })
+
+  return { prelude: pt1 as AnyStream, preludeIsEmpty: firstChunk === null }
+}
+
+export function getServerPrerender(ComponentMod: {
+  prerender: (...args: any[]) => Promise<any>
+}): (...args: any[]) => any {
+  return ComponentMod.prerender
+}
+
+export const getClientPrerender: typeof import('react-dom/static').prerender =
+  prerender

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -4,10 +4,8 @@
  * When __NEXT_USE_NODE_STREAMS is true, uses Node.js pipeable stream APIs.
  * Otherwise, uses web ReadableStream APIs.
  *
- * Types are always sourced from stream-ops.web (the API surface is identical).
- * In the Node path, AnyStream is Readable at runtime, but consumers see
- * ReadableStream<Uint8Array> from the type exports — the module-level cast
- * bridges this intentional mismatch in one place.
+ * Both modules export AnyStream = StreamLike so their type surfaces are
+ * structurally identical — no `as unknown as` cast is needed.
  */
 export type {
   AnyStream,
@@ -25,73 +23,33 @@ export type {
 
 type WebMod = typeof import('./stream-ops.web')
 
-export let continueFizzStream: WebMod['continueFizzStream']
-export let continueStaticPrerender: WebMod['continueStaticPrerender']
-export let continueDynamicPrerender: WebMod['continueDynamicPrerender']
-export let continueStaticFallbackPrerender: WebMod['continueStaticFallbackPrerender']
-export let continueDynamicHTMLResume: WebMod['continueDynamicHTMLResume']
-export let streamToBuffer: WebMod['streamToBuffer']
-export let chainStreams: WebMod['chainStreams']
-export let createDocumentClosingStream: WebMod['createDocumentClosingStream']
-export let processPrelude: WebMod['processPrelude']
-export let createInlinedDataStream: WebMod['createInlinedDataStream']
-export let createPendingStream: WebMod['createPendingStream']
-export let createOnHeadersCallback: WebMod['createOnHeadersCallback']
-export let resumeAndAbort: WebMod['resumeAndAbort']
-export let renderToFlightStream: WebMod['renderToFlightStream']
-export let streamToString: WebMod['streamToString']
-export let renderToFizzStream: WebMod['renderToFizzStream']
-export let resumeToFizzStream: WebMod['resumeToFizzStream']
-export let getServerPrerender: WebMod['getServerPrerender']
-export let getClientPrerender: WebMod['getClientPrerender']
-export let pipeRuntimePrefetchTransform: WebMod['pipeRuntimePrefetchTransform']
-
+let _m: WebMod
 if (process.env.__NEXT_USE_NODE_STREAMS) {
-  // The node module uses Readable where the web module uses ReadableStream.
-  // Consumers always see the web types via the type exports above, so we
-  // bridge to WebMod once here rather than casting per-export.
-  const _m: WebMod =
-    require('./stream-ops.node') as typeof import('./stream-ops.node') as unknown as WebMod
-  continueFizzStream = _m.continueFizzStream
-  continueStaticPrerender = _m.continueStaticPrerender
-  continueDynamicPrerender = _m.continueDynamicPrerender
-  continueStaticFallbackPrerender = _m.continueStaticFallbackPrerender
-  continueDynamicHTMLResume = _m.continueDynamicHTMLResume
-  streamToBuffer = _m.streamToBuffer
-  chainStreams = _m.chainStreams
-  createDocumentClosingStream = _m.createDocumentClosingStream
-  processPrelude = _m.processPrelude
-  createInlinedDataStream = _m.createInlinedDataStream
-  createPendingStream = _m.createPendingStream
-  createOnHeadersCallback = _m.createOnHeadersCallback
-  resumeAndAbort = _m.resumeAndAbort
-  renderToFlightStream = _m.renderToFlightStream
-  streamToString = _m.streamToString
-  renderToFizzStream = _m.renderToFizzStream
-  resumeToFizzStream = _m.resumeToFizzStream
-  getServerPrerender = _m.getServerPrerender
-  getClientPrerender = _m.getClientPrerender
-  pipeRuntimePrefetchTransform = _m.pipeRuntimePrefetchTransform
+  _m = require('./stream-ops.node') as typeof import('./stream-ops.node')
 } else {
-  const _m = require('./stream-ops.web') as typeof import('./stream-ops.web')
-  continueFizzStream = _m.continueFizzStream
-  continueStaticPrerender = _m.continueStaticPrerender
-  continueDynamicPrerender = _m.continueDynamicPrerender
-  continueStaticFallbackPrerender = _m.continueStaticFallbackPrerender
-  continueDynamicHTMLResume = _m.continueDynamicHTMLResume
-  streamToBuffer = _m.streamToBuffer
-  chainStreams = _m.chainStreams
-  createDocumentClosingStream = _m.createDocumentClosingStream
-  processPrelude = _m.processPrelude
-  createInlinedDataStream = _m.createInlinedDataStream
-  createPendingStream = _m.createPendingStream
-  createOnHeadersCallback = _m.createOnHeadersCallback
-  resumeAndAbort = _m.resumeAndAbort
-  renderToFlightStream = _m.renderToFlightStream
-  streamToString = _m.streamToString
-  renderToFizzStream = _m.renderToFizzStream
-  resumeToFizzStream = _m.resumeToFizzStream
-  getServerPrerender = _m.getServerPrerender
-  getClientPrerender = _m.getClientPrerender
-  pipeRuntimePrefetchTransform = _m.pipeRuntimePrefetchTransform
+  _m = require('./stream-ops.web') as typeof import('./stream-ops.web')
 }
+
+export const continueFizzStream = _m.continueFizzStream
+export const continueStaticPrerender = _m.continueStaticPrerender
+export const continueDynamicPrerender = _m.continueDynamicPrerender
+export const continueStaticFallbackPrerender =
+  _m.continueStaticFallbackPrerender
+export const continueDynamicHTMLResume = _m.continueDynamicHTMLResume
+export const streamToBuffer = _m.streamToBuffer
+export const chainStreams = _m.chainStreams
+export const createDocumentClosingStream = _m.createDocumentClosingStream
+export const processPrelude = _m.processPrelude
+export const createInlinedDataStream = _m.createInlinedDataStream
+export const createPendingStream = _m.createPendingStream
+export const createOnHeadersCallback = _m.createOnHeadersCallback
+export const resumeAndAbort = _m.resumeAndAbort
+export const renderToFlightStream = _m.renderToFlightStream
+export const streamToString = _m.streamToString
+export const renderToFizzStream = _m.renderToFizzStream
+export const resumeToFizzStream = _m.resumeToFizzStream
+export const getServerPrerender = _m.getServerPrerender
+export const getClientPrerender = _m.getClientPrerender
+export const pipeRuntimePrefetchTransform = _m.pipeRuntimePrefetchTransform
+export const teeStream = _m.teeStream
+export const toReadableStream = _m.toReadableStream

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -1,8 +1,13 @@
 /**
  * Compile-time switcher for stream operations.
  *
- * PR2: Simple re-export from the web implementation.
- * A future change will add a conditional branch for node streams.
+ * When __NEXT_USE_NODE_STREAMS is true, uses Node.js pipeable stream APIs.
+ * Otherwise, uses web ReadableStream APIs.
+ *
+ * Types are always sourced from stream-ops.web (the API surface is identical).
+ * In the Node path, AnyStream is Readable at runtime, but consumers see
+ * ReadableStream<Uint8Array> from the type exports — the module-level cast
+ * bridges this intentional mismatch in one place.
  */
 export type {
   AnyStream,
@@ -18,26 +23,75 @@ export type {
   FizzStreamResult,
 } from './stream-ops.web'
 
-export {
-  continueFizzStream,
-  continueStaticPrerender,
-  continueDynamicPrerender,
-  continueStaticFallbackPrerender,
-  continueDynamicHTMLResume,
-  streamToBuffer,
-  chainStreams,
-  createDocumentClosingStream,
-  processPrelude,
-  nodeReadableToWeb,
-  createInlinedDataStream,
-  createPendingStream,
-  createOnHeadersCallback,
-  resumeAndAbort,
-  renderToFlightStream,
-  streamToString,
-  renderToFizzStream,
-  resumeToFizzStream,
-  getServerPrerender,
-  getClientPrerender,
-  pipeRuntimePrefetchTransform,
-} from './stream-ops.web'
+type WebMod = typeof import('./stream-ops.web')
+
+export let continueFizzStream: WebMod['continueFizzStream']
+export let continueStaticPrerender: WebMod['continueStaticPrerender']
+export let continueDynamicPrerender: WebMod['continueDynamicPrerender']
+export let continueStaticFallbackPrerender: WebMod['continueStaticFallbackPrerender']
+export let continueDynamicHTMLResume: WebMod['continueDynamicHTMLResume']
+export let streamToBuffer: WebMod['streamToBuffer']
+export let chainStreams: WebMod['chainStreams']
+export let createDocumentClosingStream: WebMod['createDocumentClosingStream']
+export let processPrelude: WebMod['processPrelude']
+export let createInlinedDataStream: WebMod['createInlinedDataStream']
+export let createPendingStream: WebMod['createPendingStream']
+export let createOnHeadersCallback: WebMod['createOnHeadersCallback']
+export let resumeAndAbort: WebMod['resumeAndAbort']
+export let renderToFlightStream: WebMod['renderToFlightStream']
+export let streamToString: WebMod['streamToString']
+export let renderToFizzStream: WebMod['renderToFizzStream']
+export let resumeToFizzStream: WebMod['resumeToFizzStream']
+export let getServerPrerender: WebMod['getServerPrerender']
+export let getClientPrerender: WebMod['getClientPrerender']
+export let pipeRuntimePrefetchTransform: WebMod['pipeRuntimePrefetchTransform']
+
+if (process.env.__NEXT_USE_NODE_STREAMS) {
+  // The node module uses Readable where the web module uses ReadableStream.
+  // Consumers always see the web types via the type exports above, so we
+  // bridge to WebMod once here rather than casting per-export.
+  const _m: WebMod =
+    require('./stream-ops.node') as typeof import('./stream-ops.node') as unknown as WebMod
+  continueFizzStream = _m.continueFizzStream
+  continueStaticPrerender = _m.continueStaticPrerender
+  continueDynamicPrerender = _m.continueDynamicPrerender
+  continueStaticFallbackPrerender = _m.continueStaticFallbackPrerender
+  continueDynamicHTMLResume = _m.continueDynamicHTMLResume
+  streamToBuffer = _m.streamToBuffer
+  chainStreams = _m.chainStreams
+  createDocumentClosingStream = _m.createDocumentClosingStream
+  processPrelude = _m.processPrelude
+  createInlinedDataStream = _m.createInlinedDataStream
+  createPendingStream = _m.createPendingStream
+  createOnHeadersCallback = _m.createOnHeadersCallback
+  resumeAndAbort = _m.resumeAndAbort
+  renderToFlightStream = _m.renderToFlightStream
+  streamToString = _m.streamToString
+  renderToFizzStream = _m.renderToFizzStream
+  resumeToFizzStream = _m.resumeToFizzStream
+  getServerPrerender = _m.getServerPrerender
+  getClientPrerender = _m.getClientPrerender
+  pipeRuntimePrefetchTransform = _m.pipeRuntimePrefetchTransform
+} else {
+  const _m = require('./stream-ops.web') as typeof import('./stream-ops.web')
+  continueFizzStream = _m.continueFizzStream
+  continueStaticPrerender = _m.continueStaticPrerender
+  continueDynamicPrerender = _m.continueDynamicPrerender
+  continueStaticFallbackPrerender = _m.continueStaticFallbackPrerender
+  continueDynamicHTMLResume = _m.continueDynamicHTMLResume
+  streamToBuffer = _m.streamToBuffer
+  chainStreams = _m.chainStreams
+  createDocumentClosingStream = _m.createDocumentClosingStream
+  processPrelude = _m.processPrelude
+  createInlinedDataStream = _m.createInlinedDataStream
+  createPendingStream = _m.createPendingStream
+  createOnHeadersCallback = _m.createOnHeadersCallback
+  resumeAndAbort = _m.resumeAndAbort
+  renderToFlightStream = _m.renderToFlightStream
+  streamToString = _m.streamToString
+  renderToFizzStream = _m.renderToFizzStream
+  resumeToFizzStream = _m.resumeToFizzStream
+  getServerPrerender = _m.getServerPrerender
+  getClientPrerender = _m.getClientPrerender
+  pipeRuntimePrefetchTransform = _m.pipeRuntimePrefetchTransform
+}

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -46,6 +46,7 @@ export const createOnHeadersCallback = _m.createOnHeadersCallback
 export const resumeAndAbort = _m.resumeAndAbort
 export const renderToFlightStream = _m.renderToFlightStream
 export const streamToString = _m.streamToString
+export const streamToUint8Array = _m.streamToUint8Array
 export const renderToFizzStream = _m.renderToFizzStream
 export const resumeToFizzStream = _m.resumeToFizzStream
 export const getServerPrerender = _m.getServerPrerender

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -53,4 +53,3 @@ export const getServerPrerender = _m.getServerPrerender
 export const getClientPrerender = _m.getClientPrerender
 export const pipeRuntimePrefetchTransform = _m.pipeRuntimePrefetchTransform
 export const teeStream = _m.teeStream
-export const toWebReadableStream = _m.toWebReadableStream

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -4,7 +4,7 @@
  * When __NEXT_USE_NODE_STREAMS is true, uses Node.js pipeable stream APIs.
  * Otherwise, uses web ReadableStream APIs.
  *
- * Both modules export AnyStream = StreamLike so their type surfaces are
+ * Both modules export AnyStream = AnyStreamType so their type surfaces are
  * structurally identical — no `as unknown as` cast is needed.
  */
 export type {

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -53,4 +53,4 @@ export const getServerPrerender = _m.getServerPrerender
 export const getClientPrerender = _m.getClientPrerender
 export const pipeRuntimePrefetchTransform = _m.pipeRuntimePrefetchTransform
 export const teeStream = _m.teeStream
-export const toReadableStream = _m.toReadableStream
+export const toWebReadableStream = _m.toWebReadableStream

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -20,6 +20,7 @@ import {
   continueStaticFallbackPrerender as webContinueStaticFallbackPrerender,
   continueDynamicHTMLResume as webContinueDynamicHTMLResume,
   streamToBuffer as webStreamToBuffer,
+  streamToUint8Array as webStreamToUint8Array,
   chainStreams as webChainStreams,
   createDocumentClosingStream as webCreateDocumentClosingStream,
 } from '../stream-utils/node-web-streams-helper'
@@ -156,6 +157,12 @@ export async function continueDynamicHTMLResume(
 
 export async function streamToBuffer(stream: AnyStream): Promise<Buffer> {
   return webStreamToBuffer(stream as ReadableStream<Uint8Array>)
+}
+
+export async function streamToUint8Array(
+  stream: AnyStream
+): Promise<Uint8Array> {
+  return webStreamToUint8Array(stream as ReadableStream<Uint8Array>)
 }
 
 export function chainStreams(...streams: AnyStream[]): AnyStream {

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -278,9 +278,3 @@ export function pipeRuntimePrefetchTransform(
 export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
   return (stream as ReadableStream<Uint8Array>).tee()
 }
-
-export function toWebReadableStream(
-  stream: AnyStream
-): ReadableStream<Uint8Array> {
-  return stream as ReadableStream<Uint8Array>
-}

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -14,6 +14,7 @@ import {
   continueFizzStream as webContinueFizzStream,
 } from '../stream-utils/node-web-streams-helper'
 import { createInlinedDataReadableStream } from './use-flight-response'
+import type { StreamLike } from './app-render-prerender-utils'
 
 // ---------------------------------------------------------------------------
 // Shared types (web-only for now; will move to stream-ops.node.ts later)
@@ -106,7 +107,7 @@ export const nodeReadableToWeb:
 // ---------------------------------------------------------------------------
 
 export function createInlinedDataStream(
-  source: AnyStream,
+  source: StreamLike,
   nonce: string | undefined,
   formState: unknown | null
 ): AnyStream {

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -1,6 +1,9 @@
 /**
  * Web stream operations for the rendering pipeline.
- * Loaded by stream-ops.ts (re-export in this PR, conditional switcher later).
+ * Loaded by stream-ops.ts when __NEXT_USE_NODE_STREAMS is false (default).
+ *
+ * AnyStream = StreamLike so the exported type surface matches stream-ops.node.ts,
+ * allowing the switcher to assign either module without `as unknown as`.
  */
 
 import type { PostponedState, PrerenderOptions } from 'react-dom/static'
@@ -12,12 +15,20 @@ import {
   streamToString as webStreamToString,
   createRuntimePrefetchTransformStream,
   continueFizzStream as webContinueFizzStream,
+  continueStaticPrerender as webContinueStaticPrerender,
+  continueDynamicPrerender as webContinueDynamicPrerender,
+  continueStaticFallbackPrerender as webContinueStaticFallbackPrerender,
+  continueDynamicHTMLResume as webContinueDynamicHTMLResume,
+  streamToBuffer as webStreamToBuffer,
+  chainStreams as webChainStreams,
+  createDocumentClosingStream as webCreateDocumentClosingStream,
 } from '../stream-utils/node-web-streams-helper'
 import { createInlinedDataReadableStream } from './use-flight-response'
+import { processPrelude as webProcessPrelude } from './app-render-prerender-utils'
 import type { StreamLike } from './app-render-prerender-utils'
 
 // ---------------------------------------------------------------------------
-// Shared types (web-only for now; will move to stream-ops.node.ts later)
+// Shared types
 // ---------------------------------------------------------------------------
 
 type FlightRenderToReadableStream = (
@@ -26,7 +37,7 @@ type FlightRenderToReadableStream = (
   options?: any
 ) => ReadableStream<Uint8Array>
 
-export type AnyStream = ReadableStream<Uint8Array>
+export type AnyStream = StreamLike
 
 export type ContinueStreamSharedOptions = {
   deploymentId: string | undefined
@@ -70,37 +81,96 @@ export type FizzStreamResult = {
 }
 
 // ---------------------------------------------------------------------------
-// Continue functions
+// Continue function wrappers
+// Thin wrappers that accept AnyStream (= StreamLike) and narrow to
+// ReadableStream<Uint8Array> internally for the web helper functions.
 // ---------------------------------------------------------------------------
 
-export {
-  continueStaticPrerender,
-  continueDynamicPrerender,
-  continueStaticFallbackPrerender,
-  continueDynamicHTMLResume,
-  streamToBuffer,
-  chainStreams,
-  createDocumentClosingStream,
-} from '../stream-utils/node-web-streams-helper'
-
-export { processPrelude } from './app-render-prerender-utils'
-
-/**
- * Wrapper for continueFizzStream that accepts AnyStream.
- * The underlying implementation expects ReactDOMServerReadableStream but at
- * the stream-ops boundary we only expose AnyStream.
- */
 export function continueFizzStream(
   renderStream: AnyStream,
   opts: ContinueFizzStreamOptions
-): Promise<ReadableStream<Uint8Array>> {
-  return webContinueFizzStream(renderStream as any, opts)
+): Promise<AnyStream> {
+  return webContinueFizzStream(
+    renderStream as ReadableStream<Uint8Array> as any,
+    {
+      ...opts,
+      inlinedDataStream: opts.inlinedDataStream as
+        | ReadableStream<Uint8Array>
+        | undefined,
+    }
+  )
 }
 
-// Not available in web bundles
-export const nodeReadableToWeb:
-  | ((readable: import('node:stream').Readable) => ReadableStream<Uint8Array>)
-  | undefined = undefined
+export async function continueStaticPrerender(
+  prerenderStream: AnyStream,
+  opts: ContinueStaticPrerenderOptions
+): Promise<AnyStream> {
+  return webContinueStaticPrerender(
+    prerenderStream as ReadableStream<Uint8Array>,
+    {
+      ...opts,
+      inlinedDataStream: opts.inlinedDataStream as ReadableStream<Uint8Array>,
+    }
+  )
+}
+
+export async function continueDynamicPrerender(
+  prerenderStream: AnyStream,
+  opts: {
+    getServerInsertedHTML: () => Promise<string>
+    getServerInsertedMetadata: () => Promise<string>
+    deploymentId: string | undefined
+  }
+): Promise<AnyStream> {
+  return webContinueDynamicPrerender(
+    prerenderStream as ReadableStream<Uint8Array>,
+    opts
+  )
+}
+
+export async function continueStaticFallbackPrerender(
+  prerenderStream: AnyStream,
+  opts: ContinueStaticPrerenderOptions
+): Promise<AnyStream> {
+  return webContinueStaticFallbackPrerender(
+    prerenderStream as ReadableStream<Uint8Array>,
+    {
+      ...opts,
+      inlinedDataStream: opts.inlinedDataStream as ReadableStream<Uint8Array>,
+    }
+  )
+}
+
+export async function continueDynamicHTMLResume(
+  renderStream: AnyStream,
+  opts: ContinueDynamicHTMLResumeOptions
+): Promise<AnyStream> {
+  return webContinueDynamicHTMLResume(
+    renderStream as ReadableStream<Uint8Array>,
+    {
+      ...opts,
+      inlinedDataStream: opts.inlinedDataStream as ReadableStream<Uint8Array>,
+    }
+  )
+}
+
+export async function streamToBuffer(stream: AnyStream): Promise<Buffer> {
+  return webStreamToBuffer(stream as ReadableStream<Uint8Array>)
+}
+
+export function chainStreams(...streams: AnyStream[]): AnyStream {
+  return webChainStreams(...(streams as ReadableStream<Uint8Array>[]))
+}
+
+export function createDocumentClosingStream(): AnyStream {
+  return webCreateDocumentClosingStream()
+}
+
+export async function processPrelude(
+  unprocessedPrelude: AnyStream
+): Promise<{ prelude: AnyStream; preludeIsEmpty: boolean }> {
+  return webProcessPrelude(unprocessedPrelude as ReadableStream<Uint8Array>)
+}
 
 // ---------------------------------------------------------------------------
 // Composed helpers
@@ -196,4 +266,14 @@ export function pipeRuntimePrefetchTransform(
   return (stream as ReadableStream<Uint8Array>).pipeThrough(
     createRuntimePrefetchTransformStream(sentinel, isPartial, staleTime)
   )
+}
+
+export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
+  return (stream as ReadableStream<Uint8Array>).tee()
+}
+
+export function toReadableStream(
+  stream: AnyStream
+): ReadableStream<Uint8Array> {
+  return stream as ReadableStream<Uint8Array>
 }

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -2,7 +2,7 @@
  * Web stream operations for the rendering pipeline.
  * Loaded by stream-ops.ts when __NEXT_USE_NODE_STREAMS is false (default).
  *
- * AnyStream = StreamLike so the exported type surface matches stream-ops.node.ts,
+ * AnyStream = AnyStreamType so the exported type surface matches stream-ops.node.ts,
  * allowing the switcher to assign either module without `as unknown as`.
  */
 
@@ -26,7 +26,7 @@ import {
 } from '../stream-utils/node-web-streams-helper'
 import { createInlinedDataReadableStream } from './use-flight-response'
 import { processPrelude as webProcessPrelude } from './app-render-prerender-utils'
-import type { StreamLike } from './app-render-prerender-utils'
+import type { AnyStream as AnyStreamType } from './app-render-prerender-utils'
 
 // ---------------------------------------------------------------------------
 // Shared types
@@ -38,7 +38,7 @@ type FlightRenderToReadableStream = (
   options?: any
 ) => ReadableStream<Uint8Array>
 
-export type AnyStream = StreamLike
+export type AnyStream = AnyStreamType
 
 export type ContinueStreamSharedOptions = {
   deploymentId: string | undefined
@@ -83,7 +83,7 @@ export type FizzStreamResult = {
 
 // ---------------------------------------------------------------------------
 // Continue function wrappers
-// Thin wrappers that accept AnyStream (= StreamLike) and narrow to
+// Thin wrappers that accept AnyStream and narrow to
 // ReadableStream<Uint8Array> internally for the web helper functions.
 // ---------------------------------------------------------------------------
 
@@ -184,7 +184,7 @@ export async function processPrelude(
 // ---------------------------------------------------------------------------
 
 export function createInlinedDataStream(
-  source: StreamLike,
+  source: AnyStream,
   nonce: string | undefined,
   formState: unknown | null
 ): AnyStream {

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -279,7 +279,7 @@ export function teeStream(stream: AnyStream): [AnyStream, AnyStream] {
   return (stream as ReadableStream<Uint8Array>).tee()
 }
 
-export function toReadableStream(
+export function toWebReadableStream(
   stream: AnyStream
 ): ReadableStream<Uint8Array> {
   return stream as ReadableStream<Uint8Array>

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -21,6 +21,7 @@ import type { IncomingMessage } from 'http'
 import type { RenderResumeDataCache } from '../resume-data-cache/resume-data-cache'
 import type { ServerCacheStatus } from '../../next-devtools/dev-overlay/cache-indicator'
 import type { PrefetchHints } from '../../shared/lib/app-router-types'
+import type { AnyStream } from './stream-ops'
 
 const dynamicParamTypesSchema = s.enums([
   'c',
@@ -120,7 +121,7 @@ export interface RenderOptsPartial {
     requestId: string
   ) => void
   sendErrorsToBrowser?: (
-    errorsRscStream: ReadableStream<Uint8Array>,
+    errorsRscStream: AnyStream,
     htmlRequestId: string
   ) => void
   isBuildTimePrerendering?: boolean

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -116,7 +116,7 @@ export interface RenderOptsPartial {
   setCacheStatus?: (status: ServerCacheStatus, htmlRequestId: string) => void
   setIsrStatus?: (key: string, value: boolean | undefined) => void
   setReactDebugChannel?: (
-    debugChannel: { readable: ReadableStream<Uint8Array> },
+    debugChannel: { readable: AnyStream },
     htmlRequestId: string,
     requestId: string
   ) => void

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -76,9 +76,17 @@ export function getFlightStream<T>(
       const { Readable } =
         require('node:stream') as typeof import('node:stream')
 
-      // The types of flightStream and debugStream should match.
-      if (debugStream && !(debugStream instanceof Readable)) {
-        throw new InvariantError('Expected debug stream to be a Readable')
+      // Convert debug stream to Readable if it's a ReadableStream.
+      // This can happen when the flight stream is a Node Readable (node streams path)
+      // but the debug channel always produces web ReadableStreams.
+      let nodeDebugStream: Readable | undefined
+      if (debugStream) {
+        if (debugStream instanceof Readable) {
+          nodeDebugStream = debugStream
+        } else {
+          type WebReadableStream = import('stream/web').ReadableStream
+          nodeDebugStream = Readable.fromWeb(debugStream as WebReadableStream)
+        }
       }
 
       // react-server-dom-webpack/client.edge must not be hoisted for require cache clearing to work correctly
@@ -96,7 +104,7 @@ export function getFlightStream<T>(
         {
           findSourceMapURL,
           nonce,
-          debugChannel: debugStream,
+          debugChannel: nodeDebugStream,
           endTime: debugEndTime,
         }
       )

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -77,8 +77,8 @@ export function getFlightStream<T>(
         require('node:stream') as typeof import('node:stream')
 
       // Convert debug stream to Readable if it's a ReadableStream.
-      // This can happen when the flight stream is a Node Readable (node streams path)
-      // but the debug channel always produces web ReadableStreams.
+      // When __NEXT_USE_NODE_STREAMS is enabled, the debug channel produces
+      // Node Readables natively. Otherwise, it produces web ReadableStreams.
       let nodeDebugStream: Readable | undefined
       if (debugStream) {
         if (debugStream instanceof Readable) {

--- a/packages/next/src/server/dev/debug-channel.ts
+++ b/packages/next/src/server/dev/debug-channel.ts
@@ -1,12 +1,13 @@
+import { Readable } from 'node:stream'
 import { createBufferedTransformStream } from '../stream-utils/node-web-streams-helper'
 import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   type HmrMessageSentToBrowser,
 } from './hot-reloader-types'
+import type { AnyStream } from '../app-render/stream-ops'
 
 export interface ReactDebugChannelForBrowser {
-  readonly readable: ReadableStream<Uint8Array>
-  // Might also get a writable stream as return channel in the future.
+  readonly readable: AnyStream
 }
 
 const reactDebugChannelsByHtmlRequestId = new Map<
@@ -14,14 +15,20 @@ const reactDebugChannelsByHtmlRequestId = new Map<
   ReactDebugChannelForBrowser
 >()
 
+function toWebReadableStream(stream: AnyStream): ReadableStream<Uint8Array> {
+  if (stream instanceof ReadableStream) {
+    return stream
+  }
+  return Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>
+}
+
 export function connectReactDebugChannel(
   requestId: string,
   debugChannel: ReactDebugChannelForBrowser,
   sendToClient: (message: HmrMessageSentToBrowser) => void
 ) {
-  const reader = debugChannel.readable
+  const reader = toWebReadableStream(debugChannel.readable)
     .pipeThrough(
-      // We're sending the chunks in batches to reduce overhead in the browser.
       createBufferedTransformStream({ maxBufferByteLength: 128 * 1024 })
     )
     .getReader()

--- a/packages/next/src/server/dev/debug-channel.ts
+++ b/packages/next/src/server/dev/debug-channel.ts
@@ -1,10 +1,19 @@
-import { Readable } from 'node:stream'
+import type { Readable } from 'node:stream'
 import { createBufferedTransformStream } from '../stream-utils/node-web-streams-helper'
 import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   type HmrMessageSentToBrowser,
 } from './hot-reloader-types'
 import type { AnyStream } from '../app-render/stream-ops'
+
+function toWebReadableStream(stream: AnyStream): ReadableStream<Uint8Array> {
+  if (stream instanceof ReadableStream) {
+    return stream
+  }
+  const { Readable: ReadableClass } =
+    require('node:stream') as typeof import('node:stream')
+  return ReadableClass.toWeb(stream as Readable) as ReadableStream<Uint8Array>
+}
 
 export interface ReactDebugChannelForBrowser {
   readonly readable: AnyStream
@@ -15,13 +24,6 @@ const reactDebugChannelsByHtmlRequestId = new Map<
   ReactDebugChannelForBrowser
 >()
 
-function toWebReadableStream(stream: AnyStream): ReadableStream<Uint8Array> {
-  if (stream instanceof ReadableStream) {
-    return stream
-  }
-  return Readable.toWeb(stream) as unknown as ReadableStream<Uint8Array>
-}
-
 export function connectReactDebugChannel(
   requestId: string,
   debugChannel: ReactDebugChannelForBrowser,
@@ -29,6 +31,7 @@ export function connectReactDebugChannel(
 ) {
   const reader = toWebReadableStream(debugChannel.readable)
     .pipeThrough(
+      // We're sending the chunks in batches to reduce overhead in the browser.
       createBufferedTransformStream({ maxBufferByteLength: 128 * 1024 })
     )
     .getReader()

--- a/packages/next/src/server/dev/hot-reloader-types.ts
+++ b/packages/next/src/server/dev/hot-reloader-types.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../next-devtools/dev-overlay/cache-indicator'
 import type { DevToolsConfig } from '../../next-devtools/dev-overlay/shared'
 import type { ReactDebugChannelForBrowser } from './debug-channel'
+import type { AnyStream } from '../app-render/stream-ops'
 
 export const enum HMR_MESSAGE_SENT_TO_BROWSER {
   // JSON messages:
@@ -242,10 +243,7 @@ export interface NextJsHotReloaderInterface {
     htmlRequestId: string,
     requestId: string
   ): void
-  sendErrorsToBrowser(
-    errorsRscStream: ReadableStream<Uint8Array>,
-    htmlRequestId: string
-  ): void
+  sendErrorsToBrowser(errorsRscStream: AnyStream, htmlRequestId: string): void
   getCompilationErrors(page: string): Promise<any[]>
   onHMR(
     req: IncomingMessage,

--- a/packages/next/src/server/dev/hot-reloader-webpack.ts
+++ b/packages/next/src/server/dev/hot-reloader-webpack.ts
@@ -5,6 +5,7 @@ import type { Telemetry } from '../../telemetry/storage'
 import type { IncomingMessage, ServerResponse } from 'http'
 import type { UrlObject } from 'url'
 import type { RouteDefinition } from '../route-definitions/route-definition'
+import type { AnyStream } from '../app-render/stream-ops'
 
 import { type webpack, StringXor } from 'next/dist/compiled/webpack/webpack'
 import {
@@ -1820,7 +1821,7 @@ export default class HotReloaderWebpack implements NextJsHotReloaderInterface {
   }
 
   public sendErrorsToBrowser(
-    errorsRscStream: ReadableStream<Uint8Array>,
+    errorsRscStream: AnyStream,
     htmlRequestId: string
   ): void {
     const client = this.webpackHotMiddleware?.getClient(htmlRequestId)

--- a/packages/next/src/server/dev/serialized-errors.ts
+++ b/packages/next/src/server/dev/serialized-errors.ts
@@ -1,16 +1,14 @@
-import { streamToUint8Array } from '../stream-utils/node-web-streams-helper'
 import {
   HMR_MESSAGE_SENT_TO_BROWSER,
   type HmrMessageSentToBrowser,
 } from './hot-reloader-types'
+import type { AnyStream } from '../app-render/stream-ops'
+import { streamToUint8Array } from '../app-render/stream-ops'
 
-const errorsRscStreamsByHtmlRequestId = new Map<
-  string,
-  ReadableStream<Uint8Array>
->()
+const errorsRscStreamsByHtmlRequestId = new Map<string, AnyStream>()
 
 export function sendSerializedErrorsToClient(
-  errorsRscStream: ReadableStream<Uint8Array>,
+  errorsRscStream: AnyStream,
   sendToClient: (message: HmrMessageSentToBrowser) => void
 ) {
   streamToUint8Array(errorsRscStream).then(
@@ -43,7 +41,7 @@ export function sendSerializedErrorsToClientForHtmlRequest(
 
 export function setErrorsRscStreamForHtmlRequest(
   htmlRequestId: string,
-  errorsRscStream: ReadableStream<Uint8Array>
+  errorsRscStream: AnyStream
 ) {
   // TODO: Clean up after a timeout, in case the client never connects, e.g.
   // when CURL'ing the page, or loading the page with JavaScript disabled etc.

--- a/packages/next/src/server/lib/router-utils/router-server-context.ts
+++ b/packages/next/src/server/lib/router-utils/router-server-context.ts
@@ -41,7 +41,7 @@ export type RouterServerContext = Record<
     // allow setting ISR status in dev
     setIsrStatus?: (key: string, value: boolean | undefined) => void
     setReactDebugChannel?: (
-      debugChannel: { readable: ReadableStream<Uint8Array> },
+      debugChannel: { readable: AnyStream },
       htmlRequestId: string,
       requestId: string
     ) => void

--- a/packages/next/src/server/lib/router-utils/router-server-context.ts
+++ b/packages/next/src/server/lib/router-utils/router-server-context.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 import type { NextConfigRuntime } from '../../config-shared'
 import type { UrlWithParsedQuery } from 'node:url'
 import type { ServerCacheStatus } from '../../../next-devtools/dev-overlay/cache-indicator'
+import type { AnyStream } from '../../app-render/stream-ops'
 
 export type RevalidateFn = (config: {
   urlPath: string
@@ -46,7 +47,7 @@ export type RouterServerContext = Record<
     ) => void
     setCacheStatus?: (status: ServerCacheStatus, htmlRequestId: string) => void
     sendErrorsToBrowser?: (
-      errorsRscStream: ReadableStream<Uint8Array>,
+      errorsRscStream: AnyStream,
       htmlRequestId: string
     ) => void
     // indicates request handlers are already wrapped by next-server tracing

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -1,4 +1,5 @@
 import type { ServerResponse } from 'node:http'
+import type { Readable } from 'node:stream'
 
 import {
   ResponseAbortedName,
@@ -139,6 +140,100 @@ export async function pipeToNodeResponse(
     await readable.pipeTo(writer, { signal: controller.signal })
   } catch (err: any) {
     // If this isn't related to an abort error, re-throw it.
+    if (isAbortError(err)) return
+
+    throw new Error('failed to pipe response', { cause: err })
+  }
+}
+
+export async function pipeNodeReadableToNodeResponse(
+  readable: Readable,
+  res: ServerResponse,
+  waitUntilForEnd?: Promise<unknown>
+) {
+  try {
+    const { errored, destroyed } = res
+    if (errored || destroyed) return
+
+    let started = false
+
+    const finished = new DetachedPromise<void>()
+
+    res.once('close', () => {
+      readable.destroy()
+      finished.resolve()
+    })
+
+    readable.on('data', (chunk: Buffer) => {
+      if (!started) {
+        started = true
+
+        if (
+          'performance' in globalThis &&
+          process.env.NEXT_OTEL_PERFORMANCE_PREFIX
+        ) {
+          const metrics = getClientComponentLoaderMetrics()
+          if (metrics) {
+            performance.measure(
+              `${process.env.NEXT_OTEL_PERFORMANCE_PREFIX}:next-client-component-loading`,
+              {
+                start: metrics.clientComponentLoadStart,
+                end:
+                  metrics.clientComponentLoadStart +
+                  metrics.clientComponentLoadTimes,
+              }
+            )
+          }
+        }
+
+        res.flushHeaders()
+        getTracer().trace(
+          NextNodeServerSpan.startResponse,
+          {
+            spanName: 'start response',
+          },
+          () => undefined
+        )
+      }
+
+      const ok = res.write(chunk)
+
+      if ('flush' in res && typeof res.flush === 'function') {
+        res.flush()
+      }
+
+      if (!ok) {
+        readable.pause()
+        res.once('drain', () => {
+          readable.resume()
+        })
+      }
+    })
+
+    readable.on('end', async () => {
+      if (waitUntilForEnd) {
+        await waitUntilForEnd
+      }
+
+      if (!res.writableFinished) {
+        res.end()
+      }
+
+      finished.resolve()
+    })
+
+    readable.on('error', (err) => {
+      if (isAbortError(err)) {
+        finished.resolve()
+        return
+      }
+
+      res.destroy(err)
+      finished.resolve()
+    })
+
+    await finished.promise
+  } catch (err: any) {
     if (isAbortError(err)) return
 
     throw new Error('failed to pipe response', { cause: err })

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -253,9 +253,9 @@ export default class RenderResult<
         Readable = (require('node:stream') as typeof import('node:stream'))
           .Readable
       } else {
-        Readable = __non_webpack_require__(
-          'node:stream'
-        ) as typeof import('node:stream').Readable
+        Readable = (
+          __non_webpack_require__('node:stream') as typeof import('node:stream')
+        ).Readable
       }
       return Readable.toWeb(this.response) as ReadableStream<Uint8Array>
     }
@@ -288,9 +288,9 @@ export default class RenderResult<
         Readable = (require('node:stream') as typeof import('node:stream'))
           .Readable
       } else {
-        Readable = __non_webpack_require__(
-          'node:stream'
-        ) as typeof import('node:stream').Readable
+        Readable = (
+          __non_webpack_require__('node:stream') as typeof import('node:stream')
+        ).Readable
       }
       return [Readable.toWeb(this.response) as ReadableStream<Uint8Array>]
     } else {

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -248,16 +248,16 @@ export default class RenderResult<
     }
 
     if (isNodeReadable(this.response)) {
+      let Readable: typeof import('node:stream').Readable
       if (process.env.TURBOPACK) {
-        const { Readable: NodeReadable } =
-          require('stream') as typeof import('stream')
-        return NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>
+        Readable = (require('node:stream') as typeof import('node:stream'))
+          .Readable
       } else {
-        const { Readable: NodeReadable } = __non_webpack_require__(
-          'stream'
-        ) as typeof import('stream')
-        return NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>
+        Readable = __non_webpack_require__(
+          'node:stream'
+        ) as typeof import('node:stream').Readable
       }
+      return Readable.toWeb(this.response) as ReadableStream<Uint8Array>
     }
 
     return this.response
@@ -283,16 +283,16 @@ export default class RenderResult<
     } else if (Buffer.isBuffer(this.response)) {
       return [streamFromBuffer(this.response)]
     } else if (isNodeReadable(this.response)) {
+      let Readable: typeof import('node:stream').Readable
       if (process.env.TURBOPACK) {
-        const { Readable: NodeReadable } =
-          require('stream') as typeof import('stream')
-        return [NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>]
+        Readable = (require('node:stream') as typeof import('node:stream'))
+          .Readable
       } else {
-        const { Readable: NodeReadable } = __non_webpack_require__(
-          'stream'
-        ) as typeof import('stream')
-        return [NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>]
+        Readable = __non_webpack_require__(
+          'node:stream'
+        ) as typeof import('node:stream').Readable
       }
+      return [Readable.toWeb(this.response) as ReadableStream<Uint8Array>]
     } else {
       return [this.response]
     }

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -1,4 +1,5 @@
 import type { OutgoingHttpHeaders, ServerResponse } from 'http'
+import type { Readable } from 'node:stream'
 import type { CacheControl } from './lib/cache-control'
 import type { FetchMetrics } from './base-http'
 import type { PrefetchHints } from '../shared/lib/app-router-types'
@@ -9,7 +10,11 @@ import {
   streamFromString,
   streamToString,
 } from './stream-utils/node-web-streams-helper'
-import { isAbortError, pipeToNodeResponse } from './pipe-readable'
+import {
+  isAbortError,
+  pipeToNodeResponse,
+  pipeNodeReadableToNodeResponse,
+} from './pipe-readable'
 import type { RenderResumeDataCache } from './resume-data-cache/resume-data-cache'
 import { InvariantError } from '../shared/lib/invariant-error'
 import type {
@@ -82,6 +87,7 @@ export type RenderResultMetadata = AppPageRenderResultMetadata &
 export type RenderResultResponse =
   | ReadableStream<Uint8Array>[]
   | ReadableStream<Uint8Array>
+  | Readable
   | string
   | Buffer
   | null
@@ -92,6 +98,16 @@ export type RenderResultOptions<
   contentType: ContentTypeOption | null
   waitUntil?: Promise<unknown>
   metadata: Metadata
+}
+
+function isNodeReadable(value: unknown): value is Readable {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    typeof (value as Record<string, unknown>).pipe === 'function' &&
+    typeof (value as Record<string, unknown>).on === 'function' &&
+    !(value instanceof ReadableStream)
+  )
 }
 
 export default class RenderResult<
@@ -231,6 +247,12 @@ export default class RenderResult<
       return chainStreams(...this.response)
     }
 
+    if (isNodeReadable(this.response)) {
+      const { Readable: NodeReadable } =
+        require('node:stream') as typeof import('node:stream')
+      return NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>
+    }
+
     return this.response
   }
 
@@ -253,6 +275,10 @@ export default class RenderResult<
       return this.response
     } else if (Buffer.isBuffer(this.response)) {
       return [streamFromBuffer(this.response)]
+    } else if (isNodeReadable(this.response)) {
+      const { Readable: NodeReadable } =
+        require('node:stream') as typeof import('node:stream')
+      return [NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>]
     } else {
       return [this.response]
     }
@@ -349,6 +375,16 @@ export default class RenderResult<
    * @param res
    */
   public async pipeToNodeResponse(res: ServerResponse) {
+    if (
+      this.response !== null &&
+      typeof this.response !== 'string' &&
+      !Buffer.isBuffer(this.response) &&
+      !Array.isArray(this.response) &&
+      isNodeReadable(this.response)
+    ) {
+      await pipeNodeReadableToNodeResponse(this.response, res, this.waitUntil)
+      return
+    }
     await pipeToNodeResponse(this.readable, res, this.waitUntil)
   }
 }

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -1,5 +1,5 @@
 import type { OutgoingHttpHeaders, ServerResponse } from 'http'
-import type { Readable } from 'node:stream'
+import type { Readable } from 'stream'
 import type { CacheControl } from './lib/cache-control'
 import type { FetchMetrics } from './base-http'
 import type { PrefetchHints } from '../shared/lib/app-router-types'
@@ -248,9 +248,16 @@ export default class RenderResult<
     }
 
     if (isNodeReadable(this.response)) {
-      const { Readable: NodeReadable } =
-        require(/* webpackIgnore: true */ 'node:stream') as typeof import('node:stream')
-      return NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>
+      if (process.env.TURBOPACK) {
+        const { Readable: NodeReadable } =
+          require('stream') as typeof import('stream')
+        return NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>
+      } else {
+        const { Readable: NodeReadable } = __non_webpack_require__(
+          'stream'
+        ) as typeof import('stream')
+        return NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>
+      }
     }
 
     return this.response
@@ -276,9 +283,16 @@ export default class RenderResult<
     } else if (Buffer.isBuffer(this.response)) {
       return [streamFromBuffer(this.response)]
     } else if (isNodeReadable(this.response)) {
-      const { Readable: NodeReadable } =
-        require(/* webpackIgnore: true */ 'node:stream') as typeof import('node:stream')
-      return [NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>]
+      if (process.env.TURBOPACK) {
+        const { Readable: NodeReadable } =
+          require('stream') as typeof import('stream')
+        return [NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>]
+      } else {
+        const { Readable: NodeReadable } = __non_webpack_require__(
+          'stream'
+        ) as typeof import('stream')
+        return [NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>]
+      }
     } else {
       return [this.response]
     }

--- a/packages/next/src/server/render-result.ts
+++ b/packages/next/src/server/render-result.ts
@@ -249,7 +249,7 @@ export default class RenderResult<
 
     if (isNodeReadable(this.response)) {
       const { Readable: NodeReadable } =
-        require('node:stream') as typeof import('node:stream')
+        require(/* webpackIgnore: true */ 'node:stream') as typeof import('node:stream')
       return NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>
     }
 
@@ -277,7 +277,7 @@ export default class RenderResult<
       return [streamFromBuffer(this.response)]
     } else if (isNodeReadable(this.response)) {
       const { Readable: NodeReadable } =
-        require('node:stream') as typeof import('node:stream')
+        require(/* webpackIgnore: true */ 'node:stream') as typeof import('node:stream')
       return [NodeReadable.toWeb(this.response) as ReadableStream<Uint8Array>]
     } else {
       return [this.response]


### PR DESCRIPTION
### What?

Note: This is only the first step. There's more follow-up PRs to implement the transforms as Node.js streams.

Introduces a compile-time switchable Node.js streams layer for the app rendering pipeline, gated behind `__NEXT_USE_NODE_STREAMS`. When enabled, React's `renderToPipeableStream` / `resumeToPipeableStream` APIs produce native Node.js `Readable` streams instead of web `ReadableStream`s, eliminating repeated conversions between the two stream types during rendering.


### Why?

The current rendering pipeline uses web `ReadableStream` everywhere to be consistent between Node.js/Edge, but the Node.js server ultimately pipes responses to Node `http.ServerResponse`. We found ReadableStream to be much slower than using Node.js streams directly, especially under load. By using Node.js streams natively throughout the pipeline, we can avoid this cost.

### How?

- **`AnyStream` type** (`ReadableStream<Uint8Array> | Readable`): Introduced as the universal stream type across the rendering pipeline, replacing hardcoded `ReadableStream<Uint8Array>` in all stream-carrying signatures (`app-render.tsx`, `render-result.ts`, `flight-render-result.ts`, `hot-reloader-types.ts`, etc.).

- **`stream-ops.ts` compile-time switcher**: Changed from a simple re-export of `stream-ops.web.ts` to a conditional `require()` that loads either `stream-ops.node.ts` or `stream-ops.web.ts` based on `process.env.__NEXT_USE_NODE_STREAMS`. Both modules export the same type surface so no casts are needed.

- **`stream-ops.node.ts` (new)**: Node.js stream implementation that uses `renderToPipeableStream`, `resumeToPipeableStream`, and `PassThrough` for native pipeable rendering. Continue functions bridge to existing web transforms via `Readable.fromWeb()` / `Readable.toWeb()` at the boundary.

- **`stream-ops.web.ts`**: Updated to wrap continue/utility functions instead of re-exporting them directly, so both modules have the same shaped exports. Added `teeStream`, `streamToUint8Array`, `processPrelude` wrappers.

- **`debug-channel-server.ts` switcher**: Same compile-time pattern — loads `debug-channel-server.node.ts` (PassThrough-based) or `debug-channel-server.web.ts` (WritableStream-based).

- **`pipe-readable.ts`**: Added `pipeNodeReadableToNodeResponse()` that pipes a Node `Readable` directly to `ServerResponse` with backpressure handling, without converting to web streams first.

- **`render-result.ts`**: Accepts `Readable` as a response type. When a Node `Readable` is the response, `pipeToNodeResponse()` uses the new native pipe path. `readable` and `pipeable` getters convert via `Readable.toWeb()` only when needed.

- **`app-render.tsx`**: Replaced `ReadableStream<Uint8Array>` with `AnyStream` throughout. Replaced `.tee()` calls with `teeStream()`. Updated `accumulateStreamChunks` to handle both stream types with a shared `accumulateChunk` helper. Removed `nodeStreamFromReadableStream` utility (no longer needed).

- **`instant-validation.tsx`**: Changed from directly importing `renderToReadableStream` from `react-server-dom-webpack/server` to using the `renderToFlightStream` function from `stream-ops`, so validation uses the same stream backend as the main render.

- **`use-flight-response.tsx`**: Updated debug stream handling to accept both `Readable` and `ReadableStream`, converting as needed.