### PR TITLE
[ci] Use commit instead of PR number for preview builds in deploy tests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -783,7 +783,6 @@ jobs:
       afterBuild: |
         export NEXT_E2E_TEST_TIMEOUT=240000
         export __NEXT_EXPERIMENTAL_STRICT_ROUTE_TYPES=true
-        export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }}
         node scripts/test-new-tests.mjs \
           --mode deploy \
           --group ${{ matrix.group }}
@@ -817,7 +816,6 @@ jobs:
         export __NEXT_EXPERIMENTAL_APP_NEW_SCROLL_HANDLER=true
         export NEXT_EXTERNAL_TESTS_FILTERS="test/deploy-tests-manifest.json,test/cache-components-tests-manifest.json"
         export NEXT_E2E_TEST_TIMEOUT=240000
-        export GH_PR_NUMBER=${{ github.event.pull_request && github.event.pull_request.number || '' }}
         node scripts/test-new-tests.mjs \
           --mode deploy \
           --group ${{ matrix.group }}

--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -85,15 +85,14 @@ async function main() {
   }
 
   const RUN_TESTS_ARGS = ['run-tests.js', '-c', '1', '--retries', '0']
-  const PR_NUMBER = process.env.GH_PR_NUMBER
   // Only override the test version for deploy tests, as they need to run against
   // the artifacts for the pull request. Otherwise, we don't need to specify this property,
-  // as tests will run against the local version of Next.js
+  // as tests will run against the local version of Next.js.
+  // Always use the commit SHA endpoint to avoid GitHub API rate limits on the
+  // PR number endpoint (which resolves the PR to a SHA on every request).
   const nextTestVersion =
     testMode === 'deploy'
-      ? PR_NUMBER
-        ? `https://vercel-packages.vercel.app/next/prs/${PR_NUMBER}/next`
-        : `https://vercel-packages.vercel.app/next/commits/${commitSha}/next`
+      ? `https://vercel-packages.vercel.app/next/commits/${commitSha}/next`
       : undefined
 
   if (nextTestVersion) {


### PR DESCRIPTION
Deploy test now use a preview build from and endpoint that acts for longer as a permalink. Previously we used the PR number (only valid until next push) and now we use the commit (on only valid until next attempt). This avoids having to query GH in vercel-packages for the head commit and reduces risk of rate limiting.
---
[Slack Thread](https://vercel.slack.com/archives/C07UCHRBWGK/p1772327690086489?thread_ts=1772327690.086489&cid=C07UCHRBWGK)

<p><a href="https://cursor.com/agents/bc-124478bd-2a5f-5dc6-a3d6-8777dcbaf297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-124478bd-2a5f-5dc6-a3d6-8777dcbaf297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

