### PR TITLE
Turbopack: CompileTimeDefineValue numbers and regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9968,6 +9968,7 @@ dependencies = [
  "data-encoding",
  "either",
  "indexmap 2.13.0",
+ "num-bigint",
  "once_cell",
  "patricia_tree",
  "petgraph 0.8.3",

--- a/crates/next-core/src/segment_config.rs
+++ b/crates/next-core/src/segment_config.rs
@@ -834,9 +834,9 @@ async fn parse_config_value(
             };
 
             match value {
-                JsValue::Constant(ConstantValue::Num(ConstantNumber(val))) if val >= 0.0 => {
+                JsValue::Constant(ConstantValue::Num(ConstantNumber(val))) if *val >= 0.0 => {
                     config.revalidate = Some(NextRevalidate::Frequency {
-                        seconds: val as u32,
+                        seconds: *val as u32,
                     });
                 }
                 JsValue::Constant(ConstantValue::False) => {

--- a/turbopack/crates/turbopack-core/Cargo.toml
+++ b/turbopack/crates/turbopack-core/Cargo.toml
@@ -24,6 +24,7 @@ const_format = { workspace = true }
 data-encoding = { workspace = true }
 either = { workspace = true }
 indexmap = { workspace = true }
+num-bigint = "0.4"
 once_cell = { workspace = true }
 patricia_tree = { version = "0.10.1", features = ["serde"] }
 petgraph = { workspace = true, features = ["serde-1"] }

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -129,32 +129,18 @@ pub enum CompileTimeDefineValue {
     Regex(RcStr, RcStr),
 }
 
-fn integer_decode(val: f64) -> (u64, i16, i8) {
-    let bits: u64 = val.to_bits();
-    let sign: i8 = if bits >> 63 == 0 { 1 } else { -1 };
-    let mut exponent: i16 = ((bits >> 52) & 0x7ff) as i16;
-    let mantissa = if exponent == 0 {
-        (bits & 0xfffffffffffff) << 1
-    } else {
-        (bits & 0xfffffffffffff) | 0x10000000000000
-    };
-
-    exponent -= 1023 + 52;
-    (mantissa, exponent, sign)
-}
-
-/// Wrapper around f64 that implements total ordering and hashing based on total ordering.
+/// Wrapper around f64 that implements total Eq and Hash, based on total ordering.
 #[derive(Debug, Copy, Clone, TraceRawVcs, NonLocalValue, Encode, Decode)]
 pub struct TotalOrderF64(f64);
 impl PartialEq for TotalOrderF64 {
     fn eq(&self, other: &Self) -> bool {
-        integer_decode(self.0) == integer_decode(other.0)
+        self.0.total_cmp(&other.0) == std::cmp::Ordering::Equal
     }
 }
 impl Eq for TotalOrderF64 {}
 impl Hash for TotalOrderF64 {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        integer_decode(self.0).hash(state);
+        self.0.to_le_bytes().hash(state);
     }
 }
 impl From<f64> for TotalOrderF64 {

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -126,6 +126,7 @@ pub enum CompileTimeDefineValue {
     Object(Vec<(RcStr, CompileTimeDefineValue)>),
     Undefined,
     Evaluate(RcStr),
+    Regex(RcStr, RcStr),
 }
 
 fn integer_decode(val: f64) -> (u64, i16, i8) {

--- a/turbopack/crates/turbopack-core/src/compile_time_info.rs
+++ b/turbopack/crates/turbopack-core/src/compile_time_info.rs
@@ -1,6 +1,13 @@
+use std::{
+    fmt::Display,
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
+
 use anyhow::Result;
 use bincode::{Decode, Encode};
 use indexmap::Equivalent;
+use num_bigint::BigInt;
 use rustc_hash::FxHashSet;
 use smallvec::SmallVec;
 use turbo_rcstr::RcStr;
@@ -108,12 +115,62 @@ macro_rules! free_var_references {
 pub enum CompileTimeDefineValue {
     Null,
     Bool(bool),
-    Number(RcStr),
+    Number(TotalOrderF64),
     String(RcStr),
+    BigInt(
+        #[bincode(with_serde)]
+        #[turbo_tasks(trace_ignore)]
+        Box<BigInt>,
+    ),
     Array(Vec<CompileTimeDefineValue>),
     Object(Vec<(RcStr, CompileTimeDefineValue)>),
     Undefined,
     Evaluate(RcStr),
+}
+
+fn integer_decode(val: f64) -> (u64, i16, i8) {
+    let bits: u64 = val.to_bits();
+    let sign: i8 = if bits >> 63 == 0 { 1 } else { -1 };
+    let mut exponent: i16 = ((bits >> 52) & 0x7ff) as i16;
+    let mantissa = if exponent == 0 {
+        (bits & 0xfffffffffffff) << 1
+    } else {
+        (bits & 0xfffffffffffff) | 0x10000000000000
+    };
+
+    exponent -= 1023 + 52;
+    (mantissa, exponent, sign)
+}
+
+/// Wrapper around f64 that implements total ordering and hashing based on total ordering.
+#[derive(Debug, Copy, Clone, TraceRawVcs, NonLocalValue, Encode, Decode)]
+pub struct TotalOrderF64(f64);
+impl PartialEq for TotalOrderF64 {
+    fn eq(&self, other: &Self) -> bool {
+        integer_decode(self.0) == integer_decode(other.0)
+    }
+}
+impl Eq for TotalOrderF64 {}
+impl Hash for TotalOrderF64 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        integer_decode(self.0).hash(state);
+    }
+}
+impl From<f64> for TotalOrderF64 {
+    fn from(value: f64) -> Self {
+        Self(value)
+    }
+}
+impl Deref for TotalOrderF64 {
+    type Target = f64;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+impl Display for TotalOrderF64 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl From<bool> for CompileTimeDefineValue {
@@ -145,7 +202,11 @@ impl From<serde_json::Value> for CompileTimeDefineValue {
         match value {
             serde_json::Value::Null => Self::Null,
             serde_json::Value::Bool(b) => Self::Bool(b),
-            serde_json::Value::Number(n) => Self::Number(n.to_string().into()),
+            serde_json::Value::Number(n) => Self::Number(
+                n.as_f64()
+                    .expect("unreachable: serde-json has arbitrary_precision disabled")
+                    .into(),
+            ),
             serde_json::Value::String(s) => Self::String(s.into()),
             serde_json::Value::Array(a) => Self::Array(a.into_iter().map(|i| i.into()).collect()),
             serde_json::Value::Object(m) => {

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/builtin.rs
@@ -102,9 +102,9 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                 let JsValue::Constant(ConstantValue::Num(num)) = arg else {
                     return false;
                 };
-                sum += num.0;
+                sum += *num.0;
             }
-            *value = JsValue::Constant(ConstantValue::Num(ConstantNumber(sum)));
+            *value = JsValue::Constant(ConstantValue::Num(sum.into()));
             true
         }
 
@@ -403,7 +403,7 @@ pub fn replace_builtin(value: &mut JsValue) -> bool {
                                                     vec![
                                                         item,
                                                         JsValue::Constant(ConstantValue::Num(
-                                                            ConstantNumber(i as f64),
+                                                            (i as f64).into(),
                                                         )),
                                                     ],
                                                 )

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/graph.rs
@@ -26,8 +26,7 @@ use turbo_tasks::ResolvedVc;
 use turbopack_core::{resolve::ExportUsage, source::Source};
 
 use super::{
-    ConstantNumber, ConstantValue, ImportMap, JsValue, ObjectPart, WellKnownFunctionKind,
-    is_unresolved_id,
+    ConstantValue, ImportMap, JsValue, ObjectPart, WellKnownFunctionKind, is_unresolved_id,
 };
 use crate::{
     AnalyzeMode, SpecifiedModuleType,
@@ -519,8 +518,8 @@ impl EvalContext {
             // model their values mostly useful for truthy/falsy checks.
             match i.sym.as_str() {
                 "undefined" => JsValue::Constant(ConstantValue::Undefined),
-                "NaN" => JsValue::Constant(ConstantValue::Num(ConstantNumber(f64::NAN))),
-                "Infinity" => JsValue::Constant(ConstantValue::Num(ConstantNumber(f64::INFINITY))),
+                "NaN" => JsValue::Constant(ConstantValue::Num(f64::NAN.into())),
+                "Infinity" => JsValue::Constant(ConstantValue::Num(f64::INFINITY.into())),
                 _ => JsValue::FreeVar(i.sym.clone()),
             }
         } else {
@@ -868,7 +867,7 @@ impl EvalContext {
         }
     }
 
-    pub fn eval_single_expr_lit(expr_lit: RcStr) -> Result<JsValue> {
+    pub fn eval_single_expr_lit(expr_lit: &RcStr) -> Result<JsValue> {
         let cm = Lrc::new(SourceMap::default());
 
         let js_value = try_with_handler(cm, Default::default(), |_| {
@@ -3181,9 +3180,7 @@ impl Analyzer<'_> {
                 for (idx, elem) in arr.elems.iter().enumerate() {
                     let pat_value = Some(JsValue::member(
                         Box::new(value.clone()),
-                        Box::new(JsValue::Constant(ConstantValue::Num(ConstantNumber(
-                            idx as f64,
-                        )))),
+                        Box::new(JsValue::Constant(ConstantValue::Num((idx as f64).into()))),
                     ));
                     self.with_pat_value(pat_value, |this| {
                         let mut ast_path = ast_path

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -570,6 +570,9 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
             CompileTimeDefineValue::Number(n) => ConstantValue::Num(ConstantNumber(*n)),
             CompileTimeDefineValue::BigInt(n) => ConstantValue::BigInt(n.clone()),
             CompileTimeDefineValue::String(s) => s.as_str().into(),
+            CompileTimeDefineValue::Regex(pattern, flags) => {
+                ConstantValue::Regex(Box::new((pattern.as_str().into(), flags.as_str().into())))
+            }
             CompileTimeDefineValue::Array(a) => {
                 let mut js_value = JsValue::Array {
                     total_nodes: a.len() as u32,
@@ -615,9 +618,10 @@ impl TryFrom<&ConstantValue> for CompileTimeDefineValue {
             ConstantValue::Num(n) => CompileTimeDefineValue::Number(n.0),
             ConstantValue::Str(s) => CompileTimeDefineValue::String(s.as_rcstr()),
             ConstantValue::BigInt(n) => CompileTimeDefineValue::BigInt(n.clone()),
-            ConstantValue::Regex(_) => {
-                bail!("ConstantValue::Regex is not supported in ConstantValueCodeGen")
-            }
+            ConstantValue::Regex(regex) => CompileTimeDefineValue::Regex(
+                RcStr::from(regex.0.as_str()),
+                RcStr::from(regex.1.as_str()),
+            ),
         })
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -27,6 +27,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{FxIndexMap, FxIndexSet, Vc};
 use turbopack_core::compile_time_info::{
     CompileTimeDefineValue, DefinableNameSegmentRef, DefinableNameSegmentRefs, FreeVarReference,
+    TotalOrderF64,
 };
 
 use self::imports::ImportAnnotations;
@@ -57,43 +58,20 @@ impl Default for ObjectPart {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct ConstantNumber(pub f64);
-
-fn integer_decode(val: f64) -> (u64, i16, i8) {
-    let bits: u64 = val.to_bits();
-    let sign: i8 = if bits >> 63 == 0 { 1 } else { -1 };
-    let mut exponent: i16 = ((bits >> 52) & 0x7ff) as i16;
-    let mantissa = if exponent == 0 {
-        (bits & 0xfffffffffffff) << 1
-    } else {
-        (bits & 0xfffffffffffff) | 0x10000000000000
-    };
-
-    exponent -= 1023 + 52;
-    (mantissa, exponent, sign)
-}
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct ConstantNumber(pub TotalOrderF64);
 
 impl ConstantNumber {
     pub fn as_u32_index(&self) -> Option<usize> {
-        let index: u32 = self.0 as u32;
-        (index as f64 == self.0).then_some(index as usize)
+        let index: u32 = *self.0 as u32;
+        (index as f64 == *self.0).then_some(index as usize)
     }
 }
-
-impl Hash for ConstantNumber {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        integer_decode(self.0).hash(state);
+impl From<f64> for ConstantNumber {
+    fn from(value: f64) -> Self {
+        ConstantNumber(value.into())
     }
 }
-
-impl PartialEq for ConstantNumber {
-    fn eq(&self, other: &Self) -> bool {
-        integer_decode(self.0) == integer_decode(other.0)
-    }
-}
-
-impl Eq for ConstantNumber {}
 
 #[derive(Debug, Clone)]
 pub enum ConstantString {
@@ -206,7 +184,7 @@ impl ConstantValue {
             Self::Undefined | Self::False | Self::Null => false,
             Self::True | Self::Regex(..) => true,
             Self::Str(s) => !s.is_empty(),
-            Self::Num(ConstantNumber(n)) => *n != 0.0,
+            Self::Num(ConstantNumber(n)) => **n != 0.0,
             Self::BigInt(n) => !n.is_zero(),
         }
     }
@@ -264,7 +242,7 @@ impl From<Lit> for ConstantValue {
                 }
             }
             Lit::Null(_) => ConstantValue::Null,
-            Lit::Num(v) => ConstantValue::Num(ConstantNumber(v.value)),
+            Lit::Num(v) => ConstantValue::Num(ConstantNumber(v.value.into())),
             Lit::BigInt(v) => ConstantValue::BigInt(v.value),
             Lit::Regex(v) => ConstantValue::Regex(Box::new((v.exp, v.flags))),
             Lit::JSXText(v) => ConstantValue::Str(ConstantString::Atom(v.value)),
@@ -553,7 +531,7 @@ impl From<Box<BigInt>> for JsValue {
 
 impl From<f64> for JsValue {
     fn from(v: f64) -> Self {
-        ConstantValue::Num(ConstantNumber(v)).into()
+        ConstantValue::Num(ConstantNumber(v.into())).into()
     }
 }
 
@@ -585,13 +563,13 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
     type Error = anyhow::Error;
 
     fn try_from(value: &CompileTimeDefineValue) -> Result<Self> {
-        match value {
-            CompileTimeDefineValue::Null => Ok(JsValue::Constant(ConstantValue::Null)),
-            CompileTimeDefineValue::Bool(b) => Ok(JsValue::Constant((*b).into())),
-            CompileTimeDefineValue::Number(n) => Ok(JsValue::Constant(ConstantValue::Num(
-                ConstantNumber(n.as_str().parse::<f64>()?),
-            ))),
-            CompileTimeDefineValue::String(s) => Ok(JsValue::Constant(s.as_str().into())),
+        Ok(JsValue::Constant(match value {
+            CompileTimeDefineValue::Undefined => ConstantValue::Undefined,
+            CompileTimeDefineValue::Null => ConstantValue::Null,
+            CompileTimeDefineValue::Bool(b) => (*b).into(),
+            CompileTimeDefineValue::Number(n) => ConstantValue::Num(ConstantNumber(*n)),
+            CompileTimeDefineValue::BigInt(n) => ConstantValue::BigInt(n.clone()),
+            CompileTimeDefineValue::String(s) => s.as_str().into(),
             CompileTimeDefineValue::Array(a) => {
                 let mut js_value = JsValue::Array {
                     total_nodes: a.len() as u32,
@@ -599,7 +577,7 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
                     mutable: false,
                 };
                 js_value.update_total_nodes();
-                Ok(js_value)
+                return Ok(js_value);
             }
             CompileTimeDefineValue::Object(m) => {
                 let mut js_value = JsValue::Object {
@@ -616,11 +594,31 @@ impl TryFrom<&CompileTimeDefineValue> for JsValue {
                     mutable: false,
                 };
                 js_value.update_total_nodes();
-                Ok(js_value)
+                return Ok(js_value);
             }
-            CompileTimeDefineValue::Undefined => Ok(JsValue::Constant(ConstantValue::Undefined)),
-            CompileTimeDefineValue::Evaluate(s) => EvalContext::eval_single_expr_lit(s.clone()),
-        }
+            CompileTimeDefineValue::Evaluate(s) => {
+                return EvalContext::eval_single_expr_lit(s);
+            }
+        }))
+    }
+}
+
+impl TryFrom<&ConstantValue> for CompileTimeDefineValue {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &ConstantValue) -> Result<Self> {
+        Ok(match value {
+            ConstantValue::Undefined => CompileTimeDefineValue::Undefined,
+            ConstantValue::Null => CompileTimeDefineValue::Null,
+            ConstantValue::True => CompileTimeDefineValue::Bool(true),
+            ConstantValue::False => CompileTimeDefineValue::Bool(false),
+            ConstantValue::Num(n) => CompileTimeDefineValue::Number(n.0),
+            ConstantValue::Str(s) => CompileTimeDefineValue::String(s.as_rcstr()),
+            ConstantValue::BigInt(n) => CompileTimeDefineValue::BigInt(n.clone()),
+            ConstantValue::Regex(_) => {
+                bail!("ConstantValue::Regex is not supported in ConstantValueCodeGen")
+            }
+        })
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -3,7 +3,7 @@ use bincode::{Decode, Encode};
 use swc_core::{
     common::{DUMMY_SP, FileName, SourceMap, sync::Lrc},
     ecma::{
-        ast::{ArrayLit, EsVersion, Expr, KeyValueProp, ObjectLit, Prop, PropName, Str},
+        ast::{ArrayLit, EsVersion, Expr, KeyValueProp, Lit, ObjectLit, Prop, PropName, Str},
         parser::{Syntax, parse_file_as_expr},
     },
     quote,
@@ -37,8 +37,7 @@ impl ConstantValueCodeGen {
         let value = self.value.clone();
 
         let visitor = create_visitor!(self.path, visit_mut_expr, |expr: &mut Expr| {
-            // TODO: avoid this clone
-            *expr = define_env_to_expr((value).clone());
+            *expr = value_to_expr(&value);
         });
 
         Ok(CodeGeneration::visitors(vec![visitor]))
@@ -51,8 +50,11 @@ impl From<ConstantValueCodeGen> for CodeGen {
     }
 }
 
-fn define_env_to_expr(value: CompileTimeDefineValue) -> Expr {
+fn value_to_expr(value: &CompileTimeDefineValue) -> Expr {
     match value {
+        CompileTimeDefineValue::Undefined => {
+            quote!("(\"TURBOPACK compile-time value\", void 0)" as Expr)
+        }
         CompileTimeDefineValue::Null => {
             quote!("(\"TURBOPACK compile-time value\", null)" as Expr)
         }
@@ -62,28 +64,31 @@ fn define_env_to_expr(value: CompileTimeDefineValue) -> Expr {
         CompileTimeDefineValue::Bool(false) => {
             quote!("(\"TURBOPACK compile-time value\", false)" as Expr)
         }
-        CompileTimeDefineValue::Number(ref n) => {
-            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = n.parse::<f64>().unwrap().into())
+        CompileTimeDefineValue::Number(n) => {
+            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = (**n).into())
         }
-        CompileTimeDefineValue::String(ref s) => {
-            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = s.to_string().into())
+        CompileTimeDefineValue::String(s) => {
+            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = s.as_str().into())
+        }
+        CompileTimeDefineValue::BigInt(n) => {
+            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Lit(Lit::BigInt(n.as_ref().clone().into())))
         }
         CompileTimeDefineValue::Array(a) => {
             quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Array(ArrayLit {
                 span: DUMMY_SP,
-                elems: a.into_iter().map(|i| Some(define_env_to_expr(i).into())).collect(),
+                elems: a.iter().map(|i| Some(value_to_expr(i).into())).collect(),
             }))
         }
         CompileTimeDefineValue::Object(m) => {
             quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Object(ObjectLit {
                 span: DUMMY_SP,
                 props: m
-                    .into_iter()
+                    .iter()
                     .map(|(k, v)| {
                         swc_core::ecma::ast::PropOrSpread::Prop(
                             Prop::KeyValue(KeyValueProp {
                                 key: PropName::Str(Str::from(k.as_str())),
-                                value: define_env_to_expr(v).into(),
+                                value: value_to_expr(v).into(),
                             })
                             .into(),
                         )
@@ -91,14 +96,11 @@ fn define_env_to_expr(value: CompileTimeDefineValue) -> Expr {
                     .collect(),
             }))
         }
-        CompileTimeDefineValue::Undefined => {
-            quote!("(\"TURBOPACK compile-time value\", void 0)" as Expr)
-        }
-        CompileTimeDefineValue::Evaluate(ref s) => parse_single_expr_lit(s.clone()),
+        CompileTimeDefineValue::Evaluate(s) => parse_single_expr_lit(s),
     }
 }
 
-pub(crate) fn parse_single_expr_lit(expr_lit: RcStr) -> Expr {
+pub(crate) fn parse_single_expr_lit(expr_lit: &RcStr) -> Expr {
     let cm = Lrc::new(SourceMap::default());
     let fm = cm.new_source_file(FileName::Anon.into(), expr_lit.clone());
     parse_file_as_expr(

--- a/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/constant_value.rs
@@ -3,7 +3,9 @@ use bincode::{Decode, Encode};
 use swc_core::{
     common::{DUMMY_SP, FileName, SourceMap, sync::Lrc},
     ecma::{
-        ast::{ArrayLit, EsVersion, Expr, KeyValueProp, Lit, ObjectLit, Prop, PropName, Str},
+        ast::{
+            ArrayLit, EsVersion, Expr, KeyValueProp, Lit, ObjectLit, Prop, PropName, Regex, Str,
+        },
         parser::{Syntax, parse_file_as_expr},
     },
     quote,
@@ -72,6 +74,13 @@ fn value_to_expr(value: &CompileTimeDefineValue) -> Expr {
         }
         CompileTimeDefineValue::BigInt(n) => {
             quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Lit(Lit::BigInt(n.as_ref().clone().into())))
+        }
+        CompileTimeDefineValue::Regex(pattern, flags) => {
+            quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Lit(Lit::Regex(Regex {
+               span: DUMMY_SP,
+               exp: pattern.as_str().into(),
+               flags: flags.as_str().into(),
+            })))
         }
         CompileTimeDefineValue::Array(a) => {
             quote!("(\"TURBOPACK compile-time value\", $e)" as Expr, e: Expr = Expr::Array(ArrayLit {

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/1/graph.snapshot
@@ -37,7 +37,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/2/graph.snapshot
@@ -7,7 +7,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph-effects.snapshot
@@ -6,7 +6,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -323,7 +325,9 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -366,7 +370,9 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    2.0,
+                    TotalOrderF64(
+                        2.0,
+                    ),
                 ),
             ),
         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/array/graph.snapshot
@@ -4,7 +4,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -29,7 +31,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                1.0,
+                                TotalOrderF64(
+                                    1.0,
+                                ),
                             ),
                         ),
                     ),
@@ -66,7 +70,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -119,7 +125,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -138,7 +146,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        2.0,
+                        TotalOrderF64(
+                            2.0,
+                        ),
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/arrow/graph.snapshot
@@ -7,7 +7,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        3.0,
+                        TotalOrderF64(
+                            3.0,
+                        ),
                     ),
                 ),
             ),
@@ -21,7 +23,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        3.0,
+                        TotalOrderF64(
+                            3.0,
+                        ),
                     ),
                 ),
             ),
@@ -35,7 +39,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -49,7 +55,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -63,7 +71,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        2.0,
+                        TotalOrderF64(
+                            2.0,
+                        ),
                     ),
                 ),
             ),
@@ -77,7 +87,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -91,7 +103,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        2.0,
+                        TotalOrderF64(
+                            2.0,
+                        ),
                     ),
                 ),
             ),
@@ -105,7 +119,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        2.0,
+                        TotalOrderF64(
+                            2.0,
+                        ),
                     ),
                 ),
             ),
@@ -119,7 +135,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -133,7 +151,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        2.0,
+                        TotalOrderF64(
+                            2.0,
+                        ),
                     ),
                 ),
             ),
@@ -192,7 +212,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        4.0,
+                        TotalOrderF64(
+                            4.0,
+                        ),
                     ),
                 ),
             ),
@@ -261,7 +283,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        4.0,
+                        TotalOrderF64(
+                            4.0,
+                        ),
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/assign/graph.snapshot
@@ -41,7 +41,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -62,7 +64,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -83,14 +87,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -106,14 +114,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -129,14 +141,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/cycle-cache/graph.snapshot
@@ -59,7 +59,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -125,7 +127,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        2.0,
+                        TotalOrderF64(
+                            2.0,
+                        ),
                     ),
                 ),
             ),
@@ -191,7 +195,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        2.0,
+                        TotalOrderF64(
+                            2.0,
+                        ),
                     ),
                 ),
             ),
@@ -257,7 +263,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -271,21 +279,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -307,21 +321,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -343,21 +363,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            8.0,
+                            TotalOrderF64(
+                                8.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/declarations/graph.snapshot
@@ -51,7 +51,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    123.0,
+                    TotalOrderF64(
+                        123.0,
+                    ),
                 ),
             ),
         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph-effects.snapshot
@@ -6135,7 +6135,9 @@
                                                                 Constant(
                                                                     Num(
                                                                         ConstantNumber(
-                                                                            493.0,
+                                                                            TotalOrderF64(
+                                                                                493.0,
+                                                                            ),
                                                                         ),
                                                                     ),
                                                                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/esbuild/graph.snapshot
@@ -111,7 +111,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -290,7 +292,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array-2/graph.snapshot
@@ -90,7 +90,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),
@@ -109,7 +111,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/fn-array/graph.snapshot
@@ -90,7 +90,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),
@@ -109,7 +111,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/iife-2/graph.snapshot
@@ -20,7 +20,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-effects.snapshot
@@ -104,7 +104,9 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            1.0,
+                                            TotalOrderF64(
+                                                1.0,
+                                            ),
                                         ),
                                     ),
                                 ),
@@ -113,7 +115,9 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            1.0,
+                                            TotalOrderF64(
+                                                1.0,
+                                            ),
                                         ),
                                     ),
                                 ),
@@ -391,7 +395,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -400,7 +406,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -539,7 +547,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -548,7 +558,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/logical/graph.snapshot
@@ -71,21 +71,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -108,14 +114,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1.0,
+                                    TotalOrderF64(
+                                        1.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    2.0,
+                                    TotalOrderF64(
+                                        2.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -127,14 +137,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -177,14 +191,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -194,14 +212,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -217,21 +239,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -241,7 +269,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph-effects.snapshot
@@ -184,7 +184,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -438,7 +440,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -530,7 +534,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -666,7 +672,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -678,7 +686,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -770,7 +780,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -906,7 +918,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -918,7 +932,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -927,7 +943,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            606105819.0,
+                            TotalOrderF64(
+                                606105819.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1012,7 +1030,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1148,7 +1168,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -1160,7 +1182,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1252,7 +1276,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1388,7 +1414,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        4.0,
+                                        TotalOrderF64(
+                                            4.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -1400,7 +1428,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1492,7 +1522,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1628,7 +1660,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        5.0,
+                                        TotalOrderF64(
+                                            5.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -1640,7 +1674,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1649,7 +1685,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1200080426.0,
+                            TotalOrderF64(
+                                1200080426.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1734,7 +1772,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1870,7 +1910,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        6.0,
+                                        TotalOrderF64(
+                                            6.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -1882,7 +1924,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1974,7 +2018,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2110,7 +2156,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        7.0,
+                                        TotalOrderF64(
+                                            7.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -2122,7 +2170,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2214,7 +2264,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            8.0,
+                            TotalOrderF64(
+                                8.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2350,7 +2402,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        8.0,
+                                        TotalOrderF64(
+                                            8.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -2362,7 +2416,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2371,7 +2427,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1770035416.0,
+                            TotalOrderF64(
+                                1770035416.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2456,7 +2514,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2592,7 +2652,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        9.0,
+                                        TotalOrderF64(
+                                            9.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -2604,7 +2666,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2696,7 +2760,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2832,7 +2898,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        10.0,
+                                        TotalOrderF64(
+                                            10.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -2844,7 +2912,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2936,7 +3006,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3072,7 +3144,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        11.0,
+                                        TotalOrderF64(
+                                            11.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -3084,7 +3158,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3176,7 +3252,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3312,7 +3390,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        12.0,
+                                        TotalOrderF64(
+                                            12.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -3324,7 +3404,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3333,7 +3415,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1804603682.0,
+                            TotalOrderF64(
+                                1804603682.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3418,7 +3502,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            13.0,
+                            TotalOrderF64(
+                                13.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3554,7 +3640,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        13.0,
+                                        TotalOrderF64(
+                                            13.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -3566,7 +3654,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3658,7 +3748,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3794,7 +3886,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        14.0,
+                                        TotalOrderF64(
+                                            14.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -3806,7 +3900,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -3898,7 +3994,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -4034,7 +4132,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        15.0,
+                                        TotalOrderF64(
+                                            15.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -4046,7 +4146,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -4055,7 +4157,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1236535329.0,
+                            TotalOrderF64(
+                                1236535329.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5-reduced/graph.snapshot
@@ -7,7 +7,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1732584193.0,
+                            TotalOrderF64(
+                                1732584193.0,
+                            ),
                         ),
                     ),
                 ),
@@ -62,7 +64,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -126,7 +130,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                4.0,
+                                                TotalOrderF64(
+                                                    4.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -136,7 +142,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -200,7 +208,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                8.0,
+                                                TotalOrderF64(
+                                                    8.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -210,14 +220,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1770035416.0,
+                                    TotalOrderF64(
+                                        1770035416.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -276,7 +290,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                12.0,
+                                                TotalOrderF64(
+                                                    12.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -286,14 +302,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1804603682.0,
+                                    TotalOrderF64(
+                                        1804603682.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -380,7 +400,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                3.0,
+                                                TotalOrderF64(
+                                                    3.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -390,7 +412,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -454,7 +478,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                7.0,
+                                                TotalOrderF64(
+                                                    7.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -464,7 +490,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -528,7 +556,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                11.0,
+                                                TotalOrderF64(
+                                                    11.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -538,7 +568,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -602,7 +634,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                15.0,
+                                                TotalOrderF64(
+                                                    15.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -612,14 +646,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1236535329.0,
+                                    TotalOrderF64(
+                                        1236535329.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -706,7 +744,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                2.0,
+                                                TotalOrderF64(
+                                                    2.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -716,14 +756,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    17.0,
+                                    TotalOrderF64(
+                                        17.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    606105819.0,
+                                    TotalOrderF64(
+                                        606105819.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -782,7 +826,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                6.0,
+                                                TotalOrderF64(
+                                                    6.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -792,7 +838,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    17.0,
+                                    TotalOrderF64(
+                                        17.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -856,7 +904,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                10.0,
+                                                TotalOrderF64(
+                                                    10.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -866,7 +916,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    17.0,
+                                    TotalOrderF64(
+                                        17.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -930,7 +982,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                14.0,
+                                                TotalOrderF64(
+                                                    14.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -940,7 +994,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    17.0,
+                                    TotalOrderF64(
+                                        17.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -970,7 +1026,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            271733878.0,
+                            TotalOrderF64(
+                                271733878.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1027,7 +1085,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                1.0,
+                                                TotalOrderF64(
+                                                    1.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1037,7 +1097,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    12.0,
+                                    TotalOrderF64(
+                                        12.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1101,7 +1163,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                5.0,
+                                                TotalOrderF64(
+                                                    5.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1111,14 +1175,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    12.0,
+                                    TotalOrderF64(
+                                        12.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1200080426.0,
+                                    TotalOrderF64(
+                                        1200080426.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1177,7 +1245,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                9.0,
+                                                TotalOrderF64(
+                                                    9.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1187,7 +1257,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    12.0,
+                                    TotalOrderF64(
+                                        12.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1251,7 +1323,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                13.0,
+                                                TotalOrderF64(
+                                                    13.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1261,7 +1335,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    12.0,
+                                    TotalOrderF64(
+                                        12.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1303,7 +1379,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1319,7 +1397,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    16.0,
+                                    TotalOrderF64(
+                                        16.0,
+                                    ),
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph-effects.snapshot
@@ -2781,7 +2781,9 @@
                                                 Constant(
                                                     Num(
                                                         ConstantNumber(
-                                                            0.0,
+                                                            TotalOrderF64(
+                                                                0.0,
+                                                            ),
                                                         ),
                                                     ),
                                                 ),
@@ -5491,7 +5493,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -6137,7 +6141,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -6319,7 +6325,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        0.0,
+                                        TotalOrderF64(
+                                            0.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -6331,7 +6339,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -6469,7 +6479,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -6651,7 +6663,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -6663,7 +6677,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -6801,7 +6817,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -6983,7 +7001,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -6995,7 +7015,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -7004,7 +7026,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            606105819.0,
+                            TotalOrderF64(
+                                606105819.0,
+                            ),
                         ),
                     ),
                 ),
@@ -7135,7 +7159,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -7317,7 +7343,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -7329,7 +7357,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -7467,7 +7497,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -7649,7 +7681,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        4.0,
+                                        TotalOrderF64(
+                                            4.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -7661,7 +7695,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -7799,7 +7835,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -7981,7 +8019,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        5.0,
+                                        TotalOrderF64(
+                                            5.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -7993,7 +8033,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -8002,7 +8044,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1200080426.0,
+                            TotalOrderF64(
+                                1200080426.0,
+                            ),
                         ),
                     ),
                 ),
@@ -8133,7 +8177,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -8315,7 +8361,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        6.0,
+                                        TotalOrderF64(
+                                            6.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -8327,7 +8375,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -8465,7 +8515,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -8647,7 +8699,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        7.0,
+                                        TotalOrderF64(
+                                            7.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -8659,7 +8713,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -8797,7 +8853,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            8.0,
+                            TotalOrderF64(
+                                8.0,
+                            ),
                         ),
                     ),
                 ),
@@ -8979,7 +9037,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        8.0,
+                                        TotalOrderF64(
+                                            8.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -8991,7 +9051,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -9000,7 +9062,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1770035416.0,
+                            TotalOrderF64(
+                                1770035416.0,
+                            ),
                         ),
                     ),
                 ),
@@ -9131,7 +9195,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -9313,7 +9379,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        9.0,
+                                        TotalOrderF64(
+                                            9.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -9325,7 +9393,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -9463,7 +9533,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -9645,7 +9717,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        10.0,
+                                        TotalOrderF64(
+                                            10.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -9657,7 +9731,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -9795,7 +9871,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -9977,7 +10055,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        11.0,
+                                        TotalOrderF64(
+                                            11.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -9989,7 +10069,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -10127,7 +10209,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -10309,7 +10393,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        12.0,
+                                        TotalOrderF64(
+                                            12.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -10321,7 +10407,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -10330,7 +10418,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1804603682.0,
+                            TotalOrderF64(
+                                1804603682.0,
+                            ),
                         ),
                     ),
                 ),
@@ -10461,7 +10551,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            13.0,
+                            TotalOrderF64(
+                                13.0,
+                            ),
                         ),
                     ),
                 ),
@@ -10643,7 +10735,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        13.0,
+                                        TotalOrderF64(
+                                            13.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -10655,7 +10749,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -10793,7 +10889,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -10975,7 +11073,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        14.0,
+                                        TotalOrderF64(
+                                            14.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -10987,7 +11087,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            17.0,
+                            TotalOrderF64(
+                                17.0,
+                            ),
                         ),
                     ),
                 ),
@@ -11125,7 +11227,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -11307,7 +11411,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        15.0,
+                                        TotalOrderF64(
+                                            15.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -11319,7 +11425,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            22.0,
+                            TotalOrderF64(
+                                22.0,
+                            ),
                         ),
                     ),
                 ),
@@ -11328,7 +11436,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1236535329.0,
+                            TotalOrderF64(
+                                1236535329.0,
+                            ),
                         ),
                     ),
                 ),
@@ -11459,7 +11569,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -11641,7 +11753,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -11653,7 +11767,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -11791,7 +11907,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -11973,7 +12091,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        6.0,
+                                        TotalOrderF64(
+                                            6.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -11985,7 +12105,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -12123,7 +12245,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -12305,7 +12429,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        11.0,
+                                        TotalOrderF64(
+                                            11.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -12317,7 +12443,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -12326,7 +12454,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            643717713.0,
+                            TotalOrderF64(
+                                643717713.0,
+                            ),
                         ),
                     ),
                 ),
@@ -12457,7 +12587,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -12639,7 +12771,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        0.0,
+                                        TotalOrderF64(
+                                            0.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -12651,7 +12785,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            20.0,
+                            TotalOrderF64(
+                                20.0,
+                            ),
                         ),
                     ),
                 ),
@@ -12789,7 +12925,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -12971,7 +13109,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        5.0,
+                                        TotalOrderF64(
+                                            5.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -12983,7 +13123,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -13121,7 +13263,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -13303,7 +13447,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        10.0,
+                                        TotalOrderF64(
+                                            10.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -13315,7 +13461,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -13324,7 +13472,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            38016083.0,
+                            TotalOrderF64(
+                                38016083.0,
+                            ),
                         ),
                     ),
                 ),
@@ -13455,7 +13605,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -13637,7 +13789,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        15.0,
+                                        TotalOrderF64(
+                                            15.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -13649,7 +13803,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -13787,7 +13943,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -13969,7 +14127,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        4.0,
+                                        TotalOrderF64(
+                                            4.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -13981,7 +14141,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            20.0,
+                            TotalOrderF64(
+                                20.0,
+                            ),
                         ),
                     ),
                 ),
@@ -14119,7 +14281,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -14301,7 +14465,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        9.0,
+                                        TotalOrderF64(
+                                            9.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -14313,7 +14479,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -14322,7 +14490,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            568446438.0,
+                            TotalOrderF64(
+                                568446438.0,
+                            ),
                         ),
                     ),
                 ),
@@ -14453,7 +14623,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -14635,7 +14807,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        14.0,
+                                        TotalOrderF64(
+                                            14.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -14647,7 +14821,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -14785,7 +14961,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -14967,7 +15145,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -14979,7 +15159,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -15117,7 +15299,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            8.0,
+                            TotalOrderF64(
+                                8.0,
+                            ),
                         ),
                     ),
                 ),
@@ -15299,7 +15483,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        8.0,
+                                        TotalOrderF64(
+                                            8.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -15311,7 +15497,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            20.0,
+                            TotalOrderF64(
+                                20.0,
+                            ),
                         ),
                     ),
                 ),
@@ -15320,7 +15508,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1163531501.0,
+                            TotalOrderF64(
+                                1163531501.0,
+                            ),
                         ),
                     ),
                 ),
@@ -15451,7 +15641,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            13.0,
+                            TotalOrderF64(
+                                13.0,
+                            ),
                         ),
                     ),
                 ),
@@ -15633,7 +15825,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        13.0,
+                                        TotalOrderF64(
+                                            13.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -15645,7 +15839,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -15783,7 +15979,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -15965,7 +16163,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -15977,7 +16177,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -16115,7 +16317,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -16297,7 +16501,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        7.0,
+                                        TotalOrderF64(
+                                            7.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -16309,7 +16515,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -16318,7 +16526,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1735328473.0,
+                            TotalOrderF64(
+                                1735328473.0,
+                            ),
                         ),
                     ),
                 ),
@@ -16449,7 +16659,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -16631,7 +16843,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        12.0,
+                                        TotalOrderF64(
+                                            12.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -16643,7 +16857,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            20.0,
+                            TotalOrderF64(
+                                20.0,
+                            ),
                         ),
                     ),
                 ),
@@ -16781,7 +16997,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -16963,7 +17181,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        5.0,
+                                        TotalOrderF64(
+                                            5.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -16975,7 +17195,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -17113,7 +17335,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            8.0,
+                            TotalOrderF64(
+                                8.0,
+                            ),
                         ),
                     ),
                 ),
@@ -17295,7 +17519,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        8.0,
+                                        TotalOrderF64(
+                                            8.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -17307,7 +17533,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -17445,7 +17673,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -17627,7 +17857,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        11.0,
+                                        TotalOrderF64(
+                                            11.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -17639,7 +17871,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            16.0,
+                            TotalOrderF64(
+                                16.0,
+                            ),
                         ),
                     ),
                 ),
@@ -17648,7 +17882,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1839030562.0,
+                            TotalOrderF64(
+                                1839030562.0,
+                            ),
                         ),
                     ),
                 ),
@@ -17779,7 +18015,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -17961,7 +18199,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        14.0,
+                                        TotalOrderF64(
+                                            14.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -17973,7 +18213,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            23.0,
+                            TotalOrderF64(
+                                23.0,
+                            ),
                         ),
                     ),
                 ),
@@ -18111,7 +18353,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -18293,7 +18537,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -18305,7 +18551,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -18443,7 +18691,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -18625,7 +18875,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        4.0,
+                                        TotalOrderF64(
+                                            4.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -18637,7 +18889,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -18646,7 +18900,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1272893353.0,
+                            TotalOrderF64(
+                                1272893353.0,
+                            ),
                         ),
                     ),
                 ),
@@ -18777,7 +19033,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -18959,7 +19217,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        7.0,
+                                        TotalOrderF64(
+                                            7.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -18971,7 +19231,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            16.0,
+                            TotalOrderF64(
+                                16.0,
+                            ),
                         ),
                     ),
                 ),
@@ -19109,7 +19371,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -19291,7 +19555,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        10.0,
+                                        TotalOrderF64(
+                                            10.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -19303,7 +19569,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            23.0,
+                            TotalOrderF64(
+                                23.0,
+                            ),
                         ),
                     ),
                 ),
@@ -19441,7 +19709,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            13.0,
+                            TotalOrderF64(
+                                13.0,
+                            ),
                         ),
                     ),
                 ),
@@ -19623,7 +19893,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        13.0,
+                                        TotalOrderF64(
+                                            13.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -19635,7 +19907,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -19644,7 +19918,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            681279174.0,
+                            TotalOrderF64(
+                                681279174.0,
+                            ),
                         ),
                     ),
                 ),
@@ -19775,7 +20051,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -19957,7 +20235,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        0.0,
+                                        TotalOrderF64(
+                                            0.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -19969,7 +20249,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -20107,7 +20389,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -20289,7 +20573,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -20301,7 +20587,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            16.0,
+                            TotalOrderF64(
+                                16.0,
+                            ),
                         ),
                     ),
                 ),
@@ -20439,7 +20727,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -20621,7 +20911,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        6.0,
+                                        TotalOrderF64(
+                                            6.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -20633,7 +20925,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            23.0,
+                            TotalOrderF64(
+                                23.0,
+                            ),
                         ),
                     ),
                 ),
@@ -20642,7 +20936,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            76029189.0,
+                            TotalOrderF64(
+                                76029189.0,
+                            ),
                         ),
                     ),
                 ),
@@ -20773,7 +21069,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -20955,7 +21253,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        9.0,
+                                        TotalOrderF64(
+                                            9.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -20967,7 +21267,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -21105,7 +21407,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -21287,7 +21591,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        12.0,
+                                        TotalOrderF64(
+                                            12.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -21299,7 +21605,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -21437,7 +21745,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -21619,7 +21929,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        15.0,
+                                        TotalOrderF64(
+                                            15.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -21631,7 +21943,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            16.0,
+                            TotalOrderF64(
+                                16.0,
+                            ),
                         ),
                     ),
                 ),
@@ -21640,7 +21954,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            530742520.0,
+                            TotalOrderF64(
+                                530742520.0,
+                            ),
                         ),
                     ),
                 ),
@@ -21771,7 +22087,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -21953,7 +22271,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -21965,7 +22285,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            23.0,
+                            TotalOrderF64(
+                                23.0,
+                            ),
                         ),
                     ),
                 ),
@@ -22103,7 +22425,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -22285,7 +22609,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        0.0,
+                                        TotalOrderF64(
+                                            0.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -22297,7 +22623,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -22435,7 +22763,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            7.0,
+                            TotalOrderF64(
+                                7.0,
+                            ),
                         ),
                     ),
                 ),
@@ -22617,7 +22947,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        7.0,
+                                        TotalOrderF64(
+                                            7.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -22629,7 +22961,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -22638,7 +22972,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1126891415.0,
+                            TotalOrderF64(
+                                1126891415.0,
+                            ),
                         ),
                     ),
                 ),
@@ -22769,7 +23105,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            14.0,
+                            TotalOrderF64(
+                                14.0,
+                            ),
                         ),
                     ),
                 ),
@@ -22951,7 +23289,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        14.0,
+                                        TotalOrderF64(
+                                            14.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -22963,7 +23303,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -23101,7 +23443,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -23283,7 +23627,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        5.0,
+                                        TotalOrderF64(
+                                            5.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -23295,7 +23641,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            21.0,
+                            TotalOrderF64(
+                                21.0,
+                            ),
                         ),
                     ),
                 ),
@@ -23433,7 +23781,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            12.0,
+                            TotalOrderF64(
+                                12.0,
+                            ),
                         ),
                     ),
                 ),
@@ -23615,7 +23965,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        12.0,
+                                        TotalOrderF64(
+                                            12.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -23627,7 +23979,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -23636,7 +23990,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1700485571.0,
+                            TotalOrderF64(
+                                1700485571.0,
+                            ),
                         ),
                     ),
                 ),
@@ -23767,7 +24123,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -23949,7 +24307,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -23961,7 +24321,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -24099,7 +24461,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -24281,7 +24645,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        10.0,
+                                        TotalOrderF64(
+                                            10.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -24293,7 +24659,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -24431,7 +24799,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -24613,7 +24983,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -24625,7 +24997,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            21.0,
+                            TotalOrderF64(
+                                21.0,
+                            ),
                         ),
                     ),
                 ),
@@ -24763,7 +25137,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            8.0,
+                            TotalOrderF64(
+                                8.0,
+                            ),
                         ),
                     ),
                 ),
@@ -24945,7 +25321,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        8.0,
+                                        TotalOrderF64(
+                                            8.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -24957,7 +25335,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -24966,7 +25346,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1873313359.0,
+                            TotalOrderF64(
+                                1873313359.0,
+                            ),
                         ),
                     ),
                 ),
@@ -25097,7 +25479,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -25279,7 +25663,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        15.0,
+                                        TotalOrderF64(
+                                            15.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -25291,7 +25677,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -25429,7 +25817,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -25611,7 +26001,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        6.0,
+                                        TotalOrderF64(
+                                            6.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -25623,7 +26015,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -25761,7 +26155,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            13.0,
+                            TotalOrderF64(
+                                13.0,
+                            ),
                         ),
                     ),
                 ),
@@ -25943,7 +26339,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        13.0,
+                                        TotalOrderF64(
+                                            13.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -25955,7 +26353,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            21.0,
+                            TotalOrderF64(
+                                21.0,
+                            ),
                         ),
                     ),
                 ),
@@ -25964,7 +26364,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1309151649.0,
+                            TotalOrderF64(
+                                1309151649.0,
+                            ),
                         ),
                     ),
                 ),
@@ -26095,7 +26497,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -26277,7 +26681,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        4.0,
+                                        TotalOrderF64(
+                                            4.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -26289,7 +26695,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -26427,7 +26835,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            11.0,
+                            TotalOrderF64(
+                                11.0,
+                            ),
                         ),
                     ),
                 ),
@@ -26609,7 +27019,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        11.0,
+                                        TotalOrderF64(
+                                            11.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -26621,7 +27033,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            10.0,
+                            TotalOrderF64(
+                                10.0,
+                            ),
                         ),
                     ),
                 ),
@@ -26759,7 +27173,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -26941,7 +27357,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -26953,7 +27371,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            15.0,
+                            TotalOrderF64(
+                                15.0,
+                            ),
                         ),
                     ),
                 ),
@@ -26962,7 +27382,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            718787259.0,
+                            TotalOrderF64(
+                                718787259.0,
+                            ),
                         ),
                     ),
                 ),
@@ -27093,7 +27515,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            9.0,
+                            TotalOrderF64(
+                                9.0,
+                            ),
                         ),
                     ),
                 ),
@@ -27275,7 +27699,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        9.0,
+                                        TotalOrderF64(
+                                            9.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -27287,7 +27713,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            21.0,
+                            TotalOrderF64(
+                                21.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/md5_2/graph.snapshot
@@ -360,7 +360,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1732584193.0,
+                            TotalOrderF64(
+                                1732584193.0,
+                            ),
                         ),
                     ),
                 ),
@@ -417,7 +419,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                0.0,
+                                                TotalOrderF64(
+                                                    0.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -427,81 +431,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
-                                ),
-                            ),
-                        ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "FF",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
+                                    TotalOrderF64(
+                                        7.0,
                                     ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                4.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    7.0,
                                 ),
                             ),
                         ),
@@ -565,7 +497,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                8.0,
+                                                TotalOrderF64(
+                                                    4.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -575,14 +509,96 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Unknown {
+                            original_value: None,
+                            reason: "unsupported expression",
+                            has_side_effects: true,
+                        },
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "FF",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    8.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1770035416.0,
+                                    TotalOrderF64(
+                                        1770035416.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -641,7 +657,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                12.0,
+                                                TotalOrderF64(
+                                                    12.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -651,14 +669,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1804603682.0,
+                                    TotalOrderF64(
+                                        1804603682.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -717,7 +739,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                1.0,
+                                                TotalOrderF64(
+                                                    1.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -727,81 +751,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    5.0,
-                                ),
-                            ),
-                        ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "GG",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
+                                    TotalOrderF64(
+                                        5.0,
                                     ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                5.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    5.0,
                                 ),
                             ),
                         ),
@@ -865,7 +817,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                9.0,
+                                                TotalOrderF64(
+                                                    5.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -875,14 +829,96 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    5.0,
+                                    TotalOrderF64(
+                                        5.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Unknown {
+                            original_value: None,
+                            reason: "unsupported expression",
+                            has_side_effects: true,
+                        },
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "GG",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    9.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        5.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    568446438.0,
+                                    TotalOrderF64(
+                                        568446438.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -941,7 +977,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                13.0,
+                                                TotalOrderF64(
+                                                    13.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -951,7 +989,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    5.0,
+                                    TotalOrderF64(
+                                        5.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1015,7 +1055,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                5.0,
+                                                TotalOrderF64(
+                                                    5.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1025,7 +1067,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    4.0,
+                                    TotalOrderF64(
+                                        4.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1089,7 +1133,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                1.0,
+                                                TotalOrderF64(
+                                                    1.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1099,7 +1145,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    4.0,
+                                    TotalOrderF64(
+                                        4.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1163,7 +1211,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                13.0,
+                                                TotalOrderF64(
+                                                    13.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1173,14 +1223,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    4.0,
+                                    TotalOrderF64(
+                                        4.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    681279174.0,
+                                    TotalOrderF64(
+                                        681279174.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1239,7 +1293,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                9.0,
+                                                TotalOrderF64(
+                                                    9.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1249,7 +1305,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    4.0,
+                                    TotalOrderF64(
+                                        4.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1313,7 +1371,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                0.0,
+                                                TotalOrderF64(
+                                                    0.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1323,7 +1383,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    6.0,
+                                    TotalOrderF64(
+                                        6.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1387,7 +1449,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                12.0,
+                                                TotalOrderF64(
+                                                    12.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1397,14 +1461,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    6.0,
+                                    TotalOrderF64(
+                                        6.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1700485571.0,
+                                    TotalOrderF64(
+                                        1700485571.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1463,7 +1531,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                8.0,
+                                                TotalOrderF64(
+                                                    8.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1473,14 +1543,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    6.0,
+                                    TotalOrderF64(
+                                        6.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1873313359.0,
+                                    TotalOrderF64(
+                                        1873313359.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1539,7 +1613,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                4.0,
+                                                TotalOrderF64(
+                                                    4.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1549,7 +1625,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    6.0,
+                                    TotalOrderF64(
+                                        6.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1678,7 +1756,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                3.0,
+                                                TotalOrderF64(
+                                                    3.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1688,7 +1768,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1752,7 +1834,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                7.0,
+                                                TotalOrderF64(
+                                                    7.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1762,7 +1846,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1826,7 +1912,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                11.0,
+                                                TotalOrderF64(
+                                                    11.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1836,7 +1924,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1900,7 +1990,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                15.0,
+                                                TotalOrderF64(
+                                                    15.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1910,14 +2002,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    22.0,
+                                    TotalOrderF64(
+                                        22.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1236535329.0,
+                                    TotalOrderF64(
+                                        1236535329.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -1976,7 +2072,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                0.0,
+                                                TotalOrderF64(
+                                                    0.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -1986,81 +2084,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    20.0,
-                                ),
-                            ),
-                        ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "GG",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
+                                    TotalOrderF64(
+                                        20.0,
                                     ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                4.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    20.0,
                                 ),
                             ),
                         ),
@@ -2124,7 +2150,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                8.0,
+                                                TotalOrderF64(
+                                                    4.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2134,14 +2162,96 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    20.0,
+                                    TotalOrderF64(
+                                        20.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Unknown {
+                            original_value: None,
+                            reason: "unsupported expression",
+                            has_side_effects: true,
+                        },
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "GG",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    8.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        20.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1163531501.0,
+                                    TotalOrderF64(
+                                        1163531501.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2200,7 +2310,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                12.0,
+                                                TotalOrderF64(
+                                                    12.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2210,7 +2322,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    20.0,
+                                    TotalOrderF64(
+                                        20.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2274,7 +2388,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                14.0,
+                                                TotalOrderF64(
+                                                    14.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2284,7 +2400,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    23.0,
+                                    TotalOrderF64(
+                                        23.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2348,7 +2466,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                10.0,
+                                                TotalOrderF64(
+                                                    10.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2358,7 +2478,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    23.0,
+                                    TotalOrderF64(
+                                        23.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2422,7 +2544,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                6.0,
+                                                TotalOrderF64(
+                                                    6.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2432,14 +2556,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    23.0,
+                                    TotalOrderF64(
+                                        23.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    76029189.0,
+                                    TotalOrderF64(
+                                        76029189.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2498,7 +2626,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                2.0,
+                                                TotalOrderF64(
+                                                    2.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2508,7 +2638,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    23.0,
+                                    TotalOrderF64(
+                                        23.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2572,7 +2704,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                5.0,
+                                                TotalOrderF64(
+                                                    5.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2582,7 +2716,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    21.0,
+                                    TotalOrderF64(
+                                        21.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2646,7 +2782,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                1.0,
+                                                TotalOrderF64(
+                                                    1.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2656,7 +2794,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    21.0,
+                                    TotalOrderF64(
+                                        21.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2720,7 +2860,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                13.0,
+                                                TotalOrderF64(
+                                                    13.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2730,14 +2872,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    21.0,
+                                    TotalOrderF64(
+                                        21.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1309151649.0,
+                                    TotalOrderF64(
+                                        1309151649.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2796,7 +2942,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                9.0,
+                                                TotalOrderF64(
+                                                    9.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2806,7 +2954,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    21.0,
+                                    TotalOrderF64(
+                                        21.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -2958,7 +3108,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                2.0,
+                                                TotalOrderF64(
+                                                    2.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -2968,14 +3120,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    17.0,
+                                    TotalOrderF64(
+                                        17.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    606105819.0,
+                                    TotalOrderF64(
+                                        606105819.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -3034,7 +3190,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                6.0,
+                                                TotalOrderF64(
+                                                    6.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3044,81 +3202,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    17.0,
-                                ),
-                            ),
-                        ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "FF",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
+                                    TotalOrderF64(
+                                        17.0,
                                     ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                10.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    17.0,
                                 ),
                             ),
                         ),
@@ -3182,7 +3268,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                14.0,
+                                                TotalOrderF64(
+                                                    10.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3192,7 +3280,87 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    17.0,
+                                    TotalOrderF64(
+                                        17.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Unknown {
+                            original_value: None,
+                            reason: "unsupported expression",
+                            has_side_effects: true,
+                        },
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "FF",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    14.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        17.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -3256,7 +3424,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                11.0,
+                                                TotalOrderF64(
+                                                    11.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3266,14 +3436,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    14.0,
+                                    TotalOrderF64(
+                                        14.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    643717713.0,
+                                    TotalOrderF64(
+                                        643717713.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -3332,7 +3506,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                15.0,
+                                                TotalOrderF64(
+                                                    15.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3342,81 +3518,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    14.0,
-                                ),
-                            ),
-                        ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "GG",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
+                                    TotalOrderF64(
+                                        14.0,
                                     ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                3.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    14.0,
                                 ),
                             ),
                         ),
@@ -3480,7 +3584,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                7.0,
+                                                TotalOrderF64(
+                                                    3.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3490,14 +3596,96 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    14.0,
+                                    TotalOrderF64(
+                                        14.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Unknown {
+                            original_value: None,
+                            reason: "unsupported expression",
+                            has_side_effects: true,
+                        },
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "GG",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    7.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        14.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1735328473.0,
+                                    TotalOrderF64(
+                                        1735328473.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -3556,7 +3744,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                11.0,
+                                                TotalOrderF64(
+                                                    11.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3566,14 +3756,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    16.0,
+                                    TotalOrderF64(
+                                        16.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1839030562.0,
+                                    TotalOrderF64(
+                                        1839030562.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -3632,7 +3826,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                7.0,
+                                                TotalOrderF64(
+                                                    7.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3642,81 +3838,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    16.0,
-                                ),
-                            ),
-                        ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "HH",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
+                                    TotalOrderF64(
+                                        16.0,
                                     ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                3.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    16.0,
                                 ),
                             ),
                         ),
@@ -3780,7 +3904,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                15.0,
+                                                TotalOrderF64(
+                                                    3.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3790,14 +3916,96 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    16.0,
+                                    TotalOrderF64(
+                                        16.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Unknown {
+                            original_value: None,
+                            reason: "unsupported expression",
+                            has_side_effects: true,
+                        },
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "HH",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    15.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        16.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    530742520.0,
+                                    TotalOrderF64(
+                                        530742520.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -3856,7 +4064,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                14.0,
+                                                TotalOrderF64(
+                                                    14.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3866,7 +4076,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    15.0,
+                                    TotalOrderF64(
+                                        15.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -3930,7 +4142,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                10.0,
+                                                TotalOrderF64(
+                                                    10.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -3940,7 +4154,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    15.0,
+                                    TotalOrderF64(
+                                        15.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4004,7 +4220,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                6.0,
+                                                TotalOrderF64(
+                                                    6.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4014,7 +4232,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    15.0,
+                                    TotalOrderF64(
+                                        15.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4078,7 +4298,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                2.0,
+                                                TotalOrderF64(
+                                                    2.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4088,14 +4310,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    15.0,
+                                    TotalOrderF64(
+                                        15.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    718787259.0,
+                                    TotalOrderF64(
+                                        718787259.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4177,7 +4403,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            271733878.0,
+                            TotalOrderF64(
+                                271733878.0,
+                            ),
                         ),
                     ),
                 ),
@@ -4234,7 +4462,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                1.0,
+                                                TotalOrderF64(
+                                                    1.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4244,157 +4474,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    12.0,
-                                ),
-                            ),
-                        ),
-                        Unknown {
-                            original_value: None,
-                            reason: "unsupported expression",
-                            has_side_effects: true,
-                        },
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "FF",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
+                                    TotalOrderF64(
+                                        12.0,
                                     ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                5.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    12.0,
-                                ),
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    1200080426.0,
-                                ),
-                            ),
-                        ),
-                    ],
-                ),
-                Call(
-                    13,
-                    Variable(
-                        (
-                            "FF",
-                            #4,
-                        ),
-                    ),
-                    [
-                        Variable(
-                            (
-                                "d",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "a",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "b",
-                                #4,
-                            ),
-                        ),
-                        Variable(
-                            (
-                                "c",
-                                #4,
-                            ),
-                        ),
-                        Member(
-                            5,
-                            Variable(
-                                (
-                                    "m",
-                                    #4,
-                                ),
-                            ),
-                            Add(
-                                3,
-                                [
-                                    Variable(
-                                        (
-                                            "i",
-                                            #4,
-                                        ),
-                                    ),
-                                    Constant(
-                                        Num(
-                                            ConstantNumber(
-                                                9.0,
-                                            ),
-                                        ),
-                                    ),
-                                ],
-                            ),
-                        ),
-                        Constant(
-                            Num(
-                                ConstantNumber(
-                                    12.0,
                                 ),
                             ),
                         ),
@@ -4458,7 +4540,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                13.0,
+                                                TotalOrderF64(
+                                                    5.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4468,7 +4552,169 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    12.0,
+                                    TotalOrderF64(
+                                        12.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        1200080426.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "FF",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    9.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        12.0,
+                                    ),
+                                ),
+                            ),
+                        ),
+                        Unknown {
+                            original_value: None,
+                            reason: "unsupported expression",
+                            has_side_effects: true,
+                        },
+                    ],
+                ),
+                Call(
+                    13,
+                    Variable(
+                        (
+                            "FF",
+                            #4,
+                        ),
+                    ),
+                    [
+                        Variable(
+                            (
+                                "d",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "a",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "b",
+                                #4,
+                            ),
+                        ),
+                        Variable(
+                            (
+                                "c",
+                                #4,
+                            ),
+                        ),
+                        Member(
+                            5,
+                            Variable(
+                                (
+                                    "m",
+                                    #4,
+                                ),
+                            ),
+                            Add(
+                                3,
+                                [
+                                    Variable(
+                                        (
+                                            "i",
+                                            #4,
+                                        ),
+                                    ),
+                                    Constant(
+                                        Num(
+                                            ConstantNumber(
+                                                TotalOrderF64(
+                                                    13.0,
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                ],
+                            ),
+                        ),
+                        Constant(
+                            Num(
+                                ConstantNumber(
+                                    TotalOrderF64(
+                                        12.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4532,7 +4778,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                6.0,
+                                                TotalOrderF64(
+                                                    6.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4542,7 +4790,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4606,7 +4856,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                10.0,
+                                                TotalOrderF64(
+                                                    10.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4616,14 +4868,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    38016083.0,
+                                    TotalOrderF64(
+                                        38016083.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4682,7 +4938,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                14.0,
+                                                TotalOrderF64(
+                                                    14.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4692,7 +4950,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4756,7 +5016,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                2.0,
+                                                TotalOrderF64(
+                                                    2.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4766,7 +5028,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4830,7 +5094,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                8.0,
+                                                TotalOrderF64(
+                                                    8.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4840,7 +5106,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    11.0,
+                                    TotalOrderF64(
+                                        11.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4904,7 +5172,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                4.0,
+                                                TotalOrderF64(
+                                                    4.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4914,14 +5184,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    11.0,
+                                    TotalOrderF64(
+                                        11.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1272893353.0,
+                                    TotalOrderF64(
+                                        1272893353.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -4980,7 +5254,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                0.0,
+                                                TotalOrderF64(
+                                                    0.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -4990,7 +5266,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    11.0,
+                                    TotalOrderF64(
+                                        11.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -5054,7 +5332,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                12.0,
+                                                TotalOrderF64(
+                                                    12.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -5064,7 +5344,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    11.0,
+                                    TotalOrderF64(
+                                        11.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -5128,7 +5410,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                7.0,
+                                                TotalOrderF64(
+                                                    7.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -5138,14 +5422,18 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    10.0,
+                                    TotalOrderF64(
+                                        10.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1126891415.0,
+                                    TotalOrderF64(
+                                        1126891415.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -5204,7 +5492,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                3.0,
+                                                TotalOrderF64(
+                                                    3.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -5214,7 +5504,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    10.0,
+                                    TotalOrderF64(
+                                        10.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -5278,7 +5570,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                15.0,
+                                                TotalOrderF64(
+                                                    15.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -5288,7 +5582,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    10.0,
+                                    TotalOrderF64(
+                                        10.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -5352,7 +5648,9 @@
                                     Constant(
                                         Num(
                                             ConstantNumber(
-                                                11.0,
+                                                TotalOrderF64(
+                                                    11.0,
+                                                ),
                                             ),
                                         ),
                                     ),
@@ -5362,7 +5660,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    10.0,
+                                    TotalOrderF64(
+                                        10.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -5473,7 +5773,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -5494,7 +5796,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    16.0,
+                                    TotalOrderF64(
+                                        16.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -5672,7 +5976,9 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    0.0,
+                                    TotalOrderF64(
+                                        0.0,
+                                    ),
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph-effects.snapshot
@@ -9,7 +9,9 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -113,7 +115,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -122,7 +126,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -131,7 +137,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -143,21 +151,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    8.0,
+                                    TotalOrderF64(
+                                        8.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -229,21 +243,27 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -256,7 +276,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),
@@ -316,21 +338,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1.0,
+                                    TotalOrderF64(
+                                        1.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    2.0,
+                                    TotalOrderF64(
+                                        2.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    3.0,
+                                    TotalOrderF64(
+                                        3.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -343,7 +371,9 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    0.0,
+                    TotalOrderF64(
+                        0.0,
+                    ),
                 ),
             ),
         ),
@@ -456,21 +486,27 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -483,7 +519,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),
@@ -503,21 +541,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    4.0,
+                                    TotalOrderF64(
+                                        4.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    5.0,
+                                    TotalOrderF64(
+                                        5.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    6.0,
+                                    TotalOrderF64(
+                                        6.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -572,21 +616,27 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -599,7 +649,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),
@@ -659,21 +711,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1.0,
+                                    TotalOrderF64(
+                                        1.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    2.0,
+                                    TotalOrderF64(
+                                        2.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    3.0,
+                                    TotalOrderF64(
+                                        3.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -686,7 +744,9 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    0.0,
+                    TotalOrderF64(
+                        0.0,
+                    ),
                 ),
             ),
         ),
@@ -788,21 +848,27 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -815,7 +881,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),
@@ -832,7 +900,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
@@ -841,7 +911,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -850,7 +922,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -902,7 +976,9 @@
         prop: Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -1009,21 +1085,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    8.0,
+                                    TotalOrderF64(
+                                        8.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/member-call/graph.snapshot
@@ -7,21 +7,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),
@@ -40,21 +46,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    1.0,
+                                    TotalOrderF64(
+                                        1.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    2.0,
+                                    TotalOrderF64(
+                                        2.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    3.0,
+                                    TotalOrderF64(
+                                        3.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -67,21 +79,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    4.0,
+                                    TotalOrderF64(
+                                        4.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    5.0,
+                                    TotalOrderF64(
+                                        5.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    6.0,
+                                    TotalOrderF64(
+                                        6.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -113,21 +131,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),
@@ -137,21 +161,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    8.0,
+                                    TotalOrderF64(
+                                        8.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -203,21 +233,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    7.0,
+                                    TotalOrderF64(
+                                        7.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    8.0,
+                                    TotalOrderF64(
+                                        8.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    9.0,
+                                    TotalOrderF64(
+                                        9.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -240,7 +276,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -259,7 +297,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        1.0,
+                        TotalOrderF64(
+                            1.0,
+                        ),
                     ),
                 ),
             ),
@@ -280,21 +320,27 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            1.0,
+                                            TotalOrderF64(
+                                                1.0,
+                                            ),
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            2.0,
+                                            TotalOrderF64(
+                                                2.0,
+                                            ),
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            3.0,
+                                            TotalOrderF64(
+                                                3.0,
+                                            ),
                                         ),
                                     ),
                                 ),
@@ -307,7 +353,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -326,21 +374,27 @@
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    4.0,
+                                    TotalOrderF64(
+                                        4.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    5.0,
+                                    TotalOrderF64(
+                                        5.0,
+                                    ),
                                 ),
                             ),
                         ),
                         Constant(
                             Num(
                                 ConstantNumber(
-                                    6.0,
+                                    TotalOrderF64(
+                                        6.0,
+                                    ),
                                 ),
                             ),
                         ),
@@ -368,21 +422,27 @@
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            1.0,
+                                            TotalOrderF64(
+                                                1.0,
+                                            ),
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            2.0,
+                                            TotalOrderF64(
+                                                2.0,
+                                            ),
                                         ),
                                     ),
                                 ),
                                 Constant(
                                     Num(
                                         ConstantNumber(
-                                            3.0,
+                                            TotalOrderF64(
+                                                3.0,
+                                            ),
                                         ),
                                     ),
                                 ),
@@ -395,7 +455,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -411,21 +473,27 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            4.0,
+                            TotalOrderF64(
+                                4.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            6.0,
+                            TotalOrderF64(
+                                6.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph-effects.snapshot
@@ -144,7 +144,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -203,7 +205,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -214,7 +218,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -263,7 +269,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),
@@ -377,7 +385,9 @@
                                         Constant(
                                             Num(
                                                 ConstantNumber(
-                                                    1.0,
+                                                    TotalOrderF64(
+                                                        1.0,
+                                                    ),
                                                 ),
                                             ),
                                         ),
@@ -608,7 +618,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested-args/graph.snapshot
@@ -121,7 +121,9 @@
                                             Constant(
                                                 Num(
                                                     ConstantNumber(
-                                                        1.0,
+                                                        TotalOrderF64(
+                                                            1.0,
+                                                        ),
                                                     ),
                                                 ),
                                             ),
@@ -132,7 +134,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -159,7 +163,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                1.0,
+                                TotalOrderF64(
+                                    1.0,
+                                ),
                             ),
                         ),
                     ),
@@ -169,7 +175,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -190,7 +198,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/nested/graph.snapshot
@@ -89,7 +89,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -99,7 +101,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -109,7 +113,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -119,7 +125,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -129,7 +137,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),
@@ -139,7 +149,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    1.0,
+                    TotalOrderF64(
+                        1.0,
+                    ),
                 ),
             ),
         ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph-effects.snapshot
@@ -181,7 +181,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/non-root-assignments/graph.snapshot
@@ -22,7 +22,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    2.0,
+                    TotalOrderF64(
+                        2.0,
+                    ),
                 ),
             ),
         ),
@@ -45,7 +47,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -63,7 +67,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    3.0,
+                    TotalOrderF64(
+                        3.0,
+                    ),
                 ),
             ),
         ),
@@ -83,7 +89,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),
@@ -96,7 +104,9 @@
         Constant(
             Num(
                 ConstantNumber(
-                    2.0,
+                    TotalOrderF64(
+                        2.0,
+                    ),
                 ),
             ),
         ),
@@ -121,7 +131,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -137,14 +149,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            5.0,
+                            TotalOrderF64(
+                                5.0,
+                            ),
                         ),
                     ),
                 ),
@@ -160,14 +176,18 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
                 Constant(
                     Num(
                         ConstantNumber(
-                            3.0,
+                            TotalOrderF64(
+                                3.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/object/graph.snapshot
@@ -547,7 +547,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                1.0,
+                                TotalOrderF64(
+                                    1.0,
+                                ),
                             ),
                         ),
                     ),
@@ -563,7 +565,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                2.0,
+                                TotalOrderF64(
+                                    2.0,
+                                ),
                             ),
                         ),
                     ),
@@ -579,7 +583,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                3.0,
+                                TotalOrderF64(
+                                    3.0,
+                                ),
                             ),
                         ),
                     ),
@@ -604,7 +610,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                1.0,
+                                TotalOrderF64(
+                                    1.0,
+                                ),
                             ),
                         ),
                     ),
@@ -616,7 +624,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                2.0,
+                                TotalOrderF64(
+                                    2.0,
+                                ),
                             ),
                         ),
                     ),
@@ -632,7 +642,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                3.0,
+                                TotalOrderF64(
+                                    3.0,
+                                ),
                             ),
                         ),
                     ),
@@ -644,7 +656,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                4.0,
+                                TotalOrderF64(
+                                    4.0,
+                                ),
                             ),
                         ),
                     ),
@@ -660,7 +674,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                5.0,
+                                TotalOrderF64(
+                                    5.0,
+                                ),
                             ),
                         ),
                     ),
@@ -685,7 +701,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                11.0,
+                                TotalOrderF64(
+                                    11.0,
+                                ),
                             ),
                         ),
                     ),
@@ -709,7 +727,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                22.0,
+                                TotalOrderF64(
+                                    22.0,
+                                ),
                             ),
                         ),
                     ),
@@ -734,7 +754,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                1.0,
+                                TotalOrderF64(
+                                    1.0,
+                                ),
                             ),
                         ),
                     ),
@@ -755,7 +777,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                2.0,
+                                TotalOrderF64(
+                                    2.0,
+                                ),
                             ),
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph-effects.snapshot
@@ -1184,7 +1184,9 @@
             Constant(
                 Num(
                     ConstantNumber(
-                        0.0,
+                        TotalOrderF64(
+                            0.0,
+                        ),
                     ),
                 ),
             ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/op-assign/graph.snapshot
@@ -50,7 +50,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),
@@ -103,7 +105,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            0.0,
+                            TotalOrderF64(
+                                0.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pattern-assignment/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pattern-assignment/graph.snapshot
@@ -58,7 +58,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                0.0,
+                                TotalOrderF64(
+                                    0.0,
+                                ),
                             ),
                         ),
                     ),
@@ -102,7 +104,9 @@
                     Constant(
                         Num(
                             ConstantNumber(
-                                0.0,
+                                TotalOrderF64(
+                                    0.0,
+                                ),
                             ),
                         ),
                     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/sequences/graph.snapshot
@@ -7,7 +7,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            1.0,
+                            TotalOrderF64(
+                                1.0,
+                            ),
                         ),
                     ),
                 ),
@@ -27,7 +29,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            2.0,
+                            TotalOrderF64(
+                                2.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph-effects.snapshot
@@ -1348,7 +1348,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            200.0,
+                            TotalOrderF64(
+                                200.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1659,7 +1661,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            200.0,
+                            TotalOrderF64(
+                                200.0,
+                            ),
                         ),
                     ),
                 ),
@@ -1818,7 +1822,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            200.0,
+                            TotalOrderF64(
+                                200.0,
+                            ),
                         ),
                     ),
                 ),
@@ -2522,7 +2528,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5166.0,
+                            TotalOrderF64(
+                                5166.0,
+                            ),
                         ),
                     ),
                 ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/webpack-target-node/graph.snapshot
@@ -75,7 +75,9 @@
                 Constant(
                     Num(
                         ConstantNumber(
-                            5166.0,
+                            TotalOrderF64(
+                                5166.0,
+                            ),
                         ),
                     ),
                 ),
@@ -231,7 +233,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        1.0,
+                                        TotalOrderF64(
+                                            1.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -253,7 +257,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        2.0,
+                                        TotalOrderF64(
+                                            2.0,
+                                        ),
                                     ),
                                 ),
                             ),
@@ -275,7 +281,9 @@
                             Constant(
                                 Num(
                                     ConstantNumber(
-                                        3.0,
+                                        TotalOrderF64(
+                                            3.0,
+                                        ),
                                     ),
                                 ),
                             ),


### PR DESCRIPTION
- Number(f64) instead of Number(RcStr)
- Add BigInt
- Add Regex