### PR TITLE
bundle-analyzer: fix import chain lookup for merged _app modules

### DIFF
--- a/apps/bundle-analyzer/app/page.tsx
+++ b/apps/bundle-analyzer/app/page.tsx
@@ -20,7 +20,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { MultiSelect } from '@/components/ui/multi-select'
-import { AnalyzeData, ModulesData } from '@/lib/analyze-data'
+import { AnalyzeData, ModulesData, mergeAnalyzeData } from '@/lib/analyze-data'
 import { computeActiveEntries, computeModuleDepthMap } from '@/lib/module-graph'
 import { fetchStrict } from '@/lib/utils'
 import { formatBytes } from '@/lib/utils'
@@ -81,6 +81,22 @@ export default function Home() {
     },
   })
 
+  // Always try to load _app route data so its modules can be merged into the
+  // current route's view. Returns null gracefully when no _app route exists.
+  const { data: appRouteData } = useSWR<AnalyzeData | null>(
+    'data/_app/analyze.data',
+    fetchOptionalAnalyzeData,
+    { revalidateOnFocus: false, revalidateOnReconnect: false }
+  )
+
+  // Merge _app modules into the current route's data for visualization.
+  // Skip when viewing _app itself to avoid double-counting.
+  const mergedAnalyzeData = useMemo(() => {
+    if (!analyzeData) return undefined
+    if (!appRouteData || selectedRoute === '/_app') return analyzeData
+    return mergeAnalyzeData(analyzeData, appRouteData, '_app')
+  }, [analyzeData, appRouteData, selectedRoute])
+
   const [sidebarWidth, setSidebarWidth] = useState(20) // percentage
   const [isResizing, setIsResizing] = useState(false)
   const [isMouseInTreemap, setIsMouseInTreemap] = useState(false)
@@ -102,7 +118,7 @@ export default function Home() {
 
         if (!isInputFocused) {
           e.preventDefault()
-          const rootSourceIndex = getRootSourceIndex(analyzeData)
+          const rootSourceIndex = getRootSourceIndex(mergedAnalyzeData)
           setSelectedSourceIndex(rootSourceIndex)
           setFocusedSourceIndex(rootSourceIndex)
         }
@@ -111,21 +127,21 @@ export default function Home() {
 
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [analyzeData])
+  }, [mergedAnalyzeData])
 
   // Compute module depth map from active entries
   const moduleDepthMap = useMemo(() => {
-    if (!modulesData || !analyzeData) return new Map()
+    if (!modulesData || !mergedAnalyzeData) return new Map()
 
-    const activeEntries = computeActiveEntries(modulesData, analyzeData)
+    const activeEntries = computeActiveEntries(modulesData, mergedAnalyzeData)
     return computeModuleDepthMap(modulesData, activeEntries)
-  }, [modulesData, analyzeData])
+  }, [modulesData, mergedAnalyzeData])
 
   const filterSource = useMemo(() => {
-    if (!analyzeData) return () => true
+    if (!mergedAnalyzeData) return () => true
 
     return (sourceIndex: number) => {
-      const flags = analyzeData.getSourceFlags(sourceIndex)
+      const flags = mergedAnalyzeData.getSourceFlags(sourceIndex)
 
       // Check environment filter
       const hasEnvironment =
@@ -141,7 +157,7 @@ export default function Home() {
 
       return hasEnvironment && hasType
     }
-  }, [analyzeData, environmentFilter, typeFilter])
+  }, [mergedAnalyzeData, environmentFilter, typeFilter])
 
   const handleMouseDown = () => {
     setIsResizing(true)
@@ -159,7 +175,7 @@ export default function Home() {
 
   const error = analyzeError || modulesError
   const isAnyLoading = isAnalyzeLoading || isModulesLoading
-  const rootSourceIndex = getRootSourceIndex(analyzeData)
+  const rootSourceIndex = getRootSourceIndex(mergedAnalyzeData)
 
   return (
     <main
@@ -168,7 +184,7 @@ export default function Home() {
       onMouseUp={handleMouseUp}
     >
       <TopBar
-        analyzeData={analyzeData}
+        analyzeData={mergedAnalyzeData}
         selectedRoute={selectedRoute}
         setSelectedRoute={setSelectedRoute}
         environmentFilter={environmentFilter}
@@ -207,11 +223,11 @@ export default function Home() {
               isLoading={true}
             />
           </>
-        ) : analyzeData ? (
+        ) : mergedAnalyzeData ? (
           <>
             <div className="flex-1 min-w-0">
               <TreemapVisualizer
-                analyzeData={analyzeData}
+                analyzeData={mergedAnalyzeData}
                 sourceIndex={rootSourceIndex}
                 selectedSourceIndex={selectedSourceIndex ?? rootSourceIndex}
                 onSelectSourceIndex={setSelectedSourceIndex}
@@ -235,7 +251,7 @@ export default function Home() {
 
             <Sidebar
               sidebarWidth={sidebarWidth}
-              analyzeData={analyzeData ?? null}
+              analyzeData={mergedAnalyzeData ?? null}
               modulesData={modulesData ?? null}
               selectedSourceIndex={selectedSourceIndex}
               moduleDepthMap={moduleDepthMap}
@@ -246,7 +262,7 @@ export default function Home() {
         ) : null}
       </div>
 
-      {analyzeData && (
+      {mergedAnalyzeData && (
         <div className="flex-none border-t border-border bg-background px-4 py-2 h-10">
           <div className="text-sm text-muted-foreground">
             {hoveredNodeInfo ? (
@@ -396,6 +412,19 @@ function getRootSourceIndex(analyzeData: AnalyzeData | undefined): number {
 async function fetchAnalyzeData(url: string): Promise<AnalyzeData> {
   const resp = await fetchStrict(url)
   return new AnalyzeData(await resp.arrayBuffer())
+}
+
+async function fetchOptionalAnalyzeData(
+  url: string
+): Promise<AnalyzeData | null> {
+  let res: Response
+  try {
+    res = await fetch(url)
+  } catch {
+    return null
+  }
+  if (!res.ok) return null
+  return new AnalyzeData(await res.arrayBuffer())
 }
 
 async function fetchModulesData(url: string): Promise<ModulesData> {

--- a/apps/bundle-analyzer/lib/analyze-data.ts
+++ b/apps/bundle-analyzer/lib/analyze-data.ts
@@ -518,11 +518,16 @@ export function mergeAnalyzeData(
     // Synthetic label directory, child of the base root
     { path: `[${label}]/`, parent_source_index: baseRootIdx },
     // Extra sources with remapped parent indices.
+    // Root sources (parent_source_index === null) keep null so that
+    // getFullSourcePath() returns the original path (e.g. "[root]/path/moment.js")
+    // matching what modulesData stores, so import-chain lookups work correctly.
+    // They still appear under the synthetic label dir via source_children edges,
+    // which are built separately and do not derive from parent_source_index.
     ...extraHeader.sources.map((s) => ({
       path: s.path,
       parent_source_index:
         s.parent_source_index === null
-          ? syntheticDirIdx
+          ? null
           : s.parent_source_index + extraSourceOffset,
     })),
   ]

--- a/apps/bundle-analyzer/lib/analyze-data.ts
+++ b/apps/bundle-analyzer/lib/analyze-data.ts
@@ -483,3 +483,193 @@ export class AnalyzeData {
     return this.analyzeHeader
   }
 }
+
+/**
+ * Merges `extra` analyze data into `base`, nesting extra's modules under a
+ * synthetic `[${label}]/` directory that is added as a child of the base root.
+ * All source/chunk-part/output-file indices are remapped so the returned
+ * AnalyzeData is self-consistent and can be used directly for visualization.
+ */
+export function mergeAnalyzeData(
+  base: AnalyzeData,
+  extra: AnalyzeData,
+  label: string
+): AnalyzeData {
+  const baseHeader = base.getRawAnalyzeHeader()
+  const extraHeader = extra.getRawAnalyzeHeader()
+
+  const N = base.sourceCount() // base source count
+  const P = base.chunkPartCount() // base chunk part count
+  const F = base.outputFileCount() // base output file count
+  const M = extra.sourceCount() // extra source count
+
+  // The synthetic label directory is inserted at index N.
+  // Extra sources occupy indices N+1 .. N+M.
+  const syntheticDirIdx = N
+  const extraSourceOffset = N + 1
+
+  const baseRoots = base.sourceRoots()
+  const baseRootIdx = baseRoots[0] ?? 0
+  const extraRoots = extra.sourceRoots()
+
+  // ---- Merged sources ----
+  const mergedSources: AnalyzeSource[] = [
+    ...baseHeader.sources,
+    // Synthetic label directory, child of the base root
+    { path: `[${label}]/`, parent_source_index: baseRootIdx },
+    // Extra sources with remapped parent indices.
+    ...extraHeader.sources.map((s) => ({
+      path: s.path,
+      parent_source_index:
+        s.parent_source_index === null
+          ? syntheticDirIdx
+          : s.parent_source_index + extraSourceOffset,
+    })),
+  ]
+
+  // ---- Merged chunk parts ----
+  const mergedChunkParts: AnalyzeChunkPart[] = [
+    ...baseHeader.chunk_parts,
+    ...extraHeader.chunk_parts.map((cp) => ({
+      source_index: cp.source_index + extraSourceOffset,
+      output_file_index: cp.output_file_index + F,
+      size: cp.size,
+      compressed_size: cp.compressed_size,
+    })),
+  ]
+
+  // ---- Merged output files ----
+  const mergedOutputFiles: AnalyzeOutputFile[] = [
+    ...baseHeader.output_files,
+    ...extraHeader.output_files,
+  ]
+
+  // ---- Build source_children edge lists ----
+  const mergedSourceChildren: number[][] = new Array(N + 1 + M)
+  for (let i = 0; i < N; i++) {
+    const children = base.sourceChildren(i)
+    mergedSourceChildren[i] =
+      i === baseRootIdx ? [...children, syntheticDirIdx] : children
+  }
+  // Synthetic dir's children = extra's roots (remapped)
+  mergedSourceChildren[syntheticDirIdx] = extraRoots.map(
+    (r) => r + extraSourceOffset
+  )
+  for (let i = 0; i < M; i++) {
+    mergedSourceChildren[N + 1 + i] = extra
+      .sourceChildren(i)
+      .map((j) => j + extraSourceOffset)
+  }
+
+  // ---- Build source_chunk_parts edge lists ----
+  const mergedSourceChunkParts: number[][] = new Array(N + 1 + M)
+  for (let i = 0; i < N; i++) {
+    mergedSourceChunkParts[i] = base.sourceChunkParts(i)
+  }
+  mergedSourceChunkParts[syntheticDirIdx] = []
+  for (let i = 0; i < M; i++) {
+    mergedSourceChunkParts[N + 1 + i] = extra
+      .sourceChunkParts(i)
+      .map((j) => j + P)
+  }
+
+  // ---- Build output_file_chunk_parts edge lists ----
+  const mergedOutputFileChunkParts: number[][] = []
+  for (let i = 0; i < base.outputFileCount(); i++) {
+    mergedOutputFileChunkParts.push(base.outputFileChunkParts(i))
+  }
+  for (let i = 0; i < extra.outputFileCount(); i++) {
+    mergedOutputFileChunkParts.push(
+      extra.outputFileChunkParts(i).map((j) => j + P)
+    )
+  }
+
+  // ---- Encode an edge list into the binary CSR format ----
+  function encodeEdges(allEdges: number[][]): Uint8Array {
+    const n = allEdges.length
+    if (n === 0) return new Uint8Array(0)
+
+    const totalEdges = allEdges.reduce((sum, e) => sum + e.length, 0)
+    const byteLength = 4 + n * 4 + totalEdges * 4
+    const buf = new ArrayBuffer(byteLength)
+    const view = new DataView(buf)
+    let pos = 0
+
+    view.setUint32(pos, n, false)
+    pos += 4
+
+    let cumulative = 0
+    for (const edgeList of allEdges) {
+      cumulative += edgeList.length
+      view.setUint32(pos, cumulative, false)
+      pos += 4
+    }
+
+    for (const edgeList of allEdges) {
+      for (const edge of edgeList) {
+        view.setUint32(pos, edge, false)
+        pos += 4
+      }
+    }
+
+    return new Uint8Array(buf)
+  }
+
+  const sourceChildrenBytes = encodeEdges(mergedSourceChildren)
+  const sourceChunkPartsBytes = encodeEdges(mergedSourceChunkParts)
+  const outputFileChunkPartsBytes = encodeEdges(mergedOutputFileChunkParts)
+
+  // ---- Compute binary section layout (offsets are within binary section) ----
+  let binaryOffset = 0
+
+  const sourceChildrenRef: EdgesDataReference = {
+    offset: binaryOffset,
+    length: sourceChildrenBytes.byteLength,
+  }
+  binaryOffset += sourceChildrenBytes.byteLength
+
+  const sourceChunkPartsRef: EdgesDataReference = {
+    offset: binaryOffset,
+    length: sourceChunkPartsBytes.byteLength,
+  }
+  binaryOffset += sourceChunkPartsBytes.byteLength
+
+  const outputFileChunkPartsRef: EdgesDataReference = {
+    offset: binaryOffset,
+    length: outputFileChunkPartsBytes.byteLength,
+  }
+  binaryOffset += outputFileChunkPartsBytes.byteLength
+
+  // ---- Assemble header ----
+  const mergedHeader: AnalyzeDataHeader = {
+    sources: mergedSources,
+    chunk_parts: mergedChunkParts,
+    output_files: mergedOutputFiles,
+    output_file_chunk_parts: outputFileChunkPartsRef,
+    source_chunk_parts: sourceChunkPartsRef,
+    source_children: sourceChildrenRef,
+    source_roots: [...baseRoots],
+  }
+
+  const headerBytes = new TextEncoder().encode(JSON.stringify(mergedHeader))
+  const totalSize = 4 + headerBytes.byteLength + binaryOffset
+  const finalBuffer = new ArrayBuffer(totalSize)
+  const finalView = new DataView(finalBuffer)
+  const finalBytes = new Uint8Array(finalBuffer)
+
+  finalView.setUint32(0, headerBytes.byteLength, false)
+  finalBytes.set(headerBytes, 4)
+
+  const binaryStart = 4 + headerBytes.byteLength
+  finalBytes.set(sourceChildrenBytes, binaryStart + sourceChildrenRef.offset)
+  finalBytes.set(
+    sourceChunkPartsBytes,
+    binaryStart + sourceChunkPartsRef.offset
+  )
+  finalBytes.set(
+    outputFileChunkPartsBytes,
+    binaryStart + outputFileChunkPartsRef.offset
+  )
+
+  return new AnalyzeData(finalBuffer)
+}


### PR DESCRIPTION
## Summary

Fixes "No dependents found" in the Import Chain sidebar for modules that were merged in from `_app` (introduced in #90841).

**Root cause:** When `_app` root sources had `parent_source_index` set to the synthetic `[_app]/` directory index, `getFullSourcePath()` would return `[_app]/[root]/.../moment.js`. But `modulesData` stores paths as `[root]/.../moment.js` (without the `[_app]/` prefix), so the module-graph lookup returned empty results.

**Fix:** Keep `parent_source_index = null` for extra root sources, preserving their original paths for module-graph lookups. The treemap still shows them under `[_app]/` because `source_children` edges (used for downward treemap traversal) are built separately and are independent of `parent_source_index` (used for upward path reconstruction).

## Test plan

- [ ] Add `moment` import in `pages/_app.tsx`
- [ ] Run `next experimental-analyze`, open the analyzer
- [ ] Select a pages route, find `moment` in the treemap under `[_app]/`
- [ ] Click `moment` and verify the Import Chain shows a real dependency trace
- [ ] Verify "No dependents found" no longer appears