### PR TITLE
Turbopack: accept ChunkGroup in entry_chunk_group

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use bincode::{Decode, Encode};
 use next_core::{
     app_structure::{
@@ -1820,12 +1820,6 @@ impl AppEndpoint {
                     .concatenate(chunk_group2_assets)
             }
             NextRuntime::NodeJs => {
-                let Some(rsc_entry) = ResolvedVc::try_downcast(app_entry.rsc_entry) else {
-                    bail!("rsc_entry must be evaluatable");
-                };
-
-                let evaluatable_assets = Vc::cell(vec![rsc_entry]);
-
                 async {
                     let mut current_chunk_group = ChunkGroupResult::empty_resolved();
 
@@ -1925,7 +1919,7 @@ impl AppEndpoint {
                                             "app{original_name}.js",
                                             original_name = app_entry.original_name
                                         ))?,
-                                        evaluatable_assets,
+                                        ChunkGroup::Entry(vec![app_entry.rsc_entry]),
                                         module_graph,
                                         *current_chunks,
                                         current_referenced_assets,

--- a/crates/next-api/src/instrumentation.rs
+++ b/crates/next-api/src/instrumentation.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::Result;
 use next_core::{
     next_edge::entry::wrap_edge_entry,
     next_manifests::{InstrumentationDefinition, MiddlewaresManifestV2},
@@ -120,17 +120,13 @@ impl InstrumentationEndpoint {
         let userland_module = self.entry_module().to_resolved().await?;
         let module_graph = this.project.module_graph(*userland_module);
 
-        let Some(module) = ResolvedVc::try_downcast(userland_module) else {
-            bail!("Entry module must be evaluatable");
-        };
-
         let EntryChunkGroupResult { asset: chunk, .. } = *chunking_context
             .entry_chunk_group(
                 this.project
                     .node_root()
                     .await?
                     .join("server/instrumentation.js")?,
-                Vc::cell(vec![module]),
+                ChunkGroup::Entry(vec![userland_module]),
                 module_graph,
                 OutputAssets::empty(),
                 OutputAssets::empty(),

--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -1,6 +1,6 @@
 use std::future::IntoFuture;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use next_core::{
     middleware::get_middleware_module,
     next_edge::entry::wrap_edge_entry,
@@ -130,17 +130,13 @@ impl MiddlewareEndpoint {
         let userland_module = self.entry_module().to_resolved().await?;
         let module_graph = this.project.module_graph(*userland_module);
 
-        let Some(module) = ResolvedVc::try_downcast(userland_module) else {
-            bail!("Entry module must be evaluatable");
-        };
-
         let EntryChunkGroupResult { asset: chunk, .. } = *chunking_context
             .root_entry_chunk_group(
                 this.project
                     .node_root()
                     .await?
                     .join("server/middleware.js")?,
-                Vc::cell(vec![module]),
+                ChunkGroup::Entry(vec![userland_module]),
                 module_graph,
                 OutputAssets::empty(),
                 OutputAssets::empty(),

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -1018,13 +1018,11 @@ impl PageEndpoint {
                 .await?;
             }
 
-            let ssr_module_evaluatable = ResolvedVc::try_sidecast(ssr_module)
-                .context("could not process page loader entry module")?;
             let is_edge = matches!(runtime, NextRuntime::Edge);
             if is_edge {
                 let chunk_assets = edge_chunking_context.evaluated_chunk_group_assets(
                     ssr_module.ident(),
-                    ChunkGroup::Entry(vec![ResolvedVc::upcast(ssr_module_evaluatable)]),
+                    ChunkGroup::Entry(vec![ssr_module]),
                     ssr_module_graph,
                     current_chunk_group.await?.availability_info,
                 );
@@ -1052,7 +1050,7 @@ impl PageEndpoint {
                 let ssr_entry_chunk = node_chunking_context
                     .entry_chunk_group_asset(
                         ssr_entry_chunk_path,
-                        EvaluatableAssets::empty().with_entry(*ssr_module_evaluatable),
+                        ChunkGroup::Entry(vec![ssr_module]),
                         ssr_module_graph,
                         current_chunk_group.primary_assets(),
                         current_chunk_group.referenced_assets(),

--- a/turbopack/crates/turbopack-browser/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-browser/src/chunking_context.rs
@@ -880,7 +880,7 @@ impl ChunkingContext for BrowserChunkingContext {
     fn entry_chunk_group(
         self: Vc<Self>,
         _path: FileSystemPath,
-        _evaluatable_assets: Vc<EvaluatableAssets>,
+        _chunk_group: ChunkGroup,
         _module_graph: Vc<ModuleGraph>,
         _extra_chunks: Vc<OutputAssets>,
         _extra_referenced_assets: Vc<OutputAssets>,

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -21,8 +21,8 @@ use turbopack_cli_utils::issue::{ConsoleUi, LogOptions};
 use turbopack_core::{
     asset::Asset,
     chunk::{
-        ChunkingConfig, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssets,
-        MangleType, MinifyType, SourceMapsType, availability_info::AvailabilityInfo,
+        ChunkingConfig, ChunkingContext, ChunkingContextExt, EvaluatableAsset, MangleType,
+        MinifyType, SourceMapsType, availability_info::AvailabilityInfo,
     },
     environment::{BrowserEnvironment, Environment, ExecutionEnvironment, NodeJsEnvironment},
     ident::AssetIdent,
@@ -470,7 +470,7 @@ async fn build_internal(
                                                         .unwrap(),
                                                 )?
                                                 .with_extension("entry.js"),
-                                            EvaluatableAssets::one(*ecmascript),
+                                            ChunkGroup::Entry(vec![ResolvedVc::upcast(ecmascript)]),
                                             module_graph,
                                             OutputAssets::empty(),
                                             OutputAssets::empty(),

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -12,8 +12,8 @@ use turbo_tasks_hash::DeterministicHash;
 use crate::{
     asset::Asset,
     chunk::{
-        ChunkItem, ChunkType, ChunkableModule, EvaluatableAssets,
-        availability_info::AvailabilityInfo, chunk_id_strategy::ModuleIdStrategy,
+        ChunkItem, ChunkType, ChunkableModule, availability_info::AvailabilityInfo,
+        chunk_id_strategy::ModuleIdStrategy,
     },
     environment::Environment,
     ident::AssetIdent,
@@ -456,7 +456,7 @@ pub trait ChunkingContext {
     fn entry_chunk_group(
         self: Vc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
@@ -525,7 +525,7 @@ pub trait ChunkingContextExt {
     fn entry_chunk_group_asset(
         self: Vc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
@@ -537,7 +537,7 @@ pub trait ChunkingContextExt {
     fn root_entry_chunk_group(
         self: Vc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
@@ -548,7 +548,7 @@ pub trait ChunkingContextExt {
     fn root_entry_chunk_group_asset(
         self: Vc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
@@ -617,7 +617,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
     fn entry_chunk_group_asset(
         self: Vc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
@@ -626,7 +626,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         entry_chunk_group_asset(
             Vc::upcast_non_strict(self),
             path,
-            evaluatable_assets,
+            chunk_group,
             module_graph,
             extra_chunks,
             extra_referenced_assets,
@@ -637,14 +637,14 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
     fn root_entry_chunk_group(
         self: Vc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
     ) -> Vc<EntryChunkGroupResult> {
         self.entry_chunk_group(
             path,
-            evaluatable_assets,
+            chunk_group,
             module_graph,
             extra_chunks,
             extra_referenced_assets,
@@ -655,7 +655,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
     fn root_entry_chunk_group_asset(
         self: Vc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
@@ -663,7 +663,7 @@ impl<T: ChunkingContext + Send + Upcast<Box<dyn ChunkingContext>>> ChunkingConte
         entry_chunk_group_asset(
             Vc::upcast_non_strict(self),
             path,
-            evaluatable_assets,
+            chunk_group,
             module_graph,
             extra_chunks,
             extra_referenced_assets,
@@ -762,7 +762,7 @@ fn evaluated_chunk_group_assets(
 async fn entry_chunk_group_asset(
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     path: FileSystemPath,
-    evaluatable_assets: Vc<EvaluatableAssets>,
+    chunk_group: ChunkGroup,
     module_graph: Vc<ModuleGraph>,
     extra_chunks: Vc<OutputAssets>,
     extra_referenced_assets: Vc<OutputAssets>,
@@ -771,7 +771,7 @@ async fn entry_chunk_group_asset(
     Ok(*chunking_context
         .entry_chunk_group(
             path,
-            evaluatable_assets,
+            chunk_group,
             module_graph,
             extra_chunks,
             extra_referenced_assets,

--- a/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/worker_chunk/module.rs
@@ -6,7 +6,7 @@ use turbopack_core::{
     chunk::{
         AsyncModuleInfo, ChunkData, ChunkGroupType, ChunkableModule, ChunkingContext,
         ChunkingContextExt, ChunkingType, ChunkingTypeOption, ChunksData, EvaluatableAsset,
-        EvaluatableAssets, availability_info::AvailabilityInfo,
+        availability_info::AvailabilityInfo,
     },
     context::AssetContext,
     ident::AssetIdent,
@@ -91,7 +91,7 @@ impl WorkerLoaderModule {
                 let entry_result = chunking_context
                     .root_entry_chunk_group(
                         worker_path,
-                        EvaluatableAssets::one(*evaluatable),
+                        ChunkGroup::Isolated(ResolvedVc::upcast(evaluatable)),
                         module_graph,
                         OutputAssets::empty(),
                         OutputAssets::empty(),

--- a/turbopack/crates/turbopack-node/src/evaluate.rs
+++ b/turbopack/crates/turbopack-node/src/evaluate.rs
@@ -28,7 +28,10 @@ use turbopack_core::{
         StyledString,
     },
     module::Module,
-    module_graph::{GraphEntries, ModuleGraph, chunk_group_info::ChunkGroupEntry},
+    module_graph::{
+        GraphEntries, ModuleGraph,
+        chunk_group_info::{ChunkGroup, ChunkGroupEntry},
+    },
     output::{OutputAsset, OutputAssets},
     reference_type::{InnerAssets, ReferenceType},
     source::Source,
@@ -158,7 +161,7 @@ async fn emit_evaluate_pool_assets_operation(
 
     let bootstrap = chunking_context.root_entry_chunk_group_asset(
         entrypoint.clone(),
-        Vc::cell(entries.clone()),
+        ChunkGroup::Entry(entries.iter().cloned().map(ResolvedVc::upcast).collect()),
         *module_graph,
         OutputAssets::empty(),
         OutputAssets::empty(),

--- a/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
+++ b/turbopack/crates/turbopack-nodejs/src/chunking_context.rs
@@ -7,7 +7,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{
         AssetSuffix, Chunk, ChunkGroupResult, ChunkItem, ChunkType, ChunkableModule,
-        ChunkingConfig, ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAssets,
+        ChunkingConfig, ChunkingConfigs, ChunkingContext, EntryChunkGroupResult, EvaluatableAsset,
         MinifyType, SourceMapSourceType, SourceMapsType, UnusedReferences, UrlBehavior,
         availability_info::AvailabilityInfo,
         chunk_group::{MakeChunkGroupResult, make_chunk_group},
@@ -542,7 +542,7 @@ impl ChunkingContext for NodeJsChunkingContext {
     pub async fn entry_chunk_group(
         self: ResolvedVc<Self>,
         path: FileSystemPath,
-        evaluatable_assets: Vc<EvaluatableAssets>,
+        chunk_group: ChunkGroup,
         module_graph: Vc<ModuleGraph>,
         extra_chunks: Vc<OutputAssets>,
         extra_referenced_assets: Vc<OutputAssets>,
@@ -554,11 +554,7 @@ impl ChunkingContext for NodeJsChunkingContext {
             chunking_type = "entry",
         );
         async move {
-            let evaluatable_assets_ref = evaluatable_assets.await?;
-            let entries = evaluatable_assets_ref
-                .iter()
-                .map(|&asset| ResolvedVc::upcast::<Box<dyn Module>>(asset));
-
+            let entries = chunk_group.entries();
             let MakeChunkGroupResult {
                 chunks,
                 mut referenced_output_assets,
@@ -584,16 +580,24 @@ impl ChunkingContext for NodeJsChunkingContext {
 
             referenced_output_assets.extend(extra_referenced_assets.await?.iter().copied());
 
-            let Some(module) = ResolvedVc::try_sidecast(*evaluatable_assets_ref.last().unwrap())
+            let Some(module) = ResolvedVc::try_sidecast(chunk_group.entries().last().unwrap())
             else {
                 bail!("module must be placeable in an ecmascript chunk");
             };
+
+            let evaluatable_assets = chunk_group
+                .entries()
+                .map(|entry| {
+                    ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(entry)
+                        .context("entry_chunk_group entries must be evaluatable")
+                })
+                .collect::<Result<Vec<_>>>()?;
 
             let asset = ResolvedVc::upcast(
                 EcmascriptBuildNodeEntryChunk::new(
                     path,
                     Vc::cell(other_chunks),
-                    evaluatable_assets,
+                    Vc::cell(evaluatable_assets),
                     *module,
                     Vc::cell(referenced_output_assets),
                     Vc::cell(references),

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -5,7 +5,7 @@ mod util;
 
 use std::{collections::VecDeque, fs, io, path::PathBuf};
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result};
 use dunce::canonicalize;
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
@@ -30,7 +30,7 @@ use turbopack_core::{
     asset::Asset,
     chunk::{
         ChunkingConfig, ChunkingContext, ChunkingContextExt, EvaluatableAsset, EvaluatableAssetExt,
-        EvaluatableAssets, MinifyType, SourceMapSourceType, availability_info::AvailabilityInfo,
+        MinifyType, SourceMapSourceType, availability_info::AvailabilityInfo,
     },
     compile_time_defines,
     compile_time_info::{
@@ -51,7 +51,6 @@ use turbopack_core::{
     },
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
     reference_type::{EntryReferenceSubType, ReferenceType, UrlReferenceSubType},
-    source::Source,
 };
 use turbopack_ecmascript::{
     AnalyzeMode, EcmascriptInputTransform, TreeShakingMode, chunk::EcmascriptChunkType,
@@ -430,36 +429,22 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         Layer::new(rcstr!("test")),
     ));
 
-    let runtime_entries = maybe_load_env(asset_context, project_path.clone())
-        .await?
-        .map(|asset| EvaluatableAssets::one(asset.to_evaluatable(asset_context)));
-
     let entry_module = asset_context
         .process(
             Vc::upcast(FileSource::new(entry_asset)),
             ReferenceType::Entry(EntryReferenceSubType::Undefined),
         )
-        .module();
+        .module()
+        .to_resolved()
+        .await?;
 
-    let (evaluatable_assets, entry_modules) = if let Some(ecmascript) =
-        ResolvedVc::try_sidecast::<Box<dyn EvaluatableAsset>>(entry_module.to_resolved().await?)
-    {
-        let evaluatable_assets = runtime_entries
-            .unwrap_or_else(EvaluatableAssets::empty)
-            .with_entry(*ecmascript);
-        (
-            evaluatable_assets,
-            evaluatable_assets
-                .await?
-                .iter()
-                .copied()
-                .map(ResolvedVc::upcast)
-                .collect::<Vec<_>>(),
-        )
-    } else {
-        // TODO convert into a serve-able asset
-        bail!("Entry module is not chunkable, so it can't be used to bootstrap the application")
-    };
+    let entry_modules: Vec<ResolvedVc<Box<dyn Module>>> =
+        maybe_load_env(asset_context, project_path.clone())
+            .await?
+            .into_iter()
+            .map(ResolvedVc::upcast)
+            .chain(std::iter::once(entry_module))
+            .collect();
 
     let single_graph = SingleModuleGraph::new_with_entries(
         ResolvedVc::cell(vec![ChunkGroupEntry::Entry(entry_modules.clone())]),
@@ -607,7 +592,7 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
                             chunk_root_path
                                 .join(entry_module.ident().path().await?.file_stem().unwrap())?
                                 .with_extension("entry.js"),
-                            evaluatable_assets,
+                            ChunkGroup::Entry(entry_modules),
                             module_graph,
                             OutputAssets::empty(),
                             OutputAssets::empty(),
@@ -666,9 +651,9 @@ async fn walk_asset(
 }
 
 async fn maybe_load_env(
-    _context: Vc<Box<dyn AssetContext>>,
+    asset_context: Vc<Box<dyn AssetContext>>,
     path: FileSystemPath,
-) -> Result<Option<Vc<Box<dyn Source>>>> {
+) -> Result<Option<ResolvedVc<Box<dyn EvaluatableAsset>>>> {
     let dotenv_path = path.join("input/.env")?;
 
     if !dotenv_path.read().await?.is_content() {
@@ -676,6 +661,10 @@ async fn maybe_load_env(
     }
 
     let env = DotenvProcessEnv::new(None, dotenv_path.clone());
-    let asset = ProcessEnvAsset::new(dotenv_path, Vc::upcast(env));
-    Ok(Some(Vc::upcast(asset)))
+    let asset = ProcessEnvAsset::new(dotenv_path, Vc::upcast(env))
+        .to_evaluatable(asset_context)
+        .to_resolved()
+        .await?;
+
+    Ok(Some(asset))
 }


### PR DESCRIPTION
Now all of the chunking context functions accept `ChunkGroup`

The names are bad, but `entry_chunk_group` and `ChunkGroup::Entry` have nothing to do with each other:
- `entry_chunk_group` means: it's a standalone file where `node path/to/chunk.js` will execute it
- `ChunkGroup::Entry` = it's the top-level chunk group

For example a `evaluated_chunk_group(ChunkGroup::Entry)` is also fine

