### PR TITLE
Fix grammar in docs

### DIFF
--- a/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
+++ b/docs/02-pages/04-api-reference/01-components/image-legacy.mdx
@@ -613,7 +613,7 @@ module.exports = {
 
 The default [loader](#loader) does not optimize SVG images for a few reasons. First, SVG is a vector format meaning it can be resized losslessly. Second, SVG has many of the same features as HTML/CSS, which can lead to vulnerabilities without proper [Content Security Policy (CSP) headers](/docs/app/api-reference/config/next-config-js/headers#content-security-policy).
 
-Therefore, we recommended using the [`unoptimized`](#unoptimized) prop when the [`src`](#src) prop is known to be SVG. This happens automatically when `src` ends with `".svg"`.
+Therefore, we recommend using the [`unoptimized`](#unoptimized) prop when the [`src`](#src) prop is known to be SVG. This happens automatically when `src` ends with `".svg"`.
 
 However, if you need to serve SVG images with the default Image Optimization API, you can set `dangerouslyAllowSVG` inside your `next.config.js`:
 


### PR DESCRIPTION
Fixes grammar error in image-legacy documentation where 'recommended' should be 'recommend'.