### PR TITLE
Turbopack: restrict server HMR to app pages

### DIFF
--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -592,13 +592,22 @@ export async function createHotReloaderTurbopack(
       join(distDir, p)
     )
 
-    const { type: entryType } = splitEntryKey(key)
-    // Server HMR only applies to App Router.
-    // Pages Router uses Node's require(), root entries (middleware/instrumentation)
-    // use the edge runtime.
+    const { type: entryType, page: entryPage } = splitEntryKey(key)
+    const isAppPage =
+      entryType === 'app' &&
+      currentEntrypoints.app.get(entryPage)?.type === 'app-page'
+
+    // Server HMR only applies to app router pages since these use the Turbopack runtime.
+    // Currently, this is only app router pages.
+    //
+    // This excludes:
+    //   - Pages Router pages
+    //   - Edge routes
+    //   - Middleware
+    //   - App Router route handlers (route.ts)
     const usesServerHmr =
       experimentalServerFastRefresh &&
-      entryType === 'app' &&
+      isAppPage &&
       writtenEndpoint.type !== 'edge'
 
     for (const file of serverPaths) {

--- a/test/development/app-dir/server-hmr/app/api/hello/route.ts
+++ b/test/development/app-dir/server-hmr/app/api/hello/route.ts
@@ -1,0 +1,3 @@
+export async function GET() {
+  return new Response('version: 0')
+}

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -1,4 +1,4 @@
-import type { Response } from 'next-fetch'
+import type { Response } from 'node-fetch'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -1,3 +1,4 @@
+import type { Response } from 'next-fetch'
 import { nextTestSetup } from 'e2e-utils'
 import { retry } from 'next-test-utils'
 
@@ -153,5 +154,29 @@ describe('server-hmr', () => {
         expect(outputAfterHmr).toMatch(/page\.tsx:4:9/)
       }
     )
+  })
+
+  describe('route handler hmr', () => {
+    function getText(res: Response) {
+      return res.ok
+        ? res.text()
+        : Promise.reject(
+            new Error('Failed to fetch route handler: ' + res.status)
+          )
+    }
+
+    it('reflects route handler changes on fetch/refresh', async () => {
+      const initial = await next.fetch('/api/hello').then(getText)
+      expect(initial).toBe('version: 0')
+
+      await next.patchFile('app/api/hello/route.ts', (content) =>
+        content.replace('version: 0', 'version: 1')
+      )
+
+      await retry(async () => {
+        const updated = await next.fetch('/api/hello').then(getText)
+        expect(updated).toBe('version: 1')
+      })
+    })
   })
 })


### PR DESCRIPTION
App router types like routes go through the traditional `require` route bypassing the Turbopack runtime, so they aren't easily solved with server HMR right now.

Test Plan: Added an e2e test.
