### PR TITLE
docs: large page data error

### DIFF
--- a/errors/large-page-data.mdx
+++ b/errors/large-page-data.mdx
@@ -2,11 +2,9 @@
 title: Large Page Data
 ---
 
-> **Note:** This warning only applies to the **Pages Router**. The App Router does not use `__NEXT_DATA__` and is not affected by this limit.
-
 ## Why This Error Occurred
 
-One of your pages includes a large amount of page data (>= 128kB). In the Pages Router, data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` is serialized as JSON and embedded in the HTML inside a `<script id="__NEXT_DATA__">` tag. The browser must download, parse, and deserialize this JSON before React can hydrate the page.
+One of your pages includes a large amount of page data (> 128 kB). This warning applies only to the Pages Router, where page data is serialized as `__NEXT_DATA__` JSON and must be parsed by the client before the page is hydrated. It does not apply to the App Router, which streams data via Server Components.
 
 Large page data impacts performance in several ways:
 

--- a/errors/large-page-data.mdx
+++ b/errors/large-page-data.mdx
@@ -2,20 +2,52 @@
 title: Large Page Data
 ---
 
+> **Note:** This warning only applies to the **Pages Router**. The App Router does not use `__NEXT_DATA__` and is not affected by this limit.
+
 ## Why This Error Occurred
 
-One of your pages includes a large amount of page data (>= 128kB). This can negatively impact performance since page data must be parsed by the client before the page is hydrated.
+One of your pages includes a large amount of page data (>= 128kB). In the Pages Router, data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` is serialized as JSON and embedded in the HTML inside a `<script id="__NEXT_DATA__">` tag. The browser must download, parse, and deserialize this JSON before React can hydrate the page.
+
+Large page data impacts performance in several ways:
+
+- **Increased page weight:** The serialized data is inlined in every HTML response, increasing the document size and slowing down the initial page load, especially on slow networks.
+- **Slower hydration:** React cannot hydrate (make the page interactive) until the `__NEXT_DATA__` JSON has been fully parsed. Large payloads delay the [Time to Interactive (TTI)](https://web.dev/articles/tti).
+- **Higher memory usage:** The entire data payload is held in memory on the client, even if only a portion of it is used for rendering.
 
 ## Possible Ways to Fix It
 
-Reduce the amount of data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` to only the essential data to render the page. The default threshold of 128kB can be configured in `largePageDataBytes` if absolutely necessary and the performance implications are understood.
+Reduce the amount of data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` to only the essential data needed to render the page:
 
-To inspect the props passed to your page, you can inspect the below element's content in your browser devtools:
+- **Filter and trim data:** Only return the fields your components actually use. Avoid passing entire database records or API responses when only a subset of fields is needed.
+- **Paginate large lists:** Instead of returning hundreds of items at once, return a smaller initial set and load more on the client via API routes.
+- **Move data fetching to the client:** For non-critical or below-the-fold content, fetch it on the client side after hydration using `useEffect` or a data fetching library like [SWR](https://swr.vercel.app/) or [React Query](https://tanstack.com/query).
 
-```bash filename="Terminal"
+### Inspecting Your Page Data
+
+To see the data passed to your page, open your browser devtools console and run:
+
+```bash filename="Browser Console"
 JSON.parse(document.getElementById("__NEXT_DATA__").textContent)
 ```
 
+This lets you inspect the full payload and identify which fields are contributing to the size.
+
+### Configuring the Threshold
+
+The default threshold of 128kB is controlled by the `largePageDataBytes` option in `next.config.js`:
+
+```js filename="next.config.js"
+module.exports = {
+  experimental: {
+    largePageDataBytes: 200 * 1000, // Set threshold to 200kB
+  },
+}
+```
+
+Only increase this threshold if you have evaluated the performance implications and determined it is acceptable for your use case.
+
 ## Useful Links
 
-- [Data Fetching Documentation](/docs/pages/building-your-application/data-fetching)
+- [Pages Router Data Fetching](/docs/pages/building-your-application/data-fetching)
+- [SWR - React Hooks for Data Fetching](https://swr.vercel.app/)
+- [Time to Interactive (TTI)](https://web.dev/articles/tti)

--- a/errors/large-page-data.mdx
+++ b/errors/large-page-data.mdx
@@ -4,45 +4,45 @@ title: Large Page Data
 
 ## Why This Error Occurred
 
-One of your pages includes a large amount of page data (> 128 kB). This warning applies only to the Pages Router, where page data is serialized as `__NEXT_DATA__` JSON and must be parsed by the client before the page is hydrated. It does not apply to the App Router, which streams data via Server Components.
+One of your pages includes a large amount of page data (> 128 kB). This warning only affects the Pages Router, where Next.js serializes page data as `__NEXT_DATA__` JSON, which the client must parse before hydrating the page. The App Router streams data via Server Components and is not affected.
 
 Large page data impacts performance in several ways:
 
-- **Increased page weight:** The serialized data is inlined in every HTML response, increasing the document size and slowing down the initial page load, especially on slow networks.
-- **Slower hydration:** React cannot hydrate (make the page interactive) until the `__NEXT_DATA__` JSON has been fully parsed. Large payloads delay the [Time to Interactive (TTI)](https://web.dev/articles/tti).
-- **Higher memory usage:** The entire data payload is held in memory on the client, even if only a portion of it is used for rendering.
+- **Increased page weight:** The serialized data is inlined in every HTML response, increasing the document size and slowing down the initial page load on slow networks.
+- **Slower hydration:** React cannot hydrate (make the page interactive) until the `__NEXT_DATA__` JSON has been parsed. Large payloads delay the [Time to Interactive (TTI)](https://web.dev/articles/tti).
+- **Higher memory usage:** The entire data payload is held in memory on the client, even if only part of it is used for rendering.
 
 ## Possible Ways to Fix It
 
-Reduce the amount of data returned from `getStaticProps`, `getServerSideProps`, or `getInitialProps` to only the essential data needed to render the page:
+Return only the data your page needs to render from `getStaticProps`, `getServerSideProps`, or `getInitialProps`:
 
-- **Filter and trim data:** Only return the fields your components actually use. Avoid passing entire database records or API responses when only a subset of fields is needed.
-- **Paginate large lists:** Instead of returning hundreds of items at once, return a smaller initial set and load more on the client via API routes.
-- **Move data fetching to the client:** For non-critical or below-the-fold content, fetch it on the client side after hydration using `useEffect` or a data fetching library like [SWR](https://swr.vercel.app/) or [React Query](https://tanstack.com/query).
+- **Filter and trim data:** Only return the fields your components use. Avoid passing entire database records or API responses when only a subset of fields is needed.
+- **Paginate large lists:** Instead of returning hundreds of items at once, return a smaller initial set and fetch additional items on the client using API routes.
+- **Move data fetching to the client:** For non-critical content or content not visible on initial load, fetch it on the client side after hydration using `useEffect` or a data fetching library like [SWR](https://swr.vercel.app/) or [React Query](https://tanstack.com/query).
 
-### Inspecting Your Page Data
+### Inspect your page data
 
-To see the data passed to your page, open your browser devtools console and run:
+To inspect the data your page receives, open your browser DevTools console and run:
 
 ```bash filename="Browser Console"
 JSON.parse(document.getElementById("__NEXT_DATA__").textContent)
 ```
 
-This lets you inspect the full payload and identify which fields are contributing to the size.
+Use this to inspect the full payload and identify which fields are adding to the size.
 
-### Configuring the Threshold
+### Configure the threshold
 
-The default threshold of 128kB is controlled by the `largePageDataBytes` option in `next.config.js`:
+The default threshold of 128 kB is controlled by the `largePageDataBytes` option in `next.config.js`:
 
 ```js filename="next.config.js"
 module.exports = {
   experimental: {
-    largePageDataBytes: 200 * 1000, // Set threshold to 200kB
+    largePageDataBytes: 200 * 1000, // Set threshold to 200 kB
   },
 }
 ```
 
-Only increase this threshold if you have evaluated the performance implications and determined it is acceptable for your use case.
+Before increasing this threshold, evaluate the performance implications to confirm the trade-off is acceptable for your use case.
 
 ## Useful Links
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?
Improve the `errors/large-page-data.mdx` error page.

### Why?
The existing error page lacked clarity on the `__NEXT_DATA__` mechanism, performance impacts, configuration options, and its applicability solely to the Pages Router. This led to confusion, as highlighted in community discussions:
- https://github.com/vercel/next.js/discussions/38364#discussioncomment-3090327
- https://github.com/vercel/next.js/discussions/60193#discussioncomment-8010640

### How?
- Added a note clarifying this warning applies only to the Pages Router.
- Explained the `__NEXT_DATA__` mechanism, why the threshold exists, and its performance implications (page weight, hydration, memory).
- Provided actionable suggestions to reduce data size (filter, paginate, client-side fetching).
- Documented the `experimental.largePageDataBytes` configuration option with a `next.config.js` example.
- Included relevant external links for further reading.

Closes NEXT-
Fixes #
-->

---
[Slack Thread](https://vercel.slack.com/archives/C08N392Q9EV/p1772698459867909?thread_ts=1772698459.867909&cid=C08N392Q9EV)

<p><a href="https://cursor.com/agents/bc-f75e35d4-cde9-5300-8c76-b4a67c24d55f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f75e35d4-cde9-5300-8c76-b4a67c24d55f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->