### PR TITLE
[ci]: continue-on-error for more gh auth status checks

### DIFF
--- a/.github/workflows/test_e2e_deploy_release.yml
+++ b/.github/workflows/test_e2e_deploy_release.yml
@@ -261,6 +261,9 @@ jobs:
     steps:
       - name: Check token
         run: gh auth status
+        # This sometimes fails for unknown reasons.
+        # Ignoring failures for now to check if a failure actually blocks subsequent steps
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
       - uses: actions/github-script@v7
@@ -332,6 +335,9 @@ jobs:
     steps:
       - name: Check token
         run: gh auth status
+        # This sometimes fails for unknown reasons.
+        # Ignoring failures for now to check if a failure actually blocks subsequent steps
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ secrets.GH_UPDATE_NEXT_WORKFLOW_TRIGGER }}
       - uses: actions/github-script@v7


### PR DESCRIPTION
This seems to be failing for our deploy test workflow ([x-ref](https://github.com/vercel/next.js/actions/runs/22685809647/job/65778800145)). 

Updating to `continue-on-error` similar to https://github.com/vercel/next.js/pull/89098 because this check doesn't seem reliable.

If it fixes, will just remove in both spots all together.