### PR TITLE
turbo-persistence: streaming SST writer for reduced memory usage

### DIFF
--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -3,7 +3,7 @@ use std::{
     collections::HashSet,
     fs::{self, File, OpenOptions, ReadDir},
     io::{BufWriter, Write},
-    mem::{swap, take},
+    mem::take,
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::atomic::{AtomicBool, AtomicU32, Ordering},
@@ -36,7 +36,7 @@ use crate::{
     parallel_scheduler::ParallelScheduler,
     sst_filter::SstFilter,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile},
-    static_sorted_file_builder::{StaticSortedFileBuilderMeta, write_static_stored_file},
+    static_sorted_file_builder::{StaticSortedFileBuilderMeta, StreamingSstWriter},
     value_block_count_tracker::ValueBlockCountTracker,
     write_batch::{FinishResult, WriteBatch},
 };
@@ -1023,26 +1023,6 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     });
                                 }
 
-                                fn create_sst_file<S: ParallelScheduler>(
-                                    parallel_scheduler: &S,
-                                    entries: &[LookupEntry],
-                                    path: &Path,
-                                    seq: u32,
-                                    flags: MetaEntryFlags,
-                                ) -> Result<(u32, File, StaticSortedFileBuilderMeta<'static>)>
-                                {
-                                    let _span =
-                                        tracing::trace_span!("write merged sst file").entered();
-                                    let (meta, file) = parallel_scheduler.block_in_place(|| {
-                                        write_static_stored_file(
-                                            entries,
-                                            &path.join(format!("{seq:08}.sst")),
-                                            flags,
-                                        )
-                                    })?;
-                                    Ok((seq, file, meta))
-                                }
-
                                 // Open SST files independently for compaction.
                                 // Uses MADV_SEQUENTIAL for better OS page management
                                 // and avoids caching mmaps on MetaEntry's OnceLock.
@@ -1070,35 +1050,110 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
                                 let mut current: Option<LookupEntry> = None;
 
-                                #[derive(Default)]
                                 struct Collector {
-                                    entries: Vec<LookupEntry>,
+                                    /// The active writer and its sequence number. `None` if no
+                                    /// entries have been added since the last flush.
+                                    writer: Option<(u32, StreamingSstWriter)>,
                                     total_key_size: usize,
                                     total_value_size: usize,
+                                    entry_count: usize,
                                     value_block_tracker: ValueBlockCountTracker,
-                                    last_entries: Vec<LookupEntry>,
-                                    last_entries_total_key_size: usize,
                                     new_sst_files:
                                         Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
                                 }
                                 impl Collector {
+                                    fn new() -> Self {
+                                        Self {
+                                            writer: None,
+                                            total_key_size: 0,
+                                            total_value_size: 0,
+                                            entry_count: 0,
+                                            value_block_tracker: ValueBlockCountTracker::default(),
+                                            new_sst_files: Vec::new(),
+                                        }
+                                    }
+
                                     fn is_full(&self) -> bool {
                                         self.total_key_size + self.total_value_size
                                             > DATA_THRESHOLD_PER_COMPACTED_FILE
-                                            || self.entries.len() >= MAX_ENTRIES_PER_COMPACTED_FILE
+                                            || self.entry_count >= MAX_ENTRIES_PER_COMPACTED_FILE
                                             || self.value_block_tracker.is_full()
                                     }
 
-                                    fn is_half_full(&self) -> bool {
-                                        self.total_key_size + self.total_value_size
-                                            > DATA_THRESHOLD_PER_COMPACTED_FILE / 2
-                                            || self.entries.len()
-                                                >= MAX_ENTRIES_PER_COMPACTED_FILE / 2
-                                            || self.value_block_tracker.is_half_full()
+                                    /// Ensures a writer is open, creating one if needed.
+                                    fn ensure_writer(
+                                        &mut self,
+                                        path: &Path,
+                                        flags: MetaEntryFlags,
+                                        sequence_number: &AtomicU32,
+                                    ) -> Result<&mut StreamingSstWriter>
+                                    {
+                                        if self.writer.is_none() {
+                                            let seq =
+                                                sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
+                                            let sst_path = path.join(format!("{seq:08}.sst"));
+                                            let writer = StreamingSstWriter::new(
+                                                &sst_path,
+                                                flags,
+                                                MAX_ENTRIES_PER_COMPACTED_FILE as u64,
+                                            )?;
+                                            self.writer = Some((seq, writer));
+                                        }
+                                        Ok(&mut self.writer.as_mut().unwrap().1)
+                                    }
+
+                                    /// Finishes the current writer and records the SST file.
+                                    fn finish_current(
+                                        &mut self,
+                                        keys_written: &mut u64,
+                                    ) -> Result<()> {
+                                        if let Some((seq, writer)) = self.writer.take() {
+                                            let _span =
+                                                tracing::trace_span!("write merged sst file")
+                                                    .entered();
+                                            let (meta, file) = writer.finish()?;
+                                            *keys_written += meta.entries;
+                                            self.new_sst_files.push((seq, file, meta));
+                                        }
+                                        self.total_key_size = 0;
+                                        self.total_value_size = 0;
+                                        self.entry_count = 0;
+                                        self.value_block_tracker =
+                                            ValueBlockCountTracker::default();
+                                        Ok(())
+                                    }
+
+                                    /// Adds an entry to the collector, flushing if full.
+                                    fn add_entry(
+                                        &mut self,
+                                        entry: &LookupEntry,
+                                        path: &Path,
+                                        flags: MetaEntryFlags,
+                                        sequence_number: &AtomicU32,
+                                        keys_written: &mut u64,
+                                    ) -> Result<()> {
+                                        let key_size = entry.key.len();
+                                        let value_size = entry.value.uncompressed_size_in_sst();
+                                        let is_medium = entry.value.is_medium_value();
+                                        let small_size = entry.value.small_value_size();
+
+                                        self.total_key_size += key_size;
+                                        self.total_value_size += value_size;
+                                        self.entry_count += 1;
+                                        self.value_block_tracker.track(is_medium, small_size);
+
+                                        if self.is_full() {
+                                            self.finish_current(keys_written)?;
+                                        }
+
+                                        let writer =
+                                            self.ensure_writer(path, flags, sequence_number)?;
+                                        writer.add(entry)?;
+                                        Ok(())
                                     }
                                 }
-                                let mut used_collector = Collector::default();
-                                let mut unused_collector = Collector::default();
+                                let mut used_collector = Collector::new();
+                                let mut unused_collector = Collector::new();
                                 for entry in iter {
                                     let entry = entry?;
 
@@ -1109,81 +1164,18 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                                 used_key_hashes.as_ref().is_some_and(|amqf| {
                                                     amqf.contains_fingerprint(current.hash)
                                                 });
-                                            let collector = if is_used {
-                                                &mut used_collector
+                                            let (collector, flags) = if is_used {
+                                                (&mut used_collector, MetaEntryFlags::WARM)
                                             } else {
-                                                &mut unused_collector
+                                                (&mut unused_collector, MetaEntryFlags::COLD)
                                             };
-                                            let key_size = current.key.len();
-                                            let value_size =
-                                                current.value.uncompressed_size_in_sst();
-                                            let is_medium = current.value.is_medium_value();
-                                            let small_size = current.value.small_value_size();
-                                            collector.total_key_size += key_size;
-                                            collector.total_value_size += value_size;
-                                            collector
-                                                .value_block_tracker
-                                                .track(is_medium, small_size);
-
-                                            if collector.is_full() {
-                                                swap(
-                                                    &mut collector.entries,
-                                                    &mut collector.last_entries,
-                                                );
-                                                collector.last_entries_total_key_size =
-                                                    collector.total_key_size - key_size;
-                                                collector.total_key_size = key_size;
-                                                collector.total_value_size = value_size;
-                                                collector
-                                                    .value_block_tracker
-                                                    .reset_to(is_medium, small_size);
-
-                                                if !collector.entries.is_empty() {
-                                                    let seq = sequence_number
-                                                        .fetch_add(1, Ordering::SeqCst)
-                                                        + 1;
-
-                                                    keys_written += collector.entries.len() as u64;
-
-                                                    let mut flags = MetaEntryFlags::default();
-                                                    flags.set_cold(!is_used);
-                                                    collector.new_sst_files.push(create_sst_file(
-                                                        &self.parallel_scheduler,
-                                                        &collector.entries,
-                                                        path,
-                                                        seq,
-                                                        flags,
-                                                    )?);
-
-                                                    collector.entries.clear();
-                                                }
-                                            }
-
-                                            collector.entries.push(current);
-
-                                            // Early flush: once entries is past 50%
-                                            // of any limit, the final file won't be
-                                            // undersized, so flush last_entries to
-                                            // reduce peak memory.
-                                            if !collector.last_entries.is_empty()
-                                                && collector.is_half_full()
-                                            {
-                                                let seq = sequence_number
-                                                    .fetch_add(1, Ordering::SeqCst)
-                                                    + 1;
-                                                keys_written += collector.last_entries.len() as u64;
-                                                let mut flags = MetaEntryFlags::default();
-                                                flags.set_cold(!is_used);
-                                                collector.new_sst_files.push(create_sst_file(
-                                                    &self.parallel_scheduler,
-                                                    &collector.last_entries,
-                                                    path,
-                                                    seq,
-                                                    flags,
-                                                )?);
-                                                collector.last_entries.clear();
-                                                collector.last_entries_total_key_size = 0;
-                                            }
+                                            collector.add_entry(
+                                                &current,
+                                                path,
+                                                flags,
+                                                sequence_number,
+                                                &mut keys_written,
+                                            )?;
                                         } else {
                                             // Override value
                                             // TODO delete blob file
@@ -1195,75 +1187,24 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     let is_used = used_key_hashes
                                         .as_ref()
                                         .is_some_and(|amqf| amqf.contains_fingerprint(entry.hash));
-                                    let collector = if is_used {
-                                        &mut used_collector
+                                    let (collector, flags) = if is_used {
+                                        (&mut used_collector, MetaEntryFlags::WARM)
                                     } else {
-                                        &mut unused_collector
+                                        (&mut unused_collector, MetaEntryFlags::COLD)
                                     };
-
-                                    collector.total_key_size += entry.key.len();
-                                    // Obsolete as we no longer need total_value_size
-                                    // total_value_size += entry.value.uncompressed_size_in_sst();
-                                    collector.entries.push(entry);
+                                    collector.add_entry(
+                                        &entry,
+                                        path,
+                                        flags,
+                                        sequence_number,
+                                        &mut keys_written,
+                                    )?;
                                 }
 
-                                // If we have one set of entries left, write them to a new SST file
-                                for (collector, flags) in [
-                                    (&mut used_collector, MetaEntryFlags::WARM),
-                                    (&mut unused_collector, MetaEntryFlags::COLD),
-                                ] {
-                                    if collector.last_entries.is_empty()
-                                        && !collector.entries.is_empty()
-                                    {
-                                        let seq =
-                                            sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
+                                // Finish remaining writers
+                                used_collector.finish_current(&mut keys_written)?;
+                                unused_collector.finish_current(&mut keys_written)?;
 
-                                        keys_written += collector.entries.len() as u64;
-                                        collector.new_sst_files.push(create_sst_file(
-                                            &self.parallel_scheduler,
-                                            &collector.entries,
-                                            path,
-                                            seq,
-                                            flags,
-                                        )?);
-                                    } else
-                                    // If we have two sets of entries left, merge them and
-                                    // split it into two SST files, to avoid having a
-                                    // single SST file that is very small.
-                                    if !collector.last_entries.is_empty() {
-                                        collector.last_entries.append(&mut collector.entries);
-
-                                        collector.last_entries_total_key_size +=
-                                            collector.total_key_size;
-
-                                        let (part1, part2) = collector
-                                            .last_entries
-                                            .split_at(collector.last_entries.len() / 2);
-
-                                        let seq1 =
-                                            sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
-                                        let seq2 =
-                                            sequence_number.fetch_add(1, Ordering::SeqCst) + 1;
-
-                                        keys_written += part1.len() as u64;
-                                        collector.new_sst_files.push(create_sst_file(
-                                            &self.parallel_scheduler,
-                                            part1,
-                                            path,
-                                            seq1,
-                                            flags,
-                                        )?);
-
-                                        keys_written += part2.len() as u64;
-                                        collector.new_sst_files.push(create_sst_file(
-                                            &self.parallel_scheduler,
-                                            part2,
-                                            path,
-                                            seq2,
-                                            flags,
-                                        )?);
-                                    }
-                                }
                                 let mut new_sst_files = take(&mut unused_collector.new_sst_files);
                                 new_sst_files.append(&mut used_collector.new_sst_files);
                                 Ok(PartialMergeResult::Merged {

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -37,7 +37,6 @@ use crate::{
     sst_filter::SstFilter,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile},
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, StreamingSstWriter},
-    value_block_count_tracker::ValueBlockCountTracker,
     write_batch::{FinishResult, WriteBatch},
 };
 
@@ -1052,39 +1051,29 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
                                 struct Collector {
                                     /// The active writer and its sequence number. `None` if no
-                                    /// entries have been added since the last flush.
+                                    /// entries have been added since the last flush. We defer
+                                    /// allocation to avoid creating empty SST files for collectors
+                                    /// that receive no entries (e.g., the unused_collector when
+                                    /// all keys are in the
+                                    /// used set).
                                     writer: Option<(u32, StreamingSstWriter)>,
-                                    total_key_size: usize,
-                                    total_value_size: usize,
-                                    entry_count: usize,
-                                    value_block_tracker: ValueBlockCountTracker,
+                                    flags: MetaEntryFlags,
                                     new_sst_files:
                                         Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
                                 }
                                 impl Collector {
-                                    fn new() -> Self {
+                                    fn new(flags: MetaEntryFlags) -> Self {
                                         Self {
                                             writer: None,
-                                            total_key_size: 0,
-                                            total_value_size: 0,
-                                            entry_count: 0,
-                                            value_block_tracker: ValueBlockCountTracker::default(),
+                                            flags,
                                             new_sst_files: Vec::new(),
                                         }
-                                    }
-
-                                    fn is_full(&self) -> bool {
-                                        self.total_key_size + self.total_value_size
-                                            > DATA_THRESHOLD_PER_COMPACTED_FILE
-                                            || self.entry_count >= MAX_ENTRIES_PER_COMPACTED_FILE
-                                            || self.value_block_tracker.is_full()
                                     }
 
                                     /// Ensures a writer is open, creating one if needed.
                                     fn ensure_writer(
                                         &mut self,
                                         path: &Path,
-                                        flags: MetaEntryFlags,
                                         sequence_number: &AtomicU32,
                                     ) -> Result<&mut StreamingSstWriter>
                                     {
@@ -1094,7 +1083,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             let sst_path = path.join(format!("{seq:08}.sst"));
                                             let writer = StreamingSstWriter::new(
                                                 &sst_path,
-                                                flags,
+                                                self.flags,
                                                 MAX_ENTRIES_PER_COMPACTED_FILE as u64,
                                             )?;
                                             self.writer = Some((seq, writer));
@@ -1102,58 +1091,49 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         Ok(&mut self.writer.as_mut().unwrap().1)
                                     }
 
-                                    /// Finishes the current writer and records the SST file.
-                                    fn finish_current(
+                                    /// Closes the current SST file (flushing remaining blocks and
+                                    /// writing the index) and records it in the completed files
+                                    /// list.
+                                    fn close_sst_file(
                                         &mut self,
                                         keys_written: &mut u64,
                                     ) -> Result<()> {
                                         if let Some((seq, writer)) = self.writer.take() {
                                             let _span =
-                                                tracing::trace_span!("write merged sst file")
+                                                tracing::trace_span!("close merged sst file")
                                                     .entered();
                                             let (meta, file) = writer.finish()?;
                                             *keys_written += meta.entries;
                                             self.new_sst_files.push((seq, file, meta));
                                         }
-                                        self.total_key_size = 0;
-                                        self.total_value_size = 0;
-                                        self.entry_count = 0;
-                                        self.value_block_tracker =
-                                            ValueBlockCountTracker::default();
                                         Ok(())
                                     }
 
-                                    /// Adds an entry to the collector, flushing if full.
+                                    /// Adds an entry to the collector. Writes the entry first,
+                                    /// then checks if the file is full and closes it if so.
                                     fn add_entry(
                                         &mut self,
                                         entry: &LookupEntry,
                                         path: &Path,
-                                        flags: MetaEntryFlags,
                                         sequence_number: &AtomicU32,
                                         keys_written: &mut u64,
                                     ) -> Result<()> {
-                                        let key_size = entry.key.len();
-                                        let value_size = entry.value.uncompressed_size_in_sst();
-                                        let is_medium = entry.value.is_medium_value();
-                                        let small_size = entry.value.small_value_size();
-
-                                        self.total_key_size += key_size;
-                                        self.total_value_size += value_size;
-                                        self.entry_count += 1;
-                                        self.value_block_tracker.track(is_medium, small_size);
-
-                                        if self.is_full() {
-                                            self.finish_current(keys_written)?;
-                                        }
-
-                                        let writer =
-                                            self.ensure_writer(path, flags, sequence_number)?;
+                                        let writer = self.ensure_writer(path, sequence_number)?;
                                         writer.add(entry)?;
+
+                                        // Check fullness after adding -- the writer tracks sizes
+                                        // and block counts internally.
+                                        if writer.is_full(
+                                            MAX_ENTRIES_PER_COMPACTED_FILE,
+                                            DATA_THRESHOLD_PER_COMPACTED_FILE,
+                                        ) {
+                                            self.close_sst_file(keys_written)?;
+                                        }
                                         Ok(())
                                     }
                                 }
-                                let mut used_collector = Collector::new();
-                                let mut unused_collector = Collector::new();
+                                let mut used_collector = Collector::new(MetaEntryFlags::WARM);
+                                let mut unused_collector = Collector::new(MetaEntryFlags::COLD);
                                 for entry in iter {
                                     let entry = entry?;
 
@@ -1164,15 +1144,14 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                                 used_key_hashes.as_ref().is_some_and(|amqf| {
                                                     amqf.contains_fingerprint(current.hash)
                                                 });
-                                            let (collector, flags) = if is_used {
-                                                (&mut used_collector, MetaEntryFlags::WARM)
+                                            let collector = if is_used {
+                                                &mut used_collector
                                             } else {
-                                                (&mut unused_collector, MetaEntryFlags::COLD)
+                                                &mut unused_collector
                                             };
                                             collector.add_entry(
                                                 &current,
                                                 path,
-                                                flags,
                                                 sequence_number,
                                                 &mut keys_written,
                                             )?;
@@ -1187,23 +1166,22 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     let is_used = used_key_hashes
                                         .as_ref()
                                         .is_some_and(|amqf| amqf.contains_fingerprint(entry.hash));
-                                    let (collector, flags) = if is_used {
-                                        (&mut used_collector, MetaEntryFlags::WARM)
+                                    let collector = if is_used {
+                                        &mut used_collector
                                     } else {
-                                        (&mut unused_collector, MetaEntryFlags::COLD)
+                                        &mut unused_collector
                                     };
                                     collector.add_entry(
                                         &entry,
                                         path,
-                                        flags,
                                         sequence_number,
                                         &mut keys_written,
                                     )?;
                                 }
 
-                                // Finish remaining writers
-                                used_collector.finish_current(&mut keys_written)?;
-                                unused_collector.finish_current(&mut keys_written)?;
+                                // Close remaining writers
+                                used_collector.close_sst_file(&mut keys_written)?;
+                                unused_collector.close_sst_file(&mut keys_written)?;
 
                                 let mut new_sst_files = take(&mut unused_collector.new_sst_files);
                                 new_sst_files.append(&mut used_collector.new_sst_files);

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1102,7 +1102,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             let _span =
                                                 tracing::trace_span!("close merged sst file")
                                                     .entered();
-                                            let (meta, file) = writer.finish()?;
+                                            let (meta, file) = writer.close()?;
                                             *keys_written += meta.entries;
                                             self.new_sst_files.push((seq, file, meta));
                                         }
@@ -1130,6 +1130,15 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                             self.close_sst_file(keys_written)?;
                                         }
                                         Ok(())
+                                    }
+                                }
+                                #[cfg(debug_assertions)]
+                                impl Drop for Collector {
+                                    fn drop(&mut self) {
+                                        assert!(
+                                            self.writer.is_none(),
+                                            "Collector dropped with an open writer"
+                                        );
                                     }
                                 }
                                 let mut used_collector = Collector::new(MetaEntryFlags::WARM);

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1056,7 +1056,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     /// that receive no entries (e.g., the unused_collector when
                                     /// all keys are in the
                                     /// used set).
-                                    writer: Option<(u32, StreamingSstWriter)>,
+                                    writer: Option<(u32, StreamingSstWriter<LookupEntry>)>,
                                     flags: MetaEntryFlags,
                                     new_sst_files:
                                         Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
@@ -1075,7 +1075,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         &mut self,
                                         path: &Path,
                                         sequence_number: &AtomicU32,
-                                    ) -> Result<&mut StreamingSstWriter>
+                                    ) -> Result<&mut StreamingSstWriter<LookupEntry>>
                                     {
                                         if self.writer.is_none() {
                                             let seq =
@@ -1113,7 +1113,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     /// then checks if the file is full and closes it if so.
                                     fn add_entry(
                                         &mut self,
-                                        entry: &LookupEntry,
+                                        entry: LookupEntry,
                                         path: &Path,
                                         sequence_number: &AtomicU32,
                                         keys_written: &mut u64,
@@ -1161,7 +1161,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                                 &mut unused_collector
                                             };
                                             collector.add_entry(
-                                                &current,
+                                                current,
                                                 path,
                                                 sequence_number,
                                                 &mut keys_written,
@@ -1183,7 +1183,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         &mut unused_collector
                                     };
                                     collector.add_entry(
-                                        &entry,
+                                        entry,
                                         path,
                                         sequence_number,
                                         &mut keys_written,

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1135,10 +1135,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 #[cfg(debug_assertions)]
                                 impl Drop for Collector {
                                     fn drop(&mut self) {
-                                        assert!(
-                                            self.writer.is_none(),
-                                            "Collector dropped with an open writer"
-                                        );
+                                        if !std::thread::panicking() {
+                                            assert!(
+                                                self.writer.is_none(),
+                                                "Collector dropped with an open writer"
+                                            );
+                                        }
                                     }
                                 }
                                 let mut used_collector = Collector::new(MetaEntryFlags::WARM);

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -33,6 +33,8 @@ pub use parallel_scheduler::{ParallelScheduler, SerialScheduler};
 pub use static_sorted_file::{
     BlockCache, BlockWeighter, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData,
 };
-pub use static_sorted_file_builder::{Entry, EntryValue, write_static_stored_file};
+pub use static_sorted_file_builder::{
+    Entry, EntryValue, StreamingSstWriter, write_static_stored_file,
+};
 pub use value_buf::ValueBuffer;
 pub use write_batch::WriteBatch;

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -19,6 +19,7 @@ use crate::{
         KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_DELETED, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
         KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
     },
+    value_block_count_tracker::ValueBlockCountTracker,
 };
 
 /// The maximum number of entries that should go into a single key block
@@ -102,6 +103,8 @@ pub struct StaticSortedFileBuilderMeta<'a> {
 ///
 /// This is a convenience wrapper around [`StreamingSstWriter`] for callers that already have all
 /// entries in memory.
+// TODO: Consider adding a variant that takes ownership (Vec<E> or drain iterator)
+// to free entry memory as blocks are written.
 pub fn write_static_stored_file<E: Entry>(
     entries: &[E],
     file: &Path,
@@ -119,50 +122,11 @@ pub fn write_static_stored_file<E: Entry>(
 // Block I/O helpers (free functions for borrow-checker friendliness)
 // ---------------------------------------------------------------------------
 
-/// Writes a block to the file, optionally compressing it. Returns the block index assigned.
-fn write_block_to_file(
-    file: &mut BufWriter<File>,
-    compress_buffer: &mut Vec<u8>,
-    block_offsets: &mut Vec<u32>,
-    block: &[u8],
-    try_compress: bool,
-) -> Result<u16> {
-    let block_index: u16 = block_offsets
-        .len()
-        .try_into()
-        .expect("Block index overflow");
-
-    let (uncompressed_size, data_to_write): (u32, &[u8]) = if try_compress {
-        compress_into_buffer(block, compress_buffer)?;
-        // Same threshold as LevelDB/RocksDB: require at least 12.5% savings.
-        if compress_buffer.len() < block.len() - (block.len() / 8) {
-            (block.len().try_into().unwrap(), compress_buffer.as_slice())
-        } else {
-            (0, block)
-        }
-    } else {
-        (0, block)
-    };
-
-    let len: u32 = (data_to_write.len() + 4).try_into().unwrap();
-    let offset = block_offsets
-        .last()
-        .copied()
-        .unwrap_or_default()
-        .checked_add(len)
-        .expect("Block offset overflow");
-    block_offsets.push(offset);
-
-    file.write_u32::<BE>(uncompressed_size)
-        .context("Failed to write uncompressed_size")?;
-    file.write_all(data_to_write)
-        .context("Failed to write block data")?;
-    compress_buffer.clear();
-    Ok(block_index)
-}
-
-/// Writes a pre-compressed block to the file. Returns the block index assigned.
-fn write_compressed_block_to_file(
+/// Writes a raw (already-formatted) block to the file. Returns the block index assigned.
+///
+/// `uncompressed_size` is the original uncompressed size of the block data, or `0` if the block
+/// is stored uncompressed.
+fn write_raw_block_to_file(
     file: &mut BufWriter<File>,
     block_offsets: &mut Vec<u32>,
     uncompressed_size: u32,
@@ -185,8 +149,33 @@ fn write_compressed_block_to_file(
     file.write_u32::<BE>(uncompressed_size)
         .context("Failed to write uncompressed size")?;
     file.write_all(block)
-        .context("Failed to write compressed block")?;
+        .context("Failed to write block data")?;
     Ok(block_index)
+}
+
+/// Writes a block to the file, optionally compressing it. Returns the block index assigned.
+fn write_block_to_file(
+    file: &mut BufWriter<File>,
+    compress_buffer: &mut Vec<u8>,
+    block_offsets: &mut Vec<u32>,
+    block: &[u8],
+    try_compress: bool,
+) -> Result<u16> {
+    let (uncompressed_size, data_to_write): (u32, &[u8]) = if try_compress {
+        compress_into_buffer(block, compress_buffer)?;
+        // Same threshold as LevelDB/RocksDB: require at least 12.5% savings.
+        if compress_buffer.len() < block.len() - (block.len() / 8) {
+            (block.len().try_into().unwrap(), compress_buffer.as_slice())
+        } else {
+            (0, block)
+        }
+    } else {
+        (0, block)
+    };
+
+    let result = write_raw_block_to_file(file, block_offsets, uncompressed_size, data_to_write);
+    compress_buffer.clear();
+    result
 }
 
 // ---------------------------------------------------------------------------
@@ -201,10 +190,10 @@ enum ValueRef {
         offset: u32,
         size: u16,
     },
-    /// Value is in a small value block that hasn't been written yet.
-    /// `small_block_id` indexes into `small_block_indices` to find the block_index once flushed.
+    /// Value is in a small value block that hasn't been written yet. Will be resolved in-place
+    /// to [`ValueRef::Small`] when the small block is flushed.
     PendingSmall {
-        small_block_id: u32,
+        small_block_id: u16,
         offset: u32,
         size: u16,
     },
@@ -223,7 +212,7 @@ enum ValueRef {
 
 struct PendingKeyEntry {
     key_hash: u64,
-    key: Vec<u8>,
+    key: Box<[u8]>,
     value_ref: ValueRef,
 }
 
@@ -242,22 +231,25 @@ pub struct StreamingSstWriter {
     compress_buffer: Vec<u8>,
     block_offsets: Vec<u32>,
 
-    // Pending key entries (VecDeque for efficient front drain)
+    /// Pending key entries waiting to be flushed as key blocks.
+    ///
+    /// Entries are appended at the back and flushed from the front. The front entries up to
+    /// `first_pending_small_index` are fully resolved and eligible for key block flushing.
+    ///
+    /// **Note:** This queue is effectively unbounded. In a pathological case -- a small number of
+    /// small values followed by a large number of medium/inline values -- the queue can grow large
+    /// because the front entries reference an unflushed small value block while the back keeps
+    /// accepting resolved entries.
     pending_keys: VecDeque<PendingKeyEntry>,
 
-    // Key block size tracking (tracks the accumulated size from the front of pending_keys)
-    current_key_block_size: usize,
-    current_key_block_entry_count: usize,
-    current_key_block_max_key_len: usize,
+    /// Index into `pending_keys` of the first entry that has a `PendingSmall` reference for the
+    /// current (unflushed) small value block. All entries before this index are fully resolved
+    /// (their value block indices are known). Equals `pending_keys.len()` when no pending small
+    /// entries exist.
+    first_pending_small_index: usize,
 
-    // Small value block indirection
-    /// Maps small_block_id -> actual block_index. `None` means not yet flushed.
-    small_block_indices: Vec<Option<u16>>,
     /// The current small_block_id being accumulated into.
-    current_small_block_id: u32,
-    /// The smallest small_block_id that hasn't been resolved yet.
-    /// All IDs below this are resolved.
-    first_unresolved_small_block_id: u32,
+    current_small_block_id: u16,
 
     // Pending small value block buffer
     pending_small_values: Vec<u8>,
@@ -277,6 +269,11 @@ pub struct StreamingSstWriter {
     max_hash: u64,
     entry_count: u64,
     flags: MetaEntryFlags,
+
+    // Fullness tracking (for compaction callers)
+    total_key_size: usize,
+    total_value_size: usize,
+    value_block_count_tracker: ValueBlockCountTracker,
 }
 
 impl StreamingSstWriter {
@@ -294,12 +291,8 @@ impl StreamingSstWriter {
             compress_buffer: Vec::new(),
             block_offsets: Vec::new(),
             pending_keys: VecDeque::new(),
-            current_key_block_size: 0,
-            current_key_block_entry_count: 0,
-            current_key_block_max_key_len: 0,
-            small_block_indices: Vec::new(),
+            first_pending_small_index: 0,
             current_small_block_id: 0,
-            first_unresolved_small_block_id: 0,
             pending_small_values: Vec::new(),
             pending_small_value_count: 0,
             key_buffer: Vec::new(),
@@ -309,7 +302,19 @@ impl StreamingSstWriter {
             max_hash: 0,
             entry_count: 0,
             flags,
+            total_key_size: 0,
+            total_value_size: 0,
+            value_block_count_tracker: ValueBlockCountTracker::default(),
         })
+    }
+
+    /// Returns true if the SST file has reached capacity limits.
+    ///
+    /// This is intended for compaction callers that need to split output across multiple SST files.
+    pub fn is_full(&self, max_entries: usize, max_data_size: usize) -> bool {
+        self.entry_count as usize >= max_entries
+            || self.total_key_size + self.total_value_size > max_data_size
+            || self.value_block_count_tracker.is_full()
     }
 
     /// Adds an entry to the SST file. Entries must be added in key-hash order.
@@ -329,12 +334,22 @@ impl StreamingSstWriter {
             .expect("AMQF insert failed");
 
         // Copy key bytes
-        let mut key = Vec::with_capacity(entry.key_len());
-        entry.write_key_to(&mut key);
+        // TODO: Explore deferring key copies until key block writing time.
+        // This would require changing the Entry API to support borrowing keys or
+        // storing entry references instead of copying key bytes eagerly.
+        let mut key_buf = Vec::with_capacity(entry.key_len());
+        entry.write_key_to(&mut key_buf);
+        let key_len = key_buf.len();
+        let key: Box<[u8]> = key_buf.into_boxed_slice();
+
+        // Track key size for fullness
+        self.total_key_size += key_len;
 
         // Route value
         let value_ref = match entry.value() {
             EntryValue::Medium { value } => {
+                self.total_value_size += value.len();
+                self.value_block_count_tracker.track(true, 0);
                 let block_index = write_block_to_file(
                     &mut self.file,
                     &mut self.compress_buffer,
@@ -349,7 +364,9 @@ impl StreamingSstWriter {
                 uncompressed_size,
                 block,
             } => {
-                let block_index = write_compressed_block_to_file(
+                self.total_value_size += block.len();
+                self.value_block_count_tracker.track(true, 0);
+                let block_index = write_raw_block_to_file(
                     &mut self.file,
                     &mut self.block_offsets,
                     uncompressed_size,
@@ -359,10 +376,27 @@ impl StreamingSstWriter {
                 ValueRef::Medium { block_index }
             }
             EntryValue::Small { value } => {
+                self.total_value_size += value.len();
+                self.value_block_count_tracker.track(false, value.len());
+
+                // Flush small value block if full BEFORE adding this value,
+                // so entries referencing the previous block get resolved.
+                if self.pending_small_values.len() >= MIN_SMALL_VALUE_BLOCK_SIZE
+                    || self.pending_small_value_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
+                {
+                    self.flush_small_value_block()?;
+                }
+
                 let offset = self.pending_small_values.len() as u32;
                 let size: u16 = value.len().try_into().unwrap();
                 self.pending_small_values.extend_from_slice(value);
                 self.pending_small_value_count += 1;
+
+                // Track where the first PendingSmall entry is in the queue
+                if self.first_pending_small_index >= self.pending_keys.len() {
+                    self.first_pending_small_index = self.pending_keys.len();
+                }
+
                 let small_block_id = self.current_small_block_id;
                 ValueRef::PendingSmall {
                     small_block_id,
@@ -384,24 +418,11 @@ impl StreamingSstWriter {
         };
 
         // Push pending key entry
-        let key_len = key.len();
         self.pending_keys.push_back(PendingKeyEntry {
             key_hash,
             key,
             value_ref,
         });
-
-        // Update key block size tracking
-        self.current_key_block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
-        self.current_key_block_entry_count += 1;
-        self.current_key_block_max_key_len = self.current_key_block_max_key_len.max(key_len);
-
-        // Flush small value block if full
-        if self.pending_small_values.len() >= MIN_SMALL_VALUE_BLOCK_SIZE
-            || self.pending_small_value_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
-        {
-            self.flush_small_value_block()?;
-        }
 
         // Try to flush completed key blocks
         self.try_flush_key_blocks()?;
@@ -409,8 +430,11 @@ impl StreamingSstWriter {
         Ok(())
     }
 
-    /// Flushes the current pending small value block to disk.
+    /// Flushes the current pending small value block to disk and resolves all `PendingSmall`
+    /// entries in-place.
     fn flush_small_value_block(&mut self) -> Result<()> {
+        // Early return if empty -- this simplifies trailing small value block handling in
+        // `finish()` where we call this unconditionally.
         if self.pending_small_values.is_empty() {
             return Ok(());
         }
@@ -424,130 +448,88 @@ impl StreamingSstWriter {
         )
         .context("Failed to write small value block")?;
 
-        // Record the mapping from small_block_id -> block_index
-        let id = self.current_small_block_id as usize;
-        debug_assert_eq!(id, self.small_block_indices.len());
-        self.small_block_indices.push(Some(block_index));
+        // Resolve all PendingSmall entries for this block in-place.
+        // Only scan from first_pending_small_index -- entries before it are guaranteed
+        // already resolved (from previous flush calls).
+        let flushed_id = self.current_small_block_id;
+        for i in self.first_pending_small_index..self.pending_keys.len() {
+            let entry = &mut self.pending_keys[i];
+            if let ValueRef::PendingSmall {
+                small_block_id,
+                offset,
+                size,
+            } = entry.value_ref
+            {
+                debug_assert_eq!(small_block_id, flushed_id);
+                entry.value_ref = ValueRef::Small {
+                    block_index,
+                    offset,
+                    size,
+                };
+            }
+        }
+
+        // All PendingSmall entries are now resolved. No entries reference an unflushed block
+        // until the next Small value arrives.
+        self.first_pending_small_index = self.pending_keys.len();
 
         // Advance to next small block id
         self.current_small_block_id += 1;
         self.pending_small_values.clear();
         self.pending_small_value_count = 0;
 
-        // Advance first_unresolved_small_block_id
-        while (self.first_unresolved_small_block_id as usize) < self.small_block_indices.len()
-            && self.small_block_indices[self.first_unresolved_small_block_id as usize].is_some()
-        {
-            self.first_unresolved_small_block_id += 1;
-        }
-
         Ok(())
     }
 
-    /// Checks if a value reference is resolved (i.e., its block index is known).
-    fn is_resolved(&self, value_ref: &ValueRef) -> bool {
-        match value_ref {
-            ValueRef::PendingSmall { small_block_id, .. } => {
-                *small_block_id < self.first_unresolved_small_block_id
-            }
-            _ => true,
-        }
-    }
-
-    /// Resolves a `PendingSmall` to a `Small` value reference. Panics if not yet resolved.
-    fn resolve_value_ref(value_ref: &ValueRef, small_block_indices: &[Option<u16>]) -> ValueRef {
-        match *value_ref {
-            ValueRef::PendingSmall {
-                small_block_id,
-                offset,
-                size,
-            } => {
-                let block_index = small_block_indices[small_block_id as usize]
-                    .expect("small block not yet resolved");
-                ValueRef::Small {
-                    block_index,
-                    offset,
-                    size,
-                }
-            }
-            // Already resolved variants are returned as-is
-            ValueRef::Small {
-                block_index,
-                offset,
-                size,
-            } => ValueRef::Small {
-                block_index,
-                offset,
-                size,
-            },
-            ValueRef::Medium { block_index } => ValueRef::Medium { block_index },
-            ValueRef::Inline { data, len } => ValueRef::Inline { data, len },
-            ValueRef::Blob { blob_id } => ValueRef::Blob { blob_id },
-            ValueRef::Deleted => ValueRef::Deleted,
-        }
-    }
-
     /// Tries to flush complete key blocks from the front of `pending_keys`.
+    ///
+    /// The resolved prefix boundary is known directly from `first_pending_small_index` -- all
+    /// entries before that index have resolved value references. Within that prefix, we find
+    /// key block boundaries and flush complete blocks in a single pass.
     fn try_flush_key_blocks(&mut self) -> Result<()> {
-        // Find the resolved prefix length
-        let mut resolved_count = 0;
-        for entry in &self.pending_keys {
-            if !self.is_resolved(&entry.value_ref) {
-                break;
-            }
-            resolved_count += 1;
-        }
+        let resolved_end = self.first_pending_small_index;
 
-        if resolved_count == 0 {
+        if resolved_end == 0 {
             return Ok(());
         }
 
-        // Within the resolved prefix, find and flush complete key blocks.
-        // We need to re-scan the resolved entries to find block boundaries,
-        // tracking size from the front.
+        // Single pass: find block boundaries and flush complete blocks.
         let mut block_start = 0;
-        let mut block_size = 0;
-        let mut block_max_key_len = 0;
+        let mut block_size = 0usize;
+        let mut block_entry_count = 0usize;
+        let mut block_max_key_len = 0usize;
+        let mut last_flushed_end = 0usize;
         let mut last_hash = 0u64;
 
-        for i in 0..resolved_count {
+        for i in 0..resolved_end {
             let entry = &self.pending_keys[i];
             let key_len = entry.key.len();
             let key_hash = entry.key_hash;
 
-            // Check if we should start a new block (same logic as old code)
-            if block_size > 0
+            if block_entry_count > 0
                 && (block_size + key_len + KEY_BLOCK_ENTRY_META_OVERHEAD > MAX_KEY_BLOCK_SIZE
-                    || i - block_start >= MAX_KEY_BLOCK_ENTRIES)
+                    || block_entry_count >= MAX_KEY_BLOCK_ENTRIES)
                 && last_hash != key_hash
             {
-                // Flush this key block
                 self.flush_key_block(block_start, i, block_max_key_len)?;
+                last_flushed_end = i;
                 block_start = i;
                 block_size = 0;
                 block_max_key_len = 0;
+                block_entry_count = 0;
             }
 
             block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
             block_max_key_len = block_max_key_len.max(key_len);
+            block_entry_count += 1;
             last_hash = key_hash;
         }
 
-        // Don't flush the trailing incomplete block here -- it may grow more.
-        // But if we flushed any blocks, drain those entries and recompute tracking.
-        if block_start > 0 {
-            // Drain the consumed entries
-            self.pending_keys.drain(..block_start);
+        // Don't flush the trailing incomplete block -- it may grow more.
 
-            // Recompute key block tracking from the remaining entries
-            self.current_key_block_size = 0;
-            self.current_key_block_entry_count = self.pending_keys.len();
-            self.current_key_block_max_key_len = 0;
-            for entry in &self.pending_keys {
-                self.current_key_block_size += entry.key.len() + KEY_BLOCK_ENTRY_META_OVERHEAD;
-                self.current_key_block_max_key_len =
-                    self.current_key_block_max_key_len.max(entry.key.len());
-            }
+        if last_flushed_end > 0 {
+            self.pending_keys.drain(..last_flushed_end);
+            self.first_pending_small_index -= last_flushed_end;
         }
 
         Ok(())
@@ -563,9 +545,7 @@ impl StreamingSstWriter {
 
         for i in start..end {
             let entry = &self.pending_keys[i];
-            let resolved = Self::resolve_value_ref(&entry.value_ref, &self.small_block_indices);
-
-            match resolved {
+            match entry.value_ref {
                 ValueRef::Small {
                     block_index,
                     offset,
@@ -619,7 +599,7 @@ impl StreamingSstWriter {
     /// Finishes writing the SST file. Flushes remaining blocks, writes the index, and returns
     /// metadata.
     pub fn finish(mut self) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
-        // Flush remaining small value block
+        // Flush remaining small value block (even if under MIN_SMALL_VALUE_BLOCK_SIZE).
         self.flush_small_value_block()?;
 
         // Now all PendingSmall entries are resolved. Flush all remaining key blocks.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -295,9 +295,6 @@ pub struct StreamingSstWriter<E: Entry> {
     // Reusable buffer for building key blocks
     key_buffer: Vec<u8>,
 
-    // Reusable scratch buffer for serializing keys during key block flushing
-    key_scratch: Vec<u8>,
-
     // AMQF filter (built incrementally). Wrapped in Option for the same reason as `file`.
     filter: Option<qfilter::Filter>,
 
@@ -344,7 +341,6 @@ impl<E: Entry> StreamingSstWriter<E> {
             pending_small_values: Vec::new(),
             pending_small_value_count: 0,
             key_buffer: Vec::new(),
-            key_scratch: Vec::new(),
             filter: Some(filter),
             key_block_boundaries: Vec::new(),
             min_hash: u64::MAX,
@@ -648,40 +644,25 @@ impl<E: Entry> StreamingSstWriter<E> {
 
         for i in start..end {
             let pending = &self.pending_keys[i];
-            let key_hash = pending.entry.key_hash();
-            self.key_scratch.clear();
-            pending.entry.write_key_to(&mut self.key_scratch);
             match pending.value_ref {
                 ValueRef::Small {
                     block_index,
                     offset,
                     size,
                 } => {
-                    builder.put_small(
-                        key_hash,
-                        &self.key_scratch,
-                        block_index,
-                        offset,
-                        size,
-                        has_hash,
-                    );
+                    builder.put_small(&pending.entry, block_index, offset, size, has_hash);
                 }
                 ValueRef::Medium { block_index } => {
-                    builder.put_medium(key_hash, &self.key_scratch, block_index, has_hash);
+                    builder.put_medium(&pending.entry, block_index, has_hash);
                 }
                 ValueRef::Inline { data, len } => {
-                    builder.put_inline(
-                        key_hash,
-                        &self.key_scratch,
-                        &data[..len as usize],
-                        has_hash,
-                    );
+                    builder.put_inline(&pending.entry, &data[..len as usize], has_hash);
                 }
                 ValueRef::Blob { blob_id } => {
-                    builder.put_blob(key_hash, &self.key_scratch, blob_id, has_hash);
+                    builder.put_blob(&pending.entry, blob_id, has_hash);
                 }
                 ValueRef::Deleted => {
-                    builder.delete(key_hash, &self.key_scratch, has_hash);
+                    builder.delete(&pending.entry, has_hash);
                 }
                 ValueRef::PendingSmall { .. } => {
                     unreachable!("PendingSmall should have been resolved");
@@ -891,19 +872,23 @@ impl<'l> KeyBlockBuilder<'l> {
         BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
     }
 
+    /// Writes the hash and key from an entry.
+    fn write_entry_key<E: Entry>(&mut self, entry: &E, has_hash: bool) {
+        self.write_hash(entry.key_hash(), has_hash);
+        entry.write_key_to(self.buffer);
+    }
+
     /// Writes a small-sized value entry.
-    fn put_small(
+    fn put_small<E: Entry>(
         &mut self,
-        hash: u64,
-        key: &[u8],
+        entry: &E,
         value_block: u16,
         value_offset: u32,
         value_size: u16,
         has_hash: bool,
     ) {
         self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_SMALL);
-        self.write_hash(hash, has_hash);
-        self.buffer.extend_from_slice(key);
+        self.write_entry_key(entry, has_hash);
         self.buffer.write_u16::<BE>(value_block).unwrap();
         self.buffer.write_u16::<BE>(value_size).unwrap();
         self.buffer.write_u32::<BE>(value_offset).unwrap();
@@ -911,38 +896,34 @@ impl<'l> KeyBlockBuilder<'l> {
     }
 
     /// Writes a medium-sized value entry.
-    fn put_medium(&mut self, hash: u64, key: &[u8], value_block: u16, has_hash: bool) {
+    fn put_medium<E: Entry>(&mut self, entry: &E, value_block: u16, has_hash: bool) {
         self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_MEDIUM);
-        self.write_hash(hash, has_hash);
-        self.buffer.extend_from_slice(key);
+        self.write_entry_key(entry, has_hash);
         self.buffer.write_u16::<BE>(value_block).unwrap();
         self.current_entry += 1;
     }
 
     /// Writes a tombstone entry.
-    fn delete(&mut self, hash: u64, key: &[u8], has_hash: bool) {
+    fn delete<E: Entry>(&mut self, entry: &E, has_hash: bool) {
         self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_DELETED);
-        self.write_hash(hash, has_hash);
-        self.buffer.extend_from_slice(key);
+        self.write_entry_key(entry, has_hash);
         self.current_entry += 1;
     }
 
     /// Writes a blob value entry.
-    fn put_blob(&mut self, hash: u64, key: &[u8], blob_id: u32, has_hash: bool) {
+    fn put_blob<E: Entry>(&mut self, entry: &E, blob_id: u32, has_hash: bool) {
         self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_BLOB);
-        self.write_hash(hash, has_hash);
-        self.buffer.extend_from_slice(key);
+        self.write_entry_key(entry, has_hash);
         self.buffer.write_u32::<BE>(blob_id).unwrap();
         self.current_entry += 1;
     }
 
     /// Writes an inline value entry.
-    fn put_inline(&mut self, hash: u64, key: &[u8], value: &[u8], has_hash: bool) {
+    fn put_inline<E: Entry>(&mut self, entry: &E, value: &[u8], has_hash: bool) {
         debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
         let entry_type = KEY_BLOCK_ENTRY_TYPE_INLINE_MIN + value.len() as u8;
         self.write_entry_header(entry_type);
-        self.write_hash(hash, has_hash);
-        self.buffer.extend_from_slice(key);
+        self.write_entry_key(entry, has_hash);
         self.buffer.extend_from_slice(value);
         self.current_entry += 1;
     }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -742,17 +742,16 @@ impl<E: Entry> StreamingSstWriter<E> {
             .try_into()
             .expect("Block count overflow");
 
-        // Shrink the AMQF filter to the actual entry count. The filter was created with
-        // `max_entry_count` which may be larger than the number of entries actually added.
-        // Re-creating with the exact count reduces serialized size.
+        // Shrink the AMQF filter to the actual entry count if less than half the capacity
+        // was used. The filter was created with `max_entry_count` which may be larger than the
+        // number of entries actually added.
         let old_filter = self.filter.take().unwrap();
-        let filter = if old_filter.len() > 0 {
+        let filter = if old_filter.len() > 0 && old_filter.len() < old_filter.capacity() / 2 {
             let mut shrunk = qfilter::Filter::new(old_filter.len(), AMQF_FALSE_POSITIVE_RATE)
                 .expect("Filter can't be constructed");
             shrunk
                 .merge(false, &old_filter)
                 .expect("Failed to merge AMQF filter");
-            shrunk.shrink_to_fit();
             shrunk
         } else {
             old_filter

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -379,6 +379,8 @@ impl StreamingSstWriter {
                 uncompressed_size,
                 block,
             } => {
+                // Note: tracks compressed block size (not uncompressed) unlike EntryValue::Medium.
+                // Both are acceptable approximations of disk usage for is_full() thresholds.
                 self.total_value_size += block.len();
                 let block_index = write_raw_block_to_file(
                     &mut self.file,
@@ -442,6 +444,9 @@ impl StreamingSstWriter {
 
         // Advance the resolved boundary for non-PendingSmall entries, but only when there are
         // no earlier unresolved PendingSmall entries blocking the boundary.
+        // The `== len - 1` check means the just-pushed entry sits immediately after the current
+        // boundary, so it's safe to extend. If a PendingSmall entry exists earlier in the queue,
+        // the boundary stays put until `flush_small_value_block()` resolves all pending entries.
         if is_resolved && self.first_pending_small_index == self.pending_keys.len() - 1 {
             self.first_pending_small_index = self.pending_keys.len();
         }
@@ -550,6 +555,7 @@ impl StreamingSstWriter {
         // Don't flush the trailing incomplete block -- it may grow more.
 
         if last_flushed_end > 0 {
+            // VecDeque::drain from the front is O(1) -- it just adjusts the head pointer.
             self.pending_keys.drain(..last_flushed_end);
             self.first_pending_small_index -= last_flushed_end;
         }
@@ -888,5 +894,515 @@ impl<'l> IndexBlockBuilder<'l> {
     /// Returns the index block buffer
     fn finish(self) -> &'l mut Vec<u8> {
         self.buffer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::BuildHasherDefault;
+
+    use quick_cache::sync::Cache;
+    use rustc_hash::FxHasher;
+
+    use super::*;
+    use crate::{
+        key::hash_key,
+        lookup_entry::LookupValue,
+        static_sorted_file::{
+            BlockWeighter, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData,
+        },
+    };
+
+    type TestBlockCache =
+        Cache<(u32, u16), crate::ArcBytes, BlockWeighter, BuildHasherDefault<FxHasher>>;
+
+    fn make_cache() -> TestBlockCache {
+        TestBlockCache::with(
+            100,
+            4 * 1024 * 1024,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+        )
+    }
+
+    /// A simple entry type for testing with configurable value type.
+    struct TestEntry {
+        key: Vec<u8>,
+        hash: u64,
+        value_kind: TestValueKind,
+    }
+
+    enum TestValueKind {
+        Inline(Vec<u8>),
+        Small(Vec<u8>),
+        Medium(Vec<u8>),
+        Blob(u32),
+        Deleted,
+    }
+
+    impl TestEntry {
+        fn small(key: &[u8], value: &[u8]) -> Self {
+            let key = key.to_vec();
+            let hash = hash_key(&key);
+            Self {
+                key,
+                hash,
+                value_kind: TestValueKind::Small(value.to_vec()),
+            }
+        }
+
+        fn inline(key: &[u8], value: &[u8]) -> Self {
+            debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
+            let key = key.to_vec();
+            let hash = hash_key(&key);
+            Self {
+                key,
+                hash,
+                value_kind: TestValueKind::Inline(value.to_vec()),
+            }
+        }
+
+        fn medium(key: &[u8], value: &[u8]) -> Self {
+            let key = key.to_vec();
+            let hash = hash_key(&key);
+            Self {
+                key,
+                hash,
+                value_kind: TestValueKind::Medium(value.to_vec()),
+            }
+        }
+
+        fn blob(key: &[u8], blob_id: u32) -> Self {
+            let key = key.to_vec();
+            let hash = hash_key(&key);
+            Self {
+                key,
+                hash,
+                value_kind: TestValueKind::Blob(blob_id),
+            }
+        }
+
+        fn deleted(key: &[u8]) -> Self {
+            let key = key.to_vec();
+            let hash = hash_key(&key);
+            Self {
+                key,
+                hash,
+                value_kind: TestValueKind::Deleted,
+            }
+        }
+
+        fn expected_value(&self) -> Option<&[u8]> {
+            match &self.value_kind {
+                TestValueKind::Inline(v) | TestValueKind::Small(v) | TestValueKind::Medium(v) => {
+                    Some(v)
+                }
+                _ => None,
+            }
+        }
+    }
+
+    impl Entry for TestEntry {
+        fn key_hash(&self) -> u64 {
+            self.hash
+        }
+
+        fn key_len(&self) -> usize {
+            self.key.len()
+        }
+
+        fn write_key_to(&self, buf: &mut Vec<u8>) {
+            buf.extend_from_slice(&self.key);
+        }
+
+        fn value(&self) -> EntryValue<'_> {
+            match &self.value_kind {
+                TestValueKind::Inline(v) => EntryValue::Inline { value: v },
+                TestValueKind::Small(v) => EntryValue::Small { value: v },
+                TestValueKind::Medium(v) => EntryValue::Medium { value: v },
+                TestValueKind::Blob(id) => EntryValue::Large { blob: *id },
+                TestValueKind::Deleted => EntryValue::Deleted,
+            }
+        }
+    }
+
+    /// Sort entries by hash (required by SST writer).
+    fn sort_entries(entries: &mut [TestEntry]) {
+        entries.sort_by_key(|e| e.hash);
+    }
+
+    /// Open an SST file for lookup given a path and metadata.
+    fn open_sst(
+        dir: &Path,
+        seq: u32,
+        meta: &StaticSortedFileBuilderMeta<'_>,
+    ) -> Result<StaticSortedFile> {
+        StaticSortedFile::open(
+            dir,
+            StaticSortedFileMetaData {
+                sequence_number: seq,
+                block_count: meta.block_count,
+            },
+        )
+    }
+
+    /// Helper: write entries via StreamingSstWriter, return meta.
+    fn write_sst(
+        dir: &Path,
+        seq: u32,
+        entries: &[TestEntry],
+        flags: MetaEntryFlags,
+    ) -> Result<StaticSortedFileBuilderMeta<'static>> {
+        let sst_path = dir.join(format!("{seq:08}.sst"));
+        let mut writer = StreamingSstWriter::new(&sst_path, flags, entries.len() as u64)?;
+        for entry in entries {
+            writer.add(entry)?;
+        }
+        let (meta, _file) = writer.finish()?;
+        Ok(meta)
+    }
+
+    /// Lookup a key in an SST file and assert it matches the expected value kind.
+    fn assert_lookup(
+        sst: &StaticSortedFile,
+        entry: &TestEntry,
+        kc: &TestBlockCache,
+        vc: &TestBlockCache,
+    ) -> Result<()> {
+        let result = sst.lookup(entry.hash, &entry.key, kc, vc)?;
+        match (&entry.value_kind, result) {
+            (_, SstLookupResult::Found(LookupValue::Slice { value })) => {
+                let expected = entry
+                    .expected_value()
+                    .expect("Got Slice but entry has no value");
+                assert_eq!(
+                    value.as_ref(),
+                    expected,
+                    "value mismatch for key {:?}",
+                    std::str::from_utf8(&entry.key)
+                );
+            }
+            (
+                TestValueKind::Blob(expected_id),
+                SstLookupResult::Found(LookupValue::Blob { sequence_number }),
+            ) => {
+                assert_eq!(sequence_number, *expected_id);
+            }
+            (TestValueKind::Deleted, SstLookupResult::Found(LookupValue::Deleted)) => {}
+            _ => {
+                panic!(
+                    "Unexpected lookup result for key {:?}",
+                    std::str::from_utf8(&entry.key)
+                );
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn single_inline_entry() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut entries = vec![TestEntry::inline(b"key1", b"val1")];
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, 1);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        assert_lookup(&sst, &entries[0], &kc, &vc)?;
+        Ok(())
+    }
+
+    #[test]
+    fn single_small_entry() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let value = vec![0xAB; 100]; // > MAX_INLINE_VALUE_SIZE, <= MAX_SMALL_VALUE_SIZE
+        let mut entries = vec![TestEntry::small(b"skey", &value)];
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, 1);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        assert_lookup(&sst, &entries[0], &kc, &vc)?;
+        Ok(())
+    }
+
+    #[test]
+    fn single_medium_entry() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let value = vec![0xCD; 8192]; // > MAX_SMALL_VALUE_SIZE
+        let mut entries = vec![TestEntry::medium(b"mkey", &value)];
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, 1);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        assert_lookup(&sst, &entries[0], &kc, &vc)?;
+        Ok(())
+    }
+
+    #[test]
+    fn single_blob_entry() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut entries = vec![TestEntry::blob(b"bkey", 42)];
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, 1);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        assert_lookup(&sst, &entries[0], &kc, &vc)?;
+        Ok(())
+    }
+
+    #[test]
+    fn single_deleted_entry() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut entries = vec![TestEntry::deleted(b"dkey")];
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, 1);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        assert_lookup(&sst, &entries[0], &kc, &vc)?;
+        Ok(())
+    }
+
+    #[test]
+    fn many_small_values() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        // Create enough small entries to trigger multiple small value block flushes.
+        // MIN_SMALL_VALUE_BLOCK_SIZE = 8KB, each value is 200 bytes -> ~40 entries per block.
+        let count = 200;
+        let mut entries: Vec<TestEntry> = (0..count)
+            .map(|i| {
+                let key = format!("key-{i:04}");
+                let value = vec![(i & 0xFF) as u8; 200];
+                TestEntry::small(key.as_bytes(), &value)
+            })
+            .collect();
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, count as u64);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+
+        for entry in &entries {
+            assert_lookup(&sst, entry, &kc, &vc)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn many_medium_values() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let count = 50;
+        let mut entries: Vec<TestEntry> = (0..count)
+            .map(|i| {
+                let key = format!("mkey-{i:04}");
+                let value = vec![(i & 0xFF) as u8; 8192];
+                TestEntry::medium(key.as_bytes(), &value)
+            })
+            .collect();
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, count as u64);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+
+        for entry in &entries {
+            assert_lookup(&sst, entry, &kc, &vc)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn mixed_value_types() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let mut entries = vec![
+            TestEntry::inline(b"a-inline", b"tiny"),
+            TestEntry::small(b"b-small", &vec![0x11; 200]),
+            TestEntry::medium(b"c-medium", &vec![0x22; 8192]),
+            TestEntry::blob(b"d-blob", 99),
+            TestEntry::deleted(b"e-deleted"),
+            TestEntry::small(b"f-small2", &vec![0x33; 300]),
+            TestEntry::inline(b"g-inline2", b"mini"),
+            TestEntry::medium(b"h-medium2", &vec![0x44; 16384]),
+        ];
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, 8);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+
+        for entry in &entries {
+            assert_lookup(&sst, entry, &kc, &vc)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn is_full_entry_count_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let sst_path = dir.path().join("test.sst");
+        let mut writer =
+            StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 100).unwrap();
+
+        let max_entries = 50;
+        for i in 0..max_entries {
+            let key = format!("k{i:06}");
+            let entry = TestEntry::inline(key.as_bytes(), &[0; 4]);
+            writer.add(&entry).unwrap();
+        }
+
+        assert_eq!(writer.entry_count, max_entries as u64);
+        assert!(
+            writer.is_full(max_entries, usize::MAX),
+            "Should be full when entry count reaches max_entries"
+        );
+        assert!(
+            !writer.is_full(max_entries + 1, usize::MAX),
+            "Should not be full when limit is higher"
+        );
+    }
+
+    #[test]
+    fn is_full_data_size_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let sst_path = dir.path().join("test.sst");
+        let mut writer =
+            StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 100).unwrap();
+
+        let value = vec![0u8; 1000];
+        for i in 0..10 {
+            let key = format!("k{i:06}");
+            let entry = TestEntry::small(key.as_bytes(), &value);
+            writer.add(&entry).unwrap();
+        }
+
+        let total = writer.total_key_size + writer.total_value_size;
+        assert!(total > 10_000, "total data should exceed 10KB");
+        assert!(writer.is_full(usize::MAX, total - 1));
+        assert!(!writer.is_full(usize::MAX, total + 1));
+    }
+
+    #[test]
+    fn write_static_stored_file_matches_streaming() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+
+        let mut entries: Vec<TestEntry> = (0..100)
+            .map(|i| {
+                let key = format!("rkey-{i:04}");
+                if i % 3 == 0 {
+                    TestEntry::inline(key.as_bytes(), &[(i & 0xFF) as u8; 4])
+                } else if i % 3 == 1 {
+                    TestEntry::small(key.as_bytes(), &vec![(i & 0xFF) as u8; 200])
+                } else {
+                    TestEntry::medium(key.as_bytes(), &vec![(i & 0xFF) as u8; 8192])
+                }
+            })
+            .collect();
+        sort_entries(&mut entries);
+
+        // Write via convenience function
+        let batch_path = dir.path().join("00000001.sst");
+        let (meta1, _) =
+            write_static_stored_file(&entries, &batch_path, MetaEntryFlags::default())?;
+
+        // Write via streaming API
+        let streaming_path = dir.path().join("00000002.sst");
+        let mut writer = StreamingSstWriter::new(
+            &streaming_path,
+            MetaEntryFlags::default(),
+            entries.len() as u64,
+        )?;
+        for entry in &entries {
+            writer.add(entry)?;
+        }
+        let (meta2, _) = writer.finish()?;
+
+        // Metadata should match
+        assert_eq!(meta1.entries, meta2.entries);
+        assert_eq!(meta1.min_hash, meta2.min_hash);
+        assert_eq!(meta1.max_hash, meta2.max_hash);
+        assert_eq!(meta1.block_count, meta2.block_count);
+
+        // Both files should produce the same lookup results
+        let sst1 = StaticSortedFile::open(
+            dir.path(),
+            StaticSortedFileMetaData {
+                sequence_number: 1,
+                block_count: meta1.block_count,
+            },
+        )?;
+        let sst2 = StaticSortedFile::open(
+            dir.path(),
+            StaticSortedFileMetaData {
+                sequence_number: 2,
+                block_count: meta2.block_count,
+            },
+        )?;
+        let kc = make_cache();
+        let vc = make_cache();
+
+        for entry in &entries {
+            let r1 = sst1.lookup(entry.hash, &entry.key, &kc, &vc)?;
+            let r2 = sst2.lookup(entry.hash, &entry.key, &kc, &vc)?;
+            match (r1, r2) {
+                (
+                    SstLookupResult::Found(LookupValue::Slice { value: v1 }),
+                    SstLookupResult::Found(LookupValue::Slice { value: v2 }),
+                ) => {
+                    assert_eq!(
+                        v1.as_ref(),
+                        v2.as_ref(),
+                        "Value mismatch for key {:?}",
+                        std::str::from_utf8(&entry.key)
+                    );
+                }
+                (
+                    SstLookupResult::Found(LookupValue::Deleted),
+                    SstLookupResult::Found(LookupValue::Deleted),
+                ) => {}
+                (
+                    SstLookupResult::Found(LookupValue::Blob {
+                        sequence_number: s1,
+                    }),
+                    SstLookupResult::Found(LookupValue::Blob {
+                        sequence_number: s2,
+                    }),
+                ) => {
+                    assert_eq!(s1, s2);
+                }
+                _ => panic!(
+                    "Mismatched results for key {:?}",
+                    std::str::from_utf8(&entry.key)
+                ),
+            }
+        }
+        Ok(())
     }
 }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -243,7 +243,7 @@ enum ValueRef {
     Deleted,
 }
 
-struct PendingKeyEntry<E> {
+struct PendingEntry<E> {
     entry: E,
     value_ref: ValueRef,
 }
@@ -273,7 +273,7 @@ pub struct StreamingSstWriter<E: Entry> {
     /// small values followed by a large number of medium/inline values -- the queue can grow large
     /// because the front entries reference an unflushed small value block while the back keeps
     /// accepting resolved entries.
-    pending_keys: VecDeque<PendingKeyEntry<E>>,
+    pending_keys: VecDeque<PendingEntry<E>>,
 
     /// Index into `pending_keys` of the first entry that has a `PendingSmall` reference for the
     /// current (unflushed) small value block. All entries before this index are fully resolved
@@ -395,7 +395,10 @@ impl<E: Entry> StreamingSstWriter<E> {
             .max(self.pending_key_total_size.div_ceil(MAX_KEY_BLOCK_SIZE))
             .max(1);
         let index_block = 1;
-        blocks_written + pending_small_block + pending_key_blocks + index_block < u16::MAX as usize
+        // Add some buffer, just to be safe...
+        let buffer = 16;
+        blocks_written + pending_small_block + pending_key_blocks + index_block + buffer
+            < u16::MAX as usize
     }
 
     /// Adds an entry to the SST file. Entries must be added in (key-hash, key) order.
@@ -504,7 +507,7 @@ impl<E: Entry> StreamingSstWriter<E> {
     /// Appends a new entry to the pending-keys queue.
     fn push_pending_key_entry(&mut self, entry: E, value_ref: ValueRef) {
         self.pending_keys
-            .push_back(PendingKeyEntry { entry, value_ref });
+            .push_back(PendingEntry { entry, value_ref });
     }
 
     /// Advances `first_pending_small_index` past the just-pushed entry if it is resolved and
@@ -746,7 +749,7 @@ impl<E: Entry> StreamingSstWriter<E> {
         // was used. The filter was created with `max_entry_count` which may be larger than the
         // number of entries actually added.
         let old_filter = self.filter.take().unwrap();
-        let filter = if old_filter.len() > 0 && old_filter.len() < old_filter.capacity() / 2 {
+        let filter = if !old_filter.is_empty() && old_filter.len() < old_filter.capacity() / 2 {
             let mut shrunk = qfilter::Filter::new(old_filter.len(), AMQF_FALSE_POSITIVE_RATE)
                 .expect("Filter can't be constructed");
             shrunk

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -2,7 +2,7 @@ use std::{
     borrow::Cow,
     collections::VecDeque,
     fs::File,
-    io::{BufWriter, Seek, Write},
+    io::{BufWriter, Write},
     path::Path,
 };
 
@@ -35,32 +35,12 @@ const MAX_KEY_BLOCK_SIZE: usize = 16 * 1024;
 /// - 2 bytes size
 /// - 4 bytes position in block
 const KEY_BLOCK_ENTRY_META_OVERHEAD: usize = 20;
-/// The maximum number of entries that should go into a single small value block
-const MAX_SMALL_VALUE_BLOCK_ENTRIES: usize = MIN_SMALL_VALUE_BLOCK_SIZE;
 /// The aimed false positive rate for the AMQF
 const AMQF_FALSE_POSITIVE_RATE: f64 = 0.01;
 
 /// Determines whether to store the hash per entry based on max key length.
 fn use_hash(max_key_len: usize) -> bool {
     max_key_len > 32
-}
-
-/// Returns true when the current key block should be flushed before adding the next entry.
-///
-/// `block_size` and `block_entry_count` describe the block accumulated so far.
-/// `next_key_len` is the key length of the candidate entry being considered.
-/// `last_hash` / `next_hash` are compared to avoid splitting a block mid-hash-collision.
-fn should_flush_key_block(
-    block_size: usize,
-    block_entry_count: usize,
-    next_key_len: usize,
-    last_hash: u64,
-    next_hash: u64,
-) -> bool {
-    block_entry_count > 0
-        && (block_size + next_key_len + KEY_BLOCK_ENTRY_META_OVERHEAD > MAX_KEY_BLOCK_SIZE
-            || block_entry_count >= MAX_KEY_BLOCK_ENTRIES)
-        && last_hash != next_hash
 }
 
 /// Trait for entries from that SST files can be created
@@ -286,11 +266,7 @@ pub struct StreamingSstWriter<E: Entry> {
     current_small_block_id: u16,
 
     // Pending small value block buffer.
-    // `pending_small_value_count` counts only the entries whose bytes are currently in
-    // `pending_small_values`; it is independent of `pending_keys.len()`, which includes
-    // entries of all value types (including already-flushed small, medium, inline, etc.).
-    pending_small_values: Vec<u8>,
-    pending_small_value_count: usize,
+    pending_small_value_block: Vec<u8>,
 
     // Reusable buffer for building key blocks
     key_buffer: Vec<u8>,
@@ -348,8 +324,7 @@ impl<E: Entry> StreamingSstWriter<E> {
             first_pending_small_index: 0,
             #[cfg(debug_assertions)]
             current_small_block_id: 0,
-            pending_small_values: Vec::new(),
-            pending_small_value_count: 0,
+            pending_small_value_block: Vec::new(),
             key_buffer: Vec::new(),
             filter: Some(filter),
             key_block_boundaries: Vec::new(),
@@ -374,7 +349,7 @@ impl<E: Entry> StreamingSstWriter<E> {
     /// This is intended for compaction callers that need to split output across multiple SST files.
     pub fn is_full(&self, max_entries: usize, max_data_size: usize) -> bool {
         self.entry_count as usize >= max_entries
-            || self.total_key_size + self.total_value_size > max_data_size
+            || self.total_key_size + self.total_value_size >= max_data_size
             || !self.has_block_index_capacity()
     }
 
@@ -387,7 +362,7 @@ impl<E: Entry> StreamingSstWriter<E> {
         // - 1 pending small value block (if buffer is non-empty)
         // - key blocks for pending entries (upper bound from both entry count and byte size)
         // - 1 index block
-        let pending_small_block = usize::from(!self.pending_small_values.is_empty());
+        let pending_small_block = usize::from(!self.pending_small_value_block.is_empty());
         let pending_key_blocks = self
             .pending_keys
             .len()
@@ -457,10 +432,9 @@ impl<E: Entry> StreamingSstWriter<E> {
             EntryValue::Small { value } => {
                 self.total_value_size += value.len();
 
-                let offset = self.pending_small_values.len() as u32;
+                let offset = self.pending_small_value_block.len() as u32;
                 let size: u16 = value.len().try_into().unwrap();
-                self.pending_small_values.extend_from_slice(value);
-                self.pending_small_value_count += 1;
+                self.pending_small_value_block.extend_from_slice(value);
 
                 // Track where the first PendingSmall entry is in the queue
                 if self.first_pending_small_index >= self.pending_keys.len() {
@@ -479,9 +453,7 @@ impl<E: Entry> StreamingSstWriter<E> {
                 // Eagerly flush the small block AFTER pushing the new entry. This resolves
                 // the just-pushed entry immediately via advance_boundary_to(), so key blocks
                 // can be flushed incrementally.
-                if self.pending_small_values.len() >= MIN_SMALL_VALUE_BLOCK_SIZE
-                    || self.pending_small_value_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
-                {
+                if self.pending_small_value_block.len() >= MIN_SMALL_VALUE_BLOCK_SIZE {
                     self.flush_small_value_block()?;
                 }
 
@@ -501,7 +473,7 @@ impl<E: Entry> StreamingSstWriter<E> {
         };
 
         self.push_pending_key_entry(entry, value_ref);
-        self.advance_resolved_boundary()
+        self.try_flush_key_blocks()
     }
 
     /// Appends a new entry to the pending-keys queue.
@@ -515,7 +487,7 @@ impl<E: Entry> StreamingSstWriter<E> {
     ///
     /// Must be called immediately after [`push_pending_key_entry`] with a resolved
     /// (non-`PendingSmall`) entry.
-    fn advance_resolved_boundary(&mut self) -> Result<()> {
+    fn try_flush_key_blocks(&mut self) -> Result<()> {
         debug_assert!(!matches!(
             self.pending_keys.back().unwrap().value_ref,
             ValueRef::PendingSmall { .. }
@@ -534,31 +506,22 @@ impl<E: Entry> StreamingSstWriter<E> {
     /// must have resolved (non-`PendingSmall`) value references.
     fn advance_boundary_to(&mut self, new_boundary: usize) -> Result<()> {
         let mut last_flushed_end = 0usize;
+        // Cumulative key sizes of all entries visited so far, and the snapshot at the last
+        // flush point. The difference at the end gives the total key size of drained entries.
+        let mut cumulative_key_size = 0usize;
+        let mut flushed_key_size = 0usize;
 
         for i in self.first_pending_small_index..new_boundary {
             let entry = &self.pending_keys[i];
             let key_len = entry.entry.key_len();
             let key_hash = entry.entry.key_hash();
 
-            if should_flush_key_block(
-                self.current_key_block_size,
-                self.current_key_block_entry_count,
-                key_len,
-                self.current_key_block_last_hash,
-                key_hash,
-            ) {
-                let block_end = last_flushed_end + self.current_key_block_entry_count;
-                self.flush_key_block(
-                    last_flushed_end,
-                    block_end,
-                    self.current_key_block_max_key_len,
-                )?;
-                last_flushed_end = block_end;
-                self.current_key_block_size = 0;
-                self.current_key_block_entry_count = 0;
-                self.current_key_block_max_key_len = 0;
+            if self.try_flush_key_block(last_flushed_end, key_len, key_hash)? {
+                flushed_key_size = cumulative_key_size;
+                last_flushed_end = i;
             }
 
+            cumulative_key_size += key_len;
             self.current_key_block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
             self.current_key_block_max_key_len = self.current_key_block_max_key_len.max(key_len);
             self.current_key_block_entry_count += 1;
@@ -566,12 +529,7 @@ impl<E: Entry> StreamingSstWriter<E> {
         }
 
         if last_flushed_end > 0 {
-            let drained_key_size: usize = self
-                .pending_keys
-                .range(..last_flushed_end)
-                .map(|e| e.entry.key_len())
-                .sum();
-            self.pending_key_total_size -= drained_key_size;
+            self.pending_key_total_size -= flushed_key_size;
             self.pending_keys.drain(..last_flushed_end);
         }
 
@@ -584,7 +542,7 @@ impl<E: Entry> StreamingSstWriter<E> {
     fn flush_small_value_block(&mut self) -> Result<()> {
         // Early return if empty -- this simplifies trailing small value block handling in
         // `close()` where we call this unconditionally.
-        if self.pending_small_values.is_empty() {
+        if self.pending_small_value_block.is_empty() {
             return Ok(());
         }
 
@@ -592,7 +550,7 @@ impl<E: Entry> StreamingSstWriter<E> {
             self.file.as_mut().unwrap(),
             &mut self.compress_buffer,
             &mut self.block_offsets,
-            &self.pending_small_values,
+            &self.pending_small_value_block,
             true,
         )
         .context("Failed to write small value block")?;
@@ -612,7 +570,11 @@ impl<E: Entry> StreamingSstWriter<E> {
             } = entry.value_ref
             {
                 #[cfg(debug_assertions)]
-                debug_assert_eq!(small_block_id, flushed_id);
+                debug_assert_eq!(
+                    small_block_id, flushed_id,
+                    "all pending small entries must reference the small value block that was just \
+                     written"
+                );
                 entry.value_ref = ValueRef::Small {
                     block_index,
                     offset,
@@ -630,16 +592,47 @@ impl<E: Entry> StreamingSstWriter<E> {
         {
             self.current_small_block_id += 1;
         }
-        self.pending_small_values.clear();
-        self.pending_small_value_count = 0;
+        self.pending_small_value_block.clear();
 
         Ok(())
     }
 
+    /// Flushes the current key block if it is full (considering the next entry), then resets
+    /// the block-tracking state. Returns `true` if a block was flushed.
+    ///
+    /// `block_start` is the index into `pending_keys` where the current key block begins.
+    /// `next_key_len` / `next_key_hash` describe the entry about to be added.
+    fn try_flush_key_block(
+        &mut self,
+        block_start: usize,
+        next_key_len: usize,
+        next_key_hash: u64,
+    ) -> Result<bool> {
+        if self.current_key_block_entry_count == 0 {
+            return Ok(false);
+        }
+        let would_exceed_size =
+            self.current_key_block_size + next_key_len + KEY_BLOCK_ENTRY_META_OVERHEAD
+                > MAX_KEY_BLOCK_SIZE;
+        let would_exceed_entries = self.current_key_block_entry_count >= MAX_KEY_BLOCK_ENTRIES;
+        if !(would_exceed_size || would_exceed_entries)
+            || self.current_key_block_last_hash == next_key_hash
+        {
+            return Ok(false);
+        }
+
+        let block_end = block_start + self.current_key_block_entry_count;
+        self.flush_key_block(block_start, block_end)?;
+        self.current_key_block_size = 0;
+        self.current_key_block_entry_count = 0;
+        self.current_key_block_max_key_len = 0;
+        Ok(true)
+    }
+
     /// Flushes a single key block from `pending_keys[start..end]`.
-    fn flush_key_block(&mut self, start: usize, end: usize, max_key_len: usize) -> Result<()> {
+    fn flush_key_block(&mut self, start: usize, end: usize) -> Result<()> {
         let entry_count = end - start;
-        let has_hash = use_hash(max_key_len);
+        let has_hash = use_hash(self.current_key_block_max_key_len);
 
         self.key_buffer.clear();
         let mut builder = KeyBlockBuilder::new(&mut self.key_buffer, entry_count as u32, has_hash);
@@ -709,33 +702,39 @@ impl<E: Entry> StreamingSstWriter<E> {
             "StreamingSstWriter::close() called with no entries"
         );
 
-        // Write index block
-        self.key_buffer.clear();
-        let entry_count: u16 = (self.key_block_boundaries.len() - 1)
+        let mut file = self.file.take().unwrap();
+
+        // Write index block directly to file (index blocks are never compressed).
+        let index_entry_count: u16 = (self.key_block_boundaries.len() - 1)
             .try_into()
             .expect("Index entries count overflow");
+        let index_block_size: u32 = (INDEX_BLOCK_HEADER_SIZE
+            + index_entry_count as usize * INDEX_BLOCK_ENTRY_SIZE)
+            .try_into()
+            .unwrap();
+        // Register block offset (uncompressed_size = 0 since we store raw).
+        {
+            let block_len = index_block_size + 4; // +4 for the uncompressed_size header
+            let offset = self
+                .block_offsets
+                .last()
+                .copied()
+                .unwrap_or_default()
+                .checked_add(block_len)
+                .expect("Block offset overflow");
+            self.block_offsets.push(offset);
+        }
+        file.write_u32::<BE>(0)
+            .context("Failed to write index block header")?;
         let first_block = self.key_block_boundaries[0].1;
-        let mut index_block =
-            IndexBlockBuilder::new(&mut self.key_buffer, entry_count, first_block);
+        let mut index_block = IndexBlockBuilder::new(&mut file, first_block);
         for &(hash, block) in &self.key_block_boundaries[1..] {
             index_block.put(hash, block);
         }
-        index_block.finish();
-        write_block_to_file(
-            self.file.as_mut().unwrap(),
-            &mut self.compress_buffer,
-            &mut self.block_offsets,
-            &self.key_buffer,
-            false,
-        )
-        .context("Failed to write index block")?;
 
         // Write block offset table
         for offset in &self.block_offsets {
-            self.file
-                .as_mut()
-                .unwrap()
-                .write_u32::<BE>(*offset)
+            file.write_u32::<BE>(*offset)
                 .context("Failed to write block offset")?;
         }
 
@@ -745,37 +744,32 @@ impl<E: Entry> StreamingSstWriter<E> {
             .try_into()
             .expect("Block count overflow");
 
-        // Shrink the AMQF filter to the actual entry count if less than half the capacity
-        // was used. The filter was created with `max_entry_count` which may be larger than the
-        // number of entries actually added.
-        let old_filter = self.filter.take().unwrap();
-        let filter = if !old_filter.is_empty() && old_filter.len() < old_filter.capacity() / 2 {
-            let mut shrunk = qfilter::Filter::new(old_filter.len(), AMQF_FALSE_POSITIVE_RATE)
-                .expect("Filter can't be constructed");
-            shrunk
-                .merge(false, &old_filter)
-                .expect("Failed to merge AMQF filter");
-            shrunk
-        } else {
-            old_filter
-        };
+        // Shrink the AMQF filter to the actual entry count. The filter was created with
+        // `max_entry_count` which may be larger than the number of entries actually added.
+        let mut filter = self.filter.take().unwrap();
+        filter.shrink_to_fit();
 
         // Serialize AMQF
         let amqf =
             turbo_bincode_encode(&AmqfBincodeWrapper(filter)).expect("AMQF serialization failed");
 
-        let file = self.file.as_mut().unwrap();
+        // Compute file size from block offsets rather than calling stream_position()
+        // (which requires a flush + seek).
+        let last_block_end = self.block_offsets.last().copied().unwrap_or_default() as u64;
+        let offset_table_size = block_count as u64 * size_of::<u32>() as u64;
+        let file_size = last_block_end + offset_table_size;
+
         let meta = StaticSortedFileBuilderMeta {
             min_hash: self.min_hash,
             max_hash: self.max_hash,
             amqf: Cow::Owned(amqf.into_vec()),
             block_count,
-            size: file.stream_position()?,
+            size: file_size,
             flags: self.flags,
             entries: self.entry_count,
         };
 
-        Ok((meta, self.file.take().unwrap().into_inner()?))
+        Ok((meta, file.into_inner()?))
     }
 
     /// Flushes all remaining entries as key blocks. Called from `close()` after all small value
@@ -787,31 +781,31 @@ impl<E: Entry> StreamingSstWriter<E> {
 
         let total = self.pending_keys.len();
         let mut block_start = 0;
-        let mut block_size = 0;
-        let mut block_max_key_len = 0;
-        let mut last_hash = 0u64;
+
+        // Reset current block state so we iterate from scratch. The partially-tracked
+        // block from previous add() calls is irrelevant here since we re-scan all entries.
+        self.current_key_block_size = 0;
+        self.current_key_block_entry_count = 0;
+        self.current_key_block_max_key_len = 0;
 
         for i in 0..total {
             let entry = &self.pending_keys[i];
             let key_len = entry.entry.key_len();
             let key_hash = entry.entry.key_hash();
-            let block_entry_count = i - block_start;
 
-            if should_flush_key_block(block_size, block_entry_count, key_len, last_hash, key_hash) {
-                self.flush_key_block(block_start, i, block_max_key_len)?;
+            if self.try_flush_key_block(block_start, key_len, key_hash)? {
                 block_start = i;
-                block_size = 0;
-                block_max_key_len = 0;
             }
 
-            block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
-            block_max_key_len = block_max_key_len.max(key_len);
-            last_hash = key_hash;
+            self.current_key_block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
+            self.current_key_block_max_key_len = self.current_key_block_max_key_len.max(key_len);
+            self.current_key_block_entry_count += 1;
+            self.current_key_block_last_hash = key_hash;
         }
 
         // Flush the final block
         if block_start < total {
-            self.flush_key_block(block_start, total, block_max_key_len)?;
+            self.flush_key_block(block_start, total)?;
         }
 
         self.pending_keys.clear();
@@ -959,33 +953,29 @@ impl<'l> KeyBlockBuilder<'l> {
 // ---------------------------------------------------------------------------
 
 /// Builder for a single index block.
-struct IndexBlockBuilder<'l> {
-    buffer: &'l mut Vec<u8>,
+struct IndexBlockBuilder<W: Write> {
+    writer: W,
 }
 
-impl<'l> IndexBlockBuilder<'l> {
+/// Size of a single index block entry (u64 hash + u16 block index).
+const INDEX_BLOCK_ENTRY_SIZE: usize = size_of::<u64>() + size_of::<u16>();
+
+/// Size of the index block header (u8 type + u16 first_block).
+const INDEX_BLOCK_HEADER_SIZE: usize = size_of::<u8>() + size_of::<u16>();
+
+impl<W: Write> IndexBlockBuilder<W> {
     /// Creates a new builder for an index block with the specified number of entries and a pointer
     /// to the first block.
-    fn new(buffer: &'l mut Vec<u8>, entry_count: u16, first_block: u16) -> Self {
-        buffer.reserve(
-            entry_count as usize * (size_of::<u64>() + size_of::<u16>())
-                + size_of::<u8>()
-                + size_of::<u16>(),
-        );
-        buffer.write_u8(BLOCK_TYPE_INDEX).unwrap();
-        buffer.write_u16::<BE>(first_block).unwrap();
-        Self { buffer }
+    fn new(mut writer: W, first_block: u16) -> Self {
+        writer.write_u8(BLOCK_TYPE_INDEX).unwrap();
+        writer.write_u16::<BE>(first_block).unwrap();
+        Self { writer }
     }
 
     /// Adds a hash boundary to the index block.
     fn put(&mut self, hash: u64, block: u16) {
-        self.buffer.write_u64::<BE>(hash).unwrap();
-        self.buffer.write_u16::<BE>(block).unwrap();
-    }
-
-    /// Returns the index block buffer
-    fn finish(self) -> &'l mut Vec<u8> {
-        self.buffer
+        self.writer.write_u64::<BE>(hash).unwrap();
+        self.writer.write_u16::<BE>(block).unwrap();
     }
 }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -76,6 +76,21 @@ pub trait Entry {
     fn value(&self) -> EntryValue<'_>;
 }
 
+impl<E: Entry> Entry for &E {
+    fn key_hash(&self) -> u64 {
+        (*self).key_hash()
+    }
+    fn key_len(&self) -> usize {
+        (*self).key_len()
+    }
+    fn write_key_to(&self, buf: &mut Vec<u8>) {
+        (*self).write_key_to(buf)
+    }
+    fn value(&self) -> EntryValue<'_> {
+        (*self).value()
+    }
+}
+
 /// Reference to a value
 #[derive(Copy, Clone)]
 pub enum EntryValue<'l> {
@@ -228,9 +243,8 @@ enum ValueRef {
     Deleted,
 }
 
-struct PendingKeyEntry {
-    key_hash: u64,
-    key: Box<[u8]>,
+struct PendingKeyEntry<E> {
+    entry: E,
     value_ref: ValueRef,
 }
 
@@ -243,7 +257,7 @@ struct PendingKeyEntry {
 ///
 /// The SST reader is block-index-addressed (not file-position-addressed), so interleaving block
 /// types is fully compatible.
-pub struct StreamingSstWriter {
+pub struct StreamingSstWriter<E: Entry> {
     // File I/O. Wrapped in Option so close() can take ownership without a partial-move
     // compile error (partial moves are forbidden when the type has a Drop impl).
     file: Option<BufWriter<File>>,
@@ -259,7 +273,7 @@ pub struct StreamingSstWriter {
     /// small values followed by a large number of medium/inline values -- the queue can grow large
     /// because the front entries reference an unflushed small value block while the back keeps
     /// accepting resolved entries.
-    pending_keys: VecDeque<PendingKeyEntry>,
+    pending_keys: VecDeque<PendingKeyEntry<E>>,
 
     /// Index into `pending_keys` of the first entry that has a `PendingSmall` reference for the
     /// current (unflushed) small value block. All entries before this index are fully resolved
@@ -280,6 +294,9 @@ pub struct StreamingSstWriter {
 
     // Reusable buffer for building key blocks
     key_buffer: Vec<u8>,
+
+    // Reusable scratch buffer for serializing keys during key block flushing
+    key_scratch: Vec<u8>,
 
     // AMQF filter (built incrementally). Wrapped in Option for the same reason as `file`.
     filter: Option<qfilter::Filter>,
@@ -305,7 +322,7 @@ pub struct StreamingSstWriter {
     finished: bool,
 }
 
-impl StreamingSstWriter {
+impl<E: Entry> StreamingSstWriter<E> {
     /// Creates a new streaming SST writer.
     ///
     /// `max_entry_count` is used to size the AMQF filter. It must be an upper bound on the number
@@ -327,6 +344,7 @@ impl StreamingSstWriter {
             pending_small_values: Vec::new(),
             pending_small_value_count: 0,
             key_buffer: Vec::new(),
+            key_scratch: Vec::new(),
             filter: Some(filter),
             key_block_boundaries: Vec::new(),
             min_hash: u64::MAX,
@@ -371,8 +389,9 @@ impl StreamingSstWriter {
     }
 
     /// Adds an entry to the SST file. Entries must be added in (key-hash, key) order.
-    pub fn add<E: Entry>(&mut self, entry: &E) -> Result<()> {
+    pub fn add(&mut self, entry: E) -> Result<()> {
         let key_hash = entry.key_hash();
+        let key_len = entry.key_len();
 
         // Update metadata
         if self.entry_count == 0 {
@@ -387,15 +406,6 @@ impl StreamingSstWriter {
             .unwrap()
             .insert_fingerprint(false, key_hash)
             .expect("AMQF insert failed");
-
-        // Copy key bytes
-        // TODO: Explore deferring key copies until key block writing time.
-        // This would require changing the Entry API to support borrowing keys or
-        // storing entry references instead of copying key bytes eagerly.
-        let mut key_buf = Vec::with_capacity(entry.key_len());
-        entry.write_key_to(&mut key_buf);
-        let key_len = key_buf.len();
-        let key: Box<[u8]> = key_buf.into_boxed_slice();
 
         // Track key size for fullness and block capacity
         self.total_key_size += key_len;
@@ -451,7 +461,7 @@ impl StreamingSstWriter {
                     size,
                 };
 
-                self.push_pending_key_entry(key_hash, key, value_ref);
+                self.push_pending_key_entry(entry, value_ref);
                 self.try_advance_resolved_boundary();
 
                 // Eagerly flush the small block AFTER pushing the new entry. This resolves
@@ -478,18 +488,15 @@ impl StreamingSstWriter {
             EntryValue::Deleted => ValueRef::Deleted,
         };
 
-        self.push_pending_key_entry(key_hash, key, value_ref);
+        self.push_pending_key_entry(entry, value_ref);
         self.try_advance_resolved_boundary();
         self.try_flush_key_blocks()
     }
 
     /// Appends a new entry to the pending-keys queue.
-    fn push_pending_key_entry(&mut self, key_hash: u64, key: Box<[u8]>, value_ref: ValueRef) {
-        self.pending_keys.push_back(PendingKeyEntry {
-            key_hash,
-            key,
-            value_ref,
-        });
+    fn push_pending_key_entry(&mut self, entry: E, value_ref: ValueRef) {
+        self.pending_keys
+            .push_back(PendingKeyEntry { entry, value_ref });
     }
 
     /// Advances `first_pending_small_index` past the just-pushed entry if that entry is
@@ -595,8 +602,8 @@ impl StreamingSstWriter {
 
         for i in 0..resolved_end {
             let entry = &self.pending_keys[i];
-            let key_len = entry.key.len();
-            let key_hash = entry.key_hash;
+            let key_len = entry.entry.key_len();
+            let key_hash = entry.entry.key_hash();
 
             if should_flush_key_block(block_size, block_entry_count, key_len, last_hash, key_hash) {
                 self.flush_key_block(block_start, i, block_max_key_len)?;
@@ -620,7 +627,7 @@ impl StreamingSstWriter {
             let drained_key_size: usize = self
                 .pending_keys
                 .range(..last_flushed_end)
-                .map(|e| e.key.len())
+                .map(|e| e.entry.key_len())
                 .sum();
             self.pending_key_total_size -= drained_key_size;
             // VecDeque::drain from the front is O(1) -- it just adjusts the head pointer.
@@ -640,16 +647,19 @@ impl StreamingSstWriter {
         let mut builder = KeyBlockBuilder::new(&mut self.key_buffer, entry_count as u32, has_hash);
 
         for i in start..end {
-            let entry = &self.pending_keys[i];
-            match entry.value_ref {
+            let pending = &self.pending_keys[i];
+            let key_hash = pending.entry.key_hash();
+            self.key_scratch.clear();
+            pending.entry.write_key_to(&mut self.key_scratch);
+            match pending.value_ref {
                 ValueRef::Small {
                     block_index,
                     offset,
                     size,
                 } => {
                     builder.put_small(
-                        entry.key_hash,
-                        &entry.key,
+                        key_hash,
+                        &self.key_scratch,
                         block_index,
                         offset,
                         size,
@@ -657,16 +667,21 @@ impl StreamingSstWriter {
                     );
                 }
                 ValueRef::Medium { block_index } => {
-                    builder.put_medium(entry.key_hash, &entry.key, block_index, has_hash);
+                    builder.put_medium(key_hash, &self.key_scratch, block_index, has_hash);
                 }
                 ValueRef::Inline { data, len } => {
-                    builder.put_inline(entry.key_hash, &entry.key, &data[..len as usize], has_hash);
+                    builder.put_inline(
+                        key_hash,
+                        &self.key_scratch,
+                        &data[..len as usize],
+                        has_hash,
+                    );
                 }
                 ValueRef::Blob { blob_id } => {
-                    builder.put_blob(entry.key_hash, &entry.key, blob_id, has_hash);
+                    builder.put_blob(key_hash, &self.key_scratch, blob_id, has_hash);
                 }
                 ValueRef::Deleted => {
-                    builder.delete(entry.key_hash, &entry.key, has_hash);
+                    builder.delete(key_hash, &self.key_scratch, has_hash);
                 }
                 ValueRef::PendingSmall { .. } => {
                     unreachable!("PendingSmall should have been resolved");
@@ -678,7 +693,7 @@ impl StreamingSstWriter {
         builder.finish();
 
         // Record boundary
-        let first_hash = self.pending_keys[start].key_hash;
+        let first_hash = self.pending_keys[start].entry.key_hash();
         let block_index = write_block_to_file(
             self.file.as_mut().unwrap(),
             &mut self.compress_buffer,
@@ -780,8 +795,8 @@ impl StreamingSstWriter {
 
         for i in 0..total {
             let entry = &self.pending_keys[i];
-            let key_len = entry.key.len();
-            let key_hash = entry.key_hash;
+            let key_len = entry.entry.key_len();
+            let key_hash = entry.entry.key_hash();
             let block_entry_count = i - block_start;
 
             if should_flush_key_block(block_size, block_entry_count, key_len, last_hash, key_hash) {
@@ -808,7 +823,7 @@ impl StreamingSstWriter {
 }
 
 #[cfg(debug_assertions)]
-impl Drop for StreamingSstWriter {
+impl<E: Entry> Drop for StreamingSstWriter<E> {
     fn drop(&mut self) {
         // Skip assertion during panic unwinding to avoid a double-panic (which would abort).
         if !std::thread::panicking() {
@@ -1370,7 +1385,7 @@ mod tests {
         for i in 0..max_entries {
             let key = format!("k{i:06}");
             let entry = TestEntry::inline(key.as_bytes(), &[0; 4]);
-            writer.add(&entry).unwrap();
+            writer.add(entry).unwrap();
         }
 
         assert_eq!(writer.entry_count, max_entries as u64);
@@ -1396,7 +1411,7 @@ mod tests {
         for i in 0..10 {
             let key = format!("k{i:06}");
             let entry = TestEntry::small(key.as_bytes(), &value);
-            writer.add(&entry).unwrap();
+            writer.add(entry).unwrap();
         }
 
         let total = writer.total_key_size + writer.total_value_size;
@@ -1508,7 +1523,8 @@ mod tests {
     fn close_empty_writer_panics() {
         let dir = tempfile::tempdir().unwrap();
         let sst_path = dir.path().join("empty.sst");
-        let writer = StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 0).unwrap();
+        let writer =
+            StreamingSstWriter::<TestEntry>::new(&sst_path, MetaEntryFlags::default(), 0).unwrap();
         writer.close().unwrap();
     }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -314,6 +314,16 @@ pub struct StreamingSstWriter<E: Entry> {
     /// Total byte size of keys in `pending_keys` (for block capacity estimation).
     pending_key_total_size: usize,
 
+    /// Accumulated byte size of the current incomplete key block at the tail
+    /// of the resolved prefix.
+    current_key_block_size: usize,
+    /// Entry count in the current incomplete key block.
+    current_key_block_entry_count: usize,
+    /// Maximum key length in the current incomplete key block.
+    current_key_block_max_key_len: usize,
+    /// Hash of the last entry added to the current incomplete key block.
+    current_key_block_last_hash: u64,
+
     /// Set to `true` by `close()` so the Drop guard can detect writers dropped without closing.
     #[cfg(debug_assertions)]
     finished: bool,
@@ -350,6 +360,10 @@ impl<E: Entry> StreamingSstWriter<E> {
             total_key_size: 0,
             total_value_size: 0,
             pending_key_total_size: 0,
+            current_key_block_size: 0,
+            current_key_block_entry_count: 0,
+            current_key_block_max_key_len: 0,
+            current_key_block_last_hash: 0,
             #[cfg(debug_assertions)]
             finished: false,
         })
@@ -458,18 +472,17 @@ impl<E: Entry> StreamingSstWriter<E> {
                 };
 
                 self.push_pending_key_entry(entry, value_ref);
-                self.try_advance_resolved_boundary();
 
                 // Eagerly flush the small block AFTER pushing the new entry. This resolves
-                // the just-pushed entry immediately, so the subsequent key-block flush below
-                // can include it rather than leaving it behind in `pending_keys`.
+                // the just-pushed entry immediately via advance_boundary_to(), so key blocks
+                // can be flushed incrementally.
                 if self.pending_small_values.len() >= MIN_SMALL_VALUE_BLOCK_SIZE
                     || self.pending_small_value_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
                 {
                     self.flush_small_value_block()?;
                 }
 
-                return self.try_flush_key_blocks();
+                return Ok(());
             }
             EntryValue::Inline { value } => {
                 debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
@@ -485,8 +498,7 @@ impl<E: Entry> StreamingSstWriter<E> {
         };
 
         self.push_pending_key_entry(entry, value_ref);
-        self.try_advance_resolved_boundary();
-        self.try_flush_key_blocks()
+        self.advance_resolved_boundary()
     }
 
     /// Appends a new entry to the pending-keys queue.
@@ -495,23 +507,73 @@ impl<E: Entry> StreamingSstWriter<E> {
             .push_back(PendingKeyEntry { entry, value_ref });
     }
 
-    /// Advances `first_pending_small_index` past the just-pushed entry if that entry is
-    /// immediately resolved (not `PendingSmall`) and sits right at the current boundary.
+    /// Advances `first_pending_small_index` past the just-pushed entry if it is resolved and
+    /// sits right at the current boundary. Flushes complete key blocks incrementally.
     ///
-    /// Must be called immediately after [`push_pending_key_entry`].
-    fn try_advance_resolved_boundary(&mut self) {
-        // Advance the resolved boundary for non-PendingSmall entries, but only when there are
-        // no earlier unresolved PendingSmall entries blocking the boundary.
-        // The `== len - 1` check means the just-pushed entry sits immediately after the current
-        // boundary, so it's safe to extend. If a PendingSmall entry exists earlier in the queue,
-        // the boundary stays put until `flush_small_value_block()` resolves all pending entries.
-        let is_last_resolved = !matches!(
+    /// Must be called immediately after [`push_pending_key_entry`] with a resolved
+    /// (non-`PendingSmall`) entry.
+    fn advance_resolved_boundary(&mut self) -> Result<()> {
+        debug_assert!(!matches!(
             self.pending_keys.back().unwrap().value_ref,
             ValueRef::PendingSmall { .. }
-        );
-        if is_last_resolved && self.first_pending_small_index == self.pending_keys.len() - 1 {
-            self.first_pending_small_index = self.pending_keys.len();
+        ));
+        if self.first_pending_small_index != self.pending_keys.len() - 1 {
+            // Boundary is blocked by earlier unresolved PendingSmall entries.
+            return Ok(());
         }
+        self.advance_boundary_to(self.pending_keys.len())
+    }
+
+    /// Advances the resolved boundary from its current position to `new_boundary`,
+    /// incrementally tracking key block sizes and flushing complete key blocks.
+    ///
+    /// All entries in `pending_keys[self.first_pending_small_index..new_boundary]`
+    /// must have resolved (non-`PendingSmall`) value references.
+    fn advance_boundary_to(&mut self, new_boundary: usize) -> Result<()> {
+        let mut last_flushed_end = 0usize;
+
+        for i in self.first_pending_small_index..new_boundary {
+            let entry = &self.pending_keys[i];
+            let key_len = entry.entry.key_len();
+            let key_hash = entry.entry.key_hash();
+
+            if should_flush_key_block(
+                self.current_key_block_size,
+                self.current_key_block_entry_count,
+                key_len,
+                self.current_key_block_last_hash,
+                key_hash,
+            ) {
+                let block_end = last_flushed_end + self.current_key_block_entry_count;
+                self.flush_key_block(
+                    last_flushed_end,
+                    block_end,
+                    self.current_key_block_max_key_len,
+                )?;
+                last_flushed_end = block_end;
+                self.current_key_block_size = 0;
+                self.current_key_block_entry_count = 0;
+                self.current_key_block_max_key_len = 0;
+            }
+
+            self.current_key_block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
+            self.current_key_block_max_key_len = self.current_key_block_max_key_len.max(key_len);
+            self.current_key_block_entry_count += 1;
+            self.current_key_block_last_hash = key_hash;
+        }
+
+        if last_flushed_end > 0 {
+            let drained_key_size: usize = self
+                .pending_keys
+                .range(..last_flushed_end)
+                .map(|e| e.entry.key_len())
+                .sum();
+            self.pending_key_total_size -= drained_key_size;
+            self.pending_keys.drain(..last_flushed_end);
+        }
+
+        self.first_pending_small_index = new_boundary - last_flushed_end;
+        Ok(())
     }
 
     /// Flushes the current pending small value block to disk and resolves all `PendingSmall`
@@ -556,9 +618,9 @@ impl<E: Entry> StreamingSstWriter<E> {
             }
         }
 
-        // All PendingSmall entries are now resolved. No entries reference an unflushed block
-        // until the next Small value arrives.
-        self.first_pending_small_index = self.pending_keys.len();
+        // All PendingSmall entries are now resolved. Advance the boundary through all of
+        // them, flushing key blocks incrementally as we go.
+        self.advance_boundary_to(self.pending_keys.len())?;
 
         // Advance to next small block id (debug-only consistency check)
         #[cfg(debug_assertions)]
@@ -567,69 +629,6 @@ impl<E: Entry> StreamingSstWriter<E> {
         }
         self.pending_small_values.clear();
         self.pending_small_value_count = 0;
-
-        Ok(())
-    }
-
-    /// Tries to flush complete key blocks from the front of `pending_keys`.
-    ///
-    /// The resolved prefix boundary is known directly from `first_pending_small_index` -- all
-    /// entries before that index have resolved value references. Within that prefix, we find
-    /// key block boundaries and flush complete blocks in a single pass.
-    ///
-    /// TODO: This scan is O(pending_keys.len()) in the worst case. When small value blocks are
-    /// rare relative to medium/inline entries, `pending_keys` can grow large because the front
-    /// entry references an unflushed small block while the back keeps accumulating resolved
-    /// entries. A future improvement could track the resolved-prefix length incrementally.
-    fn try_flush_key_blocks(&mut self) -> Result<()> {
-        let resolved_end = self.first_pending_small_index;
-
-        if resolved_end == 0 {
-            return Ok(());
-        }
-
-        // Single pass: find block boundaries and flush complete blocks.
-        let mut block_start = 0;
-        let mut block_size = 0usize;
-        let mut block_entry_count = 0usize;
-        let mut block_max_key_len = 0usize;
-        let mut last_flushed_end = 0usize;
-        let mut last_hash = 0u64;
-
-        for i in 0..resolved_end {
-            let entry = &self.pending_keys[i];
-            let key_len = entry.entry.key_len();
-            let key_hash = entry.entry.key_hash();
-
-            if should_flush_key_block(block_size, block_entry_count, key_len, last_hash, key_hash) {
-                self.flush_key_block(block_start, i, block_max_key_len)?;
-                last_flushed_end = i;
-                block_start = i;
-                block_size = 0;
-                block_max_key_len = 0;
-                block_entry_count = 0;
-            }
-
-            block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
-            block_max_key_len = block_max_key_len.max(key_len);
-            block_entry_count += 1;
-            last_hash = key_hash;
-        }
-
-        // Don't flush the trailing incomplete block -- it may grow more.
-
-        if last_flushed_end > 0 {
-            // Subtract drained entries' key sizes from the pending total.
-            let drained_key_size: usize = self
-                .pending_keys
-                .range(..last_flushed_end)
-                .map(|e| e.entry.key_len())
-                .sum();
-            self.pending_key_total_size -= drained_key_size;
-            // VecDeque::drain from the front is O(1) -- it just adjusts the head pointer.
-            self.pending_keys.drain(..last_flushed_end);
-            self.first_pending_small_index -= last_flushed_end;
-        }
 
         Ok(())
     }
@@ -799,6 +798,9 @@ impl<E: Entry> StreamingSstWriter<E> {
 
         self.pending_keys.clear();
         self.pending_key_total_size = 0;
+        self.current_key_block_size = 0;
+        self.current_key_block_entry_count = 0;
+        self.current_key_block_max_key_len = 0;
         Ok(())
     }
 }
@@ -1332,13 +1334,13 @@ mod tests {
         let dir = tempfile::tempdir()?;
         let mut entries = vec![
             TestEntry::inline(b"a-inline", b"tiny"),
-            TestEntry::small(b"b-small", &vec![0x11; 200]),
-            TestEntry::medium(b"c-medium", &vec![0x22; 8192]),
+            TestEntry::small(b"b-small", &[0x11; 200]),
+            TestEntry::medium(b"c-medium", &[0x22; 8192]),
             TestEntry::blob(b"d-blob", 99),
             TestEntry::deleted(b"e-deleted"),
-            TestEntry::small(b"f-small2", &vec![0x33; 300]),
+            TestEntry::small(b"f-small2", &[0x33; 300]),
             TestEntry::inline(b"g-inline2", b"mini"),
-            TestEntry::medium(b"h-medium2", &vec![0x44; 16384]),
+            TestEntry::medium(b"h-medium2", &[0x44; 16384]),
         ];
         sort_entries(&mut entries);
 
@@ -1412,9 +1414,9 @@ mod tests {
                 if i % 3 == 0 {
                     TestEntry::inline(key.as_bytes(), &[(i & 0xFF) as u8; 4])
                 } else if i % 3 == 1 {
-                    TestEntry::small(key.as_bytes(), &vec![(i & 0xFF) as u8; 200])
+                    TestEntry::small(key.as_bytes(), &[(i & 0xFF) as u8; 200])
                 } else {
-                    TestEntry::medium(key.as_bytes(), &vec![(i & 0xFF) as u8; 8192])
+                    TestEntry::medium(key.as_bytes(), &[(i & 0xFF) as u8; 8192])
                 }
             })
             .collect();

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -1,5 +1,6 @@
 use std::{
     borrow::Cow,
+    collections::VecDeque,
     fs::File,
     io::{BufWriter, Seek, Write},
     path::Path,
@@ -7,7 +8,7 @@ use std::{
 
 use anyhow::{Context, Result};
 use byteorder::{BE, ByteOrder, WriteBytesExt};
-use turbo_bincode::{TurboBincodeBuffer, turbo_bincode_encode};
+use turbo_bincode::turbo_bincode_encode;
 
 use crate::{
     compression::compress_into_buffer,
@@ -97,388 +98,655 @@ pub struct StaticSortedFileBuilderMeta<'a> {
     pub entries: u64,
 }
 
+/// Writes an SST file from a pre-sorted slice of entries.
+///
+/// This is a convenience wrapper around [`StreamingSstWriter`] for callers that already have all
+/// entries in memory.
 pub fn write_static_stored_file<E: Entry>(
     entries: &[E],
     file: &Path,
     flags: MetaEntryFlags,
 ) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
     debug_assert!(entries.iter().map(|e| e.key_hash()).is_sorted());
-
-    let mut file = BufWriter::new(File::create(file)?);
-
-    // We use a shared buffer for all operations to avoid excessive allocations
-    let mut buffer = Vec::new();
-
-    let mut block_writer = BlockWriter::new(&mut file, &mut buffer);
-
-    // Another shared buffer for the uncompressed blocks
-    // The existing shared buffer will be used for compressed blocks
-    // So we need both
-    let mut buffer = Vec::new();
-
-    let min_hash = entries.first().map_or(u64::MAX, |e| e.key_hash());
-    let value_locations = write_value_blocks(entries, &mut block_writer, &mut buffer)
-        .context("Failed to write value blocks")?;
-    let amqf = write_key_blocks_and_compute_amqf(
-        entries,
-        &value_locations,
-        &mut block_writer,
-        &mut buffer,
-    )
-    .context("Failed to write key blocks")?;
-    let max_hash = entries.last().map_or(0, |e| e.key_hash());
-
-    let block_count = block_writer.block_count();
-    for offset in &block_writer.block_offsets {
-        file.write_u32::<BE>(*offset)
-            .context("Failed to write block offset")?;
+    let mut writer = StreamingSstWriter::new(file, flags, entries.len() as u64)?;
+    for entry in entries {
+        writer.add(entry)?;
     }
-
-    let meta = StaticSortedFileBuilderMeta {
-        min_hash,
-        max_hash,
-        amqf: Cow::Owned(amqf.into_vec()),
-        block_count,
-        size: file.stream_position()?,
-        flags,
-        entries: entries.len() as u64,
-    };
-    Ok((meta, file.into_inner()?))
+    writer.finish()
 }
 
-enum CompressionConfig {
-    /// Attempt compression; use the result only if it's smaller than the original.
-    TryCompress,
-    /// Write the block uncompressed.
-    Uncompressed,
-}
+// ---------------------------------------------------------------------------
+// Block I/O helpers (free functions for borrow-checker friendliness)
+// ---------------------------------------------------------------------------
 
-struct BlockWriter<'l> {
-    buffer: &'l mut Vec<u8>,
-    block_offsets: Vec<u32>,
-    writer: &'l mut BufWriter<File>,
-}
+/// Writes a block to the file, optionally compressing it. Returns the block index assigned.
+fn write_block_to_file(
+    file: &mut BufWriter<File>,
+    compress_buffer: &mut Vec<u8>,
+    block_offsets: &mut Vec<u32>,
+    block: &[u8],
+    try_compress: bool,
+) -> Result<u16> {
+    let block_index: u16 = block_offsets
+        .len()
+        .try_into()
+        .expect("Block index overflow");
 
-impl<'l> BlockWriter<'l> {
-    fn new(writer: &'l mut BufWriter<File>, buffer: &'l mut Vec<u8>) -> Self {
-        Self {
-            buffer,
-            block_offsets: Vec::new(),
-            writer,
+    let (uncompressed_size, data_to_write): (u32, &[u8]) = if try_compress {
+        compress_into_buffer(block, compress_buffer)?;
+        // Same threshold as LevelDB/RocksDB: require at least 12.5% savings.
+        if compress_buffer.len() < block.len() - (block.len() / 8) {
+            (block.len().try_into().unwrap(), compress_buffer.as_slice())
+        } else {
+            (0, block)
         }
-    }
+    } else {
+        (0, block)
+    };
 
-    fn next_block_index(&mut self) -> u16 {
-        self.block_offsets
-            .len()
-            .try_into()
-            .expect("Block index overflow")
-    }
+    let len: u32 = (data_to_write.len() + 4).try_into().unwrap();
+    let offset = block_offsets
+        .last()
+        .copied()
+        .unwrap_or_default()
+        .checked_add(len)
+        .expect("Block offset overflow");
+    block_offsets.push(offset);
 
-    fn block_count(&self) -> u16 {
-        self.block_offsets
-            .len()
-            .try_into()
-            .expect("Block count overflow")
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    fn write_key_block(&mut self, block: &[u8]) -> Result<()> {
-        self.write_block(block, CompressionConfig::TryCompress)
-            .context("Failed to write key block")
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    fn write_index_block(&mut self, block: &[u8]) -> Result<()> {
-        // Index blocks are minimally compressible so don't try
-        self.write_block(block, CompressionConfig::Uncompressed)
-            .context("Failed to write index block")
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    fn write_small_value_block(&mut self, block: &[u8]) -> Result<()> {
-        self.write_block(block, CompressionConfig::TryCompress)
-            .context("Failed to write small value block")
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    fn write_value_block(&mut self, block: &[u8]) -> Result<()> {
-        self.write_block(block, CompressionConfig::TryCompress)
-            .context("Failed to write value block")
-    }
-
-    fn write_block(&mut self, block: &[u8], compression: CompressionConfig) -> Result<()> {
-        let (uncompressed_size, data_to_write): (u32, &[u8]) = match compression {
-            CompressionConfig::TryCompress => {
-                self.compress_block_into_buffer(block)?;
-                // Same threshold as LevelDB/RocksDB: require at least 12.5% savings to store
-                // compressed.
-                // See https://github.com/google/leveldb/blob/ac691084fdc5546421a55b25e7653d450e5a25fb/table/table_builder.cc#L164
-                // Uncompressed blocks take more time to read but we can directly leverage the mmap
-                // on the read side, compressed blocks need to be decompressed and managed in a
-                // cache. So we should only do it if we expect to save time.
-                if self.buffer.len() < block.len() - (block.len() / 8) {
-                    // Compression helped - use compressed data
-                    (block.len().try_into().unwrap(), self.buffer.as_slice())
-                } else {
-                    // Compression didn't help - use uncompressed with sentinel size value
-                    (0, block)
-                }
-            }
-            CompressionConfig::Uncompressed => (0, block),
-        };
-
-        let len: u32 = (data_to_write.len() + 4).try_into().unwrap();
-        let offset = self
-            .block_offsets
-            .last()
-            .copied()
-            .unwrap_or_default()
-            .checked_add(len)
-            .expect("Block offset overflow");
-        self.block_offsets.push(offset);
-
-        self.writer
-            .write_u32::<BE>(uncompressed_size)
-            .context("Failed to write uncompressed_size")?;
-        self.writer
-            .write_all(data_to_write)
-            .context("Failed to write block data")?;
-        self.buffer.clear();
-        Ok(())
-    }
-
-    fn write_compressed_block(&mut self, uncompressed_size: u32, block: &[u8]) -> Result<()> {
-        let len = (block.len() + 4).try_into().unwrap();
-        let offset = self
-            .block_offsets
-            .last()
-            .copied()
-            .unwrap_or_default()
-            .checked_add(len)
-            .expect("Block offset overflow");
-        self.block_offsets.push(offset);
-
-        self.writer
-            .write_u32::<BE>(uncompressed_size)
-            .context("Failed to write uncompressed size")?;
-        self.writer
-            .write_all(block)
-            .context("Failed to write compressed block")?;
-        Ok(())
-    }
-
-    /// Compresses a block using LZ4.
-    fn compress_block_into_buffer(&mut self, block: &[u8]) -> Result<()> {
-        compress_into_buffer(block, self.buffer)
-    }
+    file.write_u32::<BE>(uncompressed_size)
+        .context("Failed to write uncompressed_size")?;
+    file.write_all(data_to_write)
+        .context("Failed to write block data")?;
+    compress_buffer.clear();
+    Ok(block_index)
 }
 
-/// Splits the values of the entries into blocks and writes them to the writer.
-#[tracing::instrument(level = "trace", skip_all)]
-fn write_value_blocks(
-    entries: &[impl Entry],
-    writer: &mut BlockWriter<'_>,
-    buffer: &mut Vec<u8>,
-) -> Result<Vec<(u16, u32)>> {
-    let mut value_locations: Vec<(u16, u32)> = Vec::with_capacity(entries.len());
+/// Writes a pre-compressed block to the file. Returns the block index assigned.
+fn write_compressed_block_to_file(
+    file: &mut BufWriter<File>,
+    block_offsets: &mut Vec<u32>,
+    uncompressed_size: u32,
+    block: &[u8],
+) -> Result<u16> {
+    let block_index: u16 = block_offsets
+        .len()
+        .try_into()
+        .expect("Block index overflow");
 
-    let mut current_block_start = 0;
-    let mut current_block_count = 0;
-    let mut current_block_size = 0;
-    for (i, entry) in entries.iter().enumerate() {
-        match entry.value() {
-            EntryValue::Small { value } => {
-                value_locations.push((0, current_block_size.try_into().unwrap()));
-                current_block_size += value.len();
-                current_block_count += 1;
-                if current_block_size >= MIN_SMALL_VALUE_BLOCK_SIZE
-                    || current_block_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
-                {
-                    let block_index = writer.next_block_index();
-                    buffer.reserve(current_block_size);
-                    for j in current_block_start..=i {
-                        if let EntryValue::Small { value } = &entries[j].value() {
-                            buffer.extend_from_slice(value);
-                            value_locations[j].0 = block_index;
-                        }
-                    }
-                    writer.write_small_value_block(buffer)?;
-                    buffer.clear();
-                    current_block_start = i + 1;
-                    current_block_size = 0;
-                    current_block_count = 0;
-                }
-            }
+    let len: u32 = (block.len() + 4).try_into().unwrap();
+    let offset = block_offsets
+        .last()
+        .copied()
+        .unwrap_or_default()
+        .checked_add(len)
+        .expect("Block offset overflow");
+    block_offsets.push(offset);
+
+    file.write_u32::<BE>(uncompressed_size)
+        .context("Failed to write uncompressed size")?;
+    file.write_all(block)
+        .context("Failed to write compressed block")?;
+    Ok(block_index)
+}
+
+// ---------------------------------------------------------------------------
+// StreamingSstWriter
+// ---------------------------------------------------------------------------
+
+/// Where a key entry's value lives (or will live once the small block flushes).
+enum ValueRef {
+    /// Value in a known small value block (already flushed).
+    Small {
+        block_index: u16,
+        offset: u32,
+        size: u16,
+    },
+    /// Value is in a small value block that hasn't been written yet.
+    /// `small_block_id` indexes into `small_block_indices` to find the block_index once flushed.
+    PendingSmall {
+        small_block_id: u32,
+        offset: u32,
+        size: u16,
+    },
+    /// Medium value already written to its own block.
+    Medium { block_index: u16 },
+    /// Inline value (stored directly in the key block).
+    Inline {
+        data: [u8; MAX_INLINE_VALUE_SIZE],
+        len: u8,
+    },
+    /// Large blob stored externally.
+    Blob { blob_id: u32 },
+    /// Tombstone.
+    Deleted,
+}
+
+struct PendingKeyEntry {
+    key_hash: u64,
+    key: Vec<u8>,
+    value_ref: ValueRef,
+}
+
+/// A streaming SST file writer that writes blocks to disk incrementally.
+///
+/// Instead of materializing all entries in memory and then writing all value blocks followed by all
+/// key blocks, this writer interleaves block writes as entries arrive. Medium values are written
+/// immediately, small values are accumulated into blocks, and key blocks are flushed as soon as
+/// their value references are all resolved.
+///
+/// The SST reader is block-index-addressed (not file-position-addressed), so interleaving block
+/// types is fully compatible.
+pub struct StreamingSstWriter {
+    // File I/O
+    file: BufWriter<File>,
+    compress_buffer: Vec<u8>,
+    block_offsets: Vec<u32>,
+
+    // Pending key entries (VecDeque for efficient front drain)
+    pending_keys: VecDeque<PendingKeyEntry>,
+
+    // Key block size tracking (tracks the accumulated size from the front of pending_keys)
+    current_key_block_size: usize,
+    current_key_block_entry_count: usize,
+    current_key_block_max_key_len: usize,
+
+    // Small value block indirection
+    /// Maps small_block_id -> actual block_index. `None` means not yet flushed.
+    small_block_indices: Vec<Option<u16>>,
+    /// The current small_block_id being accumulated into.
+    current_small_block_id: u32,
+    /// The smallest small_block_id that hasn't been resolved yet.
+    /// All IDs below this are resolved.
+    first_unresolved_small_block_id: u32,
+
+    // Pending small value block buffer
+    pending_small_values: Vec<u8>,
+    pending_small_value_count: usize,
+
+    // Reusable buffer for building key blocks
+    key_buffer: Vec<u8>,
+
+    // AMQF filter (built incrementally)
+    filter: qfilter::Filter,
+
+    // Index block data: (first_hash, block_index) for each key block written
+    key_block_boundaries: Vec<(u64, u16)>,
+
+    // Metadata
+    min_hash: u64,
+    max_hash: u64,
+    entry_count: u64,
+    flags: MetaEntryFlags,
+}
+
+impl StreamingSstWriter {
+    /// Creates a new streaming SST writer.
+    ///
+    /// `entry_count_hint` is used to size the AMQF filter. It may be an upper bound; a slightly
+    /// oversized filter only improves the false-positive rate.
+    pub fn new(file: &Path, flags: MetaEntryFlags, entry_count_hint: u64) -> Result<Self> {
+        let file = BufWriter::new(File::create(file)?);
+        let filter = qfilter::Filter::new(entry_count_hint.max(1), AMQF_FALSE_POSITIVE_RATE)
+            .expect("Filter can't be constructed");
+
+        Ok(Self {
+            file,
+            compress_buffer: Vec::new(),
+            block_offsets: Vec::new(),
+            pending_keys: VecDeque::new(),
+            current_key_block_size: 0,
+            current_key_block_entry_count: 0,
+            current_key_block_max_key_len: 0,
+            small_block_indices: Vec::new(),
+            current_small_block_id: 0,
+            first_unresolved_small_block_id: 0,
+            pending_small_values: Vec::new(),
+            pending_small_value_count: 0,
+            key_buffer: Vec::new(),
+            filter,
+            key_block_boundaries: Vec::new(),
+            min_hash: u64::MAX,
+            max_hash: 0,
+            entry_count: 0,
+            flags,
+        })
+    }
+
+    /// Adds an entry to the SST file. Entries must be added in key-hash order.
+    pub fn add<E: Entry>(&mut self, entry: &E) -> Result<()> {
+        let key_hash = entry.key_hash();
+
+        // Update metadata
+        if self.entry_count == 0 {
+            self.min_hash = key_hash;
+        }
+        self.max_hash = key_hash;
+        self.entry_count += 1;
+
+        // Insert into AMQF
+        self.filter
+            .insert_fingerprint(false, key_hash)
+            .expect("AMQF insert failed");
+
+        // Copy key bytes
+        let mut key = Vec::with_capacity(entry.key_len());
+        entry.write_key_to(&mut key);
+
+        // Route value
+        let value_ref = match entry.value() {
             EntryValue::Medium { value } => {
-                let block_index = writer.next_block_index();
-                value_locations.push((block_index, 0));
-                writer.write_value_block(value)?;
+                let block_index = write_block_to_file(
+                    &mut self.file,
+                    &mut self.compress_buffer,
+                    &mut self.block_offsets,
+                    value,
+                    true,
+                )
+                .context("Failed to write value block")?;
+                ValueRef::Medium { block_index }
             }
             EntryValue::MediumRaw {
                 uncompressed_size,
                 block,
             } => {
-                let block_index = writer.next_block_index();
-                value_locations.push((block_index, 0));
-                writer.write_compressed_block(uncompressed_size, block)?;
-            }
-            EntryValue::Inline { .. } | EntryValue::Deleted | EntryValue::Large { .. } => {
-                // Inline values are stored in the key block, not in value blocks
-                value_locations.push((0, 0));
-            }
-        }
-    }
-    if current_block_count > 0 {
-        let block_index = writer.next_block_index();
-        buffer.reserve(current_block_size);
-        for j in current_block_start..entries.len() {
-            if let EntryValue::Small { value } = &entries[j].value() {
-                buffer.extend_from_slice(value);
-                value_locations[j].0 = block_index;
-            }
-        }
-        writer.write_small_value_block(buffer)?;
-        buffer.clear();
-    }
-
-    Ok(value_locations)
-}
-
-/// Splits the keys of the entries into blocks and writes them to the writer. Also writes an index
-/// block.
-#[tracing::instrument(level = "trace", skip_all)]
-fn write_key_blocks_and_compute_amqf(
-    entries: &[impl Entry],
-    value_locations: &[(u16, u32)],
-    writer: &mut BlockWriter<'_>,
-    buffer: &mut Vec<u8>,
-) -> Result<TurboBincodeBuffer> {
-    let mut filter = qfilter::Filter::new(entries.len() as u64, AMQF_FALSE_POSITIVE_RATE)
-        // This won't fail as we limit the number of entries per SST file
-        .expect("Filter can't be constructed");
-
-    let mut key_block_boundaries = Vec::new();
-
-    // Split the keys into blocks
-    fn add_entry_to_block<E: Entry>(
-        entry: &E,
-        value_location: &(u16, u32),
-        block: &mut KeyBlockBuilder,
-    ) {
-        match entry.value() {
-            EntryValue::Inline { value } => {
-                block.put_inline(entry, value);
+                let block_index = write_compressed_block_to_file(
+                    &mut self.file,
+                    &mut self.block_offsets,
+                    uncompressed_size,
+                    block,
+                )
+                .context("Failed to write compressed value block")?;
+                ValueRef::Medium { block_index }
             }
             EntryValue::Small { value } => {
-                block.put_small(
-                    entry,
-                    value_location.0,
-                    value_location.1,
-                    value.len().try_into().unwrap(),
-                );
+                let offset = self.pending_small_values.len() as u32;
+                let size: u16 = value.len().try_into().unwrap();
+                self.pending_small_values.extend_from_slice(value);
+                self.pending_small_value_count += 1;
+                let small_block_id = self.current_small_block_id;
+                ValueRef::PendingSmall {
+                    small_block_id,
+                    offset,
+                    size,
+                }
             }
-            EntryValue::Medium { .. } | EntryValue::MediumRaw { .. } => {
-                block.put_medium(entry, value_location.0);
+            EntryValue::Inline { value } => {
+                debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
+                let mut data = [0u8; MAX_INLINE_VALUE_SIZE];
+                data[..value.len()].copy_from_slice(value);
+                ValueRef::Inline {
+                    data,
+                    len: value.len() as u8,
+                }
             }
-            EntryValue::Large { blob } => {
-                block.put_blob(entry, blob);
-            }
-            EntryValue::Deleted => {
-                block.delete(entry);
-            }
-        }
-    }
-    let mut current_block_start = 0;
-    let mut current_block_size = 0;
-    let mut current_block_max_key_len = 0;
-    let mut last_hash = 0;
-    for (i, entry) in entries.iter().enumerate() {
-        let key_hash = entry.key_hash();
-        let key_len = entry.key_len();
+            EntryValue::Large { blob } => ValueRef::Blob { blob_id: blob },
+            EntryValue::Deleted => ValueRef::Deleted,
+        };
 
-        // Add to AMQF
-        filter
-            .insert_fingerprint(false, key_hash)
-            // This can't fail as we allocated enough capacity
-            .expect("AMQF insert failed");
+        // Push pending key entry
+        let key_len = key.len();
+        self.pending_keys.push_back(PendingKeyEntry {
+            key_hash,
+            key,
+            value_ref,
+        });
 
-        // Accumulate until the block is full
-        if current_block_size > 0
-                && (current_block_size + key_len + KEY_BLOCK_ENTRY_META_OVERHEAD
-                    > MAX_KEY_BLOCK_SIZE
-                    || i - current_block_start >= MAX_KEY_BLOCK_ENTRIES) &&
-                    // avoid breaking the block in the middle of a hash conflict
-                    last_hash != key_hash
+        // Update key block size tracking
+        self.current_key_block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
+        self.current_key_block_entry_count += 1;
+        self.current_key_block_max_key_len = self.current_key_block_max_key_len.max(key_len);
+
+        // Flush small value block if full
+        if self.pending_small_values.len() >= MIN_SMALL_VALUE_BLOCK_SIZE
+            || self.pending_small_value_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
         {
-            let entry_count = i - current_block_start;
-            let has_hash = use_hash(current_block_max_key_len);
-            let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, has_hash);
-            for j in current_block_start..i {
-                let entry = &entries[j];
-                let value_location = &value_locations[j];
-                add_entry_to_block(entry, value_location, &mut block);
+            self.flush_small_value_block()?;
+        }
+
+        // Try to flush completed key blocks
+        self.try_flush_key_blocks()?;
+
+        Ok(())
+    }
+
+    /// Flushes the current pending small value block to disk.
+    fn flush_small_value_block(&mut self) -> Result<()> {
+        if self.pending_small_values.is_empty() {
+            return Ok(());
+        }
+
+        let block_index = write_block_to_file(
+            &mut self.file,
+            &mut self.compress_buffer,
+            &mut self.block_offsets,
+            &self.pending_small_values,
+            true,
+        )
+        .context("Failed to write small value block")?;
+
+        // Record the mapping from small_block_id -> block_index
+        let id = self.current_small_block_id as usize;
+        debug_assert_eq!(id, self.small_block_indices.len());
+        self.small_block_indices.push(Some(block_index));
+
+        // Advance to next small block id
+        self.current_small_block_id += 1;
+        self.pending_small_values.clear();
+        self.pending_small_value_count = 0;
+
+        // Advance first_unresolved_small_block_id
+        while (self.first_unresolved_small_block_id as usize) < self.small_block_indices.len()
+            && self.small_block_indices[self.first_unresolved_small_block_id as usize].is_some()
+        {
+            self.first_unresolved_small_block_id += 1;
+        }
+
+        Ok(())
+    }
+
+    /// Checks if a value reference is resolved (i.e., its block index is known).
+    fn is_resolved(&self, value_ref: &ValueRef) -> bool {
+        match value_ref {
+            ValueRef::PendingSmall { small_block_id, .. } => {
+                *small_block_id < self.first_unresolved_small_block_id
             }
-            key_block_boundaries.push((
-                entries[current_block_start].key_hash(),
-                writer.next_block_index(),
-            ));
-            block.finish();
-            writer.write_key_block(buffer)?;
-            buffer.clear();
-            current_block_size = 0;
-            current_block_max_key_len = 0;
-            current_block_start = i;
+            _ => true,
         }
-        current_block_size += entry.key_len() + KEY_BLOCK_ENTRY_META_OVERHEAD;
-        current_block_max_key_len = current_block_max_key_len.max(key_len);
-        last_hash = key_hash;
     }
 
-    // Finish the last block
-    if current_block_size > 0 {
-        let entry_count = entries.len() - current_block_start;
-        let has_hash = use_hash(current_block_max_key_len);
-        let mut block = KeyBlockBuilder::new(buffer, entry_count as u32, has_hash);
-        for j in current_block_start..entries.len() {
-            let entry = &entries[j];
-            let value_location = &value_locations[j];
-            add_entry_to_block(entry, value_location, &mut block);
+    /// Resolves a `PendingSmall` to a `Small` value reference. Panics if not yet resolved.
+    fn resolve_value_ref(value_ref: &ValueRef, small_block_indices: &[Option<u16>]) -> ValueRef {
+        match *value_ref {
+            ValueRef::PendingSmall {
+                small_block_id,
+                offset,
+                size,
+            } => {
+                let block_index = small_block_indices[small_block_id as usize]
+                    .expect("small block not yet resolved");
+                ValueRef::Small {
+                    block_index,
+                    offset,
+                    size,
+                }
+            }
+            // Already resolved variants are returned as-is
+            ValueRef::Small {
+                block_index,
+                offset,
+                size,
+            } => ValueRef::Small {
+                block_index,
+                offset,
+                size,
+            },
+            ValueRef::Medium { block_index } => ValueRef::Medium { block_index },
+            ValueRef::Inline { data, len } => ValueRef::Inline { data, len },
+            ValueRef::Blob { blob_id } => ValueRef::Blob { blob_id },
+            ValueRef::Deleted => ValueRef::Deleted,
         }
-        key_block_boundaries.push((
-            entries[current_block_start].key_hash(),
-            writer.next_block_index(),
-        ));
-        block.finish();
-        writer.write_key_block(buffer)?;
-        buffer.clear();
     }
 
-    // Compute the index
-    let mut index_block = IndexBlockBuilder::new(
-        buffer,
-        key_block_boundaries
+    /// Tries to flush complete key blocks from the front of `pending_keys`.
+    fn try_flush_key_blocks(&mut self) -> Result<()> {
+        // Find the resolved prefix length
+        let mut resolved_count = 0;
+        for entry in &self.pending_keys {
+            if !self.is_resolved(&entry.value_ref) {
+                break;
+            }
+            resolved_count += 1;
+        }
+
+        if resolved_count == 0 {
+            return Ok(());
+        }
+
+        // Within the resolved prefix, find and flush complete key blocks.
+        // We need to re-scan the resolved entries to find block boundaries,
+        // tracking size from the front.
+        let mut block_start = 0;
+        let mut block_size = 0;
+        let mut block_max_key_len = 0;
+        let mut last_hash = 0u64;
+
+        for i in 0..resolved_count {
+            let entry = &self.pending_keys[i];
+            let key_len = entry.key.len();
+            let key_hash = entry.key_hash;
+
+            // Check if we should start a new block (same logic as old code)
+            if block_size > 0
+                && (block_size + key_len + KEY_BLOCK_ENTRY_META_OVERHEAD > MAX_KEY_BLOCK_SIZE
+                    || i - block_start >= MAX_KEY_BLOCK_ENTRIES)
+                && last_hash != key_hash
+            {
+                // Flush this key block
+                self.flush_key_block(block_start, i, block_max_key_len)?;
+                block_start = i;
+                block_size = 0;
+                block_max_key_len = 0;
+            }
+
+            block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
+            block_max_key_len = block_max_key_len.max(key_len);
+            last_hash = key_hash;
+        }
+
+        // Don't flush the trailing incomplete block here -- it may grow more.
+        // But if we flushed any blocks, drain those entries and recompute tracking.
+        if block_start > 0 {
+            // Drain the consumed entries
+            self.pending_keys.drain(..block_start);
+
+            // Recompute key block tracking from the remaining entries
+            self.current_key_block_size = 0;
+            self.current_key_block_entry_count = self.pending_keys.len();
+            self.current_key_block_max_key_len = 0;
+            for entry in &self.pending_keys {
+                self.current_key_block_size += entry.key.len() + KEY_BLOCK_ENTRY_META_OVERHEAD;
+                self.current_key_block_max_key_len =
+                    self.current_key_block_max_key_len.max(entry.key.len());
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Flushes a single key block from `pending_keys[start..end]`.
+    fn flush_key_block(&mut self, start: usize, end: usize, max_key_len: usize) -> Result<()> {
+        let entry_count = end - start;
+        let has_hash = use_hash(max_key_len);
+
+        self.key_buffer.clear();
+        let mut builder = KeyBlockBuilder::new(&mut self.key_buffer, entry_count as u32, has_hash);
+
+        for i in start..end {
+            let entry = &self.pending_keys[i];
+            let resolved = Self::resolve_value_ref(&entry.value_ref, &self.small_block_indices);
+
+            match resolved {
+                ValueRef::Small {
+                    block_index,
+                    offset,
+                    size,
+                } => {
+                    builder.put_small(
+                        entry.key_hash,
+                        &entry.key,
+                        block_index,
+                        offset,
+                        size,
+                        has_hash,
+                    );
+                }
+                ValueRef::Medium { block_index } => {
+                    builder.put_medium(entry.key_hash, &entry.key, block_index, has_hash);
+                }
+                ValueRef::Inline { data, len } => {
+                    builder.put_inline(entry.key_hash, &entry.key, &data[..len as usize], has_hash);
+                }
+                ValueRef::Blob { blob_id } => {
+                    builder.put_blob(entry.key_hash, &entry.key, blob_id, has_hash);
+                }
+                ValueRef::Deleted => {
+                    builder.delete(entry.key_hash, &entry.key, has_hash);
+                }
+                ValueRef::PendingSmall { .. } => {
+                    unreachable!("PendingSmall should have been resolved");
+                }
+            }
+        }
+
+        // Drop builder to release borrow on key_buffer before writing
+        builder.finish();
+
+        // Record boundary
+        let first_hash = self.pending_keys[start].key_hash;
+        let block_index = write_block_to_file(
+            &mut self.file,
+            &mut self.compress_buffer,
+            &mut self.block_offsets,
+            &self.key_buffer,
+            true,
+        )
+        .context("Failed to write key block")?;
+        self.key_block_boundaries.push((first_hash, block_index));
+
+        Ok(())
+    }
+
+    /// Finishes writing the SST file. Flushes remaining blocks, writes the index, and returns
+    /// metadata.
+    pub fn finish(mut self) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
+        // Flush remaining small value block
+        self.flush_small_value_block()?;
+
+        // Now all PendingSmall entries are resolved. Flush all remaining key blocks.
+        self.flush_remaining_key_blocks()?;
+
+        // Handle empty file edge case
+        if self.key_block_boundaries.is_empty() {
+            // No entries were added. Write a minimal index block.
+            self.key_buffer.clear();
+            let index_block = IndexBlockBuilder::new(&mut self.key_buffer, 0, 0);
+            index_block.finish();
+            write_block_to_file(
+                &mut self.file,
+                &mut self.compress_buffer,
+                &mut self.block_offsets,
+                &self.key_buffer,
+                false,
+            )
+            .context("Failed to write index block")?;
+        } else {
+            // Write index block
+            self.key_buffer.clear();
+            let entry_count: u16 = (self.key_block_boundaries.len() - 1)
+                .try_into()
+                .expect("Index entries count overflow");
+            let first_block = self.key_block_boundaries[0].1;
+            let mut index_block =
+                IndexBlockBuilder::new(&mut self.key_buffer, entry_count, first_block);
+            for &(hash, block) in &self.key_block_boundaries[1..] {
+                index_block.put(hash, block);
+            }
+            index_block.finish();
+            write_block_to_file(
+                &mut self.file,
+                &mut self.compress_buffer,
+                &mut self.block_offsets,
+                &self.key_buffer,
+                false,
+            )
+            .context("Failed to write index block")?;
+        }
+
+        // Write block offset table
+        for offset in &self.block_offsets {
+            self.file
+                .write_u32::<BE>(*offset)
+                .context("Failed to write block offset")?;
+        }
+
+        let block_count: u16 = self
+            .block_offsets
             .len()
             .try_into()
-            .expect("Index entries count overflow"),
-        key_block_boundaries[0].1,
-    );
-    for (hash, block) in &key_block_boundaries[1..] {
-        index_block.put(*hash, *block);
-    }
-    let _ = writer.next_block_index();
-    index_block.finish();
-    writer.write_index_block(buffer)?;
-    buffer.clear();
+            .expect("Block count overflow");
 
-    Ok(turbo_bincode_encode(&AmqfBincodeWrapper(filter)).expect("AMQF serialization failed"))
+        // Serialize AMQF
+        let amqf = turbo_bincode_encode(&AmqfBincodeWrapper(self.filter))
+            .expect("AMQF serialization failed");
+
+        let meta = StaticSortedFileBuilderMeta {
+            min_hash: self.min_hash,
+            max_hash: self.max_hash,
+            amqf: Cow::Owned(amqf.into_vec()),
+            block_count,
+            size: self.file.stream_position()?,
+            flags: self.flags,
+            entries: self.entry_count,
+        };
+
+        Ok((meta, self.file.into_inner()?))
+    }
+
+    /// Flushes all remaining entries as key blocks. Called from `finish()` after all small value
+    /// blocks have been flushed, so all PendingSmall entries are resolved.
+    fn flush_remaining_key_blocks(&mut self) -> Result<()> {
+        if self.pending_keys.is_empty() {
+            return Ok(());
+        }
+
+        let total = self.pending_keys.len();
+        let mut block_start = 0;
+        let mut block_size = 0;
+        let mut block_max_key_len = 0;
+        let mut last_hash = 0u64;
+
+        for i in 0..total {
+            let entry = &self.pending_keys[i];
+            let key_len = entry.key.len();
+            let key_hash = entry.key_hash;
+
+            if block_size > 0
+                && (block_size + key_len + KEY_BLOCK_ENTRY_META_OVERHEAD > MAX_KEY_BLOCK_SIZE
+                    || i - block_start >= MAX_KEY_BLOCK_ENTRIES)
+                && last_hash != key_hash
+            {
+                self.flush_key_block(block_start, i, block_max_key_len)?;
+                block_start = i;
+                block_size = 0;
+                block_max_key_len = 0;
+            }
+
+            block_size += key_len + KEY_BLOCK_ENTRY_META_OVERHEAD;
+            block_max_key_len = block_max_key_len.max(key_len);
+            last_hash = key_hash;
+        }
+
+        // Flush the final block
+        if block_start < total {
+            self.flush_key_block(block_start, total, block_max_key_len)?;
+        }
+
+        self.pending_keys.clear();
+        Ok(())
+    }
 }
 
-/// Builder for a single key block
-pub struct KeyBlockBuilder<'l> {
+// ---------------------------------------------------------------------------
+// KeyBlockBuilder
+// ---------------------------------------------------------------------------
+
+/// Builder for a single key block.
+///
+/// Entries are added via `put_*` methods which write key data and value references into the buffer.
+/// The block format uses a fixed-size header table followed by variable-length entry data.
+struct KeyBlockBuilder<'l> {
     current_entry: usize,
     header_size: usize,
-    has_hash: bool,
     buffer: &'l mut Vec<u8>,
 }
 
@@ -487,7 +755,7 @@ const KEY_BLOCK_HEADER_SIZE: usize = 4;
 
 impl<'l> KeyBlockBuilder<'l> {
     /// Creates a new key block builder for the number of entries.
-    pub fn new(buffer: &'l mut Vec<u8>, entry_count: u32, has_hash: bool) -> Self {
+    fn new(buffer: &'l mut Vec<u8>, entry_count: u32, has_hash: bool) -> Self {
         debug_assert!(entry_count < (1 << 24));
 
         const ESTIMATED_KEY_SIZE: usize = 16;
@@ -505,103 +773,90 @@ impl<'l> KeyBlockBuilder<'l> {
         Self {
             current_entry: 0,
             header_size: buffer.len(),
-            has_hash,
             buffer,
         }
     }
 
-    /// Writes the 8-byte hash if `has_hash` is true.
-    fn write_hash<E: Entry>(&mut self, entry: &E) {
-        if self.has_hash {
-            let hash_bytes = entry.key_hash().to_be_bytes();
-            self.buffer.extend_from_slice(&hash_bytes);
+    /// Writes the 8-byte hash from a raw u64 if `has_hash` is true.
+    fn write_hash(&mut self, hash: u64, has_hash: bool) {
+        if has_hash {
+            self.buffer.extend_from_slice(&hash.to_be_bytes());
         }
     }
 
-    /// Writes a small-sized value to the buffer.
-    pub fn put_small<E: Entry>(
+    /// Writes the entry header (position + type) for the current entry.
+    fn write_entry_header(&mut self, entry_type: u8) {
+        let pos = self.buffer.len() - self.header_size;
+        let header_offset = KEY_BLOCK_HEADER_SIZE + self.current_entry * 4;
+        let header = (pos as u32) | ((entry_type as u32) << 24);
+        BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
+    }
+
+    /// Writes a small-sized value entry.
+    fn put_small(
         &mut self,
-        entry: &E,
+        hash: u64,
+        key: &[u8],
         value_block: u16,
         value_offset: u32,
         value_size: u16,
+        has_hash: bool,
     ) {
-        let pos = self.buffer.len() - self.header_size;
-        let header_offset = KEY_BLOCK_HEADER_SIZE + self.current_entry * 4;
-        let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_SMALL as u32) << 24);
-        BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
-
-        self.write_hash(entry);
-        entry.write_key_to(self.buffer);
+        self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_SMALL);
+        self.write_hash(hash, has_hash);
+        self.buffer.extend_from_slice(key);
         self.buffer.write_u16::<BE>(value_block).unwrap();
         self.buffer.write_u16::<BE>(value_size).unwrap();
         self.buffer.write_u32::<BE>(value_offset).unwrap();
-
         self.current_entry += 1;
     }
 
-    /// Writes a medium-sized value to the buffer.
-    pub fn put_medium<E: Entry>(&mut self, entry: &E, value_block: u16) {
-        let pos = self.buffer.len() - self.header_size;
-        let header_offset = KEY_BLOCK_HEADER_SIZE + self.current_entry * 4;
-        let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_MEDIUM as u32) << 24);
-        BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
-
-        self.write_hash(entry);
-        entry.write_key_to(self.buffer);
+    /// Writes a medium-sized value entry.
+    fn put_medium(&mut self, hash: u64, key: &[u8], value_block: u16, has_hash: bool) {
+        self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_MEDIUM);
+        self.write_hash(hash, has_hash);
+        self.buffer.extend_from_slice(key);
         self.buffer.write_u16::<BE>(value_block).unwrap();
-
         self.current_entry += 1;
     }
 
-    /// Writes a tombstone to the buffer.
-    pub fn delete<E: Entry>(&mut self, entry: &E) {
-        let pos = self.buffer.len() - self.header_size;
-        let header_offset = KEY_BLOCK_HEADER_SIZE + self.current_entry * 4;
-        let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_DELETED as u32) << 24);
-        BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
-
-        self.write_hash(entry);
-        entry.write_key_to(self.buffer);
-
+    /// Writes a tombstone entry.
+    fn delete(&mut self, hash: u64, key: &[u8], has_hash: bool) {
+        self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_DELETED);
+        self.write_hash(hash, has_hash);
+        self.buffer.extend_from_slice(key);
         self.current_entry += 1;
     }
 
-    /// Writes a blob value to the buffer.
-    pub fn put_blob<E: Entry>(&mut self, entry: &E, blob: u32) {
-        let pos = self.buffer.len() - self.header_size;
-        let header_offset = KEY_BLOCK_HEADER_SIZE + self.current_entry * 4;
-        let header = (pos as u32) | ((KEY_BLOCK_ENTRY_TYPE_BLOB as u32) << 24);
-        BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
-
-        self.write_hash(entry);
-        entry.write_key_to(self.buffer);
-        self.buffer.write_u32::<BE>(blob).unwrap();
-
+    /// Writes a blob value entry.
+    fn put_blob(&mut self, hash: u64, key: &[u8], blob_id: u32, has_hash: bool) {
+        self.write_entry_header(KEY_BLOCK_ENTRY_TYPE_BLOB);
+        self.write_hash(hash, has_hash);
+        self.buffer.extend_from_slice(key);
+        self.buffer.write_u32::<BE>(blob_id).unwrap();
         self.current_entry += 1;
     }
 
-    /// Writes an inline value directly to the key block.
-    pub fn put_inline<E: Entry>(&mut self, entry: &E, value: &[u8]) {
+    /// Writes an inline value entry.
+    fn put_inline(&mut self, hash: u64, key: &[u8], value: &[u8], has_hash: bool) {
         debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
-        let pos = self.buffer.len() - self.header_size;
-        let header_offset = KEY_BLOCK_HEADER_SIZE + self.current_entry * 4;
         let entry_type = KEY_BLOCK_ENTRY_TYPE_INLINE_MIN + value.len() as u8;
-        let header = (pos as u32) | ((entry_type as u32) << 24);
-        BE::write_u32(&mut self.buffer[header_offset..header_offset + 4], header);
-
-        self.write_hash(entry);
-        entry.write_key_to(self.buffer);
+        self.write_entry_header(entry_type);
+        self.write_hash(hash, has_hash);
+        self.buffer.extend_from_slice(key);
         self.buffer.extend_from_slice(value);
-
         self.current_entry += 1;
     }
 
-    /// Returns the key block buffer
-    pub fn finish(self) -> &'l mut Vec<u8> {
+    /// Returns the key block buffer.
+    fn finish(self) -> &'l mut Vec<u8> {
         self.buffer
     }
 }
+
+// ---------------------------------------------------------------------------
+// IndexBlockBuilder
+// ---------------------------------------------------------------------------
 
 /// Builder for a single index block.
 pub struct IndexBlockBuilder<'l> {

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -19,7 +19,6 @@ use crate::{
         KEY_BLOCK_ENTRY_TYPE_BLOB, KEY_BLOCK_ENTRY_TYPE_DELETED, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN,
         KEY_BLOCK_ENTRY_TYPE_MEDIUM, KEY_BLOCK_ENTRY_TYPE_SMALL,
     },
-    value_block_count_tracker::ValueBlockCountTracker,
 };
 
 /// The maximum number of entries that should go into a single key block
@@ -273,7 +272,6 @@ pub struct StreamingSstWriter {
     // Fullness tracking (for compaction callers)
     total_key_size: usize,
     total_value_size: usize,
-    value_block_count_tracker: ValueBlockCountTracker,
 }
 
 impl StreamingSstWriter {
@@ -304,7 +302,6 @@ impl StreamingSstWriter {
             flags,
             total_key_size: 0,
             total_value_size: 0,
-            value_block_count_tracker: ValueBlockCountTracker::default(),
         })
     }
 
@@ -314,7 +311,26 @@ impl StreamingSstWriter {
     pub fn is_full(&self, max_entries: usize, max_data_size: usize) -> bool {
         self.entry_count as usize >= max_entries
             || self.total_key_size + self.total_value_size > max_data_size
-            || self.value_block_count_tracker.is_full()
+            || !self.has_block_index_capacity()
+    }
+
+    /// Returns true if the SST file has room for more blocks without overflowing the `u16` block
+    /// index. Uses the exact count of blocks already written plus a conservative estimate of
+    /// blocks still needed for pending entries and the index.
+    fn has_block_index_capacity(&self) -> bool {
+        let blocks_written = self.block_offsets.len();
+        // Blocks still needed:
+        // - 1 pending small value block (if buffer is non-empty)
+        // - key blocks for pending entries (upper bound)
+        // - 1 index block
+        let pending_small_block = usize::from(!self.pending_small_values.is_empty());
+        let pending_key_blocks = self
+            .pending_keys
+            .len()
+            .div_ceil(MAX_KEY_BLOCK_ENTRIES)
+            .max(1);
+        let index_block = 1;
+        blocks_written + pending_small_block + pending_key_blocks + index_block < u16::MAX as usize
     }
 
     /// Adds an entry to the SST file. Entries must be added in key-hash order.
@@ -349,7 +365,6 @@ impl StreamingSstWriter {
         let value_ref = match entry.value() {
             EntryValue::Medium { value } => {
                 self.total_value_size += value.len();
-                self.value_block_count_tracker.track(true, 0);
                 let block_index = write_block_to_file(
                     &mut self.file,
                     &mut self.compress_buffer,
@@ -365,7 +380,6 @@ impl StreamingSstWriter {
                 block,
             } => {
                 self.total_value_size += block.len();
-                self.value_block_count_tracker.track(true, 0);
                 let block_index = write_raw_block_to_file(
                     &mut self.file,
                     &mut self.block_offsets,
@@ -377,7 +391,6 @@ impl StreamingSstWriter {
             }
             EntryValue::Small { value } => {
                 self.total_value_size += value.len();
-                self.value_block_count_tracker.track(false, value.len());
 
                 // Flush small value block if full BEFORE adding this value,
                 // so entries referencing the previous block get resolved.
@@ -417,12 +430,21 @@ impl StreamingSstWriter {
             EntryValue::Deleted => ValueRef::Deleted,
         };
 
+        // Track whether this entry is immediately resolved (not PendingSmall).
+        let is_resolved = !matches!(value_ref, ValueRef::PendingSmall { .. });
+
         // Push pending key entry
         self.pending_keys.push_back(PendingKeyEntry {
             key_hash,
             key,
             value_ref,
         });
+
+        // Advance the resolved boundary for non-PendingSmall entries, but only when there are
+        // no earlier unresolved PendingSmall entries blocking the boundary.
+        if is_resolved && self.first_pending_small_index == self.pending_keys.len() - 1 {
+            self.first_pending_small_index = self.pending_keys.len();
+        }
 
         // Try to flush completed key blocks
         self.try_flush_key_blocks()?;

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -742,9 +742,25 @@ impl<E: Entry> StreamingSstWriter<E> {
             .try_into()
             .expect("Block count overflow");
 
-        // Serialize AMQF — take ownership via Option::take to avoid partial-move error.
-        let amqf = turbo_bincode_encode(&AmqfBincodeWrapper(self.filter.take().unwrap()))
-            .expect("AMQF serialization failed");
+        // Shrink the AMQF filter to the actual entry count. The filter was created with
+        // `max_entry_count` which may be larger than the number of entries actually added.
+        // Re-creating with the exact count reduces serialized size.
+        let old_filter = self.filter.take().unwrap();
+        let filter = if old_filter.len() > 0 {
+            let mut shrunk = qfilter::Filter::new(old_filter.len(), AMQF_FALSE_POSITIVE_RATE)
+                .expect("Filter can't be constructed");
+            shrunk
+                .merge(false, &old_filter)
+                .expect("Failed to merge AMQF filter");
+            shrunk.shrink_to_fit();
+            shrunk
+        } else {
+            old_filter
+        };
+
+        // Serialize AMQF
+        let amqf =
+            turbo_bincode_encode(&AmqfBincodeWrapper(filter)).expect("AMQF serialization failed");
 
         let file = self.file.as_mut().unwrap();
         let meta = StaticSortedFileBuilderMeta {

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -413,14 +413,6 @@ impl StreamingSstWriter {
             EntryValue::Small { value } => {
                 self.total_value_size += value.len();
 
-                // Flush small value block if full BEFORE adding this value,
-                // so entries referencing the previous block get resolved.
-                if self.pending_small_values.len() >= MIN_SMALL_VALUE_BLOCK_SIZE
-                    || self.pending_small_value_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
-                {
-                    self.flush_small_value_block()?;
-                }
-
                 let offset = self.pending_small_values.len() as u32;
                 let size: u16 = value.len().try_into().unwrap();
                 self.pending_small_values.extend_from_slice(value);
@@ -431,12 +423,26 @@ impl StreamingSstWriter {
                     self.first_pending_small_index = self.pending_keys.len();
                 }
 
-                ValueRef::PendingSmall {
+                let value_ref = ValueRef::PendingSmall {
                     #[cfg(debug_assertions)]
                     small_block_id: self.current_small_block_id,
                     offset,
                     size,
+                };
+
+                self.push_pending_key_entry(key_hash, key, value_ref);
+                self.try_advance_resolved_boundary();
+
+                // Eagerly flush the small block AFTER pushing the new entry. This resolves
+                // the just-pushed entry immediately, so the subsequent key-block flush below
+                // can include it rather than leaving it behind in `pending_keys`.
+                if self.pending_small_values.len() >= MIN_SMALL_VALUE_BLOCK_SIZE
+                    || self.pending_small_value_count >= MAX_SMALL_VALUE_BLOCK_ENTRIES
+                {
+                    self.flush_small_value_block()?;
                 }
+
+                return self.try_flush_key_blocks();
             }
             EntryValue::Inline { value } => {
                 debug_assert!(value.len() <= MAX_INLINE_VALUE_SIZE);
@@ -451,29 +457,37 @@ impl StreamingSstWriter {
             EntryValue::Deleted => ValueRef::Deleted,
         };
 
-        // Track whether this entry is immediately resolved (not PendingSmall).
-        let is_resolved = !matches!(value_ref, ValueRef::PendingSmall { .. });
+        self.push_pending_key_entry(key_hash, key, value_ref);
+        self.try_advance_resolved_boundary();
+        self.try_flush_key_blocks()
+    }
 
-        // Push pending key entry
+    /// Appends a new entry to the pending-keys queue.
+    fn push_pending_key_entry(&mut self, key_hash: u64, key: Box<[u8]>, value_ref: ValueRef) {
         self.pending_keys.push_back(PendingKeyEntry {
             key_hash,
             key,
             value_ref,
         });
+    }
 
+    /// Advances `first_pending_small_index` past the just-pushed entry if that entry is
+    /// immediately resolved (not `PendingSmall`) and sits right at the current boundary.
+    ///
+    /// Must be called immediately after [`push_pending_key_entry`].
+    fn try_advance_resolved_boundary(&mut self) {
         // Advance the resolved boundary for non-PendingSmall entries, but only when there are
         // no earlier unresolved PendingSmall entries blocking the boundary.
         // The `== len - 1` check means the just-pushed entry sits immediately after the current
         // boundary, so it's safe to extend. If a PendingSmall entry exists earlier in the queue,
         // the boundary stays put until `flush_small_value_block()` resolves all pending entries.
-        if is_resolved && self.first_pending_small_index == self.pending_keys.len() - 1 {
+        let is_last_resolved = !matches!(
+            self.pending_keys.back().unwrap().value_ref,
+            ValueRef::PendingSmall { .. }
+        );
+        if is_last_resolved && self.first_pending_small_index == self.pending_keys.len() - 1 {
             self.first_pending_small_index = self.pending_keys.len();
         }
-
-        // Try to flush completed key blocks
-        self.try_flush_key_blocks()?;
-
-        Ok(())
     }
 
     /// Flushes the current pending small value block to disk and resolves all `PendingSmall`
@@ -538,6 +552,11 @@ impl StreamingSstWriter {
     /// The resolved prefix boundary is known directly from `first_pending_small_index` -- all
     /// entries before that index have resolved value references. Within that prefix, we find
     /// key block boundaries and flush complete blocks in a single pass.
+    ///
+    /// TODO: This scan is O(pending_keys.len()) in the worst case. When small value blocks are
+    /// rare relative to medium/inline entries, `pending_keys` can grow large because the front
+    /// entry references an unflushed small block while the back keeps accumulating resolved
+    /// entries. A future improvement could track the resolved-prefix length incrementally.
     fn try_flush_key_blocks(&mut self) -> Result<()> {
         let resolved_end = self.first_pending_small_index;
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -45,6 +45,24 @@ fn use_hash(max_key_len: usize) -> bool {
     max_key_len > 32
 }
 
+/// Returns true when the current key block should be flushed before adding the next entry.
+///
+/// `block_size` and `block_entry_count` describe the block accumulated so far.
+/// `next_key_len` is the key length of the candidate entry being considered.
+/// `last_hash` / `next_hash` are compared to avoid splitting a block mid-hash-collision.
+fn should_flush_key_block(
+    block_size: usize,
+    block_entry_count: usize,
+    next_key_len: usize,
+    last_hash: u64,
+    next_hash: u64,
+) -> bool {
+    block_entry_count > 0
+        && (block_size + next_key_len + KEY_BLOCK_ENTRY_META_OVERHEAD > MAX_KEY_BLOCK_SIZE
+            || block_entry_count >= MAX_KEY_BLOCK_ENTRIES)
+        && last_hash != next_hash
+}
+
 /// Trait for entries from that SST files can be created
 pub trait Entry {
     /// Returns the hash of the key
@@ -253,7 +271,10 @@ pub struct StreamingSstWriter {
     #[cfg(debug_assertions)]
     current_small_block_id: u16,
 
-    // Pending small value block buffer
+    // Pending small value block buffer.
+    // `pending_small_value_count` counts only the entries whose bytes are currently in
+    // `pending_small_values`; it is independent of `pending_keys.len()`, which includes
+    // entries of all value types (including already-flushed small, medium, inline, etc.).
     pending_small_values: Vec<u8>,
     pending_small_value_count: usize,
 
@@ -577,11 +598,7 @@ impl StreamingSstWriter {
             let key_len = entry.key.len();
             let key_hash = entry.key_hash;
 
-            if block_entry_count > 0
-                && (block_size + key_len + KEY_BLOCK_ENTRY_META_OVERHEAD > MAX_KEY_BLOCK_SIZE
-                    || block_entry_count >= MAX_KEY_BLOCK_ENTRIES)
-                && last_hash != key_hash
-            {
+            if should_flush_key_block(block_size, block_entry_count, key_len, last_hash, key_hash) {
                 self.flush_key_block(block_start, i, block_max_key_len)?;
                 last_flushed_end = i;
                 block_start = i;
@@ -765,12 +782,9 @@ impl StreamingSstWriter {
             let entry = &self.pending_keys[i];
             let key_len = entry.key.len();
             let key_hash = entry.key_hash;
+            let block_entry_count = i - block_start;
 
-            if block_size > 0
-                && (block_size + key_len + KEY_BLOCK_ENTRY_META_OVERHEAD > MAX_KEY_BLOCK_SIZE
-                    || i - block_start >= MAX_KEY_BLOCK_ENTRIES)
-                && last_hash != key_hash
-            {
+            if should_flush_key_block(block_size, block_entry_count, key_len, last_hash, key_hash) {
                 self.flush_key_block(block_start, i, block_max_key_len)?;
                 block_start = i;
                 block_size = 0;
@@ -796,10 +810,13 @@ impl StreamingSstWriter {
 #[cfg(debug_assertions)]
 impl Drop for StreamingSstWriter {
     fn drop(&mut self) {
-        assert!(
-            self.finished || self.entry_count == 0,
-            "StreamingSstWriter dropped without calling close()"
-        );
+        // Skip assertion during panic unwinding to avoid a double-panic (which would abort).
+        if !std::thread::panicking() {
+            assert!(
+                self.finished || self.entry_count == 0,
+                "StreamingSstWriter dropped without calling close()"
+            );
+        }
     }
 }
 
@@ -926,14 +943,14 @@ impl<'l> KeyBlockBuilder<'l> {
 // ---------------------------------------------------------------------------
 
 /// Builder for a single index block.
-pub struct IndexBlockBuilder<'l> {
+struct IndexBlockBuilder<'l> {
     buffer: &'l mut Vec<u8>,
 }
 
 impl<'l> IndexBlockBuilder<'l> {
     /// Creates a new builder for an index block with the specified number of entries and a pointer
     /// to the first block.
-    pub fn new(buffer: &'l mut Vec<u8>, entry_count: u16, first_block: u16) -> Self {
+    fn new(buffer: &'l mut Vec<u8>, entry_count: u16, first_block: u16) -> Self {
         buffer.reserve(
             entry_count as usize * (size_of::<u64>() + size_of::<u16>())
                 + size_of::<u8>()
@@ -945,7 +962,7 @@ impl<'l> IndexBlockBuilder<'l> {
     }
 
     /// Adds a hash boundary to the index block.
-    pub fn put(&mut self, hash: u64, block: u16) {
+    fn put(&mut self, hash: u64, block: u16) {
         self.buffer.write_u64::<BE>(hash).unwrap();
         self.buffer.write_u16::<BE>(block).unwrap();
     }
@@ -996,6 +1013,8 @@ mod tests {
         Inline(Vec<u8>),
         Small(Vec<u8>),
         Medium(Vec<u8>),
+        /// Already-formatted block with `uncompressed_size = 0` (stored as-is).
+        MediumRaw(Vec<u8>),
         Blob(u32),
         Deleted,
     }
@@ -1052,11 +1071,23 @@ mod tests {
             }
         }
 
+        fn medium_raw(key: &[u8], value: &[u8]) -> Self {
+            let key = key.to_vec();
+            let hash = hash_key(&key);
+            Self {
+                key,
+                hash,
+                // Store as uncompressed raw block (uncompressed_size = 0 means "not compressed").
+                value_kind: TestValueKind::MediumRaw(value.to_vec()),
+            }
+        }
+
         fn expected_value(&self) -> Option<&[u8]> {
             match &self.value_kind {
-                TestValueKind::Inline(v) | TestValueKind::Small(v) | TestValueKind::Medium(v) => {
-                    Some(v)
-                }
+                TestValueKind::Inline(v)
+                | TestValueKind::Small(v)
+                | TestValueKind::Medium(v)
+                | TestValueKind::MediumRaw(v) => Some(v),
                 _ => None,
             }
         }
@@ -1080,6 +1111,11 @@ mod tests {
                 TestValueKind::Inline(v) => EntryValue::Inline { value: v },
                 TestValueKind::Small(v) => EntryValue::Small { value: v },
                 TestValueKind::Medium(v) => EntryValue::Medium { value: v },
+                TestValueKind::MediumRaw(v) => EntryValue::MediumRaw {
+                    // uncompressed_size = 0 means the block is stored as-is (no compression).
+                    uncompressed_size: 0,
+                    block: v,
+                },
                 TestValueKind::Blob(id) => EntryValue::Large { blob: *id },
                 TestValueKind::Deleted => EntryValue::Deleted,
             }
@@ -1464,6 +1500,61 @@ mod tests {
                 ),
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    #[should_panic(expected = "StreamingSstWriter::close() called with no entries")]
+    fn close_empty_writer_panics() {
+        let dir = tempfile::tempdir().unwrap();
+        let sst_path = dir.path().join("empty.sst");
+        let writer = StreamingSstWriter::new(&sst_path, MetaEntryFlags::default(), 0).unwrap();
+        writer.close().unwrap();
+    }
+
+    #[test]
+    fn key_block_boundary_at_max_entries() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let count = MAX_KEY_BLOCK_ENTRIES + 1;
+        let mut entries: Vec<TestEntry> = (0..count)
+            .map(|i| {
+                let key = format!("boundary-{i:06}");
+                TestEntry::inline(key.as_bytes(), &[0u8; 4])
+            })
+            .collect();
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, count as u64);
+        // count > MAX_KEY_BLOCK_ENTRIES so we need at least 2 key blocks plus 1 index block
+        assert!(
+            meta.block_count >= 3,
+            "expected at least 2 key blocks + 1 index block"
+        );
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        for entry in &entries {
+            assert_lookup(&sst, entry, &kc, &vc)?;
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn single_medium_raw_entry() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let value = vec![0xBE; 8192];
+        let mut entries = vec![TestEntry::medium_raw(b"rkey", &value)];
+        sort_entries(&mut entries);
+
+        let meta = write_sst(dir.path(), 1, &entries, MetaEntryFlags::default())?;
+        assert_eq!(meta.entries, 1);
+
+        let sst = open_sst(dir.path(), 1, &meta)?;
+        let kc = make_cache();
+        let vc = make_cache();
+        assert_lookup(&sst, &entries[0], &kc, &vc)?;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -192,6 +192,7 @@ enum ValueRef {
     /// Value is in a small value block that hasn't been written yet. Will be resolved in-place
     /// to [`ValueRef::Small`] when the small block is flushed.
     PendingSmall {
+        #[cfg(debug_assertions)]
         small_block_id: u16,
         offset: u32,
         size: u16,
@@ -247,7 +248,8 @@ pub struct StreamingSstWriter {
     /// entries exist.
     first_pending_small_index: usize,
 
-    /// The current small_block_id being accumulated into.
+    /// The current small_block_id being accumulated into (debug-only consistency check).
+    #[cfg(debug_assertions)]
     current_small_block_id: u16,
 
     // Pending small value block buffer
@@ -272,6 +274,9 @@ pub struct StreamingSstWriter {
     // Fullness tracking (for compaction callers)
     total_key_size: usize,
     total_value_size: usize,
+
+    /// Total byte size of keys in `pending_keys` (for block capacity estimation).
+    pending_key_total_size: usize,
 }
 
 impl StreamingSstWriter {
@@ -291,6 +296,7 @@ impl StreamingSstWriter {
             block_offsets: Vec::new(),
             pending_keys: VecDeque::new(),
             first_pending_small_index: 0,
+            #[cfg(debug_assertions)]
             current_small_block_id: 0,
             pending_small_values: Vec::new(),
             pending_small_value_count: 0,
@@ -303,6 +309,7 @@ impl StreamingSstWriter {
             flags,
             total_key_size: 0,
             total_value_size: 0,
+            pending_key_total_size: 0,
         })
     }
 
@@ -322,13 +329,14 @@ impl StreamingSstWriter {
         let blocks_written = self.block_offsets.len();
         // Blocks still needed:
         // - 1 pending small value block (if buffer is non-empty)
-        // - key blocks for pending entries (upper bound)
+        // - key blocks for pending entries (upper bound from both entry count and byte size)
         // - 1 index block
         let pending_small_block = usize::from(!self.pending_small_values.is_empty());
         let pending_key_blocks = self
             .pending_keys
             .len()
             .div_ceil(MAX_KEY_BLOCK_ENTRIES)
+            .max(self.pending_key_total_size.div_ceil(MAX_KEY_BLOCK_SIZE))
             .max(1);
         let index_block = 1;
         blocks_written + pending_small_block + pending_key_blocks + index_block < u16::MAX as usize
@@ -359,8 +367,9 @@ impl StreamingSstWriter {
         let key_len = key_buf.len();
         let key: Box<[u8]> = key_buf.into_boxed_slice();
 
-        // Track key size for fullness
+        // Track key size for fullness and block capacity
         self.total_key_size += key_len;
+        self.pending_key_total_size += key_len;
 
         // Route value
         let value_ref = match entry.value() {
@@ -413,9 +422,9 @@ impl StreamingSstWriter {
                     self.first_pending_small_index = self.pending_keys.len();
                 }
 
-                let small_block_id = self.current_small_block_id;
                 ValueRef::PendingSmall {
-                    small_block_id,
+                    #[cfg(debug_assertions)]
+                    small_block_id: self.current_small_block_id,
                     offset,
                     size,
                 }
@@ -479,15 +488,18 @@ impl StreamingSstWriter {
         // Resolve all PendingSmall entries for this block in-place.
         // Only scan from first_pending_small_index -- entries before it are guaranteed
         // already resolved (from previous flush calls).
+        #[cfg(debug_assertions)]
         let flushed_id = self.current_small_block_id;
         for i in self.first_pending_small_index..self.pending_keys.len() {
             let entry = &mut self.pending_keys[i];
             if let ValueRef::PendingSmall {
+                #[cfg(debug_assertions)]
                 small_block_id,
                 offset,
                 size,
             } = entry.value_ref
             {
+                #[cfg(debug_assertions)]
                 debug_assert_eq!(small_block_id, flushed_id);
                 entry.value_ref = ValueRef::Small {
                     block_index,
@@ -501,8 +513,11 @@ impl StreamingSstWriter {
         // until the next Small value arrives.
         self.first_pending_small_index = self.pending_keys.len();
 
-        // Advance to next small block id
-        self.current_small_block_id += 1;
+        // Advance to next small block id (debug-only consistency check)
+        #[cfg(debug_assertions)]
+        {
+            self.current_small_block_id += 1;
+        }
         self.pending_small_values.clear();
         self.pending_small_value_count = 0;
 
@@ -556,6 +571,13 @@ impl StreamingSstWriter {
         // Don't flush the trailing incomplete block -- it may grow more.
 
         if last_flushed_end > 0 {
+            // Subtract drained entries' key sizes from the pending total.
+            let drained_key_size: usize = self
+                .pending_keys
+                .range(..last_flushed_end)
+                .map(|e| e.key.len())
+                .sum();
+            self.pending_key_total_size -= drained_key_size;
             // VecDeque::drain from the front is O(1) -- it just adjusts the head pointer.
             self.pending_keys.drain(..last_flushed_end);
             self.first_pending_small_index -= last_flushed_end;
@@ -730,6 +752,7 @@ impl StreamingSstWriter {
         }
 
         self.pending_keys.clear();
+        self.pending_key_total_size = 0;
         Ok(())
     }
 }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -277,11 +277,12 @@ pub struct StreamingSstWriter {
 impl StreamingSstWriter {
     /// Creates a new streaming SST writer.
     ///
-    /// `entry_count_hint` is used to size the AMQF filter. It may be an upper bound; a slightly
-    /// oversized filter only improves the false-positive rate.
-    pub fn new(file: &Path, flags: MetaEntryFlags, entry_count_hint: u64) -> Result<Self> {
+    /// `max_entry_count` is used to size the AMQF filter. It must be an upper bound on the number
+    /// of entries that will be added; the filter is not resizable. A slightly oversized value only
+    /// improves the false-positive rate.
+    pub fn new(file: &Path, flags: MetaEntryFlags, max_entry_count: u64) -> Result<Self> {
         let file = BufWriter::new(File::create(file)?);
-        let filter = qfilter::Filter::new(entry_count_hint.max(1), AMQF_FALSE_POSITIVE_RATE)
+        let filter = qfilter::Filter::new(max_entry_count.max(1), AMQF_FALSE_POSITIVE_RATE)
             .expect("Filter can't be constructed");
 
         Ok(Self {
@@ -333,7 +334,7 @@ impl StreamingSstWriter {
         blocks_written + pending_small_block + pending_key_blocks + index_block < u16::MAX as usize
     }
 
-    /// Adds an entry to the SST file. Entries must be added in key-hash order.
+    /// Adds an entry to the SST file. Entries must be added in (key-hash, key) order.
     pub fn add<E: Entry>(&mut self, entry: &E) -> Result<()> {
         let key_hash = entry.key_hash();
 
@@ -633,42 +634,31 @@ impl StreamingSstWriter {
         // Now all PendingSmall entries are resolved. Flush all remaining key blocks.
         self.flush_remaining_key_blocks()?;
 
-        // Handle empty file edge case
-        if self.key_block_boundaries.is_empty() {
-            // No entries were added. Write a minimal index block.
-            self.key_buffer.clear();
-            let index_block = IndexBlockBuilder::new(&mut self.key_buffer, 0, 0);
-            index_block.finish();
-            write_block_to_file(
-                &mut self.file,
-                &mut self.compress_buffer,
-                &mut self.block_offsets,
-                &self.key_buffer,
-                false,
-            )
-            .context("Failed to write index block")?;
-        } else {
-            // Write index block
-            self.key_buffer.clear();
-            let entry_count: u16 = (self.key_block_boundaries.len() - 1)
-                .try_into()
-                .expect("Index entries count overflow");
-            let first_block = self.key_block_boundaries[0].1;
-            let mut index_block =
-                IndexBlockBuilder::new(&mut self.key_buffer, entry_count, first_block);
-            for &(hash, block) in &self.key_block_boundaries[1..] {
-                index_block.put(hash, block);
-            }
-            index_block.finish();
-            write_block_to_file(
-                &mut self.file,
-                &mut self.compress_buffer,
-                &mut self.block_offsets,
-                &self.key_buffer,
-                false,
-            )
-            .context("Failed to write index block")?;
+        assert!(
+            !self.key_block_boundaries.is_empty(),
+            "StreamingSstWriter::finish() called with no entries"
+        );
+
+        // Write index block
+        self.key_buffer.clear();
+        let entry_count: u16 = (self.key_block_boundaries.len() - 1)
+            .try_into()
+            .expect("Index entries count overflow");
+        let first_block = self.key_block_boundaries[0].1;
+        let mut index_block =
+            IndexBlockBuilder::new(&mut self.key_buffer, entry_count, first_block);
+        for &(hash, block) in &self.key_block_boundaries[1..] {
+            index_block.put(hash, block);
         }
+        index_block.finish();
+        write_block_to_file(
+            &mut self.file,
+            &mut self.compress_buffer,
+            &mut self.block_offsets,
+            &self.key_buffer,
+            false,
+        )
+        .context("Failed to write index block")?;
 
         // Write block offset table
         for offset in &self.block_offsets {

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -114,7 +114,7 @@ pub fn write_static_stored_file<E: Entry>(
     for entry in entries {
         writer.add(entry)?;
     }
-    writer.finish()
+    writer.close()
 }
 
 // ---------------------------------------------------------------------------
@@ -226,8 +226,9 @@ struct PendingKeyEntry {
 /// The SST reader is block-index-addressed (not file-position-addressed), so interleaving block
 /// types is fully compatible.
 pub struct StreamingSstWriter {
-    // File I/O
-    file: BufWriter<File>,
+    // File I/O. Wrapped in Option so close() can take ownership without a partial-move
+    // compile error (partial moves are forbidden when the type has a Drop impl).
+    file: Option<BufWriter<File>>,
     compress_buffer: Vec<u8>,
     block_offsets: Vec<u32>,
 
@@ -259,8 +260,8 @@ pub struct StreamingSstWriter {
     // Reusable buffer for building key blocks
     key_buffer: Vec<u8>,
 
-    // AMQF filter (built incrementally)
-    filter: qfilter::Filter,
+    // AMQF filter (built incrementally). Wrapped in Option for the same reason as `file`.
+    filter: Option<qfilter::Filter>,
 
     // Index block data: (first_hash, block_index) for each key block written
     key_block_boundaries: Vec<(u64, u16)>,
@@ -277,6 +278,10 @@ pub struct StreamingSstWriter {
 
     /// Total byte size of keys in `pending_keys` (for block capacity estimation).
     pending_key_total_size: usize,
+
+    /// Set to `true` by `close()` so the Drop guard can detect writers dropped without closing.
+    #[cfg(debug_assertions)]
+    finished: bool,
 }
 
 impl StreamingSstWriter {
@@ -291,7 +296,7 @@ impl StreamingSstWriter {
             .expect("Filter can't be constructed");
 
         Ok(Self {
-            file,
+            file: Some(file),
             compress_buffer: Vec::new(),
             block_offsets: Vec::new(),
             pending_keys: VecDeque::new(),
@@ -301,7 +306,7 @@ impl StreamingSstWriter {
             pending_small_values: Vec::new(),
             pending_small_value_count: 0,
             key_buffer: Vec::new(),
-            filter,
+            filter: Some(filter),
             key_block_boundaries: Vec::new(),
             min_hash: u64::MAX,
             max_hash: 0,
@@ -310,6 +315,8 @@ impl StreamingSstWriter {
             total_key_size: 0,
             total_value_size: 0,
             pending_key_total_size: 0,
+            #[cfg(debug_assertions)]
+            finished: false,
         })
     }
 
@@ -355,6 +362,8 @@ impl StreamingSstWriter {
 
         // Insert into AMQF
         self.filter
+            .as_mut()
+            .unwrap()
             .insert_fingerprint(false, key_hash)
             .expect("AMQF insert failed");
 
@@ -376,7 +385,7 @@ impl StreamingSstWriter {
             EntryValue::Medium { value } => {
                 self.total_value_size += value.len();
                 let block_index = write_block_to_file(
-                    &mut self.file,
+                    self.file.as_mut().unwrap(),
                     &mut self.compress_buffer,
                     &mut self.block_offsets,
                     value,
@@ -393,7 +402,7 @@ impl StreamingSstWriter {
                 // Both are acceptable approximations of disk usage for is_full() thresholds.
                 self.total_value_size += block.len();
                 let block_index = write_raw_block_to_file(
-                    &mut self.file,
+                    self.file.as_mut().unwrap(),
                     &mut self.block_offsets,
                     uncompressed_size,
                     block,
@@ -471,13 +480,13 @@ impl StreamingSstWriter {
     /// entries in-place.
     fn flush_small_value_block(&mut self) -> Result<()> {
         // Early return if empty -- this simplifies trailing small value block handling in
-        // `finish()` where we call this unconditionally.
+        // `close()` where we call this unconditionally.
         if self.pending_small_values.is_empty() {
             return Ok(());
         }
 
         let block_index = write_block_to_file(
-            &mut self.file,
+            self.file.as_mut().unwrap(),
             &mut self.compress_buffer,
             &mut self.block_offsets,
             &self.pending_small_values,
@@ -635,7 +644,7 @@ impl StreamingSstWriter {
         // Record boundary
         let first_hash = self.pending_keys[start].key_hash;
         let block_index = write_block_to_file(
-            &mut self.file,
+            self.file.as_mut().unwrap(),
             &mut self.compress_buffer,
             &mut self.block_offsets,
             &self.key_buffer,
@@ -649,7 +658,12 @@ impl StreamingSstWriter {
 
     /// Finishes writing the SST file. Flushes remaining blocks, writes the index, and returns
     /// metadata.
-    pub fn finish(mut self) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
+    pub fn close(mut self) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
+        #[cfg(debug_assertions)]
+        {
+            self.finished = true;
+        }
+
         // Flush remaining small value block (even if under MIN_SMALL_VALUE_BLOCK_SIZE).
         self.flush_small_value_block()?;
 
@@ -658,7 +672,7 @@ impl StreamingSstWriter {
 
         assert!(
             !self.key_block_boundaries.is_empty(),
-            "StreamingSstWriter::finish() called with no entries"
+            "StreamingSstWriter::close() called with no entries"
         );
 
         // Write index block
@@ -674,7 +688,7 @@ impl StreamingSstWriter {
         }
         index_block.finish();
         write_block_to_file(
-            &mut self.file,
+            self.file.as_mut().unwrap(),
             &mut self.compress_buffer,
             &mut self.block_offsets,
             &self.key_buffer,
@@ -685,6 +699,8 @@ impl StreamingSstWriter {
         // Write block offset table
         for offset in &self.block_offsets {
             self.file
+                .as_mut()
+                .unwrap()
                 .write_u32::<BE>(*offset)
                 .context("Failed to write block offset")?;
         }
@@ -695,24 +711,25 @@ impl StreamingSstWriter {
             .try_into()
             .expect("Block count overflow");
 
-        // Serialize AMQF
-        let amqf = turbo_bincode_encode(&AmqfBincodeWrapper(self.filter))
+        // Serialize AMQF — take ownership via Option::take to avoid partial-move error.
+        let amqf = turbo_bincode_encode(&AmqfBincodeWrapper(self.filter.take().unwrap()))
             .expect("AMQF serialization failed");
 
+        let file = self.file.as_mut().unwrap();
         let meta = StaticSortedFileBuilderMeta {
             min_hash: self.min_hash,
             max_hash: self.max_hash,
             amqf: Cow::Owned(amqf.into_vec()),
             block_count,
-            size: self.file.stream_position()?,
+            size: file.stream_position()?,
             flags: self.flags,
             entries: self.entry_count,
         };
 
-        Ok((meta, self.file.into_inner()?))
+        Ok((meta, self.file.take().unwrap().into_inner()?))
     }
 
-    /// Flushes all remaining entries as key blocks. Called from `finish()` after all small value
+    /// Flushes all remaining entries as key blocks. Called from `close()` after all small value
     /// blocks have been flushed, so all PendingSmall entries are resolved.
     fn flush_remaining_key_blocks(&mut self) -> Result<()> {
         if self.pending_keys.is_empty() {
@@ -754,6 +771,16 @@ impl StreamingSstWriter {
         self.pending_keys.clear();
         self.pending_key_total_size = 0;
         Ok(())
+    }
+}
+
+#[cfg(debug_assertions)]
+impl Drop for StreamingSstWriter {
+    fn drop(&mut self) {
+        assert!(
+            self.finished || self.entry_count == 0,
+            "StreamingSstWriter dropped without calling close()"
+        );
     }
 }
 
@@ -1072,7 +1099,7 @@ mod tests {
         for entry in entries {
             writer.add(entry)?;
         }
-        let (meta, _file) = writer.finish()?;
+        let (meta, _file) = writer.close()?;
         Ok(meta)
     }
 
@@ -1300,6 +1327,7 @@ mod tests {
             !writer.is_full(max_entries + 1, usize::MAX),
             "Should not be full when limit is higher"
         );
+        writer.close().unwrap();
     }
 
     #[test]
@@ -1320,6 +1348,7 @@ mod tests {
         assert!(total > 10_000, "total data should exceed 10KB");
         assert!(writer.is_full(usize::MAX, total - 1));
         assert!(!writer.is_full(usize::MAX, total + 1));
+        writer.close().unwrap();
     }
 
     #[test]
@@ -1355,7 +1384,7 @@ mod tests {
         for entry in &entries {
             writer.add(entry)?;
         }
-        let (meta2, _) = writer.finish()?;
+        let (meta2, _) = writer.close()?;
 
         // Metadata should match
         assert_eq!(meta1.entries, meta2.entries);

--- a/turbopack/crates/turbo-persistence/src/value_block_count_tracker.rs
+++ b/turbopack/crates/turbo-persistence/src/value_block_count_tracker.rs
@@ -33,21 +33,9 @@ impl ValueBlockCountTracker {
             >= MAX_VALUE_BLOCK_COUNT
     }
 
-    /// Returns true if the tracked value block count has reached half of the maximum.
-    pub fn is_half_full(&self) -> bool {
-        self.value_block_count + (self.current_small_value_block_size > 0) as usize
-            >= MAX_VALUE_BLOCK_COUNT / 2
-    }
-
     /// Reset the tracker to empty.
     pub fn reset(&mut self) {
         self.value_block_count = 0;
         self.current_small_value_block_size = 0;
-    }
-
-    /// Reset the tracker to contain only the given entry.
-    pub fn reset_to(&mut self, is_medium: bool, small_value_size: usize) {
-        self.value_block_count = if is_medium { 1 } else { 0 };
-        self.current_small_value_block_size = small_value_size;
     }
 }


### PR DESCRIPTION
### What?

Replace the two-pass SST file write approach with a single-pass `StreamingSstWriter` that writes blocks incrementally as entries arrive. Also replace the compaction `Collector`'s double-buffered `last_entries` pattern with a streaming collector that wraps the new writer.

### Why?

The previous SST write path materialized all entries in memory (keys + values), then wrote all value blocks, then all key blocks. During compaction, the `Collector` maintained two full entry vectors (`entries` + `last_entries`) for size balancing. For large SST files (256MB+), this required holding hundreds of MB of entry data in memory simultaneously.

The streaming approach reduces peak memory per writer from hundreds of MB to ~200KB by writing blocks to disk as soon as possible rather than buffering everything.

### How?

**Phase 1: `StreamingSstWriter` in `static_sorted_file_builder.rs`**

The key insight is that the SST reader is **block-index-addressed** — it locates blocks by index via the offset table, not by file position. So interleaving value blocks and key blocks in any order is fully compatible with the reader.

The writer processes entries one at a time:
- **Medium values** are written to disk immediately as individual blocks
- **Small values** accumulate in a buffer and flush when reaching 8KB
- **Key blocks** flush incrementally as the resolved boundary advances

A `VecDeque<PendingKeyEntry>` holds entries waiting for their value blocks to be written. Each pending entry contains a `ValueRef` that tracks where its value lives:
- `Small { block_index, offset, size }` — already resolved
- `PendingSmall { small_block_id, offset, size }` — waiting for small block flush
- `Medium { block_index }` — already resolved (written immediately)
- `Inline`, `Blob`, `Deleted` — no value block needed

The `first_pending_small_index` partitions `pending_keys` into resolved entries (front) and unresolved entries (back). Key blocks are flushed **incrementally** via `try_flush_key_blocks()` at the two points where this boundary advances:
- When a small value block is flushed — resolves all `PendingSmall` entries, then calls `try_flush_key_blocks()` to flush any complete key blocks from the resolved region
- In `advance_boundary_to()` — processes resolved entries and flushes key blocks via `try_flush_key_block()` when they exceed size or entry count limits

This makes adding N entries **O(N) total** instead of O(N²) from the earlier per-call scan approach.

**Key block flushing**: The `try_flush_key_block()` method combines the check-and-flush logic — it tests whether adding the next entry would exceed `MAX_KEY_BLOCK_SIZE` (16KB) or `MAX_KEY_BLOCK_ENTRIES`, and if so, flushes the accumulated key block. Entries sharing the same key hash are never split across blocks.

**AMQF filter**: Created with `max_entry_count` (an upper bound), then shrunk via `shrink_to_fit()` on `close()` to reclaim unused capacity while preserving false positive rates.

**Index block writing**: `IndexBlockBuilder` is generic over `Write` and writes directly to the `BufWriter` during `close()`, avoiding an intermediate buffer allocation. Index blocks use `write_raw_block_to_file` since they are never compressed.

**File size**: Computed from the last block offset plus the offset table size, avoiding a `stream_position()` call (which would trigger an unnecessary flush + seek syscall).

`write_static_stored_file()` is reimplemented as a thin wrapper around `StreamingSstWriter`, so existing callers (`write_batch.rs`, benchmarks) need zero changes.

**Phase 2: Streaming compaction in `db.rs`**

The compaction `Collector` is simplified to wrap an `Option<(u32, StreamingSstWriter)>`. The old pattern of maintaining `entries` + `last_entries` vectors with swap/early-flush/split logic (~100 lines) is replaced by direct calls to `writer.add()`. The collector tracks total key/value sizes and a `ValueBlockCountTracker` to know when to finish the current writer and start a new one.

**Memory savings:**

| | Previous (compaction) | Streaming |
|---|---|---|
| Entry storage | `entries` + `last_entries` (up to 2× full entry vecs) | ~800 pending key entries (~80KB) |
| Value data | All values held in memory until written | Written immediately (medium) or after 8KB (small) |
| Peak for 256MB SST | Hundreds of MB | ~200KB per writer |

**Performance**
Both compaction and write benchmarks are within the noise.  It makes sense that this might be slightly slower due to some additional per-entry work, but writing is dominated by other factors `write` syscalls, compression and memcopies into temporary buffers. 

**Files changed:**
- `turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs` — `StreamingSstWriter` with incremental key block flushing via `try_flush_key_block()`, `PendingKeyEntry`, `ValueRef`; generic `IndexBlockBuilder<W: Write>`; `write_static_stored_file` as wrapper; AMQF `shrink_to_fit()` on close
- `turbopack/crates/turbo-persistence/src/db.rs` — Replaced compaction `Collector` with streaming version
- `turbopack/crates/turbo-persistence/src/lib.rs` — Export `StreamingSstWriter`
- `turbopack/crates/turbo-persistence/src/value_block_count_tracker.rs` — Removed dead `is_half_full()`/`reset_to()` methods

**Verification:**
- `cargo clippy -p turbo-persistence` — zero warnings
- `cargo test -p turbo-persistence` — all 46 tests pass
- `cargo fmt -p turbo-persistence -- --check` — clean
- Criterion benchmarks show no performance regressions (write + compaction within noise)
