### PR TITLE
[otel] fix missing http.route attribute

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -549,6 +549,7 @@ export async function handler(
       interceptionRoutePatterns
     )
     res.setHeader('Vary', varyHeader)
+    let parentSpan: Span | undefined
     const invokeRouteModule = async (
       span: Span | undefined,
       context: AppPageRouteHandlerContext
@@ -592,6 +593,12 @@ export async function handler(
             'next.span_name': name,
           })
           span.updateName(name)
+
+          // Propagate http.route to the parent span if one exists (e.g.
+          // a platform-created HTTP span in adapter deployments).
+          if (parentSpan && parentSpan !== span) {
+            parentSpan.setAttribute('http.route', route)
+          }
         } else {
           span.updateName(`${method} ${srcPage}`)
         }
@@ -1597,6 +1604,7 @@ export async function handler(
     if (isWrappedByNextServer && activeSpan) {
       await handleResponse(activeSpan)
     } else {
+      parentSpan = tracer.getActiveScopeSpan()
       return await tracer.withPropagatedContext(
         req.headers,
         () =>

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -263,6 +263,7 @@ export async function handler(
   )
 
   try {
+    let parentSpan: Span | undefined
     const invokeRouteModule = async (span?: Span) => {
       return routeModule.handle(nextReq, context).finally(() => {
         if (!span) return
@@ -300,6 +301,12 @@ export async function handler(
             'next.span_name': name,
           })
           span.updateName(name)
+
+          // Propagate http.route to the parent span if one exists (e.g.
+          // a platform-created HTTP span in adapter deployments).
+          if (parentSpan && parentSpan !== span) {
+            parentSpan.setAttribute('http.route', route)
+          }
         } else {
           span.updateName(`${method} ${srcPage}`)
         }
@@ -497,6 +504,7 @@ export async function handler(
     if (isWrappedByNextServer && activeSpan) {
       await handleResponse(activeSpan)
     } else {
+      parentSpan = tracer.getActiveScopeSpan()
       await tracer.withPropagatedContext(
         req.headers,
         () =>

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -86,6 +86,7 @@ export async function handler(
     const onRequestError =
       routeModule.instrumentationOnRequestError.bind(routeModule)
 
+    let parentSpan: Span | undefined
     const invokeRouteModule = async (span?: Span) =>
       routeModule
         .render(req, res, {
@@ -147,6 +148,12 @@ export async function handler(
               'next.span_name': name,
             })
             span.updateName(name)
+
+            // Propagate http.route to the parent span if one exists (e.g.
+            // a platform-created HTTP span in adapter deployments).
+            if (parentSpan && parentSpan !== span) {
+              parentSpan.setAttribute('http.route', route)
+            }
           } else {
             span.updateName(`${method} ${srcPage}`)
           }
@@ -157,6 +164,7 @@ export async function handler(
     if (isWrappedByNextServer && activeSpan) {
       await invokeRouteModule(activeSpan)
     } else {
+      parentSpan = tracer.getActiveScopeSpan()
       await tracer.withPropagatedContext(
         req.headers,
         () =>

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -876,6 +876,13 @@ export default abstract class Server<
     const tracer = getTracer()
 
     return tracer.withPropagatedContext(req.headers, () => {
+      // Capture the parent span before creating the handleRequest span.
+      // When deployed with an adapter, the platform's runtime may create its
+      // own OTEL HTTP server span before Next.js runs. We propagate http.route
+      // to this parent span so APM tools (e.g. Datadog) can derive the
+      // resource name correctly.
+      const parentSpan = tracer.getActiveScopeSpan()
+
       return tracer.trace(
         BaseServerSpan.handleRequest,
         {
@@ -934,6 +941,14 @@ export default abstract class Server<
                 'next.span_name': name,
               })
               span.updateName(name)
+
+              // Propagate http.route to the parent span if one exists and
+              // is different from the handleRequest span. This ensures APM
+              // tools that read attributes from the outermost span (e.g.
+              // a platform-created HTTP span) can derive the resource name.
+              if (parentSpan && parentSpan !== span) {
+                parentSpan.setAttribute('http.route', route)
+              }
             } else {
               span.updateName(isRSCRequest ? `RSC ${method}` : `${method}`)
             }

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -236,6 +236,7 @@ export const getHandler = ({
         query: hasStaticProps ? {} : originalQuery,
       })
 
+      let parentSpan: Span | undefined
       const handleResponse = async (span?: Span) => {
         const responseGenerator: ResponseGenerator = async ({
           previousCacheEntry,
@@ -422,6 +423,13 @@ export const getHandler = ({
                       'next.span_name': name,
                     })
                     span.updateName(name)
+
+                    // Propagate http.route to the parent span if one exists
+                    // (e.g. a platform-created HTTP span in adapter
+                    // deployments).
+                    if (parentSpan && parentSpan !== span) {
+                      parentSpan.setAttribute('http.route', route)
+                    }
                   } else {
                     span.updateName(`${method} ${srcPage}`)
                   }
@@ -755,6 +763,7 @@ export const getHandler = ({
       if (activeSpan) {
         await handleResponse()
       } else {
+        parentSpan = tracer.getActiveScopeSpan()
         await tracer.withPropagatedContext(req.headers, () =>
           tracer.trace(
             BaseServerSpan.handleRequest,

--- a/test/e2e/app-dir/otel-parent-span-propagation/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/otel-parent-span-propagation/app/[slug]/page.tsx
@@ -1,0 +1,8 @@
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p>slug: {slug}</p>
+}

--- a/test/e2e/app-dir/otel-parent-span-propagation/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/otel-parent-span-propagation/app/[slug]/page.tsx
@@ -1,8 +1,20 @@
-export default async function Page({
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function SlugContent({ params }: { params: Promise<{ slug: string }> }) {
+  await connection()
+  const { slug } = await params
+  return <p>slug: {slug}</p>
+}
+
+export default function Page({
   params,
 }: {
   params: Promise<{ slug: string }>
 }) {
-  const { slug } = await params
-  return <p>slug: {slug}</p>
+  return (
+    <Suspense fallback={<p>loading...</p>}>
+      <SlugContent params={params} />
+    </Suspense>
+  )
 }

--- a/test/e2e/app-dir/otel-parent-span-propagation/app/layout.tsx
+++ b/test/e2e/app-dir/otel-parent-span-propagation/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/otel-parent-span-propagation/app/page.tsx
+++ b/test/e2e/app-dir/otel-parent-span-propagation/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/otel-parent-span-propagation/collector.ts
+++ b/test/e2e/app-dir/otel-parent-span-propagation/collector.ts
@@ -1,0 +1,62 @@
+import { Server as HttpServer } from 'node:http'
+import { SavedSpan } from './constants'
+
+export interface Collector {
+  getSpans: () => SavedSpan[]
+  shutdown: () => Promise<void>
+}
+
+export async function connectCollector({
+  port,
+}: {
+  port: number
+}): Promise<Collector> {
+  const spans: SavedSpan[] = []
+
+  const server = new HttpServer(async (req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405)
+      res.end()
+      return
+    }
+
+    const body = await new Promise<Buffer>((resolve, reject) => {
+      const acc: Buffer[] = []
+      req.on('data', (chunk: Buffer) => {
+        acc.push(chunk)
+      })
+      req.on('end', () => {
+        resolve(Buffer.concat(acc))
+      })
+      req.on('error', reject)
+    })
+
+    const newSpans = JSON.parse(body.toString('utf-8')) as SavedSpan[]
+    spans.push(...newSpans)
+    res.statusCode = 202
+    res.end()
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.listen(port, (err?: Error) => {
+      if (err) {
+        reject(err)
+      } else {
+        resolve()
+      }
+    })
+  })
+
+  return {
+    getSpans() {
+      return spans
+    },
+    shutdown() {
+      return new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      ).catch((err) => {
+        console.warn('WARN: collector server disconnect failure:', err)
+      })
+    },
+  }
+}

--- a/test/e2e/app-dir/otel-parent-span-propagation/constants.ts
+++ b/test/e2e/app-dir/otel-parent-span-propagation/constants.ts
@@ -1,0 +1,14 @@
+import { SpanKind } from '@opentelemetry/api'
+
+export type SavedSpan = {
+  runtime?: string
+  traceId?: string
+  parentId?: string
+  name?: string
+  id?: string
+  kind?: SpanKind
+  timestamp?: number
+  duration?: number
+  attributes?: Record<string, any>
+  status?: any
+}

--- a/test/e2e/app-dir/otel-parent-span-propagation/instrumentation.ts
+++ b/test/e2e/app-dir/otel-parent-span-propagation/instrumentation.ts
@@ -1,0 +1,88 @@
+import { Resource } from '@opentelemetry/resources'
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions'
+import {
+  SimpleSpanProcessor,
+  SpanExporter,
+  ReadableSpan,
+  BasicTracerProvider,
+} from '@opentelemetry/sdk-trace-base'
+import { AsyncLocalStorageContextManager } from '@opentelemetry/context-async-hooks'
+import {
+  ExportResult,
+  ExportResultCode,
+  hrTimeToMicroseconds,
+} from '@opentelemetry/core'
+
+import { SavedSpan } from './constants'
+
+const serializeSpan = (span: ReadableSpan): SavedSpan => ({
+  runtime: process.env.NEXT_RUNTIME,
+  traceId: span.spanContext().traceId,
+  parentId: span.parentSpanId,
+  name: span.name,
+  id: span.spanContext().spanId,
+  kind: span.kind,
+  timestamp: hrTimeToMicroseconds(span.startTime),
+  duration: hrTimeToMicroseconds(span.duration),
+  attributes: span.attributes,
+  status: span.status,
+})
+
+class TestExporter implements SpanExporter {
+  constructor(private port: number) {}
+
+  async export(
+    spans: ReadableSpan[],
+    resultCallback: (result: ExportResult) => void
+  ) {
+    try {
+      const response = await fetch(`http://localhost:${this.port}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(spans.map(serializeSpan)),
+      })
+      try {
+        await response.arrayBuffer()
+      } catch (e) {
+        // ignore.
+      }
+      if (response.status >= 400) {
+        resultCallback({
+          code: ExportResultCode.FAILED,
+          error: new Error(`http status ${response.status}`),
+        })
+        return
+      }
+      resultCallback({ code: ExportResultCode.SUCCESS })
+    } catch (e) {
+      resultCallback({ code: ExportResultCode.FAILED, error: e })
+    }
+  }
+  shutdown(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+export async function register() {
+  if (!process.env.TEST_OTEL_COLLECTOR_PORT) {
+    throw new Error('TEST_OTEL_COLLECTOR_PORT is not set')
+  }
+  const port = parseInt(process.env.TEST_OTEL_COLLECTOR_PORT)
+
+  const contextManager = new AsyncLocalStorageContextManager()
+  contextManager.enable()
+
+  const provider = new BasicTracerProvider({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: 'test-next-app',
+    }),
+  })
+
+  provider.addSpanProcessor(new SimpleSpanProcessor(new TestExporter(port)))
+
+  provider.register({
+    contextManager,
+  })
+}

--- a/test/e2e/app-dir/otel-parent-span-propagation/next.config.js
+++ b/test/e2e/app-dir/otel-parent-span-propagation/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/otel-parent-span-propagation/otel-parent-span-propagation.test.ts
+++ b/test/e2e/app-dir/otel-parent-span-propagation/otel-parent-span-propagation.test.ts
@@ -1,0 +1,73 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { type Collector, connectCollector } from './collector'
+
+const COLLECTOR_PORT = 9876
+
+describe('otel-parent-span-propagation', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    dependencies: require('./package.json').dependencies,
+    env: {
+      TEST_OTEL_COLLECTOR_PORT: String(COLLECTOR_PORT),
+      NEXT_TELEMETRY_DISABLED: '1',
+    },
+  })
+
+  if (skipped) {
+    return
+  }
+
+  let collector: Collector
+
+  beforeEach(async () => {
+    collector = await connectCollector({ port: COLLECTOR_PORT })
+  })
+
+  afterEach(async () => {
+    await collector.shutdown()
+  })
+
+  // Verifies that http.route is set on the handleRequest span.
+  // In production, when external OTEL instrumentation (e.g. Datadog,
+  // @opentelemetry/instrumentation-http) creates a parent HTTP server span,
+  // our fix also propagates http.route to that parent span so APM tools
+  // derive the resource name correctly (e.g. "GET /[slug]" instead of "GET").
+  // Parent span propagation is verified manually in production environments.
+  it('should set http.route on handleRequest span for dynamic routes', async () => {
+    await next.fetch('/test-slug')
+
+    await retry(async () => {
+      const spans = collector.getSpans()
+
+      const handleRequestSpan = spans.find(
+        (s) =>
+          s.attributes?.['next.span_type'] === 'BaseServer.handleRequest' &&
+          s.attributes?.['http.target'] === '/test-slug'
+      )
+      expect(handleRequestSpan).toBeDefined()
+      expect(handleRequestSpan!.attributes?.['http.route']).toBe('/[slug]')
+      expect(handleRequestSpan!.attributes?.['next.route']).toBe('/[slug]')
+      expect(handleRequestSpan!.name).toBe('GET /[slug]')
+    })
+  })
+
+  it('should set http.route on handleRequest span for static routes', async () => {
+    await next.fetch('/')
+
+    await retry(async () => {
+      const spans = collector.getSpans()
+
+      const handleRequestSpan = spans.find(
+        (s) =>
+          s.attributes?.['next.span_type'] === 'BaseServer.handleRequest' &&
+          s.attributes?.['http.target'] === '/'
+      )
+      expect(handleRequestSpan).toBeDefined()
+      expect(handleRequestSpan!.attributes?.['http.route']).toBe('/')
+      expect(handleRequestSpan!.attributes?.['next.route']).toBe('/')
+      expect(handleRequestSpan!.name).toBe('GET /')
+    })
+  })
+})

--- a/test/e2e/app-dir/otel-parent-span-propagation/package.json
+++ b/test/e2e/app-dir/otel-parent-span-propagation/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/context-async-hooks": "^1.21.0",
+    "@opentelemetry/core": "^1.21.0",
+    "@opentelemetry/resources": "^1.21.0",
+    "@opentelemetry/sdk-trace-base": "^1.21.0",
+    "@opentelemetry/semantic-conventions": "^1.21.0"
+  }
+}


### PR DESCRIPTION
Propagate http.route to parent OTEL span

When external OTEL instrumentation creates an HTTP server span before Next.js handles the request, Next.js sets `http.route` only on its own child `handleRequest` span. APM tools like Datadog derive `resource_name` from the outermost span — which never received the attribute. This caused resource names to show as "POST" instead of "POST /api/foo".

After setting `http.route` on the Next.js span, we now also propagate it to the parent span if one exists. This is applied across all handler code paths:
base-server.ts, and the app-route, app-page, pages-api, and pages templates.