### PR TITLE
replace escape-string-regexp with tiny-escape in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "cross-spawn": "6.0.5",
     "dd-trace": "4.12.0",
     "es5-ext": "0.10.53",
-    "escape-string-regexp": "2.0.0",
+    "tiny-escape": "^1.1.0",
     "eslint": "9.37.0",
     "eslint-config-next": "workspace:*",
     "eslint-formatter-codeframe": "7.32.1",

--- a/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
+++ b/test/e2e/app-dir/use-cache-hanging-inputs/use-cache-hanging-inputs.test.ts
@@ -1,5 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
-import escapeStringRegexp from 'escape-string-regexp'
+import escapeStringRegexp from 'tiny-escape'
 import {
   getRedboxDescription,
   getRedboxSource,

--- a/test/e2e/edge-pages-support/index.test.ts
+++ b/test/e2e/edge-pages-support/index.test.ts
@@ -2,7 +2,7 @@ import { nextTestSetup } from 'e2e-utils'
 import { fetchViaHTTP, normalizeRegEx } from 'next-test-utils'
 import cheerio from 'cheerio'
 import { join } from 'path'
-import escapeStringRegexp from 'escape-string-regexp'
+import escapeStringRegexp from 'tiny-escape'
 import fs from 'fs-extra'
 
 describe('edge-render-getserversideprops', () => {

--- a/test/e2e/getserversideprops/test/index.test.ts
+++ b/test/e2e/getserversideprops/test/index.test.ts
@@ -2,7 +2,7 @@
 
 import cheerio from 'cheerio'
 import { createNext, FileRef } from 'e2e-utils'
-import escapeRegex from 'escape-string-regexp'
+import escapeRegex from 'tiny-escape'
 import {
   check,
   retry,

--- a/test/e2e/middleware-rewrites/test/index.test.ts
+++ b/test/e2e/middleware-rewrites/test/index.test.ts
@@ -6,7 +6,7 @@ import webdriver from 'next-webdriver'
 import { NextInstance } from 'e2e-utils'
 import { check, fetchViaHTTP, retry } from 'next-test-utils'
 import { createNext, FileRef } from 'e2e-utils'
-import escapeStringRegexp from 'escape-string-regexp'
+import escapeStringRegexp from 'tiny-escape'
 
 describe('Middleware Rewrite', () => {
   let next: NextInstance

--- a/test/e2e/prerender.test.ts
+++ b/test/e2e/prerender.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra'
 import cookie from 'cookie'
 import cheerio from 'cheerio'
 import { join, sep } from 'path'
-import escapeRegex from 'escape-string-regexp'
+import escapeRegex from 'tiny-escape'
 import { createNext, FileRef } from 'e2e-utils'
 import { NextInstance } from 'e2e-utils'
 import {

--- a/test/integration/css-customization/test/index.test.ts
+++ b/test/integration/css-customization/test/index.test.ts
@@ -3,7 +3,7 @@
 import { join } from 'path'
 import { readdir, readFile, remove } from 'fs-extra'
 import { nextBuild } from 'next-test-utils'
-import escapeStringRegexp from 'escape-string-regexp'
+import escapeStringRegexp from 'tiny-escape'
 
 const fixturesDir = join(__dirname, '../..', 'css-fixtures')
 const BUILD_FAILURE_RE = /Build failed because of (webpack|Rspack) errors/

--- a/test/integration/i18n-support/test/shared.ts
+++ b/test/integration/i18n-support/test/shared.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra'
 import cheerio from 'cheerio'
 import { join } from 'path'
 import webdriver from 'next-webdriver'
-import escapeRegex from 'escape-string-regexp'
+import escapeRegex from 'tiny-escape'
 import assert from 'assert'
 import {
   fetchViaHTTP,

--- a/test/integration/repeated-slashes/test/index.test.ts
+++ b/test/integration/repeated-slashes/test/index.test.ts
@@ -2,7 +2,7 @@
 import { join } from 'path'
 import fs from 'fs-extra'
 import webdriver from 'next-webdriver'
-import escapeRegex from 'escape-string-regexp'
+import escapeRegex from 'tiny-escape'
 import {
   nextBuild,
   File,

--- a/test/lib/next-modes/base.ts
+++ b/test/lib/next-modes/base.ts
@@ -17,7 +17,7 @@ import {
 import cheerio from 'cheerio'
 import { once } from 'events'
 import { Playwright } from 'next-webdriver'
-import escapeStringRegexp from 'escape-string-regexp'
+import escapeStringRegexp from 'tiny-escape'
 import { Page, Response } from 'playwright'
 
 type Event = 'stdout' | 'stderr' | 'error' | 'destroy'

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -31,7 +31,7 @@ import { Playwright } from 'next-webdriver'
 
 import { shouldUseTurbopack } from './turbo'
 import stripAnsi from 'strip-ansi'
-import escapeRegex from 'escape-string-regexp'
+import escapeRegex from 'tiny-escape'
 
 // TODO: Create dedicated Jest environment that sets up these matchers
 // Edge Runtime unit tests fail with "EvalError: Code generation from strings disallowed for this context" if these matchers are imported in those tests.


### PR DESCRIPTION
### What?

Replace `escape-string-regexp` (pinned at v2.0.0) with `tiny-escape` in all test files.

### Why?

`escape-string-regexp@2.0.0` is from 2019. The current version (v5) is ESM-only, so upgrading would break the test suite.

[`tiny-escape`](https://npmgraph.js.org/?q=tiny-escape) has the same API and ships ESM + CJS with TypeScript types. 192 bytes gzipped, zero dependencies.

Next.js already has an internal `escapeStringRegexp` for runtime code (`packages/next/src/shared/lib/escape-regexp.ts`). This PR only touches test files that were using the npm package.

### How?

- Replaced `escape-string-regexp` with `tiny-escape` in root `package.json` devDependencies
- Updated imports in 10 test files (module specifier only, local variable names unchanged)