### PR TITLE
Fix path for login route in API reference

### DIFF
--- a/docs/01-app/03-api-reference/03-file-conventions/parallel-routes.mdx
+++ b/docs/01-app/03-api-reference/03-file-conventions/parallel-routes.mdx
@@ -276,7 +276,7 @@ export default function Default() {
 }
 ```
 
-Inside your `@auth` slot, intercept the `/login` route by importing the `<Modal>` component and its children into the `@auth/(.)login/page.tsx` file, and updating the folder name to `/@auth/(.)login/page.tsx`.
+Inside your `@auth` slot, intercept the `/login` route by importing the `<Modal>` component and its children into the `@auth/login/page.tsx` file, and updating the folder name to `/@auth/(.)login/page.tsx`.
 
 ```tsx filename="app/@auth/(.)login/page.tsx" switcher
 import { Modal } from '@/app/ui/modal'


### PR DESCRIPTION
Fixes an incorrect path in parallel routing docs.