### PR TITLE
Upgrade turbopack-dev-server from hyper 0.14 to hyper 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,7 +480,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "itoa",
  "matchit",
@@ -506,7 +506,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -530,12 +530,6 @@ dependencies = [
  "object 0.31.1",
  "rustc-demangle",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -2636,25 +2630,6 @@ checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.11",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
@@ -2889,17 +2864,6 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http 0.2.11",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -2917,7 +2881,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2941,30 +2905,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.24",
- "http 0.2.11",
- "http-body 0.4.5",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -2973,9 +2913,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.7",
+ "h2",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2993,7 +2933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.1.0",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -3008,7 +2948,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3023,7 +2963,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3033,15 +2973,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-tungstenite"
-version = "0.9.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "880b8b1c98a5ec2a505c7c90db6d3f6f1f480af5655d9c5b55facc9382a5a5b5"
+checksum = "bc778da281a749ed28d2be73a9f2cd13030680a1574bc729debd1195e44f00e9"
 dependencies = [
- "hyper 0.14.32",
- "pin-project",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
  "tokio",
  "tokio-tungstenite",
- "tungstenite 0.18.0",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -3056,13 +2998,13 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.7.0",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -4270,9 +4212,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "log",
  "rand 0.9.0",
@@ -5740,7 +5682,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -5778,7 +5720,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6128,9 +6070,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -7033,16 +6975,6 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "managed",
-]
-
-[[package]]
-name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -8989,14 +8921,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.18.0",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -9144,11 +9076,11 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.7",
+ "h2",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -9208,7 +9140,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.1",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower 0.5.2",
@@ -9356,25 +9288,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
-dependencies = [
- "base64 0.13.1",
- "byteorder",
- "bytes",
- "http 0.2.11",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
@@ -9408,6 +9321,23 @@ dependencies = [
  "sha1",
  "thiserror 1.0.69",
  "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand 0.9.0",
+ "sha1",
+ "thiserror 2.0.12",
  "utf-8",
 ]
 
@@ -10056,8 +9986,10 @@ dependencies = [
  "bincode 2.0.1",
  "flate2",
  "futures",
- "hyper 0.14.32",
+ "http-body-util",
+ "hyper",
  "hyper-tungstenite",
+ "hyper-util",
  "mime",
  "mime_guess",
  "parking_lot",
@@ -10066,7 +9998,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "socket2 0.4.9",
+ "socket2 0.5.10",
  "tokio",
  "tokio-stream",
  "tokio-util",

--- a/turbopack/crates/turbopack-dev-server/Cargo.toml
+++ b/turbopack/crates/turbopack-dev-server/Cargo.toml
@@ -21,8 +21,10 @@ auto-hash-map = { workspace = true }
 bincode = { workspace = true }
 flate2 = { workspace = true }
 futures = { workspace = true }
-hyper = { version = "0.14", features = ["full"] }
-hyper-tungstenite = "0.9.0"
+http-body-util = "0.1"
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-tungstenite = "0.19"
+hyper-util = { version = "0.1", features = ["tokio", "server-auto", "server-graceful"] }
 mime = { workspace = true }
 mime_guess = "2.0.4"
 parking_lot = { workspace = true }
@@ -31,7 +33,7 @@ rustc-hash = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_qs = { workspace = true }
-socket2 = "0.4.9"
+socket2 = "0.5"
 tokio = { workspace = true }
 tokio-stream = "0.1.9"
 tokio-util = { workspace = true }

--- a/turbopack/crates/turbopack-dev-server/src/http.rs
+++ b/turbopack/crates/turbopack-dev-server/src/http.rs
@@ -1,18 +1,18 @@
-use std::{io::Read, iter};
+use std::io::Read;
 
 use anyhow::{Result, anyhow};
 use auto_hash_map::AutoSet;
 use flate2::{Compression, bufread::GzEncoder};
-use futures::{StreamExt, TryStreamExt, stream};
+use futures::TryStreamExt;
+use http_body_util::BodyExt;
 use hyper::{
     Request, Response,
-    header::{CONTENT_ENCODING, CONTENT_LENGTH, HeaderName},
-    http::HeaderValue,
+    body::Incoming,
+    header::{CONTENT_ENCODING, CONTENT_LENGTH, HeaderName, HeaderValue},
 };
 use mime::Mime;
 use turbo_tasks::{
     CollectiblesSource, OperationVc, ReadRef, ResolvedVc, TransientInstance, Vc, apply_effects,
-    util::SharedError,
 };
 use turbo_tasks_bytes::Bytes;
 use turbo_tasks_fs::FileContent;
@@ -22,10 +22,13 @@ use turbopack_core::{
     version::VersionedContent,
 };
 
-use crate::source::{
-    Body, ContentSource, ContentSourceSideEffect, HeaderList, ProxyResult,
-    request::SourceRequest,
-    resolve::{ResolveSourceRequestResult, resolve_source_request},
+use crate::{
+    ResponseBody, empty_body, full_body,
+    source::{
+        Body, ContentSource, ContentSourceSideEffect, HeaderList, ProxyResult,
+        request::SourceRequest,
+        resolve::{ResolveSourceRequestResult, resolve_source_request},
+    },
 };
 
 #[turbo_tasks::value(serialization = "none")]
@@ -75,10 +78,10 @@ async fn get_from_source_operation(
 /// response.
 pub async fn process_request_with_content_source(
     source: OperationVc<Box<dyn ContentSource>>,
-    request: Request<hyper::Body>,
+    request: Request<Incoming>,
     issue_reporter: Vc<Box<dyn IssueReporter>>,
 ) -> Result<(
-    Response<hyper::Body>,
+    Response<ResponseBody>,
     AutoSet<ResolvedVc<Box<dyn ContentSourceSideEffect>>>,
 )> {
     let original_path = request.uri().path().to_string();
@@ -111,14 +114,14 @@ pub async fn process_request_with_content_source(
                 for (header_name, header_value) in headers {
                     header_map.append(
                         HeaderName::try_from(header_name.as_str())?,
-                        hyper::header::HeaderValue::try_from(header_value.as_str())?,
+                        HeaderValue::try_from(header_value.as_str())?,
                     );
                 }
 
                 for (header_name, header_value) in header_overwrites.iter() {
                     header_map.insert(
                         HeaderName::try_from(header_name.as_str())?,
-                        hyper::header::HeaderValue::try_from(header_value.as_str())?,
+                        HeaderValue::try_from(header_value.as_str())?,
                     );
                 }
 
@@ -141,7 +144,7 @@ pub async fn process_request_with_content_source(
                 if let Some(content_type) = file.content_type() {
                     header_map.append(
                         "content-type",
-                        hyper::header::HeaderValue::try_from(content_type.to_string())?,
+                        HeaderValue::try_from(content_type.to_string())?,
                     );
 
                     should_compress = should_compress_predicate(content_type);
@@ -152,7 +155,7 @@ pub async fn process_request_with_content_source(
                     // If a text type, application/javascript, or application/json was
                     // guessed, use a utf-8 charset as we most likely generated it as
                     // such.
-                    entry.insert(hyper::header::HeaderValue::try_from(
+                    entry.insert(HeaderValue::try_from(
                         if (guess.type_() == mime::TEXT
                             || guess.subtype() == mime::JAVASCRIPT
                             || guess.subtype() == mime::JSON)
@@ -167,40 +170,28 @@ pub async fn process_request_with_content_source(
 
                 if !header_map.contains_key("cache-control") {
                     // The dev server contents might change at any time, we can't cache them.
-                    header_map.append(
-                        "cache-control",
-                        hyper::header::HeaderValue::try_from("must-revalidate")?,
-                    );
+                    header_map.append("cache-control", HeaderValue::try_from("must-revalidate")?);
                 }
 
                 let content = file.content();
                 let response = if should_compress {
                     header_map.insert(CONTENT_ENCODING, HeaderValue::from_static("gzip"));
 
-                    // Hyper requires an owned reader... We could do this with streaming by cloning
-                    // each `Bytes` and implementing `BufRead` for `Iterator<bytes::Bytes>`, but
-                    // it's not really worth it, just compressing the whole thing up-front is fine.
-                    //
-                    // Use fast compression, since we're likely just tranferring data over
-                    // localhost.
                     let mut gz_bytes = Vec::new();
                     GzEncoder::new(content.read(), Compression::fast())
                         .read_to_end(&mut gz_bytes)
                         .expect("read of Rope should never fail");
-                    response.body(hyper::Body::wrap_stream(stream::iter(iter::once(
-                        hyper::Result::Ok(gz_bytes),
-                    ))))?
+                    response.body(full_body(gz_bytes))?
                 } else {
-                    // hyper requires an owned stream, so we must clone the iterator items
-                    // this is relatively cheap: each chunk is a `Bytes`, so `Clone` updates a
-                    // refcount
-                    let owned_chunks: Vec<_> =
-                        content.read().cloned().map(hyper::Result::Ok).collect();
+                    let mut all_bytes = Vec::new();
+                    for chunk in content.read() {
+                        all_bytes.extend_from_slice(chunk);
+                    }
                     header_map.insert(
                         CONTENT_LENGTH,
-                        hyper::header::HeaderValue::try_from(content.len().to_string())?,
+                        HeaderValue::try_from(all_bytes.len().to_string())?,
                     );
-                    response.body(hyper::Body::wrap_stream(stream::iter(owned_chunks)))?
+                    response.body(full_body(all_bytes))?
                 };
 
                 return Ok((response, side_effects));
@@ -213,40 +204,42 @@ pub async fn process_request_with_content_source(
             for (name, value) in &proxy_result.headers {
                 headers.append(
                     HeaderName::from_bytes(name.as_bytes())?,
-                    hyper::header::HeaderValue::from_str(value)?,
+                    HeaderValue::from_str(value)?,
                 );
             }
 
-            return Ok((
-                response.body(hyper::Body::wrap_stream(proxy_result.body.read()))?,
-                side_effects,
-            ));
+            // Collect proxy body from async stream into bytes
+            let mut body_bytes = Vec::new();
+            let mut body_stream = proxy_result.body.read();
+            while let Some(chunk) = body_stream.try_next().await? {
+                body_bytes.extend_from_slice(&chunk);
+            }
+
+            return Ok((response.body(full_body(body_bytes))?, side_effects));
         }
         GetFromSourceResult::NotFound => {}
     }
 
     Ok((
-        Response::builder().status(404).body(hyper::Body::empty())?,
+        Response::builder().status(404).body(empty_body())?,
         side_effects,
     ))
 }
 
-async fn http_request_to_source_request(request: Request<hyper::Body>) -> Result<SourceRequest> {
+async fn http_request_to_source_request(request: Request<Incoming>) -> Result<SourceRequest> {
     let (parts, body) = request.into_parts();
 
-    // For simplicity, we fully consume the body now and early return if there were
-    // any errors.
-    let bytes: Vec<_> = body
-        .map(|bytes| {
-            bytes.map_or_else(
-                |e| Err(SharedError::new(anyhow!(e))),
-                // The outer Ok is consumed by try_collect, but the Body type requires a Result, so
-                // we need to double wrap.
-                |b| Ok(Ok(Bytes::from(b))),
-            )
-        })
-        .try_collect::<Vec<_>>()
-        .await?;
+    // Collect the entire body
+    let collected = body
+        .collect()
+        .await
+        .map_err(|e| anyhow!("failed to collect request body: {e}"))?;
+    let body_bytes = collected.to_bytes();
+    let bytes = if body_bytes.is_empty() {
+        vec![]
+    } else {
+        vec![Ok(Bytes::from(body_bytes))]
+    };
 
     Ok(SourceRequest {
         method: parts.method.to_string(),

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -22,10 +22,11 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use hyper::{
-    Request, Response, Server,
-    server::{Builder, conn::AddrIncoming},
-    service::{make_service_fn, service_fn},
+use http_body_util::{Either, Empty, Full};
+use hyper::{Request, Response, body::Bytes};
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    server::conn::auto,
 };
 use parking_lot::Mutex;
 use socket2::{Domain, Protocol, Socket, Type};
@@ -42,6 +43,9 @@ use crate::{
     invalidation::{ServerRequest, ServerRequestSideEffects},
     source::ContentSourceSideEffect,
 };
+
+/// The response body type used throughout the dev server.
+pub(crate) type ResponseBody = Either<Full<Bytes>, Empty<Bytes>>;
 
 pub trait SourceProvider: Send + Clone + 'static {
     /// must call a turbo-tasks function internally
@@ -62,7 +66,7 @@ pub struct DevServerBuilder {
     #[turbo_tasks(trace_ignore)]
     pub addr: SocketAddr,
     #[turbo_tasks(trace_ignore)]
-    server: Builder<AddrIncoming>,
+    listener: TcpListener,
 }
 
 #[derive(TraceRawVcs, NonLocalValue)]
@@ -75,12 +79,10 @@ pub struct DevServer {
 
 impl DevServer {
     pub fn listen(addr: SocketAddr) -> Result<DevServerBuilder, anyhow::Error> {
-        // This is annoying. The hyper::Server doesn't allow us to know which port was
-        // bound (until we build it with a request handler) when using the standard
-        // `server::try_bind` approach. This is important when binding the `0` port,
-        // because the OS will remap that to an actual free port, and we need to know
-        // that port before we build the request handler. So we need to construct a
-        // real TCP listener, see if it bound, and get its bound address.
+        // This is annoying. We need to know which port was bound (important when
+        // binding the `0` port, because the OS will remap that to an actual free
+        // port). So we need to construct a real TCP listener, see if it bound,
+        // and get its bound address.
         let socket = Socket::new(Domain::for_address(addr), Type::STREAM, Some(Protocol::TCP))
             .context("unable to create socket")?;
         // Allow the socket to be reused immediately after closing. This ensures that
@@ -98,13 +100,15 @@ impl DevServer {
             .bind(&sock_addr)
             .context("not able to bind address")?;
         socket.listen(128).context("not able to listen on socket")?;
+        socket
+            .set_nonblocking(true)
+            .context("not able to set nonblocking")?;
 
         let listener: TcpListener = socket.into();
         let addr = listener
             .local_addr()
             .context("not able to get bound address")?;
-        let server = Server::from_tcp(listener).context("Not able to start server")?;
-        Ok(DevServerBuilder { addr, server })
+        Ok(DevServerBuilder { addr, listener })
     }
 }
 
@@ -118,182 +122,224 @@ impl DevServerBuilder {
         let ongoing_side_effects = Arc::new(Mutex::new(VecDeque::<
             Arc<tokio::sync::Mutex<Option<JoinHandle<Result<()>>>>>,
         >::with_capacity(16)));
-        let make_svc = make_service_fn(move |_| {
-            let tt = turbo_tasks.clone();
-            let source_provider = source_provider.clone();
-            let get_issue_reporter = get_issue_reporter.clone();
-            let ongoing_side_effects = ongoing_side_effects.clone();
-            async move {
-                let handler = move |request: Request<hyper::Body>| {
-                    let request_span = info_span!(parent: None, "request", name = ?request.uri());
-                    let start = Instant::now();
-                    let tt = tt.clone();
-                    let get_issue_reporter = get_issue_reporter.clone();
-                    let ongoing_side_effects = ongoing_side_effects.clone();
-                    let source_provider = source_provider.clone();
-                    let future = async move {
-                        event!(parent: Span::current(), Level::DEBUG, "request start");
-                        // Wait until all ongoing side effects are completed
-                        // We only need to wait for the ongoing side effects that were started
-                        // before this request. Later added side effects are not relevant for this.
-                        let current_ongoing_side_effects = {
-                            // Cleanup the ongoing_side_effects list
-                            let mut guard = ongoing_side_effects.lock();
-                            while let Some(front) = guard.front() {
-                                let Ok(front_guard) = front.try_lock() else {
-                                    break;
-                                };
-                                if front_guard.is_some() {
-                                    break;
-                                }
-                                drop(front_guard);
-                                guard.pop_front();
-                            }
-                            // Get a clone of the remaining list
-                            (*guard).clone()
-                        };
-                        // Wait for the side effects to complete
-                        for side_effect_mutex in current_ongoing_side_effects {
-                            let mut guard = side_effect_mutex.lock().await;
-                            if let Some(join_handle) = guard.take() {
-                                join_handle.await??;
-                            }
-                            drop(guard);
-                        }
-                        let reason = ServerRequest {
-                            method: request.method().clone(),
-                            uri: request.uri().clone(),
-                        };
-                        let side_effects_reason = ServerRequestSideEffects {
-                            method: request.method().clone(),
-                            uri: request.uri().clone(),
-                        };
-                        run_once_with_reason(tt.clone(), reason, async move {
-                            // TODO: `get_issue_reporter` should be an `OperationVc`, as there's a
-                            // risk it could be a task-local Vc, which is not safe for us to await.
-                            let issue_reporter = get_issue_reporter();
 
-                            if hyper_tungstenite::is_upgrade_request(&request) {
-                                let uri = request.uri();
-                                let path = uri.path();
-
-                                if path == "/turbopack-hmr" {
-                                    let (response, websocket) =
-                                        hyper_tungstenite::upgrade(request, None)?;
-                                    let update_server =
-                                        UpdateServer::new(source_provider, issue_reporter);
-                                    update_server.run(&*tt, websocket);
-                                    return Ok(response);
-                                }
-
-                                println!("[404] {path} (WebSocket)");
-                                if path == "/_next/webpack-hmr" {
-                                    // Special-case requests to webpack-hmr as these are made by
-                                    // Next.js clients built
-                                    // without turbopack, which may be making requests in
-                                    // development.
-                                    println!(
-                                        "A non-turbopack next.js client is trying to connect."
-                                    );
-                                    println!(
-                                        "Make sure to reload/close any browser window which has \
-                                         been opened without --turbo."
-                                    );
-                                }
-
-                                return Ok(Response::builder()
-                                    .status(404)
-                                    .body(hyper::Body::empty())?);
-                            }
-
-                            let uri = request.uri();
-                            let path = uri.path().to_string();
-                            let source_op = source_provider.get_source();
-                            // HACK: Resolve `source` now so that we can get any issues on it
-                            let _ = source_op.resolve_strongly_consistent().await?;
-                            apply_effects(source_op).await?;
-                            handle_issues(
-                                source_op,
-                                issue_reporter,
-                                IssueSeverity::Fatal,
-                                Some(&path),
-                                Some("get source"),
-                            )
-                            .await?;
-                            let (response, side_effects) =
-                                http::process_request_with_content_source(
-                                    // HACK: pass `source` here (instead of `resolved_source`
-                                    // because the underlying API wants to do it's own
-                                    // `resolve_strongly_consistent` call.
-                                    //
-                                    // It's unlikely (the calls happen one-after-another), but this
-                                    // could cause inconsistency between the reported issues and
-                                    // the generated HTTP response.
-                                    source_op,
-                                    request,
-                                    issue_reporter,
-                                )
-                                .await?;
-                            let status = response.status().as_u16();
-                            let is_error = response.status().is_client_error()
-                                || response.status().is_server_error();
-                            let elapsed = start.elapsed();
-                            if is_error
-                                || (cfg!(feature = "log_request_stats")
-                                    && elapsed > Duration::from_secs(1))
-                            {
-                                println!(
-                                    "[{status}] {path} ({duration})",
-                                    duration = FormatDuration(elapsed)
-                                );
-                            }
-                            if !side_effects.is_empty() {
-                                let join_handle = tokio::spawn(run_once_with_reason(
-                                    tt.clone(),
-                                    side_effects_reason,
-                                    async move {
-                                        for side_effect in side_effects {
-                                            side_effect.apply().await?;
-                                        }
-                                        Ok(())
-                                    },
-                                ));
-                                ongoing_side_effects.lock().push_back(Arc::new(
-                                    tokio::sync::Mutex::new(Some(join_handle)),
-                                ));
-                            }
-                            Ok(response)
-                        })
-                        .await
-                    };
-                    async move {
-                        match future.await {
-                            Ok(r) => Ok::<_, hyper::http::Error>(r),
-                            Err(e) => {
-                                println!(
-                                    "[500] error ({}): {}",
-                                    FormatDuration(start.elapsed()),
-                                    PrettyPrintError(&e),
-                                );
-                                Ok(Response::builder()
-                                    .status(500)
-                                    .body(hyper::Body::from(format!("{}", PrettyPrintError(&e))))?)
-                            }
-                        }
-                    }
-                    .instrument(request_span)
-                };
-                anyhow::Ok(service_fn(handler))
-            }
-        });
-        let server = self.server.serve(make_svc);
+        let listener = tokio::net::TcpListener::from_std(self.listener)
+            .expect("failed to create tokio TcpListener");
 
         DevServer {
             addr: self.addr,
             future: Box::pin(async move {
-                server.await?;
-                Ok(())
+                loop {
+                    let (stream, _) = listener.accept().await?;
+                    let io = TokioIo::new(stream);
+
+                    let tt = turbo_tasks.clone();
+                    let source_provider = source_provider.clone();
+                    let get_issue_reporter = get_issue_reporter.clone();
+                    let ongoing_side_effects = ongoing_side_effects.clone();
+
+                    tokio::spawn(async move {
+                        let service = hyper::service::service_fn(
+                            move |request: Request<hyper::body::Incoming>| {
+                                let request_span =
+                                    info_span!(parent: None, "request", name = ?request.uri());
+                                let start = Instant::now();
+                                let tt = tt.clone();
+                                let get_issue_reporter = get_issue_reporter.clone();
+                                let ongoing_side_effects = ongoing_side_effects.clone();
+                                let source_provider = source_provider.clone();
+                                let future = async move {
+                                    event!(parent: Span::current(), Level::DEBUG, "request start");
+                                    // Wait until all ongoing side effects are completed
+                                    // We only need to wait for the ongoing side effects that were
+                                    // started before this
+                                    // request. Later added side effects are not relevant for this.
+                                    let current_ongoing_side_effects = {
+                                        // Cleanup the ongoing_side_effects list
+                                        let mut guard = ongoing_side_effects.lock();
+                                        while let Some(front) = guard.front() {
+                                            let Ok(front_guard) = front.try_lock() else {
+                                                break;
+                                            };
+                                            if front_guard.is_some() {
+                                                break;
+                                            }
+                                            drop(front_guard);
+                                            guard.pop_front();
+                                        }
+                                        // Get a clone of the remaining list
+                                        (*guard).clone()
+                                    };
+                                    // Wait for the side effects to complete
+                                    for side_effect_mutex in current_ongoing_side_effects {
+                                        let mut guard = side_effect_mutex.lock().await;
+                                        if let Some(join_handle) = guard.take() {
+                                            join_handle.await??;
+                                        }
+                                        drop(guard);
+                                    }
+                                    let reason = ServerRequest {
+                                        method: request.method().clone(),
+                                        uri: request.uri().clone(),
+                                    };
+                                    let side_effects_reason = ServerRequestSideEffects {
+                                        method: request.method().clone(),
+                                        uri: request.uri().clone(),
+                                    };
+                                    run_once_with_reason(tt.clone(), reason, async move {
+                                        // TODO: `get_issue_reporter` should be an `OperationVc`, as
+                                        // there's a risk it
+                                        // could be a task-local Vc, which is not safe for us to
+                                        // await.
+                                        let issue_reporter = get_issue_reporter();
+
+                                        if hyper_tungstenite::is_upgrade_request(&request) {
+                                            let uri = request.uri();
+                                            let path = uri.path();
+
+                                            if path == "/turbopack-hmr" {
+                                                let (response, websocket) =
+                                                    hyper_tungstenite::upgrade(request, None)?;
+                                                let update_server = UpdateServer::new(
+                                                    source_provider,
+                                                    issue_reporter,
+                                                );
+                                                update_server.run(&*tt, websocket);
+                                                return Ok(response
+                                                    .map(|b| -> ResponseBody { Either::Left(b) }));
+                                            }
+
+                                            println!("[404] {path} (WebSocket)");
+                                            if path == "/_next/webpack-hmr" {
+                                                // Special-case requests to webpack-hmr as these are
+                                                // made by
+                                                // Next.js clients built
+                                                // without turbopack, which may be making requests
+                                                // in
+                                                // development.
+                                                println!(
+                                                    "A non-turbopack next.js client is trying to \
+                                                     connect."
+                                                );
+                                                println!(
+                                                    "Make sure to reload/close any browser window \
+                                                     which has been opened without --turbo."
+                                                );
+                                            }
+
+                                            return Ok(Response::builder()
+                                                .status(404)
+                                                .body(empty_body())?);
+                                        }
+
+                                        let uri = request.uri();
+                                        let path = uri.path().to_string();
+                                        let source_op = source_provider.get_source();
+                                        // HACK: Resolve `source` now so that we can get any issues
+                                        // on it
+                                        let _ = source_op.resolve_strongly_consistent().await?;
+                                        apply_effects(source_op).await?;
+                                        handle_issues(
+                                            source_op,
+                                            issue_reporter,
+                                            IssueSeverity::Fatal,
+                                            Some(&path),
+                                            Some("get source"),
+                                        )
+                                        .await?;
+                                        let (response, side_effects) =
+                                            crate::http::process_request_with_content_source(
+                                                // HACK: pass `source` here (instead of
+                                                // `resolved_source`
+                                                // because the underlying API wants to do it's own
+                                                // `resolve_strongly_consistent` call.
+                                                //
+                                                // It's unlikely (the calls happen
+                                                // one-after-another), but this
+                                                // could cause inconsistency between the reported
+                                                // issues and
+                                                // the generated HTTP response.
+                                                source_op,
+                                                request,
+                                                issue_reporter,
+                                            )
+                                            .await?;
+                                        let status = response.status().as_u16();
+                                        let is_error = response.status().is_client_error()
+                                            || response.status().is_server_error();
+                                        let elapsed = start.elapsed();
+                                        if is_error
+                                            || (cfg!(feature = "log_request_stats")
+                                                && elapsed > Duration::from_secs(1))
+                                        {
+                                            println!(
+                                                "[{status}] {path} ({duration})",
+                                                duration = FormatDuration(elapsed)
+                                            );
+                                        }
+                                        if !side_effects.is_empty() {
+                                            let join_handle = tokio::spawn(run_once_with_reason(
+                                                tt.clone(),
+                                                side_effects_reason,
+                                                async move {
+                                                    for side_effect in side_effects {
+                                                        side_effect.apply().await?;
+                                                    }
+                                                    Ok(())
+                                                },
+                                            ));
+                                            ongoing_side_effects.lock().push_back(Arc::new(
+                                                tokio::sync::Mutex::new(Some(join_handle)),
+                                            ));
+                                        }
+                                        Ok(response)
+                                    })
+                                    .await
+                                };
+                                async move {
+                                    match future.await {
+                                        Ok(r) => Ok::<_, anyhow::Error>(r),
+                                        Err(e) => {
+                                            println!(
+                                                "[500] error ({}): {}",
+                                                FormatDuration(start.elapsed()),
+                                                PrettyPrintError(&e),
+                                            );
+                                            Ok(Response::builder().status(500).body(full_body(
+                                                format!("{}", PrettyPrintError(&e)),
+                                            ))?)
+                                        }
+                                    }
+                                }
+                                .instrument(request_span)
+                            },
+                        );
+
+                        if let Err(err) = auto::Builder::new(TokioExecutor::new())
+                            .serve_connection_with_upgrades(io, service)
+                            .await
+                        {
+                            // Connection errors are expected when clients disconnect.
+                            // hyper-util wraps errors in Box<dyn Error>, so we downcast
+                            // to check for hyper-specific incomplete message errors.
+                            let is_expected = err
+                                .downcast_ref::<hyper::Error>()
+                                .is_some_and(|e| e.is_incomplete_message());
+                            if !is_expected {
+                                eprintln!("Error serving connection: {err}");
+                            }
+                        }
+                    });
+                }
             }),
         }
     }
+}
+
+pub(crate) fn full_body(content: impl Into<Bytes>) -> ResponseBody {
+    Either::Left(Full::new(content.into()))
+}
+
+pub(crate) fn empty_body() -> ResponseBody {
+    Either::Right(Empty::new())
 }

--- a/turbopack/crates/turbopack-dev-server/src/update/server.rs
+++ b/turbopack/crates/turbopack-dev-server/src/update/server.rs
@@ -8,6 +8,7 @@ use anyhow::{Context as _, Error, Result};
 use futures::{SinkExt, prelude::*, ready, stream::FusedStream};
 use hyper::{HeaderMap, Uri, upgrade::Upgraded};
 use hyper_tungstenite::{HyperWebsocket, WebSocketStream, tungstenite::Message};
+use hyper_util::rt::TokioIo;
 use pin_project_lite::pin_project;
 use tokio::select;
 use tokio_stream::StreamMap;
@@ -239,7 +240,7 @@ fn resource_to_request(resource: &ResourceIdentifier) -> Result<SourceRequest> {
 pin_project! {
     struct UpdateClient {
         #[pin]
-        ws: WebSocketStream<Upgraded>,
+        ws: WebSocketStream<TokioIo<Upgraded>>,
         ended: bool,
     }
 }
@@ -332,8 +333,8 @@ impl<'a> Sink<ClientUpdateInstruction<'a>> for UpdateClient {
     }
 }
 
-impl From<WebSocketStream<Upgraded>> for UpdateClient {
-    fn from(ws: WebSocketStream<Upgraded>) -> Self {
+impl From<WebSocketStream<TokioIo<Upgraded>>> for UpdateClient {
+    fn from(ws: WebSocketStream<TokioIo<Upgraded>>) -> Self {
         Self { ws, ended: false }
     }
 }


### PR DESCRIPTION
## Summary

Upgrade `turbopack-dev-server` from hyper 0.14 to hyper 1.x (the only crate in the workspace that directly depends on hyper).

Stacked on #90945 (tokio 1.47.3 update).

### Changes

**Dependency updates:**
- `hyper` 0.14 → 1.x (with `server` and `http1` features)
- `hyper-tungstenite` 0.9 → 0.19 (hyper 1.x compatible)
- `socket2` 0.4 → 0.5
- Added `hyper-util` 0.1 (replaces removed `hyper::Server`)
- Added `http-body-util` 0.1 (replaces removed `hyper::Body`)

**Code migration:**
- **Server setup** (`lib.rs`): Replaced `hyper::Server` + `make_service_fn` + `AddrIncoming` with a manual `tokio::net::TcpListener` accept loop + `hyper_util::server::conn::auto::Builder` (the recommended hyper 1.x pattern)
- **Request body** (`http.rs`): `Request<hyper::Body>` → `Request<hyper::body::Incoming>`, body collected via `http_body_util::BodyExt::collect()`
- **Response body** (`lib.rs`, `http.rs`): `hyper::Body` → `Either<Full<Bytes>, Empty<Bytes>>` type alias
- **WebSocket** (`update/server.rs`): `WebSocketStream<Upgraded>` → `WebSocketStream<TokioIo<Upgraded>>`
- **Error handling** (`lib.rs`): Service error type changed from `hyper::Error` to `anyhow::Error`; connection error check uses downcast for `is_incomplete_message()`

### Duplicate dependencies eliminated

This upgrade removes **7 duplicate crate pairs** from the dependency tree:
- `hyper` 0.14 / 1.7 → just 1.7
- `h2` 0.3 / 0.4 → eliminated (hyper 1.x doesn't pull h2 directly)
- `http-body` 0.4 / 1.0 → just 1.0
- `socket2` 0.4 / 0.5 → just 0.5
- `tungstenite` 0.18 / 0.20 → just 0.28
- `base64` 0.13 → eliminated

## Test plan

- [x] `cargo check` full workspace passes
- [ ] CI build and test suite