### PR TITLE
Fix edge index page _next/data route

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -677,6 +677,11 @@ export async function handleBuildComplete({
         }
 
         const route = page.page.replace(/^(app|pages)\//, '')
+        const pathname = isAppPrefix
+          ? normalizeAppPath(route)
+          : route === '/index'
+            ? '/'
+            : route
 
         const output: Omit<AdapterOutput[typeof type], 'type'> & {
           type: any
@@ -685,7 +690,7 @@ export async function handleBuildComplete({
           id: page.name,
           runtime: 'edge',
           sourcePage: route,
-          pathname: isAppPrefix ? normalizeAppPath(route) : route,
+          pathname,
           filePath: path.join(
             distDir,
             page.files.find(
@@ -766,16 +771,16 @@ export async function handleBuildComplete({
             pathname: rscPathname,
             id: page.name + '.rsc',
           })
-        } else if (serverPropsPages.has(route === '/index' ? '/' : route)) {
+        } else if (serverPropsPages.has(pathname)) {
           const nextDataPath = path.posix.join(
             '/_next/data/',
             buildId,
-            normalizePagePath(output.pathname) + '.json'
+            normalizePagePath(pathname) + '.json'
           )
-          outputs.appPages.push({
+          outputs.pages.push({
             ...output,
             pathname: nextDataPath,
-            id: page.name,
+            id: nextDataPath,
           })
         }
       }

--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -780,7 +780,6 @@ export async function handleBuildComplete({
           outputs.pages.push({
             ...output,
             pathname: nextDataPath,
-            id: nextDataPath,
           })
         }
       }

--- a/test/e2e/edge-pages-support/app/my-adapter.js
+++ b/test/e2e/edge-pages-support/app/my-adapter.js
@@ -1,15 +1,5 @@
 module.exports = {
   onBuildComplete({ outputs }) {
-    const duplicateIds = new Set()
-    const seenIds = new Set()
-    for (const output of outputs.pages) {
-      if (seenIds.has(output.id)) {
-        duplicateIds.add(output.id)
-      } else {
-        seenIds.add(output.id)
-      }
-    }
-
     const pagesDataPathnames = outputs.pages
       .map((item) => item.pathname)
       .filter((item) => item.startsWith('/_next/data/'))
@@ -27,10 +17,6 @@ module.exports = {
       ...pagesDataPathnames,
       ...appPagesDataPathnames,
     ].some((item) => /^\/_next\/data\/[^/]+\/index\/index\.json$/.test(item))
-    const hasDataPathWithDifferentId = outputs.pages.some(
-      (item) =>
-        item.pathname.startsWith('/_next/data/') && item.id !== item.pathname
-    )
 
     if (!hasIndexData || !hasDynamicData || hasDoubleIndexData) {
       throw new Error(
@@ -41,8 +27,6 @@ module.exports = {
           `hasIndexData=${hasIndexData}`,
           `hasDynamicData=${hasDynamicData}`,
           `hasDoubleIndexData=${hasDoubleIndexData}`,
-          `hasDataPathWithDifferentId=${hasDataPathWithDifferentId}`,
-          `duplicateIds=${JSON.stringify(Array.from(duplicateIds))}`,
         ].join('\n')
       )
     }
@@ -50,16 +34,6 @@ module.exports = {
     if (appPagesDataPathnames.length > 0) {
       throw new Error(
         `Expected no pages-router data outputs in appPages: ${JSON.stringify(appPagesDataPathnames)}`
-      )
-    }
-    if (hasDataPathWithDifferentId) {
-      throw new Error(
-        `Expected pages-router _next/data outputs to use pathname as id: ${JSON.stringify(outputs.pages.filter((item) => item.pathname.startsWith('/_next/data/')))}`
-      )
-    }
-    if (duplicateIds.size > 0) {
-      throw new Error(
-        `Expected unique output ids, found duplicates: ${JSON.stringify(Array.from(duplicateIds))}`
       )
     }
   },

--- a/test/e2e/edge-pages-support/app/my-adapter.js
+++ b/test/e2e/edge-pages-support/app/my-adapter.js
@@ -1,0 +1,66 @@
+module.exports = {
+  onBuildComplete({ outputs }) {
+    const duplicateIds = new Set()
+    const seenIds = new Set()
+    for (const output of outputs.pages) {
+      if (seenIds.has(output.id)) {
+        duplicateIds.add(output.id)
+      } else {
+        seenIds.add(output.id)
+      }
+    }
+
+    const pagesDataPathnames = outputs.pages
+      .map((item) => item.pathname)
+      .filter((item) => item.startsWith('/_next/data/'))
+    const appPagesDataPathnames = outputs.appPages
+      .map((item) => item.pathname)
+      .filter((item) => item.startsWith('/_next/data/'))
+
+    const hasIndexData = pagesDataPathnames.some((item) =>
+      /^\/_next\/data\/[^/]+\/index\.json$/.test(item)
+    )
+    const hasDynamicData = pagesDataPathnames.some((item) =>
+      /^\/_next\/data\/[^/]+\/\[id\]\.json$/.test(item)
+    )
+    const hasDoubleIndexData = [
+      ...pagesDataPathnames,
+      ...appPagesDataPathnames,
+    ].some((item) => /^\/_next\/data\/[^/]+\/index\/index\.json$/.test(item))
+    const hasDataPathWithDifferentId = outputs.pages.some(
+      (item) =>
+        item.pathname.startsWith('/_next/data/') && item.id !== item.pathname
+    )
+
+    if (!hasIndexData || !hasDynamicData || hasDoubleIndexData) {
+      throw new Error(
+        [
+          'Unexpected edge pages data output from adapter build:',
+          `pagesDataPathnames=${JSON.stringify(pagesDataPathnames)}`,
+          `appPagesDataPathnames=${JSON.stringify(appPagesDataPathnames)}`,
+          `hasIndexData=${hasIndexData}`,
+          `hasDynamicData=${hasDynamicData}`,
+          `hasDoubleIndexData=${hasDoubleIndexData}`,
+          `hasDataPathWithDifferentId=${hasDataPathWithDifferentId}`,
+          `duplicateIds=${JSON.stringify(Array.from(duplicateIds))}`,
+        ].join('\n')
+      )
+    }
+
+    if (appPagesDataPathnames.length > 0) {
+      throw new Error(
+        `Expected no pages-router data outputs in appPages: ${JSON.stringify(appPagesDataPathnames)}`
+      )
+    }
+    if (hasDataPathWithDifferentId) {
+      throw new Error(
+        `Expected pages-router _next/data outputs to use pathname as id: ${JSON.stringify(outputs.pages.filter((item) => item.pathname.startsWith('/_next/data/')))}`
+      )
+    }
+    if (duplicateIds.size > 0) {
+      throw new Error(
+        `Expected unique output ids, found duplicates: ${JSON.stringify(Array.from(duplicateIds))}`
+      )
+    }
+  },
+}

--- a/test/e2e/edge-pages-support/app/next.config.js
+++ b/test/e2e/edge-pages-support/app/next.config.js
@@ -11,4 +11,8 @@ module.exports = {
       },
     ]
   },
+  experimental: {
+    adapterPath:
+      process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.js'),
+  },
 }

--- a/test/e2e/edge-pages-support/edge-document.test.ts
+++ b/test/e2e/edge-pages-support/edge-document.test.ts
@@ -8,7 +8,9 @@ describe('edge render - custom _document with edge runtime', () => {
       'pages/index.js': new FileRef(
         join(__dirname, 'app', 'pages', 'index.js')
       ),
+      'pages/[id].js': new FileRef(join(__dirname, 'app', 'pages', '[id].js')),
       'next.config.js': new FileRef(join(__dirname, 'app', 'next.config.js')),
+      'my-adapter.js': new FileRef(join(__dirname, 'app', 'my-adapter.js')),
       'pages/_document.js': `
         import Document, { Html, Head, Main, NextScript } from 'next/document'
         export default class MyDocument extends Document {


### PR DESCRIPTION
Fixes failing assertion with turbopack

Verified against turbopack + adapter deploy test locally
<img width="2076" height="1336" alt="CleanShot 2026-02-26 at 13 25 30@2x" src="https://github.com/user-attachments/assets/a8c66314-8163-4371-b02a-dc7146989425" />


x-ref: https://github.com/vercel/next.js/pull/90600#issuecomment-3968044160