### PR TITLE
feat: add initial @next/org integration package

### DIFF
--- a/packages/next-org/index.js
+++ b/packages/next-org/index.js
@@ -1,0 +1,26 @@
+module.exports =
+  (pluginOptions = {}) =>
+  (nextConfig = {}) => {
+    const extension = pluginOptions.extension || /\.org$/
+
+    return Object.assign({}, nextConfig, {
+      webpack(config, options) {
+        config.module.rules.push({
+          test: extension,
+          use: [
+            options.defaultLoaders.babel,
+            {
+              loader: require.resolve('@orgajs/loader'),
+              options: pluginOptions.options,
+            },
+          ],
+        })
+
+        if (typeof nextConfig.webpack === 'function') {
+          return nextConfig.webpack(config, options)
+        }
+
+        return config
+      },
+    })
+  }

--- a/packages/next-org/license.md
+++ b/packages/next-org/license.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 Vercel, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/next-org/package.json
+++ b/packages/next-org/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@next/org",
+  "version": "10.2.1-canary.5",
+  "main": "index.js",
+  "license": "MIT",
+  "repository": {
+    "url": "vercel/next.js",
+    "directory": "packages/next-org"
+  },
+  "peerDependencies": {
+    "@orgajs/loader": "*",
+    "@orgajs/react": "*"
+  }
+}

--- a/packages/next-org/readme.md
+++ b/packages/next-org/readme.md
@@ -1,0 +1,71 @@
+# Next.js + OrgX
+
+Use [OrgX](https://github.com/orgapp/orgajs/tree/main/packages/orgx) with [Next.js](https://github.com/vercel/next.js)
+
+## Installation
+
+```
+npm install @next/org @orgajs/loader @orgajs/react
+```
+
+or
+
+```
+yarn add @next/org @orgajs/loader @orgajs/react
+```
+
+## Usage
+
+Create a `next.config.js` in your project
+
+```js
+// next.config.js
+const withOrg = require('@next/org')()
+module.exports = withOrg()
+```
+
+Optionally you can provide OrgX loader options:
+
+```js
+// next.config.js
+const withOrg = require('@next/org')({
+  options: {},
+})
+module.exports = withOrg()
+```
+
+Optionally you can add your custom Next.js configuration as parameter
+
+```js
+// next.config.js
+const withOrg = require('@next/org')()
+module.exports = withOrg({
+  webpack(config, options) {
+    return config
+  },
+})
+```
+
+Optionally you can match other file extensions for OrgX compilation, by default only `.org` is supported
+
+```js
+// next.config.js
+const withOrg = require('@next/org')({
+  extension: /\.(org|orgx)$/,
+})
+module.exports = withOrg()
+```
+
+## Top level .org pages
+
+Define the `pageExtensions` option to have Next.js handle `.org` files in the `pages` directory as pages:
+
+```js
+// next.config.js
+const withOrg = require('@next/org')({
+  extension: /\.org$/,
+})
+module.exports = withOrg({
+  pageExtensions: ['js', 'jsx', 'org'],
+})
+```


### PR DESCRIPTION
## Summary
- add new `packages/next-org` package modeled after `packages/next-mdx`
- wire a minimal webpack plugin that compiles `.org` files via `@orgajs/loader`
- include package metadata, MIT license file, and usage docs

## Feature
- [ ] Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR.
- [ ] Related issues linked using `fixes #number`
- [ ] Integration tests added
- [x] Documentation added
- [ ] Telemetry added. In case of a feature if it's used or not.

## Notes
- This is an initial draft for review of package shape and API parity with `@next/mdx`.
- Follow-up work planned: add integration tests and discuss issue/RFC alignment and telemetry expectations.
