### PR TITLE
Less dynamic pages manifest path

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -548,12 +548,10 @@ async function writeClientSsgManifest(
     buildId,
     distDir,
     locales,
-    deploymentId,
   }: {
     buildId: string
     distDir: string
     locales: readonly string[] | undefined
-    deploymentId: string
   }
 ) {
   const ssgPages = new Set<string>(
@@ -570,12 +568,11 @@ async function writeClientSsgManifest(
     ssgPages
   )};self.__SSG_MANIFEST_CB&&self.__SSG_MANIFEST_CB()`
 
-  // When skew protection is enabled, we instead just rely on the deployment id query string to
-  // load the correct manifests, to avoid the build id.
-  let ssgManifestPath = deploymentId
-    ? path.join(CLIENT_STATIC_FILES_PATH, '_ssgManifest.js')
-    : path.join(CLIENT_STATIC_FILES_PATH, buildId, '_ssgManifest.js')
-
+  let ssgManifestPath = path.join(
+    CLIENT_STATIC_FILES_PATH,
+    buildId,
+    '_ssgManifest.js'
+  )
   await writeFileUtf8(
     path.join(distDir, ssgManifestPath),
     clientSsgManifestContent
@@ -2591,16 +2588,11 @@ export default async function build(
               2
             )};self.__MIDDLEWARE_MATCHERS_CB && self.__MIDDLEWARE_MATCHERS_CB()`
 
-            let clientMiddlewareManifestPath = config.deploymentId
-              ? path.join(
-                  CLIENT_STATIC_FILES_PATH,
-                  TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST
-                )
-              : path.join(
-                  CLIENT_STATIC_FILES_PATH,
-                  buildId,
-                  TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST
-                )
+            let clientMiddlewareManifestPath = path.join(
+              CLIENT_STATIC_FILES_PATH,
+              buildId,
+              TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST
+            )
 
             await writeFileUtf8(
               path.join(distDir, clientMiddlewareManifestPath),
@@ -3959,7 +3951,6 @@ export default async function build(
           distDir,
           buildId,
           locales: config.i18n?.locales,
-          deploymentId: config.deploymentId,
         })
       } else {
         await writePrerenderManifest(distDir, {

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -179,7 +179,6 @@ export async function turbopackBuild(): Promise<{
       distDir,
       encryptionKey,
       dev: false,
-      deploymentId: config.deploymentId,
       sriEnabled,
     })
 

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -143,11 +143,9 @@ export async function turbopackBuild(): Promise<{
     await fs.writeFile(path.join(distDir, 'turbopack'), '')
 
     await fs.mkdir(path.join(distDir, 'server'), { recursive: true })
-    if (!config.deploymentId) {
-      await fs.mkdir(path.join(distDir, 'static', buildId), {
-        recursive: true,
-      })
-    }
+    await fs.mkdir(path.join(distDir, 'static', buildId), {
+      recursive: true,
+    })
     await fs.writeFile(
       path.join(distDir, 'package.json'),
       '{"type": "commonjs"}'

--- a/packages/next/src/build/webpack-config.ts
+++ b/packages/next/src/build/webpack-config.ts
@@ -2127,8 +2127,6 @@ export default async function getBaseWebpackConfig(
       isClient &&
         new BuildManifestPlugin({
           buildId,
-          dev,
-          deploymentId: config.deploymentId,
           rewrites,
           isDevFallback,
           appDirEnabled: hasAppDir,

--- a/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/build-manifest-plugin.ts
@@ -27,20 +27,8 @@ import {
 
 type DeepMutable<T> = { -readonly [P in keyof T]: DeepMutable<T[P]> }
 
-// nodejs: '/static/<build id>/low-priority.js'
-// or with skew protection: '/static/low-priority.js'
-function buildNodejsLowPriorityPath(
-  filename: string,
-  buildId: string,
-  dev: boolean,
-  deploymentId: string
-) {
-  if (!dev && deploymentId) {
-    // Leverage skew protection
-    return `${CLIENT_STATIC_FILES_PATH}/${filename}`
-  } else {
-    return `${CLIENT_STATIC_FILES_PATH}/${buildId}/${filename}`
-  }
+function buildNodejsLowPriorityPath(filename: string, buildId: string) {
+  return `${CLIENT_STATIC_FILES_PATH}/${buildId}/${filename}`
 }
 
 // This function takes the asset map generated in BuildManifestPlugin and creates a
@@ -113,8 +101,6 @@ export function getEntrypointFiles(entrypoint: any): string[] {
 // It has a mapping of "entry" filename to real filename. Because the real filename can be hashed in production
 export default class BuildManifestPlugin {
   private buildId: string
-  private dev: boolean
-  private deploymentId: string
   private rewrites: CustomRoutes['rewrites']
   private isDevFallback: boolean
   private appDirEnabled: boolean
@@ -122,16 +108,12 @@ export default class BuildManifestPlugin {
 
   constructor(options: {
     buildId: string
-    dev: boolean
-    deploymentId: string
     rewrites: CustomRoutes['rewrites']
     isDevFallback?: boolean
     appDirEnabled: boolean
     clientRouterFilters?: Parameters<typeof generateClientManifest>[2]
   }) {
     this.buildId = options.buildId
-    this.dev = options.dev
-    this.deploymentId = options.deploymentId
     this.isDevFallback = !!options.isDevFallback
     this.rewrites = {
       beforeFiles: [],
@@ -223,15 +205,11 @@ export default class BuildManifestPlugin {
         // downloaded by the client.
         const buildManifestPath = buildNodejsLowPriorityPath(
           '_buildManifest.js',
-          this.buildId,
-          this.dev,
-          this.deploymentId
+          this.buildId
         )
         const ssgManifestPath = buildNodejsLowPriorityPath(
           '_ssgManifest.js',
-          this.buildId,
-          this.dev,
-          this.deploymentId
+          this.buildId
         )
         assetMap.lowPriorityFiles.push(buildManifestPath, ssgManifestPath)
         compilation.emitAsset(
@@ -267,9 +245,7 @@ export default class BuildManifestPlugin {
       if (!this.isDevFallback) {
         const buildManifestPath = buildNodejsLowPriorityPath(
           '_buildManifest.js',
-          this.buildId,
-          this.dev,
-          this.deploymentId
+          this.buildId
         )
         compilation.emitAsset(
           buildManifestPath,

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -449,7 +449,6 @@ export async function createHotReloaderTurbopack(
     distDir,
     encryptionKey,
     dev: true,
-    deploymentId: nextConfig.deploymentId,
     sriEnabled: false,
   })
 

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -226,7 +226,6 @@ export class TurbopackManifestLoader {
     distDir: string
     encryptionKey: string
     dev: boolean
-    deploymentId: string
     sriEnabled: boolean
   }) {
     this.distDir = distDir

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -212,7 +212,6 @@ export class TurbopackManifestLoader {
 
   private readonly distDir: string
   private readonly buildId: string
-  private readonly deploymentId: string
   private readonly dev: boolean
   private readonly sriEnabled: boolean
 
@@ -221,7 +220,6 @@ export class TurbopackManifestLoader {
     buildId,
     encryptionKey,
     dev,
-    deploymentId,
     sriEnabled,
   }: {
     buildId: string
@@ -235,7 +233,6 @@ export class TurbopackManifestLoader {
     this.buildId = buildId
     this.encryptionKey = encryptionKey
     this.dev = dev
-    this.deploymentId = deploymentId
     this.sriEnabled = sriEnabled
   }
 
@@ -641,25 +638,16 @@ export class TurbopackManifestLoader {
 
     const sortedPageKeys = getSortedRoutes(pagesKeys)
 
-    let buildManifestPath
-    let ssgManifestPath
-    if (this.deploymentId && !this.dev) {
-      // When skew protection is enabled, we instead just rely on the deployment id query string to
-      // load the correct manifests, to avoid the build id.
-      buildManifestPath = join(CLIENT_STATIC_FILES_PATH, '_buildManifest.js')
-      ssgManifestPath = join(CLIENT_STATIC_FILES_PATH, '_ssgManifest.js')
-    } else {
-      buildManifestPath = join(
-        CLIENT_STATIC_FILES_PATH,
-        this.buildId,
-        '_buildManifest.js'
-      )
-      ssgManifestPath = join(
-        CLIENT_STATIC_FILES_PATH,
-        this.buildId,
-        '_ssgManifest.js'
-      )
-    }
+    let buildManifestPath = join(
+      CLIENT_STATIC_FILES_PATH,
+      this.buildId,
+      '_buildManifest.js'
+    )
+    let ssgManifestPath = join(
+      CLIENT_STATIC_FILES_PATH,
+      this.buildId,
+      '_ssgManifest.js'
+    )
 
     if (
       this.dev &&
@@ -850,14 +838,11 @@ export class TurbopackManifestLoader {
   private writeMiddlewareManifest(): {
     clientMiddlewareManifestPath: string
   } {
-    let clientMiddlewareManifestPath =
-      this.deploymentId && !this.dev
-        ? join(CLIENT_STATIC_FILES_PATH, TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST)
-        : join(
-            CLIENT_STATIC_FILES_PATH,
-            this.buildId,
-            TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST
-          )
+    let clientMiddlewareManifestPath = join(
+      CLIENT_STATIC_FILES_PATH,
+      this.buildId,
+      TURBOPACK_CLIENT_MIDDLEWARE_MANIFEST
+    )
 
     if (this.dev && !this.middlewareManifests.takeChanged()) {
       return {

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-asset-prefix.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-asset-prefix.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-app-asset-prefix', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       assetPrefix: '/assets',
@@ -9,9 +9,7 @@ describe('invalid-static-asset-404-app-asset-prefix', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = isNextDeploy
-      ? '/assets/_next/static/_buildManifest.js'
-      : `/assets/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/assets/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-app-base-path', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       basePath: '/base',
@@ -9,9 +9,7 @@ describe('invalid-static-asset-404-app-base-path', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = isNextDeploy
-      ? '/base/_next/static/_buildManifest.js'
-      : `/base/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/base/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-app', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = isNextDeploy
-      ? '/_next/static/_buildManifest.js'
-      : `/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-asset-prefix.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-asset-prefix.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-pages-asset-prefix', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       assetPrefix: '/assets',
@@ -9,9 +9,7 @@ describe('invalid-static-asset-404-pages-asset-prefix', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = isNextDeploy
-      ? '/assets/_next/static/_buildManifest.js'
-      : `/assets/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/assets/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-base-path.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-base-path.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-pages-base-path', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     nextConfig: {
       basePath: '/base',
@@ -9,9 +9,7 @@ describe('invalid-static-asset-404-pages-base-path', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = isNextDeploy
-      ? '/base/_next/static/_buildManifest.js'
-      : `/base/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/base/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
@@ -1,14 +1,12 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('invalid-static-asset-404-pages', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = isNextDeploy
-      ? '/_next/static/_buildManifest.js'
-      : `/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
@@ -6,7 +6,7 @@ describe('invalid-static-asset-404-pages', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
+    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
@@ -48,7 +48,7 @@ describe('Middleware custom matchers i18n', () => {
 })
 
 describe('Middleware custom matchers with root', () => {
-  const { next, isNextDeploy } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: {
       pages: new FileRef(join(__dirname, '../app', 'pages')),
       'next.config.js': new FileRef(

--- a/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
@@ -76,9 +76,7 @@ describe('Middleware custom matchers with root', () => {
 
   it('should not match', async () => {
     const res = await next.fetch(
-      isNextDeploy
-        ? '/_next/static/_buildManifest.js'
-        : `/_next/static/${next.buildId}/_buildManifest.js`
+      `/_next/static/${next.buildId}/_buildManifest.js`
     )
     expect(res.status).toBe(200)
     expect(res.headers.get('x-from-middleware')).toBeFalsy()


### PR DESCRIPTION
_Two steps forward, one step back_

Reverts https://github.com/vercel/next.js/pull/88641 and https://github.com/vercel/next.js/pull/88806

I ended up having to keep the build id in `_next/data` routes anyway (and made the id a constant if skew protection is enabled). This was because it was utterly impossible to change the routes from `_next/data/:buildId/*` to `_next/data/*` in the builder in a backwards-compatible way.

So there is no need to remove the build id from `_next/static` here either. It just makes testing a huge pain because the paths keep changing