### PR TITLE
Turbopack: Revert default loader runtime backend to child processes

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -2059,10 +2059,10 @@ impl NextConfig {
 
     #[turbo_tasks::function]
     pub fn turbopack_plugin_runtime_strategy(&self) -> Vc<TurbopackPluginRuntimeStrategy> {
-        #[cfg(feature = "worker_pool")]
-        let default = TurbopackPluginRuntimeStrategy::WorkerThreads;
-        #[cfg(all(not(feature = "worker_pool"), feature = "process_pool"))]
+        #[cfg(feature = "process_pool")]
         let default = TurbopackPluginRuntimeStrategy::ChildProcesses;
+        #[cfg(all(feature = "worker_pool", not(feature = "process_pool")))]
+        let default = TurbopackPluginRuntimeStrategy::WorkerThreads;
 
         self.experimental
             .turbopack_plugin_runtime_strategy

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1722,7 +1722,7 @@ export const defaultConfig = Object.freeze({
     turbopackFileSystemCacheForDev: true,
     turbopackFileSystemCacheForBuild: false,
     turbopackInferModuleSideEffects: true,
-    turbopackPluginRuntimeStrategy: 'workerThreads',
+    turbopackPluginRuntimeStrategy: 'childProcesses',
     devCacheControlNoCache: false,
   },
   htmlLimitedBots: undefined,


### PR DESCRIPTION
We're getting crashes in node: https://github.com/vercel/workflow/actions/runs/22500511618/job/65186125774#step:10:224

It looks like this should be fixed in newer versions of node:

- https://github.com/napi-rs/napi-rs/issues/2555#issuecomment-3645173223
- https://github.com/nodejs/node/pull/55877
- https://github.com/nodejs/node/pull/61400
- https://github.com/nodejs/node/pull/61661

So we may enable the worker threads feature by default if we detect a new enough version of node or bun.