### PR TITLE
Don't require collect-build-traces with Turbopack

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -47,9 +47,7 @@ import { getRedirectStatus, modifyRouteRegex } from '../../lib/redirect-status'
 import { getNamedRouteRegex } from '../../shared/lib/router/utils/route-regex'
 import { escapeStringRegexp } from '../../shared/lib/escape-regexp'
 import { sortSortableRoutes } from '../../shared/lib/router/utils/sortable-routes'
-import { nodeFileTrace } from 'next/dist/compiled/@vercel/nft'
 import { defaultOverrides } from '../../server/require-hook'
-import { makeIgnoreFn } from '../collect-build-traces'
 import { generateRoutesManifest } from '../generate-routes-manifest'
 import { Bundler } from '../../lib/bundler'
 
@@ -500,24 +498,6 @@ export async function handleBuildComplete({
       const pagesSharedNodeAssets: Record<string, string> = {}
       const appPagesSharedNodeAssets: Record<string, string> = {}
 
-      const sharedTraceIgnores = [
-        '**/next/dist/compiled/next-server/**/*.dev.js',
-        '**/next/dist/compiled/webpack/*',
-        '**/node_modules/webpack5/**/*',
-        '**/next/dist/server/lib/route-resolver*',
-        'next/dist/compiled/semver/semver/**/*.js',
-        '**/node_modules/react{,-dom,-dom-server-turbopack}/**/*.development.js',
-        '**/*.d.ts',
-        '**/*.map',
-        '**/next/dist/pages/**/*',
-        '**/node_modules/sharp/**/*',
-        '**/@img/sharp-libvips*/**/*',
-        '**/next/dist/compiled/edge-runtime/**/*',
-        '**/next/dist/server/web/sandbox/**/*',
-        '**/next/dist/server/post-process.js',
-      ]
-      const sharedIgnoreFn = makeIgnoreFn(tracingRoot, sharedTraceIgnores)
-
       for (const file of requiredServerFiles) {
         // add to shared node assets
         const filePath = path.join(dir, file)
@@ -576,6 +556,29 @@ export async function handleBuildComplete({
       }
 
       if (bundler !== Bundler.Turbopack) {
+        const { nodeFileTrace } =
+          require('next/dist/compiled/@vercel/nft') as typeof import('next/dist/compiled/@vercel/nft')
+        const { makeIgnoreFn } =
+          require('../collect-build-traces') as typeof import('../collect-build-traces')
+
+        const sharedTraceIgnores = [
+          '**/next/dist/compiled/next-server/**/*.dev.js',
+          '**/next/dist/compiled/webpack/*',
+          '**/node_modules/webpack5/**/*',
+          '**/next/dist/server/lib/route-resolver*',
+          'next/dist/compiled/semver/semver/**/*.js',
+          '**/node_modules/react{,-dom,-dom-server-turbopack}/**/*.development.js',
+          '**/*.d.ts',
+          '**/*.map',
+          '**/next/dist/pages/**/*',
+          '**/node_modules/sharp/**/*',
+          '**/@img/sharp-libvips*/**/*',
+          '**/next/dist/compiled/edge-runtime/**/*',
+          '**/next/dist/server/web/sandbox/**/*',
+          '**/next/dist/server/post-process.js',
+        ]
+        const sharedIgnoreFn = makeIgnoreFn(tracingRoot, sharedTraceIgnores)
+
         // These are modules that are necessary for bootstrapping node env
         const necessaryNodeDependencies = [
           require.resolve('next/dist/server/node-environment'),

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -166,7 +166,6 @@ import { startTypeChecking } from './type-check'
 import { generateInterceptionRoutesRewrites } from '../lib/generate-interception-routes-rewrites'
 
 import { buildDataRoute } from '../server/lib/router-utils/build-data-route'
-import { collectBuildTraces } from './collect-build-traces'
 import type { BuildTraceContext } from './webpack/plugins/next-trace-entrypoints-plugin'
 import { formatManifest } from './manifests/formatter/format-manifest'
 import {
@@ -2624,6 +2623,8 @@ export default async function build(
         buildTracesPromise = nextBuildSpan
           .traceChild('collect-build-traces')
           .traceAsyncFn(() => {
+            const { collectBuildTraces } =
+              require('./collect-build-traces') as typeof import('./collect-build-traces')
             return collectBuildTraces({
               dir,
               config,


### PR DESCRIPTION
So that we don't require `next/dist/compiled/@vercel/nft` or `next/dist/compiled/webpack/webpack` when using Turbopack