### PR TITLE
Replace mark_root() with #[turbo_tasks::function(root)] flag

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -33,7 +33,7 @@ use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
     Completion, Completions, FxIndexMap, IntoTraitRef, NonLocalValue, OperationValue, OperationVc,
     ReadRef, ResolvedVc, State, TaskInput, TransientInstance, TryFlatJoinIterExt, Vc,
-    debug::ValueDebugFormat, fxindexmap, mark_root, trace::TraceRawVcs,
+    debug::ValueDebugFormat, fxindexmap, trace::TraceRawVcs,
 };
 use turbo_tasks_env::{EnvMap, ProcessEnv};
 use turbo_tasks_fs::{
@@ -2381,12 +2381,10 @@ impl Project {
 
 // This is a performance optimization. This function is a root aggregation function that
 // aggregates over the whole subgraph.
-#[turbo_tasks::function(operation)]
+#[turbo_tasks::function(operation, root)]
 async fn whole_app_module_graph_operation(
     project: ResolvedVc<Project>,
 ) -> Result<Vc<BaseAndFullModuleGraph>> {
-    mark_root();
-
     let next_mode = project.next_mode();
     let next_mode_ref = next_mode.await?;
     let should_trace = next_mode_ref.is_production();

--- a/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/mod.rs
@@ -1485,6 +1485,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> TaskId {
+        let is_root = task_type.native_fn.is_root;
+
         // First check if the task exists in the cache which only uses a read lock
         if let Some(task_id) = self.task_cache.get(&task_type) {
             let task_id = *task_id;
@@ -1503,6 +1505,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         let tx = check_backing_storage
             .then(|| self.backing_storage.start_read_transaction())
             .flatten();
+        let mut is_new = false;
         let (task_id, task_type) = {
             // Safety: `tx` is a valid transaction from `self.backend.backing_storage`.
             if let Some(task_id) = unsafe {
@@ -1541,6 +1544,7 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                         let task_id = self.persisted_task_id_factory.get();
                         e.insert(task_type.clone(), task_id);
                         self.track_cache_miss(&task_type);
+                        is_new = true;
                         (task_id, ArcOrOwned::Arc(task_type))
                     }
                 };
@@ -1552,6 +1556,18 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 (task_id, task_type)
             }
         };
+
+        if is_new && is_root {
+            let mut ctx = self.execute_context(turbo_tasks);
+            AggregationUpdateQueue::run(
+                AggregationUpdateJob::UpdateAggregationNumber {
+                    task_id,
+                    base_aggregation_number: u32::MAX,
+                    distance: None,
+                },
+                &mut ctx,
+            );
+        }
 
         // Safety: `tx` is a valid transaction from `self.backend.backing_storage`.
         unsafe {
@@ -1573,6 +1589,8 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         parent_task: Option<TaskId>,
         turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
     ) -> TaskId {
+        let is_root = task_type.native_fn.is_root;
+
         if let Some(parent_task) = parent_task
             && !parent_task.is_transient()
         {
@@ -1613,6 +1631,19 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
                 let task_id = self.transient_task_id_factory.get();
                 e.insert(task_type.clone(), task_id);
                 self.track_cache_miss(&task_type);
+
+                if is_root {
+                    let mut ctx = self.execute_context(turbo_tasks);
+                    AggregationUpdateQueue::run(
+                        AggregationUpdateJob::UpdateAggregationNumber {
+                            task_id,
+                            base_aggregation_number: u32::MAX,
+                            distance: None,
+                        },
+                        &mut ctx,
+                    );
+                }
+
                 self.connect_child(
                     parent_task,
                     task_id,
@@ -3038,23 +3069,6 @@ impl<B: BackingStorage> TurboTasksBackendInner<B> {
         }
     }
 
-    fn set_own_task_aggregation_number(
-        &self,
-        task: TaskId,
-        aggregation_number: u32,
-        turbo_tasks: &dyn TurboTasksBackendApi<TurboTasksBackend<B>>,
-    ) {
-        let mut ctx = self.execute_context(turbo_tasks);
-        AggregationUpdateQueue::run(
-            AggregationUpdateJob::UpdateAggregationNumber {
-                task_id: task,
-                base_aggregation_number: aggregation_number,
-                distance: None,
-            },
-            &mut ctx,
-        );
-    }
-
     fn connect_task(
         &self,
         task: TaskId,
@@ -3567,16 +3581,6 @@ impl<B: BackingStorage> Backend for TurboTasksBackend<B> {
         turbo_tasks: &dyn TurboTasksBackendApi<Self>,
     ) {
         self.0.mark_own_task_as_finished(task_id, turbo_tasks);
-    }
-
-    fn set_own_task_aggregation_number(
-        &self,
-        task: TaskId,
-        aggregation_number: u32,
-        turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) {
-        self.0
-            .set_own_task_aggregation_number(task, aggregation_number, turbo_tasks);
     }
 
     fn mark_own_task_as_session_dependent(

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", or "operation"
+error: unexpected token, expected one of: "fs", "network", "operation", or "root"
   --> tests/function/fail_attribute_invalid_args.rs:10:25
    |
 10 | #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
+++ b/turbopack/crates/turbo-tasks-macros-tests/tests/function/fail_attribute_invalid_args_inherent_impl.stderr
@@ -1,4 +1,4 @@
-error: unexpected token, expected one of: "fs", "network", or "operation"
+error: unexpected token, expected one of: "fs", "network", "operation", or "root"
   --> tests/function/fail_attribute_invalid_args_inherent_impl.rs:15:29
    |
 15 |     #[turbo_tasks::function(invalid_argument)]

--- a/turbopack/crates/turbo-tasks-macros/src/func.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/func.rs
@@ -725,6 +725,9 @@ pub struct FunctionArguments {
     ///
     /// If there is an error due to this option being set, it should be reported to this span.
     pub operation: Option<Span>,
+    /// Should the task be marked as a root in the aggregation graph on initial creation?
+    /// Root tasks start with aggregation number `u32::MAX`.
+    pub root: Option<Span>,
 }
 
 impl Parse for FunctionArguments {
@@ -749,10 +752,14 @@ impl Parse for FunctionArguments {
                 ("operation", Meta::Path(_)) => {
                     parsed_args.operation = Some(meta.span());
                 }
+                ("root", Meta::Path(_)) => {
+                    parsed_args.root = Some(meta.span());
+                }
                 (_, meta) => {
                     return Err(syn::Error::new_spanned(
                         meta,
-                        "unexpected token, expected one of: \"fs\", \"network\", or \"operation\"",
+                        "unexpected token, expected one of: \"fs\", \"network\", \"operation\", \
+                         or \"root\"",
                     ));
                 }
             }
@@ -1078,6 +1085,7 @@ pub struct NativeFn {
     /// Used only if `is_method` is true.
     pub is_self_used: bool,
     pub filter_trait_call_args: Option<FilterTraitCallArgsTokens>,
+    pub is_root: bool,
 }
 
 impl NativeFn {
@@ -1093,6 +1101,7 @@ impl NativeFn {
             is_method,
             is_self_used,
             filter_trait_call_args,
+            is_root,
         } = self;
 
         if *is_method {
@@ -1120,6 +1129,7 @@ impl NativeFn {
                             #function_global_name,
                             #arg_filter,
                             #function_path,
+                            #is_root,
                         )
                     }
                 }
@@ -1132,6 +1142,7 @@ impl NativeFn {
                             #function_global_name,
                             #arg_filter,
                             #function_path,
+                            #is_root,
                         )
                     }
                 }
@@ -1144,6 +1155,7 @@ impl NativeFn {
                         #function_path_string,
                         #function_global_name,
                         #function_path,
+                        #is_root,
                     )
                 }
             }

--- a/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/function_macro.rs
@@ -42,6 +42,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         .inspect_err(|err| errors.push(err.to_compile_error()))
         .unwrap_or_default();
     let is_self_used = args.operation.is_some() || is_self_used(&block);
+    let is_root = args.root.is_some();
 
     let Some(turbo_fn) = TurboFn::new(&sig, DefinitionContext::NakedFn, args, is_self_used) else {
         return quote! {
@@ -64,6 +65,7 @@ pub fn function(args: TokenStream, input: TokenStream) -> TokenStream {
         is_method: turbo_fn.is_method(),
         is_self_used,
         filter_trait_call_args: None, // not a trait method
+        is_root,
     };
     let native_function_ident = get_native_function_ident(ident);
     let native_function_ty = native_fn.ty();

--- a/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_impl_macro.rs
@@ -123,6 +123,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                 is_method: turbo_fn.is_method(),
                 is_self_used,
                 filter_trait_call_args: None, // not a trait method
+                is_root: false,
             };
 
             let native_function_ident = get_inherent_impl_function_ident(ty_ident, ident);
@@ -244,6 +245,7 @@ pub fn value_impl(args: TokenStream, input: TokenStream) -> TokenStream {
                     is_method: turbo_fn.is_method(),
                     is_self_used,
                     filter_trait_call_args: turbo_fn.filter_trait_call_args(),
+                    is_root: false,
                 };
 
                 let native_function_ident =

--- a/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
+++ b/turbopack/crates/turbo-tasks-macros/src/value_trait_macro.rs
@@ -211,6 +211,7 @@ pub fn value_trait(args: TokenStream, input: TokenStream) -> TokenStream {
                 is_method: turbo_fn.is_method(),
                 is_self_used,
                 filter_trait_call_args: turbo_fn.filter_trait_call_args(),
+                is_root: false,
             };
 
             let native_function_ident = get_trait_default_impl_function_ident(trait_ident, ident);

--- a/turbopack/crates/turbo-tasks-testing/src/lib.rs
+++ b/turbopack/crates/turbo-tasks-testing/src/lib.rs
@@ -298,10 +298,6 @@ impl TurboTasksApi for VcStorage {
         // no-op
     }
 
-    fn set_own_task_aggregation_number(&self, _task: TaskId, _aggregation_number: u32) {
-        // no-op
-    }
-
     fn spawn_detached_for_testing(
         &self,
         _f: std::pin::Pin<Box<dyn Future<Output = ()> + Send + 'static>>,

--- a/turbopack/crates/turbo-tasks/src/backend.rs
+++ b/turbopack/crates/turbo-tasks/src/backend.rs
@@ -609,15 +609,6 @@ pub trait Backend: Sync + Send {
         // Do nothing by default
     }
 
-    fn set_own_task_aggregation_number(
-        &self,
-        _task: TaskId,
-        _aggregation_number: u32,
-        _turbo_tasks: &dyn TurboTasksBackendApi<Self>,
-    ) {
-        // Do nothing by default
-    }
-
     fn mark_own_task_as_session_dependent(
         &self,
         _task: TaskId,

--- a/turbopack/crates/turbo-tasks/src/lib.rs
+++ b/turbopack/crates/turbo-tasks/src/lib.rs
@@ -115,7 +115,7 @@ pub use crate::{
     manager::{
         CurrentCellRef, ReadCellTracking, ReadConsistency, ReadTracking, TaskPersistence,
         TaskPriority, TurboTasks, TurboTasksApi, TurboTasksBackendApi, TurboTasksCallApi, Unused,
-        UpdateInfo, dynamic_call, emit, get_serialization_invalidator, mark_finished, mark_root,
+        UpdateInfo, dynamic_call, emit, get_serialization_invalidator, mark_finished,
         mark_session_dependent, mark_stateful, prevent_gc, run, run_once, run_once_with_reason,
         trait_call, turbo_tasks, turbo_tasks_scope, turbo_tasks_weak, with_turbo_tasks,
     },

--- a/turbopack/crates/turbo-tasks/src/manager.rs
+++ b/turbopack/crates/turbo-tasks/src/manager.rs
@@ -177,7 +177,6 @@ pub trait TurboTasksApi: TurboTasksCallApi + Sync + Send {
         verification_mode: VerificationMode,
     );
     fn mark_own_task_as_finished(&self, task: TaskId);
-    fn set_own_task_aggregation_number(&self, task: TaskId, aggregation_number: u32);
     fn mark_own_task_as_session_dependent(&self, task: TaskId);
 
     fn connect_task(&self, task: TaskId);
@@ -1564,11 +1563,6 @@ impl<B: Backend + 'static> TurboTasksApi for TurboTasks<B> {
         self.backend.mark_own_task_as_finished(task, self);
     }
 
-    fn set_own_task_aggregation_number(&self, task: TaskId, aggregation_number: u32) {
-        self.backend
-            .set_own_task_aggregation_number(task, aggregation_number, self);
-    }
-
     fn mark_own_task_as_session_dependent(&self, task: TaskId) {
         self.backend.mark_own_task_as_session_dependent(task, self);
     }
@@ -1844,14 +1838,6 @@ pub fn current_task_for_testing() -> Option<TaskId> {
 pub fn mark_session_dependent() {
     with_turbo_tasks(|tt| {
         tt.mark_own_task_as_session_dependent(current_task("turbo_tasks::mark_session_dependent()"))
-    });
-}
-
-/// Marks the current task as a root in the aggregation graph.  This means it starts with the
-/// correct aggregation number instead of needing to recompute it after the fact.
-pub fn mark_root() {
-    with_turbo_tasks(|tt| {
-        tt.set_own_task_aggregation_number(current_task("turbo_tasks::mark_root()"), u32::MAX)
     });
 }
 

--- a/turbopack/crates/turbo-tasks/src/native_function.rs
+++ b/turbopack/crates/turbo-tasks/src/native_function.rs
@@ -157,6 +157,10 @@ pub struct NativeFunction {
 
     // The globally unique name for this function, used when persisting
     pub(crate) global_name: &'static str,
+
+    /// Whether this function's tasks should be treated as root nodes in the aggregation graph.
+    /// Root tasks start with aggregation number `u32::MAX` on initial creation.
+    pub is_root: bool,
 }
 
 impl Debug for NativeFunction {
@@ -173,6 +177,7 @@ impl NativeFunction {
         name: &'static str,
         global_name: &'static str,
         implementation: impl IntoTaskFn<Mode, Inputs>,
+        is_root: bool,
     ) -> Self
     where
         Inputs: TaskInput + Encode + Decode<()> + 'static,
@@ -182,6 +187,7 @@ impl NativeFunction {
             global_name,
             arg_meta: ArgMeta::new::<Inputs>(),
             implementation: Box::new(implementation.into_task_fn()),
+            is_root,
         }
     }
 
@@ -190,6 +196,7 @@ impl NativeFunction {
         global_name: &'static str,
         arg_filter: Option<(FilterOwnedArgsFunctor, FilterAndResolveFunctor)>,
         implementation: I,
+        is_root: bool,
     ) -> Self
     where
         Inputs: TaskInput + Encode + Decode<()> + 'static,
@@ -204,6 +211,7 @@ impl NativeFunction {
                 ArgMeta::new::<Inputs>()
             },
             implementation: Box::new(implementation.into_task_fn()),
+            is_root,
         }
     }
 
@@ -212,6 +220,7 @@ impl NativeFunction {
         global_name: &'static str,
         arg_filter: Option<(FilterOwnedArgsFunctor, FilterAndResolveFunctor)>,
         implementation: I,
+        is_root: bool,
     ) -> Self
     where
         This: Sync + Send + 'static,
@@ -227,6 +236,7 @@ impl NativeFunction {
                 ArgMeta::new::<Inputs>()
             },
             implementation: Box::new(implementation.into_task_fn_with_this()),
+            is_root,
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the runtime `mark_root()` call with a declarative `root` flag on the `#[turbo_tasks::function]` attribute macro. This moves root task aggregation number assignment from an imperative runtime call to a compile-time declaration, making the intent clearer and applying the aggregation number at task creation time rather than during execution.

### What changed

- **Macro parsing**: Added `root` as a new flag option for `#[turbo_tasks::function(root)]` (can be combined with other flags, e.g. `#[turbo_tasks::function(operation, root)]`)
- **NativeFunction**: Added `is_root: bool` field and parameter to all three constructors (`new_function`, `new_method`, `new_method_without_this`)
- **Backend**: In `get_or_create_persistent_task` and `get_or_create_transient_task`, checks `native_fn.is_root` on brand-new task creation (not cache hits or backing storage restores) and sets `UpdateAggregationNumber` with `u32::MAX`
- **Usage site**: Changed `whole_app_module_graph_operation` in `crates/next-api/src/project.rs` from `#[turbo_tasks::function(operation)]` + `mark_root()` to `#[turbo_tasks::function(operation, root)]`
- **Cleanup**: Removed `mark_root()`, `set_own_task_aggregation_number` from `TurboTasksApi` trait, `Backend` trait, and all implementations (turbo-tasks-backend, turbo-tasks-testing)

### Key design decisions

- Root aggregation number is only set on **brand-new task creation** (Vacant entry in the task cache when not found in backing storage either), not on cache hits or when restoring from backing storage
- The `root` flag is stored on `NativeFunction` (which is a static singleton per function), so it's accessible via `CachedTaskType.native_fn.is_root` in the backend without any additional runtime overhead

## Test Plan

- `cargo check -p turbo-tasks-macros -p turbo-tasks -p turbo-tasks-backend -p next-api` passes
- `cargo test -p turbo-tasks-backend` passes
- `pnpm swc-build-native` builds successfully