### PR TITLE
test(cdn-cache-busting): add runtime prefetch tests

### DIFF
--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/app/page.tsx
@@ -11,6 +11,16 @@ export default function Page() {
           Redirects to target page
         </LinkAccordion>
       </li>
+      <li>
+        <LinkAccordion href="/runtime-target-page">
+          Runtime target page
+        </LinkAccordion>
+      </li>
+      <li>
+        <LinkAccordion href="/redirect-to-runtime-target-page">
+          Redirects to runtime target page
+        </LinkAccordion>
+      </li>
     </ul>
   )
 }

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/app/runtime-target-page/page.tsx
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/app/runtime-target-page/page.tsx
@@ -1,0 +1,12 @@
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [] }],
+}
+
+export default function RuntimeTargetPage() {
+  return (
+    <div id="runtime-target-page" data-testid="runtime-prefetch-result">
+      Runtime target page
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
@@ -11,8 +11,6 @@ describe('segment cache (CDN cache busting)', () => {
     return
   }
 
-  // TODO(runtime-ppr): add tests for runtime prefetches
-
   // To debug these tests locally, run:
   //   node start.mjs
   //
@@ -138,6 +136,123 @@ describe('segment cache (CDN cache busting)', () => {
         const div = await browser.elementById('target-page')
         expect(await div.text()).toBe('Target page')
       }, 'no-requests')
+    }
+  )
+
+  it(
+    "perform runtime prefetched navigation with a CDN that doesn't respect " +
+      'the Vary header',
+    async () => {
+      let act
+      const browser = await webdriver(port, '/', {
+        beforePageLoad(p: Playwright.Page) {
+          act = createRouterAct(p)
+        },
+      })
+
+      // Initiate a runtime prefetch by revealing the link. The runtime
+      // prefetch uses a different next-router-prefetch header value ('2'
+      // instead of '1'), which produces a different _rsc cache-busting
+      // search param. This ensures the CDN caches runtime prefetch
+      // responses separately from full prefetch responses.
+      await act(
+        async () => {
+          const linkToggle = await browser.elementByCss(
+            '[data-link-accordion="/runtime-target-page"]'
+          )
+          await linkToggle.click()
+        },
+        {
+          // Use a unique data attribute from the target page to avoid
+          // matching the link label text on the home page.
+          includes: 'runtime-prefetch-result',
+        }
+      )
+
+      // Navigate to the runtime-prefetched target page.
+      await act(async () => {
+        const link = await browser.elementByCss(
+          'a[href="/runtime-target-page"]'
+        )
+        await link.click()
+
+        // The page was prefetched, so we're able to render the target
+        // page immediately.
+        const div = await browser.elementById('runtime-target-page')
+        expect(await div.text()).toBe('Runtime target page')
+      })
+    }
+  )
+
+  it(
+    'prevent cache poisoning attacks for runtime prefetch by responding with ' +
+      'a redirect to correct cache busting query param',
+    async () => {
+      const browser = await webdriver(port, '/')
+      // All header values below are hardcoded Next.js internal headers.
+      // 'next-router-prefetch: 2' is the runtime prefetch header value
+      // (vs '1' for static prefetch in the existing test above).
+      const { status, responseUrl, redirected } = await browser.eval(
+        async () => {
+          const res = await fetch('/runtime-target-page', {
+            headers: {
+              rsc: '1',
+              'next-router-prefetch': '2',
+              'next-router-segment-prefetch': '/_tree',
+            },
+          })
+          return {
+            status: res.status,
+            responseUrl: res.url,
+            redirected: res.redirected,
+          }
+        }
+      )
+      expect(status).toBe(200)
+      expect(responseUrl).toContain('_rsc=')
+      expect(redirected).toBe(true)
+    }
+  )
+
+  it(
+    'perform runtime prefetched navigation when a third-party proxy ' +
+      'performs a redirect',
+    async () => {
+      let act
+      const browser = await webdriver(port, '/', {
+        beforePageLoad(p: Playwright.Page) {
+          act = createRouterAct(p)
+        },
+      })
+
+      await act(
+        async () => {
+          const linkToggle = await browser.elementByCss(
+            '[data-link-accordion="/redirect-to-runtime-target-page"]'
+          )
+          await linkToggle.click()
+        },
+        // The proxy redirect causes the content to appear in multiple
+        // responses (the redirect target and the segment prefetch), so
+        // we provide two expectations.
+        [
+          { includes: 'runtime-prefetch-result' },
+          { includes: 'runtime-prefetch-result' },
+        ]
+      )
+
+      // Navigate to the runtime-prefetched target page via proxy redirect.
+      await act(async () => {
+        const link = await browser.elementByCss(
+          'a[href="/redirect-to-runtime-target-page"]'
+        )
+        await link.click()
+
+        // The page was prefetched, so we're able to render the target
+        // page immediately.
+        const div = await browser.elementById('runtime-target-page')
+        expect(await div.text()).toBe('Runtime target page')
+      })
     }
   )
 })

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/next.config.js
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/next.config.js
@@ -2,6 +2,7 @@
  * @type {import('next').NextConfig}
  */
 const nextConfig = {
+  cacheComponents: true,
   experimental: {
     validateRSCRequestHeaders: true,
   },

--- a/test/e2e/app-dir/segment-cache/cdn-cache-busting/server.mjs
+++ b/test/e2e/app-dir/segment-cache/cdn-cache-busting/server.mjs
@@ -13,6 +13,7 @@ const dir = dirname(fileURLToPath(import.meta.url))
 // target page.
 const proxyRedirects = {
   '/redirect-to-target-page': '/target-page',
+  '/redirect-to-runtime-target-page': '/runtime-target-page',
 }
 
 async function spawnNext(port) {


### PR DESCRIPTION
## Summary

Resolves the `TODO(runtime-ppr)` in the CDN cache-busting test suite by adding three new test cases for runtime prefetch:

- **Runtime prefetched navigation through CDN** — verifies that runtime prefetch uses a distinct `_rsc` cache-busting param (`next-router-prefetch: 2` vs `1`), preventing cache collisions with full prefetch responses
- **Cache poisoning prevention for runtime prefetch** — verifies the server redirects to the correct `_rsc` param when a runtime prefetch request is sent without one
- **Runtime prefetch navigation through proxy redirect** — verifies runtime prefetch works correctly when a third-party proxy performs a 307 redirect

### Changes

- `next.config.js` — enabled `cacheComponents: true` (required for `unstable_instant`)
- `app/runtime-target-page/page.tsx` — new fixture page with `unstable_instant` runtime prefetch config
- `app/page.tsx` — added LinkAccordion entries for the new routes
- `server.mjs` — added proxy redirect mapping for `/redirect-to-runtime-target-page`
- `cdn-cache-busting.test.ts` — removed TODO, added 3 new tests

### How I tested this

```bash
NEXT_SKIP_ISOLATE=1 NEXT_TEST_MODE=start pnpm testheadless test/e2e/app-dir/segment-cache/cdn-cache-busting/cdn-cache-busting.test.ts
```

All 6 tests pass (3 existing + 3 new).