### PR TITLE
Remove leaf segment force-refetch check

### DIFF
--- a/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
+++ b/packages/next/src/server/app-render/walk-tree-with-flight-router-state.tsx
@@ -99,8 +99,6 @@ export async function walkTreeWithFlightRouterState({
     !flightRouterState ||
     // Segment in router state does not match current segment
     !matchSegment(actualSegment, flightRouterState[0]) ||
-    // Last item in the tree
-    parallelRoutesKeys.length === 0 ||
     // Explicit refresh
     flightRouterState[3] === 'refetch'
 


### PR DESCRIPTION
Remove the `parallelRoutesKeys.length === 0` condition from `renderComponentsOnThisLevel` in walk-tree-with-flight-router-state.

This check was added to support the behavior where clicking the same link twice forces all page segments to re-render on the server. This should no longer be necessary because the client already adds a refetch marker on those segments, so there's no need to special-case leaf segments on the server side.