### PR TITLE
[devtools] Stop blocking overlay on error details copy

### DIFF
--- a/packages/next/src/next-devtools/dev-overlay/components/copy-button/index.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/copy-button/index.tsx
@@ -1,77 +1,7 @@
 import * as React from 'react'
 import { cx } from '../../utils/cx'
 
-function useCopyLegacy(content: string) {
-  type CopyState =
-    | {
-        state: 'initial'
-      }
-    | {
-        state: 'error'
-        error: unknown
-      }
-    | { state: 'success' }
-    | { state: 'pending' }
-
-  // This would be simpler with useActionState but we need to support React 18 here.
-  // React 18 also doesn't have async transitions.
-  const [copyState, dispatch] = React.useReducer(
-    (
-      state: CopyState,
-      action:
-        | { type: 'reset' | 'copied' | 'copying' }
-        | { type: 'error'; error: unknown }
-    ): CopyState => {
-      if (action.type === 'reset') {
-        return { state: 'initial' }
-      }
-      if (action.type === 'copied') {
-        return { state: 'success' }
-      }
-      if (action.type === 'copying') {
-        return { state: 'pending' }
-      }
-      if (action.type === 'error') {
-        return { state: 'error', error: action.error }
-      }
-      return state
-    },
-    {
-      state: 'initial',
-    }
-  )
-  function copy() {
-    if (isPending) {
-      return
-    }
-
-    if (!navigator.clipboard) {
-      dispatch({
-        type: 'error',
-        error: 'Copy to clipboard is not supported in this browser',
-      })
-    } else {
-      dispatch({ type: 'copying' })
-      navigator.clipboard.writeText(content).then(
-        () => {
-          dispatch({ type: 'copied' })
-        },
-        (error) => {
-          dispatch({ type: 'error', error })
-        }
-      )
-    }
-  }
-  const reset = React.useCallback(() => {
-    dispatch({ type: 'reset' })
-  }, [])
-
-  const isPending = copyState.state === 'pending'
-
-  return [copyState, copy, reset, isPending] as const
-}
-
-function useCopyModern(content: string) {
+function useCopy(getContent: () => Promise<string>) {
   type CopyState =
     | {
         state: 'initial'
@@ -97,14 +27,16 @@ function useCopyModern(content: string) {
             error: 'Copy to clipboard is not supported in this browser',
           }
         }
-        return navigator.clipboard.writeText(content).then(
-          () => {
-            return { state: 'success' }
-          },
-          (error) => {
-            return { state: 'error', error }
-          }
-        )
+        return getContent().then((content) => {
+          return navigator.clipboard.writeText(content).then(
+            () => {
+              return { state: 'success' }
+            },
+            (error) => {
+              return { state: 'error', error }
+            }
+          )
+        })
       }
       return state
     },
@@ -130,9 +62,6 @@ function useCopyModern(content: string) {
   return [copyState, copy, reset, isPending] as const
 }
 
-const useCopy =
-  typeof React.useActionState === 'function' ? useCopyModern : useCopyLegacy
-
 type CopyButtonProps = React.HTMLProps<HTMLButtonElement> & {
   actionLabel: string
   successLabel: string
@@ -140,7 +69,10 @@ type CopyButtonProps = React.HTMLProps<HTMLButtonElement> & {
 }
 
 export function CopyButton(
-  props: CopyButtonProps & { content?: string; getContent?: () => string }
+  props: CopyButtonProps & {
+    content?: string
+    getContent?: () => Promise<string>
+  }
 ) {
   const {
     content,
@@ -151,17 +83,16 @@ export function CopyButton(
     disabled,
     ...rest
   } = props
-  const getContentString = (): string => {
+  const getContentString = (): Promise<string> => {
     if (content) {
-      return content
+      return Promise.resolve(content)
     }
     if (getContent) {
       return getContent()
     }
-    return ''
+    return Promise.resolve('')
   }
-  const contentString = getContentString()
-  const [copyState, copy, reset, isPending] = useCopy(contentString)
+  const [copyState, copy, reset, isPending] = useCopy(getContentString)
 
   const error = copyState.state === 'error' ? copyState.error : null
   React.useEffect(() => {
@@ -206,8 +137,8 @@ export function CopyButton(
       title={label}
       aria-label={label}
       aria-disabled={isDisabled}
-      disabled={isDisabled}
       data-nextjs-copy-button
+      data-pending={isPending}
       className={cx(
         props.className,
         'nextjs-data-copy-button',
@@ -269,18 +200,21 @@ export const COPY_BUTTON_STYLES = `
       height: var(--size-16);
     }
   }
-  .nextjs-data-copy-button:disabled {
+  .nextjs-data-copy-button[aria-disabled="true"] {
     background-color: var(--color-gray-100);
     cursor: not-allowed;
   }
-  .nextjs-data-copy-button--initial:hover:not(:disabled) {
+  .nextjs-data-copy-button[data-pending="true"] {
+    cursor: wait;
+  }
+  .nextjs-data-copy-button--initial:hover:not([aria-disabled="true"]) {
     cursor: pointer;
   }
-  .nextjs-data-copy-button--error:not(:disabled),
-  .nextjs-data-copy-button--error:hover:not(:disabled) {
+  .nextjs-data-copy-button--error:not([aria-disabled="true"]),
+  .nextjs-data-copy-button--error:hover:not([aria-disabled="true"]) {
     color: var(--color-ansi-red);
   }
-  .nextjs-data-copy-button--success:not(:disabled) {
+  .nextjs-data-copy-button--success:not([aria-disabled="true"]) {
     color: var(--color-ansi-green);
   }
 `

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-layout/error-overlay-layout.tsx
@@ -52,7 +52,7 @@ export interface ErrorOverlayLayoutProps extends ErrorBaseProps {
   activeIdx?: number
   setActiveIndex?: (index: number) => void
   dialogResizerRef?: React.RefObject<HTMLDivElement | null>
-  generateErrorInfo: () => string
+  generateErrorInfo: () => Promise<string>
 }
 
 export function ErrorOverlayLayout({

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/copy-error-button.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/copy-error-button.tsx
@@ -5,7 +5,7 @@ export function CopyErrorButton({
   generateErrorInfo,
 }: {
   error: Error
-  generateErrorInfo: () => string
+  generateErrorInfo: () => Promise<string>
 }) {
   return (
     <CopyButton

--- a/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/errors/error-overlay-toolbar/error-overlay-toolbar.tsx
@@ -7,7 +7,7 @@ type ErrorOverlayToolbarProps = {
   error: Error
   debugInfo: DebugInfo | undefined
   feedbackButton?: React.ReactNode
-  generateErrorInfo: () => string
+  generateErrorInfo: () => Promise<string>
 }
 
 export function ErrorOverlayToolbar({

--- a/packages/next/src/next-devtools/dev-overlay/container/build-error.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/build-error.tsx
@@ -37,7 +37,7 @@ export const BuildError: React.FC<BuildErrorProps> = function BuildError({
     [message]
   )
 
-  const generateErrorInfo = useCallback(() => {
+  const generateErrorInfo = useCallback(async () => {
     const parts: string[] = []
 
     // 1. Error Type

--- a/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/container/errors.tsx
@@ -15,7 +15,6 @@ import {
   NEXTJS_HYDRATION_ERROR_LINK,
 } from '../../shared/react-19-hydration-error'
 import type { ReadyRuntimeError } from '../utils/get-error-by-type'
-import { useFrames } from '../utils/get-error-by-type'
 import type { ErrorBaseProps } from '../components/errors/error-overlay/error-overlay'
 import type { HydrationErrorState } from '../../shared/hydration-error'
 import { useActiveRuntimeError } from '../hooks/use-active-runtime-error'
@@ -605,21 +604,7 @@ export function Errors({
     setActiveIndex,
   } = useActiveRuntimeError({ runtimeErrors, getSquashedHydrationErrorDetails })
 
-  // Get parsed frames data
-  const frames = useFrames(activeError)
-
-  const firstFrame = useMemo(() => {
-    const firstFirstPartyFrameIndex = frames.findIndex(
-      (entry) =>
-        !entry.ignored &&
-        Boolean(entry.originalCodeFrame) &&
-        Boolean(entry.originalStackFrame)
-    )
-
-    return frames[firstFirstPartyFrameIndex] ?? null
-  }, [frames])
-
-  const generateErrorInfo = useCallback(() => {
+  const generateErrorInfo = useCallback(async () => {
     if (!activeError) return ''
 
     const parts: string[] = []
@@ -641,37 +626,58 @@ export function Errors({
     if (message) {
       parts.push(`## Error Message\n${message}`)
     }
-    // Append call stack
-    if (frames.length > 0) {
-      const visibleFrames = frames.filter((frame) => !frame.ignored)
-      if (visibleFrames.length > 0) {
-        const stackLines = visibleFrames
-          .map((frame) => {
-            if (frame.originalStackFrame) {
-              const { methodName, file, line1, column1 } =
-                frame.originalStackFrame
-              return `    at ${methodName} (${file}:${line1}:${column1})`
-            } else if (frame.sourceStackFrame) {
-              const { methodName, file, line1, column1 } =
-                frame.sourceStackFrame
-              return `    at ${methodName} (${file}:${line1}:${column1})`
-            }
-            return ''
-          })
-          .filter(Boolean)
 
-        if (stackLines.length > 0) {
-          parts.push(`\n${stackLines.join('\n')}`)
+    const frames = await Promise.race([
+      activeError.frames(),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 2000)),
+    ])
+
+    // Append call stack
+    if (frames === null) {
+      parts.push(
+        'Unable to retrieve stack frames for this error. Falling back to unsourcemapped stack\n\n' +
+          error.stack
+      )
+    } else {
+      if (frames.length > 0) {
+        const visibleFrames = frames.filter((frame) => !frame.ignored)
+        if (visibleFrames.length > 0) {
+          const stackLines = visibleFrames
+            .map((frame) => {
+              if (frame.originalStackFrame) {
+                const { methodName, file, line1, column1 } =
+                  frame.originalStackFrame
+                return `    at ${methodName} (${file}:${line1}:${column1})`
+              } else if (frame.sourceStackFrame) {
+                const { methodName, file, line1, column1 } =
+                  frame.sourceStackFrame
+                return `    at ${methodName} (${file}:${line1}:${column1})`
+              }
+              return ''
+            })
+            .filter(Boolean)
+
+          if (stackLines.length > 0) {
+            parts.push(`\n${stackLines.join('\n')}`)
+          }
         }
       }
-    }
 
-    // 3. Code Frame (decoded)
-    if (firstFrame?.originalCodeFrame) {
-      const decodedCodeFrame = stripAnsi(
-        formatCodeFrame(firstFrame.originalCodeFrame)
+      // 3. Code Frame (decoded)
+      const firstFirstPartyFrameIndex = frames.findIndex(
+        (entry) =>
+          !entry.ignored &&
+          Boolean(entry.originalCodeFrame) &&
+          Boolean(entry.originalStackFrame)
       )
-      parts.push(`## Code Frame\n${decodedCodeFrame}`)
+
+      const firstFrame = frames[firstFirstPartyFrameIndex] ?? null
+      if (firstFrame?.originalCodeFrame) {
+        const decodedCodeFrame = stripAnsi(
+          formatCodeFrame(firstFrame.originalCodeFrame)
+        )
+        parts.push(`## Code Frame\n${decodedCodeFrame}`)
+      }
     }
 
     // Format as markdown error info
@@ -680,7 +686,7 @@ export function Errors({
 Next.js version: ${props.versionInfo.installed} (${process.env.__NEXT_BUNDLER})\n`
 
     return errorInfo
-  }, [activeError, errorType, firstFrame, frames, props.versionInfo])
+  }, [activeError, errorType, props.versionInfo])
 
   if (isLoading) {
     // TODO: better loading state


### PR DESCRIPTION
The toolbar was blocked on sourcemapping the stackframes for the "copy details button". This suspended the whole devtools which meant you couldn't even see the error

Now we only block on sourcemapping when we actually copy. We can leverage `useActionState` now that devtools is using modern React. We're only blocking for up to 2s and then fallback to including the unsourcemapped stack.

Before:

https://github.com/user-attachments/assets/601c0aa5-fb3a-42ce-b41e-afff06c5aba2


After:


https://github.com/user-attachments/assets/9d80b0c1-2346-421f-a4bc-d2e87753c46c


