### PR TITLE
Turbopack: pass reference type to CustomModuleType

### DIFF
--- a/crates/next-core/src/next_image/module.rs
+++ b/crates/next-core/src/next_image/module.rs
@@ -4,8 +4,7 @@ use turbo_rcstr::rcstr;
 use turbo_tasks::{NonLocalValue, ResolvedVc, TaskInput, Vc, fxindexmap, trace::TraceRawVcs};
 use turbopack::{ModuleAssetContext, module_options::CustomModuleType};
 use turbopack_core::{
-    context::AssetContext, module::Module, reference_type::ReferenceType, resolve::ModulePart,
-    source::Source,
+    context::AssetContext, module::Module, reference_type::ReferenceType, source::Source,
 };
 use turbopack_ecmascript::EcmascriptInputTransforms;
 use turbopack_static::ecma::StaticUrlJsModule;
@@ -90,7 +89,7 @@ impl CustomModuleType for StructuredImageModuleType {
         &self,
         source: Vc<Box<dyn Source>>,
         module_asset_context: Vc<ModuleAssetContext>,
-        _part: Option<ModulePart>,
+        _reference_type: ReferenceType,
     ) -> Vc<Box<dyn Module>> {
         StructuredImageModuleType::create_module(
             source,

--- a/crates/next-core/src/raw_ecmascript_module.rs
+++ b/crates/next-core/src/raw_ecmascript_module.rs
@@ -21,7 +21,7 @@ use turbopack_core::{
     ident::AssetIdent,
     module::{Module, ModuleSideEffects},
     module_graph::ModuleGraph,
-    resolve::ModulePart,
+    reference_type::ReferenceType,
     source::{OptionSource, Source},
     source_map::GenerateSourceMap,
 };
@@ -45,7 +45,7 @@ impl CustomModuleType for RawEcmascriptModuleType {
         &self,
         source: Vc<Box<dyn Source>>,
         module_asset_context: Vc<ModuleAssetContext>,
-        _part: Option<ModulePart>,
+        _reference_type: ReferenceType,
     ) -> Vc<Box<dyn Module>> {
         Vc::upcast(RawEcmascriptModule::new(
             source,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -33,8 +33,7 @@ use turbopack_core::{
     output::{ExpandedOutputAssets, OutputAsset},
     raw_module::RawModule,
     reference_type::{
-        CssReferenceSubType, EcmaScriptModulesReferenceSubType, ImportContext, InnerAssets,
-        ReferenceType,
+        CssReferenceSubType, EcmaScriptModulesReferenceSubType, InnerAssets, ReferenceType,
     },
     resolve::{
         ExternalTraced, ExternalType, ModulePart, ModuleResolveResult, ModuleResolveResultItem,
@@ -81,15 +80,23 @@ async fn apply_module_type(
     source: ResolvedVc<Box<dyn Source>>,
     module_asset_context: Vc<ModuleAssetContext>,
     module_type: Vc<ModuleType>,
-    part: Option<ModulePart>,
+    reference_type: ReferenceType,
     inner_assets: Option<ResolvedVc<InnerAssets>>,
-    css_import_context: Option<ResolvedVc<ImportContext>>,
-    runtime_code: bool,
 ) -> Result<Vc<ProcessResult>> {
     let tree_shaking_mode = module_asset_context
         .module_options_context()
         .await?
         .tree_shaking_mode;
+    let part = match &reference_type {
+        ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportPart(part)) => {
+            Some(part)
+        }
+        _ => None,
+    };
+    let css_import_context = match reference_type {
+        ReferenceType::Css(CssReferenceSubType::AtImport(import)) => import,
+        _ => None,
+    };
     let is_evaluation = matches!(&part, Some(ModulePart::Evaluation));
 
     let module_type = &*module_type.await?;
@@ -176,7 +183,7 @@ async fn apply_module_type(
             }
 
             let module = builder.build().to_resolved().await?;
-            if runtime_code {
+            if matches!(reference_type, ReferenceType::Runtime) {
                 ResolvedVc::upcast(module)
             } else {
                 // Check side effect free on the intermediate module before following reexports
@@ -195,7 +202,7 @@ async fn apply_module_type(
                     Some(TreeShakingMode::ModuleFragments) => {
                         Vc::upcast(EcmascriptModulePartAsset::select_part(
                             *module,
-                            part.unwrap_or(ModulePart::facade()),
+                            part.cloned().unwrap_or(ModulePart::facade()),
                         ))
                     }
                     Some(TreeShakingMode::ReexportsOnly) => {
@@ -214,7 +221,7 @@ async fn apply_module_type(
                                                 .resolve()
                                                 .await?,
                                             ),
-                                            part,
+                                            part.clone(),
                                         )
                                         .await?
                                     }
@@ -278,7 +285,7 @@ async fn apply_module_type(
         ),
         ModuleType::Custom(custom) => {
             custom
-                .create_module(*source, module_asset_context, part)
+                .create_module(*source, module_asset_context, reference_type)
                 .to_resolved()
                 .await?
         }
@@ -649,12 +656,6 @@ async fn process_default_internal(
         module_asset_context.resolve_options_context(),
     );
 
-    let part: Option<ModulePart> = match &reference_type {
-        ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportPart(part)) => {
-            Some(part.clone())
-        }
-        _ => None,
-    };
     let inner_assets = match &reference_type {
         ReferenceType::Internal(inner_assets) => Some(*inner_assets),
         _ => None,
@@ -760,10 +761,8 @@ async fn process_default_internal(
                         current_source,
                         module_asset_context,
                         module_type.cell(),
-                        part,
+                        reference_type,
                         inner_assets,
-                        None,
-                        false,
                     )
                     .await;
                 }
@@ -893,14 +892,8 @@ async fn process_default_internal(
         current_source,
         module_asset_context,
         module_type.cell(),
-        part,
+        reference_type,
         inner_assets,
-        if let ReferenceType::Css(CssReferenceSubType::AtImport(import)) = reference_type {
-            import
-        } else {
-            None
-        },
-        matches!(reference_type, ReferenceType::Runtime),
     )
     .await?;
 

--- a/turbopack/crates/turbopack/src/module_options/custom_module_type.rs
+++ b/turbopack/crates/turbopack/src/module_options/custom_module_type.rs
@@ -1,5 +1,5 @@
 use turbo_tasks::Vc;
-use turbopack_core::{module::Module, resolve::ModulePart, source::Source};
+use turbopack_core::{module::Module, reference_type::ReferenceType, source::Source};
 use turbopack_ecmascript::EcmascriptInputTransforms;
 
 use crate::ModuleAssetContext;
@@ -11,7 +11,7 @@ pub trait CustomModuleType {
         self: Vc<Self>,
         source: Vc<Box<dyn Source>>,
         module_asset_context: Vc<ModuleAssetContext>,
-        part: Option<ModulePart>,
+        reference_type: ReferenceType,
     ) -> Vc<Box<dyn Module>>;
 
     #[turbo_tasks::function]


### PR DESCRIPTION
No reason to restrict it to `ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::ImportPart(part))`