### PR TITLE
fix(turbopack): force development mode for next-devtools bundle to pr…

### DIFF
--- a/packages/next/next-devtools.webpack-config.js
+++ b/packages/next/next-devtools.webpack-config.js
@@ -26,7 +26,7 @@ module.exports = ({ dev, ...rest }) => {
   return {
     entry: path.join(__dirname, 'src/next-devtools/entrypoint.ts'),
     target,
-    mode: dev ? 'development' : 'production',
+    mode: 'development',
     output: {
       path: path.join(__dirname, 'dist/compiled/next-devtools'),
       filename: `index.js`,


### PR DESCRIPTION
### What?
Forces the `next-devtools` Webpack bundle to compile in development mode rather than defaulting to production mode.

### Why?
When running a Next.js application using `next dev --turbo`, the React DevTools extension incorrectly displays a "production build" warning. 

Upon debugging the injected renderers via `window.__REACT_DEVTOOLS_GLOBAL_HOOK?.renderers`, it is evident that Turbopack injects 3 renderers. Two are correctly instantiated as development (`bundleType: 1`), but the third one acts as a rogue production renderer (`bundleType: 0`). 

The network initiator for this rogue renderer is the pre-compiled `next-devtools` chunk. Previously, `packages/next/next-devtools.webpack-config.js` set the bundle mode to `mode: dev ? 'development' : 'production'`. Because the build process defaults this to `production`, Webpack statically bakes `process.env.NODE_ENV = 'production'` into the devtools bundle artifact. Consequently, the internal React alias resolves to `react-dom.production.js` instead of the development version.

### How?
Applied a minimal, surgical fix to the Webpack configuration of the `next-devtools` bundle:
* Hardcoded the `mode` to `'development'` in `next-devtools.webpack-config.js`.
* This ensures `react-dom.development.js` is resolved and `NODE_ENV` is correctly set for this specific bundle.
* The overall bundle size and performance remain unaffected because `optimization.minimize: true` is still explicitly preserved in the configuration.

### Testing
- Verified locally using `examples/hello-world` via `node packages/next/dist/bin/next dev examples/hello-world --turbo`.
- Verified in the browser console that all 3 renderers now return `bundleType: 1` and the React DevTools "production" warning has disappeared.

### Visual Proof

**Before:** (The rogue production renderer is injected, triggering the warning)
<img width="911" height="239" alt="Screenshot 2026-03-06 at 02 56 12" src="https://github.com/user-attachments/assets/066431dd-828b-49cd-ae65-7b389e14f796" />


**After:** (All renderers are correctly identified as development)
<img width="891" height="238" alt="Screenshot 2026-03-06 at 02 50 57" src="https://github.com/user-attachments/assets/b3c74ceb-7503-404a-af1b-1366f0b1059f" />


Fixes #90744