### PR TITLE
Update the link in the request body size warning to a non-redirecting, version-specific URL

### DIFF
--- a/packages/next/src/server/body-streams.ts
+++ b/packages/next/src/server/body-streams.ts
@@ -94,8 +94,7 @@ export function getCloneableBody<T extends IncomingMessage>(
           limitExceeded = true
           const urlInfo = readable.url ? ` for ${readable.url}` : ''
           console.warn(
-            // TODO(jiwon): Update this document link
-            `Request body exceeded ${bytes.format(bodySizeLimit)}${urlInfo}. Only the first ${bytes.format(bodySizeLimit)} will be available unless configured. See https://nextjs.org/docs/app/api-reference/config/next-config-js/middlewareClientMaxBodySize for more details.`
+            `Request body exceeded ${bytes.format(bodySizeLimit)}${urlInfo}. Only the first ${bytes.format(bodySizeLimit)} will be available unless configured. See https://nextjs.org/docs/15/app/api-reference/config/next-config-js/middlewareClientMaxBodySize for more details.`
           )
           p1.push(null)
           p2.push(null)


### PR DESCRIPTION
Currently, when v15 users encounter this warning and click the link (https://nextjs.org/docs/app/api-reference/config/next-config-js/middlewareClientMaxBodySize), they are redirected to the v16 `proxyClientMaxBodySize` page (https://nextjs.org/docs/app/api-reference/config/next-config-js/proxyClientMaxBodySize).

They also cannot switch the doc version back to v15 to reach the `middlewareClientMaxBodySize` page. Switching from the v16 `proxyClientMaxBodySize` page to v15 does not redirect to the corresponding `middlewareClientMaxBodySize` page.

As a result, users must first notice that the link was redirected and then manually locate the correct page. This is confusing.

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
