### PR TITLE
Prefix pr-status replies with :robot: emoji

### DIFF
--- a/scripts/pr-status.js
+++ b/scripts/pr-status.js
@@ -372,6 +372,7 @@ function getPRComments(prNumber) {
 // ============================================================================
 
 function replyToThread(threadId, body) {
+  body = ':robot: ' + body
   const mutation = `
     mutation($threadId: ID!, $body: String!) {
       addPullRequestReviewThreadReply(input: {


### PR DESCRIPTION
### What?

Prefixes replies posted by `scripts/pr-status.js` with the `:robot:` (🤖) emoji.

### Why?

When the pr-status script replies to PR review threads, there's no visual indicator that the reply was generated by AI rather than a human. Adding the robot emoji makes it immediately clear.

### How?

One-line change in the `replyToThread()` function in `scripts/pr-status.js` that prepends `:robot: ` to the reply body before posting it via the GitHub GraphQL API.