### PR TITLE
[CC] Failing tests for pages that only suspend in client

### DIFF
--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/(index)/layout.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/(index)/layout.tsx
@@ -1,0 +1,7 @@
+export default async function RootLayout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/(index)/page.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/(index)/page.tsx
@@ -1,0 +1,49 @@
+import Link from 'next/link'
+
+export default async function Page() {
+  return (
+    <main>
+      <h2>Suspense above body</h2>
+      <ul>
+        <li>
+          <Link href="/suspense-above-body/use-params/123">
+            /suspense-above-body/use-params/123
+          </Link>
+        </li>
+        <li>
+          <Link href="/suspense-above-body/use-search-params">
+            /suspense-above-body/use-search-params
+          </Link>
+        </li>
+      </ul>
+
+      <h2>Suspense inside body</h2>
+      <ul>
+        <li>
+          <Link href="/suspense-inside-body/use-params/123">
+            /suspense-inside-body/use-params/123
+          </Link>
+        </li>
+        <li>
+          <Link href="/suspense-inside-body/use-search-params">
+            /suspense-inside-body/use-search-params
+          </Link>
+        </li>
+      </ul>
+
+      <h2>instant = false</h2>
+      <ul>
+        <li>
+          <Link href="/instant-false/use-params/123">
+            /instant-false/use-params/123
+          </Link>
+        </li>
+        <li>
+          <Link href="/instant-false/use-search-params">
+            /instant-false/use-search-params
+          </Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/layout.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/layout.tsx
@@ -1,0 +1,16 @@
+export const unstable_instant = false
+
+export default async function RootLayout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>
+        <p>
+          This root layout has <code>instant = false</code> and no suspense
+          boundaries.
+        </p>
+        <hr />
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-params/[slug]/client.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-params/[slug]/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { useParams } from 'next/navigation'
+
+export function ClientSlug() {
+  const { slug } = useParams()
+  return <div>Slug: {slug}</div>
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-params/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { ClientSlug } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>This page suspends on params in a client component.</p>
+      <ClientSlug />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-search-params/client.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-search-params/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+
+export function ClientSearch() {
+  const search = useSearchParams()
+  return <div>Search: {search.toString()}</div>
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-search-params/page.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/instant-false/use-search-params/page.tsx
@@ -1,0 +1,10 @@
+import { ClientSearch } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>This page suspends on search params in a client component.</p>
+      <ClientSearch />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/layout.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/layout.tsx
@@ -1,0 +1,15 @@
+import { Suspense } from 'react'
+
+export default async function RootLayout({ children }: LayoutProps<'/'>) {
+  return (
+    <Suspense>
+      <html>
+        <body>
+          <p>This root layout has a Suspense above the body.</p>
+          <hr />
+          {children}
+        </body>
+      </html>
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-params/[slug]/client.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-params/[slug]/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { useParams } from 'next/navigation'
+
+export function ClientSlug() {
+  const { slug } = useParams()
+  return <div>Slug: {slug}</div>
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-params/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { ClientSlug } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>This page suspends on params in a client component.</p>
+      <ClientSlug />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-search-params/client.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-search-params/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+
+export function ClientSearch() {
+  const search = useSearchParams()
+  return <div>Search: {search.toString()}</div>
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-search-params/page.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-above-body/use-search-params/page.tsx
@@ -1,0 +1,10 @@
+import { ClientSearch } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>This page suspends on search params in a client component.</p>
+      <ClientSearch />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/layout.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/layout.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react'
+
+export default async function Layout({ children }: LayoutProps<'/'>) {
+  return (
+    <html>
+      <body>
+        <p>This root layout has a Suspense inside the body.</p>
+        <hr />
+        <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-params/[slug]/client.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-params/[slug]/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { useParams } from 'next/navigation'
+
+export function ClientSlug() {
+  const { slug } = useParams()
+  return <div>Slug: {slug}</div>
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-params/[slug]/page.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-params/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { ClientSlug } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>This page suspends on params in a client component.</p>
+      <ClientSlug />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-search-params/client.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-search-params/client.tsx
@@ -1,0 +1,7 @@
+'use client'
+import { useSearchParams } from 'next/navigation'
+
+export function ClientSearch() {
+  const search = useSearchParams()
+  return <div>Search: {search.toString()}</div>
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-search-params/page.tsx
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/app/suspense-inside-body/use-search-params/page.tsx
@@ -1,0 +1,10 @@
+import { ClientSearch } from './client'
+
+export default async function Page() {
+  return (
+    <main>
+      <p>This page suspends on search params in a client component.</p>
+      <ClientSearch />
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-components-postpone-in-client/cache-components-postpone-in-client.test.ts
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/cache-components-postpone-in-client.test.ts
@@ -1,0 +1,76 @@
+import { nextTestSetup } from '../../../lib/e2e-utils'
+
+describe('cache components - postponing in client', () => {
+  const { next, isNextStart } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+    skipStart: true,
+  })
+
+  if (!isNextStart) {
+    // TODO: test validation behavior in dev
+    it.skip('Build-time only test', () => {})
+    return
+  }
+
+  const prerender = async (pathname: string) => {
+    const args = [
+      '--experimental-build-mode',
+      'generate',
+      '--debug-build-paths',
+      `app${pathname}/page.tsx`,
+    ]
+    return await next.build({
+      args,
+      env: {
+        NEXT_TEST_LOG_VALIDATION: '1',
+      },
+    })
+  }
+
+  beforeAll(async () => {
+    await next.build({ args: ['--experimental-build-mode', 'compile'] })
+  })
+
+  // NOTE: These tests repro a bug that happens when the page
+  // - doesn't suspend in a server component
+  // - does suspend (postpone) in a client component.
+  // Adding a server dynamic hole makes the build errors go away.
+
+  describe('with suspense above body', () => {
+    it('prerenders a page that suspends on params in a client component', async () => {
+      const result = await prerender('/suspense-above-body/use-params/[slug]')
+      expect(result.cliOutput).not.toContain('Error occurred prerendering page')
+      expect(result.exitCode).toBe(0)
+    })
+    it('prerenders a page that suspends on search params in a client component', async () => {
+      const result = await prerender('/suspense-above-body/use-search-params')
+      expect(result.cliOutput).not.toContain('Error occurred prerendering page')
+      expect(result.exitCode).toBe(0)
+    })
+  })
+  describe('with suspense inside body', () => {
+    it('prerenders a page that suspends on params in a client component', async () => {
+      const result = await prerender('/suspense-inside-body/use-params/[slug]')
+      expect(result.cliOutput).not.toContain('Error occurred prerendering page')
+      expect(result.exitCode).toBe(0)
+    })
+    it('prerenders a page that suspends on search params in a client component', async () => {
+      const result = await prerender('/suspense-inside-body/use-search-params')
+      expect(result.cliOutput).not.toContain('Error occurred prerendering page')
+      expect(result.exitCode).toBe(0)
+    })
+  })
+  describe('with instant = false', () => {
+    it('prerenders a page that suspends on params in a client component', async () => {
+      const result = await prerender('/instant-false/use-params/[slug]')
+      expect(result.cliOutput).not.toContain('Error occurred prerendering page')
+      expect(result.exitCode).toBe(0)
+    })
+    it('prerenders a page that suspends on search params in a client component', async () => {
+      const result = await prerender('/instant-false/use-search-params')
+      expect(result.cliOutput).not.toContain('Error occurred prerendering page')
+      expect(result.exitCode).toBe(0)
+    })
+  })
+})

--- a/test/e2e/app-dir/cache-components-postpone-in-client/next.config.ts
+++ b/test/e2e/app-dir/cache-components-postpone-in-client/next.config.ts
@@ -1,0 +1,14 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  cacheComponents: true,
+  experimental: {
+    // reactDebugChannel: true,
+    prerenderEarlyExit: false,
+  },
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+}
+
+export default nextConfig


### PR DESCRIPTION
Prerendering seems to crash if you have suspense-above-body/`instant = false` and a page that only pospones in a client component (i.e. no dynamic holes in server component). adding something dynamic in server code fixes the crash.

The error is `Render in Browser should be wrapped in a suspense boundary at page`. This comes from `createRenderInBrowserAbortSignal` which is used in the "Server isn't dynamic" prerendering codepaths.

NAR-800