### PR TITLE
preserve allowQuery for partial fallback shells

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1601,14 +1601,22 @@ export async function handleBuildComplete({
         if (typeof fallback === 'string') {
           if (fallbackRootParams && fallbackRootParams.length > 0) {
             htmlAllowQuery = fallbackRootParams as string[]
-          } // We additionally vary based on if there's a postponed prerender
+          }
+
+          // We additionally vary based on if there's a postponed prerender
           // because if there isn't, then that means that we generated an
           // empty shell, and producing an empty RSC shell would be a waste.
           // If there is a postponed prerender, then the RSC shell would be
           // non-empty, and it would be valuable to also generate an empty
           // RSC shell.
           else if (meta.postponed) {
-            htmlAllowQuery = []
+            // If there's postponed fallback content, we usually collapse to a shared shell (`[]`).
+            // For partial fallbacks in cache components, keep route allowQuery so
+            // fallback shells can be upgraded per-param instead of sharing one cache key.
+            htmlAllowQuery =
+              partialFallback && routesManifest.rsc.clientParamParsing
+                ? allowQuery
+                : []
           }
         }
 


### PR DESCRIPTION
Analogous change to https://github.com/vercel/vercel/pull/15338, but for the new Next.js adapter API.

This updates only allowQuery for fallback HTML when the route is a true partialFallback (PPR fallback with postponed state) and cache components is enabled. For all other fallback cases, behavior stays the same as today (allowQuery is cleared to [] for shared fallback caching).

This change is needed because partial-fallback shells can be param-specific, so collapsing them to one shared fallback cache key can serve the wrong shell across params and block correct upgrade behavior. Gating this behind partialFallback lets us roll out the new behavior safely and independently, without changing legacy fallback semantics for non-partial paths.