### PR TITLE
feat: add llms.txt metadata route support

### DIFF
--- a/crates/next-core/src/app_structure.rs
+++ b/crates/next-core/src/app_structure.rs
@@ -174,6 +174,7 @@ pub struct GlobalMetadata {
     pub favicon: Option<MetadataItem>,
     pub robots: Option<MetadataItem>,
     pub manifest: Option<MetadataItem>,
+    pub llms: Option<MetadataItem>,
 }
 
 impl GlobalMetadata {
@@ -182,8 +183,9 @@ impl GlobalMetadata {
             favicon,
             robots,
             manifest,
+            llms,
         } = self;
-        favicon.is_none() && robots.is_none() && manifest.is_none()
+        favicon.is_none() && robots.is_none() && manifest.is_none() && llms.is_none()
     }
 }
 
@@ -1695,9 +1697,15 @@ async fn directory_tree_to_entrypoints_internal_untraced(
             favicon,
             robots,
             manifest,
+            llms,
         } = &*global_metadata.await?;
 
-        for meta in favicon.iter().chain(robots.iter()).chain(manifest.iter()) {
+        for meta in favicon
+            .iter()
+            .chain(robots.iter())
+            .chain(manifest.iter())
+            .chain(llms.iter())
+        {
             let app_page =
                 app_page.clone_push_str(&get_metadata_route_name(meta.clone()).await?)?;
 
@@ -2041,6 +2049,7 @@ pub async fn get_global_metadata(
             "favicon" => &mut metadata.favicon,
             "manifest" => &mut metadata.manifest,
             "robots" => &mut metadata.robots,
+            "llms" => &mut metadata.llms,
             _ => continue,
         };
 

--- a/crates/next-core/src/next_app/metadata/mod.rs
+++ b/crates/next-core/src/next_app/metadata/mod.rs
@@ -32,6 +32,7 @@ pub static STATIC_GLOBAL_METADATA: Lazy<FxHashMap<&'static str, &'static [&'stat
             ("favicon", &["ico"] as &'static [&'static str]),
             ("manifest", &["webmanifest", "json"]),
             ("robots", &["txt"]),
+            ("llms", &["txt"]),
         ])
     });
 
@@ -103,6 +104,9 @@ pub(crate) async fn get_content_type(path: FileSystemPath) -> Result<String> {
         return Ok("application/xml".to_string());
     }
     if name == "robots" {
+        return Ok("text/plain".to_string());
+    }
+    if name == "llms" {
         return Ok("text/plain".to_string());
     }
     if name == "manifest" {
@@ -330,6 +334,8 @@ pub fn normalize_metadata_route(mut page: AppPage) -> Result<AppPage> {
     let mut suffix: Option<String> = None;
     if route == "/robots" {
         route += ".txt"
+    } else if route == "/llms" {
+        route += ".txt"
     } else if route == "/manifest" {
         route += ".webmanifest"
     } else if route.ends_with("/sitemap") {
@@ -381,6 +387,7 @@ mod test {
                 "/client/(meme)/more-route/twitter-image2-769mad/route",
             ],
             ["/robots.txt", "/robots.txt/route"],
+            ["/llms.txt", "/llms.txt/route"],
             ["/manifest.webmanifest", "/manifest.webmanifest/route"],
             ["/sitemap", "/sitemap.xml/route"],
             ["/sitemap.xml", "/sitemap.xml/route"],

--- a/crates/next-core/src/next_app/metadata/route.rs
+++ b/crates/next-core/src/next_app/metadata/route.rs
@@ -43,7 +43,7 @@ pub async fn get_app_metadata_route_source(
             let stem = path.file_stem();
             let stem = stem.unwrap_or_default();
 
-            if stem == "robots" || stem == "manifest" {
+            if stem == "robots" || stem == "manifest" || stem == "llms" {
                 dynamic_text_route_source(path)
             } else if stem == "sitemap" {
                 dynamic_site_map_route_source(path, is_multi_dynamic)

--- a/docs/01-app/03-api-reference/03-file-conventions/01-metadata/llms.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/01-metadata/llms.mdx
@@ -1,0 +1,151 @@
+---
+title: llms.txt
+description: API Reference for llms.txt file.
+---
+
+Add or generate a `llms.txt` file that matches the [llms.txt standard](https://llmstxt.org/) in the **root** of `app` directory to help Large Language Models (LLMs) understand your website's structure and content.
+
+## Static `llms.txt`
+
+```txt filename="app/llms.txt"
+# My Site
+
+> A brief description of my site.
+
+## Docs
+
+- [Getting Started](https://example.com/docs/getting-started): Learn how to get started
+- [API Reference](https://example.com/docs/api): Full API documentation
+```
+
+## Generate an llms.txt file
+
+Add a `llms.js` or `llms.ts` file that returns either a plain string or an [`Llms` object](#llms-object).
+
+> **Good to know**: `llms.js` is a special Route Handler that is cached by default unless it uses a [Dynamic API](/docs/app/guides/caching#dynamic-apis) or [dynamic config](/docs/app/guides/caching#segment-config-options) option.
+
+```ts filename="app/llms.ts" switcher
+import type { MetadataRoute } from 'next'
+
+export default function llms(): MetadataRoute.Llms {
+  return {
+    title: 'My Site',
+    description: 'A brief description of my site.',
+    sections: [
+      {
+        heading: 'Docs',
+        links: [
+          {
+            title: 'Getting Started',
+            url: 'https://example.com/docs/getting-started',
+            description: 'Learn how to get started',
+          },
+          {
+            title: 'API Reference',
+            url: 'https://example.com/docs/api',
+            description: 'Full API documentation',
+          },
+        ],
+      },
+    ],
+  }
+}
+```
+
+```js filename="app/llms.js" switcher
+export default function llms() {
+  return {
+    title: 'My Site',
+    description: 'A brief description of my site.',
+    sections: [
+      {
+        heading: 'Docs',
+        links: [
+          {
+            title: 'Getting Started',
+            url: 'https://example.com/docs/getting-started',
+            description: 'Learn how to get started',
+          },
+          {
+            title: 'API Reference',
+            url: 'https://example.com/docs/api',
+            description: 'Full API documentation',
+          },
+        ],
+      },
+    ],
+  }
+}
+```
+
+Output:
+
+```txt
+# My Site
+
+> A brief description of my site.
+
+## Docs
+
+- [Getting Started](https://example.com/docs/getting-started): Learn how to get started
+- [API Reference](https://example.com/docs/api): Full API documentation
+```
+
+### Returning a string
+
+You can also return a plain string if you prefer to write the Markdown content directly:
+
+```ts filename="app/llms.ts" switcher
+import type { MetadataRoute } from 'next'
+
+export default function llms(): MetadataRoute.Llms {
+  return `# My Site
+
+> A brief description of my site.
+
+## Docs
+
+- [Getting Started](https://example.com/docs/getting-started): Learn how to get started
+`
+}
+```
+
+```js filename="app/llms.js" switcher
+export default function llms() {
+  return `# My Site
+
+> A brief description of my site.
+
+## Docs
+
+- [Getting Started](https://example.com/docs/getting-started): Learn how to get started
+`
+}
+```
+
+### Llms object
+
+```tsx
+type Llms =
+  | string
+  | {
+      title: string
+      description?: string
+      details?: string
+      sections?: Array<{
+        heading: string
+        description?: string
+        links?: Array<{
+          title: string
+          url: string
+          description?: string
+        }>
+      }>
+    }
+```
+
+## Version History
+
+| Version   | Changes            |
+| --------- | ------------------ |
+| `v16.2.0` | `llms` introduced. |

--- a/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
+++ b/packages/next/src/build/webpack/loaders/metadata/resolve-route-data.ts
@@ -149,9 +149,38 @@ export function resolveManifest(data: MetadataRoute.Manifest): string {
   return JSON.stringify(data)
 }
 
+export function resolveLlms(data: MetadataRoute.Llms): string {
+  if (typeof data === 'string') return data
+
+  let content = `# ${data.title}\n`
+  if (data.description) content += `\n> ${data.description}\n`
+  if (data.details) content += `\n${data.details}\n`
+  if (data.sections) {
+    for (const section of data.sections) {
+      content += `\n## ${section.heading}\n`
+      if (section.description) content += `\n${section.description}\n`
+      if (section.links) {
+        content += '\n'
+        for (const link of section.links) {
+          if (link.description) {
+            content += `- [${link.title}](${link.url}): ${link.description}\n`
+          } else {
+            content += `- [${link.title}](${link.url})\n`
+          }
+        }
+      }
+    }
+  }
+  return content
+}
+
 export function resolveRouteData(
-  data: MetadataRoute.Robots | MetadataRoute.Sitemap | MetadataRoute.Manifest,
-  fileType: 'robots' | 'sitemap' | 'manifest'
+  data:
+    | MetadataRoute.Robots
+    | MetadataRoute.Sitemap
+    | MetadataRoute.Manifest
+    | MetadataRoute.Llms,
+  fileType: 'robots' | 'sitemap' | 'manifest' | 'llms'
 ): string {
   if (fileType === 'robots') {
     return resolveRobots(data as MetadataRoute.Robots)
@@ -161,6 +190,9 @@ export function resolveRouteData(
   }
   if (fileType === 'manifest') {
     return resolveManifest(data as MetadataRoute.Manifest)
+  }
+  if (fileType === 'llms') {
+    return resolveLlms(data as MetadataRoute.Llms)
   }
   return ''
 }

--- a/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-metadata-route-loader.ts
@@ -67,6 +67,7 @@ function getContentType(resourcePath: string) {
   if (name === 'favicon' && ext === 'ico') return 'image/x-icon'
   if (name === 'sitemap') return 'application/xml'
   if (name === 'robots') return 'text/plain'
+  if (name === 'llms') return 'text/plain'
   if (name === 'manifest') return 'application/manifest+json'
 
   if (ext === 'png' || ext === 'jpeg' || ext === 'ico' || ext === 'svg') {
@@ -384,7 +385,11 @@ const nextMetadataRouterLoader: webpack.LoaderDefinitionFunction<MetadataRouteLo
 
     let code = ''
     if (isDynamicRouteExtension === '1') {
-      if (fileBaseName === 'robots' || fileBaseName === 'manifest') {
+      if (
+        fileBaseName === 'robots' ||
+        fileBaseName === 'manifest' ||
+        fileBaseName === 'llms'
+      ) {
         code = await getDynamicTextRouteCode(filePath, this)
       } else if (fileBaseName === 'sitemap') {
         code = await getSitemapRouteCode(filePath, this)

--- a/packages/next/src/lib/metadata/get-metadata-route.ts
+++ b/packages/next/src/lib/metadata/get-metadata-route.ts
@@ -110,6 +110,8 @@ export function normalizeMetadataRoute(page: string) {
   let suffix = ''
   if (page === '/robots') {
     route += '.txt'
+  } else if (page === '/llms') {
+    route += '.txt'
   } else if (page === '/manifest') {
     route += '.webmanifest'
   } else {

--- a/packages/next/src/lib/metadata/is-metadata-route.test.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.test.ts
@@ -92,6 +92,9 @@ describe('isMetadataRouteFile', () => {
       )
       expect(isMetadataRouteFile('/favicon.ico', [], true)).toBe(true)
       expect(isMetadataRouteFile('/robots.txt', [], true)).toBe(true)
+      expect(isMetadataRouteFile('/llms.txt', [], true)).toBe(true)
+      // llms is root-only (global metadata), not matched in subdirectories
+      expect(isMetadataRouteFile('/foo/llms.txt', [], true)).toBe(false)
       expect(isMetadataRouteFile('/manifest.json', [], true)).toBe(true)
       expect(isMetadataRouteFile('/sitemap.xml', [], true)).toBe(true)
     })
@@ -121,7 +124,9 @@ describe('isMetadataRoute', () => {
 
   it('should match metadata routes', () => {
     expect(isMetadataRoute('/app/robots/route')).toBe(true)
+    expect(isMetadataRoute('/app/llms/route')).toBe(true)
     expect(isMetadataRoute('/robots/route')).toBe(true)
+    expect(isMetadataRoute('/llms/route')).toBe(true)
     expect(isMetadataRoute('/sitemap/[__metadata_id__]/route')).toBe(true)
     expect(isMetadataRoute('/app/sitemap/page')).toBe(false)
     expect(isMetadataRoute('/icon-a102f4/route')).toBe(true)
@@ -146,6 +151,7 @@ describe('isMetadataPage', () => {
     expect(isMetadataPage('/favicon.ico')).toBe(true)
     expect(isMetadataPage('/manifest.json')).toBe(true)
     expect(isMetadataPage('/robots.txt')).toBe(true)
+    expect(isMetadataPage('/llms.txt')).toBe(true)
   })
 
   it('should not match app router page path or error boundary path', () => {

--- a/packages/next/src/lib/metadata/is-metadata-route.ts
+++ b/packages/next/src/lib/metadata/is-metadata-route.ts
@@ -62,6 +62,7 @@ const ROBOTS_TXT_REGEX = /^[\\/]robots\.txt$/
 const MANIFEST_JSON_REGEX = /^[\\/]manifest\.json$/
 const MANIFEST_WEBMANIFEST_REGEX = /^[\\/]manifest\.webmanifest$/
 const SITEMAP_XML_REGEX = /[\\/]sitemap\.xml$/
+const LLMS_TXT_REGEX = /^[\\/]llms\.txt$/
 
 // Cache for compiled regex patterns based on parameters
 const compiledRegexCache = new Map<string, RegExp[]>()
@@ -76,12 +77,14 @@ function fastPathCheck(normalizedPath: string): boolean | null {
   if (MANIFEST_JSON_REGEX.test(normalizedPath)) return true
   if (MANIFEST_WEBMANIFEST_REGEX.test(normalizedPath)) return true
   if (SITEMAP_XML_REGEX.test(normalizedPath)) return true
+  if (LLMS_TXT_REGEX.test(normalizedPath)) return true
 
   // Quick negative check - if it doesn't contain any metadata keywords, skip
   if (
     !normalizedPath.includes('robots') &&
     !normalizedPath.includes('manifest') &&
     !normalizedPath.includes('sitemap') &&
+    !normalizedPath.includes('llms') &&
     !normalizedPath.includes('icon') &&
     !normalizedPath.includes('apple-icon') &&
     !normalizedPath.includes('opengraph-image') &&
@@ -115,6 +118,8 @@ function getCompiledRegexes(
   // Pre-compute extension arrays to avoid repeated concatenation
   const robotsExts =
     pageExtensions.length > 0 ? [...pageExtensions, 'txt'] : ['txt']
+  const llmsExts =
+    pageExtensions.length > 0 ? [...pageExtensions, 'txt'] : ['txt']
   const manifestExts =
     pageExtensions.length > 0
       ? [...pageExtensions, 'webmanifest', 'json']
@@ -123,6 +128,9 @@ function getCompiledRegexes(
   const regexes = [
     new RegExp(
       `^[\\\\/]robots${getExtensionRegexString(robotsExts, null)}${trailingMatcher}`
+    ),
+    new RegExp(
+      `^[\\\\/]llms${getExtensionRegexString(llmsExts, null)}${trailingMatcher}`
     ),
     new RegExp(
       `^[\\\\/]manifest${getExtensionRegexString(manifestExts, null)}${trailingMatcher}`
@@ -213,6 +221,7 @@ export function isStaticMetadataRoute(route: string) {
     // These routes can either be built by static or dynamic entrypoints,
     // so we assume they're dynamic
     pathname !== '/robots.txt' &&
+    pathname !== '/llms.txt' &&
     pathname !== '/manifest.webmanifest' &&
     !pathname.endsWith('/sitemap.xml')
 

--- a/packages/next/src/lib/metadata/types/metadata-interface.ts
+++ b/packages/next/src/lib/metadata/types/metadata-interface.ts
@@ -716,12 +716,32 @@ type SitemapFile = Array<{
   videos?: Videos[] | undefined
 }>
 
+type LlmsLink = {
+  title: string
+  url: string
+  description?: string | undefined
+}
+
+type LlmsSection = {
+  heading: string
+  description?: string | undefined
+  links?: LlmsLink[] | undefined
+}
+
+type LlmsFile = {
+  title: string
+  description?: string | undefined
+  details?: string | undefined
+  sections?: LlmsSection[] | undefined
+}
+
 type ResolvingMetadata = Promise<ResolvedMetadata>
 declare namespace MetadataRoute {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   export type Robots = RobotsFile
   export type Sitemap = SitemapFile
   export type Manifest = ManifestFile
+  export type Llms = string | LlmsFile
 }
 
 /**

--- a/test/e2e/app-dir/llms-txt/app/layout.tsx
+++ b/test/e2e/app-dir/llms-txt/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/llms-txt/app/llms.ts
+++ b/test/e2e/app-dir/llms-txt/app/llms.ts
@@ -1,0 +1,36 @@
+import type { MetadataRoute } from 'next'
+
+export default function llms(): MetadataRoute.Llms {
+  return {
+    title: 'My Site',
+    description: 'A description of my site',
+    details: 'Some additional details about the site.',
+    sections: [
+      {
+        heading: 'Docs',
+        description: 'Documentation section',
+        links: [
+          {
+            title: 'Getting Started',
+            url: 'https://example.com/docs/getting-started',
+            description: 'Learn how to get started',
+          },
+          {
+            title: 'API Reference',
+            url: 'https://example.com/docs/api',
+          },
+        ],
+      },
+      {
+        heading: 'Blog',
+        links: [
+          {
+            title: 'Latest Post',
+            url: 'https://example.com/blog/latest',
+            description: 'Read the latest post',
+          },
+        ],
+      },
+    ],
+  }
+}

--- a/test/e2e/app-dir/llms-txt/app/page.tsx
+++ b/test/e2e/app-dir/llms-txt/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/llms-txt/llms-txt.test.ts
+++ b/test/e2e/app-dir/llms-txt/llms-txt.test.ts
@@ -1,0 +1,68 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('llms-txt - structured object', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should serve /llms.txt with correct content-type', async () => {
+    const res = await next.fetch('/llms.txt')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/plain')
+  })
+
+  it('should render structured llms.txt content', async () => {
+    const res = await next.fetch('/llms.txt')
+    const text = await res.text()
+
+    expect(text).toContain('# My Site')
+    expect(text).toContain('> A description of my site')
+    expect(text).toContain('Some additional details about the site.')
+    expect(text).toContain('## Docs')
+    expect(text).toContain('Documentation section')
+    expect(text).toContain(
+      '- [Getting Started](https://example.com/docs/getting-started): Learn how to get started'
+    )
+    expect(text).toContain('- [API Reference](https://example.com/docs/api)')
+    expect(text).toContain('## Blog')
+    expect(text).toContain(
+      '- [Latest Post](https://example.com/blog/latest): Read the latest post'
+    )
+  })
+})
+
+describe('llms-txt - string return', () => {
+  const { next } = nextTestSetup({
+    files: {
+      'app/layout.tsx': `export default function Layout({ children }) { return <html><body>{children}</body></html> }`,
+      'app/page.tsx': `export default function Page() { return <p>hello</p> }`,
+      'app/llms.ts': `export default function llms() { return '# My Site\\n\\nCustom llms.txt content' }`,
+    },
+  })
+
+  it('should serve string llms.txt content', async () => {
+    const res = await next.fetch('/llms.txt')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/plain')
+    const text = await res.text()
+    expect(text).toBe('# My Site\n\nCustom llms.txt content')
+  })
+})
+
+describe('llms-txt - static file', () => {
+  const { next } = nextTestSetup({
+    files: {
+      'app/layout.tsx': `export default function Layout({ children }) { return <html><body>{children}</body></html> }`,
+      'app/page.tsx': `export default function Page() { return <p>hello</p> }`,
+      'app/llms.txt': `# Static Site\n\nThis is a static llms.txt file.`,
+    },
+  })
+
+  it('should serve static llms.txt file', async () => {
+    const res = await next.fetch('/llms.txt')
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/plain')
+    const text = await res.text()
+    expect(text).toContain('# Static Site')
+  })
+})

--- a/test/e2e/app-dir/llms-txt/next.config.js
+++ b/test/e2e/app-dir/llms-txt/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/production/typescript-basic/typechecking/metadata/llms.ts
+++ b/test/production/typescript-basic/typechecking/metadata/llms.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from 'next'
+// eslint-disable-next-line @typescript-eslint/no-unused-expressions
+;() => {
+  // String form
+  '# My Site' satisfies MetadataRoute.Llms
+
+  // Object form
+  ;({
+    title: 'My Site',
+    description: undefined,
+    details: undefined,
+    sections: [
+      {
+        heading: 'Docs',
+        description: undefined,
+        links: [
+          {
+            title: 'Getting Started',
+            url: 'https://example.com/docs',
+            description: undefined,
+          },
+        ],
+      },
+    ],
+  }) satisfies MetadataRoute.Llms
+}


### PR DESCRIPTION
### What?

Introduces [llms.txt](https://llmstxt.org/) metadata file (`llms.tsx` or `llms.js`) in the app router, as requested in #81182. It behaves similarly to how `sitemap.xml` or `robots.txt` generation works. 

### Why?

It's being widely adopted as best-practice for LLMs indexing. While this functionality can be achieved simply with GET routes, adopting a metadata file might make easier for maintainability and convenience.

### How?

It mimics the same functionality of sitemaps and robots to generate an internal route. It accepts both a structure output that generates a markdown file OR accepts a string if to keep control directly of the output.