### PR TITLE
Publish @next/playwright to npm as part of canary releases

### DIFF
--- a/packages/next-playwright/package.json
+++ b/packages/next-playwright/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@next/playwright",
   "version": "16.2.0-canary.70",
-  "private": true,
   "repository": {
     "url": "vercel/next.js",
     "directory": "packages/next-playwright"


### PR DESCRIPTION
@next/playwright is an experimental package that provides Playwright helpers for testing Next.js navigation behavior. Its main feature is an `instant()` API that lets you assert whether a route is correctly structured for instant navigation — rendering only cached/prefetched content without waiting for dynamic data.

The package requires Cache Components to be enabled. It works by setting a cookie that tells Next.js to serve only cached data during navigations, deferring dynamic content until the cookie is cleared. The design is intentionally thin so that other testing frameworks can replicate the same mechanism.

Removing the "private" field so the package is included in the next canary publish.