### PR TITLE
Fix middleware case with adapters

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -771,7 +771,10 @@ export async function handleBuildComplete({
             pathname: rscPathname,
             id: page.name + '.rsc',
           })
-        } else if (serverPropsPages.has(pathname)) {
+        } else if (
+          type !== AdapterOutputType.MIDDLEWARE &&
+          serverPropsPages.has(pathname)
+        ) {
           const nextDataPath = path.posix.join(
             '/_next/data/',
             buildId,


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/90611 this fixes the middleware case to ensure it doesn't create a `_next/data` output. 

x-ref: https://github.com/vercel/next.js/actions/runs/22465910596/job/65075127711#step:34:302