### PR TITLE
turbo-persistence: add TURBO_PERSISTENCE_MMAP=0 to disable mmap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9458,6 +9458,7 @@ dependencies = [
  "quick_cache",
  "rand 0.10.0",
  "rayon",
+ "rstest",
  "rustc-hash 2.1.1",
  "smallvec",
  "tempfile",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -39,6 +39,7 @@ xxhash-rust = { workspace = true }
 criterion = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
+rstest = { workspace = true }
 tempfile = { workspace = true }
 turbo-tasks-malloc = { workspace = true }
 

--- a/turbopack/crates/turbo-persistence/benches/mod.rs
+++ b/turbopack/crates/turbo-persistence/benches/mod.rs
@@ -578,6 +578,7 @@ fn prefill_multi_value_database(
         family_configs: [FamilyConfig {
             kind: FamilyKind::MultiValue,
         }],
+        ..TpDbConfig::new()
     };
     let db =
         TurboPersistence::<SerialScheduler, 1>::open_with_config(path.to_path_buf(), db_config)?;
@@ -650,6 +651,7 @@ fn open_multi_value_db(path: &Path) -> TurboPersistence<SerialScheduler, 1> {
         family_configs: [FamilyConfig {
             kind: FamilyKind::MultiValue,
         }],
+        ..TpDbConfig::new()
     };
     TurboPersistence::<SerialScheduler, 1>::open_with_config(path.to_path_buf(), db_config).unwrap()
 }
@@ -916,6 +918,7 @@ fn bench_write_multi_value(c: &mut Criterion) {
                             family_configs: [FamilyConfig {
                                 kind: FamilyKind::MultiValue,
                             }],
+                            ..TpDbConfig::new()
                         };
                         let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
                             tempdir.path().to_path_buf(),
@@ -1160,7 +1163,12 @@ fn bench_static_sorted_file_lookup(c: &mut Criterion) {
                 sequence_number: 1,
                 block_count: meta.block_count,
             };
-            let sst = StaticSortedFile::open(tempdir.path(), sst_meta).unwrap();
+            let sst = StaticSortedFile::open(
+                tempdir.path(),
+                sst_meta,
+                turbo_persistence::AccessMode::Mmap,
+            )
+            .unwrap();
 
             // Create block caches
             let key_block_cache: BlockCache = BlockCache::with(

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -2,37 +2,48 @@ use std::{
     borrow::Borrow,
     fmt::{self, Debug, Formatter},
     hash::{Hash, Hasher},
+    io::{self, Read},
     ops::{Deref, Range},
     sync::Arc,
 };
 
 use memmap2::Mmap;
 
-use crate::{
-    compression::decompress_into_arc,
-    shared_bytes::{SharedBytes, is_subslice_of},
-};
 /// The backing storage for an `ArcBytes`.
 ///
 /// The inner values are never read directly — they exist solely to keep the
 /// backing memory alive while the raw `data` pointer in `ArcBytes` references it.
 #[derive(Clone)]
-enum Backing {
-    Arc { _backing: Arc<[u8]> },
-    Mmap { _backing: Arc<Mmap> },
+enum Backing<'l> {
+    Arc {
+        _backing: Arc<[u8]>,
+    },
+    Mmap {
+        _backing: Arc<Mmap>,
+    },
+    /// A borrowed reference to an `Arc<Mmap>`, avoiding an `Arc::clone` when the
+    /// caller only needs short-lived access to the mapped data.
+    MmapRef {
+        _backing: &'l Arc<Mmap>,
+    },
 }
 
-/// An owned byte slice backed by either an `Arc<[u8]>` or a memory-mapped file.
+/// A byte slice backed by either an `Arc<[u8]>`, a memory-mapped file, or a borrowed
+/// reference to a memory-mapped file.
+///
+/// Most code uses `ArcBytes<'static>` which owns its backing storage.
+/// A shorter lifetime is used when the backing is borrowed (e.g. `MmapRef`),
+/// and can be promoted to `'static` via [`ArcBytes::into_static`].
 #[derive(Clone)]
-pub struct ArcBytes {
+pub struct ArcBytes<'l> {
     data: *const [u8],
-    backing: Backing,
+    backing: Backing<'l>,
 }
 
-unsafe impl Send for ArcBytes {}
-unsafe impl Sync for ArcBytes {}
+unsafe impl Send for ArcBytes<'_> {}
+unsafe impl Sync for ArcBytes<'_> {}
 
-impl From<Arc<[u8]>> for ArcBytes {
+impl From<Arc<[u8]>> for ArcBytes<'_> {
     fn from(arc: Arc<[u8]>) -> Self {
         Self {
             data: &*arc as *const [u8],
@@ -41,13 +52,13 @@ impl From<Arc<[u8]>> for ArcBytes {
     }
 }
 
-impl From<Box<[u8]>> for ArcBytes {
+impl From<Box<[u8]>> for ArcBytes<'_> {
     fn from(b: Box<[u8]>) -> Self {
         Self::from(Arc::from(b))
     }
 }
 
-impl Deref for ArcBytes {
+impl Deref for ArcBytes<'_> {
     type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
@@ -55,43 +66,61 @@ impl Deref for ArcBytes {
     }
 }
 
-impl Borrow<[u8]> for ArcBytes {
+impl Borrow<[u8]> for ArcBytes<'_> {
     fn borrow(&self) -> &[u8] {
         self
     }
 }
 
-impl Hash for ArcBytes {
+impl Hash for ArcBytes<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.deref().hash(state)
     }
 }
 
-impl PartialEq for ArcBytes {
+impl PartialEq for ArcBytes<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.deref().eq(other.deref())
     }
 }
 
-impl Debug for ArcBytes {
+impl Debug for ArcBytes<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         Debug::fmt(&**self, f)
     }
 }
 
-impl Eq for ArcBytes {}
+impl Eq for ArcBytes<'_> {}
 
-impl ArcBytes {
-    /// Returns `true` if this `ArcBytes` is backed by a memory-mapped file.
-    pub fn is_mmap_backed(&self) -> bool {
-        matches!(self.backing, Backing::Mmap { .. })
+impl Read for ArcBytes<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let available = &**self;
+        let len = std::cmp::min(buf.len(), available.len());
+        buf[..len].copy_from_slice(&available[..len]);
+        // Advance the slice view
+        self.data = &available[len..] as *const [u8];
+        Ok(len)
     }
 }
 
-impl SharedBytes for ArcBytes {
-    type MmapHandle = Arc<Mmap>;
+/// Returns `true` if `subslice` lies entirely within `backing`.
+fn is_subslice_of(subslice: &[u8], backing: &[u8]) -> bool {
+    let backing = backing.as_ptr_range();
+    let sub = subslice.as_ptr_range();
+    sub.start >= backing.start && sub.end <= backing.end
+}
 
-    fn slice(self, range: Range<usize>) -> Self {
+fn backing_as_slice<'a>(backing: &'a Backing<'a>) -> &'a [u8] {
+    match backing {
+        Backing::Arc { _backing } => _backing,
+        Backing::Mmap { _backing } => _backing,
+        Backing::MmapRef { _backing } => _backing,
+    }
+}
+
+impl<'l> ArcBytes<'l> {
+    /// Returns a new `ArcBytes` that points to a sub-range of the current slice.
+    pub fn slice(self, range: Range<usize>) -> ArcBytes<'l> {
         let data = &*self;
         let data = &data[range] as *const [u8];
         Self {
@@ -100,15 +129,16 @@ impl SharedBytes for ArcBytes {
         }
     }
 
-    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self {
+    /// Creates a sub-slice from a slice reference that points into this ArcBytes' backing data.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `subslice` points to memory within this ArcBytes'
+    /// backing storage (not just within the current slice view, but anywhere in the original
+    /// backing data).
+    pub unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> ArcBytes<'l> {
         debug_assert!(
-            is_subslice_of(
-                subslice,
-                match &self.backing {
-                    Backing::Arc { _backing } => _backing,
-                    Backing::Mmap { _backing } => _backing,
-                }
-            ),
+            is_subslice_of(subslice, backing_as_slice(&self.backing)),
             "slice_from_subslice: subslice is not within the backing storage"
         );
         Self {
@@ -117,23 +147,58 @@ impl SharedBytes for ArcBytes {
         }
     }
 
-    unsafe fn from_mmap(mmap: &Arc<Mmap>, subslice: &[u8]) -> Self {
-        debug_assert!(
-            is_subslice_of(subslice, mmap),
-            "from_mmap: subslice is not within the mmap"
-        );
+    /// Converts this `ArcBytes` into one with a `'static` lifetime.
+    ///
+    /// For `Arc` and `Mmap` backings this is a no-op. For `MmapRef` backings this
+    /// clones the inner `Arc<Mmap>` to produce an owned backing.
+    pub fn into_static(self) -> ArcBytes<'static> {
         ArcBytes {
-            data: subslice as *const [u8],
-            backing: Backing::Mmap {
-                _backing: mmap.clone(),
+            data: self.data,
+            backing: match self.backing {
+                Backing::Arc { _backing } => Backing::Arc { _backing },
+                Backing::Mmap { _backing } => Backing::Mmap { _backing },
+                Backing::MmapRef { _backing } => Backing::Mmap {
+                    _backing: _backing.clone(),
+                },
             },
         }
     }
 
-    fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self> {
-        Ok(ArcBytes::from(decompress_into_arc(
-            uncompressed_length,
-            block,
-        )?))
+    /// Returns `true` if this `ArcBytes` is backed by a memory-mapped file.
+    pub fn is_mmap_backed(&self) -> bool {
+        matches!(self.backing, Backing::Mmap { .. } | Backing::MmapRef { .. })
+    }
+
+    /// Creates an `ArcBytes` backed by a memory-mapped file.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `subslice` points to memory within the given `mmap`.
+    pub unsafe fn from_mmap(mmap: Arc<Mmap>, subslice: &[u8]) -> ArcBytes<'static> {
+        debug_assert!(
+            is_subslice_of(subslice, &mmap),
+            "from_mmap: subslice is not within the mmap"
+        );
+        ArcBytes {
+            data: subslice as *const [u8],
+            backing: Backing::Mmap { _backing: mmap },
+        }
+    }
+
+    /// Creates an `ArcBytes` that borrows a reference to an `Arc<Mmap>`, avoiding an
+    /// `Arc::clone`. The returned `ArcBytes` is only valid for the lifetime of the reference.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `subslice` points to memory within the given `mmap`.
+    pub unsafe fn from_mmap_ref(mmap: &'l Arc<Mmap>, subslice: &[u8]) -> ArcBytes<'l> {
+        debug_assert!(
+            is_subslice_of(subslice, mmap),
+            "from_mmap_ref: subslice is not within the mmap"
+        );
+        ArcBytes {
+            data: subslice as *const [u8],
+            backing: Backing::MmapRef { _backing: mmap },
+        }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -226,7 +226,7 @@ fn collect_sst_info(db_path: &Path) -> Result<BTreeMap<u32, Vec<SstInfo>>> {
         let filename = meta_path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
         let seq_num: u32 = filename.parse().unwrap_or(0);
 
-        let meta_file = MetaFile::open(db_path, seq_num)
+        let meta_file = MetaFile::open(db_path, seq_num, turbo_persistence::AccessMode::Mmap)
             .with_context(|| format!("Failed to open {}", meta_path.display()))?;
 
         let family = meta_file.family();

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -1,4 +1,4 @@
-use std::{mem::MaybeUninit, rc::Rc, sync::Arc};
+use std::{mem::MaybeUninit, sync::Arc};
 
 use anyhow::{Context, Result};
 use lzzzz::lz4::{self, decompress};
@@ -37,17 +37,6 @@ pub fn decompress_into_arc(uncompressed_length: u32, block: &[u8]) -> Result<Arc
     let mut buffer = unsafe { buffer.assume_init() };
     // We just created this Arc so refcount is 1; get_mut always succeeds.
     let dest = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
-    decompress_block(block, dest, uncompressed_length)?;
-    Ok(buffer)
-}
-
-/// Like [`decompress_into_arc`] but returns an `Rc<[u8]>` for thread-local use.
-pub fn decompress_into_rc(uncompressed_length: u32, block: &[u8]) -> Result<Rc<[u8]>> {
-    let buffer: Rc<[MaybeUninit<u8>]> = Rc::new_uninit_slice(uncompressed_length as usize);
-    // Safety: decompression will fully initialize the buffer (verified by the assert in
-    // decompress_block).
-    let mut buffer = unsafe { buffer.assume_init() };
-    let dest = Rc::get_mut(&mut buffer).expect("Rc refcount should be 1");
     decompress_block(block, dest, uncompressed_length)?;
     Ok(buffer)
 }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::HashSet,
     fs::{self, File, OpenOptions, ReadDir},
     io::{BufWriter, Write},
@@ -12,6 +11,7 @@ use std::{
 use anyhow::{Context, Result, bail};
 use byteorder::{BE, ReadBytesExt, WriteBytesExt};
 use dashmap::DashSet;
+use either::Either;
 use jiff::Timestamp;
 use memmap2::Mmap;
 use nohash_hasher::BuildNoHashHasher;
@@ -21,7 +21,7 @@ use tracing::span::EnteredSpan;
 
 pub use crate::compaction::selector::CompactConfig;
 use crate::{
-    DbConfig, FamilyKind, QueryKey,
+    AccessMode, DbConfig, FamilyKind, QueryKey,
     arc_bytes::ArcBytes,
     compaction::selector::{Compactable, get_merge_segments},
     compression::{checksum_block, decompress_into_arc},
@@ -30,15 +30,14 @@ use crate::{
         MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE, VALUE_BLOCK_CACHE_SIZE,
     },
     key::{StoreKey, hash_key},
-    lookup_entry::{IterValue, LookupEntry, LookupValue},
+    lookup_entry::{LazyLookupValue, LookupEntry, LookupValue},
     merge_iter::MergeIter,
     meta_file::{MetaEntryFlags, MetaFile, MetaLookupResult, StaticSortedFileRange},
     meta_file_builder::MetaFileBuilder,
     mmap_helper::advise_mmap_for_persistence,
     parallel_scheduler::ParallelScheduler,
-    rc_bytes::RcBytes,
     sst_filter::SstFilter,
-    static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFileIter},
+    static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile},
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, StreamingSstWriter},
     write_batch::{FinishResult, WriteBatch},
 };
@@ -385,7 +384,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         let mut meta_files = self
             .parallel_scheduler
             .parallel_map_collect::<_, _, Result<Vec<MetaFile>>>(&meta_files, |&seq| {
-                let meta_file = MetaFile::open(&self.path, seq)?;
+                let meta_file = MetaFile::open(&self.path, seq, self.config.access_mode)?;
                 Ok(meta_file)
             })?;
 
@@ -402,23 +401,40 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
     /// Reads and decompresses a blob file. This is not backed by any cache.
     #[tracing::instrument(level = "info", name = "reading database blob", skip_all)]
-    fn read_blob(&self, seq: u32) -> Result<ArcBytes> {
+    fn read_blob(&self, seq: u32) -> Result<ArcBytes<'static>> {
         let path = self.path.join(format!("{seq:08}.blob"));
         let file = File::open(&path)
             .with_context(|| format!("Failed to open blob file {}", path.display()))?;
-        let mmap = unsafe { Mmap::map(&file) }.with_context(|| {
-            format!(
-                "Failed to mmap blob file {} ({} bytes)",
-                path.display(),
-                file.metadata().map(|m| m.len()).unwrap_or(0)
-            )
-        })?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Sequential)?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::WillNeed)?;
-        advise_mmap_for_persistence(&mmap)?;
-        let mut reader = &mmap[..];
+
+        // Read the blob data either via mmap or plain file reads, avoiding an
+        // extra copy in the mmap path.
+        let data: Either<Mmap, Vec<u8>> = if self.config.access_mode == AccessMode::Mmap {
+            let mmap = unsafe { Mmap::map(&file) }.with_context(|| {
+                format!(
+                    "Failed to mmap blob file {} ({} bytes)",
+                    path.display(),
+                    file.metadata().map(|m| m.len()).unwrap_or(0)
+                )
+            })?;
+            #[cfg(unix)]
+            mmap.advise(memmap2::Advice::Sequential)?;
+            #[cfg(unix)]
+            mmap.advise(memmap2::Advice::WillNeed)?;
+            advise_mmap_for_persistence(&mmap)?;
+            Either::Left(mmap)
+        } else {
+            use std::io::Read;
+            let mut buf = Vec::new();
+            let mut file = std::io::BufReader::new(file);
+            file.read_to_end(&mut buf)
+                .with_context(|| format!("Failed to read blob file {}", path.display()))?;
+            Either::Right(buf)
+        };
+
+        let mut reader: &[u8] = match &data {
+            Either::Left(mmap) => mmap,
+            Either::Right(vec) => vec,
+        };
         let uncompressed_length = reader
             .read_u32::<BE>()
             .context("Failed to read uncompressed length from blob file")?;
@@ -579,7 +595,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
             .parallel_scheduler
             .parallel_map_collect_owned::<_, _, Result<Vec<_>>>(new_meta_files, |(seq, file)| {
                 file.sync_all()?;
-                let meta_file = MetaFile::open(&self.path, seq)?;
+                let meta_file = MetaFile::open(&self.path, seq, self.config.access_mode)?;
                 Ok(meta_file)
             })?;
 
@@ -1027,16 +1043,16 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
                     // Merge SST files
                     let span = tracing::trace_span!("merge files");
-                    enum PartialMergeResult<'l> {
+                    enum PartialMergeResult {
                         Merged {
-                            new_sst_files: Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
+                            new_sst_files: Vec<(u32, File, StaticSortedFileBuilderMeta)>,
                             blob_seq_numbers_to_delete: Vec<u32>,
                             keys_written: u64,
                             indices: SmallVec<[usize; 1]>,
                         },
                         Move {
                             seq: u32,
-                            meta: StaticSortedFileBuilderMeta<'l>,
+                            meta: StaticSortedFileBuilderMeta,
                         },
                     }
                     let merge_result = self
@@ -1050,7 +1066,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 let index_in_meta = ssts_with_ranges[index].index_in_meta;
                                 let meta_file = &meta_files[meta_index];
                                 let entry = meta_file.entry(index_in_meta);
-                                let amqf = Cow::Borrowed(entry.raw_amqf(meta_file.amqf_data()));
+                                let amqf = entry.raw_amqf(meta_file)?.into_static().into();
                                 let meta = StaticSortedFileBuilderMeta {
                                     min_hash: entry.min_hash(),
                                     max_hash: entry.max_hash(),
@@ -1075,7 +1091,12 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     let meta_index = ssts_with_ranges[index].meta_index;
                                     let index_in_meta = ssts_with_ranges[index].index_in_meta;
                                     let entry = meta_files[meta_index].entry(index_in_meta);
-                                    StaticSortedFileIter::open(path, entry.sst_metadata())
+                                    StaticSortedFile::open_for_compaction(
+                                        path,
+                                        entry.sst_metadata(),
+                                        self.config.access_mode,
+                                    )?
+                                    .try_into_iter()
                                 })
                                 .collect::<Result<Vec<_>>>()?;
 
@@ -1092,8 +1113,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                 /// used set).
                                 writer: Option<(u32, StreamingSstWriter<LookupEntry>)>,
                                 flags: MetaEntryFlags,
-                                new_sst_files:
-                                    Vec<(u32, File, StaticSortedFileBuilderMeta<'static>)>,
+                                new_sst_files: Vec<(u32, File, StaticSortedFileBuilderMeta)>,
                                 /// Hash of the last key added. Used to ensure we only split
                                 /// SST files at key boundaries (not mid-key-group for MultiValue).
                                 last_hash: Option<u64>,
@@ -1184,7 +1204,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             }
                             let mut used_collector = Collector::new(MetaEntryFlags::WARM);
                             let mut unused_collector = Collector::new(MetaEntryFlags::COLD);
-                            let mut current_key: Option<RcBytes> = None;
+                            let mut current_key: Option<ArcBytes<'static>> = None;
                             let mut keys_written = 0;
 
                             // MergeIter yields entries from newer SSTs first (by SST sequence
@@ -1216,7 +1236,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         FamilyKind::MultiValue => {
                                             // For MultiValue families we only skip remaining if we
                                             // see a tombstone
-                                            if matches!(entry.value, IterValue::Deleted) {
+                                            if matches!(
+                                                entry.value,
+                                                LazyLookupValue::Eager(LookupValue::Deleted)
+                                            ) {
                                                 skip_remaining_for_this_key = true;
                                             }
                                         }
@@ -1236,7 +1259,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     // Entry is being dropped (superseded by newer entry or
                                     // pruned by tombstone). If it references a blob file,
                                     // mark that blob for deletion.
-                                    if let IterValue::Blob { sequence_number } = &entry.value {
+                                    if let LazyLookupValue::Eager(LookupValue::Blob {
+                                        sequence_number,
+                                    }) = &entry.value
+                                    {
                                         blob_seq_numbers_to_delete.push(*sequence_number);
                                     }
                                 }
@@ -1389,7 +1415,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
 
     /// Get a value from the database. Returns None if the key is not found. The returned value
     /// might hold onto a block of the database and it should not be hold long-term.
-    pub fn get<K: QueryKey>(&self, family: usize, key: &K) -> Result<Option<ArcBytes>> {
+    pub fn get<K: QueryKey>(&self, family: usize, key: &K) -> Result<Option<ArcBytes<'static>>> {
         debug_assert!(family < FAMILIES, "Family index out of bounds");
         if self.config.family_configs[family].kind != FamilyKind::SingleValue {
             // This is an error in our caller so just panic
@@ -1421,7 +1447,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         &self,
         family: usize,
         key: &K,
-    ) -> Result<SmallVec<[ArcBytes; 1]>> {
+    ) -> Result<SmallVec<[ArcBytes<'static>; 1]>> {
         debug_assert!(family < FAMILIES, "Family index out of bounds");
         if self.config.family_configs[family].kind != FamilyKind::MultiValue {
             // This is an error in our caller so just panic
@@ -1447,10 +1473,10 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         family: usize,
         key: &K,
         span: &EnteredSpan,
-    ) -> Result<SmallVec<[ArcBytes; 1]>> {
+    ) -> Result<SmallVec<[ArcBytes<'static>; 1]>> {
         let hash = hash_key(key);
         let inner = self.inner.read();
-        let mut output: SmallVec<[ArcBytes; 1]> = SmallVec::new();
+        let mut output: SmallVec<[ArcBytes<'static>; 1]> = SmallVec::new();
         // Track whether we found the key in any SST (even if deleted).
         // Used for miss_global stat: only fires if key was never found anywhere.
         #[cfg(feature = "stats")]
@@ -1558,7 +1584,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         &self,
         family: usize,
         keys: &[K],
-    ) -> Result<Vec<Option<ArcBytes>>> {
+    ) -> Result<Vec<Option<ArcBytes<'static>>>> {
         debug_assert!(family < FAMILIES, "Family index out of bounds");
         if self.config.family_configs[family].kind != FamilyKind::SingleValue {
             // This is an error in our caller so just panic
@@ -1696,18 +1722,15 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                 let entries = meta_file
                     .entries()
                     .iter()
-                    .map(|entry| {
-                        let amqf = entry.raw_amqf(meta_file.amqf_data());
-                        MetaFileEntryInfo {
-                            sequence_number: entry.sequence_number(),
-                            min_hash: entry.min_hash(),
-                            max_hash: entry.max_hash(),
-                            sst_size: entry.size(),
-                            flags: entry.flags(),
-                            amqf_size: entry.amqf_size(),
-                            amqf_entries: amqf.len(),
-                            block_count: entry.block_count(),
-                        }
+                    .map(|entry| MetaFileEntryInfo {
+                        sequence_number: entry.sequence_number(),
+                        min_hash: entry.min_hash(),
+                        max_hash: entry.max_hash(),
+                        sst_size: entry.size(),
+                        flags: entry.flags(),
+                        amqf_size: entry.amqf_size(),
+                        amqf_entries: entry.amqf_size() as usize,
+                        block_count: entry.block_count(),
                     })
                     .collect();
                 MetaFileInfo {

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -3,7 +3,6 @@
 #![feature(iter_collect_into)]
 
 mod arc_bytes;
-pub(crate) mod be;
 mod collector;
 mod collector_entry;
 mod compaction;
@@ -17,8 +16,6 @@ pub mod meta_file;
 mod meta_file_builder;
 pub mod mmap_helper;
 mod parallel_scheduler;
-mod rc_bytes;
-mod shared_bytes;
 mod sst_filter;
 pub mod static_sorted_file;
 mod static_sorted_file_builder;
@@ -32,6 +29,15 @@ mod tests;
 pub use arc_bytes::ArcBytes;
 pub use compression::checksum_block;
 pub use db::{CompactConfig, MetaFileEntryInfo, MetaFileInfo, TurboPersistence};
+
+/// Controls how SST and meta files are read from disk.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AccessMode {
+    /// Memory-map the file and access blocks via the mapped region.
+    Mmap,
+    /// Read blocks directly from the file via pread (no mmap).
+    File,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FamilyKind {
@@ -60,15 +66,42 @@ pub struct FamilyConfig {
 #[derive(Clone, Debug)]
 pub struct DbConfig<const FAMILIES: usize> {
     pub family_configs: [FamilyConfig; FAMILIES],
+    /// How SST and meta files are read from disk.
+    pub access_mode: AccessMode,
 }
 
-impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
-    fn default() -> Self {
+/// Reads the `TURBO_PERSISTENCE_MMAP` env var (cached). Returns `AccessMode::File` when the var
+/// is set to `"0"`, `AccessMode::Mmap` otherwise.
+fn access_mode_env_var() -> AccessMode {
+    static ACCESS_MODE_ENV: std::sync::LazyLock<AccessMode> = std::sync::LazyLock::new(|| {
+        if std::env::var("TURBO_PERSISTENCE_MMAP")
+            .map(|v| v == "0")
+            .unwrap_or(false)
+        {
+            AccessMode::File
+        } else {
+            AccessMode::Mmap
+        }
+    });
+    *ACCESS_MODE_ENV
+}
+
+impl<const FAMILIES: usize> DbConfig<FAMILIES> {
+    /// Returns a config with all defaults, reading the `TURBO_PERSISTENCE_MMAP` env var
+    /// to determine the access mode.
+    pub fn new() -> Self {
         Self {
             family_configs: [FamilyConfig {
                 kind: FamilyKind::SingleValue,
             }; FAMILIES],
+            access_mode: access_mode_env_var(),
         }
+    }
+}
+
+impl<const FAMILIES: usize> Default for DbConfig<FAMILIES> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 pub use key::{KeyBase, QueryKey, StoreKey, hash_key};

--- a/turbopack/crates/turbo-persistence/src/lookup_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/lookup_entry.rs
@@ -1,58 +1,89 @@
 use crate::{
     ArcBytes,
     constants::{MAX_INLINE_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
-    rc_bytes::RcBytes,
     static_sorted_file_builder::{Entry, EntryValue},
 };
 
-/// A value from a SST file. Generic over the byte representation, defaulting to
-/// `ArcBytes` for the lookup path. The compaction/iteration path uses
-/// `LookupValue<RcBytes>` which is convertible to `IterValue`.
+/// A value from a SST file lookup.
 #[derive(PartialEq)]
-pub enum LookupValue<B = ArcBytes> {
+pub enum LookupValue {
     /// The value was deleted.
     Deleted,
     /// The value is stored in the SST file.
     ///
-    /// The bytes will be pointing either at a keyblock or a value block in the SST
-    Slice { value: B },
+    /// The ArcBytes will be pointing either at a keyblock or a value block in the SST
+    Slice { value: ArcBytes<'static> },
     /// The value is stored in a blob file.
     Blob { sequence_number: u32 },
 }
 
-/// A value from SST file iteration (compaction path, uses RcBytes for
-/// non-atomic refcounting).
-pub enum IterValue {
-    /// The value was deleted.
-    Deleted,
-    /// The value is stored in the SST file.
-    Slice { value: RcBytes },
-    /// The value is stored in a blob file.
-    Blob { sequence_number: u32 },
+/// A value from a SST file lookup.
+pub enum LazyLookupValue {
+    /// A LookupValue
+    Eager(LookupValue),
     /// A medium sized value that is still compressed.
     Medium {
         uncompressed_size: u32,
         checksum: u32,
-        block: RcBytes,
+        block: ArcBytes<'static>,
     },
 }
-impl From<LookupValue<RcBytes>> for IterValue {
-    fn from(v: LookupValue<RcBytes>) -> Self {
-        match v {
-            LookupValue::Deleted => IterValue::Deleted,
-            LookupValue::Slice { value } => IterValue::Slice { value },
-            LookupValue::Blob { sequence_number } => IterValue::Blob { sequence_number },
+
+impl LazyLookupValue {
+    /// Returns the size of the value in the SST file.
+    pub fn uncompressed_size_in_sst(&self) -> usize {
+        match self {
+            LazyLookupValue::Eager(LookupValue::Slice { value }) => value.len(),
+            LazyLookupValue::Eager(LookupValue::Deleted) => 0,
+            LazyLookupValue::Eager(LookupValue::Blob { .. }) => 0,
+            LazyLookupValue::Medium {
+                uncompressed_size,
+                block,
+                ..
+            } => {
+                if *uncompressed_size == 0 {
+                    block.len()
+                } else {
+                    *uncompressed_size as usize
+                }
+            }
+        }
+    }
+
+    /// Returns true if this value gets its own dedicated value block.
+    pub fn is_medium_value(&self) -> bool {
+        match self {
+            LazyLookupValue::Eager(LookupValue::Slice { value })
+                if value.len() > MAX_SMALL_VALUE_SIZE =>
+            {
+                true
+            }
+            LazyLookupValue::Medium { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Returns the value size if it will be packed into a small value block, or 0 otherwise.
+    pub fn small_value_size(&self) -> usize {
+        match self {
+            LazyLookupValue::Eager(LookupValue::Slice { value })
+                if value.len() > MAX_INLINE_VALUE_SIZE && value.len() <= MAX_SMALL_VALUE_SIZE =>
+            {
+                value.len()
+            }
+            _ => 0,
         }
     }
 }
-/// An entry from SST file iteration (compaction path, uses RcBytes).
+
+/// An entry from a SST file lookup.
 pub struct LookupEntry {
     /// The hash of the key.
     pub hash: u64,
     /// The key.
-    pub key: RcBytes,
+    pub key: ArcBytes<'static>,
     /// The value.
-    pub value: IterValue,
+    pub value: LazyLookupValue,
 }
 
 impl Entry for LookupEntry {
@@ -70,8 +101,8 @@ impl Entry for LookupEntry {
 
     fn value(&self) -> EntryValue<'_> {
         match &self.value {
-            IterValue::Deleted => EntryValue::Deleted,
-            IterValue::Slice { value } => {
+            LazyLookupValue::Eager(LookupValue::Deleted) => EntryValue::Deleted,
+            LazyLookupValue::Eager(LookupValue::Slice { value }) => {
                 if value.len() <= MAX_INLINE_VALUE_SIZE {
                     EntryValue::Inline { value }
                 } else if value.len() > MAX_SMALL_VALUE_SIZE {
@@ -80,10 +111,10 @@ impl Entry for LookupEntry {
                     EntryValue::Small { value }
                 }
             }
-            IterValue::Blob { sequence_number } => EntryValue::Large {
+            LazyLookupValue::Eager(LookupValue::Blob { sequence_number }) => EntryValue::Large {
                 blob: *sequence_number,
             },
-            IterValue::Medium {
+            LazyLookupValue::Medium {
                 uncompressed_size,
                 checksum,
                 block,

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -5,7 +5,7 @@ use std::{
     io::{BufReader, Seek},
     ops::Deref,
     path::{Path, PathBuf},
-    sync::OnceLock,
+    sync::{Arc, OnceLock},
 };
 
 use anyhow::{Context, Result, bail};
@@ -17,10 +17,13 @@ use smallvec::SmallVec;
 use turbo_bincode::turbo_bincode_decode;
 
 use crate::{
-    QueryKey,
+    AccessMode, QueryKey,
+    arc_bytes::ArcBytes,
     lookup_entry::LookupValue,
     mmap_helper::advise_mmap_for_persistence,
-    static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
+    static_sorted_file::{
+        BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData, pread,
+    },
 };
 
 bitfield! {
@@ -103,15 +106,15 @@ impl MetaEntry {
         self.end_of_amqf_data_offset - self.start_of_amqf_data_offset
     }
 
-    pub fn raw_amqf<'l>(&self, amqf_data: &'l [u8]) -> &'l [u8] {
-        amqf_data
-            .get(self.start_of_amqf_data_offset as usize..self.end_of_amqf_data_offset as usize)
-            .expect("AMQF data out of bounds")
+    pub fn raw_amqf<'a>(&self, meta: &'a MetaFile) -> Result<ArcBytes<'a>> {
+        let start = self.start_of_amqf_data_offset as usize;
+        let end = self.end_of_amqf_data_offset as usize;
+        meta.read_range(start, end)
     }
 
     pub fn deserialize_amqf(&self, meta: &MetaFile) -> Result<qfilter::Filter> {
-        let amqf = self.raw_amqf(meta.amqf_data());
-        Ok(turbo_bincode_decode::<AmqfBincodeWrapper>(amqf)
+        let amqf = self.raw_amqf(meta)?;
+        Ok(turbo_bincode_decode::<AmqfBincodeWrapper>(&amqf)
             .with_context(|| {
                 format!(
                     "Failed to deserialize AMQF from {:08}.meta for {:08}.sst",
@@ -131,12 +134,14 @@ impl MetaEntry {
 
     pub fn sst(&self, meta: &MetaFile) -> Result<&StaticSortedFile> {
         self.sst.get_or_try_init(|| {
-            StaticSortedFile::open(&meta.db_path, self.sst_data).with_context(|| {
-                format!(
-                    "Unable to open static sorted file referenced from {:08}.meta",
-                    meta.sequence_number()
-                )
-            })
+            StaticSortedFile::open(&meta.db_path, self.sst_data, meta.access_mode).with_context(
+                || {
+                    format!(
+                        "Unable to open static sorted file referenced from {:08}.meta",
+                        meta.sequence_number()
+                    )
+                },
+            )
         })
     }
 
@@ -210,6 +215,20 @@ pub struct StaticSortedFileRange {
     pub max_hash: u64,
 }
 
+/// The backing storage for the AMQF data portion of a meta file.
+enum MetaFileBacking {
+    Mmap {
+        /// The memory mapped AMQF data region.
+        mmap: Arc<Mmap>,
+    },
+    File {
+        /// The file handle for on-demand reads.
+        file: File,
+        /// The byte offset in the file where the AMQF data starts (end of header).
+        base_offset: u64,
+    },
+}
+
 pub struct MetaFile {
     /// The database path
     db_path: PathBuf,
@@ -229,24 +248,29 @@ pub struct MetaFile {
     /// The offset of the end of the "used keys" AMQF data in the the meta file relative to the end
     /// of the header.
     end_of_used_keys_amqf_data_offset: u32,
-    /// Byte offset of the start of AMQF data within the mmap (= end of the header).
-    amqf_data_start: usize,
-    /// The memory mapped file.
-    mmap: Mmap,
+    /// The backing storage for AMQF data.
+    backing: MetaFileBacking,
+    /// How SST files opened from this meta file should be read.
+    access_mode: AccessMode,
 }
 
 impl MetaFile {
-    /// Opens a meta file at the given path. This memory maps the file, but does not read it yet.
-    /// It's lazy read on demand.
-    pub fn open(db_path: &Path, sequence_number: u32) -> Result<Self> {
+    /// Opens a meta file at the given path. The AMQF data portion is either memory mapped
+    /// or read on demand from the file, depending on `access_mode`.
+    pub fn open(db_path: &Path, sequence_number: u32, access_mode: AccessMode) -> Result<Self> {
         let filename = format!("{sequence_number:08}.meta");
         let path = db_path.join(&filename);
-        Self::open_internal(db_path.to_path_buf(), sequence_number, &path)
+        Self::open_internal(db_path.to_path_buf(), sequence_number, &path, access_mode)
             .with_context(|| format!("Unable to open meta file {filename}"))
     }
 
-    fn open_internal(db_path: PathBuf, sequence_number: u32, path: &Path) -> Result<Self> {
-        let mut file = BufReader::new(File::open(path).context("Failed to open meta file")?);
+    fn open_internal(
+        db_path: PathBuf,
+        sequence_number: u32,
+        path: &Path,
+        access_mode: AccessMode,
+    ) -> Result<Self> {
+        let mut file = BufReader::new(File::open(path)?);
         let magic = file.read_u32::<BE>()?;
         if magic != 0xFE4ADA4A {
             bail!("Invalid magic number");
@@ -283,16 +307,25 @@ impl MetaFile {
         let start_of_used_keys_amqf_data_offset = start_of_amqf_data_offset;
         let end_of_used_keys_amqf_data_offset = file.read_u32::<BE>()?;
 
-        let offset = file
-            .stream_position()
-            .context("Failed to get stream position")?;
+        let base_offset = file.stream_position()?;
         let file = file.into_inner();
-        let mmap = unsafe { MmapOptions::new().map(&file) }.context("Failed to mmap")?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Random)
-            .context("Failed to advise mmap")?;
-        advise_mmap_for_persistence(&mmap)?;
-        let file = Self {
+
+        let backing = if access_mode == AccessMode::Mmap {
+            let mut options = MmapOptions::new();
+            options.offset(base_offset);
+            let mmap = unsafe { options.map(&file) }
+                .with_context(|| format!("Failed to mmap meta file {}", path.display()))?;
+            #[cfg(unix)]
+            mmap.advise(memmap2::Advice::Random)?;
+            advise_mmap_for_persistence(&mmap)?;
+            MetaFileBacking::Mmap {
+                mmap: Arc::new(mmap),
+            }
+        } else {
+            MetaFileBacking::File { file, base_offset }
+        };
+
+        Ok(Self {
             db_path,
             sequence_number,
             family,
@@ -301,10 +334,9 @@ impl MetaFile {
             obsolete_sst_files,
             start_of_used_keys_amqf_data_offset,
             end_of_used_keys_amqf_data_offset,
-            amqf_data_start: offset as usize,
-            mmap,
-        };
-        Ok(file)
+            backing,
+            access_mode,
+        })
     }
 
     pub fn clear_cache(&mut self) {
@@ -338,17 +370,37 @@ impl MetaFile {
         &self.entries[index]
     }
 
-    pub fn amqf_data(&self) -> &[u8] {
-        &self.mmap[self.amqf_data_start..]
+    /// Reads a byte range from the AMQF data region (offsets relative to the AMQF data start).
+    fn read_range(&self, start: usize, end: usize) -> Result<ArcBytes<'_>> {
+        match &self.backing {
+            MetaFileBacking::Mmap { mmap } => {
+                let slice = &mmap[start..end];
+                // SAFETY: slice points into mmap.
+                Ok(unsafe { ArcBytes::from_mmap_ref(mmap, slice) })
+            }
+            MetaFileBacking::File { file, base_offset } => {
+                let len = end - start;
+                let mut buf = vec![0u8; len];
+                pread(file, &mut buf, base_offset + start as u64).with_context(|| {
+                    format!(
+                        "Failed to read AMQF data range {}..{} from {:08}.meta",
+                        start, end, self.sequence_number
+                    )
+                })?;
+                Ok(ArcBytes::from(buf.into_boxed_slice()))
+            }
+        }
     }
 
     pub fn deserialize_used_key_hashes_amqf(&self) -> Result<Option<qfilter::Filter>> {
         if self.start_of_used_keys_amqf_data_offset == self.end_of_used_keys_amqf_data_offset {
             return Ok(None);
         }
-        let amqf = &self.amqf_data()[self.start_of_used_keys_amqf_data_offset as usize
-            ..self.end_of_used_keys_amqf_data_offset as usize];
-        Ok(Some(pot::from_slice(amqf).with_context(|| {
+        let amqf = self.read_range(
+            self.start_of_used_keys_amqf_data_offset as usize,
+            self.end_of_used_keys_amqf_data_offset as usize,
+        )?;
+        Ok(Some(pot::from_slice(&amqf).with_context(|| {
             format!(
                 "Failed to deserialize used key hashes AMQF from {:08}.meta",
                 self.sequence_number

--- a/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file_builder.rs
@@ -10,17 +10,17 @@ use qfilter::Filter;
 
 use crate::static_sorted_file_builder::StaticSortedFileBuilderMeta;
 
-pub struct MetaFileBuilder<'a> {
+pub struct MetaFileBuilder {
     family: u32,
     /// Entries in the meta file, tuples of (sequence_number, StaticSortedFileBuilderMetaResult)
-    entries: Vec<(u32, StaticSortedFileBuilderMeta<'a>)>,
+    entries: Vec<(u32, StaticSortedFileBuilderMeta)>,
     /// Obsolete SST files, represented by their sequence numbers
     obsolete_sst_files: Vec<u32>,
     /// Optional AMQF for used key hashes
     used_key_hashes_amqf: Option<Filter>,
 }
 
-impl<'a> MetaFileBuilder<'a> {
+impl MetaFileBuilder {
     pub fn new(family: u32) -> Self {
         Self {
             family,
@@ -30,7 +30,7 @@ impl<'a> MetaFileBuilder<'a> {
         }
     }
 
-    pub fn add(&mut self, sequence_number: u32, sst: StaticSortedFileBuilderMeta<'a>) {
+    pub fn add(&mut self, sequence_number: u32, sst: StaticSortedFileBuilderMeta) {
         self.entries.push((sequence_number, sst));
     }
 

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -1,22 +1,27 @@
-use std::{cmp::Ordering, fs::File, hash::BuildHasherDefault, path::Path, rc::Rc, sync::Arc};
+use std::{
+    cmp::Ordering,
+    fs::File,
+    hash::BuildHasherDefault,
+    io,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
-use anyhow::{Context, Result, bail, ensure};
+use anyhow::{Context, Result, bail};
+use byteorder::{BE, ReadBytesExt};
 use memmap2::Mmap;
 use quick_cache::sync::GuardResult;
 use rustc_hash::FxHasher;
 use smallvec::SmallVec;
 
 use crate::{
-    QueryKey,
+    AccessMode, QueryKey,
     arc_bytes::ArcBytes,
-    be,
-    compression::checksum_block,
+    compression::{checksum_block, decompress_into_arc},
     constants::MAX_INLINE_VALUE_SIZE,
-    lookup_entry::{IterValue, LookupEntry, LookupValue},
+    lookup_entry::{LazyLookupValue, LookupEntry, LookupValue},
     mmap_helper::advise_mmap_for_persistence,
-    rc_bytes::RcBytes,
-    shared_bytes::SharedBytes,
-    static_sorted_file_builder::{BLOCK_HEADER_SIZE, INDEX_BLOCK_ENTRY_SIZE},
+    static_sorted_file_builder::BLOCK_HEADER_SIZE,
 };
 
 /// The block header for an index block.
@@ -74,8 +79,8 @@ impl From<LookupValue> for SstLookupResult {
 #[derive(Clone, Default)]
 pub struct BlockWeighter;
 
-impl quick_cache::Weighter<(u32, u16), ArcBytes> for BlockWeighter {
-    fn weight(&self, _key: &(u32, u16), val: &ArcBytes) -> u64 {
+impl quick_cache::Weighter<(u32, u16), ArcBytes<'static>> for BlockWeighter {
+    fn weight(&self, _key: &(u32, u16), val: &ArcBytes<'static>) -> u64 {
         if val.is_mmap_backed() {
             // Mmap-backed blocks are cheap (just a pointer + Arc clone), so we
             // assign a small fixed weight. Caching them avoids re-parsing block
@@ -87,60 +92,46 @@ impl quick_cache::Weighter<(u32, u16), ArcBytes> for BlockWeighter {
     }
 }
 
-pub type BlockCache =
-    quick_cache::sync::Cache<(u32, u16), ArcBytes, BlockWeighter, BuildHasherDefault<FxHasher>>;
+pub type BlockCache = quick_cache::sync::Cache<
+    (u32, u16),
+    ArcBytes<'static>,
+    BlockWeighter,
+    BuildHasherDefault<FxHasher>,
+>;
 
-/// Trait abstracting value block reading for `handle_key_match_generic`.
+/// Trait abstracting value block caching for `handle_key_match`.
 ///
-/// Provides cached reads (small value blocks) and uncached reads (medium value
-/// blocks). Generic over the byte type so it works for both the lookup path
-/// (`ArcBytes` with `BlockCache`) and the iteration path (`RcBytes` with a
-/// single-entry `Option` cache).
-trait ValueBlockCache<B: SharedBytes> {
-    fn get_or_read(
-        self,
-        mmap: &B::MmapHandle,
-        meta: &StaticSortedFileMetaData,
-        block_index: u16,
-    ) -> Result<B>;
+/// Implemented by `&BlockCache` (global shared cache for lookups) and
+/// `&mut Option<(u16, ArcBytes<'static>)>` (lightweight single-entry cache for
+/// sequential iteration).
+trait ValueBlockCache {
+    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes<'static>>;
 }
 
-/// Lookup-path: concurrent `BlockCache`.
-impl ValueBlockCache<ArcBytes> for &BlockCache {
-    fn get_or_read(
-        self,
-        mmap: &Arc<Mmap>,
-        meta: &StaticSortedFileMetaData,
-        block_index: u16,
-    ) -> Result<ArcBytes> {
-        Ok(
-            match self.get_value_or_guard(&(meta.sequence_number, block_index), None) {
-                GuardResult::Value(block) => block,
-                GuardResult::Guard(guard) => {
-                    let block: ArcBytes = read_block_generic(mmap, meta, block_index)?;
-                    let _ = guard.insert(block.clone());
-                    block
-                }
-                GuardResult::Timeout => unreachable!(),
-            },
-        )
+impl ValueBlockCache for &BlockCache {
+    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes<'static>> {
+        let this = &sst;
+        let block = match self.get_value_or_guard(&(this.meta.sequence_number, block_index), None) {
+            GuardResult::Value(block) => block,
+            GuardResult::Guard(guard) => {
+                let block = this.read_small_value_block(block_index)?;
+                let _ = guard.insert(block.clone());
+                block
+            }
+            GuardResult::Timeout => unreachable!(),
+        };
+        Ok(block)
     }
 }
 
-/// Iteration-path: lightweight single-entry cache for sequential reads.
-impl ValueBlockCache<RcBytes> for &mut Option<(u16, RcBytes)> {
-    fn get_or_read(
-        self,
-        mmap: &Rc<Mmap>,
-        meta: &StaticSortedFileMetaData,
-        block_index: u16,
-    ) -> Result<RcBytes> {
+impl ValueBlockCache for &mut Option<(u16, ArcBytes<'static>)> {
+    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes<'static>> {
         if let Some((idx, block)) = self.as_ref()
             && *idx == block_index
         {
             return Ok(block.clone());
         }
-        let block: RcBytes = read_block_generic(mmap, meta, block_index)?;
+        let block = sst.read_small_value_block(block_index)?;
         *self = Some((block_index, block.clone()));
         Ok(block)
     }
@@ -161,42 +152,154 @@ impl StaticSortedFileMetaData {
     }
 }
 
-/// A memory mapped SST file.
+/// Reads exactly `buf.len()` bytes from `file` at the given offset, without changing the file's
+/// seek position.
+pub(crate) fn pread(file: &File, buf: &mut [u8], offset: u64) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::FileExt;
+        file.read_exact_at(buf, offset)
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::FileExt;
+        let mut pos = 0;
+        while pos < buf.len() {
+            let n = file.seek_read(&mut buf[pos..], offset + pos as u64)?;
+            if n == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "unexpected eof in pread",
+                ));
+            }
+            pos += n;
+        }
+        Ok(())
+    }
+}
+
+/// The backing storage for an SST file: either a memory-mapped region or a plain file handle.
+enum StaticSortedFileBacking {
+    Mmap {
+        /// The memory mapped file. Stored as an Arc so we can hand out references
+        /// (via ArcBytes) that can outlive this struct.
+        mmap: Arc<Mmap>,
+    },
+    File {
+        /// The file handle, shared via Arc for ArcBytes references.
+        file: Arc<File>,
+        /// The file length in bytes (cached at open time).
+        file_len: usize,
+        /// Block offset table read into memory at open time.
+        /// `block_offsets[i]` is the end offset of block `i` (in bytes from file start).
+        block_offsets: Vec<u32>,
+    },
+}
+
+/// An SST file backed by either mmap or direct file reads.
 pub struct StaticSortedFile {
     /// The meta file of this file.
     meta: StaticSortedFileMetaData,
-    /// The memory mapped file.
-    /// We store as an Arc so we can hand out references (via ArcBytes) that can outlive this
-    /// struct (not that we expect them to outlive it by very much)
-    mmap: Arc<Mmap>,
+    /// The backing storage.
+    backing: StaticSortedFileBacking,
 }
 
 impl StaticSortedFile {
-    /// Opens an SST file at the given path. This memory maps the file, but does not read it yet.
-    /// It's lazy read on demand.
-    pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
+    /// Opens an SST file at the given path. This memory maps the file (or opens it for direct
+    /// reads if `access_mode` is `File`), but does not read block data yet — it's lazy read on
+    /// demand.
+    pub fn open(
+        db_path: &Path,
+        meta: StaticSortedFileMetaData,
+        access_mode: AccessMode,
+    ) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
+        Self::open_internal(path, meta, false, access_mode)
+            .with_context(|| format!("Unable to open static sorted file {filename}"))
+    }
+
+    /// Opens an SST file for compaction. Uses MADV_SEQUENTIAL instead of MADV_RANDOM,
+    /// since compaction reads blocks sequentially and benefits from OS read-ahead
+    /// and page reclamation.
+    pub fn open_for_compaction(
+        db_path: &Path,
+        meta: StaticSortedFileMetaData,
+        access_mode: AccessMode,
+    ) -> Result<Self> {
+        let filename = format!("{:08}.sst", meta.sequence_number);
+        let path = db_path.join(&filename);
+        Self::open_internal(path, meta, true, access_mode)
+            .with_context(|| format!("Unable to open static sorted file {filename}"))
+    }
+
+    fn open_internal(
+        path: PathBuf,
+        meta: StaticSortedFileMetaData,
+        sequential: bool,
+        access_mode: AccessMode,
+    ) -> Result<Self> {
         let file = File::open(&path)
             .with_context(|| format!("Failed to open SST file {}", path.display()))?;
-        let mmap = unsafe { Mmap::map(&file) }.with_context(|| {
-            format!(
-                "Failed to mmap SST file {} ({} bytes)",
-                path.display(),
-                file.metadata().map(|m| m.len()).unwrap_or(0)
-            )
-        })?;
-        #[cfg(unix)]
-        {
-            mmap.advise(memmap2::Advice::Random)?;
-            let offset = meta.block_offsets_start(mmap.len());
-            let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
-        }
-        advise_mmap_for_persistence(&mmap)?;
-        Ok(Self {
-            meta,
-            mmap: Arc::new(mmap),
-        })
+
+        let backing = if access_mode == AccessMode::Mmap {
+            let mmap = unsafe { Mmap::map(&file) }.with_context(|| {
+                format!(
+                    "Failed to mmap SST file {} ({} bytes)",
+                    path.display(),
+                    file.metadata().map(|m| m.len()).unwrap_or(0)
+                )
+            })?;
+            #[cfg(unix)]
+            if sequential {
+                mmap.advise(memmap2::Advice::Sequential)?;
+            } else {
+                mmap.advise(memmap2::Advice::Random)?;
+                let offset = meta.block_offsets_start(mmap.len());
+                let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
+            }
+            advise_mmap_for_persistence(&mmap)?;
+            StaticSortedFileBacking::Mmap {
+                mmap: Arc::new(mmap),
+            }
+        } else {
+            let file_len = file.metadata()?.len() as usize;
+            let block_count = meta.block_count as usize;
+            let offsets_start = meta.block_offsets_start(file_len);
+            let mut offsets_buf = vec![0u8; block_count * 4];
+            pread(&file, &mut offsets_buf, offsets_start as u64).with_context(|| {
+                format!(
+                    "Failed to read block offset table from SST file {}",
+                    path.display()
+                )
+            })?;
+            let block_offsets: Vec<u32> = offsets_buf
+                .chunks_exact(4)
+                .map(|chunk| u32::from_be_bytes(chunk.try_into().unwrap()))
+                .collect();
+            StaticSortedFileBacking::File {
+                file: Arc::new(file),
+                file_len,
+                block_offsets,
+            }
+        };
+
+        Ok(Self { meta, backing })
+    }
+
+    /// Consume this file and return an iterator over all entries in sorted order.
+    /// The iterator takes ownership of the SST file, so the mmap and its pages
+    /// are freed when the iterator is dropped.
+    pub fn try_into_iter(self) -> Result<StaticSortedFileIter> {
+        let block_count = self.meta.block_count;
+        let mut iter = StaticSortedFileIter {
+            this: self,
+            stack: Vec::new(),
+            current_key_block: None,
+            value_block_cache: None,
+        };
+        iter.enter_block(block_count - 1)?;
+        Ok(iter)
     }
 
     /// Looks up a key in this file.
@@ -212,13 +315,9 @@ impl StaticSortedFile {
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
         let mut current_block = self.meta.block_count - 1;
-        // TODO: there is only one index block per file, so we can simplify control flow directly
-        // parsing the index block and then proceeding to key blocks.  Basically there is no need to
-        // loop.
         loop {
-            let key_block_arc = self.get_key_block(current_block, key_block_cache)?;
-            ensure!(!key_block_arc.is_empty(), "empty key block");
-            let block_type = be::read_u8(&key_block_arc);
+            let mut key_block_arc = self.get_key_block(current_block, key_block_cache)?;
+            let block_type = key_block_arc.read_u8()?;
             match block_type {
                 BLOCK_TYPE_INDEX => {
                     current_block = self.lookup_index_block(&key_block_arc, key_hash)?;
@@ -251,20 +350,20 @@ impl StaticSortedFile {
     }
 
     /// Looks up a hash in a index block.
-    fn lookup_index_block(&self, block: &[u8], hash: u64) -> Result<u16> {
-        ensure!(block.len() >= 3, "index block too short");
-        let first_block = be::read_u16(&block[1..]);
-        let (entries, remainder) = block[3..].as_chunks::<INDEX_BLOCK_ENTRY_SIZE>();
+    fn lookup_index_block(&self, mut block: &[u8], hash: u64) -> Result<u16> {
+        let first_block = block.read_u16::<BE>()?;
+        // Each entry is 10 bytes: 8 bytes for the hash, 2 bytes for the block index
+        let (entries, remainder) = block.as_chunks::<10>();
         if entries.is_empty() {
             return Ok(first_block);
         }
         if !remainder.is_empty() {
             bail!("invalid index block, {} extra bytes", remainder.len())
         }
-        match entries.binary_search_by(|entry| be::read_u64(entry).cmp(&hash)) {
-            Ok(i) => Ok(be::read_u16(&entries[i][8..])),
+        match entries.binary_search_by(|entry| (&entry[..]).read_u64::<BE>().unwrap().cmp(&hash)) {
+            Ok(i) => Ok((&entries[i][8..]).read_u16::<BE>()?),
             Err(0) => Ok(first_block),
-            Err(i) => Ok(be::read_u16(&entries[i - 1][8..])),
+            Err(i) => Ok((&entries[i - 1][8..]).read_u16::<BE>()?),
         }
     }
 
@@ -274,22 +373,16 @@ impl StaticSortedFile {
     /// If `FIND_ALL` is true, collects all entries with the same key.
     fn lookup_key_block<K: QueryKey, const FIND_ALL: bool>(
         &self,
-        block: ArcBytes,
+        mut block: ArcBytes<'static>,
         key_hash: u64,
         key: &K,
         has_hash: bool,
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
         let hash_len: u8 = if has_hash { 8 } else { 0 };
-        ensure!(block.len() >= 4, "key block too short");
-        let entry_count = be::read_u24(&block[1..]) as usize;
-        let data = &block[4..];
-        ensure!(
-            data.len() >= entry_count * 4,
-            "key block too short for {entry_count} entries"
-        );
-        let offsets = &data[..entry_count * 4];
-        let entries = &data[entry_count * 4..];
+        let entry_count = block.read_u24::<BE>()? as usize;
+        let offsets = &block[..entry_count * 4];
+        let entries = &block[entry_count * 4..];
 
         self.lookup_block_inner::<K, FIND_ALL>(
             &block,
@@ -307,24 +400,19 @@ impl StaticSortedFile {
     /// enabling direct indexing during binary search.
     fn lookup_fixed_key_block<K: QueryKey, const FIND_ALL: bool>(
         &self,
-        block: ArcBytes,
+        mut block: ArcBytes<'static>,
         key_hash: u64,
         key: &K,
         has_hash: bool,
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
         let hash_len: u8 = if has_hash { 8 } else { 0 };
-        ensure!(block.len() >= 6, "fixed key block too short");
-        let entry_count = be::read_u24(&block[1..]) as usize;
-        let key_size = be::read_u8(&block[4..]) as usize;
-        let value_type = be::read_u8(&block[5..]);
+        let entry_count = block.read_u24::<BE>()? as usize;
+        let key_size = block.read_u8()? as usize;
+        let value_type = block.read_u8()?;
         let val_size = entry_val_size(value_type)?;
         let stride = hash_len as usize + key_size + val_size;
-        let entries = &block[6..];
-        ensure!(
-            entries.len() == entry_count * stride,
-            "fixed key block for {entry_count} entries must is the wrong size"
-        );
+        let entries = &block[..];
 
         self.lookup_block_inner::<K, FIND_ALL>(
             &block,
@@ -346,7 +434,7 @@ impl StaticSortedFile {
     /// key blocks (offset table lookup) and fixed-size key blocks (stride-based indexing).
     fn lookup_block_inner<'a, K: QueryKey, const FIND_ALL: bool>(
         &self,
-        block: &ArcBytes,
+        block: &ArcBytes<'static>,
         entry_count: usize,
         key_hash: u64,
         key: &K,
@@ -428,18 +516,37 @@ impl StaticSortedFile {
     fn handle_key_match(
         &self,
         ty: u8,
-        val: &[u8],
-        key_block_arc: &ArcBytes,
-        value_block_cache: &BlockCache,
+        mut val: &[u8],
+        key_block_arc: &ArcBytes<'static>,
+        value_block_cache: impl ValueBlockCache,
     ) -> Result<LookupValue> {
-        handle_key_match_generic(
-            &self.mmap,
-            &self.meta,
-            ty,
-            val,
-            key_block_arc,
-            value_block_cache,
-        )
+        Ok(match ty {
+            KEY_BLOCK_ENTRY_TYPE_SMALL => {
+                let block = val.read_u16::<BE>()?;
+                let size = val.read_u16::<BE>()? as usize;
+                let position = val.read_u32::<BE>()? as usize;
+                let value = value_block_cache
+                    .get_or_read(self, block)?
+                    .slice(position..position + size);
+                LookupValue::Slice { value }
+            }
+            KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
+                let block = val.read_u16::<BE>()?;
+                let value = self.read_value_block(block)?;
+                LookupValue::Slice { value }
+            }
+            KEY_BLOCK_ENTRY_TYPE_BLOB => {
+                let sequence_number = val.read_u32::<BE>()?;
+                LookupValue::Blob { sequence_number }
+            }
+            KEY_BLOCK_ENTRY_TYPE_DELETED => LookupValue::Deleted,
+            _ => {
+                // Inline value — val is already the correct slice
+                // SAFETY: val points into key_block_arc's data
+                let value = unsafe { key_block_arc.slice_from_subslice(val) };
+                LookupValue::Slice { value }
+            }
+        })
     }
 
     /// Gets a key block from the cache or reads it from the file.
@@ -447,7 +554,7 @@ impl StaticSortedFile {
         &self,
         block: u16,
         key_block_cache: &BlockCache,
-    ) -> Result<ArcBytes, anyhow::Error> {
+    ) -> Result<ArcBytes<'static>, anyhow::Error> {
         Ok(
             match key_block_cache.get_value_or_guard(&(self.meta.sequence_number, block), None) {
                 GuardResult::Value(block) => block,
@@ -462,209 +569,238 @@ impl StaticSortedFile {
     }
 
     /// Reads a key block from the file.
-    fn read_key_block(&self, block_index: u16) -> Result<ArcBytes> {
+    fn read_key_block(&self, block_index: u16) -> Result<ArcBytes<'static>> {
         self.read_block(block_index)
+    }
+
+    /// Reads a small value block from the file.
+    fn read_small_value_block(&self, block_index: u16) -> Result<ArcBytes<'static>> {
+        self.read_block(block_index)
+    }
+
+    /// Reads a value block from the file.
+    fn read_value_block(&self, block_index: u16) -> Result<ArcBytes<'static>> {
+        self.read_block(block_index)
+    }
+
+    /// Verifies the CRC32 checksum of on-disk block data. Returns an error on mismatch.
+    fn verify_checksum(&self, data: &[u8], expected: u32, block_index: u16) -> Result<()> {
+        let actual = checksum_block(data);
+        if actual != expected {
+            bail!(
+                "Cache corruption detected: checksum mismatch in block {} of {:08}.sst (expected \
+                 {:08x}, got {:08x})",
+                block_index,
+                self.meta.sequence_number,
+                expected,
+                actual
+            );
+        }
+        Ok(())
     }
 
     /// Reads a block from the file, decompressing if needed, and verifies its checksum.
     ///
     /// The checksum is verified on the raw on-disk data **before** decompression, so
     /// corruption is caught before passing data to LZ4.
-    fn read_block(&self, block_index: u16) -> Result<ArcBytes> {
-        read_block_generic(&self.mmap, &self.meta, block_index)
-    }
-}
+    #[tracing::instrument(level = "info", name = "reading database block", skip_all)]
+    fn read_block(&self, block_index: u16) -> Result<ArcBytes<'static>> {
+        let (uncompressed_length, expected_checksum, block) =
+            self.get_raw_block_slice(block_index).with_context(|| {
+                format!(
+                    "Failed to read raw block {} from {:08}.sst",
+                    block_index, self.meta.sequence_number
+                )
+            })?;
 
-/// Gets the raw block slice directly from a memory-mapped file.
-/// Returns `(uncompressed_length, checksum, block_data)`.
-fn get_raw_block_slice<'a>(
-    mmap: &'a Mmap,
-    meta: &StaticSortedFileMetaData,
-    block_index: u16,
-) -> Result<(u32, u32, &'a [u8])> {
-    #[cfg(feature = "strict_checks")]
-    if block_index >= meta.block_count {
-        bail!(
-            "Corrupted file seq:{} block:{} > number of blocks {} (block_offsets: {:x})",
-            meta.sequence_number,
-            block_index,
-            meta.block_count,
-            meta.block_offsets_start(mmap.len()),
-        );
-    }
-    let offset = meta.block_offsets_start(mmap.len()) + block_index as usize * 4;
-    #[cfg(feature = "strict_checks")]
-    if offset + 4 > mmap.len() {
-        bail!(
-            "Corrupted file seq:{} block:{} block offset locations {} + 4 bytes > file end {} \
-             (block_offsets: {:x})",
-            meta.sequence_number,
-            block_index,
-            offset,
-            mmap.len(),
-            meta.block_offsets_start(mmap.len()),
-        );
-    }
-    let block_start = if block_index == 0 {
-        0
-    } else {
-        be::read_u32(&mmap[offset - 4..]) as usize
-    };
-    let block_end = be::read_u32(&mmap[offset..]) as usize;
-    #[cfg(feature = "strict_checks")]
-    if block_end > mmap.len() || block_start > mmap.len() {
-        bail!(
-            "Corrupted file seq:{} block:{} block {} - {} > file end {} (block_offsets: {:x})",
-            meta.sequence_number,
-            block_index,
-            block_start,
-            block_end,
-            mmap.len(),
-            meta.block_offsets_start(mmap.len()),
-        );
-    }
-    ensure!(
-        block_start + BLOCK_HEADER_SIZE <= block_end,
-        "block {} header truncated in {:08}.sst",
-        block_index,
-        meta.sequence_number
-    );
-    let uncompressed_length = be::read_u32(&mmap[block_start..]);
-    let checksum = be::read_u32(&mmap[block_start + 4..]);
-    let block = &mmap[block_start + BLOCK_HEADER_SIZE..block_end];
-    Ok((uncompressed_length, checksum, block))
-}
+        // Verify checksum on the raw on-disk data before decompression.
+        self.verify_checksum(&block, expected_checksum, block_index)?;
 
-/// Verifies the CRC32 checksum of on-disk block data. Returns an error on mismatch.
-fn verify_checksum(
-    meta: &StaticSortedFileMetaData,
-    data: &[u8],
-    expected: u32,
-    block_index: u16,
-) -> Result<()> {
-    let actual = checksum_block(data);
-    if actual != expected {
-        bail!(
-            "Cache corruption detected: checksum mismatch in block {} of {:08}.sst (expected \
-             {:08x}, got {:08x})",
-            block_index,
-            meta.sequence_number,
-            expected,
-            actual
-        );
-    }
-    Ok(())
-}
+        // 0 means the block was not compressed, promote to owned ArcBytes
+        if uncompressed_length == 0 {
+            return Ok(block.into_static());
+        }
 
-/// Returns `(uncompressed_length, checksum, block)` wrapping the raw on-disk
-/// data as the given byte type. Generic over `ArcBytes`/`RcBytes`.
-fn get_raw_block_generic<B: SharedBytes>(
-    mmap: &B::MmapHandle,
-    meta: &StaticSortedFileMetaData,
-    block_index: u16,
-) -> Result<(u32, u32, B)> {
-    let (uncompressed_length, checksum, block) = get_raw_block_slice(mmap, meta, block_index)?;
-    // SAFETY: block points into mmap which backs the MmapHandle.
-    Ok((uncompressed_length, checksum, unsafe {
-        B::from_mmap(mmap, block)
-    }))
-}
-
-/// Reads a block, decompresses if needed, and verifies its checksum.
-/// Generic over the byte type (`ArcBytes` or `RcBytes`).
-#[tracing::instrument(level = "info", name = "reading database block", skip_all)]
-fn read_block_generic<B: SharedBytes>(
-    mmap: &B::MmapHandle,
-    meta: &StaticSortedFileMetaData,
-    block_index: u16,
-) -> Result<B> {
-    let (uncompressed_length, expected_checksum, block) =
-        get_raw_block_slice(mmap, meta, block_index).with_context(|| {
+        let buffer = decompress_into_arc(uncompressed_length, &block).with_context(|| {
             format!(
-                "Failed to read raw block {} from {:08}.sst",
-                block_index, meta.sequence_number
+                "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+                block_index, self.meta.sequence_number, uncompressed_length
+            )
+        })?;
+        Ok(ArcBytes::from(buffer))
+    }
+
+    /// Returns `(uncompressed_length, checksum, block_data)`.
+    /// For mmap-backed files, the returned `ArcBytes` borrows the mmap (no Arc clone).
+    /// For file-backed files, the data is read via pread into an owned buffer.
+    fn get_raw_block_slice(&self, block_index: u16) -> Result<(u32, u32, ArcBytes<'_>)> {
+        match &self.backing {
+            StaticSortedFileBacking::Mmap { mmap } => {
+                self.get_raw_block_slice_mmap(mmap, block_index)
+            }
+            StaticSortedFileBacking::File {
+                file,
+                file_len,
+                block_offsets,
+            } => self.get_raw_block_slice_file(file, *file_len, block_offsets, block_index),
+        }
+    }
+
+    /// mmap path: reads block offsets and data directly from mapped memory.
+    /// Returns a borrowed `ArcBytes` that references the mmap without cloning
+    /// the `Arc<Mmap>`. The caller can promote to `ArcBytes<'static>` via `into_static()`.
+    fn get_raw_block_slice_mmap<'a>(
+        &self,
+        mmap: &'a Arc<Mmap>,
+        block_index: u16,
+    ) -> Result<(u32, u32, ArcBytes<'a>)> {
+        #[cfg(feature = "strict_checks")]
+        if block_index >= self.meta.block_count {
+            bail!(
+                "Corrupted file seq:{} block:{} > number of blocks {} (block_offsets: {:x})",
+                self.meta.sequence_number,
+                block_index,
+                self.meta.block_count,
+                self.meta.block_offsets_start(mmap.len()),
+            );
+        }
+        let offset = self.meta.block_offsets_start(mmap.len()) + block_index as usize * 4;
+        #[cfg(feature = "strict_checks")]
+        if offset + 4 > mmap.len() {
+            bail!(
+                "Corrupted file seq:{} block:{} block offset locations {} + 4 bytes > file end {} \
+                 (block_offsets: {:x})",
+                self.meta.sequence_number,
+                block_index,
+                offset,
+                mmap.len(),
+                self.meta.block_offsets_start(mmap.len()),
+            );
+        }
+        let block_start = if block_index == 0 {
+            0
+        } else {
+            (&mmap[offset - 4..offset])
+                .read_u32::<BE>()
+                .with_context(|| {
+                    format!(
+                        "Failed to read block_start offset for block {} in {:08}.sst",
+                        block_index, self.meta.sequence_number
+                    )
+                })? as usize
+        };
+        let block_end = (&mmap[offset..offset + 4])
+            .read_u32::<BE>()
+            .with_context(|| {
+                format!(
+                    "Failed to read block_end offset for block {} in {:08}.sst",
+                    block_index, self.meta.sequence_number
+                )
+            })? as usize;
+        #[cfg(feature = "strict_checks")]
+        if block_end > mmap.len() || block_start > mmap.len() {
+            bail!(
+                "Corrupted file seq:{} block:{} block {} - {} > file end {} (block_offsets: {:x})",
+                self.meta.sequence_number,
+                block_index,
+                block_start,
+                block_end,
+                mmap.len(),
+                self.meta.block_offsets_start(mmap.len()),
+            );
+        }
+        let uncompressed_length =
+            u32::from_be_bytes(mmap[block_start..block_start + 4].try_into().with_context(
+                || {
+                    format!(
+                        "Failed to read uncompressed_length from block {} header in {:08}.sst",
+                        block_index, self.meta.sequence_number
+                    )
+                },
+            )?);
+        let checksum = u32::from_be_bytes(
+            mmap[block_start + 4..block_start + 8]
+                .try_into()
+                .with_context(|| {
+                    format!(
+                        "Failed to read checksum from block {} header in {:08}.sst",
+                        block_index, self.meta.sequence_number
+                    )
+                })?,
+        );
+        let block = &mmap[block_start + BLOCK_HEADER_SIZE..block_end];
+        // SAFETY: block points into mmap.
+        let arc_bytes = unsafe { ArcBytes::from_mmap_ref(mmap, block) };
+        Ok((uncompressed_length, checksum, arc_bytes))
+    }
+
+    /// File path: reads block data via pread using the in-memory block offset table.
+    fn get_raw_block_slice_file(
+        &self,
+        file: &Arc<File>,
+        file_len: usize,
+        block_offsets: &[u32],
+        block_index: u16,
+    ) -> Result<(u32, u32, ArcBytes<'_>)> {
+        let block_start = if block_index == 0 {
+            0usize
+        } else {
+            block_offsets[block_index as usize - 1] as usize
+        };
+        let block_end = block_offsets[block_index as usize] as usize;
+
+        #[cfg(feature = "strict_checks")]
+        if block_end > file_len || block_start > file_len {
+            bail!(
+                "Corrupted file seq:{} block:{} block {} - {} > file end {} (block_offsets: {:x})",
+                self.meta.sequence_number,
+                block_index,
+                block_start,
+                block_end,
+                file_len,
+                self.meta.block_offsets_start(file_len),
+            );
+        }
+        let _ = file_len;
+
+        // Read the entire block (header + data) in one pread call
+        let total_len = block_end - block_start;
+        let mut buf = vec![0u8; total_len];
+        pread(file, &mut buf, block_start as u64).with_context(|| {
+            format!(
+                "Failed to read block {} from {:08}.sst",
+                block_index, self.meta.sequence_number
             )
         })?;
 
-    verify_checksum(meta, block, expected_checksum, block_index)?;
+        let uncompressed_length = u32::from_be_bytes(buf[0..4].try_into().unwrap());
+        let checksum = u32::from_be_bytes(buf[4..8].try_into().unwrap());
 
-    if uncompressed_length == 0 {
-        // SAFETY: callers guarantee block points into the mmap.
-        return Ok(unsafe { B::from_mmap(mmap, block) });
+        // Remove the header, keep only the block data
+        let data: ArcBytes<'static> =
+            ArcBytes::from(Arc::from(buf.into_boxed_slice())).slice(BLOCK_HEADER_SIZE..total_len);
+        Ok((uncompressed_length, checksum, data))
     }
-
-    let buffer = B::from_decompressed(uncompressed_length, block).with_context(|| {
-        format!(
-            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-            block_index, meta.sequence_number, uncompressed_length
-        )
-    })?;
-    Ok(buffer)
-}
-
-/// Handles a key match by resolving the value reference. Generic over byte type.
-fn handle_key_match_generic<B: SharedBytes>(
-    mmap: &B::MmapHandle,
-    meta: &StaticSortedFileMetaData,
-    ty: u8,
-    val: &[u8],
-    key_block: &B,
-    reader: impl ValueBlockCache<B>,
-) -> Result<LookupValue<B>> {
-    Ok(match ty {
-        KEY_BLOCK_ENTRY_TYPE_SMALL => {
-            let block = be::read_u16(val);
-            let size = be::read_u16(&val[2..]) as usize;
-            let position = be::read_u32(&val[4..]) as usize;
-            let value = reader
-                .get_or_read(mmap, meta, block)?
-                .slice(position..position + size);
-            LookupValue::Slice { value }
-        }
-        KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
-            let block = be::read_u16(val);
-            let value = read_block_generic(mmap, meta, block)?;
-            LookupValue::Slice { value }
-        }
-        KEY_BLOCK_ENTRY_TYPE_BLOB => {
-            let sequence_number = be::read_u32(val);
-            LookupValue::Blob { sequence_number }
-        }
-        KEY_BLOCK_ENTRY_TYPE_DELETED => LookupValue::Deleted,
-        _ => {
-            // Inline value — val is already the correct slice
-            // SAFETY: val points into key_block's data
-            let value = unsafe { key_block.slice_from_subslice(val) };
-            LookupValue::Slice { value }
-        }
-    })
 }
 
 /// An iterator over all entries in a SST file in sorted order.
 pub struct StaticSortedFileIter {
-    /// The memory-mapped file, wrapped in `Rc` for non-atomic refcounting.
-    /// All `RcBytes` slices produced during iteration share this `Rc`.
-    mmap: Rc<Mmap>,
-    /// Metadata (sequence number, block count) needed for block access.
-    meta: StaticSortedFileMetaData,
+    this: StaticSortedFile,
 
-    /// The root index block entries (body bytes starting after the type byte).
-    /// SST files have exactly one index level.
-    index_entries: RcBytes,
-    /// Total key block references in the index block (first_child + boundary entries).
-    num_index_entries: usize,
-    /// Next index entry to read from the index block.
-    index_pos: usize,
-    current_key_block: CurrentKeyBlock,
+    stack: Vec<CurrentIndexBlock>,
+    current_key_block: Option<CurrentKeyBlock>,
     /// Single-entry value block cache. Within a key block, entries reference
     /// value blocks sequentially and don't revisit earlier blocks, so caching
     /// just the current one avoids redundant decompression.
-    value_block_cache: Option<(u16, RcBytes)>,
+    value_block_cache: Option<(u16, ArcBytes<'static>)>,
 }
 
 enum CurrentKeyBlockKind {
     /// Variable-size entries with an offset table for random access.
-    Variable { offsets: RcBytes, hash_len: u8 },
+    Variable {
+        offsets: ArcBytes<'static>,
+        hash_len: u8,
+    },
     /// Fixed-size entries with uniform key size and value type (no offset table).
     Fixed {
         hash_len: u8,
@@ -676,11 +812,15 @@ enum CurrentKeyBlockKind {
 
 struct CurrentKeyBlock {
     kind: CurrentKeyBlockKind,
-    entries: RcBytes,
-    /// Number of entries in this key block (max ~819 per 16 KiB block).
-    entry_count: u32,
-    /// Current position within the key block.
-    index: u32,
+    entries: ArcBytes<'static>,
+    entry_count: usize,
+    index: usize,
+}
+
+struct CurrentIndexBlock {
+    entries: ArcBytes<'static>,
+    block_indices_count: usize,
+    index: usize,
 }
 
 impl Iterator for StaticSortedFileIter {
@@ -692,105 +832,48 @@ impl Iterator for StaticSortedFileIter {
 }
 
 impl StaticSortedFileIter {
-    /// Opens an SST file for sequential iteration. Uses `MADV_SEQUENTIAL` for
-    /// read-ahead and wraps the mmap in `Rc<Mmap>` directly (no `Arc`),
-    /// eliminating all atomic refcounting during iteration.
-    pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        let filename = format!("{:08}.sst", meta.sequence_number);
-        let path = db_path.join(&filename);
-        let file = File::open(&path)
-            .with_context(|| format!("Failed to open SST file {}", path.display()))?;
-        let mmap = unsafe { Mmap::map(&file) }.with_context(|| {
-            format!(
-                "Failed to mmap SST file {} ({} bytes)",
-                path.display(),
-                file.metadata().map(|m| m.len()).unwrap_or(0)
-            )
-        })?;
-        #[cfg(unix)]
-        mmap.advise(memmap2::Advice::Sequential)?;
-        advise_mmap_for_persistence(&mmap)?;
-        Self::new(Rc::new(mmap), meta)
-            .with_context(|| format!("Unable to open static sorted file {filename}"))
-    }
-
-    fn new(mmap: Rc<Mmap>, meta: StaticSortedFileMetaData) -> Result<Self> {
-        let root_block_index = meta.block_count - 1;
-        let block: RcBytes = read_block_generic(&mmap, &meta, root_block_index)?;
-        let block_type = block[0];
-
-        // The builder always writes an index block as the root block.
-        if block_type != BLOCK_TYPE_INDEX {
-            bail!("Root block must be an index block");
-        }
-        let block_len = block.len();
-        ensure!(block_len >= 3, "index block too short");
-        let index_entries = block.slice(1..block_len);
-        let first_child = be::read_u16(&index_entries);
-        // Index block body layout: [first_child: u16] [hash: u64, block: u16]*
-        // Compute total key block references (first_child + N boundary entries)
-        // using ceil division: (body_len - sizeof(first_child) + ENTRY_SIZE - 1) / ENTRY_SIZE + 1
-        // simplified to (body_len + ENTRY_SIZE - 2) / ENTRY_SIZE
-        let num_index_entries: usize = (index_entries.len() + INDEX_BLOCK_ENTRY_SIZE
-            - size_of::<u16>())
-            / INDEX_BLOCK_ENTRY_SIZE;
-
-        let current_key_block = Self::parse_key_block(&mmap, &meta, first_child)?;
-        Ok(StaticSortedFileIter {
-            mmap,
-            meta,
-            index_entries,
-            num_index_entries,
-            index_pos: 1,
-            current_key_block,
-            value_block_cache: None,
-        })
-    }
-
-    /// Parses a key block at the given index, returning `RcBytes`-backed data.
-    fn parse_key_block(
-        mmap: &Rc<Mmap>,
-        meta: &StaticSortedFileMetaData,
-        block_index: u16,
-    ) -> Result<CurrentKeyBlock> {
-        let block: RcBytes = read_block_generic(mmap, meta, block_index)?;
-        let data = &*block;
-        ensure!(data.len() >= 4, "key block too short");
-        let block_type = data[0];
-        let entry_count = be::read_u24(&data[1..]);
+    /// Enters a block at the given index.
+    fn enter_block(&mut self, block_index: u16) -> Result<()> {
+        let block_arc = self.this.read_key_block(block_index)?;
+        let mut block = &*block_arc;
+        let block_type = block.read_u8()?;
         match block_type {
+            BLOCK_TYPE_INDEX => {
+                let block_indices_count = (block.len() + 8) / 10;
+                let range = 1..block_arc.len();
+                self.stack.push(CurrentIndexBlock {
+                    entries: block_arc.slice(range),
+                    block_indices_count,
+                    index: 0,
+                });
+            }
             BLOCK_TYPE_KEY_WITH_HASH | BLOCK_TYPE_KEY_NO_HASH => {
-                let hash_len = if block_type == BLOCK_TYPE_KEY_WITH_HASH {
-                    8
-                } else {
-                    0
-                };
-                let n = entry_count as usize;
-                let offsets_range = 4..4 + n * 4;
-                let entries_range = 4 + n * 4..block.len();
-                let offsets = block.clone().slice(offsets_range);
-                let entries = block.slice(entries_range);
-                Ok(CurrentKeyBlock {
+                let has_hash = block_type == BLOCK_TYPE_KEY_WITH_HASH;
+                let hash_len = if has_hash { 8 } else { 0 };
+                let entry_count = block.read_u24::<BE>()? as usize;
+                let offsets_range = 4..4 + entry_count * 4;
+                let entries_range = 4 + entry_count * 4..block_arc.len();
+                let offsets = block_arc.clone().slice(offsets_range);
+                let entries = block_arc.slice(entries_range);
+                self.current_key_block = Some(CurrentKeyBlock {
                     kind: CurrentKeyBlockKind::Variable { offsets, hash_len },
                     entries,
                     entry_count,
                     index: 0,
-                })
+                });
             }
             BLOCK_TYPE_FIXED_KEY_WITH_HASH | BLOCK_TYPE_FIXED_KEY_NO_HASH => {
-                let hash_len = if block_type == BLOCK_TYPE_FIXED_KEY_WITH_HASH {
-                    8
-                } else {
-                    0
-                };
-                let key_size = data[4] as usize;
-                let value_type = data[5];
+                let has_hash = block_type == BLOCK_TYPE_FIXED_KEY_WITH_HASH;
+                let hash_len = if has_hash { 8 } else { 0 };
+                let entry_count = block.read_u24::<BE>()? as usize;
+                let key_size = block.read_u8()? as usize;
+                let value_type = block.read_u8()?;
                 let val_size = entry_val_size(value_type)?;
                 let stride = hash_len as usize + key_size + val_size;
                 // Header is 6 bytes for fixed-size blocks
-                let entries_range = 6..block.len();
-                let entries = block.slice(entries_range);
-                Ok(CurrentKeyBlock {
+                let entries_range = 6..block_arc.len();
+                let entries = block_arc.slice(entries_range);
+                self.current_key_block = Some(CurrentKeyBlock {
                     kind: CurrentKeyBlockKind::Fixed {
                         hash_len,
                         key_size,
@@ -800,24 +883,28 @@ impl StaticSortedFileIter {
                     entries,
                     entry_count,
                     index: 0,
-                })
+                });
             }
             _ => {
-                bail!("Invalid key block type: {block_type}");
+                bail!("Invalid block type");
             }
         }
+        Ok(())
     }
 
     /// Gets the next entry in the file and moves the cursor.
     fn next_internal(&mut self) -> Result<Option<LookupEntry>> {
         loop {
-            let kb = &mut self.current_key_block;
-            if kb.index < kb.entry_count {
-                let index = kb.index as usize;
-                let entry_count = kb.entry_count as usize;
-                let GetKeyEntryResult { hash, key, ty, val } = match &kb.kind {
+            if let Some(CurrentKeyBlock {
+                kind,
+                entries,
+                entry_count,
+                index,
+            }) = self.current_key_block.take()
+            {
+                let GetKeyEntryResult { hash, key, ty, val } = match &kind {
                     CurrentKeyBlockKind::Variable { offsets, hash_len } => {
-                        get_key_entry(offsets, &kb.entries, entry_count, index, *hash_len)?
+                        get_key_entry(offsets, &entries, entry_count, index, *hash_len)?
                     }
                     CurrentKeyBlockKind::Fixed {
                         hash_len,
@@ -825,7 +912,7 @@ impl StaticSortedFileIter {
                         value_type,
                         stride,
                     } => get_fixed_key_entry(
-                        &kb.entries,
+                        &entries,
                         index,
                         *hash_len,
                         *key_size,
@@ -833,45 +920,62 @@ impl StaticSortedFileIter {
                         *stride,
                     ),
                 };
+                // Convert hash slice to u64, computing from key if no hash stored
                 let full_hash = if hash.is_empty() {
                     crate::key::hash_key(&key)
                 } else {
-                    be::read_u64(hash)
+                    u64::from_be_bytes(hash.try_into().unwrap())
                 };
                 let value = if ty == KEY_BLOCK_ENTRY_TYPE_MEDIUM {
-                    let block = be::read_u16(val);
+                    let mut val = val;
+                    let block = val.read_u16::<BE>()?;
                     let (uncompressed_size, checksum, block) =
-                        get_raw_block_generic(&self.mmap, &self.meta, block)?;
-                    IterValue::Medium {
+                        self.this.get_raw_block_slice(block)?;
+                    LazyLookupValue::Medium {
                         uncompressed_size,
                         checksum,
-                        block,
+                        block: block.into_static(),
                     }
                 } else {
-                    handle_key_match_generic(
-                        &self.mmap,
-                        &self.meta,
+                    let value = self.this.handle_key_match(
                         ty,
                         val,
-                        &kb.entries,
+                        &entries,
                         &mut self.value_block_cache,
-                    )?
-                    .into()
+                    )?;
+                    LazyLookupValue::Eager(value)
                 };
                 let entry = LookupEntry {
                     hash: full_hash,
-                    key: unsafe { kb.entries.slice_from_subslice(key) },
+                    // SAFETY: key points into entries which is backed by the same Arc
+                    key: unsafe { entries.slice_from_subslice(key) },
                     value,
                 };
-                kb.index += 1;
+                if index + 1 < entry_count {
+                    self.current_key_block = Some(CurrentKeyBlock {
+                        kind,
+                        entries,
+                        entry_count,
+                        index: index + 1,
+                    });
+                }
                 return Ok(Some(entry));
             }
-            if self.index_pos < self.num_index_entries {
-                let base = self.index_pos * INDEX_BLOCK_ENTRY_SIZE;
-                let block_index = be::read_u16(&self.index_entries[base..]);
-                self.index_pos += 1;
-                self.current_key_block =
-                    Self::parse_key_block(&self.mmap, &self.meta, block_index)?;
+            if let Some(CurrentIndexBlock {
+                entries,
+                block_indices_count,
+                index,
+            }) = self.stack.pop()
+            {
+                let block_index = (&entries[index * 10..]).read_u16::<BE>()?;
+                if index + 1 < block_indices_count {
+                    self.stack.push(CurrentIndexBlock {
+                        entries,
+                        block_indices_count,
+                        index: index + 1,
+                    });
+                }
+                self.enter_block(block_index)?;
             } else {
                 return Ok(None);
             }
@@ -944,17 +1048,6 @@ fn entry_val_size(ty: u8) -> Result<usize> {
     }
 }
 
-/// Reads the type and start offset from an offset table entry.
-/// Each entry is 4 bytes: 1 byte type + 3 bytes BE offset.
-#[inline(always)]
-fn read_offset_entry(offsets: &[u8], index: usize) -> (u8, usize) {
-    let base = index * 4;
-    let word = be::read_u32(&offsets[base..]);
-    let ty = (word >> 24) as u8;
-    let offset = (word & 0x00FF_FFFF) as usize;
-    (ty, offset)
-}
-
 /// Reads a key entry from a key block.
 fn get_key_entry<'l>(
     offsets: &[u8],
@@ -964,12 +1057,13 @@ fn get_key_entry<'l>(
     hash_len: u8,
 ) -> Result<GetKeyEntryResult<'l>> {
     let hash_len_usize = hash_len as usize;
-    let (ty, start) = read_offset_entry(offsets, index);
+    let mut offset = &offsets[index * 4..];
+    let ty = offset.read_u8()?;
+    let start = offset.read_u24::<BE>()? as usize;
     let end = if index == entry_count - 1 {
         entries.len()
     } else {
-        let (_, next_start) = read_offset_entry(offsets, index + 1);
-        next_start
+        (&offsets[(index + 1) * 4 + 1..]).read_u24::<BE>()? as usize
     };
     // Return the raw hash bytes slice (0-8 bytes depending on hash_len)
     let hash = &entries[start..start + hash_len_usize];

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -1,8 +1,9 @@
 use std::{
-    borrow::Cow,
     collections::VecDeque,
+    fmt,
     fs::File,
     io::{BufWriter, Write},
+    ops::Deref,
     path::Path,
 };
 
@@ -11,6 +12,7 @@ use byteorder::{BE, ByteOrder, WriteBytesExt};
 use turbo_bincode::turbo_bincode_encode;
 
 use crate::{
+    arc_bytes::ArcBytes,
     compression::{checksum_block, compress_into_buffer},
     constants::{MAX_INLINE_VALUE_SIZE, MAX_SMALL_VALUE_SIZE, MIN_SMALL_VALUE_BLOCK_SIZE},
     meta_file::{AmqfBincodeWrapper, MetaEntryFlags},
@@ -254,14 +256,51 @@ pub enum EntryValue<'l> {
     Deleted,
 }
 
+/// Owned byte data for an AMQF filter, backed by either an `ArcBytes<'static>` (zero-copy from
+/// mmap / pread) or a `Vec<u8>` (freshly serialized).
+#[derive(Clone)]
+pub enum AmqfData {
+    ArcBytes(ArcBytes<'static>),
+    Vec(Vec<u8>),
+}
+
+impl Deref for AmqfData {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        match self {
+            AmqfData::ArcBytes(a) => a,
+            AmqfData::Vec(v) => v,
+        }
+    }
+}
+
+impl fmt::Debug for AmqfData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("AmqfData").field(&self.len()).finish()
+    }
+}
+
+impl From<ArcBytes<'static>> for AmqfData {
+    fn from(a: ArcBytes<'static>) -> Self {
+        AmqfData::ArcBytes(a)
+    }
+}
+
+impl From<Vec<u8>> for AmqfData {
+    fn from(v: Vec<u8>) -> Self {
+        AmqfData::Vec(v)
+    }
+}
+
 #[derive(Debug, Clone)]
-pub struct StaticSortedFileBuilderMeta<'a> {
+pub struct StaticSortedFileBuilderMeta {
     /// The minimum hash of the keys in the SST file
     pub min_hash: u64,
     /// The maximum hash of the keys in the SST file
     pub max_hash: u64,
     /// The AMQF data
-    pub amqf: Cow<'a, [u8]>,
+    pub amqf: AmqfData,
     /// The number of blocks in the SST file
     pub block_count: u16,
     /// The file size of the SST file
@@ -282,7 +321,7 @@ pub fn write_static_stored_file<E: Entry>(
     entries: &[E],
     file: &Path,
     flags: MetaEntryFlags,
-) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
+) -> Result<(StaticSortedFileBuilderMeta, File)> {
     debug_assert!(entries.iter().map(|e| e.key_hash()).is_sorted());
     let mut writer = StreamingSstWriter::new(file, flags, entries.len() as u64)?;
     for entry in entries {
@@ -895,7 +934,7 @@ impl<E: Entry> StreamingSstWriter<E> {
 
     /// Finishes writing the SST file. Flushes remaining blocks, writes the index, and returns
     /// metadata.
-    pub fn close(mut self) -> Result<(StaticSortedFileBuilderMeta<'static>, File)> {
+    pub fn close(mut self) -> Result<(StaticSortedFileBuilderMeta, File)> {
         #[cfg(debug_assertions)]
         {
             self.finished = true;
@@ -969,7 +1008,7 @@ impl<E: Entry> StreamingSstWriter<E> {
         let meta = StaticSortedFileBuilderMeta {
             min_hash: self.min_hash,
             max_hash: self.max_hash,
-            amqf: Cow::Owned(amqf.into_vec()),
+            amqf: amqf.into_vec().into(),
             block_count,
             size: file_size,
             flags: self.flags,
@@ -1234,7 +1273,7 @@ mod tests {
     };
 
     type TestBlockCache =
-        Cache<(u32, u16), crate::ArcBytes, BlockWeighter, BuildHasherDefault<FxHasher>>;
+        Cache<(u32, u16), crate::ArcBytes<'static>, BlockWeighter, BuildHasherDefault<FxHasher>>;
 
     fn make_cache() -> TestBlockCache {
         TestBlockCache::with(
@@ -1349,7 +1388,7 @@ mod tests {
     fn open_sst(
         dir: &Path,
         seq: u32,
-        meta: &StaticSortedFileBuilderMeta<'_>,
+        meta: &StaticSortedFileBuilderMeta,
     ) -> Result<StaticSortedFile> {
         StaticSortedFile::open(
             dir,
@@ -1357,6 +1396,7 @@ mod tests {
                 sequence_number: seq,
                 block_count: meta.block_count,
             },
+            crate::AccessMode::Mmap,
         )
     }
 
@@ -1366,7 +1406,7 @@ mod tests {
         seq: u32,
         entries: &[TestEntry],
         flags: MetaEntryFlags,
-    ) -> Result<StaticSortedFileBuilderMeta<'static>> {
+    ) -> Result<StaticSortedFileBuilderMeta> {
         let sst_path = dir.join(format!("{seq:08}.sst"));
         let mut writer = StreamingSstWriter::new(&sst_path, flags, entries.len() as u64)?;
         for entry in entries {
@@ -1680,6 +1720,7 @@ mod tests {
                 sequence_number: 1,
                 block_count: meta1.block_count,
             },
+            crate::AccessMode::Mmap,
         )?;
         let sst2 = StaticSortedFile::open(
             dir.path(),
@@ -1687,6 +1728,7 @@ mod tests {
                 sequence_number: 2,
                 block_count: meta2.block_count,
             },
+            crate::AccessMode::Mmap,
         )?;
         let kc = make_cache();
         let vc = make_cache();
@@ -1812,7 +1854,7 @@ mod tests {
     fn assert_corruption_detected(
         dir: &Path,
         seq: u32,
-        meta: &StaticSortedFileBuilderMeta<'_>,
+        meta: &StaticSortedFileBuilderMeta,
         entries: &[TestEntry],
     ) {
         let sst = open_sst(dir, seq, meta).unwrap();

--- a/turbopack/crates/turbo-persistence/src/tests.rs
+++ b/turbopack/crates/turbo-persistence/src/tests.rs
@@ -2,9 +2,10 @@ use std::{fs, path::Path, time::Instant};
 
 use anyhow::Result;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rstest::rstest;
 
 use crate::{
-    DbConfig, FamilyConfig, FamilyKind,
+    AccessMode, DbConfig, FamilyConfig, FamilyKind,
     constants::{MAX_MEDIUM_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
     db::{CompactConfig, TurboPersistence},
     parallel_scheduler::ParallelScheduler,
@@ -104,8 +105,59 @@ impl ParallelScheduler for RayonParallelScheduler {
     }
 }
 
-#[test]
-fn full_cycle() -> Result<()> {
+fn config_with_mmap<const F: usize>(mmap: bool) -> DbConfig<F> {
+    DbConfig {
+        access_mode: if mmap {
+            AccessMode::Mmap
+        } else {
+            AccessMode::File
+        },
+        ..DbConfig::new()
+    }
+}
+
+fn open_db<const F: usize>(
+    path: &std::path::Path,
+    mmap: bool,
+) -> Result<TurboPersistence<RayonParallelScheduler, F>> {
+    open_db_with_config(path, config_with_mmap(mmap))
+}
+
+fn open_db_with_config<const F: usize>(
+    path: &std::path::Path,
+    config: DbConfig<F>,
+) -> Result<TurboPersistence<RayonParallelScheduler, F>> {
+    TurboPersistence::open_with_config_and_parallel_scheduler(
+        path.to_path_buf(),
+        config,
+        RayonParallelScheduler,
+    )
+}
+
+fn multi_value_config_with_mmap(mmap: bool) -> DbConfig<1> {
+    DbConfig {
+        family_configs: [FamilyConfig {
+            kind: FamilyKind::MultiValue,
+        }],
+        access_mode: if mmap {
+            AccessMode::Mmap
+        } else {
+            AccessMode::File
+        },
+    }
+}
+
+fn open_multi_value_db(
+    path: &std::path::Path,
+    mmap: bool,
+) -> Result<TurboPersistence<RayonParallelScheduler, 1>> {
+    open_db_with_config(path, multi_value_config_with_mmap(mmap))
+}
+
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn full_cycle(#[case] mmap: bool) -> Result<()> {
     let mut test_cases = Vec::new();
     type TestCases = Vec<(
         &'static str,
@@ -326,10 +378,7 @@ fn full_cycle() -> Result<()> {
 
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             let mut batch = db.write_batch()?;
             write(&mut batch)?;
             db.commit_write_batch(batch)?;
@@ -345,10 +394,7 @@ fn full_cycle() -> Result<()> {
         }
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("{name} restore time: {:?}", start.elapsed());
             let start = Instant::now();
             read(&db)?;
@@ -374,10 +420,7 @@ fn full_cycle() -> Result<()> {
         }
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("{name} restore time after compact: {:?}", start.elapsed());
             let start = Instant::now();
             read(&db)?;
@@ -411,10 +454,7 @@ fn full_cycle() -> Result<()> {
 
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             let mut batch = db.write_batch()?;
             for (_, write, _) in test_cases.iter() {
                 write(&mut batch)?;
@@ -434,10 +474,7 @@ fn full_cycle() -> Result<()> {
         }
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("All restore time: {:?}", start.elapsed());
             for (name, _, read) in test_cases.iter() {
                 let start = Instant::now();
@@ -469,10 +506,7 @@ fn full_cycle() -> Result<()> {
 
         {
             let start = Instant::now();
-            let db = TurboPersistence::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<16>(path, mmap)?;
             println!("All restore time after compact: {:?}", start.elapsed());
 
             for (name, _, read) in test_cases.iter() {
@@ -506,8 +540,10 @@ fn full_cycle() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn persist_changes() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn persist_changes(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
@@ -535,10 +571,7 @@ fn persist_changes() -> Result<()> {
     }
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         put(&b, 1, 11)?;
         put(&b, 2, 21)?;
@@ -554,10 +587,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         put(&b, 1, 12)?;
         put(&b, 2, 22)?;
@@ -571,10 +601,7 @@ fn persist_changes() -> Result<()> {
     }
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         put(&b, 1, 13)?;
         db.commit_write_batch(b)?;
@@ -588,10 +615,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
 
         check(&db, 1, 13)?;
         check(&db, 2, 22)?;
@@ -602,10 +626,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
 
         db.compact(&CompactConfig {
             optimal_merge_count: 4,
@@ -623,10 +644,7 @@ fn persist_changes() -> Result<()> {
 
     println!("---");
     {
-        let db = TurboPersistence::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
 
         check(&db, 1, 13)?;
         check(&db, 2, 22)?;
@@ -638,8 +656,10 @@ fn persist_changes() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn partial_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn partial_compaction(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
@@ -671,10 +691,7 @@ fn partial_compaction() -> Result<()> {
         println!("--- Iteration {i} ---");
         println!("Add more entries");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
             let b = db.write_batch()?;
             put(&b, i, i)?;
             put(&b, i + 1, i)?;
@@ -693,10 +710,7 @@ fn partial_compaction() -> Result<()> {
 
         println!("Compaction");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             db.compact(&CompactConfig {
                 optimal_merge_count: 4,
@@ -717,10 +731,7 @@ fn partial_compaction() -> Result<()> {
 
         println!("Restore check");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             for j in 0..i {
                 check(&db, j, j)?;
@@ -736,8 +747,10 @@ fn partial_compaction() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn merge_file_removal() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn merge_file_removal(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
@@ -776,10 +789,7 @@ fn merge_file_removal() -> Result<()> {
 
     {
         println!("--- Init ---");
-        let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<1>(path, mmap)?;
         let b = db.write_batch()?;
         for j in 0..=255 {
             put(&b, j, 0)?;
@@ -795,10 +805,7 @@ fn merge_file_removal() -> Result<()> {
         let i = i * 37;
         println!("Add more entries");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
             let b = db.write_batch()?;
             for j in iter_bits(i) {
                 println!("Put {j} = {i}");
@@ -816,10 +823,7 @@ fn merge_file_removal() -> Result<()> {
 
         println!("Compaction");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             db.compact(&CompactConfig {
                 optimal_merge_count: 4,
@@ -837,10 +841,7 @@ fn merge_file_removal() -> Result<()> {
 
         println!("Restore check");
         {
-            let db = TurboPersistence::<_, 1>::open_with_parallel_scheduler(
-                path.to_path_buf(),
-                RayonParallelScheduler,
-            )?;
+            let db = open_db::<1>(path, mmap)?;
 
             for j in 0..32 {
                 check(&db, j, expected_values[j as usize])?;
@@ -853,15 +854,14 @@ fn merge_file_removal() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_basic() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_basic(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write some test data
     let batch = db.write_batch()?;
@@ -885,15 +885,14 @@ fn batch_get_basic() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_all_existing() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_all_existing(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write test data
     let batch = db.write_batch()?;
@@ -915,15 +914,14 @@ fn batch_get_all_existing() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_none_existing() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_none_existing(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write some data but query different keys
     let batch = db.write_batch()?;
@@ -945,15 +943,14 @@ fn batch_get_none_existing() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_empty() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_empty(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write some data
     let batch = db.write_batch()?;
@@ -970,15 +967,14 @@ fn batch_get_empty() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_duplicate_keys() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_duplicate_keys(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write test data
     let batch = db.write_batch()?;
@@ -1007,15 +1003,14 @@ fn batch_get_duplicate_keys() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_large_batch() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_large_batch(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write many entries
     let batch = db.write_batch()?;
@@ -1048,15 +1043,14 @@ fn batch_get_large_batch() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_different_sizes() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_different_sizes(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write values of different sizes
     let batch = db.write_batch()?;
@@ -1102,15 +1096,14 @@ fn batch_get_different_sizes() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_across_families() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_across_families(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write to multiple families
     let batch = db.write_batch()?;
@@ -1148,15 +1141,14 @@ fn batch_get_across_families() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_after_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_after_compaction(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write data across multiple batches to create multiple SST files
     for batch_num in 0..5u8 {
@@ -1193,15 +1185,14 @@ fn batch_get_after_compaction() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_with_overwrites() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_with_overwrites(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write initial data
     let batch = db.write_batch()?;
@@ -1243,15 +1234,14 @@ fn batch_get_with_overwrites() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_comparison_with_get() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_comparison_with_get(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-        path.to_path_buf(),
-        RayonParallelScheduler,
-    )?;
+    let db = open_db::<16>(path, mmap)?;
 
     // Write test data
     let batch = db.write_batch()?;
@@ -1297,17 +1287,16 @@ fn batch_get_comparison_with_get() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn batch_get_after_restore() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn batch_get_after_restore(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
     // Write data and close
     {
-        let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<16>(path, mmap)?;
 
         let batch = db.write_batch()?;
         for i in 0..100u8 {
@@ -1319,10 +1308,7 @@ fn batch_get_after_restore() -> Result<()> {
 
     // Reopen and test batch_get
     {
-        let db = TurboPersistence::<_, 16>::open_with_parallel_scheduler(
-            path.to_path_buf(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_db::<16>(path, mmap)?;
 
         let keys_to_fetch: Vec<Vec<u8>> = (0..100u8).step_by(5).map(|i| vec![i]).collect();
         let results = db.batch_get(0, &keys_to_fetch)?;
@@ -1344,8 +1330,10 @@ fn batch_get_after_restore() -> Result<()> {
 
 /// Test that compaction works with many small values without overflowing block indices.
 /// Reproduces a CI benchmark failure with key_4/value_512/entries_1.98Mi/compacted.
-#[test]
-fn many_small_values_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn many_small_values_compaction(#[case] mmap: bool) -> Result<()> {
     use rand::{RngExt, SeedableRng, rngs::SmallRng};
 
     use crate::parallel_scheduler::SerialScheduler;
@@ -1353,7 +1341,10 @@ fn many_small_values_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+        path.to_path_buf(),
+        config_with_mmap(mmap),
+    )?;
 
     let mut rng = SmallRng::seed_from_u64(42);
 
@@ -1385,8 +1376,10 @@ fn many_small_values_compaction() -> Result<()> {
 
 /// Test compaction with MAX_SMALL_VALUE_SIZE (4096-byte) values.
 /// Worst case for small value blocks: fewest entries per block.
-#[test]
-fn many_max_small_values_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn many_max_small_values_compaction(#[case] mmap: bool) -> Result<()> {
     use rand::{RngExt, SeedableRng, rngs::SmallRng};
 
     use crate::{constants::MAX_SMALL_VALUE_SIZE, parallel_scheduler::SerialScheduler};
@@ -1394,7 +1387,10 @@ fn many_max_small_values_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+        path.to_path_buf(),
+        config_with_mmap(mmap),
+    )?;
 
     let mut rng = SmallRng::seed_from_u64(43);
 
@@ -1425,8 +1421,10 @@ fn many_max_small_values_compaction() -> Result<()> {
 
 /// Test compaction with 4097-byte values (minimum medium size).
 /// Each medium value gets its own dedicated block, so this is the worst case for block count.
-#[test]
-fn many_medium_values_compaction() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn many_medium_values_compaction(#[case] mmap: bool) -> Result<()> {
     use rand::{RngExt, SeedableRng, rngs::SmallRng};
 
     use crate::{constants::MAX_SMALL_VALUE_SIZE, parallel_scheduler::SerialScheduler};
@@ -1434,7 +1432,10 @@ fn many_medium_values_compaction() -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let db = TurboPersistence::<SerialScheduler, 1>::open(path.to_path_buf())?;
+    let db = TurboPersistence::<SerialScheduler, 1>::open_with_config(
+        path.to_path_buf(),
+        config_with_mmap(mmap),
+    )?;
 
     let mut rng = SmallRng::seed_from_u64(44);
 
@@ -1464,21 +1465,17 @@ fn many_medium_values_compaction() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn compaction_multi_value_preserves_different_values() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_multi_value_preserves_different_values(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write same key with different values in separate batches
         let batch = db.write_batch()?;
@@ -1518,29 +1515,17 @@ fn compaction_multi_value_preserves_different_values() -> Result<()> {
     Ok(())
 }
 
-fn multi_value_config() -> DbConfig<1> {
-    let mut config = DbConfig::<1>::default();
-    config.family_configs[0] = FamilyConfig {
-        kind: FamilyKind::MultiValue,
-    };
-    config
-}
-
-#[test]
-fn compaction_multi_value_multiple_compactions() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn compaction_multi_value_multiple_compactions(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write initial values
         for value in [1u8, 2, 3] {
@@ -1590,11 +1575,7 @@ fn compaction_multi_value_multiple_compactions() -> Result<()> {
 
     // Reopen and verify persistence
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert_eq!(results.len(), 6, "Should still have 6 values after reopen");
@@ -1605,20 +1586,17 @@ fn compaction_multi_value_multiple_compactions() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_delete_key() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_delete_key(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let config = multi_value_config();
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write multiple values for the same key across separate batches
         for value in [1u8, 2, 3] {
@@ -1657,11 +1635,7 @@ fn multi_value_delete_key() -> Result<()> {
 
     // Reopen and verify deletion persists
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert!(
@@ -1675,20 +1649,17 @@ fn multi_value_delete_key() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_delete_then_rewrite() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_delete_then_rewrite(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let config = multi_value_config();
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write initial values
         for value in [1u8, 2, 3] {
@@ -1741,11 +1712,7 @@ fn multi_value_delete_then_rewrite() -> Result<()> {
 
     // Reopen and verify
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert_eq!(results.len(), 2, "Should have 2 values after reopen");
@@ -1763,20 +1730,17 @@ fn multi_value_delete_then_rewrite() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_delete_with_compaction_interleaved() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_delete_with_compaction_interleaved(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
 
-    let config = multi_value_config();
     let key = vec![42u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write values 1, 2
         for value in [1u8, 2] {
@@ -1833,11 +1797,7 @@ fn multi_value_delete_with_compaction_interleaved() -> Result<()> {
 
     // Reopen and verify
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config,
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         let results = db.get_multiple(0, &key.as_slice())?;
         assert_eq!(results.len(), 1, "Should have only value 4 after reopen");
@@ -1875,23 +1835,19 @@ fn single_value_duplicate_key_panics() {
     db.commit_write_batch(batch).unwrap(); // panics during commit
 }
 
-#[test]
-fn multi_value_tombstone_only_shadows_older_ssts() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_tombstone_only_shadows_older_ssts(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     // For MultiValue, a tombstone only shadows entries from older SSTs.
     // Entries in the same batch are NOT shadowed by the tombstone.
     let key = vec![3u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // First write an older value in a separate batch (separate SST)
         let batch = db.write_batch()?;
@@ -1924,22 +1880,18 @@ fn multi_value_tombstone_only_shadows_older_ssts() -> Result<()> {
     Ok(())
 }
 
-#[test]
-fn multi_value_tombstone_shadows_older_sst_only() -> Result<()> {
+#[rstest]
+#[case(true)]
+#[case(false)]
+fn multi_value_tombstone_shadows_older_sst_only(#[case] mmap: bool) -> Result<()> {
     let tempdir = tempfile::tempdir()?;
     let path = tempdir.path();
-
-    let config = multi_value_config();
 
     // For MultiValue, tombstone in a batch shadows only entries from older SSTs.
     let key = vec![4u8];
 
     {
-        let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(
-            path.to_path_buf(),
-            config.clone(),
-            RayonParallelScheduler,
-        )?;
+        let db = open_multi_value_db(path, mmap)?;
 
         // Write an older value in a separate batch
         let batch = db.write_batch()?;
@@ -2099,6 +2051,7 @@ fn compaction_deletes_blob_multi_value_tombstone() -> Result<()> {
         family_configs: [FamilyConfig {
             kind: FamilyKind::MultiValue,
         }],
+        ..DbConfig::new()
     };
 
     let db = TurboPersistence::<_, 1>::open_with_config_and_parallel_scheduler(

--- a/turbopack/crates/turbo-persistence/src/write_batch.rs
+++ b/turbopack/crates/turbo-persistence/src/write_batch.rs
@@ -81,7 +81,7 @@ pub struct WriteBatch<K: StoreKey + Send, S: ParallelScheduler, const FAMILIES: 
     /// Collectors in use. The thread local collectors flush into these when they are full.
     collectors: [Mutex<GlobalCollectorState<K>>; FAMILIES],
     /// Meta file builders for each family.
-    meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMeta<'static>)>>; FAMILIES],
+    meta_collectors: [Mutex<Vec<(u32, StaticSortedFileBuilderMeta)>>; FAMILIES],
     /// The list of new SST files that have been created.
     /// Tuple of (sequence number, file).
     new_sst_files: Mutex<Vec<(u32, File)>>,
@@ -488,6 +488,7 @@ impl<K: StoreKey + Send + Sync, S: ParallelScheduler, const FAMILIES: usize>
                     sequence_number: seq,
                     block_count: meta.block_count,
                 },
+                true,
             )?;
             let cache2 = BlockCache::with(
                 10,

--- a/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/database/turbo/mod.rs
@@ -49,15 +49,16 @@ pub struct TurboKeyValueDatabase {
 
 impl TurboKeyValueDatabase {
     pub fn new(versioned_path: PathBuf, is_ci: bool, is_short_session: bool) -> Result<Self> {
-        const CONFIG: DbConfig<FAMILIES> = DbConfig {
+        let config = DbConfig {
             family_configs: [
                 KeySpace::Infra.family_config(),
                 KeySpace::TaskMeta.family_config(),
                 KeySpace::TaskData.family_config(),
                 KeySpace::TaskCache.family_config(),
             ],
+            ..DbConfig::new()
         };
-        let db = Arc::new(TurboPersistence::open_with_config(versioned_path, CONFIG)?);
+        let db = Arc::new(TurboPersistence::open_with_config(versioned_path, config)?);
         Ok(Self {
             db: db.clone(),
             is_ci,
@@ -73,7 +74,7 @@ impl KeyValueDatabase for TurboKeyValueDatabase {
     }
 
     type ValueBuffer<'l>
-        = ArcBytes
+        = ArcBytes<'static>
     where
         Self: 'l;
 
@@ -187,7 +188,7 @@ pub struct TurboWriteBatch<'a> {
 
 impl<'a> ConcurrentWriteBatch<'a> for TurboWriteBatch<'a> {
     type ValueBuffer<'l>
-        = ArcBytes
+        = ArcBytes<'static>
     where
         Self: 'l,
         'a: 'l;


### PR DESCRIPTION
## Summary

Adds an environment variable \`TURBO_PERSISTENCE_MMAP=0\` to disable memory-mapped I/O in turbo-persistence. When set, SST and meta files are read via direct file I/O (\`pread\`) instead of \`mmap\`, while keeping the block offset table cached in memory at open time for efficient random access.

### Motivation

Memory-mapped I/O can cause issues in certain environments (e.g., containers with limited virtual address space, or when mmap overhead outweighs the benefits for specific workloads). This change allows opting out of mmap without code changes.

### Implementation

**New types:**
- `StaticSortedFileBacking` enum — `Mmap { mmap: Arc<Mmap> }` or `File { file: Arc<File>, file_len, block_offsets }`. The file variant eagerly reads the block offset table into memory at open time, then uses `pread` for individual block reads.
- `MetaFileBacking` enum — `Mmap { mmap: Arc<Mmap> }` or `File { file, base_offset }`. AMQF data is read on demand via `pread`.
- Cross-platform `pread` helper using `read_exact_at` (unix) / `seek_read` (windows).
- `ArcBytes<'l>` — a reference-counted byte buffer supporting three backing variants:
  - `Arc { _backing: Arc<[u8]> }` — owned heap allocation
  - `Mmap { _backing: Arc<Mmap> }` — owned mmap reference
  - `MmapRef { _backing: &'l Arc<Mmap> }` — borrowed mmap reference (avoids `Arc::clone`)
  - Use `ArcBytes<'static>` throughout most of the codebase; `ArcBytes<'_>` from `get_raw_block_slice`/`raw_amqf`; call `.into_static()` when needed to promote to owned.

**Config plumbing:**
- `AccessMode` enum: `Mmap` (default) or `File`.
- `DbConfig` has an `access_mode: AccessMode` field.
- Both `DbConfig::new()` and `Default::default()` read the `TURBO_PERSISTENCE_MMAP` env var (cached in a `LazyLock`) to determine the access mode. `default()` delegates to `new()`.

**Return type changes:**
- `get_raw_block_slice` returns `ArcBytes<'_>` (was `&[u8]`), backed by either a zero-copy mmap slice (via `MmapRef`, no Arc clone) or a heap buffer from pread.
- `MetaEntry::raw_amqf` returns `Result<ArcBytes<'_>>` for the mmap path (zero-copy, no Arc clone) and `ArcBytes<'static>` for the file path.

**Compaction path:**
- Replaced the `RcBytes`/`SharedBytes`-generic `StaticSortedFileIter` with `StaticSortedFile::try_into_iter()` that dispatches on `StaticSortedFileBacking`. The compaction iterator yields `LookupEntry` (with `LazyLookupValue`) for both mmap and file modes.

**Blob reads simplified:**
- `read_blob` always uses plain file read (the prior mmap path immediately called `.to_vec()`, making the mmap pointless).

### Testing

All existing tests are parameterized with `rstest` to run with both `AccessMode::Mmap` and `AccessMode::File`, ensuring both code paths are exercised. Test helpers (`open_db`, `open_multi_value_db`) were extracted to reduce duplication.

## Test plan

- [x] `cargo test -p turbo-persistence -- --test-threads=1` — all 86 tests pass (43 with mmap, 43 without)
- [x] `cargo check -p turbo-tasks-backend` — compiles cleanly
- [x] `cargo bench -p turbo-persistence --no-run` — benchmarks compile