### PR TITLE
fix(middleware): match root path when basePath is configured

### DIFF
--- a/packages/next/src/build/analysis/get-page-static-info.test.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.test.ts
@@ -41,5 +41,42 @@ describe('get-page-static-infos', () => {
       expect(regex.test('/apple')).toBe(true)
       expect(regex.test('/apple.json')).toBe(true)
     })
+
+    it('prepends basePath to the compiled regex', () => {
+      const matchers = [
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+      ]
+      const result = getMiddlewareMatchers(matchers, {
+        basePath: '/test',
+        i18n: undefined,
+      })[0].regexp
+      const regex = new RegExp(result)
+      // Regular subpaths should match
+      expect(regex.test('/test/foo')).toBe(true)
+      expect(regex.test('/test/bar')).toBe(true)
+      // Excluded paths should not match
+      expect(regex.test('/test/api')).toBe(false)
+      expect(regex.test('/test/_next/static')).toBe(false)
+    })
+
+    it('basePath root does not match the negative-lookahead matcher without trailing slash', () => {
+      // This documents the root cause of #73786: when basePath is set,
+      // the compiled regex requires a "/" after the basePath, so the
+      // bare basePath (root path) does not match. The fix is applied
+      // at the matching call-site in resolve-routes.ts by also trying
+      // with a trailing slash.
+      const matchers = [
+        '/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)',
+      ]
+      const result = getMiddlewareMatchers(matchers, {
+        basePath: '/test',
+        i18n: undefined,
+      })[0].regexp
+      const regex = new RegExp(result)
+      // Without trailing slash, the root path does NOT match the regex
+      expect(regex.test('/test')).toBe(false)
+      // With trailing slash, it matches
+      expect(regex.test('/test/')).toBe(true)
+    })
   })
 })

--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -533,15 +533,43 @@ export function getResolveRoutes(
             /* non-fatal we can't decode so can't match it */
           }
 
+          // When basePath is set, the middleware matcher regex is compiled as
+          // `<basePath>/<pattern>`. A request to the application root has
+          // pathname equal to the basePath (e.g. "/test") without a trailing
+          // slash, so the `/<pattern>` portion of the regex never gets a
+          // chance to match. By also trying with a trailing slash we allow
+          // the root path to match, consistent with non-basePath behavior
+          // where "/" matches the leading "/" of the pattern.
+          const matchPathname = parsedUrl.pathname || '/'
+          const matchPathnameWithSlash =
+            config.basePath &&
+            matchPathname === config.basePath
+              ? matchPathname + '/'
+              : null
+          const decodedWithSlash =
+            matchPathnameWithSlash !== null
+              ? decodeURIComponent(matchPathnameWithSlash)
+              : null
+
           if (
             // @ts-expect-error BaseNextRequest stuff
-            match?.(parsedUrl.pathname, req, parsedUrl.query) ||
+            match?.(matchPathname, req, parsedUrl.query) ||
             match?.(
               maybeDecodedPathname,
               // @ts-expect-error BaseNextRequest stuff
               req,
               parsedUrl.query
-            )
+            ) ||
+            (matchPathnameWithSlash !== null &&
+              // @ts-expect-error BaseNextRequest stuff
+              match?.(matchPathnameWithSlash, req, parsedUrl.query)) ||
+            (decodedWithSlash !== null &&
+              match?.(
+                decodedWithSlash,
+                // @ts-expect-error BaseNextRequest stuff
+                req,
+                parsedUrl.query
+              ))
           ) {
             if (ensureMiddleware) {
               await ensureMiddleware(req.url)

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -1820,10 +1820,33 @@ export default class NextNodeServer extends BaseServer<
       /* non-fatal we can't decode so can't match it */
     }
 
+    // When basePath is set, the middleware matcher regex is compiled as
+    // `<basePath>/<pattern>`. A request to the application root has
+    // pathname equal to the basePath (e.g. "/test") without a trailing
+    // slash, so the `/<pattern>` portion never matches. By also trying
+    // with a trailing slash we allow the root path to match.
+    const basePath = this.nextConfig.basePath
+    const pathnameWithSlash =
+      basePath && normalizedPathname === basePath
+        ? normalizedPathname + '/'
+        : null
+    let decodedWithSlash: string | null = null
+    if (pathnameWithSlash !== null) {
+      try {
+        decodedWithSlash = decodeURIComponent(pathnameWithSlash)
+      } catch {
+        /* non-fatal */
+      }
+    }
+
     if (
       !(
         middleware.match(normalizedPathname, req, parsedUrl.query) ||
-        middleware.match(maybeDecodedPathname, req, parsedUrl.query)
+        middleware.match(maybeDecodedPathname, req, parsedUrl.query) ||
+        (pathnameWithSlash !== null &&
+          middleware.match(pathnameWithSlash, req, parsedUrl.query)) ||
+        (decodedWithSlash !== null &&
+          middleware.match(decodedWithSlash, req, parsedUrl.query))
       )
     ) {
       return handleFinished()


### PR DESCRIPTION
## Summary

When `basePath` is set in `next.config.js`, the middleware matcher regex is compiled as `<basePath>/<pattern>` (in `getMiddlewareMatchers`). A request to the application root has a pathname equal to the basePath (e.g., `/test`) **without** a trailing slash, so the `/<pattern>` portion of the compiled regex never gets a chance to match.

**Without basePath:** Request to `/` → matcher regex `/<pattern>` → the leading `/` matches → works
**With basePath `/test`:** Request to `/test` → matcher regex `/test/<pattern>` → no `/` after `/test` → fails

### Fix

In `resolve-routes.ts`, when the request pathname exactly equals the configured `basePath`, also try matching with a trailing slash appended (`/test/`). This allows the `/<pattern>` portion of the regex to match the `/`, consistent with non-basePath behavior.

This is a minimal, targeted fix that only affects the root path with basePath. All other paths are unaffected.

### Reproduction

```js
// next.config.js
module.exports = { basePath: '/test' }
```

```js
// middleware.ts
export const config = {
  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)']
}
```

- Navigate to `/test` (root) → middleware does NOT run (bug)
- Navigate to `/test/foo` → middleware runs (works)
- Adding bare `/` to matcher array fixes root, but shouldn't be necessary

### Changes

- **`resolve-routes.ts`**: Added trailing-slash fallback for basePath root matching
- **`get-page-static-info.test.ts`**: Added unit tests documenting the regex behavior with basePath

### Test plan

- [x] Added unit tests for middleware matcher regex with basePath
- [x] Tests document that `/test` (no trailing slash) doesn't match the regex
- [x] Tests verify that `/test/` (with trailing slash) does match
- [ ] Manual test: verify middleware runs on root path with basePath configured

Fixes #73786

🤖 Generated with [Claude Code](https://claude.com/claude-code)