### PR TITLE
experimental.prefetchInlining: bundle segment prefetches into a single response

### DIFF
--- a/packages/next/src/build/define-env.ts
+++ b/packages/next/src/build/define-env.ts
@@ -235,6 +235,9 @@ export function getDefineEnv({
     'process.env.__NEXT_DYNAMIC_ON_HOVER': Boolean(
       config.experimental.dynamicOnHover
     ),
+    'process.env.__NEXT_PREFETCH_INLINING': Boolean(
+      config.experimental.prefetchInlining
+    ),
     'process.env.__NEXT_OPTIMISTIC_CLIENT_CACHE':
       config.experimental.optimisticClientCache ?? true,
     'process.env.__NEXT_MIDDLEWARE_PREFETCH':

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -724,6 +724,7 @@ export async function handler(
               nextConfig.experimental.optimisticRouting
             ),
             inlineCss: Boolean(nextConfig.experimental.inlineCss),
+            prefetchInlining: Boolean(nextConfig.experimental.prefetchInlining),
             authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
             clientTraceMetadata:
               nextConfig.experimental.clientTraceMetadata || ([] as any),

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -161,6 +161,7 @@ async function requestHandler(
         dynamicOnHover: Boolean(nextConfig.experimental.dynamicOnHover),
         optimisticRouting: Boolean(nextConfig.experimental.optimisticRouting),
         inlineCss: Boolean(nextConfig.experimental.inlineCss),
+        prefetchInlining: Boolean(nextConfig.experimental.prefetchInlining),
         authInterrupts: Boolean(nextConfig.experimental.authInterrupts),
         clientTraceMetadata:
           nextConfig.experimental.clientTraceMetadata || ([] as any),

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2,6 +2,8 @@ import type {
   TreePrefetch,
   RootTreePrefetch,
   SegmentPrefetch,
+  InlinedPrefetchResponse,
+  InlinedSegmentPrefetch,
 } from '../../../server/app-render/collect-segment-data'
 import type {
   CacheNodeSeedData,
@@ -1980,6 +1982,176 @@ export async function fetchSegmentOnCacheMiss(
     // decoding the response.
     rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
     return null
+  }
+}
+
+// TODO: The inlined prefetch flow below is temporary. Eventually, inlining
+// will be the default behavior controlled by a size heuristic rather than a
+// boolean flag. At that point, the per-segment and inlined fetch paths will
+// merge, and these separate functions will be removed.
+//
+// The call site in the scheduler is guarded by
+// process.env.__NEXT_PREFETCH_INLINING, so these functions are
+// dead-code-eliminated from the client bundle when the feature is disabled.
+
+export async function fetchInlinedSegmentsOnCacheMiss(
+  route: FulfilledRouteCacheEntry,
+  routeKey: RouteCacheKey,
+  tree: RouteTree,
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
+): Promise<PrefetchSubtaskResult<null> | null> {
+  // When prefetch inlining is enabled, all segment data for a route is bundled
+  // into a single /_inlined response instead of individual per-segment
+  // requests. This function fetches that response and walks the tree to fill
+  // all segment cache entries at once.
+  const url = new URL(route.canonicalUrl, location.origin)
+  const nextUrl = routeKey.nextUrl
+
+  const headers: RequestHeaders = {
+    [RSC_HEADER]: '1',
+    [NEXT_ROUTER_PREFETCH_HEADER]: '1',
+    [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]: '/_inlined',
+  }
+  if (nextUrl !== null) {
+    headers[NEXT_URL] = nextUrl
+  }
+  addInstantPrefetchHeaderIfLocked(headers)
+
+  try {
+    const response = await fetchPrefetchResponse(url, headers)
+    if (
+      !response ||
+      !response.ok ||
+      response.status === 204 ||
+      (response.headers.get(NEXT_DID_POSTPONE_HEADER) !== '2' &&
+        !isOutputExportMode) ||
+      !response.body
+    ) {
+      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      return null
+    }
+
+    const closed = createPromiseWithResolvers<void>()
+
+    const prefetchStream = createPrefetchResponseStream(
+      response.body,
+      closed.resolve,
+      function onResponseSizeUpdate() {
+        // For inlined responses, size tracking per segment is approximate.
+        // We don't track individual sizes since they're all in one response.
+      }
+    )
+    const serverData =
+      await createFromNextReadableStream<InlinedPrefetchResponse>(
+        prefetchStream,
+        headers,
+        { allowPartialStream: true }
+      )
+
+    if (
+      (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
+        serverData.tree.segment.buildId) !== getNavigationBuildId()
+    ) {
+      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+      return null
+    }
+
+    const now = Date.now()
+
+    // Walk the inlined tree in parallel with the RouteTree and fill
+    // segment cache entries.
+    fillInlinedSegmentEntries(now, route, tree, serverData.tree, spawnedEntries)
+
+    // Fill the head entry.
+    const headStaleAt = now + getStaleTimeMs(serverData.head.staleTime)
+    const headKey = route.metadata.requestKey
+    const ownedHeadEntry = spawnedEntries.get(headKey)
+    if (ownedHeadEntry !== undefined) {
+      fulfillSegmentCacheEntry(
+        ownedHeadEntry,
+        serverData.head.rsc,
+        headStaleAt,
+        serverData.head.isPartial
+      )
+    } else {
+      // The head was already cached. Try to upsert if the entry is empty.
+      const existingEntry = readOrCreateSegmentCacheEntry(
+        now,
+        FetchStrategy.PPR,
+        route.metadata
+      )
+      if (existingEntry.status === EntryStatus.Empty) {
+        fulfillSegmentCacheEntry(
+          upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
+          serverData.head.rsc,
+          headStaleAt,
+          serverData.head.isPartial
+        )
+      }
+    }
+
+    // Reject any remaining entries that were not fulfilled by the response.
+    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+
+    return { value: null, closed: closed.promise }
+  } catch (error) {
+    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
+    return null
+  }
+}
+
+function fillInlinedSegmentEntries(
+  now: number,
+  route: FulfilledRouteCacheEntry,
+  tree: RouteTree,
+  inlinedNode: InlinedSegmentPrefetch,
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
+): void {
+  // Check if the spawned entries map has an entry for this segment's key.
+  const segment = inlinedNode.segment
+  const staleAt = now + getStaleTimeMs(segment.staleTime)
+  const ownedEntry = spawnedEntries.get(tree.requestKey)
+  if (ownedEntry !== undefined) {
+    // We own this entry. Fulfill it directly.
+    fulfillSegmentCacheEntry(
+      ownedEntry,
+      segment.rsc,
+      staleAt,
+      segment.isPartial
+    )
+  } else {
+    // Not owned by us — this is extra data from the inlined response for a
+    // segment that was already cached. Try to upsert if the entry is empty.
+    const existingEntry = readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      tree
+    )
+    if (existingEntry.status === EntryStatus.Empty) {
+      fulfillSegmentCacheEntry(
+        upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
+        segment.rsc,
+        staleAt,
+        segment.isPartial
+      )
+    }
+  }
+
+  // Recurse into children.
+  if (tree.slots !== null && inlinedNode.slots !== null) {
+    for (const parallelRouteKey in tree.slots) {
+      const childTree = tree.slots[parallelRouteKey]
+      const childInlinedNode = inlinedNode.slots[parallelRouteKey]
+      if (childInlinedNode !== undefined) {
+        fillInlinedSegmentEntries(
+          now,
+          route,
+          childTree,
+          childInlinedNode,
+          spawnedEntries
+        )
+      }
+    }
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -10,6 +10,7 @@ import {
   readOrCreateSegmentCacheEntry,
   fetchRouteOnCacheMiss,
   fetchSegmentOnCacheMiss,
+  fetchInlinedSegmentsOnCacheMiss,
   EntryStatus,
   type FulfilledRouteCacheEntry,
   type RouteCacheEntry,
@@ -793,6 +794,7 @@ function pingRootRouteTree(
               )
             }
           }
+
           return PrefetchTaskExitStatus.Done
         }
         case FetchStrategy.Full:
@@ -1482,6 +1484,25 @@ function pingStaticSegmentData(
 ): void {
   switch (segment.status) {
     case EntryStatus.Empty:
+      if (process.env.__NEXT_PREFETCH_INLINING) {
+        // All segment data for this route is bundled into a single
+        // /_inlined response. Walk the full route tree to collect all
+        // Empty segments, upgrade them to Pending, and spawn one
+        // bundled request. Subsequent calls for other segments in the
+        // same tree will see them as Pending and skip.
+        const inlinedEntries = collectInlinedEntries(now, route)
+        if (inlinedEntries.size > 0) {
+          spawnPrefetchSubtask(
+            fetchInlinedSegmentsOnCacheMiss(
+              route,
+              routeKey,
+              route.tree,
+              inlinedEntries
+            )
+          )
+        }
+        break
+      }
       // Upgrade to Pending so we know there's already a request in progress
       spawnPrefetchSubtask(
         fetchSegmentOnCacheMiss(
@@ -1555,6 +1576,51 @@ function pingStaticSegmentData(
   // Segments do not have dependent tasks, so once the prefetch is initiated,
   // there's nothing else for us to do (except write the server data into the
   // entry, which is handled by `fetchSegmentOnCacheMiss`).
+}
+
+/**
+ * Walks the RouteTree (including the head metadata) and collects any segments
+ * that are still Empty into a Map, upgrading them to Pending. These entries
+ * will be fulfilled by the inlined prefetch response.
+ */
+function collectInlinedEntries(
+  now: number,
+  route: FulfilledRouteCacheEntry
+): Map<SegmentRequestKey, PendingSegmentCacheEntry> {
+  const entries = new Map<SegmentRequestKey, PendingSegmentCacheEntry>()
+  collectInlinedEntriesImpl(now, route.tree, entries)
+  // Also collect the head/metadata entry.
+  const headEntry = readOrCreateSegmentCacheEntry(
+    now,
+    FetchStrategy.PPR,
+    route.metadata
+  )
+  if (headEntry.status === EntryStatus.Empty) {
+    entries.set(
+      route.metadata.requestKey,
+      upgradeToPendingSegment(headEntry, FetchStrategy.PPR)
+    )
+  }
+  return entries
+}
+
+function collectInlinedEntriesImpl(
+  now: number,
+  tree: RouteTree,
+  entries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
+): void {
+  const entry = readOrCreateSegmentCacheEntry(now, FetchStrategy.PPR, tree)
+  if (entry.status === EntryStatus.Empty) {
+    entries.set(
+      tree.requestKey,
+      upgradeToPendingSegment(entry, FetchStrategy.PPR)
+    )
+  }
+  if (tree.slots !== null) {
+    for (const parallelRouteKey in tree.slots) {
+      collectInlinedEntriesImpl(now, tree.slots[parallelRouteKey], entries)
+    }
+  }
 }
 
 function pingPPRSegmentRevalidation(

--- a/packages/next/src/export/index.ts
+++ b/packages/next/src/export/index.ts
@@ -509,6 +509,7 @@ async function exportAppImpl(
       dynamicOnHover: nextConfig.experimental.dynamicOnHover ?? false,
       optimisticRouting: nextConfig.experimental.optimisticRouting ?? false,
       inlineCss: nextConfig.experimental.inlineCss ?? false,
+      prefetchInlining: nextConfig.experimental.prefetchInlining ?? false,
       authInterrupts: !!nextConfig.experimental.authInterrupts,
       maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
         nextConfig.experimental.maxPostponedStateSize

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -6114,7 +6114,8 @@ async function collectSegmentData(
     fullPageDataBuffer,
     staleTime,
     clientModules,
-    serverConsumerManifest
+    serverConsumerManifest,
+    renderOpts.experimental.prefetchInlining
   )
 }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -87,6 +87,31 @@ export type SegmentPrefetch = {
   varyParams: Set<string> | null
 }
 
+/**
+ * A node in the inlined prefetch tree. Wraps a SegmentPrefetch with child
+ * slots so all segments for a route can be bundled into a single response.
+ *
+ * This is a separate type from SegmentPrefetch because the inlined flow is
+ * temporary — eventually inlining will be the default behavior (controlled by
+ * a size heuristic rather than a boolean flag), and the per-segment and inlined
+ * paths will merge.
+ */
+export type InlinedSegmentPrefetch = {
+  segment: SegmentPrefetch
+  slots: null | {
+    [parallelRouteKey: string]: InlinedSegmentPrefetch
+  }
+}
+
+/**
+ * The response shape for the /_inlined prefetch endpoint. Contains all segment
+ * data for a route bundled into a single tree structure, plus the head segment.
+ */
+export type InlinedPrefetchResponse = {
+  tree: InlinedSegmentPrefetch
+  head: SegmentPrefetch
+}
+
 const filterStackFrame =
   process.env.NODE_ENV !== 'production'
     ? (require('../lib/source-maps') as typeof import('../lib/source-maps'))
@@ -120,7 +145,8 @@ export async function collectSegmentData(
   fullPageDataBuffer: Buffer,
   staleTime: number,
   clientModules: ManifestNode,
-  serverConsumerManifest: any
+  serverConsumerManifest: any,
+  prefetchInlining: boolean
 ): Promise<Map<SegmentRequestKey, Buffer>> {
   // Traverse the router tree and generate a prefetch response for each segment.
 
@@ -168,6 +194,7 @@ export async function collectSegmentData(
       staleTime={staleTime}
       segmentTasks={segmentTasks}
       onCompletedProcessingRouteTree={onCompletedProcessingRouteTree}
+      prefetchInlining={prefetchInlining}
     />,
     clientModules,
     {
@@ -202,6 +229,7 @@ async function PrefetchTreeData({
   staleTime,
   segmentTasks,
   onCompletedProcessingRouteTree,
+  prefetchInlining,
 }: {
   isClientParamParsingEnabled: boolean
   fullPageDataBuffer: Buffer
@@ -210,6 +238,7 @@ async function PrefetchTreeData({
   staleTime: number
   segmentTasks: Array<Promise<[SegmentRequestKey, Buffer]>>
   onCompletedProcessingRouteTree: () => void
+  prefetchInlining: boolean
 }): Promise<RootTreePrefetch | null> {
   // We're currently rendering a Flight response for the route tree prefetch.
   // Inside this component, decode the Flight stream for the whole page. This is
@@ -250,7 +279,8 @@ async function PrefetchTreeData({
 
   // Compute the route metadata tree by traversing the FlightRouterState. As we
   // walk the tree, we will also spawn a task to produce a prefetch response for
-  // each segment.
+  // each segment (unless prefetch inlining is enabled, in which case all
+  // segments are bundled into a single /_inlined response).
   const tree = collectSegmentDataImpl(
     isClientParamParsingEnabled,
     flightRouterState,
@@ -259,25 +289,45 @@ async function PrefetchTreeData({
     seedData,
     clientModules,
     ROOT_SEGMENT_REQUEST_KEY,
-    segmentTasks
+    segmentTasks,
+    prefetchInlining
   )
 
-  // Also spawn a task to produce a prefetch response for the "head" segment.
-  // The head contains metadata, like the title; it's not really a route
-  // segment, but it contains RSC data, so it's treated like a segment by
-  // the client cache.
-  segmentTasks.push(
-    waitAtLeastOneReactRenderTask().then(() =>
-      renderSegmentPrefetch(
-        buildId,
-        staleTime,
-        head,
-        HEAD_REQUEST_KEY,
-        headVaryParams,
-        clientModules
+  if (prefetchInlining) {
+    // When prefetch inlining is enabled, bundle all segment data into a single
+    // /_inlined response instead of individual per-segment responses. The head
+    // is also included in the inlined response.
+    segmentTasks.push(
+      waitAtLeastOneReactRenderTask().then(() =>
+        renderInlinedPrefetchResponse(
+          flightRouterState,
+          buildId,
+          staleTime,
+          seedData,
+          head,
+          headVaryParams,
+          clientModules
+        )
       )
     )
-  )
+  } else {
+    // Also spawn a task to produce a prefetch response for the "head" segment.
+    // The head contains metadata, like the title; it's not really a route
+    // segment, but it contains RSC data, so it's treated like a segment by
+    // the client cache.
+    segmentTasks.push(
+      waitAtLeastOneReactRenderTask().then(() =>
+        renderSegmentPrefetch(
+          buildId,
+          staleTime,
+          head,
+          HEAD_REQUEST_KEY,
+          headVaryParams,
+          clientModules
+        )
+      )
+    )
+  }
 
   // Notify the abort controller that we're done processing the route tree.
   // Anything async that happens after this point must be due to hanging
@@ -303,7 +353,8 @@ function collectSegmentDataImpl(
   seedData: CacheNodeSeedData | null,
   clientModules: ManifestNode,
   requestKey: SegmentRequestKey,
-  segmentTasks: Array<Promise<[string, Buffer]>>
+  segmentTasks: Array<Promise<[string, Buffer]>>,
+  prefetchInlining: boolean
 ): TreePrefetch {
   // Metadata about the segment. Sent as part of the tree prefetch. Null if
   // there are no children.
@@ -330,7 +381,8 @@ function collectSegmentDataImpl(
       childSeedData,
       clientModules,
       childRequestKey,
-      segmentTasks
+      segmentTasks,
+      prefetchInlining
     )
     if (slotMetadata === null) {
       slotMetadata = {}
@@ -349,28 +401,33 @@ function collectSegmentDataImpl(
   const varyParams =
     varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
 
-  if (seedData !== null) {
-    // Spawn a task to write the segment data to a new Flight stream.
-    segmentTasks.push(
-      // Since we're already in the middle of a render, wait until after the
-      // current task to escape the current rendering context.
-      waitAtLeastOneReactRenderTask().then(() =>
-        renderSegmentPrefetch(
-          buildId,
-          staleTime,
-          seedData[0],
-          requestKey,
-          varyParams,
-          clientModules
+  if (!prefetchInlining) {
+    // When prefetch inlining is disabled, spawn individual segment tasks.
+    // When enabled, segment data is bundled into the /_inlined response
+    // instead, so we skip per-segment tasks here.
+    if (seedData !== null) {
+      // Spawn a task to write the segment data to a new Flight stream.
+      segmentTasks.push(
+        // Since we're already in the middle of a render, wait until after the
+        // current task to escape the current rendering context.
+        waitAtLeastOneReactRenderTask().then(() =>
+          renderSegmentPrefetch(
+            buildId,
+            staleTime,
+            seedData[0],
+            requestKey,
+            varyParams,
+            clientModules
+          )
         )
       )
-    )
-  } else {
-    // This segment does not have any seed data. Skip generating a prefetch
-    // response for it. We'll still include it in the route tree, though.
-    // TODO: We should encode in the route tree whether a segment is missing
-    // so we don't attempt to fetch it for no reason. As of now this shouldn't
-    // ever happen in practice, though.
+    } else {
+      // This segment does not have any seed data. Skip generating a prefetch
+      // response for it. We'll still include it in the route tree, though.
+      // TODO: We should encode in the route tree whether a segment is missing
+      // so we don't attempt to fetch it for no reason. As of now this shouldn't
+      // ever happen in practice, though.
+    }
   }
 
   const segment = route[0]
@@ -438,6 +495,99 @@ async function renderSegmentPrefetch(
   } else {
     return [requestKey, segmentBuffer]
   }
+}
+
+async function renderInlinedPrefetchResponse(
+  route: FlightRouterState,
+  buildId: string | undefined,
+  staleTime: number,
+  seedData: CacheNodeSeedData | null,
+  head: HeadData,
+  headVaryParams: Set<string> | null,
+  clientModules: ManifestNode
+): Promise<[SegmentRequestKey, Buffer]> {
+  // Build the inlined tree by walking the route and collecting all segments.
+  const inlinedTree = await buildInlinedSegmentPrefetch(
+    route,
+    buildId,
+    staleTime,
+    seedData,
+    clientModules
+  )
+
+  // Build the head segment.
+  const headPrefetch: SegmentPrefetch = {
+    rsc: head,
+    isPartial: await isPartialRSCData(head, clientModules),
+    staleTime,
+    varyParams: headVaryParams,
+  }
+  if (buildId) {
+    headPrefetch.buildId = buildId
+  }
+
+  const response: InlinedPrefetchResponse = {
+    tree: inlinedTree,
+    head: headPrefetch,
+  }
+
+  // Render as a single Flight response.
+  const abortController = new AbortController()
+  waitAtLeastOneReactRenderTask().then(() => abortController.abort())
+  const { prelude } = await prerender(response, clientModules, {
+    filterStackFrame,
+    signal: abortController.signal,
+    onError: onSegmentPrerenderError,
+  })
+  const buffer = await streamToBuffer(prelude)
+  return ['/_inlined' as SegmentRequestKey, buffer]
+}
+
+async function buildInlinedSegmentPrefetch(
+  route: FlightRouterState,
+  buildId: string | undefined,
+  staleTime: number,
+  seedData: CacheNodeSeedData | null,
+  clientModules: ManifestNode
+): Promise<InlinedSegmentPrefetch> {
+  let slots: {
+    [parallelRouteKey: string]: InlinedSegmentPrefetch
+  } | null = null
+
+  const children = route[1]
+  const seedDataChildren = seedData !== null ? seedData[1] : null
+  for (const parallelRouteKey in children) {
+    const childRoute = children[parallelRouteKey]
+    const childSeedData =
+      seedDataChildren !== null ? seedDataChildren[parallelRouteKey] : null
+    const childPrefetch = await buildInlinedSegmentPrefetch(
+      childRoute,
+      buildId,
+      staleTime,
+      childSeedData,
+      clientModules
+    )
+    if (slots === null) {
+      slots = {}
+    }
+    slots[parallelRouteKey] = childPrefetch
+  }
+
+  const rsc = seedData !== null ? seedData[0] : null
+  const varyParamsThenable = seedData !== null ? seedData[4] : null
+  const varyParams =
+    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+
+  const segment: SegmentPrefetch = {
+    rsc,
+    isPartial: rsc !== null ? await isPartialRSCData(rsc, clientModules) : true,
+    staleTime,
+    varyParams,
+  }
+  if (buildId) {
+    segment.buildId = buildId
+  }
+  return { segment, slots }
 }
 
 async function isPartialRSCData(

--- a/packages/next/src/server/app-render/types.ts
+++ b/packages/next/src/server/app-render/types.ts
@@ -160,6 +160,7 @@ export interface RenderOptsPartial {
     dynamicOnHover: boolean
     optimisticRouting: boolean
     inlineCss: boolean
+    prefetchInlining: boolean
     authInterrupts: boolean
 
     /**

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -573,6 +573,8 @@ export default abstract class Server<
         optimisticRouting:
           this.nextConfig.experimental.optimisticRouting ?? false,
         inlineCss: this.nextConfig.experimental.inlineCss ?? false,
+        prefetchInlining:
+          this.nextConfig.experimental.prefetchInlining ?? false,
         authInterrupts: !!this.nextConfig.experimental.authInterrupts,
         maxPostponedStateSizeBytes: parseMaxPostponedStateSize(
           this.nextConfig.experimental.maxPostponedStateSize

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -221,6 +221,7 @@ export const experimentalSchema = {
   dynamicOnHover: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   varyParams: z.boolean().optional(),
+  prefetchInlining: z.boolean().optional(),
   disableOptimizedLoading: z.boolean().optional(),
   disablePostcssPresetEnv: z.boolean().optional(),
   cacheComponents: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -355,6 +355,7 @@ export interface ExperimentalConfig {
   dynamicOnHover?: boolean
   optimisticRouting?: boolean
   varyParams?: boolean
+  prefetchInlining?: boolean
   preloadEntriesOnStart?: boolean
   clientRouterFilter?: boolean
   clientRouterFilterRedirects?: boolean
@@ -1636,6 +1637,7 @@ export const defaultConfig = Object.freeze({
     clientParamParsingOrigins: undefined,
     dynamicOnHover: false,
     varyParams: false,
+    prefetchInlining: false,
     preloadEntriesOnStart: true,
     clientRouterFilter: true,
     clientRouterFilterRedirects: false,
@@ -1780,6 +1782,7 @@ export interface NextConfigRuntime {
     | 'dynamicOnHover'
     | 'optimisticRouting'
     | 'inlineCss'
+    | 'prefetchInlining'
     | 'authInterrupts'
     | 'clientTraceMetadata'
     | 'clientParamParsingOrigins'
@@ -1843,6 +1846,7 @@ export function getNextConfigRuntime(
         dynamicOnHover: ex.dynamicOnHover,
         optimisticRouting: ex.optimisticRouting,
         inlineCss: ex.inlineCss,
+        prefetchInlining: ex.prefetchInlining,
         authInterrupts: ex.authInterrupts,
         clientTraceMetadata: ex.clientTraceMetadata,
         clientParamParsingOrigins: ex.clientParamParsingOrigins,

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -1,0 +1,22 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/shared/a/b/c">Route A</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/shared/a/d/e">Route B</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/shared/a/b/c" id="duplicate-a">
+            Route A (duplicate)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/b/c/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/b/c/page.tsx
@@ -1,0 +1,3 @@
+export default function PageC() {
+  return <p id="page-c">Page C</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/b/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/b/layout.tsx
@@ -1,0 +1,4 @@
+import { ReactNode } from 'react'
+export default function BLayout({ children }: { children: ReactNode }) {
+  return <div id="b-layout">{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/d/e/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/d/e/page.tsx
@@ -1,0 +1,3 @@
+export default function PageE() {
+  return <p id="page-e">Page E</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/d/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/d/layout.tsx
@@ -1,0 +1,4 @@
+import { ReactNode } from 'react'
+export default function DLayout({ children }: { children: ReactNode }) {
+  return <div id="d-layout">{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/a/layout.tsx
@@ -1,0 +1,4 @@
+import { ReactNode } from 'react'
+export default function ALayout({ children }: { children: ReactNode }) {
+  return <div id="a-layout">{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/shared/layout.tsx
@@ -1,0 +1,4 @@
+import { ReactNode } from 'react'
+export default function SharedLayout({ children }: { children: ReactNode }) {
+  return <div id="shared-layout">{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/components/link-accordion.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/components/link-accordion.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  id,
+}: {
+  href: LinkProps['href']
+  children: React.ReactNode
+  id?: string
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={id ?? href}
+      />
+      {isVisible ? (
+        <Link href={href}>{children}</Link>
+      ) : (
+        `${children} (link is hidden)`
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/next.config.js
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    prefetchInlining: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -1,0 +1,129 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('prefetch inlining', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    it('disabled in development', () => {})
+    return
+  }
+
+  it('bundles all segment data into a single request per route', async () => {
+    // The test app has two routes that are 5 segments deep:
+    //   /shared/a/b/c  and  /shared/a/d/e
+    // Without inlining, prefetching each route would issue one request per
+    // segment plus one for the head (6+ requests). With inlining enabled,
+    // all segment data is bundled into a single /_inlined response, so
+    // revealing a link should produce at most 2 prefetch requests per route:
+    // one for /_tree and one for /_inlined.
+
+    let rscRequestCount = 0
+    let page: Playwright.Page
+
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+        p.on('request', (request: Playwright.Request) => {
+          if (request.headers()['rsc']) {
+            rscRequestCount++
+          }
+        })
+      },
+    })
+    const act = createRouterAct(page!)
+
+    // Reveal the first link to trigger a prefetch of /shared/a/b/c
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/shared/a/b/c"]')
+          .click()
+      },
+      {
+        includes: 'Page C',
+      }
+    )
+
+    // Snapshot the request count before revealing the second link
+    const countBeforeSecondPrefetch = rscRequestCount
+
+    // Reveal the second link to trigger a prefetch of /shared/a/d/e
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/shared/a/d/e"]')
+          .click()
+      },
+      {
+        includes: 'Page E',
+      }
+    )
+
+    // The delta should be at most 2 requests (/_tree + /_inlined).
+    // Without inlining, there would be 6+ individual segment requests.
+    const delta = rscRequestCount - countBeforeSecondPrefetch
+    expect(delta).toBeLessThanOrEqual(2)
+
+    // Navigate to the second route. Because the data was fully prefetched,
+    // there should be no additional requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/shared/a/d/e"]').click()
+    }, 'no-requests')
+
+    // Verify the page rendered correctly
+    const text = await browser.elementByCss('#page-e').text()
+    expect(text).toBe('Page E')
+  })
+
+  it('deduplicates inlined prefetch requests for the same route', async () => {
+    // Two links point to the same route (/shared/a/b/c). When the first
+    // link is revealed, its prefetch spawns an inlined request. While
+    // that request is still pending, revealing the second link should
+    // not spawn any additional requests because the segments are already
+    // Pending from the first task.
+    let page: Playwright.Page
+
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        // Reveal the first link, blocking its response so the prefetch
+        // stays in-flight.
+        await act(async () => {
+          await browser
+            .elementByCss('input[data-link-accordion="/shared/a/b/c"]')
+            .click()
+        }, 'block')
+
+        // While the first prefetch is still pending, reveal a second
+        // link to the same route. This should not spawn any new
+        // requests because the segments are already Pending.
+        await act(async () => {
+          await browser
+            .elementByCss('input[data-link-accordion="duplicate-a"]')
+            .click()
+        }, 'no-requests')
+      },
+      {
+        includes: 'Page C',
+      }
+    )
+
+    // Navigate to the route. Because the data was fully prefetched,
+    // no additional requests are needed.
+    await act(async () => {
+      await browser.elementByCss('a[href="/shared/a/b/c"]').click()
+    }, 'no-requests')
+
+    const text = await browser.elementByCss('#page-c').text()
+    expect(text).toBe('Page C')
+  })
+})


### PR DESCRIPTION
## Background

Next.js 16 introduced per-segment prefetching through the Client Segment Cache. Rather than fetching all data for a route in a single request, the client issues individual requests for each segment in the route tree. This design improves cache efficiency: shared layouts between sibling routes (e.g., /dashboard/settings and /dashboard/profile sharing a /dashboard layout) are fetched once and reused from the client cache, avoiding redundant data transfer.

The trade-off is request volume. A route with N segments now produces N prefetch requests instead of one. Users upgrading from older versions notice significantly more network activity in their devtools, even though the total bytes transferred may be similar or lower due to deduplication.

Per-segment fetching is still a reasonable default for many sites. These prefetch requests are served from cache, they're fast, and they run in parallel. The main scenario where the trade-off breaks down is deployment environments that charge per-request. But even setting aside cost, there is a theoretical performance threshold where very small segments are better off inlined — the per-request overhead (connection setup, headers, scheduling) exceeds the cost of transferring duplicate bytes. This is analogous to JS bundlers, which inline small modules rather than creating separate chunks, because the overhead of an additional script tag or dynamic import outweighs the bytes saved.

## What this change does

This adds `experimental.prefetchInlining`, a boolean option in next.config.js. When enabled, the server bundles all segment data for a route into a single `/_inlined` response rather than serving each segment individually. The tree prefetch (`/_tree`), which provides route structure metadata, remains a separate request — but optimistic routing (#88965) eliminates that request entirely by predicting the route structure client-side. With both features enabled, prefetching is effectively one request per link.

The fundamental trade-off is straightforward: inlining reduces request count at the cost of deduplication. Each inlined response includes its own copy of any shared layout data, so two sibling routes will each transfer the shared layout rather than sharing a single cached copy. This is the same trade-off that compilers and bundlers face when deciding whether to inline a function: inlining eliminates the overhead of indirection (here, extra HTTP requests) but increases total size when the same data appears in multiple call sites.

## Future direction

The boolean flag is a stepping stone. The observation that there is a natural size threshold below which inlining is strictly better — where per-request overhead dominates the cost of any duplicate bytes — points toward a size-based heuristic, analogous to how compilers choose an inlining threshold. Small segments would be inlined automatically; segments exceeding a byte threshold would be "outlined" into separate requests where deduplication can take effect. For most applications, this would require no configuration. For applications with specific latency or bandwidth constraints, an option to adjust the threshold would let developers tune their position on the requests-vs-bytes curve. Adaptive heuristics based on network conditions are also possible, though further out.