### PR TITLE
[ci] Use `NEXT_TEST_CI` instead of `CI` for e2e test retry guard

### DIFF
--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -126,7 +126,7 @@ if (!e2eGlobal.__NEXT_E2E_TEST_CONFIG_PATCHED__) {
       global.test = wrapJestTestFn(global.test) as jest.It
     }
 
-    if (process.env.CI) {
+    if (process.env.NEXT_TEST_CI) {
       jest.retryTimes(1)
     }
   }


### PR DESCRIPTION
`run-tests.js` explicitly unsets `CI` in the spawned Jest child process and preserves the original value as `NEXT_TEST_CI`. Since `test/lib/e2e-utils/index.ts` runs inside that child process, `process.env.CI` is always empty, making the `jest.retryTimes(1)` call effectively dead code in CI.