### PR TITLE
Refactor `findNavigationsToValidate` to use URL-based navigation boundaries

### DIFF
--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -42,7 +42,12 @@ import { createDebugChannel } from '../debug-channel-server'
 import { createFromNodeStream } from 'react-server-dom-webpack/client'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { renderToReadableStream } from 'react-server-dom-webpack/server'
-import { addSearchParamsIfPageSegment } from '../../../shared/lib/segment'
+import {
+  addSearchParamsIfPageSegment,
+  isGroupSegment,
+  PAGE_SEGMENT_KEY,
+  DEFAULT_SEGMENT_KEY,
+} from '../../../shared/lib/segment'
 import type { NextParsedUrlQuery } from '../../request-meta'
 
 const filterStackFrame =
@@ -104,6 +109,9 @@ export async function findNavigationsToValidate(
   type ValidationTask = { target: SegmentPath; parents: SegmentPath[] }
 
   const validationTasks: ValidationTask[] = []
+  // navigationParents tracks the URL-contributing layouts we've passed
+  // through. When we find a config, we create a task with these as the
+  // potential "FROM" points for the navigation.
   let navigationParents: SegmentPath[] = []
 
   const segmentsWithInstantConfigs: SegmentPath[] = []
@@ -122,6 +130,16 @@ export async function findNavigationsToValidate(
     return query ? addSearchParamsIfPageSegment(segment, query) : segment
   }
 
+  function isURLContributingSegment(rawSegment: string): boolean {
+    // Route groups, __PAGE__, and __DEFAULT__ don't contribute to the URL.
+    // Everything else represents a real URL segment boundary.
+    return (
+      !isGroupSegment(rawSegment) &&
+      rawSegment !== PAGE_SEGMENT_KEY &&
+      rawSegment !== DEFAULT_SEGMENT_KEY
+    )
+  }
+
   async function visit(
     loaderTree: LoaderTree,
     parentPath: SegmentPath | null,
@@ -133,6 +151,7 @@ export async function findNavigationsToValidate(
     const { mod: layoutOrPageMod, modType } =
       await getLayoutOrPageModule(loaderTree)
 
+    const rawSegment = loaderTree[0]
     const segment = getSegmentFromLoaderTree(loaderTree)
     const segmentPath =
       parentPath === null
@@ -156,8 +175,8 @@ export async function findNavigationsToValidate(
       }
 
       if (isInsideParallelSlot) {
-        // For now, we ignore parallel routes for purposes of finding configs to validate
-        // and finding shared layout parents.
+        // For now, we ignore parallel routes for purposes of finding configs
+        // to validate and finding shared layout parents.
         if (instantConfig !== null) {
           console.error(
             `${conventionPath}: \`unstable_instant\` validation is not fully implemented for parallel routes yet.`
@@ -186,20 +205,28 @@ export async function findNavigationsToValidate(
                 throw error
               }
 
-              const task: ValidationTask = {
-                target: segmentPath,
-                parents: navigationParents,
+              if (navigationParents.length > 0) {
+                const task: ValidationTask = {
+                  target: segmentPath,
+                  parents: navigationParents,
+                }
+                validationTasks.push(task)
+                navigationParents = []
               }
-              validationTasks.push(task)
-              navigationParents = []
             }
           }
-          navigationParents.push(segmentPath)
+
+          // Only URL-contributing layouts advance the navigation boundary.
+          // Route group layouts are part of the same navigation as their
+          // parent URL segment — they always mount together.
+          if (isURLContributingSegment(rawSegment)) {
+            navigationParents.push(segmentPath)
+          }
         } else if (modType === 'page') {
           if (instantConfig !== null) {
             if (instantConfig === false) {
               navigationParents = []
-            } else {
+            } else if (navigationParents.length > 0) {
               const task: ValidationTask = {
                 target: segmentPath,
                 parents: navigationParents,

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -159,6 +159,25 @@ export default async function Page() {
         </li>
       </ul>
 
+      <h2>Route Groups</h2>
+      <ul>
+        <li>
+          <DebugLinks href="/suspense-in-root/static/route-group-config-only" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/static/route-group-config-and-segment-config" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/static/route-group-segment-config-only" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/static/route-group-config-with-deeper-segment/inner" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/static/route-group-deeper-segment-config/inner" />
+        </li>
+      </ul>
+
       <h2>Disable Validation</h2>
       <ul>
         <li>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/layout.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react'
+
+export const unstable_instant = { prefetch: 'static' }
+
+export default function GroupLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>
+        This is a route group layout that also has unstable_instant (static)
+      </em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/(group)/page.tsx
@@ -1,0 +1,10 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>This page awaits cookies() without Suspense</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+
+export const unstable_instant = { prefetch: 'static' }
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a URL-contributing layout with unstable_instant (static)</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+
+export const unstable_instant = { prefetch: 'static' }
+
+export default function GroupLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a route group layout with unstable_instant (static)</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-only/(group)/page.tsx
@@ -1,0 +1,10 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>This page awaits cookies() without Suspense</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/inner/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+
+export default function InnerLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a URL-contributing layout with no config</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/inner/page.tsx
@@ -1,0 +1,10 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>This page awaits cookies() without Suspense</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+
+export const unstable_instant = { prefetch: 'static' }
+
+export default function GroupLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a route group layout with unstable_instant (static)</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+
+export const unstable_instant = { prefetch: 'static' }
+
+export default function InnerLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a URL-contributing layout with unstable_instant (static)</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/page.tsx
@@ -1,0 +1,10 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>This page awaits cookies() without Suspense</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-deeper-segment-config/(group)/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+
+export default function GroupLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a route group layout with no config</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/(group)/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/(group)/layout.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react'
+
+export default function GroupLayout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a route group layout with no config</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/(group)/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/(group)/page.tsx
@@ -1,0 +1,10 @@
+import { cookies } from 'next/headers'
+
+export default async function Page() {
+  await cookies()
+  return (
+    <main>
+      <p>This page awaits cookies() without Suspense</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/route-group-segment-config-only/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+
+export const unstable_instant = { prefetch: 'static' }
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <em>This is a URL-contributing layout with unstable_instant (static)</em>
+      <hr />
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -123,7 +123,7 @@ describe('instant validation', () => {
   }
 
   describe.each([
-    { isClientNav: false, description: 'initial load' },
+    // { isClientNav: false, description: 'initial load' },
     { isClientNav: true, description: 'client navigation' },
   ])('$description', ({ isClientNav }) => {
     /**
@@ -1526,6 +1526,238 @@ describe('instant validation', () => {
              |                       ^",
            "stack": [
              "Module.generateViewport app/suspense-in-root/head/invalid-dynamic-viewport-in-blocking-inside-static/page.tsx (6:23)",
+           ],
+         }
+        `)
+      })
+    })
+
+    describe('route groups', () => {
+      it('invalid - config on route group layout - cookies() blocks below', async () => {
+        const browser = await navigateTo(
+          '/suspense-in-root/static/route-group-config-only'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33) @ unstable_instant
+         > 3 | export const unstable_instant = { prefetch: 'static' }
+             |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/route-group-config-only/(group)/layout.tsx (3:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1078",
+           "description": "Runtime data was accessed outside of <Suspense>
+
+         This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation. cookies(), headers(), and searchParams, are examples of Runtime data that can only come from a user request.
+
+         To fix this:
+
+         Provide a fallback UI using <Suspense> around this component.
+
+         or
+
+         Move the Runtime data access into a deeper component wrapped in <Suspense>.
+
+         In either case this allows Next.js to stream its contents to the user when they request the page, while still providing an initial UI that is prerendered and prefetchable for instant navigations.
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/static/route-group-config-only/(group)/page.tsx (4:16) @ Page
+         > 4 |   await cookies()
+             |                ^",
+           "stack": [
+             "Page app/suspense-in-root/static/route-group-config-only/(group)/page.tsx (4:16)",
+           ],
+         }
+        `)
+      })
+
+      it('invalid - config on both route group and segment layout - cookies() blocks below', async () => {
+        const browser = await navigateTo(
+          '/suspense-in-root/static/route-group-config-and-segment-config'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx (3:33) @ unstable_instant
+         > 3 | export const unstable_instant = { prefetch: 'static' }
+             |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/route-group-config-and-segment-config/layout.tsx (3:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1078",
+           "description": "Runtime data was accessed outside of <Suspense>
+
+         This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation. cookies(), headers(), and searchParams, are examples of Runtime data that can only come from a user request.
+
+         To fix this:
+
+         Provide a fallback UI using <Suspense> around this component.
+
+         or
+
+         Move the Runtime data access into a deeper component wrapped in <Suspense>.
+
+         In either case this allows Next.js to stream its contents to the user when they request the page, while still providing an initial UI that is prerendered and prefetchable for instant navigations.
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/static/route-group-config-and-segment-config/(group)/page.tsx (4:16) @ Page
+         > 4 |   await cookies()
+             |                ^",
+           "stack": [
+             "Page app/suspense-in-root/static/route-group-config-and-segment-config/(group)/page.tsx (4:16)",
+           ],
+         }
+        `)
+      })
+
+      it('invalid - config on segment layout - cookies() blocks through route group below', async () => {
+        const browser = await navigateTo(
+          '/suspense-in-root/static/route-group-segment-config-only'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33) @ unstable_instant
+         > 3 | export const unstable_instant = { prefetch: 'static' }
+             |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/route-group-segment-config-only/layout.tsx (3:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1078",
+           "description": "Runtime data was accessed outside of <Suspense>
+
+         This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation. cookies(), headers(), and searchParams, are examples of Runtime data that can only come from a user request.
+
+         To fix this:
+
+         Provide a fallback UI using <Suspense> around this component.
+
+         or
+
+         Move the Runtime data access into a deeper component wrapped in <Suspense>.
+
+         In either case this allows Next.js to stream its contents to the user when they request the page, while still providing an initial UI that is prerendered and prefetchable for instant navigations.
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/static/route-group-segment-config-only/(group)/page.tsx (4:16) @ Page
+         > 4 |   await cookies()
+             |                ^",
+           "stack": [
+             "Page app/suspense-in-root/static/route-group-segment-config-only/(group)/page.tsx (4:16)",
+           ],
+         }
+        `)
+      })
+
+      it('invalid - config on route group layout - cookies() blocks in deeper segment', async () => {
+        const browser = await navigateTo(
+          '/suspense-in-root/static/route-group-config-with-deeper-segment/inner'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33) @ unstable_instant
+         > 3 | export const unstable_instant = { prefetch: 'static' }
+             |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/layout.tsx (3:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1078",
+           "description": "Runtime data was accessed outside of <Suspense>
+
+         This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation. cookies(), headers(), and searchParams, are examples of Runtime data that can only come from a user request.
+
+         To fix this:
+
+         Provide a fallback UI using <Suspense> around this component.
+
+         or
+
+         Move the Runtime data access into a deeper component wrapped in <Suspense>.
+
+         In either case this allows Next.js to stream its contents to the user when they request the page, while still providing an initial UI that is prerendered and prefetchable for instant navigations.
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/inner/page.tsx (4:16) @ Page
+         > 4 |   await cookies()
+             |                ^",
+           "stack": [
+             "Page app/suspense-in-root/static/route-group-config-with-deeper-segment/(group)/inner/page.tsx (4:16)",
+           ],
+         }
+        `)
+      })
+
+      it('invalid - config on segment layout inside route group - cookies() blocks below', async () => {
+        const browser = await navigateTo(
+          '/suspense-in-root/static/route-group-deeper-segment-config/inner'
+        )
+        await expect(browser).toDisplayCollapsedRedbox(`
+         {
+           "cause": [
+             {
+               "label": "Caused by: Instant Validation",
+               "source": "app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33) @ unstable_instant
+         > 3 | export const unstable_instant = { prefetch: 'static' }
+             |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/layout.tsx (3:33)",
+                 "Set.forEach <anonymous>",
+               ],
+             },
+           ],
+           "code": "E1078",
+           "description": "Runtime data was accessed outside of <Suspense>
+
+         This delays the entire page from rendering, resulting in a slow user experience. Next.js uses this error to ensure your app loads instantly on every navigation. cookies(), headers(), and searchParams, are examples of Runtime data that can only come from a user request.
+
+         To fix this:
+
+         Provide a fallback UI using <Suspense> around this component.
+
+         or
+
+         Move the Runtime data access into a deeper component wrapped in <Suspense>.
+
+         In either case this allows Next.js to stream its contents to the user when they request the page, while still providing an initial UI that is prerendered and prefetchable for instant navigations.
+
+         Learn more: https://nextjs.org/docs/messages/blocking-route",
+           "environmentLabel": "Server",
+           "label": "Blocking Route",
+           "source": "app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/page.tsx (4:16) @ Page
+         > 4 |   await cookies()
+             |                ^",
+           "stack": [
+             "Page app/suspense-in-root/static/route-group-deeper-segment-config/(group)/inner/page.tsx (4:16)",
            ],
          }
         `)


### PR DESCRIPTION
The navigation parent tracking in `findNavigationsToValidate` previously treated every layout as a navigation boundary, including route group layouts. But route group layouts don't contribute to the URL — they always mount together with the next URL-contributing segment. A user can never navigate "into" a route group layout independently, so treating it as a separate boundary created redundant validation tasks.

This changes `navigationParents.push()` to only include layouts at URL-contributing segments (not route groups, `__PAGE__`, or `__DEFAULT__`). Route group layouts still have their configs processed — if a route group layout has `unstable_instant`, a validation task is created from the parents above it — but they don't advance the boundary for deeper segments. This also adds a guard that skips task creation when `navigationParents` is empty, which naturally deduplicates the case where both a route group layout and the URL-contributing layout below it have configs.