### PR TITLE
fix: sanitize worker args for worker_threads compatibility

### DIFF
--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -245,29 +245,39 @@ export class Worker {
       hangingTimer = activeTasks > 0 && setTimeout(onHanging, timeout)
     }
 
+    // TODO: Remove this once callers stop passing non-serializable values
+    // (e.g. functions) in worker method arguments. The structured clone
+    // algorithm used by worker_threads rejects functions, unlike
+    // child_process which silently drops them via JSON serialization.
+    const sanitizeArgs = farmOptions.enableWorkerThreads
+      ? (args: any[]) => JSON.parse(JSON.stringify(args))
+      : (args: any[]) => args
+
     for (const method of farmOptions.exposedMethods) {
       if (method.startsWith('_')) continue
       ;(this as any)[method] = timeout
         ? // eslint-disable-next-line no-loop-func
           async (...args: any[]) => {
             activeTasks++
+            const sanitizedArgs = sanitizeArgs(args)
             try {
               let attempts = 0
               for (;;) {
                 onActivityImpl()
                 const result = await Promise.race([
-                  (this._worker as any)[method](...args),
+                  (this._worker as any)[method](...sanitizedArgs),
                   restartPromise,
                 ])
                 if (result !== RESTARTED) return result
-                if (onRestart) onRestart(method, args, ++attempts)
+                if (onRestart) onRestart(method, sanitizedArgs, ++attempts)
               }
             } finally {
               activeTasks--
               onActivityImpl()
             }
           }
-        : (this._worker as any)[method].bind(this._worker)
+        : (...args: any[]) =>
+            (this._worker as any)[method](...sanitizeArgs(args))
     }
   }
 


### PR DESCRIPTION
### What?

Sanitize worker method arguments when `enableWorkerThreads` is true to avoid `DataCloneError`.

### Why?

When `enableWorkerThreads: true` is set in the build static worker, `postMessage()` uses the structured clone algorithm which throws `DataCloneError` on function-valued properties (e.g. `generateBuildId: () => null` from the default config). The default `child_process` mode uses JSON serialization which silently drops functions.

### How?

Adds a `JSON.parse(JSON.stringify(args))` sanitization step for worker method arguments when worker threads are enabled, stripping non-serializable values before they reach `postMessage()`. This is a no-op when using child_process (the default).

This is a temporary workaround. The proper fix is to stop passing non-serializable objects (like the full `NextConfigComplete` with function properties) to worker methods in the first place. The main offender is `exportPages` in `export/index.ts` which passes the entire `nextConfig` object. Callers should be updated to extract only the serializable fields the worker actually needs, similar to how `isPageStatic` already does it. Once that's done, this sanitization can be removed.