### PR TITLE
Set DontFork and Unmergeable on all mmap sites in turbo-persistence

### DIFF
--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -27,7 +27,10 @@ use turbo_persistence::static_sorted_file::{
     KEY_BLOCK_ENTRY_TYPE_DELETED, KEY_BLOCK_ENTRY_TYPE_INLINE_MIN, KEY_BLOCK_ENTRY_TYPE_MEDIUM,
     KEY_BLOCK_ENTRY_TYPE_SMALL,
 };
-use turbo_persistence::{BLOCK_HEADER_SIZE, checksum_block, meta_file::MetaFile};
+use turbo_persistence::{
+    BLOCK_HEADER_SIZE, checksum_block, meta_file::MetaFile,
+    mmap_helper::advise_mmap_for_persistence,
+};
 
 /// Block size information
 #[derive(Default, Debug, Clone)]
@@ -230,10 +233,7 @@ fn analyze_sst_file(db_path: &Path, info: &SstInfo) -> Result<SstStats> {
     let file = File::open(&path).with_context(|| format!("Failed to open {}", filename))?;
     let file_size = file.metadata()?.len();
     let mmap = unsafe { Mmap::map(&file)? };
-    #[cfg(target_os = "linux")]
-    mmap.advise(memmap2::Advice::DontFork)?;
-    #[cfg(target_os = "linux")]
-    mmap.advise(memmap2::Advice::Unmergeable)?;
+    advise_mmap_for_persistence(&mmap)?;
 
     let mut stats = SstStats {
         block_directory_size: info.block_count as u64 * 4,

--- a/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
+++ b/turbopack/crates/turbo-persistence/src/bin/sst_inspect.rs
@@ -230,6 +230,10 @@ fn analyze_sst_file(db_path: &Path, info: &SstInfo) -> Result<SstStats> {
     let file = File::open(&path).with_context(|| format!("Failed to open {}", filename))?;
     let file_size = file.metadata()?.len();
     let mmap = unsafe { Mmap::map(&file)? };
+    #[cfg(target_os = "linux")]
+    mmap.advise(memmap2::Advice::DontFork)?;
+    #[cfg(target_os = "linux")]
+    mmap.advise(memmap2::Advice::Unmergeable)?;
 
     let mut stats = SstStats {
         block_directory_size: info.block_count as u64 * 4,

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -34,6 +34,7 @@ use crate::{
     merge_iter::MergeIter,
     meta_file::{MetaEntryFlags, MetaFile, MetaLookupResult, StaticSortedFileRange},
     meta_file_builder::MetaFileBuilder,
+    mmap_helper::advise_mmap_for_persistence,
     parallel_scheduler::ParallelScheduler,
     sst_filter::SstFilter,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile},
@@ -415,7 +416,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         mmap.advise(memmap2::Advice::Sequential)?;
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::WillNeed)?;
-        crate::mmap_helper::advise_mmap_for_persistence(&mmap)?;
+        advise_mmap_for_persistence(&mmap)?;
         let mut reader = &mmap[..];
         let uncompressed_length = reader
             .read_u32::<BE>()

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -415,10 +415,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
         mmap.advise(memmap2::Advice::Sequential)?;
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::WillNeed)?;
-        #[cfg(target_os = "linux")]
-        mmap.advise(memmap2::Advice::DontFork)?;
-        #[cfg(target_os = "linux")]
-        mmap.advise(memmap2::Advice::Unmergeable)?;
+        crate::mmap_helper::advise_mmap_for_persistence(&mmap)?;
         let mut reader = &mmap[..];
         let uncompressed_length = reader
             .read_u32::<BE>()

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -14,6 +14,7 @@ mod lookup_entry;
 mod merge_iter;
 pub mod meta_file;
 mod meta_file_builder;
+pub mod mmap_helper;
 mod parallel_scheduler;
 mod sst_filter;
 pub mod static_sorted_file;

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -288,10 +288,7 @@ impl MetaFile {
             .with_context(|| format!("Failed to mmap meta file {}", path.display()))?;
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Random)?;
-        #[cfg(target_os = "linux")]
-        mmap.advise(memmap2::Advice::DontFork)?;
-        #[cfg(target_os = "linux")]
-        mmap.advise(memmap2::Advice::Unmergeable)?;
+        crate::mmap_helper::advise_mmap_for_persistence(&mmap)?;
         let file = Self {
             db_path,
             sequence_number,

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -288,6 +288,10 @@ impl MetaFile {
             .with_context(|| format!("Failed to mmap meta file {}", path.display()))?;
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Random)?;
+        #[cfg(target_os = "linux")]
+        mmap.advise(memmap2::Advice::DontFork)?;
+        #[cfg(target_os = "linux")]
+        mmap.advise(memmap2::Advice::Unmergeable)?;
         let file = Self {
             db_path,
             sequence_number,

--- a/turbopack/crates/turbo-persistence/src/meta_file.rs
+++ b/turbopack/crates/turbo-persistence/src/meta_file.rs
@@ -19,6 +19,7 @@ use turbo_bincode::turbo_bincode_decode;
 use crate::{
     QueryKey,
     lookup_entry::LookupValue,
+    mmap_helper::advise_mmap_for_persistence,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile, StaticSortedFileMetaData},
 };
 
@@ -288,7 +289,7 @@ impl MetaFile {
             .with_context(|| format!("Failed to mmap meta file {}", path.display()))?;
         #[cfg(unix)]
         mmap.advise(memmap2::Advice::Random)?;
-        crate::mmap_helper::advise_mmap_for_persistence(&mmap)?;
+        advise_mmap_for_persistence(&mmap)?;
         let file = Self {
             db_path,
             sequence_number,

--- a/turbopack/crates/turbo-persistence/src/mmap_helper.rs
+++ b/turbopack/crates/turbo-persistence/src/mmap_helper.rs
@@ -1,0 +1,17 @@
+/// Apply Linux-specific mmap advice flags that should be set on all persistent mmaps.
+///
+/// - `DontFork`: prevents mmap regions from being copied into child processes on `fork()`, avoiding
+///   unnecessary memory duplication and potential SIGBUS.
+/// - `Unmergeable`: opts pages out of KSM (Kernel Same-page Merging) since our data is unique
+///   compressed content that won't benefit from deduplication scanning.
+#[cfg(target_os = "linux")]
+pub fn advise_mmap_for_persistence(mmap: &memmap2::Mmap) -> anyhow::Result<()> {
+    mmap.advise(memmap2::Advice::DontFork)?;
+    mmap.advise(memmap2::Advice::Unmergeable)?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn advise_mmap_for_persistence(_mmap: &memmap2::Mmap) -> anyhow::Result<()> {
+    Ok(())
+}

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -185,6 +185,10 @@ impl StaticSortedFile {
             let offset = meta.block_offsets_start(mmap.len());
             let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
         }
+        #[cfg(target_os = "linux")]
+        mmap.advise(memmap2::Advice::DontFork)?;
+        #[cfg(target_os = "linux")]
+        mmap.advise(memmap2::Advice::Unmergeable)?;
         let file = Self {
             meta,
             mmap: Arc::new(mmap),

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -19,6 +19,7 @@ use crate::{
     compression::{checksum_block, decompress_into_arc},
     constants::MAX_INLINE_VALUE_SIZE,
     lookup_entry::{LazyLookupValue, LookupEntry, LookupValue},
+    mmap_helper::advise_mmap_for_persistence,
     static_sorted_file_builder::BLOCK_HEADER_SIZE,
 };
 
@@ -185,7 +186,7 @@ impl StaticSortedFile {
             let offset = meta.block_offsets_start(mmap.len());
             let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
         }
-        crate::mmap_helper::advise_mmap_for_persistence(&mmap)?;
+        advise_mmap_for_persistence(&mmap)?;
         let file = Self {
             meta,
             mmap: Arc::new(mmap),

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -185,10 +185,7 @@ impl StaticSortedFile {
             let offset = meta.block_offsets_start(mmap.len());
             let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
         }
-        #[cfg(target_os = "linux")]
-        mmap.advise(memmap2::Advice::DontFork)?;
-        #[cfg(target_os = "linux")]
-        mmap.advise(memmap2::Advice::Unmergeable)?;
+        crate::mmap_helper::advise_mmap_for_persistence(&mmap)?;
         let file = Self {
             meta,
             mmap: Arc::new(mmap),


### PR DESCRIPTION
## Summary

- Add `madvise(MADV_DONTFORK)` and `madvise(MADV_UNMERGEABLE)` to all mmap sites in turbo-persistence
- Extract a shared `advise_mmap_for_persistence` helper into a dedicated `mmap_helper` module

## Why

`read_blob` in `db.rs` already correctly sets `DontFork` and `Unmergeable` on its mmap, but three other mmap sites were missing these flags:

- **`static_sorted_file.rs`** (`open_internal`) — SST file mmaps used for lookups and compaction
- **`meta_file.rs`** (`open_internal`) — meta file mmaps storing AMQF filters and SST metadata
- **`sst_inspect.rs`** (`analyze_sst_file`) — diagnostic tool mmap

`MADV_DONTFORK` prevents mmap regions from being copied into child processes on `fork()`, avoiding unnecessary memory duplication and potential SIGBUS issues if the parent unmaps before the child accesses the page. `MADV_UNMERGEABLE` opts the pages out of KSM (Kernel Same-page Merging), avoiding the overhead of scanning these pages for deduplication since they contain unique compressed data.

Both flags are Linux-only (`#[cfg(target_os = "linux")]`), matching the existing pattern in `read_blob`.

## Implementation

Rather than duplicating `#[cfg(target_os = "linux")]` madvise calls at each mmap site, a shared helper `advise_mmap_for_persistence()` is extracted into `src/mmap_helper.rs`. The function applies both flags on Linux and is a no-op on other platforms. All four mmap sites (`db.rs`, `static_sorted_file.rs`, `meta_file.rs`, `sst_inspect.rs`) now call this single helper.

## Test Plan

- `cargo check -p turbo-persistence` passes
- `cargo fmt` clean
- No behavioral change on non-Linux platforms (flags are gated behind `#[cfg(target_os = "linux")]`)