### PR TITLE
fix(types): apply AppType generic to top-level props instead of pageProps

### DIFF
--- a/packages/next/src/shared/lib/utils.ts
+++ b/packages/next/src/shared/lib/utils.ts
@@ -31,7 +31,7 @@ export type DocumentType = NextComponentType<
 export type AppType<P = {}> = NextComponentType<
   AppContextType,
   P,
-  AppPropsType<any, P>
+  AppPropsType<any, unknown> & P
 >
 
 export type AppTreeType = ComponentType<


### PR DESCRIPTION
## Summary

Fixes #42846

`AppType<P>` incorrectly routes `P` to `pageProps` via `AppPropsType<any, P>`. At runtime, `App.getInitialProps` returns props that merge directly onto the App component's top-level props, not into `pageProps`. This mismatch means custom props added by `getInitialProps` are typed on the wrong level.

### Before

```ts
export type AppType<P = {}> = NextComponentType<
  AppContextType,
  P,
  AppPropsType<any, P>  // P goes to pageProps
>
```

Using `AppType<{ customProp: string }>` incorrectly types `customProp` as part of `pageProps` instead of top-level props.

### After

```ts
export type AppType<P = {}> = NextComponentType<
  AppContextType,
  P,
  AppPropsType<any, unknown> & P  // P intersected with top-level props
>
```

Now `customProp` correctly appears on the component's top-level props, matching how `getInitialProps` actually works at runtime.

### Related

- PR #85293 proposed this same fix with regression test and was identified by community triage as the correct approach
- The `TODO` comment at `packages/next/src/shared/lib/utils.ts` line 19 (`parseUrlForPages`) is unrelated to this change