### PR TITLE
tests: Fix immutableAssetToken extraction

### DIFF
--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -144,7 +144,8 @@ export class NextDeployInstance extends NextInstance {
         `Failed to get immutableAssetToken from logs ${this._cliOutput}`
       )
     }
-    this._immutableAssetToken = immutableAssetToken
+    this._immutableAssetToken =
+      immutableAssetToken === 'undefined' ? undefined : immutableAssetToken
 
     require('console').log(
       `Got buildId: ${this._buildId}, deploymentId: ${this._deploymentId}, immutableAssetToken: ${this._immutableAssetToken}`


### PR DESCRIPTION
Fixes this deploy test failure: https://github.com/vercel/next.js/actions/runs/22499483165/attempts/2

The output might be:
```
Building: └ ○ /nested
Building: ○  (Static)   prerendered as static content
Building: ƒ  (Dynamic)  server-rendered on demand
Building: > @ post-build /vercel/path0
Building: > node -e 'console.log("BUILD" + "_ID: " + fs.readFileSync(".next/BUILD_ID") + "\nDEPLOYMENT" + "_ID: " + process.env.NEXT_DEPLOYMENT_ID + "\nIMMUTABLE_ASSET" + "_TOKEN: " + process.env.VERCEL_IMMUTABLE_ASSET_TOKEN)'
Building: BUILD_ID: build-TfctsWXpff2fKS
Building: DEPLOYMENT_ID: dpl_5Qad8NbhCPWn7QRf5TiCePi58vVi
Building: IMMUTABLE_ASSET_TOKEN: undefined
Building: Build Completed in /vercel/output [15s]
Building: Deploying outputs...
Building: Deployment completed
```