### PR TITLE
tests: Assert dpl query string in all tests for Turbopack

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -474,6 +474,27 @@ export function getResolveRoutes(
               if (output.locale) {
                 addRequestMeta(req, 'locale', output.locale)
               }
+
+              if (
+                process.env.__NEXT_TEST_MODE &&
+                process.env.IS_TURBOPACK_TEST &&
+                output.type === 'nextStaticFolder' &&
+                config.deploymentId
+              ) {
+                const expectedToken = config.deploymentId
+                if (parsedUrl.query.dpl !== expectedToken) {
+                  console.error(
+                    `Invalid dpl query param: ${req.url}, expected: ${expectedToken}`
+                  )
+                  return {
+                    finished: true,
+                    parsedUrl,
+                    resHeaders,
+                    matchedOutput: null,
+                  }
+                }
+              }
+
               return {
                 parsedUrl,
                 resHeaders,

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -700,9 +700,26 @@ export default class NextNodeServer extends BaseServer<
         return
       }
 
-      const { isAbsolute, href } = paramsResult
+      let { href } = paramsResult
 
-      const imageUpstream = isAbsolute
+      if (
+        process.env.__NEXT_TEST_MODE &&
+        process.env.IS_TURBOPACK_TEST &&
+        !paramsResult.isAbsolute
+      ) {
+        // Forward the dpl query param from the original /_next/image request to the
+        // internal static file request so that the static file validation in
+        // resolve-routes.ts can verify it.
+        const dpl =
+          typeof req.url === 'string'
+            ? new URL(req.url, 'http://n').searchParams.get('dpl')
+            : undefined
+        if (dpl) {
+          href += `${href.includes('?') ? '&' : '?'}dpl=${dpl}`
+        }
+      }
+
+      const imageUpstream = paramsResult.isAbsolute
         ? await fetchExternalImage(
             href,
             this.nextConfig.images.dangerouslyAllowLocalIP,

--- a/test/e2e/app-dir-export/test/utils.ts
+++ b/test/e2e/app-dir-export/test/utils.ts
@@ -210,6 +210,7 @@ export function runTests({
     files: join(__dirname, '..'),
     skipDeployment: true,
     skipStart: true,
+    disableAutoSkewProtection: true,
   })
   if (skipped) {
     return

--- a/test/e2e/app-dir/app-esm-js/standalone.test.ts
+++ b/test/e2e/app-dir/app-esm-js/standalone.test.ts
@@ -52,6 +52,7 @@ if (!(globalThis as any).isNextStart) {
           /- Local:/,
           {
             ...process.env,
+            ...next.env,
             PORT: appPort.toString(),
           },
           undefined,

--- a/test/e2e/app-dir/app/standalone-gsp.test.ts
+++ b/test/e2e/app-dir/app/standalone-gsp.test.ts
@@ -69,6 +69,7 @@ if (!(globalThis as any).isNextStart) {
           /- Local:/,
           {
             ...process.env,
+            ...next.env,
             PORT: appPort.toString(),
           },
           undefined,

--- a/test/e2e/app-dir/app/standalone.test.ts
+++ b/test/e2e/app-dir/app/standalone.test.ts
@@ -73,6 +73,7 @@ if (!(globalThis as any).isNextStart) {
           /- Local:/,
           {
             ...process.env,
+            ...next.env,
             PORT: appPort.toString(),
           },
           undefined,

--- a/test/e2e/app-dir/mdx/mdx.test.ts
+++ b/test/e2e/app-dir/mdx/mdx.test.ts
@@ -61,7 +61,7 @@ for (const type of ['with-mdx-rs', 'without-mdx-rs']) {
       it('should work with next/image', async () => {
         const $ = await next.render$('/image')
         expect($('img').attr('src')).toBe(
-          '/_next/image?url=%2Ftest.jpg&w=384&q=75'
+          `/_next/image?url=%2Ftest.jpg&w=384&q=75${next.getDeploymentIdQuery(true)}`
         )
       })
 

--- a/test/e2e/app-dir/next-image/next-image-proxy.test.ts
+++ b/test/e2e/app-dir/next-image/next-image-proxy.test.ts
@@ -1,5 +1,5 @@
 import { join } from 'path'
-import { findPort, check } from 'next-test-utils'
+import { findPort, retry } from 'next-test-utils'
 import https from 'https'
 import httpProxy from 'http-proxy'
 import fs from 'fs'
@@ -77,32 +77,21 @@ describe('next-image-proxy', () => {
     })
 
     const local = await browser.elementByCss('#app-page').getAttribute('src')
-
-    if (process.env.IS_TURBOPACK_TEST) {
-      expect(local).toMatchInlineSnapshot(
-        `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=90"`
-      )
-    } else {
-      expect(local).toMatchInlineSnapshot(
-        `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90"`
-      )
-    }
+    expect(local.replace(/test\.[0-9a-f]{8,}\.png/g, 'test.HASH.png')).toEqual(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=90${next.getAssetQuery(true)}`
+    )
 
     const remote = await browser
       .elementByCss('#remote-app-page')
       .getAttribute('src')
-    if (process.env.IS_TURBOPACK_TEST) {
-      expect(remote).toMatchInlineSnapshot(
-        `"/_next/image?url=https%3A%2F%2Fimage-optimization-test.vercel.app%2Ftest.jpg&w=640&q=90"`
-      )
-    } else {
-      expect(remote).toMatchInlineSnapshot(
-        `"/_next/image?url=https%3A%2F%2Fimage-optimization-test.vercel.app%2Ftest.jpg&w=640&q=90"`
-      )
-    }
+    expect(remote).toEqual(
+      `/_next/image?url=https%3A%2F%2Fimage-optimization-test.vercel.app%2Ftest.jpg&w=640&q=90`
+    )
 
-    const expected = JSON.stringify({ fulfilledCount: 4, failCount: 0 })
-    await check(() => JSON.stringify({ fulfilledCount, failCount }), expected)
+    await retry(() => {
+      expect(fulfilledCount).toBe(4)
+      expect(failCount).toBe(0)
+    })
     await browser.close()
   })
 

--- a/test/e2e/app-dir/next-image/next-image.test.ts
+++ b/test/e2e/app-dir/next-image/next-image.test.ts
@@ -1,151 +1,106 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextDeploy, nextTestSetup } from 'e2e-utils'
 import fs from 'fs-extra'
 import { join } from 'path'
 
 describe('app dir - next-image', () => {
-  const { next, skipped } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
-    skipDeployment: true,
   })
 
-  if (skipped) {
-    return
-  }
-
   describe('ssr content', () => {
-    it('should handle HEAD requests for uncached images', async () => {
-      const imagesDir = join(next.testDir, '.next/cache/images')
-      await fs.remove(imagesDir).catch(() => {})
+    if (!isNextDeploy) {
+      it('should handle HEAD requests for uncached images', async () => {
+        const imagesDir = join(next.testDir, '.next/cache/images')
+        await fs.remove(imagesDir).catch(() => {})
 
-      const $ = await next.render$('/')
-      const imageUrl = $('#app-layout').attr('src')
+        const $ = await next.render$('/')
+        const imageUrl = $('#app-layout').attr('src')
 
-      const headRes = await next.fetch(imageUrl, { method: 'HEAD' })
-      expect(headRes.status).toBe(200)
-      expect(headRes.headers.get('content-type')).toMatch(/^image\//)
-      expect(headRes.headers.get('X-Nextjs-Cache')).toBe('MISS')
+        const headRes = await next.fetch(imageUrl, { method: 'HEAD' })
+        expect(headRes.status).toBe(200)
+        expect(headRes.headers.get('content-type')).toMatch(/^image\//)
+        expect(headRes.headers.get('X-Nextjs-Cache')).toBe('MISS')
 
-      const contentLength = headRes.headers.get('content-length')
-      expect(Number(contentLength || '0')).toBeGreaterThan(0)
-      const headBody = await headRes.arrayBuffer()
-      expect(headBody.byteLength).toBe(0)
+        const contentLength = headRes.headers.get('content-length')
+        expect(Number(contentLength || '0')).toBeGreaterThan(0)
+        const headBody = await headRes.arrayBuffer()
+        expect(headBody.byteLength).toBe(0)
 
-      const getRes = await next.fetch(imageUrl)
-      expect(getRes.status).toBe(200)
-      expect(getRes.headers.get('content-type')).toMatch(/^image\//)
-      expect(getRes.headers.get('X-Nextjs-Cache')).toBe('HIT')
+        const getRes = await next.fetch(imageUrl)
+        expect(getRes.status).toBe(200)
+        expect(getRes.headers.get('content-type')).toMatch(/^image\//)
+        expect(getRes.headers.get('X-Nextjs-Cache')).toBe('HIT')
 
-      const getContentLength = getRes.headers.get('content-length')
-      expect(Number(getContentLength || '0')).toBeGreaterThan(0)
+        const getContentLength = getRes.headers.get('content-length')
+        expect(Number(getContentLength || '0')).toBeGreaterThan(0)
 
-      const getBody = await getRes.arrayBuffer()
-      expect(getBody.byteLength).toBeGreaterThan(0)
-      expect(getBody.byteLength).toBe(Number(getContentLength))
-    })
+        const getBody = await getRes.arrayBuffer()
+        expect(getBody.byteLength).toBeGreaterThan(0)
+        expect(getBody.byteLength).toBe(Number(getContentLength))
+      })
+    }
 
     it('should render images on / route', async () => {
       const $ = await next.render$('/')
 
       const layout = $('#app-layout')
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(layout.attr('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=85"`
-        )
-      } else {
-        expect(layout.attr('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85"`
-        )
-      }
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(layout.attr('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=85 2x"`
-        )
-      } else {
-        expect(layout.attr('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x"`
-        )
-      }
+      expect(stripTestHash(layout.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)}`
+      )
+      expect(stripTestHash(layout.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=85${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)} 2x`
+      )
 
       const page = $('#app-page')
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(page.attr('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=90"`
-        )
-      } else {
-        expect(page.attr('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90"`
-        )
-      }
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(page.attr('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=90 2x"`
-        )
-      } else {
-        expect(page.attr('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90 2x"`
-        )
-      }
+      expect(stripTestHash(page.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=90${next.getAssetQuery(true)}`
+      )
+      expect(stripTestHash(page.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=90${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=90${next.getAssetQuery(true)} 2x`
+      )
 
       const comp = $('#app-comp')
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(comp.attr('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=80"`
-        )
-      } else {
-        expect(comp.attr('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80"`
-        )
-      }
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(comp.attr('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=80 2x"`
-        )
-      } else {
-        expect(comp.attr('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80 2x"`
-        )
-      }
+      expect(stripTestHash(comp.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=80${next.getAssetQuery(true)}`
+      )
+      expect(stripTestHash(comp.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=80${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=80${next.getAssetQuery(true)} 2x`
+      )
     })
 
     it('should render images on /client route', async () => {
       const $ = await next.render$('/client')
 
       const root = $('#app-layout')
-      expect(root.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=85/
+      expect(stripTestHash(root.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)}`
       )
-      expect(root.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=640&q=85 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=85 2x/
+      expect(stripTestHash(root.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=85${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)} 2x`
       )
 
       const layout = $('#app-client-layout')
-      expect(layout.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=55/
+      expect(stripTestHash(layout.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=55${next.getAssetQuery(true)}`
       )
-      expect(layout.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=640&q=55 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=55 2x/
+      expect(stripTestHash(layout.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=55${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=55${next.getAssetQuery(true)} 2x`
       )
 
       const page = $('#app-client-page')
-      expect(page.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=60/
+      expect(stripTestHash(page.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=60${next.getAssetQuery(true)}`
       )
-      expect(page.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=640&q=60 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=60 2x/
+      expect(stripTestHash(page.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=60${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=60${next.getAssetQuery(true)} 2x`
       )
 
       const comp = $('#app-client-comp')
-      expect(comp.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=50/
+      expect(stripTestHash(comp.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=50${next.getAssetQuery(true)}`
       )
-      expect(comp.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=640&q=50 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=50 2x/
+      expect(stripTestHash(comp.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=50${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=50${next.getAssetQuery(true)} 2x`
       )
     })
 
@@ -153,35 +108,35 @@ describe('app dir - next-image', () => {
       const $ = await next.render$('/nested')
 
       const root = $('#app-layout')
-      expect(root.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=85/
+      expect(stripTestHash(root.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)}`
       )
-      expect(root.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=640&q=85 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=85 2x/
+      expect(stripTestHash(root.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=85${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)} 2x`
       )
 
       const layout = $('#app-nested-layout')
-      expect(layout.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=70/
+      expect(stripTestHash(layout.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=70${next.getAssetQuery(true)}`
       )
-      expect(layout.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=640&q=70 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=70 2x/
+      expect(stripTestHash(layout.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=70${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=70${next.getAssetQuery(true)} 2x`
       )
 
       const page = $('#app-nested-page')
-      expect(page.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=75/
+      expect(stripTestHash(page.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${next.getAssetQuery(true)}`
       )
-      expect(page.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=640&q=75 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=75 2x/
+      expect(stripTestHash(page.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=75${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${next.getAssetQuery(true)} 2x`
       )
 
       const comp = $('#app-nested-comp')
-      expect(comp.attr('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=65/
+      expect(stripTestHash(comp.attr('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=65${next.getAssetQuery(true)}`
       )
-      expect(comp.attr('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=640&q=65 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=65 2x/
+      expect(stripTestHash(comp.attr('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=65${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=65${next.getAssetQuery(true)} 2x`
       )
     })
   })
@@ -191,105 +146,63 @@ describe('app dir - next-image', () => {
       const browser = await next.browser('/')
 
       const layout = await browser.elementById('app-layout')
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(await layout.getAttribute('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=85"`
-        )
-      } else {
-        expect(await layout.getAttribute('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85"`
-        )
-      }
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(await layout.getAttribute('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=85 2x"`
-        )
-      } else {
-        expect(await layout.getAttribute('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=85 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=85 2x"`
-        )
-      }
+      expect(stripTestHash(await layout.getAttribute('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)}`
+      )
+      expect(stripTestHash(await layout.getAttribute('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=85${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)} 2x`
+      )
 
       const page = await browser.elementById('app-page')
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(await page.getAttribute('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=90"`
-        )
-      } else {
-        expect(await page.getAttribute('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90"`
-        )
-      }
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(await page.getAttribute('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=90 2x"`
-        )
-      } else {
-        expect(await page.getAttribute('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=90 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=90 2x"`
-        )
-      }
+      expect(stripTestHash(await page.getAttribute('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=90${next.getAssetQuery(true)}`
+      )
+      expect(stripTestHash(await page.getAttribute('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=90${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=90${next.getAssetQuery(true)} 2x`
+      )
 
       const comp = await browser.elementById('app-comp')
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(await comp.getAttribute('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=80"`
-        )
-      } else {
-        expect(await comp.getAttribute('src')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80"`
-        )
-      }
-
-      if (process.env.IS_TURBOPACK_TEST) {
-        expect(await comp.getAttribute('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.c5ae911e.png&w=828&q=80 2x"`
-        )
-      } else {
-        expect(await comp.getAttribute('srcset')).toMatchInlineSnapshot(
-          `"/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=640&q=80 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.3f1a293b.png&w=828&q=80 2x"`
-        )
-      }
+      expect(stripTestHash(await comp.getAttribute('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=80${next.getAssetQuery(true)}`
+      )
+      expect(stripTestHash(await comp.getAttribute('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=80${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=80${next.getAssetQuery(true)} 2x`
+      )
     })
 
     it('should render images nested under page dir on /nested route', async () => {
       const browser = await next.browser('/nested')
 
       const root = await browser.elementById('app-layout')
-      expect(await root.getAttribute('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=85/
+      expect(stripTestHash(await root.getAttribute('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)}`
       )
-      expect(await root.getAttribute('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=640&q=85 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.png&w=828&q=85 2x/
+      expect(stripTestHash(await root.getAttribute('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=85${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=85${next.getAssetQuery(true)} 2x`
       )
 
       const layout = await browser.elementById('app-nested-layout')
-      expect(await layout.getAttribute('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=70/
+      expect(stripTestHash(await layout.getAttribute('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=70${next.getAssetQuery(true)}`
       )
-      expect(await layout.getAttribute('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=640&q=70 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=70 2x/
+      expect(stripTestHash(await layout.getAttribute('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=70${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=70${next.getAssetQuery(true)} 2x`
       )
 
       const page = await browser.elementById('app-nested-page')
-      expect(await page.getAttribute('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=75/
+      expect(stripTestHash(await page.getAttribute('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${next.getAssetQuery(true)}`
       )
-      expect(await page.getAttribute('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=640&q=75 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=75 2x/
+      expect(stripTestHash(await page.getAttribute('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=75${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${next.getAssetQuery(true)} 2x`
       )
 
       const comp = await browser.elementById('app-nested-comp')
-      expect(await comp.getAttribute('src')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=65/
+      expect(stripTestHash(await comp.getAttribute('src'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=65${next.getAssetQuery(true)}`
       )
-      expect(await comp.getAttribute('srcset')).toMatch(
-        /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=640&q=65 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.([^.]+)\.jpg&w=828&q=65 2x/
+      expect(stripTestHash(await comp.getAttribute('srcset'))).toBe(
+        `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=65${next.getAssetQuery(true)} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=65${next.getAssetQuery(true)} 2x`
       )
     })
   })
@@ -376,3 +289,7 @@ describe('app dir - next-image', () => {
     })
   })
 })
+
+function stripTestHash(text: string) {
+  return text.replace(/test\.[0-9a-f]{8,}\.(png|jpe?g)/g, 'test.HASH.$1')
+}

--- a/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
+++ b/test/e2e/app-dir/node-worker-threads/node-worker-threads.test.ts
@@ -75,8 +75,8 @@ describe('node-worker-threads', () => {
       /\/_next\/static.*\/test-image\.[a-f0-9]+\.png/
     )
     if (!isNextDev) {
-      expect(next.deploymentId).toMatch(/.+/)
-      expect(url.searchParams.get('dpl')).toBe(next.deploymentId)
+      expect(next.assetToken).toMatch(/.+/)
+      expect(url.searchParams.get('dpl')).toBe(next.assetToken)
     }
 
     // Now fetch the PNG URL from the client to verify it's accessible

--- a/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
+++ b/test/e2e/app-dir/segment-cache/deployment-skew/deployment-skew.test.ts
@@ -65,6 +65,7 @@ describe('segment cache (deployment skew)', () => {
         // rely on skew protection when deployed
         NEXT_DEPLOYMENT_ID: isNextDeploy ? undefined : 'test-deployment-id',
       },
+      disableAutoSkewProtection: true,
     })
 
     // Deployment skew is hard to properly e2e deploy test, so this just checks for the header.

--- a/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
+++ b/test/e2e/app-dir/segment-cache/export/segment-cache-output-export.test.ts
@@ -22,7 +22,10 @@ describe('segment cache (output: "export")', () => {
 
   beforeAll(async () => {
     const appDir = __dirname
-    await nextBuild(appDir, undefined, { cwd: appDir })
+    await nextBuild(appDir, undefined, {
+      cwd: appDir,
+      disableAutoSkewProtection: true,
+    })
     port = await findPort()
     server.listen(port)
   })

--- a/test/e2e/app-dir/worker/worker.test.ts
+++ b/test/e2e/app-dir/worker/worker.test.ts
@@ -8,6 +8,7 @@ describe('app dir - workers', () => {
     env: {
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
     },
+    disableAutoSkewProtection: true,
   })
 
   function beforePageLoad(page: Page) {

--- a/test/e2e/app-dir/worker/worker.test.ts
+++ b/test/e2e/app-dir/worker/worker.test.ts
@@ -18,7 +18,7 @@ describe('app dir - workers', () => {
         const url = request.url()
         if (url.includes('/_next/')) {
           let parsed = new URL(url, next.url)
-          expect(parsed.searchParams.get('dpl')).toBe(next.deploymentId)
+          expect(parsed.searchParams.get('dpl')).toBe(next.assetToken)
         }
       })
     }

--- a/test/e2e/app-document/rendering.test.ts
+++ b/test/e2e/app-document/rendering.test.ts
@@ -89,13 +89,11 @@ describe('Document and App - Rendering via HTTP', () => {
         })
         $('link[rel=preload]').each((index, element) => {
           const href = $(element).attr('href')
-          expect(href.match(/\?/g)).toHaveLength(1)
-          expect(href).toMatch(/\?ts=/)
+          expect(href).toMatch(/^[^?]+\?ts=\d+$/)
         })
         $('script[src]').each((index, element) => {
           const src = $(element).attr('src')
-          expect(src.match(/\?/g)).toHaveLength(1)
-          expect(src).toMatch(/\?ts=/)
+          expect(src).toMatch(/^[^?]+\?ts=\d+$/)
         })
       })
     }

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-asset-prefix.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-asset-prefix.test.ts
@@ -9,7 +9,7 @@ describe('invalid-static-asset-404-app-asset-prefix', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/assets/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/assets/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app-base-path.test.ts
@@ -9,7 +9,7 @@ describe('invalid-static-asset-404-app-base-path', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/base/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/base/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app.test.ts
+++ b/test/e2e/invalid-static-asset-404-app/invalid-static-asset-404-app.test.ts
@@ -6,7 +6,7 @@ describe('invalid-static-asset-404-app', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-asset-prefix.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-asset-prefix.test.ts
@@ -9,7 +9,7 @@ describe('invalid-static-asset-404-pages-asset-prefix', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/assets/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/assets/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-base-path.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages-base-path.test.ts
@@ -9,7 +9,7 @@ describe('invalid-static-asset-404-pages-base-path', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/base/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/base/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
+++ b/test/e2e/invalid-static-asset-404-pages/invalid-static-asset-404-pages.test.ts
@@ -6,7 +6,7 @@ describe('invalid-static-asset-404-pages', () => {
   })
 
   it('should return correct output with status 200 on valid asset path', async () => {
-    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js`
+    const buildManifestPath = `/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
 
     const res = await next.fetch(buildManifestPath)
     expect(res.status).toBe(200)

--- a/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
+++ b/test/e2e/middleware-custom-matchers-i18n/test/index.test.ts
@@ -76,7 +76,7 @@ describe('Middleware custom matchers with root', () => {
 
   it('should not match', async () => {
     const res = await next.fetch(
-      `/_next/static/${next.buildId}/_buildManifest.js`
+      `/_next/static/${next.buildId}/_buildManifest.js${next.getDeploymentIdQuery()}`
     )
     expect(res.status).toBe(200)
     expect(res.headers.get('x-from-middleware')).toBeFalsy()

--- a/test/e2e/pages-ssg-data-deployment-skew/pages-ssg-data-deployment-skew.test.ts
+++ b/test/e2e/pages-ssg-data-deployment-skew/pages-ssg-data-deployment-skew.test.ts
@@ -125,6 +125,7 @@ describe('pages ssg data deployment skew - hard navigate when a new deployment o
               NEXT_DEPLOYMENT_ID: NEXT_DEPLOYMENT_ID1,
               OUTPUT_MODE,
             },
+            disableAutoSkewProtection: true,
           })
           let appPort1 = await findPort()
           apps.push(
@@ -134,6 +135,7 @@ describe('pages ssg data deployment skew - hard navigate when a new deployment o
                 NEXT_DEPLOYMENT_ID: NEXT_DEPLOYMENT_ID1,
                 OUTPUT_MODE,
               },
+              disableAutoSkewProtection: true,
             })
           )
 
@@ -142,6 +144,7 @@ describe('pages ssg data deployment skew - hard navigate when a new deployment o
               DIST_DIR: '2',
               NEXT_DEPLOYMENT_ID: NEXT_DEPLOYMENT_ID2,
             },
+            disableAutoSkewProtection: true,
           })
           let appPort2 = await findPort()
           apps.push(
@@ -150,6 +153,7 @@ describe('pages ssg data deployment skew - hard navigate when a new deployment o
                 DIST_DIR: '2',
                 NEXT_DEPLOYMENT_ID: NEXT_DEPLOYMENT_ID2,
               },
+              disableAutoSkewProtection: true,
             })
           )
 

--- a/test/e2e/streaming-ssr/index.test.ts
+++ b/test/e2e/streaming-ssr/index.test.ts
@@ -102,6 +102,7 @@ if (isNextProd) {
         /Listening/,
         {
           ...process.env,
+          ...next.env,
           PORT: appPort,
         },
         undefined,

--- a/test/e2e/twoslash/standalone.test.ts
+++ b/test/e2e/twoslash/standalone.test.ts
@@ -47,6 +47,7 @@ if (!(globalThis as any).isNextStart) {
         /- Local:/,
         {
           ...process.env,
+          ...next.env,
           PORT: appPort.toString(),
         },
         undefined,

--- a/test/e2e/url/url.test.ts
+++ b/test/e2e/url/url.test.ts
@@ -43,7 +43,7 @@ describe(`Handle new URL asset references`, () => {
     if (isNextDev || !isTurbopack) {
       expectedToken = undefined
     } else {
-      expectedToken = next.deploymentId
+      expectedToken = next.assetToken
       if (!expectedToken) {
         throw new Error('Missing deployment id')
       }

--- a/test/e2e/url/url.test.ts
+++ b/test/e2e/url/url.test.ts
@@ -16,6 +16,9 @@ describe(`Handle new URL asset references`, () => {
     env: {
       // rely on skew protection when deployed
       NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
+      VERCEL_IMMUTABLE_DEPLOYMENT_ID: isNextStart
+        ? 'test-immutable-tkn-7890'
+        : undefined,
     },
     skipDeployment: true,
   })

--- a/test/integration/api-support/pages/api/proxy-self.js
+++ b/test/integration/api-support/pages/api/proxy-self.js
@@ -5,7 +5,9 @@ export default async function handler(req, res) {
   const proxy = httpProxy.createProxy({
     target: `http://127.0.0.1:${port}/${
       req.query.buildId
-        ? `_next/static/${req.query.buildId}/_ssgManifest.js`
+        ? process.env.NEXT_DEPLOYMENT_ID
+          ? `_next/static/${req.query.buildId}/_ssgManifest.js?dpl=${process.env.NEXT_DEPLOYMENT_ID}`
+          : `_next/static/${req.query.buildId}/_ssgManifest.js`
         : `user`
     }`,
     ignorePath: true,

--- a/test/integration/critical-css/test/index.test.ts
+++ b/test/integration/critical-css/test/index.test.ts
@@ -37,7 +37,7 @@ function runTests() {
   it('should inline critical CSS', async () => {
     const html = await renderViaHTTP(appPort, '/')
     expect(html).toMatch(
-      /<link rel="stylesheet" href="\/_next\/static\/.*\.css" .*>/
+      /<link rel="stylesheet" href="\/_next\/static\/.*\.css(\?dpl=.*)?" .*>/
     )
     expect(html).toMatch(/body{/)
   })
@@ -45,7 +45,7 @@ function runTests() {
   it('should inline critical CSS (dynamic)', async () => {
     const html = await renderViaHTTP(appPort, '/another')
     expect(html).toMatch(
-      /<link rel="stylesheet" href="\/_next\/static\/.*\.css" .*>/
+      /<link rel="stylesheet" href="\/_next\/static\/.*\.css(\?dpl=.*)?" .*>/
     )
     expect(html).toMatch(/body{/)
   })
@@ -70,9 +70,12 @@ describe('CSS optimization for SSR apps', () => {
         if (fs.pathExistsSync(join(appDir, '.next'))) {
           await fs.remove(join(appDir, '.next'))
         }
-        await nextBuild(appDir)
+        // TODO optimizeCss is broken when ?dpl is added to CSS URLs
+        await nextBuild(appDir, undefined, { disableAutoSkewProtection: true })
         appPort = await findPort()
-        app = await nextStart(appDir, appPort)
+        app = await nextStart(appDir, appPort, {
+          disableAutoSkewProtection: true,
+        })
       })
       afterAll(async () => {
         await killApp(app)

--- a/test/integration/custom-routes/test/index.test.ts
+++ b/test/integration/custom-routes/test/index.test.ts
@@ -2653,12 +2653,15 @@ describe('Custom routes', () => {
           {
             stdout: true,
             stderr: true,
+            disableAutoSkewProtection: true,
           }
         )
         stdout = buildStdout
         stderr = buildStderr
         appPort = await findPort()
-        app = await nextStart(appDir, appPort)
+        app = await nextStart(appDir, appPort, {
+          disableAutoSkewProtection: true,
+        })
         buildId = await fs.readFile(join(appDir, '.next/BUILD_ID'), 'utf8')
       })
       afterAll(() => killApp(app))

--- a/test/integration/dynamic-routing/test/index.test.ts
+++ b/test/integration/dynamic-routing/test/index.test.ts
@@ -1582,8 +1582,6 @@ function runTests({ dev }) {
   }
 }
 
-const nextConfig = join(appDir, 'next.config.js')
-
 describe('Dynamic Routing', () => {
   if (process.env.__MIDDLEWARE_TEST) {
     const middlewarePath = join(__dirname, '../middleware.js')
@@ -1606,8 +1604,6 @@ describe('Dynamic Routing', () => {
     'development mode',
     () => {
       beforeAll(async () => {
-        await fs.remove(nextConfig)
-
         appPort = await findPort()
         app = await launchApp(appDir, appPort)
         buildId = 'development'
@@ -1621,13 +1617,15 @@ describe('Dynamic Routing', () => {
     'production mode',
     () => {
       beforeAll(async () => {
-        await fs.remove(nextConfig)
-
-        await nextBuild(appDir)
+        await nextBuild(appDir, undefined, {
+          disableAutoSkewProtection: true,
+        })
         buildId = await fs.readFile(buildIdPath, 'utf8')
 
         appPort = await findPort()
-        app = await nextStart(appDir, appPort)
+        app = await nextStart(appDir, appPort, {
+          disableAutoSkewProtection: true,
+        })
       })
       afterAll(() => killApp(app))
 

--- a/test/integration/i18n-support/test/shared.ts
+++ b/test/integration/i18n-support/test/shared.ts
@@ -13,6 +13,7 @@ import {
   waitFor,
   normalizeRegEx,
   check,
+  getDeploymentId,
 } from 'next-test-utils'
 
 const domainLocales = ['go', 'go-BE', 'do', 'do-BE']
@@ -61,16 +62,22 @@ export function runTests(ctx) {
       cwd: join(ctx.appDir, '.next/static'),
     })
 
+    const deploymentDpl = getDeploymentId(ctx.appDir, ctx.isDev)
+
     // Only use a subset of the locales to speed up the test
     for (const locale of [
       ...nonDomainLocales.slice(0, 2),
       ...domainLocales.slice(0, 2),
     ]) {
       for (const asset of assets) {
+        const dpl = asset.includes(ctx.buildId)
+          ? deploymentDpl.getDeploymentIdQuery()
+          : deploymentDpl.getAssetQuery()
+
         // _next/static asset
         const res = await fetchViaHTTP(
           ctx.appPort,
-          `${ctx.basePath || ''}/${locale}/_next/static/${encodeURI(asset)}`,
+          `${ctx.basePath || ''}/${locale}/_next/static/${encodeURI(asset)}${dpl}`,
           undefined,
           { redirect: 'manual' }
         )

--- a/test/integration/image-optimizer/test/util.ts
+++ b/test/integration/image-optimizer/test/util.ts
@@ -8,6 +8,7 @@ import {
   fetchViaHTTP,
   File,
   findPort,
+  getDeploymentId,
   getDistDir,
   killApp,
   launchApp,
@@ -1522,10 +1523,14 @@ export function runTests(ctx: RunTestsCtx) {
         .readdirSync(join(ctx.appDir, '.next/static/media'))
         .find((f) => /^test\.[0-9a-f]+\.jpg$/.test(f))
       expect(filename).toBeString()
-      const query = {
+      const query: Record<string, string> = {
         url: `/_next/static/media/${filename}`,
-        w: ctx.w,
-        q: ctx.q,
+        w: String(ctx.w),
+        q: String(ctx.q),
+      }
+      const assetToken = getDeploymentId(ctx.appDir, false).assetToken
+      if (assetToken) {
+        query.dpl = assetToken
       }
       const opts = { headers: { accept: 'image/webp' } }
 

--- a/test/integration/next-image-legacy/base-path/test/index.test.ts
+++ b/test/integration/next-image-legacy/base-path/test/index.test.ts
@@ -11,6 +11,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  getDeploymentId,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -58,7 +59,12 @@ function getRatio(width, height) {
   return height / width
 }
 
-function runTests(mode) {
+function runTests(mode: 'dev' | 'server') {
+  let dpl: string
+  beforeAll(() => {
+    dpl = getDeploymentId(appDir, mode === 'dev').getDeploymentIdQuery(true)
+  })
+
   it('should load the images', async () => {
     let browser = await webdriver(appPort, '/docs')
     try {
@@ -75,7 +81,7 @@ function runTests(mode) {
       }, /result-correct/)
 
       expect(await getImageUrls(browser)).toContain(
-        `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75`
+        `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75${dpl}`
       )
     } finally {
       await browser.close()
@@ -127,10 +133,10 @@ function runTests(mode) {
       const delta = 250
       const id = 'fixed1'
       expect(await getSrc(browser, id)).toBe(
-        '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+        `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl}`
       )
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1x, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 2x'
+        `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75${dpl} 1x, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl} 2x`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBeFalsy()
       await browser.setDimensions({
@@ -160,12 +166,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1x, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 2x'
+        `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75${dpl} 1x, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl} 2x`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBeFalsy()
       await browser.setDimensions({
@@ -201,12 +207,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
+        `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75${dpl} 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75${dpl} 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75${dpl} 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75${dpl} 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75${dpl} 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75${dpl} 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75${dpl} 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       await browser.setDimensions({
@@ -242,12 +248,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
+        `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75${dpl} 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75${dpl} 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75${dpl} 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75${dpl} 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75${dpl} 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75${dpl} 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75${dpl} 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       await browser.setDimensions({
@@ -283,12 +289,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
+        `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75${dpl} 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75${dpl} 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75${dpl} 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75${dpl} 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75${dpl} 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75${dpl} 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75${dpl} 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       expect(await getComputed(browser, id, 'width')).toBe(width)
@@ -334,12 +340,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75'
+          `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/docs/_next/image?url=%2Fdocs%2Fwide.png&w=32&q=75 32w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=48&q=75 48w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=64&q=75 64w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=96&q=75 96w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=128&q=75 128w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=256&q=75 256w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=384&q=75 384w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75 3840w'
+        `/docs/_next/image?url=%2Fdocs%2Fwide.png&w=32&q=75${dpl} 32w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=48&q=75${dpl} 48w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=64&q=75${dpl} 64w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=96&q=75${dpl} 96w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=128&q=75${dpl} 128w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=256&q=75${dpl} 256w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=384&q=75${dpl} 384w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=640&q=75${dpl} 640w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=750&q=75${dpl} 750w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=828&q=75${dpl} 828w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1080&q=75${dpl} 1080w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1200&q=75${dpl} 1200w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=1920&q=75${dpl} 1920w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=2048&q=75${dpl} 2048w, /docs/_next/image?url=%2Fdocs%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBe(
         '(max-width: 2048px) 1200px, 3840px'

--- a/test/integration/next-image-legacy/default/test/index.test.ts
+++ b/test/integration/next-image-legacy/default/test/index.test.ts
@@ -15,6 +15,7 @@ import {
   nextStart,
   renderViaHTTP,
   waitFor,
+  getDeploymentId,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -68,7 +69,12 @@ function getRatio(width, height) {
   return height / width
 }
 
-function runTests(mode) {
+function runTests(mode: 'dev' | 'server') {
+  let dpl: string
+  beforeAll(() => {
+    dpl = getDeploymentId(appDir, mode === 'dev').getDeploymentIdQuery(true)
+  })
+
   it('should load the images', async () => {
     let browser
     try {
@@ -87,7 +93,7 @@ function runTests(mode) {
       }, /result-correct/)
 
       expect(await getImageUrls(browser)).toContain(
-        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75${dpl}`
       )
     } finally {
       if (browser) {
@@ -120,31 +126,27 @@ function runTests(mode) {
         const imagesizes = await link.getAttribute('imagesizes')
         entries.push({ imagesrcset, imagesizes })
       }
+
       expect(entries).toEqual([
         {
           imagesizes: '',
-          imagesrcset:
-            '/_next/image?url=%2Ftest.jpg&w=640&q=75 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75 2x',
+          imagesrcset: `/_next/image?url=%2Ftest.jpg&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.jpg&w=828&q=75${dpl} 2x`,
         },
         {
           imagesizes: '',
-          imagesrcset:
-            '/_next/image?url=%2Ftest.gif&w=640&q=75 1x, /_next/image?url=%2Ftest.gif&w=828&q=75 2x',
+          imagesrcset: `/_next/image?url=%2Ftest.gif&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.gif&w=828&q=75${dpl} 2x`,
         },
         {
           imagesizes: '',
-          imagesrcset:
-            '/_next/image?url=%2Ftest.png&w=640&q=75 1x, /_next/image?url=%2Ftest.png&w=828&q=75 2x',
+          imagesrcset: `/_next/image?url=%2Ftest.png&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.png&w=828&q=75${dpl} 2x`,
         },
         {
           imagesizes: '100vw',
-          imagesrcset:
-            '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w',
+          imagesrcset: `/_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`,
         },
         {
           imagesizes: '',
-          imagesrcset:
-            '/_next/image?url=%2Ftest.tiff&w=640&q=75 1x, /_next/image?url=%2Ftest.tiff&w=828&q=75 2x',
+          imagesrcset: `/_next/image?url=%2Ftest.tiff&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.tiff&w=828&q=75${dpl} 2x`,
         },
       ])
 
@@ -480,12 +482,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x'
+        `/_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1x, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 2x`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBeFalsy()
       await browser.setDimensions({
@@ -518,12 +520,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x'
+        `/_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1x, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 2x`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBeFalsy()
       await browser.setDimensions({
@@ -562,12 +564,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+        `/_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       await browser.setDimensions({
@@ -606,12 +608,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+        `/_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       await browser.setDimensions({
@@ -650,7 +652,7 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
@@ -659,7 +661,7 @@ function runTests(mode) {
         return browser.eval(
           `document.querySelector('#${id}').getAttribute('srcset')`
         )
-      }, '/_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      }, `/_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`)
 
       expect(await browser.elementById(id).getAttribute('sizes')).toBe('100vw')
       expect(await getComputed(browser, id, 'width')).toBe(width)
@@ -695,14 +697,14 @@ function runTests(mode) {
         return browser.eval(
           `document.querySelector('#fill3').getAttribute('srcset')`
         )
-      }, '/_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      }, `/_next/image?url=%2Fwide.png&w=256&q=75${dpl} 256w, /_next/image?url=%2Fwide.png&w=384&q=75${dpl} 384w, /_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`)
 
       await browser.eval(`document.getElementById("fill4").scrollIntoView()`)
       await check(() => {
         return browser.eval(
           `document.querySelector('#fill4').getAttribute('srcset')`
         )
-      }, '/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w')
+      }, `/_next/image?url=%2Fwide.png&w=32&q=75${dpl} 32w, /_next/image?url=%2Fwide.png&w=48&q=75${dpl} 48w, /_next/image?url=%2Fwide.png&w=64&q=75${dpl} 64w, /_next/image?url=%2Fwide.png&w=96&q=75${dpl} 96w, /_next/image?url=%2Fwide.png&w=128&q=75${dpl} 128w, /_next/image?url=%2Fwide.png&w=256&q=75${dpl} 256w, /_next/image?url=%2Fwide.png&w=384&q=75${dpl} 384w, /_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`)
     } finally {
       if (browser) {
         await browser.close()
@@ -721,12 +723,12 @@ function runTests(mode) {
 
       await check(async () => {
         expect(await getSrc(browser, id)).toBe(
-          '/_next/image?url=%2Fwide.png&w=3840&q=75'
+          `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
         )
         return 'success'
       }, 'success')
       expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-        '/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+        `/_next/image?url=%2Fwide.png&w=32&q=75${dpl} 32w, /_next/image?url=%2Fwide.png&w=48&q=75${dpl} 48w, /_next/image?url=%2Fwide.png&w=64&q=75${dpl} 64w, /_next/image?url=%2Fwide.png&w=96&q=75${dpl} 96w, /_next/image?url=%2Fwide.png&w=128&q=75${dpl} 128w, /_next/image?url=%2Fwide.png&w=256&q=75${dpl} 256w, /_next/image?url=%2Fwide.png&w=384&q=75${dpl} 384w, /_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById(id).getAttribute('sizes')).toBe(
         '(max-width: 2048px) 1200px, 3840px'
@@ -1440,14 +1442,14 @@ function runTests(mode) {
 
       const imageUrls = await getImageUrls(browser)
       expect(imageUrls).not.toContain(
-        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75${dpl}`
       )
       expect(imageUrls).toContain(
-        `http://localhost:${appPort}/_next/image?url=%2Ftest.png&w=828&q=75`
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.png&w=828&q=75${dpl}`
       )
       expect(imageUrls).toContain(`http://localhost:${appPort}/test.svg`)
       expect(imageUrls).not.toContain(
-        `http://localhost:${appPort}/_next/image?url=%2Ftest.webp&w=828&q=75`
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.webp&w=828&q=75${dpl}`
       )
     } finally {
       if (browser) {

--- a/test/integration/next-image-legacy/unoptimized/test/index.test.ts
+++ b/test/integration/next-image-legacy/unoptimized/test/index.test.ts
@@ -2,12 +2,13 @@
 
 import { join } from 'path'
 import {
-  check,
   findPort,
+  getDeploymentId,
   killApp,
   launchApp,
   nextBuild,
   nextStart,
+  retry,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 
@@ -15,9 +16,12 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-function runTests() {
+function runTests(mode: 'dev' | 'server') {
   it('should not optimize any image', async () => {
     const browser = await webdriver(appPort, '/')
+
+    const dpl = getDeploymentId(appDir, mode === 'dev').getDeploymentIdQuery()
+    const assetDpl = getDeploymentId(appDir, mode === 'dev').getAssetQuery()
 
     expect(
       await browser.elementById('internal-image').getAttribute('src')
@@ -29,7 +33,7 @@ function runTests() {
       await browser.elementById('external-image').getAttribute('src')
     ).toMatch('data:')
     expect(await browser.elementById('eager-image').getAttribute('src')).toBe(
-      '/test.webp'
+      `/test.webp${dpl}`
     )
 
     expect(
@@ -45,42 +49,55 @@ function runTests() {
       await browser.elementById('eager-image').getAttribute('srcset')
     ).toBeNull()
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
       )
-      return browser.eval(
-        `document.getElementById("external-image").currentSrc`
-      )
-    }, 'https://image-optimization-test.vercel.app/test.jpg')
+      expect(
+        await browser.eval(
+          `document.getElementById("external-image").currentSrc`
+        )
+      ).toBe('https://image-optimization-test.vercel.app/test.jpg')
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("internal-image").scrollIntoView()`
       )
-      return browser.elementById('internal-image').getAttribute('src')
-    }, '/test.png')
+      expect(
+        await browser.elementById('internal-image').getAttribute('src')
+      ).toBe(`/test.png${dpl}`)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("static-image").scrollIntoView()`
       )
-      return browser.elementById('static-image').getAttribute('src')
-    }, /test(.*)jpg/)
+      expect(
+        (await browser.elementById('static-image').getAttribute('src')).replace(
+          /test\.[a-z0-9]+\.jpg/,
+          'test.HASH.jpg'
+        )
+      ).toMatch('/_next/static/media/test.HASH.jpg' + assetDpl)
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("external-image").scrollIntoView()`
       )
-      return browser.elementById('external-image').getAttribute('src')
-    }, 'https://image-optimization-test.vercel.app/test.jpg')
+      expect(
+        await browser.elementById('external-image').getAttribute('src')
+      ).toBe('https://image-optimization-test.vercel.app/test.jpg')
+    })
 
-    await check(async () => {
+    await retry(async () => {
       await browser.eval(
         `window.scrollTo(0, 0); document.getElementById("eager-image").scrollIntoView()`
       )
-      return browser.elementById('eager-image').getAttribute('src')
-    }, '/test.webp')
+      expect(await browser.elementById('eager-image').getAttribute('src')).toBe(
+        `/test.webp${dpl}`
+      )
+    })
 
     expect(
       await browser.elementById('internal-image').getAttribute('srcset')
@@ -109,7 +126,7 @@ describe('Unoptimized Image Tests', () => {
         await killApp(app)
       })
 
-      runTests()
+      runTests('dev')
     }
   )
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
@@ -124,7 +141,7 @@ describe('Unoptimized Image Tests', () => {
         await killApp(app)
       })
 
-      runTests()
+      runTests('server')
     }
   )
 })

--- a/test/integration/next-image-new/app-dir/test/index.test.ts
+++ b/test/integration/next-image-new/app-dir/test/index.test.ts
@@ -17,6 +17,7 @@ import {
   renderViaHTTP,
   retry,
   waitFor,
+  getDeploymentId,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -71,6 +72,13 @@ function getRatio(width, height) {
 }
 
 function runTests(mode: 'dev' | 'server') {
+  let dpl: string
+  let assetDpl: string
+  beforeAll(() => {
+    dpl = getDeploymentId(appDir, mode === 'dev').getDeploymentIdQuery(true)
+    assetDpl = getDeploymentId(appDir, mode === 'dev').getAssetQuery(true)
+  })
+
   it('should load the images', async () => {
     let browser
     try {
@@ -89,7 +97,7 @@ function runTests(mode: 'dev' | 'server') {
       }, /result-correct/)
 
       expect(await getImageUrls(browser)).toContain(
-        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75${dpl}`
       )
     } finally {
       if (browser) {
@@ -744,10 +752,10 @@ function runTests(mode: 'dev' | 'server') {
     const browser = await webdriver(appPort, '/sizes')
     const id = 'sizes1'
     expect(await getSrc(browser, id)).toBe(
-      '/_next/image?url=%2Fwide.png&w=3840&q=75'
+      `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
     )
     expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-      '/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+      `/_next/image?url=%2Fwide.png&w=32&q=75${dpl} 32w, /_next/image?url=%2Fwide.png&w=48&q=75${dpl} 48w, /_next/image?url=%2Fwide.png&w=64&q=75${dpl} 64w, /_next/image?url=%2Fwide.png&w=96&q=75${dpl} 96w, /_next/image?url=%2Fwide.png&w=128&q=75${dpl} 128w, /_next/image?url=%2Fwide.png&w=256&q=75${dpl} 256w, /_next/image?url=%2Fwide.png&w=384&q=75${dpl} 384w, /_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`
     )
     expect(await browser.elementById(id).getAttribute('sizes')).toBe(
       '(max-width: 2048px) 1200px, 3840px'
@@ -778,7 +786,7 @@ function runTests(mode: 'dev' | 'server') {
         '1200'
       )
       expect(await browser.elementById('img1').getAttribute('srcset')).toBe(
-        `/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x`
+        `/_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1x, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 2x`
       )
       expect(await browser.elementById('img1').getAttribute('loading')).toBe(
         'eager'
@@ -794,7 +802,7 @@ function runTests(mode: 'dev' | 'server') {
         '1200'
       )
       expect(await browser.elementById('img2').getAttribute('srcset')).toBe(
-        `/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w`
+        `/_next/image?url=%2Fwide.png&w=32&q=75${dpl} 32w, /_next/image?url=%2Fwide.png&w=48&q=75${dpl} 48w, /_next/image?url=%2Fwide.png&w=64&q=75${dpl} 64w, /_next/image?url=%2Fwide.png&w=96&q=75${dpl} 96w, /_next/image?url=%2Fwide.png&w=128&q=75${dpl} 128w, /_next/image?url=%2Fwide.png&w=256&q=75${dpl} 256w, /_next/image?url=%2Fwide.png&w=384&q=75${dpl} 384w, /_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById('img2').getAttribute('loading')).toBe(
         'lazy'
@@ -804,7 +812,7 @@ function runTests(mode: 'dev' | 'server') {
         'color:transparent'
       )
       expect(await browser.elementById('img3').getAttribute('srcset')).toBe(
-        `/_next/image?url=%2Ftest.png&w=640&q=75 1x, /_next/image?url=%2Ftest.png&w=828&q=75 2x`
+        `/_next/image?url=%2Ftest.png&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.png&w=828&q=75${dpl} 2x`
       )
       if (mode === 'dev') {
         await waitFor(1000)
@@ -829,17 +837,21 @@ function runTests(mode: 'dev' | 'server') {
     const browser = await webdriver(appPort, '/placeholder-blur')
 
     // blur1
-    expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur1').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=640&q=75 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75 2x/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=75${assetDpl} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl} 2x`
     )
     expect(await browser.elementById('blur1').getAttribute('loading')).toBe(
       'lazy'
     )
     expect(await browser.elementById('blur1').getAttribute('sizes')).toBeNull()
-    expect(await browser.elementById('blur1').getAttribute('style')).toMatch(
+    expect(await browser.elementById('blur1').getAttribute('style')).toContain(
       'color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;'
     )
     expect(await browser.elementById('blur1').getAttribute('height')).toBe(
@@ -853,11 +865,15 @@ function runTests(mode: 'dev' | 'server') {
       () => browser.eval(`document.getElementById("blur1").currentSrc`),
       /test(.*)jpg/
     )
-    expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur1').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=640&q=75 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75 2x/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=75${assetDpl} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl} 2x`
     )
     expect(await browser.elementById('blur1').getAttribute('loading')).toBe(
       'lazy'
@@ -872,11 +888,15 @@ function runTests(mode: 'dev' | 'server') {
     expect(await browser.elementById('blur1').getAttribute('width')).toBe('400')
 
     // blur2
-    expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur2').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=384&q=75 384w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=640&q=75 640w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=750&q=75 750w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=828&q=75 828w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1080&q=75 1080w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1200&q=75 1200w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1920&q=75 1920w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=2048&q=75 2048w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75 3840w/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=384&q=75${assetDpl} 384w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=75${assetDpl} 640w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=750&q=75${assetDpl} 750w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=75${assetDpl} 828w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1080&q=75${assetDpl} 1080w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1200&q=75${assetDpl} 1200w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1920&q=75${assetDpl} 1920w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=2048&q=75${assetDpl} 2048w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl} 3840w`
     )
     expect(await browser.elementById('blur2').getAttribute('sizes')).toBe(
       '50vw'
@@ -884,7 +904,7 @@ function runTests(mode: 'dev' | 'server') {
     expect(await browser.elementById('blur2').getAttribute('loading')).toBe(
       'lazy'
     )
-    expect(await browser.elementById('blur2').getAttribute('style')).toMatch(
+    expect(await browser.elementById('blur2').getAttribute('style')).toContain(
       'color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat'
     )
     expect(await browser.elementById('blur2').getAttribute('height')).toBe(
@@ -898,11 +918,15 @@ function runTests(mode: 'dev' | 'server') {
       () => browser.eval(`document.getElementById("blur2").currentSrc`),
       /test(.*)png/
     )
-    expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur2').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=384&q=75 384w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=640&q=75 640w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=750&q=75 750w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=828&q=75 828w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1080&q=75 1080w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1200&q=75 1200w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1920&q=75 1920w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=2048&q=75 2048w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75 3840w/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=384&q=75${assetDpl} 384w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=75${assetDpl} 640w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=750&q=75${assetDpl} 750w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=75${assetDpl} 828w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1080&q=75${assetDpl} 1080w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1200&q=75${assetDpl} 1200w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1920&q=75${assetDpl} 1920w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=2048&q=75${assetDpl} 2048w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl} 3840w`
     )
     expect(await browser.elementById('blur2').getAttribute('sizes')).toBe(
       '50vw'
@@ -940,10 +964,10 @@ function runTests(mode: 'dev' | 'server') {
     expect(await img.getAttribute('data-nimg')).toBe('fill')
     expect(await img.getAttribute('sizes')).toBe('200px')
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest.jpg&w=3840&q=75'
+      `/_next/image?url=%2Ftest.jpg&w=3840&q=75${dpl}`
     )
     expect(await img.getAttribute('srcset')).toContain(
-      '/_next/image?url=%2Ftest.jpg&w=640&q=75 640w,'
+      `/_next/image?url=%2Ftest.jpg&w=640&q=75${dpl} 640w,`
     )
     expect(await img.getAttribute('style')).toBe(
       'position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;object-fit:cover;object-position:10% 10%;color:transparent'
@@ -972,10 +996,10 @@ function runTests(mode: 'dev' | 'server') {
     expect(await img.getAttribute('sizes')).toBe('100vw')
     expect(await img.getAttribute('data-nimg')).toBe('1')
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest.png&w=3840&q=75'
+      `/_next/image?url=%2Ftest.png&w=3840&q=75${dpl}`
     )
     expect(await img.getAttribute('srcset')).toContain(
-      '/_next/image?url=%2Ftest.png&w=640&q=75 640w,'
+      `/_next/image?url=%2Ftest.png&w=640&q=75${dpl} 640w,`
     )
     expect(await img.getAttribute('style')).toBe(
       'color:transparent;width:100%;height:auto'
@@ -1013,17 +1037,17 @@ function runTests(mode: 'dev' | 'server') {
     expect(await img.getAttribute('fetchPriority')).toBeNull()
     expect(await img.getAttribute('sizes')).toBeNull()
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest_light.png&w=828&q=75'
+      `/_next/image?url=%2Ftest_light.png&w=828&q=75${dpl}`
     )
     expect(await img.getAttribute('srcset')).toBe(null)
     expect(await img.getAttribute('style')).toBe('color:transparent')
     const source1 = await browser.elementByCss('source:first-of-type')
     expect(await source1.getAttribute('srcset')).toBe(
-      '/_next/image?url=%2Ftest.png&w=640&q=75 1x, /_next/image?url=%2Ftest.png&w=828&q=75 2x'
+      `/_next/image?url=%2Ftest.png&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.png&w=828&q=75${dpl} 2x`
     )
     const source2 = await browser.elementByCss('source:last-of-type')
     expect(await source2.getAttribute('srcset')).toBe(
-      '/_next/image?url=%2Ftest_light.png&w=640&q=75 1x, /_next/image?url=%2Ftest_light.png&w=828&q=75 2x'
+      `/_next/image?url=%2Ftest_light.png&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest_light.png&w=828&q=75${dpl} 2x`
     )
   })
 
@@ -1837,3 +1861,7 @@ describe('Image Component Default Tests', () => {
     }
   )
 })
+
+function stripTestHash(text: string) {
+  return text.replace(/test\.[0-9a-f]{8,}\.(png|jpe?g)/g, 'test.HASH.$1')
+}

--- a/test/integration/next-image-new/base-path/test/index.test.ts
+++ b/test/integration/next-image-new/base-path/test/index.test.ts
@@ -11,6 +11,7 @@ import {
   nextBuild,
   nextStart,
   waitFor,
+  getDeploymentId,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -50,7 +51,7 @@ function getRatio(width, height) {
   return height / width
 }
 
-function runTests(mode) {
+function runTests(mode: 'dev' | 'server') {
   it('should load the images', async () => {
     let browser
     try {
@@ -69,7 +70,7 @@ function runTests(mode) {
       }, /result-correct/)
 
       expect(await getImageUrls(browser)).toContain(
-        `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75`
+        `http://localhost:${appPort}/docs/_next/image?url=%2Fdocs%2Ftest.jpg&w=828&q=75${getDeploymentId(appDir, mode === 'dev').getDeploymentIdQuery(true)}`
       )
     } finally {
       if (browser) {

--- a/test/integration/next-image-new/both-basepath-trailingslash/test/index.test.ts
+++ b/test/integration/next-image-new/both-basepath-trailingslash/test/index.test.ts
@@ -3,6 +3,7 @@
 import {
   fetchViaHTTP,
   findPort,
+  getDeploymentId,
   killApp,
   launchApp,
   nextBuild,
@@ -16,25 +17,32 @@ const appDir = join(__dirname, '../')
 let appPort
 let app
 
-const runTests = () => {
+const runTests = (mode: 'dev' | 'server') => {
+  let dpl: string
+  let assetDpl: string
+  beforeAll(() => {
+    dpl = getDeploymentId(appDir, mode === 'dev').getDeploymentIdQuery(true)
+    assetDpl = getDeploymentId(appDir, mode === 'dev').getAssetQuery(true)
+  })
+
   it('should correctly load image src from import', async () => {
-    expect.assertions(3)
     const browser = await webdriver(appPort, '/prefix/')
     const img = await browser.elementById('import-img')
     const src = await img.getAttribute('src')
-    expect(src).toMatch(
-      /\/prefix\/_next\/image\/\?url=%2Fprefix%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
+    expect(stripTestHash(src)).toBe(
+      `/prefix/_next/image/?url=%2Fprefix%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl}`
     )
     const res = await fetchViaHTTP(appPort, src)
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('image/jpeg')
   })
   it('should correctly load image src from string', async () => {
-    expect.assertions(3)
     const browser = await webdriver(appPort, '/prefix/')
     const img = await browser.elementById('string-img')
     const src = await img.getAttribute('src')
-    expect(src).toBe('/prefix/_next/image/?url=%2Fprefix%2Ftest.jpg&w=640&q=75')
+    expect(src).toBe(
+      `/prefix/_next/image/?url=%2Fprefix%2Ftest.jpg&w=640&q=75${dpl}`
+    )
     const res = await fetchViaHTTP(appPort, src)
     expect(res.status).toBe(200)
     expect(res.headers.get('content-type')).toBe('image/jpeg')
@@ -51,7 +59,7 @@ describe('Image Component basePath + trailingSlash Tests', () => {
       })
       afterAll(() => killApp(app))
 
-      runTests()
+      runTests('dev')
     }
   )
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
@@ -64,7 +72,11 @@ describe('Image Component basePath + trailingSlash Tests', () => {
       })
       afterAll(() => killApp(app))
 
-      runTests()
+      runTests('server')
     }
   )
 })
+
+function stripTestHash(text: string) {
+  return text.replace(/test\.[0-9a-f]{8,}\.(png|jpe?g)/g, 'test.HASH.$1')
+}

--- a/test/integration/next-image-new/default/test/index.test.ts
+++ b/test/integration/next-image-new/default/test/index.test.ts
@@ -16,6 +16,7 @@ import {
   renderViaHTTP,
   retry,
   waitFor,
+  getDeploymentId,
 } from 'next-test-utils'
 import webdriver from 'next-webdriver'
 import { join } from 'path'
@@ -73,7 +74,14 @@ function getRatio(width, height) {
   return height / width
 }
 
-function runTests(mode) {
+function runTests(mode: 'dev' | 'server') {
+  let dpl: string
+  let assetDpl: string
+  beforeAll(() => {
+    dpl = getDeploymentId(appDir, mode === 'dev').getDeploymentIdQuery(true)
+    assetDpl = getDeploymentId(appDir, mode === 'dev').getAssetQuery(true)
+  })
+
   it('should load the images', async () => {
     let browser
     try {
@@ -92,7 +100,7 @@ function runTests(mode) {
       }, /result-correct/)
 
       expect(await getImageUrls(browser)).toContain(
-        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75`
+        `http://localhost:${appPort}/_next/image?url=%2Ftest.jpg&w=828&q=75${dpl}`
       )
     } finally {
       if (browser) {
@@ -744,10 +752,10 @@ function runTests(mode) {
     const browser = await webdriver(appPort, '/sizes')
     const id = 'sizes1'
     expect(await getSrc(browser, id)).toBe(
-      '/_next/image?url=%2Fwide.png&w=3840&q=75'
+      `/_next/image?url=%2Fwide.png&w=3840&q=75${dpl}`
     )
     expect(await browser.elementById(id).getAttribute('srcset')).toBe(
-      '/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w'
+      `/_next/image?url=%2Fwide.png&w=32&q=75${dpl} 32w, /_next/image?url=%2Fwide.png&w=48&q=75${dpl} 48w, /_next/image?url=%2Fwide.png&w=64&q=75${dpl} 64w, /_next/image?url=%2Fwide.png&w=96&q=75${dpl} 96w, /_next/image?url=%2Fwide.png&w=128&q=75${dpl} 128w, /_next/image?url=%2Fwide.png&w=256&q=75${dpl} 256w, /_next/image?url=%2Fwide.png&w=384&q=75${dpl} 384w, /_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`
     )
     expect(await browser.elementById(id).getAttribute('sizes')).toBe(
       '(max-width: 2048px) 1200px, 3840px'
@@ -778,7 +786,7 @@ function runTests(mode) {
         '1200'
       )
       expect(await browser.elementById('img1').getAttribute('srcset')).toBe(
-        `/_next/image?url=%2Fwide.png&w=1200&q=75 1x, /_next/image?url=%2Fwide.png&w=3840&q=75 2x`
+        `/_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1x, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 2x`
       )
       expect(await browser.elementById('img1').getAttribute('loading')).toBe(
         'eager'
@@ -794,7 +802,7 @@ function runTests(mode) {
         '1200'
       )
       expect(await browser.elementById('img2').getAttribute('srcset')).toBe(
-        `/_next/image?url=%2Fwide.png&w=32&q=75 32w, /_next/image?url=%2Fwide.png&w=48&q=75 48w, /_next/image?url=%2Fwide.png&w=64&q=75 64w, /_next/image?url=%2Fwide.png&w=96&q=75 96w, /_next/image?url=%2Fwide.png&w=128&q=75 128w, /_next/image?url=%2Fwide.png&w=256&q=75 256w, /_next/image?url=%2Fwide.png&w=384&q=75 384w, /_next/image?url=%2Fwide.png&w=640&q=75 640w, /_next/image?url=%2Fwide.png&w=750&q=75 750w, /_next/image?url=%2Fwide.png&w=828&q=75 828w, /_next/image?url=%2Fwide.png&w=1080&q=75 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75 3840w`
+        `/_next/image?url=%2Fwide.png&w=32&q=75${dpl} 32w, /_next/image?url=%2Fwide.png&w=48&q=75${dpl} 48w, /_next/image?url=%2Fwide.png&w=64&q=75${dpl} 64w, /_next/image?url=%2Fwide.png&w=96&q=75${dpl} 96w, /_next/image?url=%2Fwide.png&w=128&q=75${dpl} 128w, /_next/image?url=%2Fwide.png&w=256&q=75${dpl} 256w, /_next/image?url=%2Fwide.png&w=384&q=75${dpl} 384w, /_next/image?url=%2Fwide.png&w=640&q=75${dpl} 640w, /_next/image?url=%2Fwide.png&w=750&q=75${dpl} 750w, /_next/image?url=%2Fwide.png&w=828&q=75${dpl} 828w, /_next/image?url=%2Fwide.png&w=1080&q=75${dpl} 1080w, /_next/image?url=%2Fwide.png&w=1200&q=75${dpl} 1200w, /_next/image?url=%2Fwide.png&w=1920&q=75${dpl} 1920w, /_next/image?url=%2Fwide.png&w=2048&q=75${dpl} 2048w, /_next/image?url=%2Fwide.png&w=3840&q=75${dpl} 3840w`
       )
       expect(await browser.elementById('img2').getAttribute('loading')).toBe(
         'lazy'
@@ -804,7 +812,7 @@ function runTests(mode) {
         'color:transparent'
       )
       expect(await browser.elementById('img3').getAttribute('srcset')).toBe(
-        `/_next/image?url=%2Ftest.png&w=640&q=75 1x, /_next/image?url=%2Ftest.png&w=828&q=75 2x`
+        `/_next/image?url=%2Ftest.png&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.png&w=828&q=75${dpl} 2x`
       )
       if (mode === 'dev') {
         await waitFor(1000)
@@ -829,17 +837,21 @@ function runTests(mode) {
     const browser = await webdriver(appPort, '/placeholder-blur')
 
     // blur1
-    expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur1').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=640&q=75 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75 2x/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=75${assetDpl} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl} 2x`
     )
     expect(await browser.elementById('blur1').getAttribute('loading')).toBe(
       'lazy'
     )
     expect(await browser.elementById('blur1').getAttribute('sizes')).toBeNull()
-    expect(await browser.elementById('blur1').getAttribute('style')).toMatch(
+    expect(await browser.elementById('blur1').getAttribute('style')).toContain(
       'color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat;'
     )
     expect(await browser.elementById('blur1').getAttribute('height')).toBe(
@@ -853,11 +865,15 @@ function runTests(mode) {
       () => browser.eval(`document.getElementById("blur1").currentSrc`),
       /test(.*)jpg/
     )
-    expect(await browser.elementById('blur1').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur1').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=640&q=75 1x, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.jpg&w=828&q=75 2x/
+    expect(
+      stripTestHash(await browser.elementById('blur1').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=640&q=75${assetDpl} 1x, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.jpg&w=828&q=75${assetDpl} 2x`
     )
     expect(await browser.elementById('blur1').getAttribute('loading')).toBe(
       'lazy'
@@ -872,11 +888,15 @@ function runTests(mode) {
     expect(await browser.elementById('blur1').getAttribute('width')).toBe('400')
 
     // blur2
-    expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur2').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=384&q=75 384w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=640&q=75 640w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=750&q=75 750w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=828&q=75 828w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1080&q=75 1080w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1200&q=75 1200w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1920&q=75 1920w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=2048&q=75 2048w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75 3840w/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=384&q=75${assetDpl} 384w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=75${assetDpl} 640w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=750&q=75${assetDpl} 750w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=75${assetDpl} 828w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1080&q=75${assetDpl} 1080w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1200&q=75${assetDpl} 1200w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1920&q=75${assetDpl} 1920w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=2048&q=75${assetDpl} 2048w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl} 3840w`
     )
     expect(await browser.elementById('blur2').getAttribute('sizes')).toBe(
       '50vw'
@@ -884,7 +904,7 @@ function runTests(mode) {
     expect(await browser.elementById('blur2').getAttribute('loading')).toBe(
       'lazy'
     )
-    expect(await browser.elementById('blur2').getAttribute('style')).toMatch(
+    expect(await browser.elementById('blur2').getAttribute('style')).toContain(
       'color:transparent;background-size:cover;background-position:50% 50%;background-repeat:no-repeat'
     )
     expect(await browser.elementById('blur2').getAttribute('height')).toBe(
@@ -898,11 +918,15 @@ function runTests(mode) {
       () => browser.eval(`document.getElementById("blur2").currentSrc`),
       /test(.*)png/
     )
-    expect(await browser.elementById('blur2').getAttribute('src')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('src'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl}`
     )
-    expect(await browser.elementById('blur2').getAttribute('srcset')).toMatch(
-      /\/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=384&q=75 384w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=640&q=75 640w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=750&q=75 750w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=828&q=75 828w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1080&q=75 1080w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1200&q=75 1200w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=1920&q=75 1920w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=2048&q=75 2048w, \/_next\/image\?url=%2F_next%2Fstatic%2Fmedia%2Ftest\.(.*)\.png&w=3840&q=75 3840w/
+    expect(
+      stripTestHash(await browser.elementById('blur2').getAttribute('srcset'))
+    ).toBe(
+      `/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=384&q=75${assetDpl} 384w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=640&q=75${assetDpl} 640w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=750&q=75${assetDpl} 750w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=828&q=75${assetDpl} 828w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1080&q=75${assetDpl} 1080w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1200&q=75${assetDpl} 1200w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=1920&q=75${assetDpl} 1920w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=2048&q=75${assetDpl} 2048w, /_next/image?url=%2F_next%2Fstatic%2Fmedia%2Ftest.HASH.png&w=3840&q=75${assetDpl} 3840w`
     )
     expect(await browser.elementById('blur2').getAttribute('sizes')).toBe(
       '50vw'
@@ -940,10 +964,10 @@ function runTests(mode) {
     expect(await img.getAttribute('data-nimg')).toBe('fill')
     expect(await img.getAttribute('sizes')).toBe('200px')
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest.jpg&w=3840&q=75'
+      `/_next/image?url=%2Ftest.jpg&w=3840&q=75${dpl}`
     )
     expect(await img.getAttribute('srcset')).toContain(
-      '/_next/image?url=%2Ftest.jpg&w=640&q=75 640w,'
+      `/_next/image?url=%2Ftest.jpg&w=640&q=75${dpl} 640w,`
     )
     expect(await img.getAttribute('style')).toBe(
       'position:absolute;height:100%;width:100%;left:0;top:0;right:0;bottom:0;object-fit:cover;object-position:10% 10%;color:transparent'
@@ -972,10 +996,10 @@ function runTests(mode) {
     expect(await img.getAttribute('sizes')).toBe('100vw')
     expect(await img.getAttribute('data-nimg')).toBe('1')
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest.png&w=3840&q=75'
+      `/_next/image?url=%2Ftest.png&w=3840&q=75${dpl}`
     )
     expect(await img.getAttribute('srcset')).toContain(
-      '/_next/image?url=%2Ftest.png&w=640&q=75 640w,'
+      `/_next/image?url=%2Ftest.png&w=640&q=75${dpl} 640w,`
     )
     expect(await img.getAttribute('style')).toBe(
       'color:transparent;width:100%;height:auto'
@@ -1013,17 +1037,17 @@ function runTests(mode) {
     expect(await img.getAttribute('fetchPriority')).toBeNull()
     expect(await img.getAttribute('sizes')).toBeNull()
     expect(await img.getAttribute('src')).toBe(
-      '/_next/image?url=%2Ftest_light.png&w=828&q=75'
+      `/_next/image?url=%2Ftest_light.png&w=828&q=75${dpl}`
     )
     expect(await img.getAttribute('srcset')).toBe(null)
     expect(await img.getAttribute('style')).toBe('color:transparent')
     const source1 = await browser.elementByCss('source:first-of-type')
     expect(await source1.getAttribute('srcset')).toBe(
-      '/_next/image?url=%2Ftest.png&w=640&q=75 1x, /_next/image?url=%2Ftest.png&w=828&q=75 2x'
+      `/_next/image?url=%2Ftest.png&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest.png&w=828&q=75${dpl} 2x`
     )
     const source2 = await browser.elementByCss('source:last-of-type')
     expect(await source2.getAttribute('srcset')).toBe(
-      '/_next/image?url=%2Ftest_light.png&w=640&q=75 1x, /_next/image?url=%2Ftest_light.png&w=828&q=75 2x'
+      `/_next/image?url=%2Ftest_light.png&w=640&q=75${dpl} 1x, /_next/image?url=%2Ftest_light.png&w=828&q=75${dpl} 2x`
     )
   })
 
@@ -1792,3 +1816,7 @@ describe('Image Component Default Tests', () => {
     }
   )
 })
+
+function stripTestHash(text: string) {
+  return text.replace(/test\.[0-9a-f]{8,}\.(png|jpe?g)/g, 'test.HASH.$1')
+}

--- a/test/integration/production-config/test/index.test.ts
+++ b/test/integration/production-config/test/index.test.ts
@@ -20,9 +20,11 @@ describe('Production Config Usage', () => {
     'production mode',
     () => {
       beforeAll(async () => {
-        await nextBuild(appDir)
+        await nextBuild(appDir, undefined, { disableAutoSkewProtection: true })
         appPort = await findPort()
-        app = await nextStart(appDir, appPort)
+        app = await nextStart(appDir, appPort, {
+          disableAutoSkewProtection: true,
+        })
       })
       afterAll(() => killApp(app))
 

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -54,6 +54,7 @@ export interface NextInstanceOpts {
   serverReadyPattern?: RegExp
   patchFileDelay?: number
   startServerTimeout?: number
+  disableAutoSkewProtection?: boolean
 }
 
 /**

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -641,8 +641,18 @@ export class NextInstance {
     return undefined
   }
 
-  public get deploymentIdQuery(): string {
-    return this.deploymentId ? `?dpl=${this.deploymentId}` : ''
+  public getDeploymentIdQuery(ampersand: boolean = false): string | undefined {
+    const prefix = ampersand ? '&' : '?'
+    return this.deploymentId ? `${prefix}dpl=${this.deploymentId}` : ''
+  }
+
+  public get assetToken(): string | undefined {
+    return this.deploymentId
+  }
+
+  public getAssetQuery(ampersand: boolean = false): string | undefined {
+    const prefix = ampersand ? '&' : '?'
+    return this.assetToken ? `${prefix}dpl=${this.assetToken}` : ''
   }
 
   public get cliOutput(): string {

--- a/test/lib/next-modes/next-start.ts
+++ b/test/lib/next-modes/next-start.ts
@@ -1,10 +1,11 @@
 import path from 'path'
 import fs from 'fs-extra'
-import { NextInstance } from './base'
+import { NextInstance, type NextInstanceOpts } from './base'
 import spawn from 'cross-spawn'
 import { Span } from 'next/dist/trace'
 import stripAnsi from 'strip-ansi'
 import { quote as shellQuote } from 'shell-quote'
+import { shouldUseTurbopack } from 'next-test-utils'
 
 export class NextStartInstance extends NextInstance {
   private _buildId: string
@@ -12,6 +13,14 @@ export class NextStartInstance extends NextInstance {
   private _cliOutput: string = ''
 
   private _prerenderFinishedTimeMS: number | null = null
+
+  constructor(opts: NextInstanceOpts) {
+    super(opts)
+
+    if (!opts.disableAutoSkewProtection && shouldUseTurbopack()) {
+      this.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
+    }
+  }
 
   public get buildId() {
     return this._buildId

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -2040,3 +2040,36 @@ export function getClientReferenceManifest(
 export const getCacheHeader = (curRes: Response) =>
   // favor generic header
   curRes.headers.get('x-nextjs-cache') || curRes.headers.get('x-vercel-cache')
+
+export function getDeploymentId(appDir: string, isDev: boolean) {
+  let requiredServerFiles
+  if (!isDev) {
+    // File isn't written in dev, but it might still exist because it was created by a prior
+    // production build.
+    try {
+      requiredServerFiles = JSON.parse(
+        readFileSync(
+          path.join(appDir, getDistDir(), 'required-server-files.json'),
+          'utf8'
+        )
+      )
+    } catch {}
+  }
+
+  const deploymentId: string | undefined =
+    requiredServerFiles?.config?.deploymentId
+  const immutableAssetToken: string | undefined =
+    requiredServerFiles?.config?.experimental?.immutableAssetToken
+  const assetToken: string | undefined = immutableAssetToken || deploymentId
+
+  return {
+    deploymentId,
+    getDeploymentIdQuery(ampersand = false) {
+      return deploymentId ? `${ampersand ? '&' : '?'}dpl=${deploymentId}` : ''
+    },
+    assetToken,
+    getAssetQuery(ampersand = false) {
+      return assetToken ? `${ampersand ? '&' : '?'}dpl=${assetToken}` : ''
+    },
+  }
+}

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -265,6 +265,7 @@ export interface NextOptions {
   stderr?: true | 'log'
   stdout?: true | 'log'
   ignoreFail?: boolean
+  disableAutoSkewProtection?: boolean
 
   onStdout?: (data: any) => void
   onStderr?: (data: any) => void
@@ -283,7 +284,7 @@ export function runNextCommand(
   const nextBin = path.join(nextDir, 'dist/bin/next')
   const cwd = options.cwd || nextDir
   // Let Next.js decide the environment
-  const env = {
+  const env: NodeJS.ProcessEnv = {
     ...process.env,
     // @ts-ignore packages/next/types/global.d.ts should allow undefined NODE_ENV
     NODE_ENV: undefined as NodeJS.ProcessEnv['NODE_ENV'],
@@ -390,6 +391,7 @@ export interface NextDevOptions {
   bootupMarker?: RegExp
   nextStart?: boolean
   turbo?: boolean
+  disableAutoSkewProtection?: boolean
 
   stderr?: false
   stdout?: false
@@ -517,6 +519,11 @@ export function nextBuild(
   args: string[] = [],
   opts: NextOptions = {}
 ) {
+  if (!opts.disableAutoSkewProtection && shouldUseTurbopack() && !opts.env) {
+    opts.env ??= {}
+    opts.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
+  }
+
   return runNextCommand(['build', dir, ...args], opts)
 }
 
@@ -539,6 +546,11 @@ export function nextStart(
   port: string | number,
   opts: NextDevOptions = {}
 ) {
+  if (!opts.disableAutoSkewProtection && shouldUseTurbopack() && !opts.env) {
+    opts.env ??= {}
+    opts.env.NEXT_DEPLOYMENT_ID = 'test-dpl-id-1234'
+  }
+
   return runNextCommandDev(
     ['start', '-p', port as string, '--hostname', '::', dir],
     undefined,

--- a/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
+++ b/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
@@ -1,8 +1,6 @@
 import { isNextStart, nextTestSetup } from 'e2e-utils'
 
 describe('css-url-deployment-id', () => {
-  const deploymentId = 'test-deployment-id'
-
   const { next } = nextTestSetup({
     files: __dirname,
     skipDeployment: true,
@@ -64,7 +62,7 @@ describe('css-url-deployment-id', () => {
     expect(assetUrls.length).toBeGreaterThanOrEqual(1)
 
     for (const assetUrl of assetUrls) {
-      expect(assetUrl).toContain('dpl=' + deploymentId)
+      expect(assetUrl).toContain('dpl=' + next.assetToken)
     }
   })
 
@@ -105,7 +103,7 @@ describe('css-url-deployment-id', () => {
     expect(imageUrls.length).toBeGreaterThanOrEqual(1)
 
     for (const imageUrl of imageUrls) {
-      expect(imageUrl).toContain('dpl=' + deploymentId)
+      expect(imageUrl).toContain('dpl=' + next.assetToken)
     }
 
     // Find font references from CSS modules
@@ -113,7 +111,7 @@ describe('css-url-deployment-id', () => {
     expect(fontUrls.length).toBeGreaterThanOrEqual(1)
 
     for (const fontUrl of fontUrls) {
-      expect(fontUrl).toContain('dpl=' + deploymentId)
+      expect(fontUrl).toContain('dpl=' + next.assetToken)
     }
   })
 })

--- a/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
+++ b/test/production/css-url-deployment-id/css-url-deployment-id.test.ts
@@ -1,4 +1,4 @@
-import { nextTestSetup } from 'e2e-utils'
+import { isNextStart, nextTestSetup } from 'e2e-utils'
 
 describe('css-url-deployment-id', () => {
   const deploymentId = 'test-deployment-id'
@@ -7,6 +7,13 @@ describe('css-url-deployment-id', () => {
     files: __dirname,
     skipDeployment: true,
     dependencies: { sass: '1.54.0' },
+    env: {
+      NEXT_DEPLOYMENT_ID: isNextStart ? 'test-deployment-id' : undefined,
+      VERCEL_IMMUTABLE_DEPLOYMENT_ID: isNextStart
+        ? 'imm-deployment-id'
+        : undefined,
+    },
+    disableAutoSkewProtection: true,
   })
 
   it('should include dpl query in CSS url() references for images and fonts', async () => {

--- a/test/production/css-url-deployment-id/next.config.js
+++ b/test/production/css-url-deployment-id/next.config.js
@@ -1,4 +1,0 @@
-/** @type {import('next').NextConfig} */
-module.exports = {
-  deploymentId: 'test-deployment-id',
-}

--- a/test/production/deployment-id-handling/deployment-id-cookie-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-cookie-handling.test.ts
@@ -10,6 +10,7 @@ describe('deployment-id-handling disabled', () => {
       COOKIE_SKEW: '1',
       NEXT_DEPLOYMENT_ID: 'thankyounext',
     },
+    disableAutoSkewProtection: true,
   })
 
   it('should set set-cookie header correctly', async () => {

--- a/test/production/deployment-id-handling/deployment-id-handling.test.ts
+++ b/test/production/deployment-id-handling/deployment-id-handling.test.ts
@@ -18,6 +18,7 @@ describe.each([
           ? '1'
           : undefined,
       },
+      disableAutoSkewProtection: true,
     })
 
     it.each([
@@ -170,6 +171,7 @@ describe('deployment-id-handling disabled', () => {
   const deploymentId = Date.now() + ''
   const { next } = nextTestSetup({
     files: join(__dirname, 'app'),
+    disableAutoSkewProtection: true,
   })
   it.each([
     { urlPath: '/' },

--- a/test/production/deterministic-build/deployment-id.test.ts
+++ b/test/production/deterministic-build/deployment-id.test.ts
@@ -207,6 +207,7 @@ const FILES = {
         },
         skipStart: true,
         skipDeployment: true,
+        disableAutoSkewProtection: true,
       })
 
       it('should produce identical build outputs even when changing deployment id', async () => {
@@ -240,6 +241,7 @@ const FILES = {
             : undefined,
         skipStart: true,
         skipDeployment: true,
+        disableAutoSkewProtection: true,
       })
 
       it('should produce identical build outputs even when changing deployment id', async () => {

--- a/test/production/pages-dir/production/test/index.test.ts
+++ b/test/production/pages-dir/production/test/index.test.ts
@@ -538,7 +538,7 @@ describe('Production Usage', () => {
       for (const file of files) {
         const res = await fetchViaHTTP(
           `http://localhost:${next.appPort}`,
-          `/_next/${encodeURI(file)}`,
+          `/_next/${encodeURI(file)}${next.getAssetQuery()}`,
           undefined,
           {
             method: 'GET',
@@ -561,7 +561,7 @@ describe('Production Usage', () => {
       for (const file of files) {
         const res = await fetchViaHTTP(
           `http://localhost:${next.appPort}`,
-          `/_next/${encodeURI(file)}`,
+          `/_next/${encodeURI(file)}${next.getAssetQuery()}`,
           undefined,
           {
             method: 'GET',
@@ -635,7 +635,10 @@ describe('Production Usage', () => {
 
       const responses = await Promise.all(
         [...resources].map((resource) =>
-          fetchViaHTTP(url, join('/_next', encodeURI(resource)))
+          fetchViaHTTP(
+            url,
+            `/_next/${encodeURI(resource)}${next.getAssetQuery()}`
+          )
         )
       )
 

--- a/test/production/prerender-prefetch/index.test.ts
+++ b/test/production/prerender-prefetch/index.test.ts
@@ -307,6 +307,8 @@ describe('Prerender prefetch', () => {
           // See https://github.com/vercel/next.js/pull/70674 for context.
           NEXT_PRIVATE_CDN_CONSUMED_SWR_CACHE_CONTROL: '1',
         },
+        // relies on changing build id
+        disableAutoSkewProtection: true,
       })
     })
     afterAll(() => next.destroy())
@@ -333,6 +335,8 @@ describe('Prerender prefetch', () => {
           // See https://github.com/vercel/next.js/pull/70674 for context.
           NEXT_PRIVATE_CDN_CONSUMED_SWR_CACHE_CONTROL: '1',
         },
+        // relies on changing build id
+        disableAutoSkewProtection: true,
       })
     })
     afterAll(() => next.destroy())

--- a/test/production/standalone-mode/ipv6/index.test.ts
+++ b/test/production/standalone-mode/ipv6/index.test.ts
@@ -50,6 +50,7 @@ describe('standalone mode: ipv6 hostname', () => {
       /- Local:/,
       {
         ...process.env,
+        ...next.env,
         HOSTNAME: '::',
         PORT: appPort,
       },

--- a/test/production/standalone-mode/optimizecss/index.test.ts
+++ b/test/production/standalone-mode/optimizecss/index.test.ts
@@ -1,42 +1,37 @@
-import { createNext } from 'e2e-utils'
-import { NextInstance } from 'e2e-utils'
-import { renderViaHTTP } from 'next-test-utils'
+import { nextTestSetup } from 'e2e-utils'
 
 describe('standalone mode and optimizeCss', () => {
-  let next: NextInstance
-
-  beforeAll(async () => {
-    next = await createNext({
-      files: {
-        'pages/index.js': `
-          import styles from './index.module.css'
-          
-          export default function Page() { 
-            return <p className={styles.home}>hello world</p>
-          } 
-        `,
-        'pages/index.module.css': `
-          .home {
-            background: orange;
-            color: black;
-          }
-        `,
+  const { next } = nextTestSetup({
+    files: {
+      'pages/index.js': `
+        import styles from './index.module.css'
+        
+        export default function Page() { 
+          return <p className={styles.home}>hello world</p>
+        } 
+      `,
+      'pages/index.module.css': `
+        .home {
+          background: orange;
+          color: black;
+        }
+      `,
+    },
+    nextConfig: {
+      experimental: {
+        optimizeCss: true,
       },
-      nextConfig: {
-        experimental: {
-          optimizeCss: true,
-        },
-        output: 'standalone',
-      },
-      dependencies: {
-        critters: '0.0.16',
-      },
-    })
+      output: 'standalone',
+    },
+    dependencies: {
+      critters: '0.0.16',
+    },
+    // TODO optimizeCss is broken when ?dpl is added to CSS URLs
+    disableAutoSkewProtection: true,
   })
-  afterAll(() => next.destroy())
 
   it('should work', async () => {
-    const html = await renderViaHTTP(next.url, '/')
+    const html = await next.render('/')
     expect(html).toContain('hello world')
     expect(html).toContain('background:orange')
   })

--- a/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-app.test.ts
@@ -84,6 +84,7 @@ describe('required server files app router', () => {
       /- Local:/,
       {
         ...process.env,
+        ...next.env,
         PORT: `${appPort}`,
       },
       undefined,

--- a/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-i18n.test.ts
@@ -118,6 +118,7 @@ describe('required server files i18n', () => {
       /- Local:/,
       {
         ...process.env,
+        ...next.env,
         PORT: `${appPort}`,
       },
       undefined,

--- a/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files-ppr.test.ts
@@ -104,6 +104,7 @@ describe.skip('required server files app router', () => {
       /- Local:/,
       {
         ...process.env,
+        ...next.env,
         __NEXT_TEST_MODE: 'e2e',
         PORT: `${appPort}`,
         NEXT_PRIVATE_DEBUG_CACHE: '1',

--- a/test/production/standalone-mode/required-server-files/required-server-files.test.ts
+++ b/test/production/standalone-mode/required-server-files/required-server-files.test.ts
@@ -145,6 +145,7 @@ describe('required server files', () => {
       /- Local:/,
       {
         ...process.env,
+        ...next.env,
         ENV_FROM_HOST: 'FOOBAR',
         PORT: `${appPort}`,
       },

--- a/test/production/standalone-mode/response-cache/index.test.ts
+++ b/test/production/standalone-mode/response-cache/index.test.ts
@@ -68,6 +68,7 @@ describe('minimal-mode-response-cache', () => {
       /- Local:/,
       {
         ...process.env,
+        ...next.env,
         HOSTNAME: '',
         PORT: port.toString(),
       },

--- a/test/production/standalone-mode/runtimeServerDeploymentId/index.test.ts
+++ b/test/production/standalone-mode/runtimeServerDeploymentId/index.test.ts
@@ -47,6 +47,7 @@ describe('standalone mode: runtimeServerDeploymentId', () => {
       /- Local:/,
       {
         ...process.env,
+        ...next.env,
         HOSTNAME: '::',
         PORT: appPort,
         NEXT_DEPLOYMENT_ID: MY_DEPLOYMENT_ID,

--- a/test/production/standalone-mode/runtimeServerDeploymentId/index.test.ts
+++ b/test/production/standalone-mode/runtimeServerDeploymentId/index.test.ts
@@ -23,6 +23,7 @@ describe('standalone mode: runtimeServerDeploymentId', () => {
         NEXT_DEPLOYMENT_ID: MY_DEPLOYMENT_ID,
       },
       skipStart: true,
+      disableAutoSkewProtection: true,
     })
     let { exitCode } = await next.build()
     // eslint-disable-next-line jest/no-standalone-expect

--- a/test/production/standalone-mode/type-module/index.test.ts
+++ b/test/production/standalone-mode/type-module/index.test.ts
@@ -28,7 +28,7 @@ describe('type-module', () => {
     const server = await initNextServerScript(
       serverFile,
       /- Local:/,
-      { ...process.env, PORT: appPort.toString() },
+      { ...process.env, ...next.env, PORT: appPort.toString() },
       undefined,
       { cwd: next.testDir }
     )


### PR DESCRIPTION
Enable skew protection for all start-mode tests when Turbopack is enabled (i.e. not dev). This works by setting `NEXT_DEPLOYMENT_ID` in the test infra

- When running the tests, `packages/next/src/server/lib/router-utils/resolve-routes.ts` now validates that all static asset requests have the correct `?dpl=...` query param value, and returns a 404 if missing.
- It can be disabled with `disableAutoSkewProtection: true` in the test options
- There were various tests that were asserting URLs and were missing the optional `?dpl` at the end.
   - `next.getDeploymentIdQuery()` can be used to get the `?dpl=dpl_123912js` string (or an empty string)
   - `next.getAssetQuery()` currently behaves like `getDeploymentIdQuery`, but will switch to prefer the immutable static token in #88607
