### PR TITLE
Revert "Turbopack: Add line numbers to debug info in release-with-assertions profile (#90474)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -269,12 +269,12 @@ opt-level = "s"
 [profile.release.package.miette]
 opt-level = "s"
 
+
 # Use a custom profile for CI where many tests are performance sensitive but we still want the additional validation of debug-assertions
 [profile.release-with-assertions]
 inherits = "release"
 debug-assertions = true
 overflow-checks = true
-debug = "line-tables-only"
 
 [profile.release-with-debug]
 inherits = "release"


### PR DESCRIPTION
Reverts #90474

It appears to have increased the artifact size so much that Turborepo remote caching doesn't work properly anymore

see https://vercel.slack.com/archives/C03LMQZL205/p1772027662111429