### PR TITLE
Cleanup non-generic assertions in our deploy test suite

### DIFF
--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -92,8 +92,8 @@ describe('unrecognized server actions', () => {
       body: 'foo=bar',
     })
 
-    // On Vercel, this would hit the 404 route which is a static page, and returns a 405 instead.
-    expect(res.status).toBe(isNextDeploy ? 405 : 404)
+    // On deploy, this would hit the 404 route which is a static page, and returns a 405 instead.
+    expect(res.status).toBeOneOf([405, 404])
   })
 
   describe.each(['nodejs', 'edge'])(
@@ -155,7 +155,7 @@ describe('unrecognized server actions', () => {
           // An MPA action, sent without JS.
 
           if (isNextDeploy) {
-            // FIXME: When deployed to vercel, the request is logged as a 500, but returns a 405.
+            // FIXME: When deployed, the request is logged as a 500, but returns a 405.
             // We also don't seem to display the error page correctly
             expect(response.status()).toBe(405)
             expect(response.headers()['content-type']).toStartWith('text/html')

--- a/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
+++ b/test/e2e/app-dir/actions-unrecognized/actions-unrecognized.test.ts
@@ -154,12 +154,9 @@ describe('unrecognized server actions', () => {
         } else {
           // An MPA action, sent without JS.
 
-          if (isNextDeploy) {
-            // FIXME: When deployed, the request is logged as a 500, but returns a 405.
-            // We also don't seem to display the error page correctly
-            expect(response.status()).toBe(405)
-            expect(response.headers()['content-type']).toStartWith('text/html')
-          } else {
+          // FIXME: When deployed, the request is logged as a 500, but returns a 405.
+          // We also don't seem to display the error page correctly
+          if (!isNextDeploy) {
             // FIXME: Currently, an unrecognized id in an MPA action results in a 500.
             // This is not ideal, and ignores all nested `error.js` files, only showing the topmost one.
             expect(response.status()).toBe(500)

--- a/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
+++ b/test/e2e/app-dir/app-routes/app-custom-routes.test.ts
@@ -225,7 +225,7 @@ describe('app-custom-routes', () => {
         })
 
         expect(res.status).toEqual(200)
-        expect(res.headers.get('content-type')).toEqual('application/json')
+        expect(res.headers.get('content-type')).toContain('application/json')
         expect(await res.json()).toEqual(meta)
       })
     })
@@ -312,16 +312,20 @@ describe('app-custom-routes', () => {
       expect(await res.text()).toEqual('delete foo')
     })
 
-    it('can read a JSON encoded body for OPTIONS requests', async () => {
-      const body = { name: 'bar' }
-      const res = await next.fetch(basePath + '/advanced/body/json', {
-        method: 'OPTIONS',
-        body: JSON.stringify(body),
-      })
+    // keeping a body during options request is not standardized
+    // behavior and depending on the server can be discarded
+    if (!isNextDeploy) {
+      it('can read a JSON encoded body for OPTIONS requests', async () => {
+        const body = { name: 'bar' }
+        const res = await next.fetch(basePath + '/advanced/body/json', {
+          method: 'OPTIONS',
+          body: JSON.stringify(body),
+        })
 
-      expect(res.status).toEqual(200)
-      expect(await res.text()).toEqual('options bar')
-    })
+        expect(res.status).toEqual(200)
+        expect(await res.text()).toEqual('options bar')
+      })
+    }
 
     // we can't stream a body to a function currently only stream response
     if (!isNextDeploy) {

--- a/test/e2e/app-dir/app/index.test.ts
+++ b/test/e2e/app-dir/app/index.test.ts
@@ -1,5 +1,10 @@
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry, waitFor } from 'next-test-utils'
+import {
+  check,
+  expectVaryHeaderToContain,
+  retry,
+  waitFor,
+} from 'next-test-utils'
 import cheerio from 'cheerio'
 import stripAnsi from 'strip-ansi'
 import {
@@ -369,9 +374,12 @@ describe('app dir - basic', () => {
   it('should return the `vary` header from edge runtime', async () => {
     const res = await next.fetch('/dashboard')
     expect(res.headers.get('x-edge-runtime')).toBe('1')
-    expect(res.headers.get('vary')).toBe(
-      'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch'
-    )
+    expectVaryHeaderToContain(res.headers.get('vary'), [
+      'rsc',
+      'next-router-state-tree',
+      'next-router-prefetch',
+      'next-router-segment-prefetch',
+    ])
   })
 
   it('should return the `vary` header from pages for flight requests', async () => {
@@ -380,11 +388,16 @@ describe('app dir - basic', () => {
         [RSC_HEADER]: '1',
       },
     })
-    expect(res.headers.get('vary')).toBe(
-      isNextDeploy
-        ? 'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch'
-        : 'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch, Accept-Encoding'
-    )
+    expectVaryHeaderToContain(res.headers.get('vary'), [
+      'rsc',
+      'next-router-state-tree',
+      'next-router-prefetch',
+      'next-router-segment-prefetch',
+    ])
+
+    if (!isNextDeploy) {
+      expectVaryHeaderToContain(res.headers.get('vary'), ['accept-encoding'])
+    }
   })
 
   it('should pass props from getServerSideProps in root layout', async () => {

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -438,8 +438,8 @@ describe('app dir - metadata dynamic routes', () => {
     let twitterImageUrlPattern
     if (isNextDeploy) {
       // absolute urls
-      ogImageUrlPattern = /https:\/\/[\w-]+.vercel.app\/opengraph-image\?/
-      twitterImageUrlPattern = /https:\/\/[\w-]+.vercel.app\/twitter-image\?/
+      ogImageUrlPattern = /https:\/\/[^/]+\/opengraph-image\?/
+      twitterImageUrlPattern = /https:\/\/[^/]+\/twitter-image\?/
     } else if (isNextStart) {
       // configured metadataBase for next start
       ogImageUrlPattern = /https:\/\/mydomain.com\/opengraph-image\?/
@@ -470,7 +470,7 @@ describe('app dir - metadata dynamic routes', () => {
     ogImages.each((_, ogImage) => {
       const ogImageUrl = $(ogImage).attr('content')
       expect(ogImageUrl).toMatch(
-        isNextDeploy ? /https:\/\/[\w-]+.vercel.app/ : /http:\/\/localhost:\d+/
+        isNextDeploy ? /https:\/\/[^/]+/ : /http:\/\/localhost:\d+/
       )
       expect(ogImageUrl).toMatch(
         /\/metadata-base\/unset\/opengraph-image2\/10\d/
@@ -478,7 +478,7 @@ describe('app dir - metadata dynamic routes', () => {
     })
 
     expect(twitterImage).toMatch(
-      isNextDeploy ? /https:\/\/[\w-]+.vercel.app/ : /http:\/\/localhost:\d+/
+      isNextDeploy ? /https:\/\/[^/]+/ : /http:\/\/localhost:\d+/
     )
     expect(twitterImage).toMatch(/\/metadata-base\/unset\/twitter-image\.png/)
   })

--- a/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
+++ b/test/e2e/app-dir/metadata-dynamic-routes/index.test.ts
@@ -465,21 +465,20 @@ describe('app dir - metadata dynamic routes', () => {
     const $ = await next.render$('/metadata-base/unset')
     const twitterImage = $('meta[name="twitter:image"]').attr('content')
     const ogImages = $('meta[property="og:image"]')
+    const hostPattern = isNextDeploy
+      ? /https?:\/\/[^/]+/
+      : /http:\/\/localhost:\d+/
 
     expect(ogImages.length).toBe(2)
     ogImages.each((_, ogImage) => {
       const ogImageUrl = $(ogImage).attr('content')
-      expect(ogImageUrl).toMatch(
-        isNextDeploy ? /https:\/\/[^/]+/ : /http:\/\/localhost:\d+/
-      )
+      expect(ogImageUrl).toMatch(hostPattern)
       expect(ogImageUrl).toMatch(
         /\/metadata-base\/unset\/opengraph-image2\/10\d/
       )
     })
 
-    expect(twitterImage).toMatch(
-      isNextDeploy ? /https:\/\/[^/]+/ : /http:\/\/localhost:\d+/
-    )
+    expect(twitterImage).toMatch(hostPattern)
     expect(twitterImage).toMatch(/\/metadata-base\/unset\/twitter-image\.png/)
   })
 

--- a/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
+++ b/test/e2e/app-dir/metadata-warnings/metadata-warnings-with-metadatabase.test.ts
@@ -34,7 +34,7 @@ describe('app dir - metadata missing metadataBase', () => {
     return isNextDev ? next.cliOutput.slice(logStartPosition) : next.cliOutput
   }
 
-  it('should not show warning in vercel deployment output in default build output mode', async () => {
+  it('should not show warning in output in default build output mode', async () => {
     const logStartPosition = next.cliOutput.length
     await next.fetch('/og-image-convention')
     const output = getCliOutput(logStartPosition)

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -417,7 +417,7 @@ describe('app dir - metadata', () => {
           : expect.stringMatching(
               new RegExp(
                 `https:\\/\\/(${
-                  isNextDeploy ? '.*?\\.vercel\\.app' : 'example\\.com'
+                  isNextDeploy ? '[^/]+' : 'example\\.com'
                 })\\/opengraph\\/static\\/opengraph-image`
               )
             ),
@@ -431,7 +431,7 @@ describe('app dir - metadata', () => {
           : expect.stringMatching(
               new RegExp(
                 `https:\\/\\/(${
-                  isNextDeploy ? '.*?\\.vercel\\.app' : 'example\\.com'
+                  isNextDeploy ? '[^/]+' : 'example\\.com'
                 })\\/opengraph\\/static\\/twitter-image`
               )
             ),

--- a/test/e2e/app-dir/rewrite-with-search-params/rewrite-with-search-params.test.ts
+++ b/test/e2e/app-dir/rewrite-with-search-params/rewrite-with-search-params.test.ts
@@ -6,17 +6,23 @@ describe('rewrite-with-search-params', () => {
   })
 
   it('should not contain params in search params after rewrite', async () => {
+    const deploymentHost = isNextDeploy ? new URL(next.url).hostname : null
+    const shouldForceHostHeader =
+      !isNextDeploy ||
+      deploymentHost === 'localhost' ||
+      deploymentHost === '127.0.0.1'
+
     const $ = await next.render$(
       '/galleries/123',
       {
         param: 'value',
       },
       {
-        headers: isNextDeploy
-          ? undefined
-          : {
+        headers: shouldForceHostHeader
+          ? {
               host: 'vercel-test.vercel.app',
-            },
+            }
+          : undefined,
       }
     )
 

--- a/test/e2e/basepath/basepath.test.ts
+++ b/test/e2e/basepath/basepath.test.ts
@@ -469,9 +469,11 @@ describe('basePath', () => {
   it('should show 404 for page not under the /docs prefix', async () => {
     const text = await renderViaHTTP(next.url, '/hello')
     expect(text).not.toContain('Hello World')
-    expect(text).toContain(
-      isNextDeploy ? 'NOT_FOUND' : 'This page could not be found'
-    )
+    // the custom 404 only shows inside of the basePath so this
+    // could be a platform default 404 page on deploy
+    if (!isNextDeploy) {
+      expect(text).toContain('This page could not be found')
+    }
   })
 
   it('should show the other-page page under the /docs prefix', async () => {

--- a/test/e2e/basepath/error-pages.test.ts
+++ b/test/e2e/basepath/error-pages.test.ts
@@ -57,13 +57,9 @@ describe('basePath', () => {
   it('should not update URL for a 404', async () => {
     const browser = await webdriver(next.url, '/missing')
 
-    if (isNextDeploy) {
-      // the custom 404 only shows inside of the basePath so this
-      // will be the Vercel default 404 page
-      expect(
-        await browser.eval('document.documentElement.innerHTML')
-      ).toContain('NOT_FOUND')
-    } else {
+    // the custom 404 only shows inside of the basePath so this
+    // could be a platform default 404 page on deploy
+    if (!isNextDeploy) {
       const pathname = await browser.eval(() => window.location.pathname)
       expect(await browser.eval(() => (window as any).next.router.asPath)).toBe(
         '/missing'
@@ -75,13 +71,9 @@ describe('basePath', () => {
   it('should handle 404 urls that start with basePath', async () => {
     const browser = await webdriver(next.url, `${basePath}hello`)
 
-    if (isNextDeploy) {
-      // the custom 404 only shows inside of the basePath so this
-      // will be the Vercel default 404 page
-      expect(
-        await browser.eval('document.documentElement.innerHTML')
-      ).toContain('404: This page could not be found')
-    } else {
+    // the custom 404 only shows inside of the basePath so this
+    // could be a platform default 404 page on deploy
+    if (!isNextDeploy) {
       expect(await browser.eval(() => (window as any).next.router.asPath)).toBe(
         `${basePath}hello`
       )
@@ -161,8 +153,10 @@ describe('basePath', () => {
   it('should show 404 for page not under the /docs prefix', async () => {
     const text = await renderViaHTTP(next.url, '/hello')
     expect(text).not.toContain('Hello World')
-    expect(text).toContain(
-      isNextDeploy ? 'NOT_FOUND' : 'This page could not be found'
-    )
+    // the custom 404 only shows inside of the basePath so this
+    // could be a platform default 404 page on deploy
+    if (!isNextDeploy) {
+      expect(text).toContain('This page could not be found')
+    }
   })
 })

--- a/test/e2e/middleware-general/test/index.test.ts
+++ b/test/e2e/middleware-general/test/index.test.ts
@@ -691,7 +691,9 @@ describe('Middleware Runtime', () => {
 
     it('should throw when using URL with a relative URL', async () => {
       const res = await fetchViaHTTP(next.url, `/url/relative-url`)
-      expect(readMiddlewareError(res)).toContain('Invalid URL')
+      expect(readMiddlewareError(res)).toMatch(
+        /Invalid URL|cannot be parsed as a URL/
+      )
     })
 
     it('should throw when using NextRequest with a relative URL', async () => {

--- a/test/e2e/module-layer/module-layer.test.ts
+++ b/test/e2e/module-layer/module-layer.test.ts
@@ -7,7 +7,7 @@ import {
 } from 'next-test-utils'
 
 describe('module layer', () => {
-  const { next, isNextStart, isNextDev } = nextTestSetup({
+  const { next, isNextStart, isNextDev, isNextDeploy } = nextTestSetup({
     files: __dirname,
   })
 
@@ -55,9 +55,21 @@ describe('module layer', () => {
         expect(json.ReactDomServer).toContain('version')
         expect(json.ReactDomServer).toContain('renderToString')
         expect(json.ReactDomServer).toContain('renderToStaticMarkup')
-        expect(json.ReactDomServer).toContain(
-          isEdge ? 'renderToReadableStream' : 'renderToPipeableStream'
-        )
+        if (isEdge) {
+          expect(json.ReactDomServer).toContain('renderToReadableStream')
+        } else if (isNextDeploy) {
+          // Deploy mode can expose either server stream API depending on runtime
+          // and bundling path, so accept both for non-edge pages/api coverage.
+          expect(
+            json.ReactDomServer.some(
+              (name) =>
+                name === 'renderToPipeableStream' ||
+                name === 'renderToReadableStream'
+            )
+          ).toBe(true)
+        } else {
+          expect(json.ReactDomServer).toContain('renderToPipeableStream')
+        }
       }
 
       await verifyReactExports('/api/default', false)

--- a/test/e2e/vary-header/test/index.test.ts
+++ b/test/e2e/vary-header/test/index.test.ts
@@ -1,4 +1,5 @@
 import { nextTestSetup } from 'e2e-utils'
+import { expectVaryHeaderToContain } from 'next-test-utils'
 import path from 'path'
 
 describe('Vary Header Tests', () => {
@@ -9,7 +10,7 @@ describe('Vary Header Tests', () => {
 
   it('should preserve custom vary header in API routes', async () => {
     const res = await next.fetch('/api/custom-vary')
-    expect(res.headers.get('vary')).toContain('Custom-Header')
+    expectVaryHeaderToContain(res.headers.get('vary'), ['custom-header'])
   })
 
   it('should preserve custom vary header and append RSC headers in app route handlers', async () => {
@@ -17,13 +18,15 @@ describe('Vary Header Tests', () => {
     const varyHeader = res.headers.get('vary')
 
     // Custom header is preserved
-    expect(varyHeader).toContain('User-Agent')
+    expectVaryHeaderToContain(varyHeader, ['user-agent'])
     expect(res.headers.get('cache-control')).toBe('s-maxage=3600')
 
     // Next.js internal headers are appended
-    expect(varyHeader).toContain('rsc')
-    expect(varyHeader).toContain('next-router-state-tree')
-    expect(varyHeader).toContain('next-router-prefetch')
+    expectVaryHeaderToContain(varyHeader, [
+      'rsc',
+      'next-router-state-tree',
+      'next-router-prefetch',
+    ])
   })
 
   it('should preserve middleware vary header in combination with route handlers', async () => {
@@ -35,12 +38,13 @@ describe('Vary Header Tests', () => {
     expect(customHeader).toBe('test')
 
     // Both middleware and route handler vary headers are preserved
-    expect(varyHeader).toContain('my-custom-header')
-    expect(varyHeader).toContain('User-Agent')
+    expectVaryHeaderToContain(varyHeader, ['my-custom-header', 'user-agent'])
 
     // Next.js internal headers are still present
-    expect(varyHeader).toContain('rsc')
-    expect(varyHeader).toContain('next-router-state-tree')
-    expect(varyHeader).toContain('next-router-prefetch')
+    expectVaryHeaderToContain(varyHeader, [
+      'rsc',
+      'next-router-state-tree',
+      'next-router-prefetch',
+    ])
   })
 })

--- a/test/lib/next-modes/next-deploy.ts
+++ b/test/lib/next-modes/next-deploy.ts
@@ -137,16 +137,21 @@ export class NextDeployInstance extends NextInstance {
       ...this.env,
     }
 
-    const cleanupRes = await execa(cleanupScriptPath, [], {
+    const cleanupChild = execa(cleanupScriptPath, [], {
       cwd: this.testDir,
       env: scriptEnv,
       reject: false,
       stderr: 'inherit',
     })
 
-    if (cleanupRes.exitCode !== 0) {
+    cleanupChild.stdout?.pipe(process.stdout)
+    cleanupChild.stderr?.pipe(process.stderr)
+
+    const { exitCode } = await cleanupChild
+
+    if (exitCode !== 0) {
       throw new Error(
-        `Custom cleanup script failed: ${cleanupRes.stdout} ${cleanupRes.stderr} (${cleanupRes.exitCode})`
+        `Custom cleanup script failed with exit code: ${exitCode}`
       )
     }
   }

--- a/test/lib/next-test-utils.ts
+++ b/test/lib/next-test-utils.ts
@@ -200,6 +200,22 @@ export function fetchViaHTTP(
   return fetch(getFullUrl(appPort, url), opts)
 }
 
+export function expectVaryHeaderToContain(
+  varyHeader: string | null,
+  expectedFields: string[]
+) {
+  const varyFields = new Set(
+    (varyHeader ?? '')
+      .split(',')
+      .map((field) => field.trim().toLowerCase())
+      .filter(Boolean)
+  )
+
+  for (const expectedField of expectedFields) {
+    expect(varyFields.has(expectedField.toLowerCase())).toBe(true)
+  }
+}
+
 /**
  * Creates request options with a unique x-invocation-id header for testing
  * cache deduplication in minimal mode. Use this when you need to ensure each


### PR DESCRIPTION
This makes sure we don't have assertions that will only pass in one environment e.g. these should work for running against bun and not just node or against a local metadata URL not just a deployed https fully qualified domain. Ensures others can leverage this test suite for their own verification easily. 