### PR TITLE
Fix missing const generic parameter in turbo-persistence lookup call

### DIFF
--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -1658,7 +1658,7 @@ mod tests {
         let sst = open_sst(dir, seq, meta).unwrap();
         let kc = make_cache();
         let vc = make_cache();
-        match sst.lookup(entries[0].hash, &entries[0].key, &kc, &vc) {
+        match sst.lookup::<_, false>(entries[0].hash, &entries[0].key, &kc, &vc) {
             Err(err) => {
                 let msg = format!("{err}");
                 assert!(


### PR DESCRIPTION
### What?

Fix a compilation error in `turbo-persistence` test code where the `StaticSortedFile::lookup` call was missing the required `FIND_ALL` const generic parameter.

### Why?

After the `FIND_ALL: bool` const generic was added to `StaticSortedFile::lookup` in #90754, a call site in the test helper `assert_corruption_detected` was not updated, causing `cargo check --all-targets` to fail with:

```
error[E0284]: type annotations needed
  --> turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs:1661:19
     |
1661 |         match sst.lookup(entries[0].hash, &entries[0].key, &kc, &vc) {
     |                   ^^^^^^ cannot infer the value of the const parameter `FIND_ALL`
```

### How?

Added explicit turbofish `::<_, false>` to the `lookup` call in the test helper. `false` is the appropriate value since the test only needs to look up a single entry to verify corruption detection.