### PR TITLE
Remove `PrerenderStorePPR` type and all `prerender-ppr` switch cases

### DIFF
--- a/packages/next/src/client/components/navigation-untracked.ts
+++ b/packages/next/src/client/components/navigation-untracked.ts
@@ -20,7 +20,6 @@ function hasFallbackRouteParams(): boolean {
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
-      case 'prerender-ppr':
         const fallbackParams = workUnitStore.fallbackRouteParams
         return fallbackParams ? fallbackParams.size > 0 : false
       case 'validation-client':

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1985,7 +1985,6 @@ async function renderToHTMLOrFlightImpl(
         case 'cache':
         case 'private-cache':
           return true
-        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'request':
         case 'unstable-cache':

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -321,7 +321,6 @@ async function createComponentTreeInternal(
         case 'prerender':
         case 'prerender-runtime':
         case 'prerender-legacy':
-        case 'prerender-ppr':
           if (workUnitStore.revalidate > defaultRevalidate) {
             workUnitStore.revalidate = defaultRevalidate
           }
@@ -1285,7 +1284,6 @@ function createSeedData(
         case 'prerender':
         case 'prerender-client':
         case 'validation-client':
-        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'cache':
         case 'private-cache':

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -144,7 +144,6 @@ export function markCurrentScopeAsDynamic(
         // A private cache scope is already dynamic by definition.
         return
       case 'prerender-legacy':
-      case 'prerender-ppr':
       case 'request':
         break
       default:
@@ -165,12 +164,6 @@ export function markCurrentScopeAsDynamic(
 
   if (workUnitStore) {
     switch (workUnitStore.type) {
-      case 'prerender-ppr':
-        return postponeWithTracking(
-          store.route,
-          expression,
-          workUnitStore.dynamicTracking
-        )
       case 'prerender-legacy':
         workUnitStore.revalidate = 0
 
@@ -240,7 +233,6 @@ export function trackDynamicDataInDynamicRender(workUnitStore: WorkUnitStore) {
     case 'prerender':
     case 'prerender-runtime':
     case 'prerender-legacy':
-    case 'prerender-ppr':
     case 'prerender-client':
     case 'validation-client':
       break
@@ -345,12 +337,7 @@ type PostponeProps = {
   route: string
 }
 export function Postpone({ reason, route }: PostponeProps): never {
-  const prerenderStore = workUnitAsyncStorage.getStore()
-  const dynamicTracking =
-    prerenderStore && prerenderStore.type === 'prerender-ppr'
-      ? prerenderStore.dynamicTracking
-      : null
-  postponeWithTracking(route, reason, dynamicTracking)
+  postponeWithTracking(route, reason, null)
 }
 
 export function postponeWithTracking(
@@ -557,7 +544,6 @@ export function createHangingInputAbortSignal(
       return controller.signal
     case 'prerender-client':
     case 'validation-client':
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':
     case 'cache':
@@ -603,17 +589,6 @@ export function useDynamicRouteParams(expression: string) {
               workStore.route,
               expression
             )
-          )
-        }
-        break
-      }
-      case 'prerender-ppr': {
-        const fallbackParams = workUnitStore.fallbackRouteParams
-        if (fallbackParams && fallbackParams.size > 0) {
-          return postponeWithTracking(
-            workStore.route,
-            expression,
-            workUnitStore.dynamicTracking
           )
         }
         break
@@ -667,8 +642,7 @@ export function useDynamicSearchParams(expression: string) {
       )
       break
     }
-    case 'prerender-legacy':
-    case 'prerender-ppr': {
+    case 'prerender-legacy': {
       if (workStore.forceStatic) {
         return
       }

--- a/packages/next/src/server/app-render/encryption.ts
+++ b/packages/next/src/server/app-render/encryption.ts
@@ -299,7 +299,6 @@ export async function decryptActionBoundArgs(
             break
           case 'prerender-client':
           case 'validation-client':
-          case 'prerender-ppr':
           case 'prerender-legacy':
           case 'request':
           case 'cache':

--- a/packages/next/src/server/app-render/instant-validation/boundary.tsx
+++ b/packages/next/src/server/app-render/instant-validation/boundary.tsx
@@ -15,7 +15,6 @@ function getValidationBoundaryTracking(): ValidationBoundaryTracking | null {
       return store.boundaryState
     case 'prerender':
     case 'prerender-client':
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'prerender-runtime':
     case 'request':

--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -124,7 +124,6 @@ export function getFlightStream<T>(
         return responseOnNextTick
       case 'prerender':
       case 'prerender-runtime':
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':

--- a/packages/next/src/server/app-render/vary-params.ts
+++ b/packages/next/src/server/app-render/vary-params.ts
@@ -126,7 +126,6 @@ export function createVaryParamsAccumulator(): VaryParamsAccumulator | null {
         }
         return null
       }
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':
@@ -154,7 +153,6 @@ export function getMetadataVaryParamsAccumulator(): VaryParamsAccumulator | null
         }
         return null
       }
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':
@@ -201,7 +199,6 @@ export function getRootParamsVaryParamsAccumulator(): VaryParamsAccumulator | nu
         }
         return null
       }
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -267,25 +267,6 @@ interface StaticPrerenderStoreCommon {
   readonly allowEmptyStaticShell: boolean
 }
 
-export interface PrerenderStorePPR
-  extends CommonWorkUnitStore,
-    RevalidateStore {
-  readonly type: 'prerender-ppr'
-  readonly rootParams: Params
-  readonly dynamicTracking: null | DynamicTrackingState
-
-  /**
-   * The set of unknown route parameters. Accessing these will be tracked as
-   * a dynamic access.
-   */
-  readonly fallbackRouteParams: OpaqueFallbackRouteParams | null
-
-  /**
-   * The resume data cache for this prerender.
-   */
-  prerenderResumeDataCache: PrerenderResumeDataCache
-}
-
 export interface PrerenderStoreLegacy
   extends CommonWorkUnitStore,
     RevalidateStore {
@@ -293,10 +274,7 @@ export interface PrerenderStoreLegacy
   readonly rootParams: Params
 }
 
-export type PrerenderStore =
-  | PrerenderStoreLegacy
-  | PrerenderStorePPR
-  | PrerenderStoreModern
+export type PrerenderStore = PrerenderStoreLegacy | PrerenderStoreModern
 
 // /** Like `PrerenderStoreModern`, but only including static prerenders (i.e. not runtime prerenders) */
 export type StaticPrerenderStore = Exclude<
@@ -385,7 +363,6 @@ export function getPrerenderResumeDataCache(
   switch (workUnitStore.type) {
     case 'prerender':
     case 'prerender-runtime':
-    case 'prerender-ppr':
       return workUnitStore.prerenderResumeDataCache
     case 'prerender-client':
     case 'validation-client':
@@ -423,8 +400,6 @@ export function getRenderResumeDataCache(
         // that is used to read from prefilled caches.
         return workUnitStore.renderResumeDataCache
       }
-    // fallthrough
-    case 'prerender-ppr':
       // Otherwise we return the mutable resume data cache here as an immutable
       // version of the cache as it can also be used for reading.
       return workUnitStore.prerenderResumeDataCache ?? null
@@ -452,7 +427,6 @@ export function getHmrRefreshHash(
         return workUnitStore.cookies.get(NEXT_HMR_REFRESH_HASH_COOKIE)?.value
       case 'prerender-client':
       case 'validation-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'unstable-cache':
         break
@@ -475,7 +449,6 @@ export function isHmrRefresh(workUnitStore: WorkUnitStore): boolean {
       case 'prerender-client':
       case 'validation-client':
       case 'prerender-runtime':
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'unstable-cache':
         break
@@ -500,7 +473,6 @@ export function getServerComponentsHmrCache(
       case 'prerender-client':
       case 'validation-client':
       case 'prerender-runtime':
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'unstable-cache':
         break
@@ -530,7 +502,6 @@ export function getDraftModeProviderForCacheScope(
       case 'prerender':
       case 'prerender-client':
       case 'validation-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
         break
       default:
@@ -551,7 +522,6 @@ export function getStagedRenderingController(
     case 'prerender':
     case 'prerender-client':
     case 'validation-client':
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':
@@ -578,7 +548,6 @@ export function getCacheSignal(
       }
       // fallthrough
     }
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':

--- a/packages/next/src/server/lib/patch-fetch.ts
+++ b/packages/next/src/server/lib/patch-fetch.ts
@@ -365,7 +365,6 @@ export function createPatchedFetcher(
             // TODO: Stop accumulating tags in client prerender. (fallthrough)
             case 'prerender-client':
             case 'validation-client':
-            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'cache':
             case 'private-cache':
@@ -407,7 +406,6 @@ export function createPatchedFetcher(
             case 'prerender-client':
             case 'validation-client':
             case 'prerender-runtime':
-            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'request':
             case 'cache':
@@ -578,7 +576,6 @@ export function createPatchedFetcher(
                 )
               }
               break
-            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'cache':
             case 'private-cache':
@@ -710,7 +707,6 @@ export function createPatchedFetcher(
                     )
                   }
                   break
-                case 'prerender-ppr':
                 case 'prerender-legacy':
                 case 'cache':
                 case 'private-cache':
@@ -756,7 +752,6 @@ export function createPatchedFetcher(
             case 'prerender-client':
             case 'validation-client':
             case 'prerender-runtime':
-            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'unstable-cache':
               break
@@ -908,7 +903,6 @@ export function createPatchedFetcher(
                       )
                     }
                   // fallthrough
-                  case 'prerender-ppr':
                   case 'prerender-legacy':
                   case 'cache':
                   case 'private-cache':
@@ -991,7 +985,6 @@ export function createPatchedFetcher(
                     )
                   }
                   break
-                case 'prerender-ppr':
                 case 'prerender-legacy':
                 case 'cache':
                 case 'private-cache':
@@ -1120,7 +1113,6 @@ export function createPatchedFetcher(
                     )
                   }
                   break
-                case 'prerender-ppr':
                 case 'prerender-legacy':
                 case 'cache':
                 case 'private-cache':
@@ -1171,7 +1163,6 @@ export function createPatchedFetcher(
                   case 'private-cache':
                   case 'unstable-cache':
                   case 'prerender-legacy':
-                  case 'prerender-ppr':
                     break
                   default:
                     workUnitStore satisfies never

--- a/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
+++ b/packages/next/src/server/node-environment-extensions/console-dim.external.tsx
@@ -246,7 +246,6 @@ function patchConsoleMethod(methodName: InterceptableConsoleMethod): void {
         }
         // intentional fallthrough
         case 'prerender-legacy':
-        case 'prerender-ppr':
         case 'cache':
         case 'unstable-cache':
         case 'private-cache':

--- a/packages/next/src/server/node-environment-extensions/io-utils.tsx
+++ b/packages/next/src/server/node-environment-extensions/io-utils.tsx
@@ -146,7 +146,6 @@ export function io(expression: string, type: ApiType) {
       }
       break
     case 'validation-client':
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':

--- a/packages/next/src/server/node-environment-extensions/unhandled-rejection.external.tsx
+++ b/packages/next/src/server/node-environment-extensions/unhandled-rejection.external.tsx
@@ -614,7 +614,6 @@ function filteringUnhandledRejectionHandler(
         }
         break
       }
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':

--- a/packages/next/src/server/request/connection.ts
+++ b/packages/next/src/server/request/connection.ts
@@ -4,7 +4,6 @@ import {
   workUnitAsyncStorage,
 } from '../app-render/work-unit-async-storage.external'
 import {
-  postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -93,14 +92,6 @@ export function connection(): Promise<void> {
             `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
           )
         }
-        case 'prerender-ppr':
-          // We use React's postpone API to interrupt rendering here to create a
-          // dynamic hole
-          return postponeWithTracking(
-            workStore.route,
-            'connection',
-            workUnitStore.dynamicTracking
-          )
         case 'prerender-legacy':
           // We throw an error here to interrupt prerendering to mark the route
           // as dynamic

--- a/packages/next/src/server/request/cookies.ts
+++ b/packages/next/src/server/request/cookies.ts
@@ -16,7 +16,6 @@ import {
   isInEarlyRenderStage,
 } from '../app-render/work-unit-async-storage.external'
 import {
-  postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -81,14 +80,6 @@ export function cookies(): Promise<ReadonlyRequestCookies> {
           const exportName = '`cookies`'
           throw new InvariantError(
             `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
-          )
-        case 'prerender-ppr':
-          // We need track dynamic access here eagerly to keep continuity with
-          // how cookies has worked in PPR without cacheComponents.
-          return postponeWithTracking(
-            workStore.route,
-            callingExpression,
-            workUnitStore.dynamicTracking
           )
         case 'prerender-legacy':
           // We track dynamic access here so we don't need to wrap the cookies

--- a/packages/next/src/server/request/draft-mode.ts
+++ b/packages/next/src/server/request/draft-mode.ts
@@ -12,7 +12,6 @@ import {
 import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
-  postponeWithTracking,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
 import { createDedupedByCallsiteServerErrorLoggerDev } from '../create-deduped-by-callsite-server-error-logger'
@@ -59,7 +58,6 @@ export function draftMode(): Promise<DraftMode> {
     // Otherwise, we fall through to providing an empty draft mode.
     // eslint-disable-next-line no-fallthrough
     case 'prerender':
-    case 'prerender-ppr':
     case 'prerender-legacy':
       // Return empty draft mode
       return createOrGetCachedDraftMode(null, workStore)
@@ -227,12 +225,6 @@ function trackDynamicDraftMode(expression: string, constructorOpt: Function) {
           const exportName = '`draftMode`'
           throw new InvariantError(
             `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
-          )
-        case 'prerender-ppr':
-          return postponeWithTracking(
-            workStore.route,
-            expression,
-            workUnitStore.dynamicTracking
           )
         case 'prerender-legacy':
           workUnitStore.revalidate = 0

--- a/packages/next/src/server/request/headers.ts
+++ b/packages/next/src/server/request/headers.ts
@@ -14,7 +14,6 @@ import {
   isInEarlyRenderStage,
 } from '../app-render/work-unit-async-storage.external'
 import {
-  postponeWithTracking,
   throwToInterruptStaticGeneration,
   trackDynamicDataInDynamicRender,
 } from '../app-render/dynamic-rendering'
@@ -80,7 +79,6 @@ export function headers(): Promise<ReadonlyHeaders> {
         case 'validation-client':
         case 'private-cache':
         case 'prerender-runtime':
-        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'request':
           break
@@ -104,16 +102,6 @@ export function headers(): Promise<ReadonlyHeaders> {
           const exportName = '`headers`'
           throw new InvariantError(
             `${exportName} must not be used within a client component. Next.js should be preventing ${exportName} from being included in client components statically, but did not in this case.`
-          )
-        case 'prerender-ppr':
-          // PPR Prerender (no cacheComponents)
-          // We are prerendering with PPR. We need track dynamic access here eagerly
-          // to keep continuity with how headers has worked in PPR without cacheComponents.
-          // TODO consider switching the semantic to throw on property access instead
-          return postponeWithTracking(
-            workStore.route,
-            callingExpression,
-            workUnitStore.dynamicTracking
           )
         case 'prerender-legacy':
           // Legacy Prerender

--- a/packages/next/src/server/request/params.ts
+++ b/packages/next/src/server/request/params.ts
@@ -10,15 +10,9 @@ import {
 } from '../app-render/vary-params'
 
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
-import {
-  throwToInterruptStaticGeneration,
-  postponeWithTracking,
-} from '../app-render/dynamic-rendering'
 
 import {
   workUnitAsyncStorage,
-  type PrerenderStorePPR,
-  type PrerenderStoreLegacy,
   type StaticPrerenderStoreModern,
   type StaticPrerenderStore,
   throwInvariantForMissingStore,
@@ -53,7 +47,6 @@ export function createParamsFromClient(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
         // Client params don't need additional vary tracking because by the
         // time they reach the client, the access would have already been
@@ -133,7 +126,6 @@ export function createServerParamsForRoute(
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':
-      case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderParams(
           underlyingParams,
@@ -204,7 +196,6 @@ export function createServerParamsForServerSegment(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderParams(
           underlyingParams,
@@ -303,7 +294,6 @@ export function createPrerenderParamsForClientSegment(
         throw new InvariantError(
           'createPrerenderParamsForClientSegment should not be called in cache contexts.'
         )
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'prerender-runtime':
       case 'request':
@@ -347,22 +337,6 @@ function createStaticPrerenderParams(
             // resolves.
             return makeHangingParams(
               underlyingParamsWithVarying,
-              workStore,
-              prerenderStore
-            )
-          }
-        }
-      }
-      break
-    }
-    case 'prerender-ppr': {
-      const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams) {
-        for (const key in underlyingParams) {
-          if (fallbackParams.has(key)) {
-            return makeErroringParams(
-              underlyingParamsWithVarying,
-              fallbackParams,
               workStore,
               prerenderStore
             )
@@ -491,65 +465,6 @@ function makeHangingParams(
   )
 
   CachedParams.set(underlyingParams, promise)
-
-  return promise
-}
-
-function makeErroringParams(
-  underlyingParams: Params,
-  fallbackParams: OpaqueFallbackRouteParams,
-  workStore: WorkStore,
-  prerenderStore: PrerenderStorePPR | PrerenderStoreLegacy
-): Promise<Params> {
-  const cachedParams = CachedParams.get(underlyingParams)
-  if (cachedParams) {
-    return cachedParams
-  }
-
-  const augmentedUnderlying = { ...underlyingParams }
-
-  // We don't use makeResolvedReactPromise here because params
-  // supports copying with spread and we don't want to unnecessarily
-  // instrument the promise with spreadable properties of ReactPromise.
-  const promise = Promise.resolve(augmentedUnderlying)
-  CachedParams.set(underlyingParams, promise)
-
-  Object.keys(underlyingParams).forEach((prop) => {
-    if (wellKnownProperties.has(prop)) {
-      // These properties cannot be shadowed because they need to be the
-      // true underlying value for Promises to work correctly at runtime
-    } else {
-      if (fallbackParams.has(prop)) {
-        Object.defineProperty(augmentedUnderlying, prop, {
-          get() {
-            const expression = describeStringPropertyAccess('params', prop)
-            // In most dynamic APIs we also throw if `dynamic = "error"` however
-            // for params is only dynamic when we're generating a fallback shell
-            // and even when `dynamic = "error"` we still support generating dynamic
-            // fallback shells
-            // TODO remove this comment when cacheComponents is the default since there
-            // will be no `dynamic = "error"`
-            if (prerenderStore.type === 'prerender-ppr') {
-              // PPR Prerender (no cacheComponents)
-              postponeWithTracking(
-                workStore.route,
-                expression,
-                prerenderStore.dynamicTracking
-              )
-            } else {
-              // Legacy Prerender
-              throwToInterruptStaticGeneration(
-                expression,
-                workStore,
-                prerenderStore
-              )
-            }
-          },
-          enumerable: true,
-        })
-      }
-    }
-  })
 
   return promise
 }

--- a/packages/next/src/server/request/pathname.ts
+++ b/packages/next/src/server/request/pathname.ts
@@ -4,16 +4,10 @@ import {
 } from '../app-render/work-async-storage.external'
 
 import {
-  postponeWithTracking,
-  type DynamicTrackingState,
-} from '../app-render/dynamic-rendering'
-
-import {
   throwInvariantForMissingStore,
   workUnitAsyncStorage,
   type PrerenderStoreLegacy,
   type PrerenderStoreModernServer,
-  type PrerenderStorePPR,
 } from '../app-render/work-unit-async-storage.external'
 import {
   delayUntilRuntimeStage,
@@ -32,7 +26,6 @@ export function createServerPathnameForMetadata(
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':
-      case 'prerender-ppr':
       case 'prerender-legacy': {
         return createPrerenderPathname(
           underlyingPathname,
@@ -69,10 +62,7 @@ export function createServerPathnameForMetadata(
 function createPrerenderPathname(
   underlyingPathname: string,
   workStore: WorkStore,
-  prerenderStore:
-    | PrerenderStoreLegacy
-    | PrerenderStorePPR
-    | PrerenderStoreModernServer
+  prerenderStore: PrerenderStoreLegacy | PrerenderStoreModernServer
 ): Promise<string> {
   switch (prerenderStore.type) {
     case 'prerender': {
@@ -86,13 +76,6 @@ function createPrerenderPathname(
       }
       break
     }
-    case 'prerender-ppr': {
-      const fallbackParams = prerenderStore.fallbackRouteParams
-      if (fallbackParams && fallbackParams.size > 0) {
-        return makeErroringPathname(workStore, prerenderStore.dynamicTracking)
-      }
-      break
-    }
     case 'prerender-legacy':
       break
     default:
@@ -101,41 +84,6 @@ function createPrerenderPathname(
 
   // We don't have any fallback params so we have an entirely static safe params object
   return Promise.resolve(underlyingPathname)
-}
-
-function makeErroringPathname<T>(
-  workStore: WorkStore,
-  dynamicTracking: null | DynamicTrackingState
-): Promise<T> {
-  let reject: null | ((reason: unknown) => void) = null
-  const promise = new Promise<T>((_, re) => {
-    reject = re
-  })
-
-  const originalThen = promise.then.bind(promise)
-
-  // We instrument .then so that we can generate a tracking event only if you actually
-  // await this promise, not just that it is created.
-  promise.then = (onfulfilled, onrejected) => {
-    if (reject) {
-      try {
-        postponeWithTracking(
-          workStore.route,
-          'metadata relative url resolving',
-          dynamicTracking
-        )
-      } catch (error) {
-        reject(error)
-        reject = null
-      }
-    }
-    return originalThen(onfulfilled, onrejected)
-  }
-
-  // We wrap in a noop proxy to trick the runtime into thinking it
-  // isn't a native promise (it's not really). This is so that awaiting
-  // the promise will call the `then` property triggering the lazy postpone
-  return new Proxy(promise, {})
 }
 
 function createRenderPathname(underlyingPathname: string): Promise<string> {

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -1,9 +1,5 @@
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
-  postponeWithTracking,
-  throwToInterruptStaticGeneration,
-} from '../app-render/dynamic-rendering'
-import {
   workAsyncStorage,
   type WorkStore,
 } from '../app-render/work-async-storage.external'
@@ -11,11 +7,9 @@ import {
   workUnitAsyncStorage,
   type PrerenderStoreLegacy,
   type PrerenderStoreModernServer,
-  type PrerenderStorePPR,
 } from '../app-render/work-unit-async-storage.external'
 import { makeHangingPromise } from '../dynamic-rendering-utils'
 import type { ParamValue } from './params'
-import { describeStringPropertyAccess } from '../../shared/lib/utils/reflect-utils'
 import { actionAsyncStorage } from '../app-render/action-async-storage.external'
 import { accumulateRootVaryParam } from '../app-render/vary-params'
 
@@ -65,7 +59,6 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
       )
     }
     case 'prerender':
-    case 'prerender-ppr':
     case 'prerender-legacy': {
       return createPrerenderRootParamPromise(
         paramName,
@@ -97,16 +90,12 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
 function createPrerenderRootParamPromise(
   paramName: string,
   workStore: WorkStore,
-  prerenderStore:
-    | PrerenderStorePPR
-    | PrerenderStoreLegacy
-    | PrerenderStoreModernServer,
+  prerenderStore: PrerenderStoreLegacy | PrerenderStoreModernServer,
   apiName: string
 ): Promise<ParamValue> {
   switch (prerenderStore.type) {
     case 'prerender':
     case 'prerender-legacy':
-    case 'prerender-ppr':
     default:
   }
 
@@ -128,22 +117,6 @@ function createPrerenderRootParamPromise(
       }
       break
     }
-    case 'prerender-ppr': {
-      // We aren't in a cacheComponents prerender, but the param is a fallback,
-      // so we need to make an erroring params object which will postpone/error if you access it
-      if (
-        prerenderStore.fallbackRouteParams &&
-        prerenderStore.fallbackRouteParams.has(paramName)
-      ) {
-        return makeErroringRootParamPromise(
-          paramName,
-          workStore,
-          prerenderStore,
-          apiName
-        )
-      }
-      break
-    }
     case 'prerender-legacy': {
       // legacy prerenders can't have fallback params
       break
@@ -156,37 +129,4 @@ function createPrerenderRootParamPromise(
   // If the param is not a fallback param, we just return the statically available value.
   accumulateRootVaryParam(paramName)
   return Promise.resolve(underlyingParams[paramName])
-}
-
-/** Deliberately async -- we want to create a rejected promise, not error synchronously. */
-async function makeErroringRootParamPromise(
-  paramName: string,
-  workStore: WorkStore,
-  prerenderStore: PrerenderStorePPR | PrerenderStoreLegacy,
-  apiName: string
-): Promise<ParamValue> {
-  const expression = describeStringPropertyAccess(apiName, paramName)
-  // In most dynamic APIs, we also throw if `dynamic = "error"`.
-  // However, root params are only dynamic when we're generating a fallback shell,
-  // and even with `dynamic = "error"` we still support generating dynamic fallback shells.
-  // TODO: remove this comment when cacheComponents is the default since there will be no `dynamic = "error"`
-  switch (prerenderStore.type) {
-    case 'prerender-ppr': {
-      return postponeWithTracking(
-        workStore.route,
-        expression,
-        prerenderStore.dynamicTracking
-      )
-    }
-    case 'prerender-legacy': {
-      return throwToInterruptStaticGeneration(
-        expression,
-        workStore,
-        prerenderStore
-      )
-    }
-    default: {
-      prerenderStore satisfies never
-    }
-  }
 }

--- a/packages/next/src/server/request/search-params.ts
+++ b/packages/next/src/server/request/search-params.ts
@@ -11,14 +11,12 @@ import {
 import { ReflectAdapter } from '../web/spec-extension/adapters/reflect'
 import {
   throwToInterruptStaticGeneration,
-  postponeWithTracking,
   annotateDynamicAccess,
 } from '../app-render/dynamic-rendering'
 
 import {
   workUnitAsyncStorage,
   type PrerenderStoreLegacy,
-  type PrerenderStorePPR,
   type PrerenderStoreModern,
   type PrerenderStoreModernRuntime,
   type StaticPrerenderStore,
@@ -56,7 +54,6 @@ export function createSearchParamsFromClient(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderSearchParams(workStore, workUnitStore)
       case 'validation-client':
@@ -115,7 +112,6 @@ export function createServerSearchParamsForServerPage(
     switch (workUnitStore.type) {
       case 'prerender':
       case 'prerender-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
         return createStaticPrerenderSearchParams(workStore, workUnitStore)
       case 'validation-client':
@@ -186,7 +182,6 @@ export function createPrerenderSearchParamsForClientPage(): Promise<SearchParams
         throw new InvariantError(
           'createPrerenderSearchParamsForClientPage should not be called in cache contexts.'
         )
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
         return Promise.resolve({})
@@ -212,7 +207,6 @@ function createStaticPrerenderSearchParams(
     case 'prerender-client':
       // We are in a cacheComponents (PPR or otherwise) prerender
       return makeHangingSearchParams(workStore, prerenderStore)
-    case 'prerender-ppr':
     case 'prerender-legacy':
       // We are in a legacy static generation and need to interrupt the
       // prerender when search params are accessed.
@@ -336,7 +330,7 @@ function makeHangingSearchParams(
 
 function makeErroringSearchParams(
   workStore: WorkStore,
-  prerenderStore: PrerenderStoreLegacy | PrerenderStorePPR
+  prerenderStore: PrerenderStoreLegacy
 ): Promise<SearchParams> {
   const cachedSearchParams = CachedSearchParams.get(workStore)
   if (cachedSearchParams) {
@@ -365,13 +359,6 @@ function makeErroringSearchParams(
           throwWithStaticGenerationBailoutErrorWithDynamicError(
             workStore.route,
             expression
-          )
-        } else if (prerenderStore.type === 'prerender-ppr') {
-          // PPR Prerender (no cacheComponents)
-          postponeWithTracking(
-            workStore.route,
-            expression,
-            prerenderStore.dynamicTracking
           )
         } else {
           // Legacy Prerender

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -60,7 +60,6 @@ import { StaticGenBailoutError } from '../../../client/components/static-generat
 import { isStaticGenEnabled } from './helpers/is-static-gen-enabled'
 import {
   abortAndThrowOnSynchronousRequestDataAccess,
-  postponeWithTracking,
   createDynamicTrackingState,
   getFirstDynamicReason,
 } from '../../app-render/dynamic-rendering'
@@ -1219,12 +1218,6 @@ function trackDynamic(
       case 'prerender-runtime':
         throw new InvariantError(
           'A runtime prerender store should not be used for a route handler.'
-        )
-      case 'prerender-ppr':
-        return postponeWithTracking(
-          store.route,
-          expression,
-          workUnitStore.dynamicTracking
         )
       case 'prerender-legacy':
         workUnitStore.revalidate = 0

--- a/packages/next/src/server/use-cache/cache-life.ts
+++ b/packages/next/src/server/use-cache/cache-life.ts
@@ -88,7 +88,6 @@ export function cacheLife(profile: CacheLifeProfiles | CacheLife): void {
     case 'prerender-client':
     case 'validation-client':
     case 'prerender-runtime':
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':
     case 'unstable-cache':

--- a/packages/next/src/server/use-cache/cache-tag.ts
+++ b/packages/next/src/server/use-cache/cache-tag.ts
@@ -15,7 +15,6 @@ export function cacheTag(...tags: string[]): void {
     case 'prerender-client':
     case 'validation-client':
     case 'prerender-runtime':
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':
     case 'unstable-cache':

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -59,7 +59,6 @@ import { getCacheHandler } from './handlers'
 import { UseCacheTimeoutError } from './use-cache-errors'
 import {
   createHangingInputAbortSignal,
-  postponeWithTracking,
   throwToInterruptStaticGeneration,
 } from '../app-render/dynamic-rendering'
 import {
@@ -243,7 +242,6 @@ function createUseCacheStore(
           break
         case 'prerender-runtime':
         case 'prerender':
-        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'unstable-cache':
           break
@@ -391,7 +389,6 @@ function propagateCacheLifeAndTags(
       case 'private-cache':
       case 'prerender':
       case 'prerender-runtime':
-      case 'prerender-ppr':
       case 'prerender-legacy':
         propagateCacheLifeAndTagsToRevalidateStore(
           cacheContext.outerWorkUnitStore,
@@ -539,8 +536,7 @@ async function collectResult(
       case 'private-cache':
       case 'cache':
       case 'unstable-cache':
-      case 'prerender-legacy':
-      case 'prerender-ppr': {
+      case 'prerender-legacy': {
         propagateCacheLifeAndTags(cacheContext, entry)
         break
       }
@@ -620,7 +616,6 @@ async function generateCacheEntryImpl(
                       }
                     })
                     break
-                  case 'prerender-ppr':
                   case 'prerender-legacy':
                   case 'request':
                   case 'cache':
@@ -761,7 +756,6 @@ async function generateCacheEntryImpl(
         await new Promise((resolve) => setTimeout(resolve))
       }
     // fallthrough
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':
@@ -960,12 +954,6 @@ export async function cache(
           workStore.route,
           expression
         )
-      case 'prerender-ppr':
-        return postponeWithTracking(
-          workStore.route,
-          expression,
-          workUnitStore.dynamicTracking
-        )
       case 'prerender-legacy':
         return throwToInterruptStaticGeneration(
           expression,
@@ -1027,7 +1015,6 @@ export async function cache(
         )
       case 'prerender':
       case 'prerender-runtime':
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':
@@ -1276,7 +1263,6 @@ export async function cache(
         break
       }
     // fallthrough
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'request':
     // TODO(restart-on-cache-miss): We need to handle params/searchParams on page components.
@@ -1436,7 +1422,6 @@ export async function cache(
               }
               break
             }
-            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'cache':
             case 'private-cache':
@@ -1485,7 +1470,6 @@ export async function cache(
               break
             }
             case 'prerender':
-            case 'prerender-ppr':
             case 'prerender-legacy':
             case 'cache':
             case 'private-cache':
@@ -1561,7 +1545,6 @@ export async function cache(
             }
             break
           case 'prerender-runtime':
-          case 'prerender-ppr':
           case 'prerender-legacy':
           case 'request':
           case 'cache':
@@ -1690,7 +1673,6 @@ export async function cache(
           break
         }
         case 'prerender-runtime':
-        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'cache':
         case 'private-cache':
@@ -1945,7 +1927,6 @@ function shouldForceRevalidate(
       case 'prerender':
       case 'prerender-client':
       case 'validation-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'unstable-cache':
         break
@@ -1989,7 +1970,6 @@ function shouldDiscardCacheEntry(
       case 'prerender-runtime':
       case 'prerender-client':
       case 'validation-client':
-      case 'prerender-ppr':
       case 'prerender-legacy':
       case 'request':
       case 'cache':

--- a/packages/next/src/server/web/spec-extension/revalidate.ts
+++ b/packages/next/src/server/web/spec-extension/revalidate.ts
@@ -1,7 +1,4 @@
-import {
-  abortAndThrowOnSynchronousRequestDataAccess,
-  postponeWithTracking,
-} from '../../app-render/dynamic-rendering'
+import { abortAndThrowOnSynchronousRequestDataAccess } from '../../app-render/dynamic-rendering'
 import { isDynamicRoute } from '../../../shared/lib/router/utils'
 import {
   NEXT_CACHE_IMPLICIT_TAG_ID,
@@ -163,12 +160,6 @@ function revalidate(
       case 'validation-client':
         throw new InvariantError(
           `${expression} must not be used within a client component. Next.js should be preventing ${expression} from being included in client components statically, but did not in this case.`
-        )
-      case 'prerender-ppr':
-        return postponeWithTracking(
-          store.route,
-          expression,
-          workUnitStore.dynamicTracking
         )
       case 'prerender-legacy':
         workUnitStore.revalidate = 0

--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -165,7 +165,6 @@ export function unstable_cache<T extends Callback>(
             case 'private-cache':
             case 'prerender':
             case 'prerender-runtime':
-            case 'prerender-ppr':
             case 'prerender-legacy':
               // We update the store's revalidate property if the option.revalidate is a higher precedence
               // options.revalidate === undefined doesn't affect timing.
@@ -412,7 +411,6 @@ function getFetchUrlPrefix(
     case 'prerender-client':
     case 'validation-client':
     case 'prerender-runtime':
-    case 'prerender-ppr':
     case 'prerender-legacy':
     case 'cache':
     case 'private-cache':

--- a/packages/next/src/server/web/spec-extension/unstable-no-store.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-no-store.ts
@@ -38,7 +38,6 @@ export function unstable_noStore() {
         case 'prerender-runtime':
           // unstable_noStore() is a noop in Dynamic I/O.
           return
-        case 'prerender-ppr':
         case 'prerender-legacy':
         case 'request':
         case 'cache':


### PR DESCRIPTION
Stacked on https://github.com/vercel/next.js/pull/90713

This PR removes `prerender-ppr` case handling in the codebase.

Verified deployment tests pass on CI: https://github.com/vercel/next.js/actions/runs/22539297668