### PR TITLE
[Prefetch Inlining] Size-based static prefetch bundling

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2,8 +2,6 @@ import type {
   TreePrefetch,
   RootTreePrefetch,
   SegmentPrefetch,
-  InlinedPrefetchResponse,
-  InlinedSegmentPrefetch,
 } from '../../../server/app-render/collect-segment-data'
 import type {
   CacheNodeSeedData,
@@ -288,6 +286,20 @@ export type NonEmptySegmentCacheEntry = Exclude<
   SegmentCacheEntry,
   EmptySegmentCacheEntry
 >
+
+/**
+ * A linked list of segment cache entries to fulfill from a single prefetch
+ * response. The head is the requested segment; subsequent nodes are parent
+ * segments whose data is bundled into the same response by the server.
+ *
+ * When segments are not bundled, the list has a single node. The list
+ * maps 1:1 to the SegmentPrefetch (or SegmentPrefetch[]) the server returns.
+ */
+export type SegmentBundle = {
+  tree: RouteTree
+  entry: SegmentCacheEntry | null
+  parent: SegmentBundle | null
+}
 
 const isOutputExportMode =
   process.env.NODE_ENV === 'production' &&
@@ -1850,12 +1862,23 @@ export async function fetchRouteOnCacheMiss(
   }
 }
 
-export async function fetchSegmentOnCacheMiss(
+function rejectSegmentBundle(entries: SegmentBundle, staleAt: number): void {
+  let node: SegmentBundle | null = entries
+  while (node !== null) {
+    if (node.entry !== null && node.entry.status === EntryStatus.Pending) {
+      rejectSegmentCacheEntry(node.entry as PendingSegmentCacheEntry, staleAt)
+    }
+    node = node.parent
+  }
+}
+
+export async function fetchSegmentsOnCacheMiss(
   route: FulfilledRouteCacheEntry,
-  segmentCacheEntry: PendingSegmentCacheEntry,
   routeKey: RouteCacheKey,
-  tree: RouteTree
-): Promise<PrefetchSubtaskResult<FulfilledSegmentCacheEntry> | null> {
+  tree: RouteTree,
+  segments: SegmentBundle,
+  segmentCount: number
+): Promise<PrefetchSubtaskResult<null> | null> {
   // This function is allowed to use async/await because it contains the actual
   // fetch that gets issued on a cache miss. Notice it writes the result to the
   // cache entry directly, rather than return data that is then written by
@@ -1919,7 +1942,7 @@ export async function fetchSegmentOnCacheMiss(
     ) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
-      rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+      rejectSegmentBundle(segments, Date.now() + 10 * 1000)
       return null
     }
 
@@ -1929,234 +1952,122 @@ export async function fetchSegmentOnCacheMiss(
     const prefetchStream = createPrefetchResponseStream(
       response.body,
       closed.resolve,
-      function onResponseSizeUpdate(size) {
-        setSizeInCacheMap(segmentCacheEntry, size)
+      function onResponseSizeUpdate(totalBytesReceivedSoFar) {
+        // Distribute the response size evenly across all segments in the list.
+        const averageSize = totalBytesReceivedSoFar / segmentCount
+        let n: SegmentBundle | null = segments
+        while (n !== null) {
+          if (n.entry !== null) {
+            setSizeInCacheMap(n.entry, averageSize)
+          }
+          n = n.parent
+        }
       }
     )
-    const serverData = await createFromNextReadableStream<SegmentPrefetch>(
-      prefetchStream,
-      headers,
-      { allowPartialStream: true }
-    )
+
+    // Parse the response. When auto inlining is enabled and there are
+    // multiple segments, the response is a SegmentPrefetch[] array.
+    // Otherwise it's a single SegmentPrefetch (wrapped into a
+    // one-element array for uniform handling).
+    let serverDataArray: SegmentPrefetch[]
+    if (process.env.__NEXT_PREFETCH_INLINING && segments.parent !== null) {
+      serverDataArray = await createFromNextReadableStream<SegmentPrefetch[]>(
+        prefetchStream,
+        headers,
+        { allowPartialStream: true }
+      )
+    } else {
+      const serverData = await createFromNextReadableStream<SegmentPrefetch>(
+        prefetchStream,
+        headers,
+        { allowPartialStream: true }
+      )
+      serverDataArray = [serverData]
+    }
+
+    const now = Date.now()
+
+    if (serverDataArray.length === 0) {
+      rejectSegmentBundle(segments, now + 10 * 1000)
+      return null
+    }
     if (
       (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
-        serverData.buildId) !== getNavigationBuildId()
+        serverDataArray[0].buildId) !== getNavigationBuildId()
     ) {
       // The server build does not match the client. Treat as a 404. During
       // an actual navigation, the router will trigger an MPA navigation.
-      rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+      rejectSegmentBundle(segments, now + 10 * 1000)
       return null
     }
-    const staleAt = Date.now() + getStaleTimeMs(serverData.staleTime)
-    const fulfilledEntry = fulfillSegmentCacheEntry(
-      segmentCacheEntry,
-      serverData.rsc,
-      staleAt,
-      serverData.isPartial
-    )
 
-    // If the server tells us which params the segment varies by, we can re-key
-    // the entry to a more generic vary path. This allows the entry to be reused
-    // across different param values for params that the segment doesn't
-    // actually depend on.
-    const varyParams = serverData.varyParams
-    if (process.env.__NEXT_VARY_PARAMS && varyParams !== null) {
-      // Re-key the entry by storing it at a more generic vary path where
-      // unused params are replaced with Fallback.
-      const fulfilledVaryPath = getFulfilledSegmentVaryPath(
-        tree.varyPath,
-        varyParams
-      )
-      const isRevalidation = false
-      setInCacheMap(
-        segmentCacheMap,
-        fulfilledVaryPath,
-        fulfilledEntry,
-        isRevalidation
-      )
+    // Walk the segments list and the response array in parallel, fulfilling
+    // each cache entry from the corresponding response element.
+    let node: SegmentBundle | null = segments
+    let dataIndex = 0
+    while (node !== null && dataIndex < serverDataArray.length) {
+      const data = serverDataArray[dataIndex]
+      const entryStaleAt = now + getStaleTimeMs(data.staleTime)
+
+      // Determine the canonical vary path for this segment. If the server
+      // tells us which params the segment varies by, re-key to a more
+      // generic path. Otherwise use the request vary path.
+      const canonicalVaryPath =
+        process.env.__NEXT_VARY_PARAMS && data.varyParams !== null
+          ? getFulfilledSegmentVaryPath(node.tree.varyPath, data.varyParams)
+          : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree)
+
+      let fulfilled: FulfilledSegmentCacheEntry | null = null
+      const nodeEntry = node.entry
+      if (nodeEntry !== null && nodeEntry.status === EntryStatus.Pending) {
+        // We own this entry — fulfill it directly.
+        fulfilled = fulfillSegmentCacheEntry(
+          nodeEntry as PendingSegmentCacheEntry,
+          data.rsc,
+          entryStaleAt,
+          data.isPartial
+        )
+      } else {
+        // We don't own this entry. Create a detached entry and attempt
+        // to upsert it into the canonical slot.
+        const detachedEntry = createDetachedSegmentCacheEntry(now)
+        fulfilled = fulfillSegmentCacheEntry(
+          upgradeToPendingSegment(detachedEntry, FetchStrategy.PPR),
+          data.rsc,
+          entryStaleAt,
+          data.isPartial
+        )
+      }
+
+      // Set the fulfilled entry into the canonical cache slot.
+      upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+
+      node = node.parent
+      dataIndex++
+    }
+
+    // If the server returned fewer segments than expected, reject any
+    // remaining pending entries so they don't stay Pending forever.
+    while (node !== null) {
+      const nodeEntry = node.entry
+      if (nodeEntry !== null && nodeEntry.status === EntryStatus.Pending) {
+        rejectSegmentCacheEntry(
+          nodeEntry as PendingSegmentCacheEntry,
+          now + 10 * 1000
+        )
+      }
+      node = node.parent
     }
 
     return {
-      value: fulfilledEntry,
-      // Return a promise that resolves when the network connection closes, so
-      // the scheduler can track the number of concurrent network connections.
+      value: null,
       closed: closed.promise,
     }
   } catch (error) {
     // Either the connection itself failed, or something bad happened while
     // decoding the response.
-    rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+    rejectSegmentBundle(segments, Date.now() + 10 * 1000)
     return null
-  }
-}
-
-// TODO: The inlined prefetch flow below is temporary. Eventually, inlining
-// will be the default behavior controlled by a size heuristic rather than a
-// boolean flag. At that point, the per-segment and inlined fetch paths will
-// merge, and these separate functions will be removed.
-//
-// The call site in the scheduler is guarded by
-// process.env.__NEXT_PREFETCH_INLINING, so these functions are
-// dead-code-eliminated from the client bundle when the feature is disabled.
-
-export async function fetchInlinedSegmentsOnCacheMiss(
-  route: FulfilledRouteCacheEntry,
-  routeKey: RouteCacheKey,
-  tree: RouteTree,
-  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
-): Promise<PrefetchSubtaskResult<null> | null> {
-  // When prefetch inlining is enabled, all segment data for a route is bundled
-  // into a single /_inlined response instead of individual per-segment
-  // requests. This function fetches that response and walks the tree to fill
-  // all segment cache entries at once.
-  const url = new URL(route.canonicalUrl, location.origin)
-  const nextUrl = routeKey.nextUrl
-
-  const headers: RequestHeaders = {
-    [RSC_HEADER]: '1',
-    [NEXT_ROUTER_PREFETCH_HEADER]: '1',
-    [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]: '/' + PAGE_SEGMENT_KEY,
-  }
-  if (nextUrl !== null) {
-    headers[NEXT_URL] = nextUrl
-  }
-  addInstantPrefetchHeaderIfLocked(headers)
-
-  try {
-    const response = await fetchPrefetchResponse(url, headers)
-    if (
-      !response ||
-      !response.ok ||
-      response.status === 204 ||
-      (response.headers.get(NEXT_DID_POSTPONE_HEADER) !== '2' &&
-        !isOutputExportMode) ||
-      !response.body
-    ) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-      return null
-    }
-
-    const closed = createPromiseWithResolvers<void>()
-
-    const prefetchStream = createPrefetchResponseStream(
-      response.body,
-      closed.resolve,
-      function onResponseSizeUpdate() {
-        // For inlined responses, size tracking per segment is approximate.
-        // We don't track individual sizes since they're all in one response.
-      }
-    )
-    const serverData =
-      await createFromNextReadableStream<InlinedPrefetchResponse>(
-        prefetchStream,
-        headers,
-        { allowPartialStream: true }
-      )
-
-    if (
-      (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
-        serverData.tree.segment.buildId) !== getNavigationBuildId()
-    ) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-      return null
-    }
-
-    const now = Date.now()
-
-    // Walk the inlined tree in parallel with the RouteTree and fill
-    // segment cache entries.
-    fillInlinedSegmentEntries(now, route, tree, serverData.tree, spawnedEntries)
-
-    // Fill the head entry.
-    const headStaleAt = now + getStaleTimeMs(serverData.head.staleTime)
-    const headKey = route.metadata.requestKey
-    const ownedHeadEntry = spawnedEntries.get(headKey)
-    if (ownedHeadEntry !== undefined) {
-      fulfillSegmentCacheEntry(
-        ownedHeadEntry,
-        serverData.head.rsc,
-        headStaleAt,
-        serverData.head.isPartial
-      )
-    } else {
-      // The head was already cached. Try to upsert if the entry is empty.
-      const existingEntry = readOrCreateSegmentCacheEntry(
-        now,
-        FetchStrategy.PPR,
-        route.metadata
-      )
-      if (existingEntry.status === EntryStatus.Empty) {
-        fulfillSegmentCacheEntry(
-          upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
-          serverData.head.rsc,
-          headStaleAt,
-          serverData.head.isPartial
-        )
-      }
-    }
-
-    // Reject any remaining entries that were not fulfilled by the response.
-    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-
-    return { value: null, closed: closed.promise }
-  } catch (error) {
-    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-    return null
-  }
-}
-
-function fillInlinedSegmentEntries(
-  now: number,
-  route: FulfilledRouteCacheEntry,
-  tree: RouteTree,
-  inlinedNode: InlinedSegmentPrefetch,
-  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
-): void {
-  // Check if the spawned entries map has an entry for this segment's key.
-  const segment = inlinedNode.segment
-  const staleAt = now + getStaleTimeMs(segment.staleTime)
-  const ownedEntry = spawnedEntries.get(tree.requestKey)
-  if (ownedEntry !== undefined) {
-    // We own this entry. Fulfill it directly.
-    fulfillSegmentCacheEntry(
-      ownedEntry,
-      segment.rsc,
-      staleAt,
-      segment.isPartial
-    )
-  } else {
-    // Not owned by us — this is extra data from the inlined response for a
-    // segment that was already cached. Try to upsert if the entry is empty.
-    const existingEntry = readOrCreateSegmentCacheEntry(
-      now,
-      FetchStrategy.PPR,
-      tree
-    )
-    if (existingEntry.status === EntryStatus.Empty) {
-      fulfillSegmentCacheEntry(
-        upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
-        segment.rsc,
-        staleAt,
-        segment.isPartial
-      )
-    }
-  }
-
-  // Recurse into children.
-  if (tree.slots !== null && inlinedNode.slots !== null) {
-    for (const parallelRouteKey in tree.slots) {
-      const childTree = tree.slots[parallelRouteKey]
-      const childInlinedNode = inlinedNode.slots[parallelRouteKey]
-      if (childInlinedNode !== undefined) {
-        fillInlinedSegmentEntries(
-          now,
-          route,
-          childTree,
-          childInlinedNode,
-          spawnedEntries
-        )
-      }
-    }
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -9,15 +9,14 @@ import {
   readOrCreateRouteCacheEntry,
   readOrCreateSegmentCacheEntry,
   fetchRouteOnCacheMiss,
-  fetchSegmentOnCacheMiss,
-  fetchInlinedSegmentsOnCacheMiss,
+  fetchSegmentsOnCacheMiss,
   EntryStatus,
   type FulfilledRouteCacheEntry,
   type RouteCacheEntry,
-  type SegmentCacheEntry,
   type RouteTree,
   fetchSegmentPrefetchesUsingDynamicRequest,
   type PendingSegmentCacheEntry,
+  type SegmentBundle,
   convertRouteTreeToFlightRouterState,
   readOrCreateRevalidatingSegmentEntry,
   upsertSegmentEntry,
@@ -750,7 +749,8 @@ function pingRootRouteTree(
             task,
             route,
             task.treeAtTimeOfPrefetch,
-            tree
+            tree,
+            null
           )
           if (exitStatus === PrefetchTaskExitStatus.InProgress) {
             // Child yielded without finishing.
@@ -855,14 +855,27 @@ function pingStaticHead(
   // The Head data for a page (metadata, viewport) is not really a route
   // segment, in the sense that it doesn't appear in the route tree. But we
   // store it in the cache as if it were, using a special key.
-  pingStaticSegmentData(
-    now,
-    task,
-    route,
-    readOrCreateSegmentCacheEntry(now, FetchStrategy.PPR, route.metadata),
-    task.key,
-    route.metadata
-  )
+  //
+  // If the head was inlined into a page's bundle (HeadOutlined is NOT set
+  // on the root), skip the standalone fetch — the head data will arrive
+  // as part of that page's response.
+  if (
+    process.env.__NEXT_PREFETCH_INLINING &&
+    !(route.tree.prefetchHints & PrefetchHint.HeadOutlined)
+  ) {
+    return
+  }
+
+  const segments: SegmentBundle = {
+    tree: route.metadata,
+    entry: readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      route.metadata
+    ),
+    parent: null,
+  }
+  pingSegmentBundle(now, task, route, task.key, route.metadata, segments)
 }
 
 function pingRuntimeHead(
@@ -897,7 +910,8 @@ function pingSharedPartOfCacheComponentsTree(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   oldTree: FlightRouterState,
-  newTree: RouteTree
+  newTree: RouteTree,
+  parentBundle: SegmentBundle | null
 ): PrefetchTaskExitStatus {
   // When Cache Components is enabled (or PPR, or a fully static route when PPR
   // is disabled; those cases are treated equivalently to Cache Components), we
@@ -910,13 +924,13 @@ function pingSharedPartOfCacheComponentsTree(
   // "new" part of the tree, we switch to a different traversal,
   // pingNewPartOfCacheComponentsTree.
 
-  // Prefetch this segment's static data.
-  const segment = readOrCreateSegmentCacheEntry(
+  const bundleInProgress = accumulateSegmentBundle(
     now,
-    task.fetchStrategy,
-    newTree
+    task,
+    route,
+    newTree,
+    parentBundle
   )
-  pingStaticSegmentData(now, task, route, segment, task.key, newTree)
 
   // Recursively ping the children.
   const oldTreeChildren = oldTree[1]
@@ -933,6 +947,14 @@ function pingSharedPartOfCacheComponentsTree(
         oldTreeChildren[parallelRouteKey]
       const oldTreeChildSegment: FlightRouterStateSegment | void =
         oldTreeChild?.[0]
+      // Only pass the bundle to the child that accepts it. A parent is
+      // only ever bundled into one child.
+      const bundleForChild =
+        process.env.__NEXT_PREFETCH_INLINING &&
+        bundleInProgress !== null &&
+        newTreeChild.prefetchHints & PrefetchHint.ParentInlinedIntoSelf
+          ? bundleInProgress
+          : null
       let childExitStatus
       if (
         oldTreeChildSegment !== undefined &&
@@ -948,7 +970,8 @@ function pingSharedPartOfCacheComponentsTree(
           task,
           route,
           oldTreeChild,
-          newTreeChild
+          newTreeChild,
+          bundleForChild
         )
       } else {
         // We've entered the "new" part of the tree. Switch
@@ -957,7 +980,8 @@ function pingSharedPartOfCacheComponentsTree(
           now,
           task,
           route,
-          newTreeChild
+          newTreeChild,
+          bundleForChild
         )
       }
       if (childExitStatus === PrefetchTaskExitStatus.InProgress) {
@@ -974,7 +998,8 @@ function pingNewPartOfCacheComponentsTree(
   now: number,
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
-  tree: RouteTree
+  tree: RouteTree,
+  parentBundle: SegmentBundle | null
 ): PrefetchTaskExitStatus.InProgress | PrefetchTaskExitStatus.Done {
   // We're now prefetching in the "new" part of the tree, the part that doesn't
   // exist on the current page. (In other words, we're deeper than the
@@ -1006,13 +1031,22 @@ function pingNewPartOfCacheComponentsTree(
     } else {
       task.spawnedRuntimePrefetches.add(tree.requestKey)
     }
-    // Then exit the traversal without prefetching anything further.
+    // If there's a pending static bundle from a parent, we need to finish
+    // prefetching it before bailing out to runtime prefetching.
+    if (parentBundle !== null) {
+      finishStaticBundleOnRuntimeBailout(now, task, route, tree, parentBundle)
+    }
     return PrefetchTaskExitStatus.Done
   }
 
-  // This segment should not be runtime prefetched. Prefetch its static data.
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
-  pingStaticSegmentData(now, task, route, segment, task.key, tree)
+  const bundleInProgress = accumulateSegmentBundle(
+    now,
+    task,
+    route,
+    tree,
+    parentBundle
+  )
+
   if (tree.slots !== null) {
     if (!hasNetworkBandwidth(task)) {
       // Stop prefetching segments until there's more bandwidth.
@@ -1021,11 +1055,20 @@ function pingNewPartOfCacheComponentsTree(
     // Recursively ping the children.
     for (const parallelRouteKey in tree.slots) {
       const childTree = tree.slots[parallelRouteKey]
+      // Only pass the bundle to the child that accepts it. A parent is
+      // only ever bundled into one child.
+      const bundleForChild =
+        process.env.__NEXT_PREFETCH_INLINING &&
+        bundleInProgress !== null &&
+        childTree.prefetchHints & PrefetchHint.ParentInlinedIntoSelf
+          ? bundleInProgress
+          : null
       const childExitStatus = pingNewPartOfCacheComponentsTree(
         now,
         task,
         route,
-        childTree
+        childTree,
+        bundleForChild
       )
       if (childExitStatus === PrefetchTaskExitStatus.InProgress) {
         // Child yielded without finishing.
@@ -1474,194 +1517,240 @@ function pingRuntimePrefetches(
   return requestTree
 }
 
-function pingStaticSegmentData(
+/**
+ * Walk a SegmentBundle, apply status-based logic to each entry, and if any
+ * entries need data, spawn a single fetch request for the whole bundle.
+ *
+ * For each entry:
+ * - Empty: upgrade to Pending (we own it, the fetch will fulfill it)
+ * - Pending/PPR|PPRRuntime|Full: already in progress, null out
+ * - Pending/LoadingBoundary: swap for a revalidation entry
+ * - Rejected/PPR|PPRRuntime|Full: wait for expiry, null out
+ * - Rejected/LoadingBoundary: swap for a revalidation entry
+ * - Fulfilled: already cached, null out
+ *
+ * If no entries need fetching, the request is skipped entirely.
+ */
+function pingSegmentBundle(
   now: number,
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
-  segment: SegmentCacheEntry,
   routeKey: RouteCacheKey,
-  tree: RouteTree
+  tree: RouteTree,
+  segments: SegmentBundle
 ): void {
-  switch (segment.status) {
-    case EntryStatus.Empty:
-      if (process.env.__NEXT_PREFETCH_INLINING) {
-        // All segment data for this route is bundled into a single
-        // /_inlined response. Walk the full route tree to collect all
-        // Empty segments, upgrade them to Pending, and spawn one
-        // bundled request. Subsequent calls for other segments in the
-        // same tree will see them as Pending and skip.
-        const inlinedEntries = collectInlinedEntries(now, route)
-        if (inlinedEntries.size > 0) {
-          spawnPrefetchSubtask(
-            fetchInlinedSegmentsOnCacheMiss(
-              route,
-              routeKey,
-              route.tree,
-              inlinedEntries
-            )
-          )
+  // Count all segments in the bundle, including ones we don't own. This
+  // is intentional: the server response contains data for every segment
+  // in the bundle regardless of ownership, so we attribute the total
+  // response size across all of them for LRU accounting purposes.
+  let segmentCount = 0
+  let needsFetch = false
+  let node: SegmentBundle | null = segments
+  while (node !== null) {
+    segmentCount++
+    const nodeEntry = node.entry
+    if (nodeEntry === null) {
+      node = node.parent
+      continue
+    }
+    switch (nodeEntry.status) {
+      case EntryStatus.Empty:
+        upgradeToPendingSegment(nodeEntry, FetchStrategy.PPR)
+        needsFetch = true
+        break
+      case EntryStatus.Pending:
+        switch (nodeEntry.fetchStrategy) {
+          case FetchStrategy.PPR:
+          case FetchStrategy.PPRRuntime:
+          case FetchStrategy.Full:
+            // Already in progress. Null out — we don't own this entry.
+            node.entry = null
+            break
+          case FetchStrategy.LoadingBoundary:
+            // Pending with the old strategy — we can't be sure if it
+            // will be fulfilled by the response. Swap for a revalidation
+            // entry so we can fetch fresh data.
+            if (background(task)) {
+              const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
+                now,
+                FetchStrategy.PPR,
+                node.tree
+              )
+              if (revalidatingEntry.status === EntryStatus.Empty) {
+                upgradeToPendingSegment(revalidatingEntry, FetchStrategy.PPR)
+                node.entry = revalidatingEntry
+                needsFetch = true
+              } else {
+                node.entry = null
+              }
+            } else {
+              node.entry = null
+            }
+            break
+          default:
+            nodeEntry.fetchStrategy satisfies never
         }
         break
-      }
-      // Upgrade to Pending so we know there's already a request in progress
-      spawnPrefetchSubtask(
-        fetchSegmentOnCacheMiss(
-          route,
-          upgradeToPendingSegment(segment, FetchStrategy.PPR),
-          routeKey,
-          tree
-        )
-      )
-      break
-    case EntryStatus.Pending: {
-      // There's already a request in progress. Depending on what kind of
-      // request it is, we may want to revalidate it.
-      switch (segment.fetchStrategy) {
-        case FetchStrategy.PPR:
-        case FetchStrategy.PPRRuntime:
-        case FetchStrategy.Full:
-          // There's already a request in progress. Don't do anything.
-          break
-        case FetchStrategy.LoadingBoundary:
-          // There's a pending request, but because it's using the old
-          // prefetching strategy, we can't be sure if it will be fulfilled by
-          // the response — it might be inside the loading boundary. Perform
-          // a revalidation, but because it's speculative, wait to do it at
-          // background priority.
-          if (background(task)) {
-            // TODO: Instead of speculatively revalidating, consider including
-            // `hasLoading` in the route tree prefetch response.
-            pingPPRSegmentRevalidation(now, route, routeKey, tree)
+      case EntryStatus.Rejected:
+        switch (nodeEntry.fetchStrategy) {
+          case FetchStrategy.PPR:
+          case FetchStrategy.PPRRuntime:
+          case FetchStrategy.Full:
+            // Previously failed. Don't retry until expiry.
+            node.entry = null
+            break
+          case FetchStrategy.LoadingBoundary: {
+            // Rejected with the old strategy — might just be behind a
+            // loading boundary. Swap for a revalidation entry.
+            const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
+              now,
+              FetchStrategy.PPR,
+              node.tree
+            )
+            if (revalidatingEntry.status === EntryStatus.Empty) {
+              upgradeToPendingSegment(revalidatingEntry, FetchStrategy.PPR)
+              node.entry = revalidatingEntry
+              needsFetch = true
+            } else {
+              node.entry = null
+            }
+            break
           }
-          break
-        default:
-          segment.fetchStrategy satisfies never
-      }
-      break
+          default:
+            nodeEntry.fetchStrategy satisfies never
+        }
+        break
+      case EntryStatus.Fulfilled:
+        // Already cached. Null out.
+        node.entry = null
+        break
+      default:
+        nodeEntry satisfies never
     }
-    case EntryStatus.Rejected: {
-      // The existing entry in the cache was rejected. Depending on how it
-      // was originally fetched, we may or may not want to revalidate it.
-      switch (segment.fetchStrategy) {
-        case FetchStrategy.PPR:
-        case FetchStrategy.PPRRuntime:
-        case FetchStrategy.Full:
-          // The previous attempt to fetch this entry failed. Don't attempt to
-          // fetch it again until the entry expires.
-          break
-        case FetchStrategy.LoadingBoundary:
-          // There's a rejected entry, but it was fetched using the loading
-          // boundary strategy. So the reason it wasn't returned by the server
-          // might just be because it was inside a loading boundary. Or because
-          // there was a dynamic rewrite. Revalidate it using the per-
-          // segment strategy.
-          //
-          // Because a rejected segment will definitely prevent the segment (and
-          // all of its children) from rendering, we perform this revalidation
-          // immediately instead of deferring it to a background task.
-          pingPPRSegmentRevalidation(now, route, routeKey, tree)
-          break
-        default:
-          segment.fetchStrategy satisfies never
-      }
-      break
-    }
-    case EntryStatus.Fulfilled:
-      // Segment is already cached. There's nothing left to prefetch.
-      break
-    default:
-      segment satisfies never
+    node = node.parent
   }
-
-  // Segments do not have dependent tasks, so once the prefetch is initiated,
-  // there's nothing else for us to do (except write the server data into the
-  // entry, which is handled by `fetchSegmentOnCacheMiss`).
+  if (!needsFetch) {
+    return
+  }
+  spawnPrefetchSubtask(
+    fetchSegmentsOnCacheMiss(route, routeKey, tree, segments, segmentCount)
+  )
 }
 
 /**
- * Walks the RouteTree (including the head metadata) and collects any segments
- * that are still Empty into a Map, upgrading them to Pending. These entries
- * will be fulfilled by the inlined prefetch response.
+ * During the tree walk, decide whether this segment should be added to the
+ * in-progress bundle (if it has InlinedIntoChild) or finalize the bundle
+ * and trigger a fetch (if it doesn't). Returns the updated bundle to pass
+ * to children, or null if a fetch was triggered.
  */
-function collectInlinedEntries(
-  now: number,
-  route: FulfilledRouteCacheEntry
-): Map<SegmentRequestKey, PendingSegmentCacheEntry> {
-  const entries = new Map<SegmentRequestKey, PendingSegmentCacheEntry>()
-  collectInlinedEntriesImpl(now, route.tree, entries)
-  // Also collect the head/metadata entry.
-  const headEntry = readOrCreateSegmentCacheEntry(
-    now,
-    FetchStrategy.PPR,
-    route.metadata
-  )
-  if (headEntry.status === EntryStatus.Empty) {
-    entries.set(
-      route.metadata.requestKey,
-      upgradeToPendingSegment(headEntry, FetchStrategy.PPR)
-    )
+/**
+ * Create a new linked list that is `chain` followed by `tail`. If chain is
+ * null, returns tail directly. Does not mutate any existing nodes.
+ */
+function appendToBundle(
+  chain: SegmentBundle | null,
+  tail: SegmentBundle
+): SegmentBundle {
+  if (chain === null) {
+    return tail
   }
-  return entries
+  return {
+    tree: chain.tree,
+    entry: chain.entry,
+    parent: appendToBundle(chain.parent, tail),
+  }
 }
 
-function collectInlinedEntriesImpl(
+function accumulateSegmentBundle(
   now: number,
+  task: PrefetchTask,
+  route: FulfilledRouteCacheEntry,
   tree: RouteTree,
-  entries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
-): void {
-  const entry = readOrCreateSegmentCacheEntry(now, FetchStrategy.PPR, tree)
-  if (entry.status === EntryStatus.Empty) {
-    entries.set(
-      tree.requestKey,
-      upgradeToPendingSegment(entry, FetchStrategy.PPR)
-    )
-  }
-  if (tree.slots !== null) {
-    for (const parallelRouteKey in tree.slots) {
-      collectInlinedEntriesImpl(now, tree.slots[parallelRouteKey], entries)
+  parentBundle: SegmentBundle | null
+): SegmentBundle | null {
+  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+
+  if (
+    process.env.__NEXT_PREFETCH_INLINING &&
+    tree.prefetchHints & PrefetchHint.InlinedIntoChild
+  ) {
+    // This segment is small enough to be bundled into a child's response.
+    // Don't issue a separate request — add it to the bundle being
+    // accumulated. Only the child with ParentInlinedIntoSelf will
+    // receive this bundle; other parallel slots get null.
+    return {
+      tree,
+      entry: segment,
+      parent: parentBundle,
     }
   }
+
+  // Not bundled. Build a single-node bundle and ping it. If this page
+  // accepts the head (HeadInlinedIntoSelf), append the head's cache entry
+  // at the tail of the bundle so it matches the server response order.
+  let effectiveParent: SegmentBundle | null = parentBundle
+  if (
+    process.env.__NEXT_PREFETCH_INLINING &&
+    tree.prefetchHints & PrefetchHint.HeadInlinedIntoSelf
+  ) {
+    effectiveParent = appendToBundle(parentBundle, {
+      tree: route.metadata,
+      entry: readOrCreateSegmentCacheEntry(
+        now,
+        FetchStrategy.PPR,
+        route.metadata
+      ),
+      parent: null,
+    })
+  }
+
+  const segments: SegmentBundle = {
+    tree,
+    entry: segment,
+    parent: effectiveParent,
+  }
+
+  pingSegmentBundle(now, task, route, task.key, tree, segments)
+  return null
 }
 
-function pingPPRSegmentRevalidation(
+function finishStaticBundleOnRuntimeBailout(
   now: number,
+  task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
-  routeKey: RouteCacheKey,
-  tree: RouteTree
+  tree: RouteTree,
+  parentBundle: SegmentBundle
 ): void {
-  const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
-    now,
-    FetchStrategy.PPR,
-    tree
-  )
-  switch (revalidatingSegment.status) {
-    case EntryStatus.Empty:
-      // Spawn a prefetch request and upsert the segment into the cache
-      // upon completion.
-      upsertSegmentOnCompletion(
-        spawnPrefetchSubtask(
-          fetchSegmentOnCacheMiss(
-            route,
-            upgradeToPendingSegment(revalidatingSegment, FetchStrategy.PPR),
-            routeKey,
-            tree
-          )
-        ),
-        getSegmentVaryPathForRequest(FetchStrategy.PPR, tree)
-      )
-      break
-    case EntryStatus.Pending:
-      // There's already a revalidation in progress.
-      break
-    case EntryStatus.Fulfilled:
-    case EntryStatus.Rejected:
-      // A previous revalidation attempt finished, but we chose not to replace
-      // the existing entry in the cache. Don't try again until or unless the
-      // revalidation entry expires.
-      break
-    default:
-      revalidatingSegment satisfies never
+  // The segments in this tree are going to be runtime prefetched, but a
+  // parent's static segment was inlined into the child. We need to finish
+  // statically prefetching the current segment bundle so the parent can
+  // be prefetched.
+  //
+  // NOTE: The server should choose not to inline a segment into its child
+  // if the parent has runtime prefetching enabled but the child does not.
+  // Arguably, we should also consider not statically generating any segments
+  // when runtime prefetching is enabled, though perhaps there are reasons
+  // to support both in the future even though they're currently
+  // mutually exclusive. We handle this case anyway for logical completeness
+  // since it's unclear whether we want to make assumptions about the
+  // relationship between runtime prefetching and inlining hints.
+  const bundle = accumulateSegmentBundle(now, task, route, tree, parentBundle)
+  if (bundle === null) {
+    // accumulateSegmentBundle already pinged the bundle. Done.
+    return
   }
+  // The segment was inlined — keep walking to find the accepting child.
+  if (tree.slots !== null) {
+    for (const parallelRouteKey in tree.slots) {
+      const childTree = tree.slots[parallelRouteKey]
+      if (childTree.prefetchHints & PrefetchHint.ParentInlinedIntoSelf) {
+        finishStaticBundleOnRuntimeBailout(now, task, route, childTree, bundle)
+        return
+      }
+    }
+  }
+  // No child accepts the bundle. This shouldn't happen if hints are
+  // consistent, but if it does, just drop the bundle.
 }
 
 function pingFullSegmentRevalidation(

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -9,7 +9,6 @@ import type {
 } from '../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../shared/lib/app-router-types'
 import { readVaryParams } from '../../shared/lib/segment-cache/vary-params-decoding'
-import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -308,7 +307,8 @@ export async function collectPrefetchHints(
     head,
     HEAD_REQUEST_KEY,
     headVaryParams,
-    clientModules
+    clientModules,
+    null
   )
   const headGzipSize = await getGzipSize(headBuffer)
 
@@ -400,7 +400,8 @@ async function collectPrefetchHintsImpl(
       seedData[0],
       requestKey,
       varyParams,
-      clientModules
+      clientModules,
+      null
     )
     currentGzipSize = await getGzipSize(buffer)
   }
@@ -607,10 +608,20 @@ async function PrefetchTreeData({
       ? readVaryParams(headVaryParamsThenable)
       : null
 
+  // Only applies when prefetch inlining is enabled — the client doesn't
+  // know to look for the head inside a page's response otherwise.
+  const headIsInlined =
+    prefetchInlining &&
+    hints !== null &&
+    !(hints.hints & PrefetchHint.HeadOutlined)
+
   // Compute the route metadata tree by traversing the FlightRouterState. As we
   // walk the tree, we will also spawn a task to produce a prefetch response for
   // each segment (unless prefetch inlining is enabled, in which case all
   // segments are bundled into a single /_inlined response).
+  const headBundle: SegmentBundleNode | null = headIsInlined
+    ? { rsc: head, varyParams: headVaryParams, next: null }
+    : null
   const tree = collectSegmentDataImpl(
     isClientParamParsingEnabled,
     flightRouterState,
@@ -621,31 +632,14 @@ async function PrefetchTreeData({
     ROOT_SEGMENT_REQUEST_KEY,
     segmentTasks,
     prefetchInlining,
-    hints
+    hints,
+    null,
+    headBundle
   )
 
-  if (prefetchInlining) {
-    // When prefetch inlining is enabled, bundle all segment data into a single
-    // /_inlined response instead of individual per-segment responses. The head
-    // is also included in the inlined response.
-    segmentTasks.push(
-      waitAtLeastOneReactRenderTask().then(() =>
-        renderInlinedPrefetchResponse(
-          flightRouterState,
-          buildId,
-          staleTime,
-          seedData,
-          head,
-          headVaryParams,
-          clientModules
-        )
-      )
-    )
-  } else {
-    // Also spawn a task to produce a prefetch response for the "head" segment.
-    // The head contains metadata, like the title; it's not really a route
-    // segment, but it contains RSC data, so it's treated like a segment by
-    // the client cache.
+  // Spawn a task to produce a prefetch response for the "head" segment,
+  // unless it was inlined into a page's bundle.
+  if (!headIsInlined) {
     segmentTasks.push(
       waitAtLeastOneReactRenderTask().then(() =>
         renderSegmentPrefetch(
@@ -654,7 +648,8 @@ async function PrefetchTreeData({
           head,
           HEAD_REQUEST_KEY,
           headVaryParams,
-          clientModules
+          clientModules,
+          null
         )
       )
     )
@@ -676,6 +671,32 @@ async function PrefetchTreeData({
   return treePrefetch
 }
 
+/**
+ * Server-side equivalent of the client's SegmentBundle linked list. Each
+ * node holds the RSC data and vary params for a segment whose data will
+ * be bundled into a descendant's response. Flattened to an array only at
+ * serialization time in renderSegmentPrefetch.
+ */
+type SegmentBundleNode = {
+  rsc: React.ReactNode
+  varyParams: Set<string> | null
+  next: SegmentBundleNode | null
+}
+
+function appendToBundleChain(
+  chain: SegmentBundleNode | null,
+  tail: SegmentBundleNode
+): SegmentBundleNode {
+  if (chain === null) {
+    return tail
+  }
+  return {
+    rsc: chain.rsc,
+    varyParams: chain.varyParams,
+    next: appendToBundleChain(chain.next, tail),
+  }
+}
+
 function collectSegmentDataImpl(
   isClientParamParsingEnabled: boolean,
   route: FlightRouterState,
@@ -686,8 +707,81 @@ function collectSegmentDataImpl(
   requestKey: SegmentRequestKey,
   segmentTasks: Array<Promise<[string, Buffer]>>,
   prefetchInlining: boolean,
-  hintTree: PrefetchHints | null
+  hintTree: PrefetchHints | null,
+  parentBundle: SegmentBundleNode | null,
+  headBundle: SegmentBundleNode | null
 ): TreePrefetch {
+  // Union the hints already embedded in the FlightRouterState with the
+  // separately-computed build-time hints. During the initial build, the
+  // FlightRouterState was produced before collectPrefetchHints ran, so
+  // inlining hints (ParentInlinedIntoSelf, InlinedIntoChild) won't be in
+  // route[4] yet. On subsequent renders the hints are already in the
+  // FlightRouterState, so the union is idempotent.
+  const prefetchHints =
+    (route[4] ?? 0) | (hintTree !== null ? hintTree.hints : 0)
+
+  // Determine which params this segment varies on.
+  // Read the vary params thenable directly from the seed data. By the time
+  // collectSegmentData runs, the thenable should be fulfilled. If it's not
+  // fulfilled or null, treat as unknown (null means we can't share cache
+  // entries across param values).
+  const varyParamsThenable = seedData !== null ? seedData[4] : null
+  const varyParams =
+    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+
+  // Determine whether this segment's data should be accumulated into a
+  // child's response (inlining) or spawned as its own task. When inlining
+  // is disabled, the hint bits may still be set (they're computed at build
+  // time regardless) but we ignore them — every segment is rendered
+  // standalone because the client doesn't know how to parse bundled
+  // responses.
+  let childBundle: SegmentBundleNode | null = null
+  if (prefetchInlining && prefetchHints & PrefetchHint.InlinedIntoChild) {
+    // This segment is small enough that its data will be included in one
+    // of its children's responses. Don't spawn a separate task — prepend
+    // this segment's data onto the linked list so the accepting child can
+    // bundle it into its response.
+    if (seedData !== null) {
+      childBundle = {
+        rsc: seedData[0],
+        varyParams,
+        next: parentBundle,
+      }
+    }
+  } else {
+    // This segment is not inlined into a child. Spawn a task to render it.
+    // If it has ParentInlinedIntoSelf, the accumulated parents are included
+    // in its response. Otherwise parentBundle is null and it renders as a
+    // standalone single-segment response.
+    if (seedData !== null) {
+      let bundle =
+        prefetchHints & PrefetchHint.ParentInlinedIntoSelf ? parentBundle : null
+      // If this page accepts the head, append it at the tail of the chain.
+      // The tail becomes the last element of the serialized array, matching
+      // the client's SegmentBundle linked list order.
+      if (
+        headBundle !== null &&
+        prefetchHints & PrefetchHint.HeadInlinedIntoSelf
+      ) {
+        bundle = appendToBundleChain(bundle, headBundle)
+      }
+      segmentTasks.push(
+        waitAtLeastOneReactRenderTask().then(() =>
+          renderSegmentPrefetch(
+            buildId,
+            staleTime,
+            seedData[0],
+            requestKey,
+            varyParams,
+            clientModules,
+            bundle
+          )
+        )
+      )
+    }
+    // childBundle stays null — reset the accumulator for children.
+  }
+
   // Metadata about the segment. Sent as part of the tree prefetch. Null if
   // there are no children.
   let slotMetadata: { [parallelRouteKey: string]: TreePrefetch } | null = null
@@ -719,59 +813,14 @@ function collectSegmentDataImpl(
       childRequestKey,
       segmentTasks,
       prefetchInlining,
-      childHintTree
+      childHintTree,
+      childBundle,
+      headBundle
     )
     if (slotMetadata === null) {
       slotMetadata = {}
     }
     slotMetadata[parallelRouteKey] = childTree
-  }
-
-  // Union the hints already embedded in the FlightRouterState with the
-  // separately-computed build-time hints. During the initial build, the
-  // FlightRouterState was produced before collectPrefetchHints ran, so
-  // inlining hints (ParentInlinedIntoSelf, InlinedIntoChild) won't be in
-  // route[4] yet. On subsequent renders the hints are already in the
-  // FlightRouterState, so the union is idempotent.
-  const prefetchHints =
-    (route[4] ?? 0) | (hintTree !== null ? hintTree.hints : 0)
-
-  // Determine which params this segment varies on.
-  // Read the vary params thenable directly from the seed data. By the time
-  // collectSegmentData runs, the thenable should be fulfilled. If it's not
-  // fulfilled or null, treat as unknown (null means we can't share cache
-  // entries across param values).
-  const varyParamsThenable = seedData !== null ? seedData[4] : null
-  const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
-
-  if (!prefetchInlining) {
-    // When prefetch inlining is disabled, spawn individual segment tasks.
-    // When enabled, segment data is bundled into the /_inlined response
-    // instead, so we skip per-segment tasks here.
-    if (seedData !== null) {
-      // Spawn a task to write the segment data to a new Flight stream.
-      segmentTasks.push(
-        // Since we're already in the middle of a render, wait until after the
-        // current task to escape the current rendering context.
-        waitAtLeastOneReactRenderTask().then(() =>
-          renderSegmentPrefetch(
-            buildId,
-            staleTime,
-            seedData[0],
-            requestKey,
-            varyParams,
-            clientModules
-          )
-        )
-      )
-    } else {
-      // This segment does not have any seed data. Skip generating a prefetch
-      // response for it. We'll still include it in the route tree, though.
-      // TODO: We should encode in the route tree whether a segment is missing
-      // so we don't attempt to fetch it for no reason. As of now this shouldn't
-      // ever happen in practice, though.
-    }
   }
 
   const segment = route[0]
@@ -807,131 +856,63 @@ async function renderSegmentPrefetch(
   rsc: React.ReactNode,
   requestKey: SegmentRequestKey,
   varyParams: Set<string> | null,
-  clientModules: ManifestNode
+  clientModules: ManifestNode,
+  bundle: SegmentBundleNode | null
 ): Promise<[SegmentRequestKey, Buffer]> {
-  // Render the segment data to a stream.
-  const segmentPrefetch: SegmentPrefetch = {
+  // Build the SegmentPrefetch for the terminal (requested) segment.
+  const selfPrefetch: SegmentPrefetch = {
     rsc,
     isPartial: await isPartialRSCData(rsc, clientModules),
     staleTime,
     varyParams,
   }
   if (buildId) {
-    segmentPrefetch.buildId = buildId
+    selfPrefetch.buildId = buildId
   }
+
+  // When there's a bundle (inlined parents/head), render as a
+  // SegmentPrefetch[] array: [terminal, innermost_parent, ...,
+  // outermost_parent]. When there's no bundle, render as a single
+  // SegmentPrefetch object.
+  let payload: SegmentPrefetch | SegmentPrefetch[]
+  if (bundle !== null) {
+    const segments: SegmentPrefetch[] = [selfPrefetch]
+    // Walk the bundle linked list and append each entry to the array.
+    let node: SegmentBundleNode | null = bundle
+    while (node !== null) {
+      const parentPrefetch: SegmentPrefetch = {
+        rsc: node.rsc,
+        isPartial: await isPartialRSCData(node.rsc, clientModules),
+        staleTime,
+        varyParams: node.varyParams,
+      }
+      if (buildId) {
+        parentPrefetch.buildId = buildId
+      }
+      segments.push(parentPrefetch)
+      node = node.next
+    }
+    payload = segments
+  } else {
+    payload = selfPrefetch
+  }
+
   // Since all we're doing is decoding and re-encoding a cached prerender, if
   // it takes longer than a microtask, it must because of hanging promises
   // caused by dynamic data. Abort the stream at the end of the current task.
   const abortController = new AbortController()
   waitAtLeastOneReactRenderTask().then(() => abortController.abort())
-  const { prelude: segmentStream } = await prerender(
-    segmentPrefetch,
-    clientModules,
-    {
-      filterStackFrame,
-      signal: abortController.signal,
-      onError: onSegmentPrerenderError,
-    }
-  )
+  const { prelude: segmentStream } = await prerender(payload, clientModules, {
+    filterStackFrame,
+    signal: abortController.signal,
+    onError: onSegmentPrerenderError,
+  })
   const segmentBuffer = await streamToBuffer(segmentStream)
   if (requestKey === ROOT_SEGMENT_REQUEST_KEY) {
     return ['/_index' as SegmentRequestKey, segmentBuffer]
   } else {
     return [requestKey, segmentBuffer]
   }
-}
-
-async function renderInlinedPrefetchResponse(
-  route: FlightRouterState,
-  buildId: string | undefined,
-  staleTime: number,
-  seedData: CacheNodeSeedData | null,
-  head: HeadData,
-  headVaryParams: Set<string> | null,
-  clientModules: ManifestNode
-): Promise<[SegmentRequestKey, Buffer]> {
-  // Build the inlined tree by walking the route and collecting all segments.
-  const inlinedTree = await buildInlinedSegmentPrefetch(
-    route,
-    buildId,
-    staleTime,
-    seedData,
-    clientModules
-  )
-
-  // Build the head segment.
-  const headPrefetch: SegmentPrefetch = {
-    rsc: head,
-    isPartial: await isPartialRSCData(head, clientModules),
-    staleTime,
-    varyParams: headVaryParams,
-  }
-  if (buildId) {
-    headPrefetch.buildId = buildId
-  }
-
-  const response: InlinedPrefetchResponse = {
-    tree: inlinedTree,
-    head: headPrefetch,
-  }
-
-  // Render as a single Flight response.
-  const abortController = new AbortController()
-  waitAtLeastOneReactRenderTask().then(() => abortController.abort())
-  const { prelude } = await prerender(response, clientModules, {
-    filterStackFrame,
-    signal: abortController.signal,
-    onError: onSegmentPrerenderError,
-  })
-  const buffer = await streamToBuffer(prelude)
-  return [('/' + PAGE_SEGMENT_KEY) as SegmentRequestKey, buffer]
-}
-
-async function buildInlinedSegmentPrefetch(
-  route: FlightRouterState,
-  buildId: string | undefined,
-  staleTime: number,
-  seedData: CacheNodeSeedData | null,
-  clientModules: ManifestNode
-): Promise<InlinedSegmentPrefetch> {
-  let slots: {
-    [parallelRouteKey: string]: InlinedSegmentPrefetch
-  } | null = null
-
-  const children = route[1]
-  const seedDataChildren = seedData !== null ? seedData[1] : null
-  for (const parallelRouteKey in children) {
-    const childRoute = children[parallelRouteKey]
-    const childSeedData =
-      seedDataChildren !== null ? seedDataChildren[parallelRouteKey] : null
-    const childPrefetch = await buildInlinedSegmentPrefetch(
-      childRoute,
-      buildId,
-      staleTime,
-      childSeedData,
-      clientModules
-    )
-    if (slots === null) {
-      slots = {}
-    }
-    slots[parallelRouteKey] = childPrefetch
-  }
-
-  const rsc = seedData !== null ? seedData[0] : null
-  const varyParamsThenable = seedData !== null ? seedData[4] : null
-  const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
-
-  const segment: SegmentPrefetch = {
-    rsc,
-    isPartial: rsc !== null ? await isPartialRSCData(rsc, clientModules) : true,
-    staleTime,
-    varyParams,
-  }
-  if (buildId) {
-    segment.buildId = buildId
-  }
-  return { segment, slots }
 }
 
 async function isPartialRSCData(

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -1,3 +1,36 @@
+import { LinkAccordion } from '../components/link-accordion'
+
 export default function Page() {
-  return <p>hello world</p>
+  return (
+    <div>
+      <h1 id="home">Home</h1>
+      <ul>
+        <li>
+          <LinkAccordion href="/test-small-chain">Small chain</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-deep/a/b/c">Deep chain</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-outlined">Outlined</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-restart/large-middle/after">
+            Restart
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-parallel">Parallel</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-dynamic/hello">Dynamic</LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-runtime-bailout">
+            Runtime bailout
+          </LinkAccordion>
+        </li>
+      </ul>
+    </div>
+  )
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-deep/a/b/c/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-deep/a/b/c/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>Deep page</p>
+  return <p id="page-deep">Deep page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-dynamic/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-dynamic/[slug]/page.tsx
@@ -4,7 +4,7 @@ export default async function Page({
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params
-  return <p>Dynamic page: {slug}</p>
+  return <p id="page-dynamic">{`Dynamic page: ${slug}`}</p>
 }
 
 export function generateStaticParams() {

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-outlined/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-outlined/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>Outlined test page</p>
+  return <p id="page-outlined">Outlined test page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-parallel/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-parallel/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>Main content</p>
+  return <p id="page-parallel">Main content</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-restart/large-middle/after/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-restart/large-middle/after/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>After page</p>
+  return <p id="page-restart">After page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-small-chain/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-small-chain/page.tsx
@@ -1,3 +1,3 @@
 export default function SmallChainPage() {
-  return <p>Small chain page</p>
+  return <p id="page-small-chain">Small chain page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -1,4 +1,6 @@
 import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
 
 // Bit values from PrefetchHint enum (const enum, so we duplicate values here)
 const ParentInlinedIntoSelf = 0b100000 // 32
@@ -138,6 +140,34 @@ describe('prefetch inlining', () => {
      outlined ■      └── "__PAGE__"
      "
     `)
+
+    // Verify client navigation works with the inlined data: prefetch via
+    // link accordion, then navigate. All segment data should be available
+    // without additional requests.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-small-chain"]')
+          .click()
+      },
+      { includes: 'Small chain page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-small-chain"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-small-chain').text()).toBe(
+      'Small chain page'
+    )
   })
 
   it('outlined: large segment breaks the inlining chain', async () => {
@@ -154,6 +184,32 @@ describe('prefetch inlining', () => {
      outlined ■      └── "__PAGE__"
      "
     `)
+
+    // Even with a large outlined segment, navigation should still work.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-outlined"]')
+          .click()
+      },
+      { includes: 'Outlined test page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-outlined"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-outlined').text()).toBe(
+      'Outlined test page'
+    )
   })
 
   it('parallel routes: parent inlines into one slot only', async () => {
@@ -190,6 +246,31 @@ describe('prefetch inlining', () => {
        "
       `)
     }
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-parallel"]')
+          .click()
+      },
+      { includes: 'Main content' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-parallel"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-parallel').text()).toBe(
+      'Main content'
+    )
   })
 
   it('home: root inlines directly into page', async () => {
@@ -223,6 +304,40 @@ describe('prefetch inlining', () => {
      outlined ■              └── "__PAGE__"
      "
     `)
+
+    // Navigate to the restart route. Two inlining groups means multiple
+    // segment responses, but navigation should still work correctly.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    // Prefetch and then navigate. This route has a large outlined segment
+    // in the middle which produces multiple inlining groups and multiple
+    // segment responses.
+    await act(
+      async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/test-restart/large-middle/after"]'
+          )
+          .click()
+      },
+      { includes: 'After page' }
+    )
+
+    await act(async () => {
+      await browser
+        .elementByCss('a[href="/test-restart/large-middle/after"]')
+        .click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-restart').text()).toBe(
+      'After page'
+    )
   })
 
   it('deep chain: all small segments inline to the leaf', async () => {
@@ -239,6 +354,31 @@ describe('prefetch inlining', () => {
      outlined ■                  └── "__PAGE__"
      "
     `)
+
+    // Navigate to the deep chain. All segments are inlined into the page's
+    // response, so a single prefetch request covers everything.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-deep/a/b/c"]')
+          .click()
+      },
+      { includes: 'Deep page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-deep/a/b/c"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-deep').text()).toBe('Deep page')
   })
 
   it('dynamic route: hints are based on concrete params, not fallback shell', async () => {
@@ -264,5 +404,68 @@ describe('prefetch inlining', () => {
     // pattern, not concrete path)
     const data2 = await fetchRouteTreePrefetch(next, '/test-dynamic/world')
     expect(renderInliningTree(data2.tree)).toBe(helloTree)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-dynamic/hello"]')
+          .click()
+      },
+      { includes: 'Dynamic page: hello' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-dynamic/hello"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-dynamic').text()).toBe(
+      'Dynamic page: hello'
+    )
+  })
+
+  it('runtime bailout: static bundle is flushed when child uses runtime prefetch', async () => {
+    // Root → small static layout → page with runtime prefetch. The layout
+    // is small enough to be bundled, but the page uses runtime prefetching.
+    // The bundled layout data must be flushed as a separate static prefetch
+    // so it's not lost when the traversal bails out to runtime mode.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    // Prefetch the route. The static layout data should be included in the
+    // prefetch responses even though the page uses runtime prefetching.
+    // We check for 'Static layout content' to verify the layout's static
+    // data was prefetched (not just the runtime page data).
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-runtime-bailout"]')
+          .click()
+      },
+      { includes: 'Static layout content' }
+    )
+
+    // Navigate and verify both the static layout and runtime page render
+    await browser
+      .elementByCss('a[href="/test-runtime-bailout"]')
+      .click()
+    expect(
+      await browser.elementByCss('#layout-runtime-bailout').text()
+    ).toBe('Static layout content')
+    expect(
+      await browser.elementByCss('#page-runtime-bailout').text()
+    ).toMatch(/Runtime page/)
   })
 })


### PR DESCRIPTION
Based on:

- https://github.com/vercel/next.js/pull/90891

---

Part 2 of 2. Wires up the client to consume the size-based hints computed in the previous commit, completing the feature.

The Client Segment Cache splits page prefetches into per-segment requests so that shared layouts can be cached independently and reused across sibling routes. A page with N segments produces N separate prefetch requests, each individually cacheable at the CDN edge. This is a significant improvement over the previous approach of fetching all page data in a single request — navigating between sibling routes that share a layout no longer re-downloads the layout's data, because it's already cached from a previous navigation.

The trade-off is request volume. Below some compressed size, the per-request overhead (HTTP headers, connection setup, CDN cache lookup latency) exceeds the deduplication benefit of a standalone cacheable response. This is the same trade-off that JS bundlers face when deciding whether to inline a module into a chunk vs keeping it as a separate file: below a threshold, inlining is strictly better.

## Static cacheability

This bundling optimization applies specifically to static prefetch responses — the ones served from the CDN. These responses must be statically cacheable, so the bundling decisions can't vary per request. This is why the hints are computed once at build time and remain fixed for the lifetime of the deployment. They're persisted to a manifest and embedded into the route tree prefetch response, so the client always sees the same bundling shape for a given build.

Hints are not recomputed during ISR/revalidation either. If revalidation could change the hints, the client would need to re-fetch the route tree after every revalidation to learn about the new bundling shape, defeating the purpose of caching the tree independently. By keeping hints stable across revalidations, the tree response and the segment responses can all be cached at the CDN edge without coordination.

Runtime prefetches (for dynamic segments that can't be pre-rendered) don't need this — they already bundle all segments into a single dynamic response, the same way navigation requests do. The bundling optimization here is about closing the gap between the request efficiency of dynamic responses and the cacheability of static ones.

## Architecture

The core abstraction is a "segment bundle" — a linked list of segment cache entries (client) or segment RSC data (server) that maps 1:1 to a single HTTP response. A standalone segment is a bundle of length 1. A segment with inlined parents is a longer bundle. The same data structure and fetch/fulfill logic handles both cases, so there are no separate code paths for inlined vs non-inlined segments.

On the server, when rendering a segment whose hint says its parent was inlined into it, the response contains a SegmentPrefetch[] array instead of a single SegmentPrefetch. The array contains the terminal segment followed by each inlined ancestor, innermost to outermost.

On the client, the prefetch tree walk accumulates a bundle linked list as it traverses segments marked InlinedIntoChild. When it reaches a segment that isn't inlined, the accumulated bundle is finalized and a single fetch is spawned. The response is then walked in parallel with the bundle, fulfilling each cache entry from its corresponding array element.

The head (metadata/viewport) is also bundled. During the hint computation pass, the head's gzip size is measured alongside the segments. At each page leaf, the algorithm checks whether the head fits within the remaining maxBundleSize. If it does, the head is appended to that page's bundle and the standalone head fetch is skipped. If no page has room, a HeadOutlined flag on the root tells the client to fetch the head separately, preserving the existing behavior.