### PR TITLE
Allow Node.js' experimental inspector flags in `next dev` and `next build`

### DIFF
--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -323,8 +323,12 @@ const nextDev = async (
         nodeOptions.inspect = formatDebugAddress(address)
       }
 
+      const { nodeOptions: formattedNodeOptions, execArgv } =
+        formatNodeOptions(nodeOptions)
+
       child = fork(startServerPath, {
         stdio: 'inherit',
+        execArgv,
         env: {
           ...defaultEnv,
           ...(isTurbopack ? { TURBOPACK: process.env.TURBOPACK } : undefined),
@@ -336,7 +340,7 @@ const nextDev = async (
           NODE_EXTRA_CA_CERTS: startServerOptions.selfSignedCertificate
             ? startServerOptions.selfSignedCertificate.rootCA
             : defaultEnv.NODE_EXTRA_CA_CERTS,
-          NODE_OPTIONS: formatNodeOptions(nodeOptions),
+          NODE_OPTIONS: formattedNodeOptions,
           // There is a node.js bug on MacOS which causes closing file watchers to be really slow.
           // This limits the number of watchers to mitigate the issue.
           // https://github.com/nodejs/node/issues/29949

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -119,12 +119,15 @@ export class Worker {
       delete nodeOptions['max_old_space_size']
     }
 
+    const { nodeOptions: formattedNodeOptions, execArgv } =
+      formatNodeOptions(nodeOptions)
+
     const createWorker = () => {
       const workerEnv: NodeJS.ProcessEnv = {
         ...process.env,
         ...((farmOptions.forkOptions?.env || {}) as any),
         IS_NEXT_WORKER: 'true',
-        NODE_OPTIONS: formatNodeOptions(nodeOptions),
+        NODE_OPTIONS: formattedNodeOptions,
       }
 
       if (workerEnv.FORCE_COLOR === undefined) {
@@ -148,6 +151,7 @@ export class Worker {
         ...farmOptions,
         forkOptions: {
           ...farmOptions.forkOptions,
+          execArgv: [...execArgv, ...(farmOptions.forkOptions?.execArgv || [])],
           env: workerEnv,
         },
         maxRetries: 0,

--- a/packages/next/src/server/lib/utils.test.ts
+++ b/packages/next/src/server/lib/utils.test.ts
@@ -48,9 +48,33 @@ describe('formatNodeOptions', () => {
       normal: '1234',
     })
 
-    expect(result).toBe(
-      '--spaces="thing with spaces" --spacesAndQuotes="thing with \\"spaces\\"" --normal=1234'
-    )
+    expect(result).toEqual({
+      execArgv: [],
+      nodeOptions:
+        '--spaces="thing with spaces" --spacesAndQuotes="thing with \\"spaces\\"" --normal=1234',
+    })
+    expect(result.execArgv).toEqual([])
+  })
+
+  it('separates exec-argv-only options from NODE_OPTIONS', () => {
+    const result = formatNodeOptions({
+      'enable-source-maps': true,
+      'experimental-network-inspection': true,
+      'experimental-storage-inspection': true,
+      'experimental-worker-inspection': true,
+      'experimental-inspector-network-resource': true,
+      'max-old-space-size': '4096',
+    })
+
+    expect(result).toEqual({
+      nodeOptions: '--enable-source-maps --max-old-space-size=4096',
+      execArgv: [
+        '--experimental-network-inspection',
+        '--experimental-storage-inspection',
+        '--experimental-worker-inspection',
+        '--experimental-inspector-network-resource',
+      ],
+    })
   })
 })
 

--- a/packages/next/src/server/lib/utils.ts
+++ b/packages/next/src/server/lib/utils.ts
@@ -166,35 +166,68 @@ export const getParsedDebugAddress = (
 }
 
 /**
+ * Node.js CLI flags that are not allowed in NODE_OPTIONS and must be
+ * passed as direct CLI arguments via execArgv.
+ * This set is the difference between all Node.js CLI flags and the ones **not**
+ * allowed in NODE_OPTIONS, as listed in the Node.js documentation:
+ * https://nodejs.org/api/cli.html#node_optionsoptions
+ *
+ * It is not exhaustive since not all options make sense for Next.js (e.g. --test)
+ */
+const EXEC_ARGV_ONLY_OPTIONS = new Set([
+  'experimental-network-inspection',
+  'experimental-storage-inspection',
+  'experimental-worker-inspection',
+  'experimental-inspector-network-resource',
+])
+
+function formatArg(
+  key: string,
+  value: string | boolean | undefined
+): string | null {
+  if (value === true) {
+    return `--${key}`
+  }
+
+  if (value) {
+    return `--${key}=${
+      // Values with spaces need to be quoted. We use JSON.stringify to
+      // also escape any nested quotes.
+      value.includes(' ') && !value.startsWith('"')
+        ? JSON.stringify(value)
+        : value
+    }`
+  }
+
+  return null
+}
+
+/**
  * Stringify the arguments to be used in a command line. It will ignore any
- * argument that has a value of `undefined`.
+ * argument that has a value of `undefined`. Options that are not allowed in
+ * NODE_OPTIONS are returned separately as execArgv.
  *
  * @param args The arguments to be stringified.
- * @returns A string with the arguments.
+ * @returns An object with `nodeOptions` string and `execArgv` array.
  */
 export function formatNodeOptions(
   args: Record<string, string | boolean | undefined>
-): string {
-  return Object.entries(args)
-    .map(([key, value]) => {
-      if (value === true) {
-        return `--${key}`
-      }
+): { nodeOptions: string; execArgv: string[] } {
+  const nodeOptionsParts: string[] = []
+  const execArgv: string[] = []
 
-      if (value) {
-        return `--${key}=${
-          // Values with spaces need to be quoted. We use JSON.stringify to
-          // also escape any nested quotes.
-          value.includes(' ') && !value.startsWith('"')
-            ? JSON.stringify(value)
-            : value
-        }`
-      }
+  for (const [key, value] of Object.entries(args)) {
+    const formatted = formatArg(key, value)
+    if (formatted === null) continue
 
-      return null
-    })
-    .filter((arg) => arg !== null)
-    .join(' ')
+    if (EXEC_ARGV_ONLY_OPTIONS.has(key)) {
+      execArgv.push(formatted)
+    } else {
+      nodeOptionsParts.push(formatted)
+    }
+  }
+
+  return { nodeOptions: nodeOptionsParts.join(' '), execArgv }
 }
 
 export function getParsedNodeOptions(): Record<
@@ -237,7 +270,7 @@ export function getFormattedNodeOptionsWithoutInspect() {
   const args = getParsedNodeOptionsWithoutInspect()
   if (Object.keys(args).length === 0) return ''
 
-  return formatNodeOptions(args)
+  return formatNodeOptions(args).nodeOptions
 }
 
 /**

--- a/test/e2e/node-cli-args/app/layout.tsx
+++ b/test/e2e/node-cli-args/app/layout.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <head />
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/node-cli-args/app/page.tsx
+++ b/test/e2e/node-cli-args/app/page.tsx
@@ -1,0 +1,4 @@
+export default async function Page() {
+  await fetch('https://next-data-api-endpoint.vercel.app/api/random')
+  return <p>hello world</p>
+}

--- a/test/e2e/node-cli-args/node-cli-args.test.ts
+++ b/test/e2e/node-cli-args/node-cli-args.test.ts
@@ -1,0 +1,18 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('node-cli-args', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+    startCommand: `node --experimental-network-inspection ./node_modules/next/dist/bin/next ${process.env.NEXT_TEST_MODE === 'dev' ? 'dev' : 'start'}`,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  it('should start server with --experimental-network-inspection', async () => {
+    if (isNextDev) {
+      await expect(next.start()).rejects.toThrow('exited unexpectedly')
+    } else {
+      await next.start()
+    }
+  })
+})

--- a/test/e2e/node-cli-args/node-cli-args.test.ts
+++ b/test/e2e/node-cli-args/node-cli-args.test.ts
@@ -9,6 +9,11 @@ describe('node-cli-args', () => {
   })
 
   it('should start server with --experimental-network-inspection', async () => {
-    await next.start()
+    if (process.version.startsWith('v20')) {
+      // --experimental-network-inspection is not supported in Node 20.
+      await expect(next.start()).rejects.toThrow()
+    } else {
+      await next.start()
+    }
   })
 })

--- a/test/e2e/node-cli-args/node-cli-args.test.ts
+++ b/test/e2e/node-cli-args/node-cli-args.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 
 describe('node-cli-args', () => {
-  const { next, isNextDev } = nextTestSetup({
+  const { next } = nextTestSetup({
     files: __dirname,
     startCommand: `node --experimental-network-inspection ./node_modules/next/dist/bin/next ${process.env.NEXT_TEST_MODE === 'dev' ? 'dev' : 'start'}`,
     skipDeployment: true,
@@ -9,10 +9,6 @@ describe('node-cli-args', () => {
   })
 
   it('should start server with --experimental-network-inspection', async () => {
-    if (isNextDev) {
-      await expect(next.start()).rejects.toThrow('exited unexpectedly')
-    } else {
-      await next.start()
-    }
+    await next.start()
   })
 })


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/87794
Fixes https://linear.app/vercel/issue/NEXT-4863/

Certain Node.js options are only supported as CLI args and not via a `NODE_OPTIONS` environment variable. However, `next dev` was always passing along CLI args to `NODE_OPTIONS`.

Now we forward a curated list of Node.js CLI args as CLI args to the dev server. Most interestingly, this enables having Node.js' experimental Network inspector running (`-experimental-network-inspection`) to enable the Network tab of Chrome DevTools when attached to Node.js.

All allowed CLI-only flags:
- `--experimental-network-inspection`
- `--experimental-storage-inspection`
- `--experimental-worker-inspection`
- `--experimental-inspector-network-resource`

`next start` was already working.

Holding off on adding better support via `next dev --experimental-network-inspection` because it's an experimental flag and I'm not too familiar with the current state.