### PR TITLE
[devtools] Stop sending codeframes for ignored frames

### DIFF
--- a/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
+++ b/packages/next/src/build/webpack/plugins/wellknown-errors-plugin/parseNotFoundError.ts
@@ -4,6 +4,7 @@ import {
   createOriginalStackFrame,
   getIgnoredSources,
 } from '../../../../server/dev/middleware-webpack'
+import isInternal from '../../../../shared/lib/is-internal'
 import type { webpack } from 'next/dist/compiled/webpack/webpack'
 import type { RawSourceMap } from 'next/dist/compiled/source-map08'
 
@@ -89,10 +90,22 @@ async function getSourceFrame(
         },
       })
 
+      if (result === null || result.originalStackFrame === null) {
+        return {
+          column1: '',
+          frame: '',
+          line1: '',
+        }
+      }
+
+      const originalStackFrame = result.originalStackFrame
       return {
-        frame: result?.originalCodeFrame ?? '',
-        line1: result?.originalStackFrame?.line1?.toString() ?? '',
-        column1: result?.originalStackFrame?.column1?.toString() ?? '',
+        frame:
+          (!isInternal(originalStackFrame.file)
+            ? result.originalCodeFrame
+            : null) ?? '',
+        line1: originalStackFrame.line1?.toString() ?? '',
+        column1: originalStackFrame.column1?.toString() ?? '',
       }
     }
   } catch {}

--- a/packages/next/src/next-devtools/server/shared.ts
+++ b/packages/next/src/next-devtools/server/shared.ts
@@ -1,5 +1,4 @@
 import { codeFrameColumns } from 'next/dist/compiled/babel/code-frame'
-import isInternal from '../../shared/lib/is-internal'
 import type { StackFrame } from '../../server/lib/parse-stack'
 import { ignoreListAnonymousStackFramesIfSandwiched as ignoreListAnonymousStackFramesIfSandwichedGeneric } from '../../server/lib/source-maps'
 
@@ -68,7 +67,7 @@ export function getOriginalCodeFrame(
   source: string | null,
   colors: boolean = process.stdout.isTTY
 ): string | null {
-  if (!source || isInternal(frame.file)) {
+  if (!source) {
     return null
   }
 

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -522,10 +522,10 @@ export async function getOriginalStackFrames({
           value: {
             originalStackFrame,
             originalCodeFrame:
-              originalStackFrame?.ignored === false
-                ? // TODO: Don't get all codeframes of non-ignored frames eagerly.
-                  stackFrame.originalCodeFrame
-                : null,
+              (originalStackFrame?.ignored ?? true)
+                ? null
+                : // TODO: Don't get all codeframes of non-ignored frames eagerly.
+                  stackFrame.originalCodeFrame,
           },
         }
       } catch (error) {

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -311,28 +311,22 @@ async function createOriginalStackFrame(
   let originalCodeFrame: string | null | undefined
 
   const tracedFrame = traced.frame
-  return Object.defineProperty(
-    {
-      originalStackFrame: {
-        arguments: tracedFrame.arguments,
-        file: normalizedStackFrameLocation,
-        line1: tracedFrame.line1,
-        column1: tracedFrame.column1,
-        ignored: tracedFrame.ignored,
-        methodName: tracedFrame.methodName,
-      },
-      originalCodeFrame: null,
+  return {
+    originalStackFrame: {
+      arguments: tracedFrame.arguments,
+      file: normalizedStackFrameLocation,
+      line1: tracedFrame.line1,
+      column1: tracedFrame.column1,
+      ignored: tracedFrame.ignored,
+      methodName: tracedFrame.methodName,
     },
-    'originalCodeFrame',
-    {
-      get: () => {
-        if (originalCodeFrame === undefined) {
-          originalCodeFrame = getOriginalCodeFrame(tracedFrame, traced.source)
-        }
-        return originalCodeFrame
-      },
-    }
-  )
+    get originalCodeFrame() {
+      if (originalCodeFrame === undefined) {
+        originalCodeFrame = getOriginalCodeFrame(tracedFrame, traced.source)
+      }
+      return originalCodeFrame
+    },
+  }
 }
 
 export function getOverlayMiddleware({

--- a/packages/next/src/server/dev/middleware-turbopack.ts
+++ b/packages/next/src/server/dev/middleware-turbopack.ts
@@ -307,17 +307,32 @@ async function createOriginalStackFrame(
     )
   }
 
-  return {
-    originalStackFrame: {
-      arguments: traced.frame.arguments,
-      file: normalizedStackFrameLocation,
-      line1: traced.frame.line1,
-      column1: traced.frame.column1,
-      ignored: traced.frame.ignored,
-      methodName: traced.frame.methodName,
+  /** undefined = not yet computed */
+  let originalCodeFrame: string | null | undefined
+
+  const tracedFrame = traced.frame
+  return Object.defineProperty(
+    {
+      originalStackFrame: {
+        arguments: tracedFrame.arguments,
+        file: normalizedStackFrameLocation,
+        line1: tracedFrame.line1,
+        column1: tracedFrame.column1,
+        ignored: tracedFrame.ignored,
+        methodName: tracedFrame.methodName,
+      },
+      originalCodeFrame: null,
     },
-    originalCodeFrame: getOriginalCodeFrame(traced.frame, traced.source),
-  }
+    'originalCodeFrame',
+    {
+      get: () => {
+        if (originalCodeFrame === undefined) {
+          originalCodeFrame = getOriginalCodeFrame(tracedFrame, traced.source)
+        }
+        return originalCodeFrame
+      },
+    }
+  )
 }
 
 export function getOverlayMiddleware({
@@ -507,7 +522,18 @@ export async function getOriginalStackFrames({
             reason: 'Failed to create original stack frame',
           }
         }
-        return { status: 'fulfilled', value: stackFrame }
+        const originalStackFrame = stackFrame.originalStackFrame
+        return {
+          status: 'fulfilled',
+          value: {
+            originalStackFrame,
+            originalCodeFrame:
+              originalStackFrame?.ignored === false
+                ? // TODO: Don't get all codeframes of non-ignored frames eagerly.
+                  stackFrame.originalCodeFrame
+                : null,
+          },
+        }
       } catch (error) {
         return {
           status: 'rejected',

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -257,21 +257,15 @@ export async function createOriginalStackFrame({
   /** undefined = not yet computed */
   let originalCodeFrame: string | null | undefined
 
-  return Object.defineProperty(
-    {
-      originalStackFrame: traced,
-      originalCodeFrame: null,
+  return {
+    originalStackFrame: traced,
+    get originalCodeFrame() {
+      if (originalCodeFrame === undefined) {
+        originalCodeFrame = getOriginalCodeFrame(traced, sourceContent)
+      }
+      return originalCodeFrame
     },
-    'originalCodeFrame',
-    {
-      get: () => {
-        if (originalCodeFrame === undefined) {
-          originalCodeFrame = getOriginalCodeFrame(traced, sourceContent)
-        }
-        return originalCodeFrame
-      },
-    }
-  )
+  }
 }
 
 async function getSourceMapFromCompilation(

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -254,10 +254,24 @@ export async function createOriginalStackFrame({
     ignored,
   }
 
-  return {
-    originalStackFrame: traced,
-    originalCodeFrame: getOriginalCodeFrame(traced, sourceContent),
-  }
+  /** undefined = not yet computed */
+  let originalCodeFrame: string | null | undefined
+
+  return Object.defineProperty(
+    {
+      originalStackFrame: traced,
+      originalCodeFrame: null,
+    },
+    'originalCodeFrame',
+    {
+      get: () => {
+        if (originalCodeFrame === undefined) {
+          originalCodeFrame = getOriginalCodeFrame(traced, sourceContent)
+        }
+        return originalCodeFrame
+      },
+    }
+  )
 }
 
 async function getSourceMapFromCompilation(
@@ -530,7 +544,15 @@ async function getOriginalStackFrame({
     }
   }
 
-  return originalStackFrameResponse
+  const originalStackFrame = originalStackFrameResponse.originalStackFrame
+  return {
+    originalStackFrame,
+    originalCodeFrame:
+      originalStackFrame?.ignored === false
+        ? // TODO: Don't get all codeframes of non-ignored frames eagerly.
+          originalStackFrameResponse.originalCodeFrame
+        : null,
+  }
 }
 
 export function getOverlayMiddleware(options: {

--- a/packages/next/src/server/dev/middleware-webpack.ts
+++ b/packages/next/src/server/dev/middleware-webpack.ts
@@ -542,10 +542,10 @@ async function getOriginalStackFrame({
   return {
     originalStackFrame,
     originalCodeFrame:
-      originalStackFrame?.ignored === false
-        ? // TODO: Don't get all codeframes of non-ignored frames eagerly.
-          originalStackFrameResponse.originalCodeFrame
-        : null,
+      (originalStackFrame?.ignored ?? true)
+        ? null
+        : // TODO: Don't get all codeframes of non-ignored frames eagerly.
+          originalStackFrameResponse.originalCodeFrame,
   }
 }
 

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -306,30 +306,24 @@ function getSourcemappedFrameIfPossible(
   /** undefined = not yet computed */
   let codeFrame: string | null | undefined
 
-  return Object.defineProperty(
-    {
-      stack: originalFrame,
-      code: null,
+  return {
+    stack: originalFrame,
+    get code() {
+      if (codeFrame === undefined) {
+        const sourceContent: string | null =
+          sourceMapConsumer.sourceContentFor(
+            sourcePosition.source,
+            /* returnNullOnMissing */ true
+          ) ?? null
+        codeFrame = getOriginalCodeFrame(
+          originalFrame,
+          sourceContent,
+          inspectOptions.colors
+        )
+      }
+      return codeFrame
     },
-    'code',
-    {
-      get: () => {
-        if (codeFrame === undefined) {
-          const sourceContent: string | null =
-            sourceMapConsumer.sourceContentFor(
-              sourcePosition.source,
-              /* returnNullOnMissing */ true
-            ) ?? null
-          codeFrame = getOriginalCodeFrame(
-            originalFrame,
-            sourceContent,
-            inspectOptions.colors
-          )
-        }
-        return codeFrame
-      },
-    }
-  )
+  }
 }
 
 function parseAndSourceMap(

--- a/packages/next/src/server/patch-error-inspect.ts
+++ b/packages/next/src/server/patch-error-inspect.ts
@@ -303,7 +303,7 @@ function getSourcemappedFrameIfPossible(
     ignored,
   }
 
-  /** undefined = not yet computed*/
+  /** undefined = not yet computed */
   let codeFrame: string | null | undefined
 
   return Object.defineProperty(


### PR DESCRIPTION
Codeframes for ignored stackframes are not used by the Redbox at the moment and impact performance of the sourcemapping request noticeably (the more ignore-listed frames, the worse).
In `test/development/app-dir/ssr-only-error/` the sourcemapping request went down to 600ms from 1.8s for both Webpack and Turbopack. On larger stacks that may be even more noticably.

I believe this should reduce flakiness of the `test/development/app-dir/ssr-only-error/ssr-only-error.test.ts` test since we currently block the Redbox on the sourcemapping request (which I also want to change later).

As a follow-up, we'll only send the codeframe for the first non-ignored frame to save even more I/O and CPU.

We'll add a dedicated endpoint to fetch codeframes on demand to allow switching codeframes for https://github.com/vercel/next.js/pull/88867/

