### PR TITLE
[devtools] Bundle for same target as Next.js browser runtime

### DIFF
--- a/packages/next/next-devtools.webpack-config.js
+++ b/packages/next/next-devtools.webpack-config.js
@@ -73,7 +73,11 @@ module.exports = ({ dev, ...rest }) => {
           test: /\.(ts|tsx)$/,
           exclude: [/node_modules/],
           loader: 'builtin:swc-loader',
+          /** @type {import('@rspack/core').SwcLoaderOptions} */
           options: {
+            env: {
+              targets: MODERN_BROWSERSLIST_TARGET,
+            },
             jsc: {
               parser: {
                 syntax: 'typescript',

--- a/packages/next/src/shared/lib/magic-identifier.ts
+++ b/packages/next/src/shared/lib/magic-identifier.ts
@@ -122,10 +122,10 @@ export function deobfuscateModuleId(moduleId: string): string {
  */
 export function removeFreeCallWrapper(text: string): string {
   // Match (0, <ident>.<ident>) patterns anywhere in the text the beginning
-  // Use Unicode property escapes (\p{ID_Start}, \p{ID_Continue}) for full JS identifier support
-  // Requires the 'u' (unicode) flag in the regex
+  // Overzealous: accept any non-whitespace member expression after the dot.
+  // TODO: Fix https://linear.app/vercel/issue/NEXT-4875 to allow using unicode property escapes
   return text.replace(
-    /\(0\s*,\s*(__TURBOPACK__[a-zA-Z0-9_$]+__\.[\p{ID_Start}_$][\p{ID_Continue}$]*)\)/u,
+    /\(0\s*,\s*(__TURBOPACK__[a-zA-Z0-9_$]+__\.[^\s)]+)\)/g,
     '$1'
   )
 }


### PR DESCRIPTION
Brings us down to 700 kB (down from 800 kB). Seems like Rspack doesn't forward the `target` option to swc-loader so we have to do that manually.

Originally noticed because async-await got transpiled away.

Before:
<img width="1226" height="390" alt="CleanShot 2026-03-02 at 12 27 01@2x" src="https://github.com/user-attachments/assets/dbd3abe7-ed6a-4d4e-8d0e-a57629dc1c14" />

After:
<img width="892" height="188" alt="CleanShot 2026-03-02 at 12 27 45@2x" src="https://github.com/user-attachments/assets/e3e69d10-cdbe-4bfe-99a0-729c97f3cfd5" />
