### PR TITLE
fix(build): support _inlined segment paths in prefetchInlining for dynamic routes

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -3342,32 +3342,60 @@ export default async function build(
                     const pageSegmentPath = metadata.segmentPaths.find((item) =>
                       item.endsWith('__PAGE__')
                     )
-                    if (!pageSegmentPath) {
+                    const inlinedSegmentPath = !pageSegmentPath
+                      ? metadata.segmentPaths.find((item) =>
+                          item.endsWith('/_inlined')
+                        )
+                      : null
+
+                    if (pageSegmentPath) {
+                      const builtSegmentDataRoute =
+                        buildPrefetchSegmentDataRoute(
+                          route.pathname,
+                          pageSegmentPath
+                        )
+
+                      builtSegmentDataRoute.source =
+                        builtSegmentDataRoute.source.replace(
+                          '/__PAGE__\\.segment\\.rsc$',
+                          `(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$`
+                        )
+                      builtSegmentDataRoute.destination =
+                        builtSegmentDataRoute.destination.replace(
+                          '/__PAGE__.segment.rsc',
+                          '$segment'
+                        )
+                      dynamicRoute.prefetchSegmentDataRoutes ??= []
+                      dynamicRoute.prefetchSegmentDataRoutes.push(
+                        builtSegmentDataRoute
+                      )
+                    } else if (inlinedSegmentPath) {
+                      // When prefetchInlining is enabled, segment data is
+                      // bundled into /_inlined instead of per-segment __PAGE__
+                      // entries. Build routing rules for the inlined format.
+                      const builtSegmentDataRoute =
+                        buildPrefetchSegmentDataRoute(
+                          route.pathname,
+                          inlinedSegmentPath
+                        )
+
+                      builtSegmentDataRoute.source =
+                        builtSegmentDataRoute.source.replace(
+                          '/_inlined\\.segment\\.rsc$',
+                          `(?<segment>/_inlined\\.segment\\.rsc|/_tree\\.segment\\.rsc|/_full\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$`
+                        )
+                      builtSegmentDataRoute.destination =
+                        builtSegmentDataRoute.destination.replace(
+                          '/_inlined.segment.rsc',
+                          '$segment'
+                        )
+                      dynamicRoute.prefetchSegmentDataRoutes ??= []
+                      dynamicRoute.prefetchSegmentDataRoutes.push(
+                        builtSegmentDataRoute
+                      )
+                    } else {
                       throw new Error(`Invariant: missing __PAGE__ segmentPath`)
                     }
-
-                    // We build a combined segment data route from the
-                    // page segment as we need to limit the number of
-                    // routes we output and they can be shared
-                    const builtSegmentDataRoute = buildPrefetchSegmentDataRoute(
-                      route.pathname,
-                      pageSegmentPath
-                    )
-
-                    builtSegmentDataRoute.source =
-                      builtSegmentDataRoute.source.replace(
-                        '/__PAGE__\\.segment\\.rsc$',
-                        `(?<segment>/__PAGE__\\.segment\\.rsc|\\.segment\\.rsc)(?:/)?$`
-                      )
-                    builtSegmentDataRoute.destination =
-                      builtSegmentDataRoute.destination.replace(
-                        '/__PAGE__.segment.rsc',
-                        '$segment'
-                      )
-                    dynamicRoute.prefetchSegmentDataRoutes ??= []
-                    dynamicRoute.prefetchSegmentDataRoutes.push(
-                      builtSegmentDataRoute
-                    )
                   }
                 }
 

--- a/test/production/app-dir/prefetch-inlining-dynamic-routes/app/layout.tsx
+++ b/test/production/app-dir/prefetch-inlining-dynamic-routes/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/prefetch-inlining-dynamic-routes/app/page.tsx
+++ b/test/production/app-dir/prefetch-inlining-dynamic-routes/app/page.tsx
@@ -1,0 +1,10 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <p>Home</p>
+      <Link href="/posts/hello">Post</Link>
+    </div>
+  )
+}

--- a/test/production/app-dir/prefetch-inlining-dynamic-routes/app/posts/[slug]/page.tsx
+++ b/test/production/app-dir/prefetch-inlining-dynamic-routes/app/posts/[slug]/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+
+async function PostContent({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  return <p id="post">{slug}</p>
+}
+
+export default function PostPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <PostContent params={params} />
+    </Suspense>
+  )
+}

--- a/test/production/app-dir/prefetch-inlining-dynamic-routes/next.config.js
+++ b/test/production/app-dir/prefetch-inlining-dynamic-routes/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    prefetchInlining: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/production/app-dir/prefetch-inlining-dynamic-routes/prefetch-inlining-dynamic-routes.test.ts
+++ b/test/production/app-dir/prefetch-inlining-dynamic-routes/prefetch-inlining-dynamic-routes.test.ts
@@ -1,0 +1,39 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('prefetch-inlining-dynamic-routes', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('disabled in development', () => {})
+    return
+  }
+
+  it('should build successfully with prefetchInlining and dynamic routes', async () => {
+    // Verify that the build succeeded by checking that the page renders.
+    const $ = await next.render$('/posts/hello')
+    expect($('#post').text()).toBe('hello')
+  })
+
+  it('should produce _inlined segment paths in the route metadata', async () => {
+    const meta = JSON.parse(
+      await next.readFile('.next/server/app/posts/[slug].meta')
+    )
+
+    // With prefetchInlining enabled, the segment paths should contain
+    // /_inlined entries instead of /__PAGE__ entries.
+    expect(meta.segmentPaths).toBeDefined()
+    expect(meta.segmentPaths.length).toBeGreaterThanOrEqual(1)
+
+    const hasInlined = meta.segmentPaths.some((p: string) =>
+      p.includes('/_inlined')
+    )
+    const hasPage = meta.segmentPaths.some((p: string) =>
+      p.includes('/__PAGE__')
+    )
+
+    expect(hasInlined).toBe(true)
+    expect(hasPage).toBe(false)
+  })
+})


### PR DESCRIPTION
## What

Handle `_inlined` segment paths during the build when `prefetchInlining` is enabled alongside dynamic routes.

## Why

When `prefetchInlining` is enabled, segment data is bundled into `/_inlined` instead of per-segment `/__PAGE__` entries. The build previously only looked for `__PAGE__` in `segmentPaths`, throwing `Invariant: missing __PAGE__ segmentPath` for any dynamic route using `prefetchInlining`.

## How

- Check for `/_inlined` as a fallback when `/__PAGE__` is not found in `segmentPaths`
- Build routing rules that match `/_inlined`, `/_tree`, `/_full`, and bare `.segment.rsc` URLs
- Only throw the invariant error when neither `__PAGE__` nor `_inlined` is present

## Test Plan

- Added production test (`test/production/app-dir/prefetch-inlining-dynamic-routes/`) with a dynamic `[slug]` route and `prefetchInlining: true`
- Verified the test fails with the old code (`Invariant: missing __PAGE__ segmentPath`)
- Verified the test passes with the fix

## Relevant PR
#90555 