### PR TITLE
Turbopack: improve cell order lint rule for TraitRef::cell

### DIFF
--- a/.config/ast-grep/rules/no-map-async-cell.yml
+++ b/.config/ast-grep/rules/no-map-async-cell.yml
@@ -13,6 +13,7 @@ rule:
         - pattern: ResolvedVc::cell($_X)
         - pattern: Vc::cell($_X)
         - pattern: ReadRef::cell($_X)
+        - pattern: TraitRef::cell($_X)
     - inside:
         stopBy: end
         all:

--- a/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
+++ b/turbopack/crates/turbopack-browser/src/ecmascript/list/version.rs
@@ -31,8 +31,9 @@ impl Version for EcmascriptDevChunkListVersion {
             let mut by_path = self
                 .by_path
                 .iter()
+                .map(|(path, version)| (path, TraitRef::cell(version.clone())))
                 .map(|(path, version)| async move {
-                    let id = TraitRef::cell(version.clone()).id().owned().await?;
+                    let id = version.id().owned().await?;
                     Ok((path, id))
                 })
                 .try_join()
@@ -44,9 +45,7 @@ impl Version for EcmascriptDevChunkListVersion {
             let mut by_merger = self
                 .by_merger
                 .iter()
-                .map(|(_merger, version)| async move {
-                    TraitRef::cell(version.clone()).id().owned().await
-                })
+                .map(|(_merger, version)| TraitRef::cell(version.clone()).id().owned())
                 .try_join()
                 .await?;
             by_merger.sort();


### PR DESCRIPTION
The "cell in async map" pattern
because `cell()` has a task-local counter that is incremented, so it shouldn't happen inside of a `.map(async` block