### PR TITLE
Examples: Migration to next-translate 3.0.0

### DIFF
--- a/examples/with-next-translate/app/[lang]/layout.js
+++ b/examples/with-next-translate/app/[lang]/layout.js
@@ -1,0 +1,25 @@
+import useTranslation from "next-translate/useTranslation";
+
+export default function LangLayout({ children }) {
+  const { t } = useTranslation("common");
+
+  return (
+    <>
+      {children}
+      <footer>
+        <span>{t("powered")} </span>
+        <a href="https://vercel.com" target="_blank" rel="noopener noreferrer">
+          ▲ Vercel
+        </a>
+        <span>&amp;</span>
+        <a
+          href="https://github.com/vinissimus/next-translate"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          next-translate
+        </a>
+      </footer>
+    </>
+  );
+}

--- a/examples/with-next-translate/app/[lang]/page.js
+++ b/examples/with-next-translate/app/[lang]/page.js
@@ -3,7 +3,7 @@ import Trans from "next-translate/Trans";
 import useTranslation from "next-translate/useTranslation";
 
 export default function Home() {
-  const { t, lang } = useTranslation();
+  const { t, lang } = useTranslation("home");
   const isRTL = lang === "ar" || lang === "he";
   const arrow = isRTL ? String.fromCharCode(8592) : String.fromCharCode(8594);
 
@@ -12,8 +12,8 @@ export default function Home() {
       <Trans
         i18nKey="home:title"
         components={[
-          <h1 className="title" />,
-          <a href="https://nextjs.org">Next.js!</a>,
+          <h1 className="title" key="title" />,
+          <a href="https://nextjs.org" key="link">Next.js!</a>,
         ]}
       />
 

--- a/examples/with-next-translate/app/layout.js
+++ b/examples/with-next-translate/app/layout.js
@@ -1,35 +1,23 @@
 import useTranslation from "next-translate/useTranslation";
+import i18n from "../i18n.json";
+import { redirect } from "next/navigation";
 import "./style.css";
 
 export const metadata = {
   title: "Next.js",
 };
 
-export default function Layout(props) {
-  const { t, lang } = useTranslation();
+export default function RootLayout({ children }) {
+  const { lang } = useTranslation("common");
+
+  // Redirect to default locale if lang is not supported. /second-page -> /en/second-page
+  if (!i18n.locales.includes(lang)) redirect(`/${i18n.defaultLocale}/${lang}`);
 
   return (
     <html lang={lang}>
+      <head />
       <body className="container">
-        {props.children}
-        <footer>
-          <span>{t("common:powered")} </span>
-          <a
-            href="https://vercel.com"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            ▲ Vercel
-          </a>
-          <span>&amp;</span>
-          <a
-            href="https://github.com/vinissimus/next-translate"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            next-translate
-          </a>
-        </footer>
+        {children}
       </body>
     </html>
   );

--- a/examples/with-next-translate/app/layout.js
+++ b/examples/with-next-translate/app/layout.js
@@ -1,6 +1,4 @@
 import useTranslation from "next-translate/useTranslation";
-import i18n from "../i18n.json";
-import { redirect } from "next/navigation";
 import "./style.css";
 
 export const metadata = {
@@ -8,17 +6,12 @@ export const metadata = {
 };
 
 export default function RootLayout({ children }) {
-  const { lang } = useTranslation("common");
-
-  // Redirect to default locale if lang is not supported. /second-page -> /en/second-page
-  if (!i18n.locales.includes(lang)) redirect(`/${i18n.defaultLocale}/${lang}`);
+  const { lang } = useTranslation();
 
   return (
     <html lang={lang}>
       <head />
-      <body className="container">
-        {children}
-      </body>
+      <body className="container">{children}</body>
     </html>
   );
 }

--- a/examples/with-next-translate/middleware.js
+++ b/examples/with-next-translate/middleware.js
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import i18n from "./i18n";
+
+const locales = i18n.locales;
+const defaultLocale = i18n.defaultLocale;
+
+function getLocale(request) {
+  // Check cookie first
+  const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
+  if (cookieLocale && locales.includes(cookieLocale)) return cookieLocale;
+
+  // Then check Accept-Language header
+  const acceptLanguage = request.headers.get("accept-language") ?? "";
+  for (const part of acceptLanguage.split(",")) {
+    const lang = part.split(";")[0].trim().split("-")[0];
+    if (locales.includes(lang)) return lang;
+  }
+
+  return defaultLocale;
+}
+
+export function middleware(request) {
+  const { pathname } = request.nextUrl;
+
+  // Skip internal Next.js paths and static files
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api") ||
+    pathname.includes(".")
+  ) {
+    return NextResponse.next();
+  }
+
+  // Check if the path already starts with a locale
+  const pathnameHasLocale = locales.some(
+    (locale) => pathname === `/${locale}` || pathname.startsWith(`/${locale}/`),
+  );
+
+  if (pathnameHasLocale) return NextResponse.next();
+
+  // Redirect to locale-prefixed path
+  const locale = getLocale(request);
+  const url = request.nextUrl.clone();
+  url.pathname = `/${locale}${pathname === "/" ? "" : pathname}`;
+
+  return NextResponse.redirect(url);
+}
+
+export const config = {
+  matcher: ["/((?!_next|api|.*\\..*).*)"],
+};

--- a/examples/with-next-translate/next.config.js
+++ b/examples/with-next-translate/next.config.js
@@ -1,3 +1,6 @@
 const nextTranslate = require("next-translate-plugin");
 
-module.exports = nextTranslate({});
+// Note: only available in Next.js +16 (for 15, you need to force a boolean)
+const isTurbopack = !process.argv.includes('--webpack');
+
+module.exports = nextTranslate({}, { turbopack: isTurbopack });

--- a/examples/with-next-translate/package.json
+++ b/examples/with-next-translate/package.json
@@ -6,12 +6,12 @@
     "start": "next start"
   },
   "dependencies": {
-    "next": "latest",
-    "next-translate": "2.5.3",
-    "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "next": "^16.1.6",
+    "next-translate": "^3.0.0",
+    "react": "19.0.0",
+    "react-dom": "19.0.0"
   },
   "devDependencies": {
-    "next-translate-plugin": "2.5.3"
+    "next-translate-plugin": "^3.0.0"
   }
 }

--- a/examples/with-next-translate/proxy.js
+++ b/examples/with-next-translate/proxy.js
@@ -19,7 +19,7 @@ function getLocale(request) {
   return defaultLocale;
 }
 
-export function middleware(request) {
+export function proxy(request) {
   const { pathname } = request.nextUrl;
 
   // Skip internal Next.js paths and static files


### PR DESCRIPTION
This Pull Request migrates the `with-next-translate` example to use **next-translate 3.0.0**, which provides enhanced support for **Next.js App Router**.

### Changes Overview

1.  **Dependency Updates**:
    - Updated `next-translate` and `next-translate-plugin` to `^3.0.0`.
    - Bumped `react` and `react-dom` to `19.0.0` to match current Next.js expectations.

2.  **Middleware Implementation**:
    - Introduced `proxy.js` to handle locale detection and redirection.
    - In the App Router, routes under a root `[lang]` segment require a mechanism to redirect the root path (`/`) to a locale-prefixed path (`/en`, `/es`, etc.). The middleware handles this by checking cookies (`NEXT_LOCALE`) and the `Accept-Language` header.

3.  **Root Layout Simplification**:
    - Cleaned up `app/layout.js`. Redirection logic was moved from the layout component to the middleware, which is the recommended and more performant approach in Next.js.
    - Removed unused `redirect` imports from `next/navigation` in the layout.

### Impact

- **Fixed 404 on Root**: Accessing `/` now correctly redirects to the default locale instead of returning a 404.
- **Modern Patterns**: Aligned the example with the latest `next-translate` documentation and best practices for internationalization in Next.js 13/14/15+.
