### PR TITLE
[turbopack] Don't schedule idle snapshots when we are in a short session

### DIFF
--- a/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
+++ b/crates/next-napi-bindings/src/next_api/turbopack_ctx.rs
@@ -223,7 +223,7 @@ pub fn create_turbo_tasks(
             BackendOptions {
                 storage_mode: Some(if std::env::var("TURBO_ENGINE_READ_ONLY").is_ok() {
                     turbo_tasks_backend::StorageMode::ReadOnly
-                } else if is_ci {
+                } else if is_ci || is_short_session {
                     turbo_tasks_backend::StorageMode::ReadWriteOnShutdown
                 } else {
                     turbo_tasks_backend::StorageMode::ReadWrite


### PR DESCRIPTION
In a few `next build` commands i saw multiple snapshots due to this.  Idle callbacks were firing near the end of the build.

```
  Creating an optimized production build ...
WARNING: The git repository is dirty, but File System Cache is still enabled. Manual removal of the filesystem cache database might be required.
✓ Finished writing to filesystem cache because: idle timeout in 6.1s
✓ Compiled successfully in 69s
✓ Collecting page data using 13 workers in 85ms
  Build ran with "compile" mode, to finalize the build run either "generate" or "generate-env" mode as well
✓ Finalizing page optimization in 32ms
Route (app)
...ommitted route table...
✓ Finished writing to filesystem cache because: stop in 3.5s
```

This is a bit wasteful since it is more efficient to write everything in a single batch at the end.

The solution is just to not schedule snapshotting operations in 'short sessions' (aka `next build`)