### PR TITLE
docs: explain deploy test custom scripts

### DIFF
--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -229,10 +229,14 @@ cd "$NEXT_TEST_DIR"
 # Write any metadata needed later to files in NEXT_TEST_DIR.
 BUILD_ID="$(cat .next/BUILD_ID)"
 DEPLOYMENT_ID="my-adapter-local"
+# If your adapter generates an immutable asset token, set it here.
+# Otherwise use "undefined" to indicate there is none.
+IMMUTABLE_ASSET_TOKEN="undefined"
 
 {
   echo "BUILD_ID: $BUILD_ID"
   echo "DEPLOYMENT_ID: $DEPLOYMENT_ID"
+  echo "IMMUTABLE_ASSET_TOKEN: $IMMUTABLE_ASSET_TOKEN"
 } >> .adapter-build.log
 
 # stdout must contain only the deployment URL.
@@ -247,6 +251,7 @@ Its output must include lines starting with:
 
 - `BUILD_ID:`
 - `DEPLOYMENT_ID:`
+- `IMMUTABLE_ASSET_TOKEN:` (use the value `undefined` if your adapter does not produce one)
 
 After those markers, you can print any additional build or server logs that would help debug failures.
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -172,61 +172,171 @@ Called after the build process completes with detailed information about routes 
 - `nextVersion`: Version of Next.js being used
 - `buildId`: Unique identifier for the current build
 
-## Running Deploy Tests with Custom Scripts
+## Testing Adapters
 
-If you want to validate an adapter with Next.js deploy-mode E2E tests, you can replace the default Vercel deployment step with custom scripts.
-
-The deploy harness looks for these environment variables:
-
-- `NEXT_TEST_DEPLOY_SCRIPT_PATH`: Executable that builds and deploys the isolated test app
-- `NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH`: Executable that returns build and runtime logs for that deployment
-- `NEXT_TEST_CLEANUP_SCRIPT_PATH`: Optional executable that tears the deployment down after the test run
-
-When you trigger Next.js's release workflow manually, these map to the `deployScriptPath`, `deployLogsScriptPath`, and `cleanupScriptPath` inputs in `.github/workflows/test_e2e_deploy_release.yml`. If you are running the tests from your own adapter repository, set the environment variables directly in your workflow.
+Next.js provides a test harness for validating adapters. Running the end-to-end tests for deployment.
 
 ```yaml filename=".github/workflows/test-e2e-deploy.yml"
-- name: Make scripts executable
-  run: |
-    chmod +x adapter/scripts/deploy.sh
-    chmod +x adapter/scripts/logs.sh
-    chmod +x adapter/scripts/cleanup.sh
+name: test-e2e-deploy
 
-- name: Run deploy tests
-  working-directory: next.js
-  env:
-    NEXT_TEST_MODE: deploy
-    NEXT_E2E_TEST_TIMEOUT: 240000
-    NEXT_EXTERNAL_TESTS_FILTERS: test/deploy-tests-manifest.json
-    NEXT_TEST_DEPLOY_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/deploy.sh
-    NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/logs.sh
-    NEXT_TEST_CLEANUP_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/cleanup.sh
-    IS_TURBOPACK_TEST: 1
-    NEXT_TEST_JOB: 1
-    NEXT_TELEMETRY_DISABLED: 1
-  run: node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+on:
+  workflow_dispatch:
+    inputs:
+      nextjsRef:
+        description: 'Next.js repo ref (branch/tag/SHA)'
+        default: 'canary'
+        type: string
+  # schedule:
+  #   - cron: '0 2 * * *'
+
+jobs:
+  build:
+    name: Build Next.js + adapter
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: adapter
+
+      - uses: actions/checkout@v4
+        with:
+          repository: vercel/next.js
+          ref: ${{ inputs.nextjsRef || 'canary' }}
+          path: nextjs
+          fetch-depth: 25
+
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: 'latest' }
+
+      - name: Setup pnpm
+        run: npm i -g corepack@0.31 && corepack enable
+
+      - name: Install & build Next.js
+        working-directory: nextjs
+        run: pnpm install && pnpm build && pnpm install
+
+      - name: Install Playwright
+        working-directory: nextjs
+        run: pnpm playwright install --with-deps chromium
+
+      - name: Build adapter
+        working-directory: adapter
+        run: pnpm install && pnpm build
+
+      - uses: actions/cache/save@v4
+        with:
+          path: |
+            nextjs
+            adapter
+            ~/.cache/ms-playwright
+          key: build-${{ github.sha }}-${{ github.run_id }}
+
+  test:
+    name: Tests (${{ matrix.group }})
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          [
+            1/16,
+            2/16,
+            3/16,
+            4/16,
+            5/16,
+            6/16,
+            7/16,
+            8/16,
+            9/16,
+            10/16,
+            11/16,
+            12/16,
+            13/16,
+            14/16,
+            15/16,
+            16/16,
+          ]
+    steps:
+      - uses: actions/cache/restore@v4
+        with:
+          path: |
+            nextjs
+            adapter-bun
+            ~/.cache/ms-playwright
+          key: build-${{ github.sha }}-${{ github.run_id }}
+
+      - uses: actions/setup-node@v4
+        with: { node-version: '20' }
+
+      - uses: oven-sh/setup-bun@v2
+        with: { bun-version: 'latest' }
+
+      - name: Setup pnpm
+        run: npm i -g corepack@0.31 && corepack enable
+
+      - name: Ensure Playwright browser
+        working-directory: nextjs
+        run: pnpm playwright install chromium
+
+      - name: Make scripts executable
+        run: chmod +x adapter/scripts/e2e-deploy.sh
+          adapter/scripts/e2e-logs.sh
+          adapter/scripts/e2e-cleanup.sh
+
+      - name: Run deploy tests
+        working-directory: nextjs
+        env:
+          NEXT_TEST_MODE: deploy
+          NEXT_E2E_TEST_TIMEOUT: 240000
+          NEXT_EXTERNAL_TESTS_FILTERS: test/deploy-tests-manifest.json
+          ADAPTER_DIR: ${{ github.workspace }}/adapter
+          IS_TURBOPACK_TEST: 1
+          NEXT_TEST_JOB: 1
+          NEXT_TELEMETRY_DISABLED: 1
+
+          # Change these to your adapter's scripts
+          # Keep as-is if the scripts are in the adapter repository `scripts` directory
+          NEXT_TEST_DEPLOY_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/e2e-deploy.sh
+          NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/e2e-logs.sh
+          NEXT_TEST_CLEANUP_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/e2e-cleanup.sh
+        run: node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
 ```
+
+The test harness looks for these environment variables:
+
+- `NEXT_TEST_DEPLOY_SCRIPT_PATH`: Path to the executable that builds and deploys the isolated test app
+- `NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH`: Path to the executable that returns build and runtime logs for that deployment
+- `NEXT_TEST_CLEANUP_SCRIPT_PATH`: Path to the optional executable that tears the deployment down after the test run
 
 ### Custom deploy script contract
 
-The deploy script is executed with `cwd` set to `NEXT_TEST_DIR`, which is the isolated temporary app created by the Next.js test harness. The full test environment is forwarded to the script, including any fixture-specific environment variables.
+The deploy script `NEXT_TEST_DEPLOY_SCRIPT_PATH` is executed with `cwd` set to the isolated temporary app created by the Next.js test harness.
 
 Your script must:
 
-- Exit with a non-zero code on failure
-- Print the final deployment URL to `stdout`
-- Avoid writing anything else to `stdout`
-- Write diagnostic output to `stderr` or to files inside `NEXT_TEST_DIR`
+- Exit with a non-zero code on failure.
+- Print the deployment URL to `stdout`. This will be used to verify the deployment. Avoid writing anything else to `stdout`.
+- Write diagnostic output to `stderr` or to files inside the working directory.
 
-Because the deploy script and logs script run as separate processes, any data you want later, such as build IDs or server logs, should be persisted to files inside `NEXT_TEST_DIR`.
+Because the deploy script and logs script run as separate processes, any data you want to use later, such as build IDs or server logs, should be persisted to files inside the working directory.
+
+Example deploy script:
 
 ```bash filename="scripts/e2e-deploy.sh"
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$NEXT_TEST_DIR"
-
 # Install your adapter, build the app, and deploy or start it.
-# Write any metadata needed later to files in NEXT_TEST_DIR.
+
+
+
+# Write any metadata needed later to files in the working directory.
 BUILD_ID="$(cat .next/BUILD_ID)"
 DEPLOYMENT_ID="my-adapter-local"
 # If your adapter generates an immutable asset token, set it here.
@@ -245,7 +355,9 @@ echo "http://127.0.0.1:3000"
 
 ### Custom logs script contract
 
-The logs script is called after deployment. It receives `NEXT_TEST_DIR` and `NEXT_TEST_DEPLOY_URL`, plus the rest of the test environment.
+The logs script `NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH` is executed with `cwd` set to the isolated temporary app created by the Next.js test harness.
+
+Additionally it receives `NEXT_TEST_DIR` and `NEXT_TEST_DEPLOY_URL` as environment variables.
 
 Its output must include lines starting with:
 
@@ -259,8 +371,6 @@ After those markers, you can print any additional build or server logs that woul
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$NEXT_TEST_DIR"
-
 if [ -f ".adapter-build.log" ]; then
   cat ".adapter-build.log"
 fi
@@ -271,7 +381,15 @@ if [ -f ".adapter-server.log" ]; then
 fi
 ```
 
-One workable pattern is to have the deploy script write `.adapter-build.log` and `.adapter-server.log`, then have the logs script replay those files so the harness can extract the required markers.
+One pattern is to have the deploy script write `.adapter-build.log` and `.adapter-server.log`, then have the logs script replay those files so the harness can extract the required markers. This is one option, each platform has different ways to get the logs.
+
+### Custom cleanup script contract
+
+The cleanup script `NEXT_TEST_CLEANUP_SCRIPT_PATH` is executed with `cwd` set to the isolated temporary app created by the Next.js test harness.
+
+Additionally it receives `NEXT_TEST_DIR` and `NEXT_TEST_DEPLOY_URL` as environment variables.
+
+The cleanup script can be used to clean up any resources created by the deploy script. It runs after the tests have completed.
 
 ## Routing with `@next/routing`
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -332,9 +332,18 @@ Example deploy script:
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Install your adapter, build the app, and deploy or start it.
+# Install the adapter, build the app, and deploy or start it.
+node -e "
+const pkg=JSON.parse(require('fs').readFileSync('package.json','utf8'));
+pkg.dependencies=pkg.dependencies||{};
+pkg.dependencies['adapter']='file:${ADAPTER_DIR}';
+require('fs').writeFileSync('package.json',JSON.stringify(pkg,null,2));
+" >&2
 
+export NEXT_ADAPTER_PATH="${ADAPTER_DIR}/dist/index.js"
 
+# Deploy or build + start the app at this point.
+provider-cli-to-deploy
 
 # Write any metadata needed later to files in the working directory.
 BUILD_ID="$(cat .next/BUILD_ID)"
@@ -349,7 +358,7 @@ IMMUTABLE_ASSET_TOKEN="undefined"
   echo "IMMUTABLE_ASSET_TOKEN: $IMMUTABLE_ASSET_TOKEN"
 } >> .adapter-build.log
 
-# stdout must contain only the deployment URL.
+# stdout must contain only the deployment URL. Replace this with the actual deployment URL.
 echo "http://127.0.0.1:3000"
 ```
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -172,6 +172,102 @@ Called after the build process completes with detailed information about routes 
 - `nextVersion`: Version of Next.js being used
 - `buildId`: Unique identifier for the current build
 
+## Running Deploy Tests with Custom Scripts
+
+If you want to validate an adapter with Next.js deploy-mode E2E tests, you can replace the default Vercel deployment step with custom scripts.
+
+The deploy harness looks for these environment variables:
+
+- `NEXT_TEST_DEPLOY_SCRIPT_PATH`: Executable that builds and deploys the isolated test app
+- `NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH`: Executable that returns build and runtime logs for that deployment
+- `NEXT_TEST_CLEANUP_SCRIPT_PATH`: Optional executable that tears the deployment down after the test run
+
+When you trigger Next.js's release workflow manually, these map to the `deployScriptPath`, `deployLogsScriptPath`, and `cleanupScriptPath` inputs in `.github/workflows/test_e2e_deploy_release.yml`. If you are running the tests from your own adapter repository, set the environment variables directly in your workflow.
+
+```yaml filename=".github/workflows/test-e2e-deploy.yml"
+- name: Make scripts executable
+  run: |
+    chmod +x adapter/scripts/deploy.sh
+    chmod +x adapter/scripts/logs.sh
+    chmod +x adapter/scripts/cleanup.sh
+
+- name: Run deploy tests
+  working-directory: next.js
+  env:
+    NEXT_TEST_MODE: deploy
+    NEXT_E2E_TEST_TIMEOUT: 240000
+    NEXT_EXTERNAL_TESTS_FILTERS: test/deploy-tests-manifest.json
+    NEXT_TEST_DEPLOY_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/deploy.sh
+    NEXT_TEST_DEPLOY_LOGS_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/logs.sh
+    NEXT_TEST_CLEANUP_SCRIPT_PATH: ${{ github.workspace }}/adapter/scripts/cleanup.sh
+    IS_TURBOPACK_TEST: 1
+    NEXT_TEST_JOB: 1
+    NEXT_TELEMETRY_DISABLED: 1
+  run: node run-tests.js --timings -g ${{ matrix.group }} -c 2 --type e2e
+```
+
+### Custom deploy script contract
+
+The deploy script is executed with `cwd` set to `NEXT_TEST_DIR`, which is the isolated temporary app created by the Next.js test harness. The full test environment is forwarded to the script, including any fixture-specific environment variables.
+
+Your script must:
+
+- Exit with a non-zero code on failure
+- Print the final deployment URL to `stdout`
+- Avoid writing anything else to `stdout`
+- Write diagnostic output to `stderr` or to files inside `NEXT_TEST_DIR`
+
+Because the deploy script and logs script run as separate processes, any data you want later, such as build IDs or server logs, should be persisted to files inside `NEXT_TEST_DIR`.
+
+```bash filename="scripts/e2e-deploy.sh"
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$NEXT_TEST_DIR"
+
+# Install your adapter, build the app, and deploy or start it.
+# Write any metadata needed later to files in NEXT_TEST_DIR.
+BUILD_ID="$(cat .next/BUILD_ID)"
+DEPLOYMENT_ID="my-adapter-local"
+
+{
+  echo "BUILD_ID: $BUILD_ID"
+  echo "DEPLOYMENT_ID: $DEPLOYMENT_ID"
+} >> .adapter-build.log
+
+# stdout must contain only the deployment URL.
+echo "http://127.0.0.1:3000"
+```
+
+### Custom logs script contract
+
+The logs script is called after deployment. It receives `NEXT_TEST_DIR` and `NEXT_TEST_DEPLOY_URL`, plus the rest of the test environment.
+
+Its output must include lines starting with:
+
+- `BUILD_ID:`
+- `DEPLOYMENT_ID:`
+
+After those markers, you can print any additional build or server logs that would help debug failures.
+
+```bash filename="scripts/e2e-logs.sh"
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$NEXT_TEST_DIR"
+
+if [ -f ".adapter-build.log" ]; then
+  cat ".adapter-build.log"
+fi
+
+if [ -f ".adapter-server.log" ]; then
+  echo "=== .adapter-server.log ==="
+  cat ".adapter-server.log"
+fi
+```
+
+One workable pattern is to have the deploy script write `.adapter-build.log` and `.adapter-server.log`, then have the logs script replay those files so the harness can extract the required markers.
+
 ## Routing with `@next/routing`
 
 You can use [`@next/routing`](https://www.npmjs.com/package/@next/routing) to reproduce Next.js route matching behavior with data from `onBuildComplete`.

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -267,7 +267,7 @@ jobs:
         with:
           path: |
             nextjs
-            adapter-bun
+            adapter
             ~/.cache/ms-playwright
           key: build-${{ github.sha }}-${{ github.run_id }}
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -176,6 +176,8 @@ Called after the build process completes with detailed information about routes 
 
 Next.js provides a test harness for validating adapters. Running the end-to-end tests for deployment.
 
+Example GitHub Actions workflow:
+
 ```yaml filename=".github/workflows/test-e2e-deploy.yml"
 name: test-e2e-deploy
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -340,10 +340,8 @@ pkg.dependencies['adapter']='file:${ADAPTER_DIR}';
 require('fs').writeFileSync('package.json',JSON.stringify(pkg,null,2));
 " >&2
 
+# Set the adapter path so that the app uses it.
 export NEXT_ADAPTER_PATH="${ADAPTER_DIR}/dist/index.js"
-
-# Deploy or build + start the app at this point.
-provider-cli-to-deploy
 
 # Write any metadata needed later to files in the working directory.
 BUILD_ID="$(cat .next/BUILD_ID)"
@@ -358,8 +356,14 @@ IMMUTABLE_ASSET_TOKEN="undefined"
   echo "IMMUTABLE_ASSET_TOKEN: $IMMUTABLE_ASSET_TOKEN"
 } >> .adapter-build.log
 
-# stdout must contain only the deployment URL. Replace this with the actual deployment URL.
-echo "http://127.0.0.1:3000"
+# Build the app
+pnpm build
+
+# Start or deploy the app. Capture the URL at this point or make the script output the URL to stdout.
+provider-cli-to-deploy
+
+# Example URL output:
+# echo "http://127.0.0.1:3000"
 ```
 
 ### Custom logs script contract

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -374,7 +374,7 @@ Its output must include lines starting with:
 - `DEPLOYMENT_ID:`
 - `IMMUTABLE_ASSET_TOKEN:` (use the value `undefined` if your adapter does not produce one)
 
-After those markers, you can print any additional build or server logs that would help debug failures.
+After those markers, the logs script can print any additional build or server logs that would help debug failures.
 
 ```bash filename="scripts/e2e-logs.sh"
 #!/usr/bin/env bash

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -209,9 +209,6 @@ jobs:
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
 
-      - uses: oven-sh/setup-bun@v2
-        with: { bun-version: 'latest' }
-
       - name: Setup pnpm
         run: npm i -g corepack@0.31 && corepack enable
 
@@ -273,9 +270,6 @@ jobs:
 
       - uses: actions/setup-node@v4
         with: { node-version: '20' }
-
-      - uses: oven-sh/setup-bun@v2
-        with: { bun-version: 'latest' }
 
       - name: Setup pnpm
         run: npm i -g corepack@0.31 && corepack enable

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -314,7 +314,7 @@ The test harness looks for these environment variables:
 
 The deploy script `NEXT_TEST_DEPLOY_SCRIPT_PATH` is executed with `cwd` set to the isolated temporary app created by the Next.js test harness.
 
-Your script must:
+The deploy script must follow this contract:
 
 - Exit with a non-zero code on failure.
 - Print the deployment URL to `stdout`. This will be used to verify the deployment. Avoid writing anything else to `stdout`.


### PR DESCRIPTION
## Summary
- document how to use custom deploy, logs, and cleanup scripts with the deploy test workflow
- describe the expected stdout/log marker contract for custom scripts
- keep the examples generic to adapter implementations