### PR TITLE
Use commit-based tarball URL in PR stats comment

### DIFF
--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -974,16 +974,13 @@ function generateDiffsSection(result) {
 }
 
 function generatePrTarballSection(actionInfo) {
-  if (actionInfo.isRelease || !actionInfo.issueId) return ''
-
-  const prNumber = String(actionInfo.issueId).trim()
-  if (!/^\d+$/.test(prNumber)) return ''
+  if (actionInfo.isRelease || !actionInfo.commitId) return ''
 
   return `<details>
 <summary><strong>📎 Tarball URL</strong></summary>
 
 \`\`\`
-next@https://vercel-packages.vercel.app/next/prs/${prNumber}/next
+https://vercel-packages.vercel.app/next/commits/${actionInfo.commitId}/next
 \`\`\`
 
 </details>

--- a/.github/actions/next-stats-action/src/add-comment.js
+++ b/.github/actions/next-stats-action/src/add-comment.js
@@ -974,13 +974,13 @@ function generateDiffsSection(result) {
 }
 
 function generatePrTarballSection(actionInfo) {
-  if (actionInfo.isRelease || !actionInfo.commitId) return ''
+  if (actionInfo.isRelease || !actionInfo.githubHeadSha) return ''
 
   return `<details>
 <summary><strong>📎 Tarball URL</strong></summary>
 
 \`\`\`
-https://vercel-packages.vercel.app/next/commits/${actionInfo.commitId}/next
+https://vercel-packages.vercel.app/next/commits/${actionInfo.githubHeadSha}/next
 \`\`\`
 
 </details>

--- a/.github/actions/next-stats-action/src/prepare/action-info.js
+++ b/.github/actions/next-stats-action/src/prepare/action-info.js
@@ -8,6 +8,7 @@ module.exports = function actionInfo() {
     ISSUE_ID,
     SKIP_CLONE,
     GITHUB_REF,
+    GITHUB_SHA,
     LOCAL_STATS,
     GIT_ROOT_DIR,
     GITHUB_ACTION,
@@ -55,6 +56,9 @@ module.exports = function actionInfo() {
     prRef: GITHUB_REF,
     isLocal: LOCAL_STATS,
     commitId: null,
+    // Mirrors github.event.after || github.sha used by build_and_deploy.yml
+    // to ensure the tarball URL matches the deployed artifact.
+    githubHeadSha: GITHUB_SHA || null,
     issueId: ISSUE_ID,
     isRelease:
       GITHUB_REPOSITORY === 'vercel/next.js' &&
@@ -69,6 +73,10 @@ module.exports = function actionInfo() {
   if (GITHUB_EVENT_PATH) {
     const event = require(GITHUB_EVENT_PATH)
     info.actionName = event.action || info.actionName
+
+    if (event.after) {
+      info.githubHeadSha = event.after
+    }
 
     if (releaseTypes.has(info.actionName)) {
       info.isRelease = true


### PR DESCRIPTION
The previous method of using the PR endpoint under the hood calls the GitHub API to get the commit SHA, which is a waste of resources, so just use the commit SHA directly in the tarball URL.