### PR TITLE
Remove unused return values from getPageStaticInfo

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -72,31 +72,26 @@ export type ProxyConfig = {
   unstable_allowDynamic?: string[]
 }
 
-export interface AppPageStaticInfo {
-  type: PAGE_TYPES.APP
-  ssg?: boolean
-  ssr?: boolean
+export interface SharedPageStaticInfo {
   rsc?: RSCModuleType
-  generateStaticParams?: boolean
   generateSitemaps?: boolean
   generateImageMetadata?: boolean
   middleware?: ProxyConfig
-  config: Omit<AppSegmentConfig, 'runtime' | 'maxDuration'> | undefined
-  runtime: AppSegmentConfig['runtime'] | undefined
-  preferredRegion: AppSegmentConfig['preferredRegion'] | undefined
   maxDuration: number | undefined
   hadUnsupportedValue: boolean
 }
 
-export interface PagesPageStaticInfo {
+export interface AppPageStaticInfo extends SharedPageStaticInfo {
+  type: PAGE_TYPES.APP
+  ssg?: boolean
+  ssr?: boolean
+  config: Omit<AppSegmentConfig, 'runtime' | 'maxDuration'> | undefined
+  runtime: AppSegmentConfig['runtime'] | undefined
+  preferredRegion: AppSegmentConfig['preferredRegion'] | undefined
+}
+
+export interface PagesPageStaticInfo extends SharedPageStaticInfo {
   type: PAGE_TYPES.PAGES
-  getStaticProps?: boolean
-  getServerSideProps?: boolean
-  rsc?: RSCModuleType
-  generateStaticParams?: boolean
-  generateSitemaps?: boolean
-  generateImageMetadata?: boolean
-  middleware?: ProxyConfig
   config:
     | (Omit<PagesSegmentConfig, 'runtime' | 'config' | 'maxDuration'> & {
         config?: Omit<PagesSegmentConfigConfig, 'runtime' | 'maxDuration'>
@@ -104,8 +99,6 @@ export interface PagesPageStaticInfo {
     | undefined
   runtime: PagesSegmentConfig['runtime'] | undefined
   preferredRegion: PagesSegmentConfigConfig['regions'] | undefined
-  maxDuration: number | undefined
-  hadUnsupportedValue: boolean
 }
 
 export type PageStaticInfo = AppPageStaticInfo | PagesPageStaticInfo
@@ -702,7 +695,6 @@ export async function getAppPageStaticInfo({
     rsc,
     generateImageMetadata,
     generateSitemaps,
-    generateStaticParams,
     config,
     middleware: parseMiddlewareConfig(page, exportedConfig.config, nextConfig),
     runtime: config.runtime,
@@ -738,11 +730,7 @@ export async function getPagesPageStaticInfo({
     isDev,
   })
 
-  const { getServerSideProps, getStaticProps, exports } = checkExports(
-    ast,
-    PagesSegmentConfigSchemaKeys,
-    page
-  )
+  const { exports } = checkExports(ast, PagesSegmentConfigSchemaKeys, page)
 
   const { type: rsc } = getRSCModuleInformation(content, true)
 
@@ -812,8 +800,6 @@ export async function getPagesPageStaticInfo({
 
   return {
     type: PAGE_TYPES.PAGES,
-    getStaticProps,
-    getServerSideProps,
     rsc,
     config,
     middleware: parseMiddlewareConfig(page, exportedConfig.config, nextConfig),

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -4,11 +4,7 @@ import type { EdgeSSRLoaderQuery } from './webpack/loaders/next-edge-ssr-loader'
 import type { EdgeAppRouteLoaderQuery } from './webpack/loaders/next-edge-app-route-loader'
 import type { NextConfigComplete } from '../server/config-shared'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
-import type {
-  ProxyConfig,
-  ProxyMatcher,
-  PageStaticInfo,
-} from './analysis/get-page-static-info'
+import type { ProxyConfig, ProxyMatcher } from './analysis/get-page-static-info'
 import type { LoadedEnvFiles } from '@next/env'
 import type { AppLoaderOptions } from './webpack/loaders/next-app-loader'
 
@@ -461,7 +457,7 @@ export async function createEntrypoints(
         (absolutePagePath.startsWith(APP_DIR_ALIAS) ||
           absolutePagePath.startsWith(appDir))
 
-      const staticInfo: PageStaticInfo = await getStaticInfoIncludingLayouts({
+      const staticInfo = await getStaticInfoIncludingLayouts({
         isInsideAppDir,
         pageExtensions,
         pageFilePath,

--- a/packages/next/src/build/get-static-info-including-layouts.ts
+++ b/packages/next/src/build/get-static-info-including-layouts.ts
@@ -31,7 +31,7 @@ export async function getStaticInfoIncludingLayouts({
   config: NextConfigComplete
   isDev: boolean
   page: string
-}): Promise<PageStaticInfo> {
+}): Promise<Omit<PageStaticInfo, 'config'>> {
   // TODO: sync types for pages: PAGE_TYPES, ROUTER_TYPE, 'app' | 'pages', etc.
   const pageType = isInsideAppDir ? PAGE_TYPES.APP : PAGE_TYPES.PAGES
 
@@ -90,7 +90,6 @@ export async function getStaticInfoIncludingLayouts({
 
   return {
     ...pageStaticInfo,
-    config,
     runtime: config.runtime,
     preferredRegion: config.preferredRegion,
     maxDuration: config.maxDuration,

--- a/test/unit/parse-page-static-info.test.ts
+++ b/test/unit/parse-page-static-info.test.ts
@@ -14,31 +14,25 @@ describe('parse page static info', () => {
     await installBindings()
   })
   it('should parse nodejs runtime correctly', async () => {
-    const { runtime, getServerSideProps, getStaticProps } =
-      await getPagesPageStaticInfo({
-        page: 'nodejs-ssr',
-        pageFilePath: join(fixtureDir, 'page-runtime/nodejs-ssr.js'),
-        nextConfig: createNextConfig(),
-        pageType: PAGE_TYPES.PAGES,
-        isDev: false,
-      })
+    const { runtime } = await getPagesPageStaticInfo({
+      page: 'nodejs-ssr',
+      pageFilePath: join(fixtureDir, 'page-runtime/nodejs-ssr.js'),
+      nextConfig: createNextConfig(),
+      pageType: PAGE_TYPES.PAGES,
+      isDev: false,
+    })
     expect(runtime).toBe('nodejs')
-    expect(getServerSideProps).toBe(true)
-    expect(getStaticProps).toBe(false)
   })
 
   it('should parse static runtime correctly', async () => {
-    const { runtime, getServerSideProps, getStaticProps } =
-      await getPagesPageStaticInfo({
-        page: 'nodejs',
-        pageFilePath: join(fixtureDir, 'page-runtime/nodejs.js'),
-        nextConfig: createNextConfig(),
-        pageType: PAGE_TYPES.PAGES,
-        isDev: false,
-      })
+    const { runtime } = await getPagesPageStaticInfo({
+      page: 'nodejs',
+      pageFilePath: join(fixtureDir, 'page-runtime/nodejs.js'),
+      nextConfig: createNextConfig(),
+      pageType: PAGE_TYPES.PAGES,
+      isDev: false,
+    })
     expect(runtime).toBe('nodejs')
-    expect(getServerSideProps).toBe(false)
-    expect(getStaticProps).toBe(false)
   })
 
   it('should parse edge runtime correctly', async () => {
@@ -61,19 +55,5 @@ describe('parse page static info', () => {
       isDev: false,
     })
     expect(runtime).toBe(undefined)
-  })
-
-  it('should parse ssr info with variable exported gSSP correctly', async () => {
-    const { getServerSideProps, getStaticProps } = await getPagesPageStaticInfo(
-      {
-        page: 'ssr-variable-gssp',
-        pageFilePath: join(fixtureDir, 'page-runtime/ssr-variable-gssp.js'),
-        nextConfig: createNextConfig(),
-        pageType: PAGE_TYPES.PAGES,
-        isDev: false,
-      }
-    )
-    expect(getStaticProps).toBe(false)
-    expect(getServerSideProps).toBe(true)
   })
 })


### PR DESCRIPTION
Some cleanup, that was never used.
- `config` from `getStaticInfoIncludingLayouts`
- `getServerSideProps` and `getStaticProps` from pages router