### PR TITLE
Next.js port conflict

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -14,6 +14,7 @@ import v8 from 'v8'
 import path from 'path'
 import http from 'http'
 import https from 'https'
+import net from 'net'
 import os from 'os'
 import { exec } from 'child_process'
 import Watchpack from 'next/dist/compiled/watchpack'
@@ -116,6 +117,60 @@ async function getProcessIdUsingPort(port: number): Promise<string | null> {
   pidPromise.finally(() => clearTimeout(timeoutId))
 
   return pidPromise
+}
+
+/**
+ * Check if a port is available on a specific host by attempting to bind to it.
+ * Returns true if available, false if in use (EADDRINUSE).
+ * Other bind errors (e.g., EADDRNOTAVAIL for missing IPv6) are treated as available.
+ */
+function isPortAvailableOnHost(port: number, host: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const tester = net.createServer()
+    tester.once('error', (err: NodeJS.ErrnoException) => {
+      resolve(err.code !== 'EADDRINUSE')
+    })
+    tester.once('listening', () => {
+      tester.close(() => resolve(true))
+    })
+    tester.listen(port, host)
+  })
+}
+
+/**
+ * Find an available port starting from the given port.
+ * Checks both IPv4 (0.0.0.0) and IPv6 (::) to detect cross-address-family
+ * conflicts that server.listen() alone may miss on some platforms (e.g., macOS
+ * where an IPv6 bind does not conflict with an existing IPv4 listener).
+ */
+async function findAvailablePort(
+  startPort: number,
+  hostname: string | undefined,
+  maxRetries: number
+): Promise<{ port: number; retryCount: number }> {
+  let port = startPort
+
+  for (let retryCount = 0; retryCount <= maxRetries; retryCount++) {
+    const hostsToCheck = hostname !== undefined ? [hostname] : ['0.0.0.0', '::']
+    let available = true
+
+    for (const host of hostsToCheck) {
+      if (!(await isPortAvailableOnHost(port, host))) {
+        available = false
+        break
+      }
+    }
+
+    if (available) {
+      return { port, retryCount }
+    }
+
+    if (retryCount < maxRetries) {
+      port++
+    }
+  }
+
+  return { port, retryCount: maxRetries }
 }
 
 export interface StartServerOptions {
@@ -292,6 +347,21 @@ export async function startServer(
 
   let portRetryCount = 0
   const originalPort = port
+
+  // Proactively detect port conflicts across address families.
+  // On some platforms (notably macOS), server.listen() with no hostname binds
+  // to IPv6 (::) which does not conflict with an existing IPv4 listener on the
+  // same port. This check catches those cross-family conflicts so the retry
+  // logic can find an available port before calling server.listen().
+  if (allowRetry && isDev) {
+    const { port: availablePort, retryCount } = await findAvailablePort(
+      port,
+      hostname,
+      10
+    )
+    portRetryCount = retryCount
+    port = availablePort
+  }
 
   server.on('error', (err: NodeJS.ErrnoException) => {
     if (

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -120,28 +120,35 @@ async function getProcessIdUsingPort(port: number): Promise<string | null> {
 }
 
 /**
- * Check if a port is available on a specific host by attempting to bind to it.
- * Returns true if available, false if in use (EADDRINUSE).
- * Other bind errors (e.g., EADDRNOTAVAIL for missing IPv6) are treated as available.
+ * Try to connect to a port on a specific host. Returns true if something is
+ * already listening (connection succeeded), false otherwise.
+ *
+ * Unlike a bind-based check, this is not affected by SO_REUSEADDR — which on
+ * macOS/BSD lets two servers bind to the same port on different addresses
+ * (e.g. 127.0.0.1 vs 0.0.0.0) without EADDRINUSE.
  */
-function isPortAvailableOnHost(port: number, host: string): Promise<boolean> {
+function isPortListening(port: number, host: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const tester = net.createServer()
-    tester.once('error', (err: NodeJS.ErrnoException) => {
-      resolve(err.code !== 'EADDRINUSE')
-    })
-    tester.once('listening', () => {
-      tester.close(() => resolve(true))
-    })
-    tester.listen(port, host)
+    const socket = new net.Socket()
+    const onDone = (listening: boolean) => {
+      socket.removeAllListeners()
+      socket.destroy()
+      resolve(listening)
+    }
+    socket.setTimeout(400)
+    socket.once('connect', () => onDone(true))
+    socket.once('error', () => onDone(false))
+    socket.once('timeout', () => onDone(false))
+    socket.connect(port, host)
   })
 }
 
 /**
  * Find an available port starting from the given port.
- * Checks both IPv4 (0.0.0.0) and IPv6 (::) to detect cross-address-family
- * conflicts that server.listen() alone may miss on some platforms (e.g., macOS
- * where an IPv6 bind does not conflict with an existing IPv4 listener).
+ * Checks both IPv4 (127.0.0.1) and IPv6 (::1) loopback addresses to detect
+ * cross-address-family conflicts that server.listen() alone may miss — for
+ * example, a Vite server on 127.0.0.1:3000 is not detected when Node.js
+ * defaults to listening on [::]:3000.
  */
 async function findAvailablePort(
   startPort: number,
@@ -151,17 +158,18 @@ async function findAvailablePort(
   let port = startPort
 
   for (let retryCount = 0; retryCount <= maxRetries; retryCount++) {
-    const hostsToCheck = hostname !== undefined ? [hostname] : ['0.0.0.0', '::']
-    let available = true
+    const hostsToCheck =
+      hostname !== undefined ? [hostname] : ['127.0.0.1', '::1']
+    let inUse = false
 
     for (const host of hostsToCheck) {
-      if (!(await isPortAvailableOnHost(port, host))) {
-        available = false
+      if (await isPortListening(port, host)) {
+        inUse = true
         break
       }
     }
 
-    if (available) {
+    if (!inUse) {
       return { port, retryCount }
     }
 

--- a/test/integration/cli/test/index.test.ts
+++ b/test/integration/cli/test/index.test.ts
@@ -830,13 +830,28 @@ describe('CLI Usage', () => {
     })
 
     test('Allow retry when port is used by IPv4-only server', async () => {
+      const net = require('net')
       let output = ''
       let ipv4Server: ReturnType<typeof http.createServer> | undefined
       let app: any
 
+      // Wait for port 3000 to be free (previous tests may still be releasing it)
+      await retry(
+        async () => {
+          await new Promise<void>((resolve, reject) => {
+            const tester = net.createServer()
+            tester.once('error', (err: any) => reject(err))
+            tester.once('listening', () => tester.close(() => resolve()))
+            tester.listen(3000, '127.0.0.1')
+          })
+        },
+        5000,
+        500
+      )
+
       try {
         // Start a server explicitly bound to IPv4 loopback (127.0.0.1:3000)
-        // to simulate a third-party server like Vite/vinext
+        // to simulate a third-party server like Vite
         ipv4Server = http.createServer((_, res) => {
           res.writeHead(200, { 'Content-Type': 'text/plain' })
           res.end('OK')

--- a/test/integration/cli/test/index.test.ts
+++ b/test/integration/cli/test/index.test.ts
@@ -829,6 +829,37 @@ describe('CLI Usage', () => {
       )
     })
 
+    test('Allow retry when port is used by IPv4-only server', async () => {
+      let output = ''
+      let ipv4Server: ReturnType<typeof http.createServer> | undefined
+      let app: any
+
+      try {
+        // Start a server explicitly bound to IPv4 loopback (127.0.0.1:3000)
+        // to simulate a third-party server like Vite/vinext
+        ipv4Server = http.createServer((_, res) => {
+          res.writeHead(200, { 'Content-Type': 'text/plain' })
+          res.end('OK')
+        })
+        await new Promise<void>((resolve, reject) => {
+          ipv4Server!.on('error', reject)
+          ipv4Server!.on('listening', () => resolve())
+          ipv4Server!.listen(3000, '127.0.0.1')
+        })
+
+        app = await runNextCommandDev([dirBasic], undefined, {
+          onStderr(msg) {
+            output += stripAnsi(msg)
+          },
+        })
+      } finally {
+        await killApp(app).catch(console.error)
+        await new Promise((resolve) => ipv4Server?.close(resolve))
+      }
+
+      expect(output).toMatch(/Port 3000 is in use/)
+    })
+
     test('-p reserved', async () => {
       const TCP_MUX_PORT = 1
       const { stderr, stdout } = await runAndCaptureOutput({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Fixing a bug

- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs

## For Maintainers

### What?
Implements a proactive port availability check for `next dev`.

### Why?
On macOS, `next dev` (binding to `::` by default) does not detect port conflicts with IPv4-only servers (e.g., Vite binding to `127.0.0.1`) because they use different address families. This leads to silent coexistence on the same port number, causing confusion for users.

### How?
Before `server.listen()`, `next dev` now attempts to bind to both `0.0.0.0` (IPv4) and `::` (IPv6) to proactively detect if the default port is in use by any address family. If a conflict is found, it retries on the next available port and logs a warning. A new integration test was added to specifically cover this cross-address-family conflict scenario.

Closes NEXT-
Fixes #

---
[Slack Thread](https://vercel.slack.com/archives/C01A2M9R8RZ/p1772749375212779?thread_ts=1772749375.212779&cid=C01A2M9R8RZ)

<p><a href="https://cursor.com/agents/bc-4b5921da-c5c5-524e-8be5-32a39e9dc2a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b5921da-c5c5-524e-8be5-32a39e9dc2a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->