### PR TITLE
Turbopack: Annotate ReadVcFuture as must_use instead of annotating functions that return it

### DIFF
--- a/turbopack/crates/turbo-tasks/src/raw_vc.rs
+++ b/turbopack/crates/turbo-tasks/src/raw_vc.rs
@@ -316,6 +316,7 @@ impl<F: Future> Future for SuppressTopLevelTaskCheckFuture<F> {
     }
 }
 
+#[must_use]
 pub struct ReadRawVcFuture {
     current: RawVc,
     read_output_options: ReadOutputOptions,

--- a/turbopack/crates/turbo-tasks/src/vc/mod.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/mod.rs
@@ -566,7 +566,6 @@ where
 {
     /// Do not use this: Use [`OperationVc::read_strongly_consistent`] instead.
     #[cfg(feature = "non_operation_vc_strongly_consistent")]
-    #[must_use]
     pub fn strongly_consistent(self) -> ReadVcFuture<T> {
         self.node
             .into_read(T::has_serialization())
@@ -576,7 +575,6 @@ where
 
     /// Returns a untracked read of the value. This will not invalidate the current function when
     /// the read value changed.
-    #[must_use]
     pub fn untracked(self) -> ReadVcFuture<T> {
         self.node
             .into_read(T::has_serialization())
@@ -586,7 +584,6 @@ where
 
     /// Read the value with the hint that this is the final read of the value. This might drop the
     /// cell content. Future reads might need to recompute the value.
-    #[must_use]
     pub fn final_read_hint(self) -> ReadVcFuture<T> {
         self.node
             .into_read(T::has_serialization())

--- a/turbopack/crates/turbo-tasks/src/vc/operation.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/operation.rs
@@ -130,7 +130,6 @@ impl<T: ?Sized> OperationVc<T> {
     /// consistent][crate::ReadConsistency::Strong] read of the value.
     ///
     /// This ensures that all internal tasks are finished before the read is returned.
-    #[must_use]
     pub fn read_strongly_consistent(self) -> ReadVcFuture<T>
     where
         T: VcValueType,

--- a/turbopack/crates/turbo-tasks/src/vc/read.rs
+++ b/turbopack/crates/turbo-tasks/src/vc/read.rs
@@ -144,6 +144,7 @@ where
     }
 }
 
+#[must_use]
 pub struct ReadVcFuture<T, Cast = VcValueTypeCast<T>>
 where
     T: ?Sized,


### PR DESCRIPTION
It's a little less error-prone if it's in one place (on the type) than in many (on the functions). I also added it to `ReadRawVcFuture`.

https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute

- **Are these equivalent?** Yes.
- **The** **`Future`** **trait already has this annotation, why do we need it on the type?** The annotation on the trait only applies if the function returns `impl Future` or `dyn Future`. Our functions return the named type.