### PR TITLE
Add static error when `unstable_instant` is used without `cacheComponents`

### DIFF
--- a/crates/next-custom-transforms/src/transforms/react_server_components.rs
+++ b/crates/next-custom-transforms/src/transforms/react_server_components.rs
@@ -99,6 +99,7 @@ enum RSCErrorKind {
     NextRscErrDeprecatedApi((String, String, Span)),
     NextSsrDynamicFalseNotAllowed(Span),
     NextRscErrIncompatibleRouteSegmentConfig(Span, String, NextConfigProperty),
+    NextRscErrRequiresRouteSegmentConfig(Span, String, NextConfigProperty),
     NextRscErrTaintWithoutConfig((String, Span)),
 }
 
@@ -121,6 +122,7 @@ enum InvalidExportKind {
     General,
     Metadata,
     RouteSegmentConfig(NextConfigProperty),
+    RequiresRouteSegmentConfig(NextConfigProperty),
 }
 
 impl<C: Comments> VisitMut for ReactServerComponents<C> {
@@ -357,6 +359,10 @@ fn report_error(app_dir: &Option<PathBuf>, filepath: &str, error_kind: RSCErrorK
         ),
         RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(span, segment, property) => (
             format!("Route segment config \"{segment}\" is not compatible with `nextConfig.{property}`. Please remove it."),
+            vec![span],
+        ),
+        RSCErrorKind::NextRscErrRequiresRouteSegmentConfig(span, segment, property) => (
+            format!("Route segment config \"{segment}\" requires `nextConfig.{property}` to be enabled."),
             vec![span],
         ),
         RSCErrorKind::NextRscErrTaintWithoutConfig((api_name, span)) => (
@@ -937,6 +943,19 @@ impl ReactServerComponentValidator {
                             );
                         }
                     }
+                    "unstable_instant" => {
+                        if !self.cache_components_enabled {
+                            possibly_invalid_exports.insert(
+                                export_name.clone(),
+                                (
+                                    InvalidExportKind::RequiresRouteSegmentConfig(
+                                        NextConfigProperty::CacheComponents,
+                                    ),
+                                    *span,
+                                ),
+                            );
+                        }
+                    }
                     _ => (),
                 };
 
@@ -973,6 +992,17 @@ impl ReactServerComponentValidator {
                             &self.app_dir,
                             &self.filepath,
                             RSCErrorKind::NextRscErrIncompatibleRouteSegmentConfig(
+                                *span,
+                                export_name.to_string(),
+                                *property,
+                            ),
+                        );
+                    }
+                    InvalidExportKind::RequiresRouteSegmentConfig(property) => {
+                        report_error(
+                            &self.app_dir,
+                            &self.filepath,
+                            RSCErrorKind::NextRscErrRequiresRouteSegmentConfig(
                                 *span,
                                 export_name.to_string(),
                                 *property,

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/instant-with-cache-components/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/instant-with-cache-components/output.js
@@ -1,0 +1,6 @@
+export const unstable_instant = {
+    prefetch: 'static'
+};
+export default function Page() {
+    return <div>Hello</div>;
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/instant-with-cache-components/page.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/cache-components/instant-with-cache-components/page.js
@@ -1,0 +1,5 @@
+export const unstable_instant = { prefetch: 'static' }
+
+export default function Page() {
+  return <div>Hello</div>
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/instant-requires-cache-components/output.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/instant-requires-cache-components/output.js
@@ -1,0 +1,6 @@
+export const unstable_instant = {
+    prefetch: 'static'
+};
+export default function Page() {
+    return <div>Hello</div>;
+}

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/instant-requires-cache-components/output.stderr
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/instant-requires-cache-components/output.stderr
@@ -1,0 +1,5 @@
+  x Route segment config "unstable_instant" requires `nextConfig.cacheComponents` to be enabled.
+   ,-[input.js:1:1]
+ 1 | export const unstable_instant = { prefetch: 'static' }
+   :              ^^^^^^^^^^^^^^^^
+   `----

--- a/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/instant-requires-cache-components/page.js
+++ b/crates/next-custom-transforms/tests/errors/react-server-components/server-graph/instant-requires-cache-components/page.js
@@ -1,0 +1,5 @@
+export const unstable_instant = { prefetch: 'static' }
+
+export default function Page() {
+  return <div>Hello</div>
+}


### PR DESCRIPTION
`unstable_instant` requires `cacheComponents` to function — without it, validation is entirely skipped and the config silently does nothing. This adds a compile-time error in the SWC transform that catches the misconfiguration early, matching the existing pattern used for segment configs like `revalidate` that are incompatible with `cacheComponents` (but inverted — `unstable_instant` requires it rather than being incompatible with it). The error points directly to the export in the user's source file.