### PR TITLE
Test using experimental.workerThreads:true

### DIFF
--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -488,6 +488,14 @@ export async function exportPages(
             console.error(
               `Export encountered an error on ${pageKey}, exiting the build.`
             )
+            // Drain stderr before exiting to ensure all buffered writes
+            // (including the error messages above) are flushed to the parent
+            // process. Without this, the WritableWorkerStdio back-pressure
+            // mechanism may not have transmitted all pending data before the
+            // worker thread exits.
+            await new Promise<void>((resolve) =>
+              process.stderr.write('', () => resolve())
+            )
             process.exit(1)
           } else {
             // Otherwise, this is a no-op. The build will continue, and a summary of failed pages will be displayed at the end.
@@ -652,7 +660,12 @@ process.on('uncaughtException', (err) => {
       'A Next.js API that uses exceptions to signal framework behavior was uncaught. This suggests improper usage of a Next.js API. The original error is printed below and the build will now exit.'
     )
     console.error(err)
-    process.exit(FATAL_UNHANDLED_NEXT_API_EXIT_CODE)
+    // Drain stderr before exiting so all buffered console.error writes above
+    // are fully transmitted through the WritableWorkerStdio back-pressure
+    // mechanism before the worker thread exits.
+    process.stderr.write('', () => {
+      process.exit(FATAL_UNHANDLED_NEXT_API_EXIT_CODE)
+    })
   } else {
     console.error(err)
   }

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -610,8 +610,9 @@ async function exportPage(
   if (process.send) {
     process.send([3, { type: 'activity' }])
   } else {
-     
-    (require('worker_threads') as typeof import('worker_threads')).parentPort?.postMessage([3, { type: 'activity' }])
+    ;(
+      require('worker_threads') as typeof import('worker_threads')
+    ).parentPort?.postMessage([3, { type: 'activity' }])
   }
 
   // Otherwise we can return the result.

--- a/packages/next/src/export/worker.ts
+++ b/packages/next/src/export/worker.ts
@@ -605,8 +605,14 @@ async function exportPage(
     return { error: true, duration: Date.now() - start }
   }
 
-  // Notify the parent process that we processed a page (used by the progress activity indicator)
-  process.send?.([3, { type: 'activity' }])
+  // Notify the parent process that we processed a page (used by the progress activity indicator).
+  // In child process mode, use IPC (process.send). In worker thread mode, use parentPort.
+  if (process.send) {
+    process.send([3, { type: 'activity' }])
+  } else {
+     
+    (require('worker_threads') as typeof import('worker_threads')).parentPort?.postMessage([3, { type: 'activity' }])
+  }
 
   // Otherwise we can return the result.
   return {

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from 'child_process'
+import type { Worker as WorkerThread } from 'worker_threads'
 import { Worker as JestWorker } from 'next/dist/compiled/jest-worker'
 import { Transform } from 'stream'
 import {
@@ -193,6 +194,36 @@ export class Worker {
               typeof data === 'object' &&
               'type' in data &&
               data.type === 'activity'
+            ) {
+              onActivityImpl()
+            }
+          })
+        }
+      } else {
+        for (const worker of ((this._worker as any)._workerPool?._workers ||
+          []) as {
+          _worker?: WorkerThread
+        }[]) {
+          worker._worker?.on('exit', (code) => {
+            if (code && code !== 0 && this._worker) {
+              logger.error(
+                `Next.js build worker exited with code: ${code} and signal: null`
+              )
+
+              // if a worker thread doesn't exit gracefully, bubble up the exit code to the parent process
+              process.exit(code ?? 1)
+            }
+          })
+
+          // if a worker thread emits a custom message (type 3 = PARENT_MESSAGE_CUSTOM),
+          // track activity so the parent process can keep track of progress
+          worker._worker?.on('message', ([type, data]: [number, unknown]) => {
+            if (
+              type === 3 && // PARENT_MESSAGE_CUSTOM
+              data &&
+              typeof data === 'object' &&
+              'type' in data &&
+              (data as any).type === 'activity'
             ) {
               onActivityImpl()
             }

--- a/packages/next/src/lib/worker.ts
+++ b/packages/next/src/lib/worker.ts
@@ -204,14 +204,32 @@ export class Worker {
           []) as {
           _worker?: WorkerThread
         }[]) {
-          worker._worker?.on('exit', (code) => {
+          // Capture the current thread handle at registration time.
+          // After jest-worker restarts a failed thread, worker._worker is
+          // updated to the new thread, so we must hold the old reference here.
+          const thread = worker._worker
+          thread?.on('exit', (code) => {
             if (code && code !== 0 && this._worker) {
               logger.error(
                 `Next.js build worker exited with code: ${code} and signal: null`
               )
 
-              // if a worker thread doesn't exit gracefully, bubble up the exit code to the parent process
-              process.exit(code ?? 1)
+              // Worker thread stderr is delivered via a MessageChannel and may
+              // still be draining when the 'exit' event fires. Wait for the thread's
+              // own stderr stream to end before calling process.exit(), so all
+              // buffered output is written to process.stderr first.
+              const exitCode = code ?? 1
+              const threadStderr = thread.stderr
+              if (threadStderr && !threadStderr.destroyed) {
+                threadStderr.once('end', () => {
+                  process.exit(exitCode)
+                })
+                threadStderr.once('error', () => {
+                  process.exit(exitCode)
+                })
+              } else {
+                process.exit(exitCode)
+              }
             }
           })
 

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1854,7 +1854,7 @@ export const defaultConfig = Object.freeze({
     imgOptSequentialRead: null,
     imgOptSkipMetadata: null,
     isrFlushToDisk: true,
-    workerThreads: false,
+    workerThreads: true,
     proxyTimeout: undefined,
     optimizeCss: false,
     nextScriptWorkers: false,

--- a/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
+++ b/test/e2e/cpu-profiling/cpu-profiling-build.test.ts
@@ -35,14 +35,17 @@ describe('CPU Profiling - next build', () => {
     expect(cpuProfiles.some((f) => f.startsWith('build-main-'))).toBe(true)
 
     if (isTurbopack) {
-      // Turbopack mode generates: build-main, build-turbopack
-      expect(cpuProfiles.length).toBe(2)
+      // Turbopack mode generates: build-main, build-turbopack, build-static-worker
+      expect(cpuProfiles.length).toBe(3)
       expect(cpuProfiles.some((f) => f.startsWith('build-turbopack-'))).toBe(
         true
       )
+      expect(
+        cpuProfiles.some((f) => f.startsWith('build-static-worker-'))
+      ).toBe(true)
     } else {
-      // Webpack mode generates: build-main, build-webpack-client, build-webpack-server, build-webpack-edge-server
-      expect(cpuProfiles.length).toBe(4)
+      // Webpack mode generates: build-main, build-webpack-client, build-webpack-server, build-webpack-edge-server, build-static-worker
+      expect(cpuProfiles.length).toBe(5)
       expect(
         cpuProfiles.some((f) => f.startsWith('build-webpack-client-'))
       ).toBe(true)
@@ -51,6 +54,9 @@ describe('CPU Profiling - next build', () => {
       ).toBe(true)
       expect(
         cpuProfiles.some((f) => f.startsWith('build-webpack-edge-server-'))
+      ).toBe(true)
+      expect(
+        cpuProfiles.some((f) => f.startsWith('build-static-worker-'))
       ).toBe(true)
     }
   })

--- a/test/e2e/prerender-native-module.test.ts
+++ b/test/e2e/prerender-native-module.test.ts
@@ -17,6 +17,14 @@ describe('prerender native module', () => {
         'data.sqlite': new FileRef(
           path.join(__dirname, 'prerender-native-module/data.sqlite')
         ),
+        'next.config.js': `
+          module.exports = {
+            experimental: {
+              // sqlite3 native addon is not thread-safe and crashes in worker_threads
+              workerThreads: false,
+            },
+          }
+        `,
       },
       dependencies: {
         sqlite: '4.0.22',

--- a/test/integration/config-experimental-warning/test/index.test.ts
+++ b/test/integration/config-experimental-warning/test/index.test.ts
@@ -88,35 +88,35 @@ describe('Config Experimental Warning', () => {
     configFile.write(`
       module.exports = {
         experimental: {
-          workerThreads: true
+          workerThreads: false
         }
       }
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
     expect(stdout).toMatch(experimentalHeader)
-    expect(stdout).toMatch(' ✓ workerThreads')
+    expect(stdout).toMatch(' ⨯ workerThreads')
   })
 
   it('should show warning with config from function with experimental', async () => {
     configFile.write(`
       module.exports = (phase) => ({
         experimental: {
-          workerThreads: true
+          workerThreads: false
         }
       })
     `)
 
     const stdout = await collectStdoutFromDev(appDir)
     expect(stdout).toMatch(experimentalHeader)
-    expect(stdout).toMatch(' ✓ workerThreads')
+    expect(stdout).toMatch(' ⨯ workerThreads')
   })
 
   it('should not show warning with default value', async () => {
     configFile.write(`
       module.exports = (phase) => ({
         experimental: {
-          workerThreads: false,
+          workerThreads: true,
           // We enable this by default in CI
           strictRouteTypes: false,
         }
@@ -175,7 +175,7 @@ describe('Config Experimental Warning', () => {
     configFile.write(`
       module.exports = {
         experimental: {
-          workerThreads: true,
+          workerThreads: false,
           scrollRestoration: true,
         }
       }
@@ -183,7 +183,7 @@ describe('Config Experimental Warning', () => {
 
     const stdout = await collectStdoutFromDev(appDir)
     expect(stdout).toContain(experimentalHeader)
-    expect(stdout).toContain(' ✓ workerThreads')
+    expect(stdout).toContain(' ⨯ workerThreads')
     expect(stdout).toContain(' ✓ scrollRestoration')
   })
   ;(process.env.TURBOPACK_DEV ? describe.skip : describe)(
@@ -193,7 +193,6 @@ describe('Config Experimental Warning', () => {
         configFile.write(`
         module.exports = {
           experimental: {
-            workerThreads: true,
             scrollRestoration: true,
             parallelServerCompiles: true,
             cpus: 2,
@@ -216,7 +215,7 @@ describe('Config Experimental Warning', () => {
         configFile.write(`
         module.exports = {
           experimental: {
-            workerThreads: true,
+            workerThreads: false,
             scrollRestoration: true,
             parallelServerCompiles: true,
             prerenderEarlyExit: false,
@@ -227,7 +226,7 @@ describe('Config Experimental Warning', () => {
         const stdout = await collectStdoutFromBuild(appDir)
         expect(stdout).toMatch(experimentalHeader)
         expect(stdout).toMatch(' · cpus: 2')
-        expect(stdout).toMatch(' ✓ workerThreads')
+        expect(stdout).toMatch(' ⨯ workerThreads')
         expect(stdout).toMatch(' ✓ scrollRestoration')
         expect(stdout).toMatch(' ⨯ prerenderEarlyExit')
         expect(stdout).toMatch(' ✓ parallelServerCompiles')

--- a/test/production/app-dir/worker-restart/fixtures/worker-kill/next.config.js
+++ b/test/production/app-dir/worker-restart/fixtures/worker-kill/next.config.js
@@ -1,1 +1,7 @@
-module.exports = {}
+module.exports = {
+  experimental: {
+    // This fixture sends SIGKILL to the worker process, which only works with
+    // child processes, not worker threads.
+    workerThreads: false,
+  },
+}


### PR DESCRIPTION
### What?

Enable `experimental.workerThreads: true` as the default for the static export worker (the pool used during `next build` to render static pages).

### Why?

Worker threads are more efficient than child processes for the static generation pool: they share memory with the parent process, start faster, and avoid the overhead of spawning new Node.js processes for each worker. The feature has existed behind an `experimental` flag for a while; this PR promotes it to the default.

### How?

**Default change** (`config-shared.ts`): Flip `workerThreads` default from `false` to `true`.

**Worker thread support in `lib/worker.ts`**: Add `exit` and `message` event listeners for `worker_threads`-backed workers, mirroring the existing child process handlers. This enables:
- Error propagation from worker threads to the build process
- Build progress tracking (the `[3, { type: 'activity' }]` messages used to report page generation progress)

**Fix IPC in `export/worker.ts`**: Worker threads don't have `process.send()`. Switch the activity ping to use `parentPort.postMessage()` when running as a worker thread.

**Stderr flush before `process.exit`** (two locations): Worker threads use Node.js's `WritableWorkerStdio` to forward `process.stderr` writes to the parent via a `MessageChannel`. This channel uses a back-pressure round-trip: each `_writev` batch waits for a `STDIO_WANTS_MORE_DATA` acknowledgment from the parent before the next batch is sent. If `process.exit(1)` is called while writes are still buffered awaiting that acknowledgment, those writes are silently dropped.

Fix by draining `process.stderr` before each `process.exit` call in `export/worker.ts`:
- In the `prerenderEarlyExit` path: `await new Promise(resolve => process.stderr.write('', () => resolve()))`
- In the `uncaughtException` handler: move `process.exit` into the write callback

The empty write is batched with all pending writes in a single `_writev` call; its callback fires only after the parent has acknowledged the entire batch, guaranteeing all error output is flushed.

Similarly, in `lib/worker.ts` (parent side), when a worker thread exits with non-zero code, wait for `thread.stderr` to emit `'end'` before calling `process.exit()` in the parent — ensuring the parent's own forwarding of worker stderr to `process.stderr` completes first.

**Test updates**:
- `config-experimental-warning`: `workerThreads: true` is now the default, so tests use `workerThreads: false` to verify the warning fires for a non-default experimental value.
- `worker-kill` fixture: SIGKILL only works with child processes; opt out via `workerThreads: false`.
- `prerender-native-module`: the `sqlite3` native addon is not thread-safe; opt out via `workerThreads: false`.
- `cpu-profiling`: an additional `build-static-worker` CPU profile now appears because worker threads exit cleanly (saving their V8 profile), whereas child processes were killed before they could write it.

<!-- NEXT_JS_LLM_PR -->