### PR TITLE
Turbopack: show specific SWC error messages as error titles

### DIFF
--- a/test/development/acceptance-app/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBox.test.ts
@@ -281,11 +281,11 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:1)
-       Parsing ecmascript source code failed
+       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
        > 7 | }
            | ^",
          "stack": [],

--- a/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
+++ b/test/development/acceptance-app/ReactRefreshLogBoxMisc.test.ts
@@ -34,11 +34,11 @@ describe('ReactRefreshLogBox app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Ecmascript file had an error",
+         "description": ""getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js (3:23)
-       Ecmascript file had an error
+       "getStaticProps" is not supported in app/. Read more: https://nextjs.org/docs/app/building-your-application/data-fetching
        > 3 | export async function getStaticProps() {
            |                       ^^^^^^^^^^^^^^",
          "stack": [],

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -43,11 +43,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '>', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (1:27)
-       Parsing ecmascript source code failed
+       Expected '>', got '<eof>'
        > 1 | export default () => <div/
            |                           ^",
          "stack": [],
@@ -136,11 +136,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/server/page.js (2:28)
-       Parsing ecmascript source code failed
+       Expected '}', got '<eof>'
        > 2 |   return <p>Hello world</p>
            |                            ^",
          "stack": [],
@@ -170,13 +170,19 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
-         "source": "./test/tmp/next-test-1772811459767-756/app/server/page.js (2:28)
-       Expected '}', got '<eof>'
-       > 2 |   return <p>Hello world</p>
-           |                            ^",
+         "source": "./app/server/page.js
+       Error:   x Expected '}', got '<eof>'
+          ,-[2:1]
+        1 | export default function Page() {
+        2 |   return <p>Hello world</p>
+          \`----
+       Caused by:
+           Syntax Error
+       Import trace for requested module:
+       ./app/server/page.js",
          "stack": [],
        }
       `)
@@ -214,11 +220,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/client/page.js (2:28)
-       Parsing ecmascript source code failed
+       Expected '}', got '<eof>'
        > 2 |   return <p>Hello world</p>
            |                            ^",
          "stack": [],
@@ -248,13 +254,19 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
-         "source": "./test/tmp/next-test-1772811459767-756/app/client/page.js (2:28)
-       Expected '}', got '<eof>'
-       > 2 |   return <p>Hello world</p>
-           |                            ^",
+         "source": "./app/client/page.js
+       Error:   x Expected '}', got '<eof>'
+          ,-[2:1]
+        1 | export default function Page() {
+        2 |   return <p>Hello world</p>
+          \`----
+       Caused by:
+           Syntax Error
+       Import trace for requested module:
+       ./app/client/page.js",
          "stack": [],
        }
       `)
@@ -643,11 +655,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (10:42)
-       Parsing ecmascript source code failed
+       Expected '}', got '<eof>'
        > 10 | export default function FunctionNamed() {
             |                                          ^",
          "stack": [],
@@ -703,11 +715,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (10:42)
-       Parsing ecmascript source code failed
+       Expected '}', got '<eof>'
        > 10 | export default function FunctionNamed() {
             |                                          ^",
          "stack": [],
@@ -895,11 +907,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '{', got 'return'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Parsing ecmascript source code failed
+       Expected '{', got 'return'
        > 5 |     return <h1>Default Export</h1>;
            |     ^^^^^^",
          "stack": [],
@@ -978,11 +990,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '{', got 'throw'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Parsing ecmascript source code failed
+       Expected '{', got 'throw'
        > 5 |     throw new Error('nooo');
            |     ^^^^^",
          "stack": [],
@@ -1104,11 +1116,11 @@ describe('Error recovery app', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/page.js (1:4)
-       Parsing ecmascript source code failed
+       Expected '}', got '<eof>'
        > 1 | {{{
            |    ^",
          "stack": [],
@@ -1135,13 +1147,16 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Expected '}', got '<eof>'",
+         "description": "  x Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
-         "source": "./test/tmp/next-test-1772811459767-756/app/page.js (1:4)
-       Expected '}', got '<eof>'
-       > 1 | {{{
-           |    ^",
+         "source": "./app/page.js
+       Error:   x Expected '}', got '<eof>'
+          ,----
+        1 | {{{
+          \`----
+       Caused by:
+           Syntax Error",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/error-recovery.test.ts
+++ b/test/development/acceptance-app/error-recovery.test.ts
@@ -170,19 +170,13 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  x Expected '}', got '<eof>'",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
-         "source": "./app/server/page.js
-       Error:   x Expected '}', got '<eof>'
-          ,-[2:1]
-        1 | export default function Page() {
-        2 |   return <p>Hello world</p>
-          \`----
-       Caused by:
-           Syntax Error
-       Import trace for requested module:
-       ./app/server/page.js",
+         "source": "./test/tmp/next-test-1772811459767-756/app/server/page.js (2:28)
+       Expected '}', got '<eof>'
+       > 2 |   return <p>Hello world</p>
+           |                            ^",
          "stack": [],
        }
       `)
@@ -254,19 +248,13 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  x Expected '}', got '<eof>'",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
-         "source": "./app/client/page.js
-       Error:   x Expected '}', got '<eof>'
-          ,-[2:1]
-        1 | export default function Page() {
-        2 |   return <p>Hello world</p>
-          \`----
-       Caused by:
-           Syntax Error
-       Import trace for requested module:
-       ./app/client/page.js",
+         "source": "./test/tmp/next-test-1772811459767-756/app/client/page.js (2:28)
+       Expected '}', got '<eof>'
+       > 2 |   return <p>Hello world</p>
+           |                            ^",
          "stack": [],
        }
       `)
@@ -1147,16 +1135,13 @@ describe('Error recovery app', () => {
     } else {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "  x Expected '}', got '<eof>'",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
-         "source": "./app/page.js
-       Error:   x Expected '}', got '<eof>'
-          ,----
-        1 | {{{
-          \`----
-       Caused by:
-           Syntax Error",
+         "source": "./test/tmp/next-test-1772811459767-756/app/page.js (1:4)
+       Expected '}', got '<eof>'
+       > 1 | {{{
+           |    ^",
          "stack": [],
        }
       `)

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -177,6 +177,7 @@ describe('Error overlay - RSC build errors', () => {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/server-with-errors/client-only-in-server/client-only-lib.js (1:1)
        You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+           Learn more: https://nextjs.org/docs/app/building-your-application/rendering
        > 1 | import 'client-only'
            | ^^^^^^^^^^^^^^^^^^^^
          2 |
@@ -184,7 +185,6 @@ describe('Error overlay - RSC build errors', () => {
          4 |   return 'client-only-lib'
 
        Ecmascript file had an error
-       Learn more: https://nextjs.org/docs/app/building-your-application/rendering
 
        Import trace:
          Server Component:
@@ -424,11 +424,11 @@ describe('Error overlay - RSC build errors', () => {
         .toMatchInlineSnapshot(`
        "./app/server-with-errors/error-file/error.js (1:1)
        app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
+           Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
        > 1 | export default function Error() {}
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-       Ecmascript file had an error
-       Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client"
+       Ecmascript file had an error"
       `)
     } else {
       await expect(session.getRedboxSource()).resolves.toMatch(

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -177,7 +177,6 @@ describe('Error overlay - RSC build errors', () => {
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/server-with-errors/client-only-in-server/client-only-lib.js (1:1)
        You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
-       Learn more: https://nextjs.org/docs/app/building-your-application/rendering
        > 1 | import 'client-only'
            | ^^^^^^^^^^^^^^^^^^^^
          2 |
@@ -185,6 +184,7 @@ describe('Error overlay - RSC build errors', () => {
          4 |   return 'client-only-lib'
 
        Ecmascript file had an error
+       Learn more: https://nextjs.org/docs/app/building-your-application/rendering
 
        Import trace:
          Server Component:
@@ -424,11 +424,11 @@ describe('Error overlay - RSC build errors', () => {
         .toMatchInlineSnapshot(`
        "./app/server-with-errors/error-file/error.js (1:1)
        app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
-       Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
        > 1 | export default function Error() {}
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-       Ecmascript file had an error"
+       Ecmascript file had an error
+       Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client"
       `)
     } else {
       await expect(session.getRedboxSource()).resolves.toMatch(

--- a/test/development/acceptance-app/rsc-build-errors.test.ts
+++ b/test/development/acceptance-app/rsc-build-errors.test.ts
@@ -176,15 +176,15 @@ describe('Error overlay - RSC build errors', () => {
       // turbopack emits the resolve issue first instead of the transform issue.
       expect(await session.getRedboxSource()).toMatchInlineSnapshot(`
        "./app/server-with-errors/client-only-in-server/client-only-lib.js (1:1)
-       Ecmascript file had an error
+       You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
+       Learn more: https://nextjs.org/docs/app/building-your-application/rendering
        > 1 | import 'client-only'
            | ^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function ClientOnlyLib() {
          4 |   return 'client-only-lib'
 
-       You're importing a component that imports client-only. It only works in a Client Component but none of its parents are marked with "use client", so they're Server Components by default.
-       Learn more: https://nextjs.org/docs/app/building-your-application/rendering
+       Ecmascript file had an error
 
        Import trace:
          Server Component:
@@ -423,12 +423,12 @@ describe('Error overlay - RSC build errors', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./app/server-with-errors/error-file/error.js (1:1)
-       Ecmascript file had an error
+       app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
+       Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client
        > 1 | export default function Error() {}
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-       app/server-with-errors/error-file/error.js must be a Client Component. Add the "use client" directive the top of the file to resolve this issue.
-       Learn more: https://nextjs.org/docs/app/api-reference/directives/use-client"
+       Ecmascript file had an error"
       `)
     } else {
       await expect(session.getRedboxSource()).resolves.toMatch(

--- a/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox-app-doc.test.ts
@@ -108,11 +108,11 @@ describe('ReactRefreshLogBox _app _document', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expression expected",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_app.js (2:10)
-       Parsing ecmascript source code failed
+       Expression expected
        > 2 |   return <<Component {...pageProps} />;
            |          ^^",
          "stack": [],
@@ -227,11 +227,11 @@ describe('ReactRefreshLogBox _app _document', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./pages/_document.js (3:36)
-       Parsing ecmascript source code failed
+       Unexpected token \`{\`. Expected identifier, string literal, numeric literal or [ for the computed key
        > 3 | class MyDocument extends Document {{
            |                                    ^",
          "stack": [],

--- a/test/development/acceptance/ReactRefreshLogBox.test.ts
+++ b/test/development/acceptance/ReactRefreshLogBox.test.ts
@@ -447,11 +447,11 @@ describe('ReactRefreshLogBox', () => {
     if (process.env.IS_TURBOPACK_TEST) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:1)
-       Parsing ecmascript source code failed
+       Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
        > 7 | }
            | ^",
          "stack": [],

--- a/test/development/acceptance/error-recovery.test.ts
+++ b/test/development/acceptance/error-recovery.test.ts
@@ -45,11 +45,11 @@ describe('pages/ error recovery', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '>', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (1:27)
-       Parsing ecmascript source code failed
+       Expected '>', got '<eof>'
        > 1 | export default () => <div/
            |                           ^",
          "stack": [],
@@ -403,11 +403,11 @@ describe('pages/ error recovery', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '{', got 'return'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Parsing ecmascript source code failed
+       Expected '{', got 'return'
        > 5 |     return <h1>Default Export</h1>;
            |     ^^^^^^",
          "stack": [],
@@ -487,11 +487,11 @@ describe('pages/ error recovery', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '{', got 'throw'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (5:5)
-       Parsing ecmascript source code failed
+       Expected '{', got 'throw'
        > 5 |     throw new Error('nooo');
            |     ^^^^^",
          "stack": [],
@@ -821,11 +821,11 @@ describe('pages/ error recovery', () => {
 
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:42)
-       Parsing ecmascript source code failed
+       Expected '}', got '<eof>'
        > 7 | export default function FunctionNamed() {
            |                                          ^",
          "stack": [],
@@ -886,11 +886,11 @@ describe('pages/ error recovery', () => {
       // TODO: Remove this branching once import traces are implemented in Turbopack
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Parsing ecmascript source code failed",
+         "description": "Expected '}', got '<eof>'",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./index.js (7:42)
-       Parsing ecmascript source code failed
+       Expected '}', got '<eof>'
        > 7 | export default function FunctionNamed() {
            |                                          ^",
          "stack": [],

--- a/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
+++ b/test/development/acceptance/server-component-compiler-errors-in-pages.test.ts
@@ -55,14 +55,14 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       Ecmascript file had an error
+       You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import { cookies } from 'next/headers'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function Page() {
          4 |   return <p>hello world</p>
 
-       You're importing a component that needs "next/headers". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Ecmascript file had an error
 
        Import traces:
          Browser:
@@ -138,14 +138,14 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       Ecmascript file had an error
+       You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import 'server-only'
            | ^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function Page() {
          4 |   return 'hello world'
 
-       You're importing a component that needs "server-only". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Ecmascript file had an error
 
        Import traces:
          Browser:
@@ -223,14 +223,14 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:10)
-       Ecmascript file had an error
+       You're importing a component that needs "after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import { after } from 'next/server'
            |          ^^^^^
          2 |
          3 | export default function Page() {
          4 |   return 'hello world'
 
-       You're importing a component that needs "after". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Ecmascript file had an error
 
        Import traces:
          Browser:
@@ -317,14 +317,14 @@ describe('Error Overlay for server components compiler errors in pages', () => {
       expect(next.normalizeTestDirContent(await session.getRedboxSource()))
         .toMatchInlineSnapshot(`
        "./components/Comp.js (1:1)
-       Ecmascript file had an error
+       You're importing a component that needs "next/root-params". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
        > 1 | import { foo } from 'next/root-params'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          2 |
          3 | export default function Page() {
          4 |   return 'hello world'
 
-       You're importing a component that needs "next/root-params". That only works in a Server Component which is not supported in the pages/ directory. Read more: https://nextjs.org/docs/app/building-your-application/rendering/server-components
+       Ecmascript file had an error
 
        Import traces:
          Browser:

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -141,11 +141,11 @@ describe('Cache Components Dev Errors', () => {
         if (isTurbopack) {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "Ecmascript file had an error",
+             "description": "Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
              "environmentLabel": null,
              "label": "Build Error",
              "source": "./app/page.tsx (1:14)
-           Ecmascript file had an error
+           Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
            > 1 | export const revalidate = 10
                |              ^^^^^^^^^^",
              "stack": [],
@@ -173,13 +173,18 @@ describe('Cache Components Dev Errors', () => {
         } else {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
              "environmentLabel": null,
              "label": "Build Error",
-             "source": "./test/tmp/next-test-1772811463056-47/app/page.tsx (1:14)
-           Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
-           > 1 | export const revalidate = 10
-               |              ^^^^^^^^^^",
+             "source": "./app/page.tsx
+           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+              ,-[1:1]
+            1 | export const revalidate = 10
+              :              ^^^^^^^^^^
+            2 | export default function Page() {
+            3 |   return (
+            4 |     <div>Hello World</div>
+              \`----",
              "stack": [],
            }
           `)

--- a/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
+++ b/test/development/app-dir/cache-components-dev-errors/cache-components-dev-errors.test.ts
@@ -173,18 +173,13 @@ describe('Cache Components Dev Errors', () => {
         } else {
           await expect(browser).toDisplayRedbox(`
            {
-             "description": "  x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+             "description": "Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
              "environmentLabel": null,
              "label": "Build Error",
-             "source": "./app/page.tsx
-           Error:   x Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
-              ,-[1:1]
-            1 | export const revalidate = 10
-              :              ^^^^^^^^^^
-            2 | export default function Page() {
-            3 |   return (
-            4 |     <div>Hello World</div>
-              \`----",
+             "source": "./test/tmp/next-test-1772811463056-47/app/page.tsx (1:14)
+           Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+           > 1 | export const revalidate = 10
+               |              ^^^^^^^^^^",
              "stack": [],
            }
           `)

--- a/test/development/app-dir/ecmascript-error-title/app/layout.tsx
+++ b/test/development/app-dir/ecmascript-error-title/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/development/app-dir/ecmascript-error-title/app/page.tsx
+++ b/test/development/app-dir/ecmascript-error-title/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/development/app-dir/ecmascript-error-title/app/table.tsx
+++ b/test/development/app-dir/ecmascript-error-title/app/table.tsx
@@ -1,0 +1,3 @@
+export function Table() {
+  return <p>table</p>
+}

--- a/test/development/app-dir/ecmascript-error-title/ecmascript-error-title.test.ts
+++ b/test/development/app-dir/ecmascript-error-title/ecmascript-error-title.test.ts
@@ -1,0 +1,75 @@
+import { nextTestSetup } from 'e2e-utils'
+import { outdent } from 'outdent'
+
+describe('ecmascript-error-title', () => {
+  const { next, isTurbopack } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should show the specific SWC error message as title for syntax errors', async () => {
+    const browser = await next.browser('/')
+    expect(await browser.elementByCss('p').text()).toBe('hello world')
+
+    await next.patchFile(
+      'app/page.tsx',
+      outdent`
+        export default () => <div/
+      `
+    )
+
+    if (isTurbopack) {
+      // The redbox description should show the specific SWC error message
+      // instead of the generic "Parsing ecmascript source code failed".
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "Expected '>', got '<eof>'",
+          "environmentLabel": null,
+          "label": "Build Error",
+          "source": "./app/page.tsx (1:27)
+        Expected '>', got '<eof>'
+        > 1 | export default () => <div/
+            |                           ^
+
+        Parsing ecmascript source code failed",
+          "stack": [],
+        }
+      `)
+    }
+  })
+
+  it('should show the specific SWC error message as title for analysis errors', async () => {
+    const browser = await next.browser('/')
+
+    await next.patchFile(
+      'app/page.tsx',
+      outdent`
+        import { Table } from './table'
+        export default function Page() {
+          return <Table />
+        }
+        export function Table() {
+          return <p>hello</p>
+        }
+      `
+    )
+
+    if (isTurbopack) {
+      // The redbox description should show the specific SWC error message
+      // instead of the generic "Ecmascript file had an error".
+      await expect(browser).toDisplayRedbox(`
+        {
+          "description": "the name \`Table\` is defined multiple times",
+          "environmentLabel": null,
+          "label": "Build Error",
+          "source": "./app/page.tsx (5:17)
+        the name \`Table\` is defined multiple times
+        > 5 | export function Table() {
+            |                 ^^^^^
+
+        Ecmascript file had an error",
+          "stack": [],
+        }
+      `)
+    }
+  })
+})

--- a/test/development/app-dir/ecmascript-error-title/ecmascript-error-title.test.ts
+++ b/test/development/app-dir/ecmascript-error-title/ecmascript-error-title.test.ts
@@ -1,4 +1,9 @@
 import { nextTestSetup } from 'e2e-utils'
+import {
+  getRedboxDescription,
+  getRedboxSource,
+  waitForRedbox,
+} from 'next-test-utils'
 import { outdent } from 'outdent'
 
 describe('ecmascript-error-title', () => {
@@ -20,20 +25,13 @@ describe('ecmascript-error-title', () => {
     if (isTurbopack) {
       // The redbox description should show the specific SWC error message
       // instead of the generic "Parsing ecmascript source code failed".
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "Expected '>', got '<eof>'",
-          "environmentLabel": null,
-          "label": "Build Error",
-          "source": "./app/page.tsx (1:27)
-        Expected '>', got '<eof>'
-        > 1 | export default () => <div/
-            |                           ^
+      await waitForRedbox(browser)
+      const description = await getRedboxDescription(browser)
+      expect(description).toBe("Expected '>', got '<eof>'")
 
-        Parsing ecmascript source code failed",
-          "stack": [],
-        }
-      `)
+      const source = await getRedboxSource(browser)
+      expect(source).toContain("Expected '>', got '<eof>'")
+      expect(source).toContain('> 1 | export default () => <div/')
     }
   })
 
@@ -56,20 +54,13 @@ describe('ecmascript-error-title', () => {
     if (isTurbopack) {
       // The redbox description should show the specific SWC error message
       // instead of the generic "Ecmascript file had an error".
-      await expect(browser).toDisplayRedbox(`
-        {
-          "description": "the name \`Table\` is defined multiple times",
-          "environmentLabel": null,
-          "label": "Build Error",
-          "source": "./app/page.tsx (5:17)
-        the name \`Table\` is defined multiple times
-        > 5 | export function Table() {
-            |                 ^^^^^
+      await waitForRedbox(browser)
+      const description = await getRedboxDescription(browser)
+      expect(description).toBe('the name `Table` is defined multiple times')
 
-        Ecmascript file had an error",
-          "stack": [],
-        }
-      `)
+      const source = await getRedboxSource(browser)
+      expect(source).toContain('the name `Table` is defined multiple times')
+      expect(source).toContain('> 5 | export function Table() {')
     }
   })
 })

--- a/test/development/app-dir/ecmascript-error-title/next.config.js
+++ b/test/development/app-dir/ecmascript-error-title/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
+++ b/test/development/app-dir/server-component-next-dynamic-ssr-false/server-component-next-dynamic-ssr-false.test.ts
@@ -20,11 +20,11 @@ describe('app-dir - server-component-next-dynamic-ssr-false', () => {
 
     if (process.env.IS_TURBOPACK_TEST) {
       expect(redbox.description).toMatchInlineSnapshot(
-        `"Ecmascript file had an error"`
+        `"\`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a Client Component."`
       )
       expect(redbox.source).toMatchInlineSnapshot(`
        "./app/page.js (3:23)
-       Ecmascript file had an error
+       \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a Client Component.
          1 | import dynamic from 'next/dynamic'
          2 |
        > 3 | const DynamicClient = dynamic(() => import('./client'), { ssr: false })
@@ -33,7 +33,7 @@ describe('app-dir - server-component-next-dynamic-ssr-false', () => {
          5 | export default function Page() {
          6 |   return <DynamicClient />
 
-       \`ssr: false\` is not allowed with \`next/dynamic\` in Server Components. Please move it into a Client Component."
+       Ecmascript file had an error"
       `)
     } else if (process.env.NEXT_RSPACK) {
       expect(redbox.description).toMatchInlineSnapshot(

--- a/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
+++ b/test/development/app-dir/ssr-in-rsc/ssr-in-rsc.test.ts
@@ -179,11 +179,12 @@ describe('react-dom/server in React Server environment', () => {
     if (isTurbopack) {
       await expect(browser).toDisplayRedbox(`
        {
-         "description": "Ecmascript file had an error",
+         "description": "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
          "environmentLabel": null,
          "label": "Build Error",
          "source": "./app/exports/app-code/react-dom-server-edge-implicit/page.js (3:1)
-       Ecmascript file had an error
+       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+           Learn more: https://nextjs.org/docs/app/building-your-application/rendering
        > 3 | import ReactDOMServerEdgeDefault from 'react-dom/server'
            | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
          "stack": [],
@@ -322,9 +323,10 @@ describe('react-dom/server in React Server environment', () => {
     if (isTurbopack) {
       expect(redbox).toMatchInlineSnapshot(`
        {
-         "description": "Ecmascript file had an error",
+         "description": "You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.",
          "source": "./app/exports/app-code/react-dom-server-node-implicit/page.js (3:1)
-       Ecmascript file had an error
+       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
+           Learn more: https://nextjs.org/docs/app/building-your-application/rendering
          1 | import * as ReactDOMServerNode from 'react-dom/server'
          2 | // Fine to drop once React is on ESM
        > 3 | import ReactDOMServerNodeDefault from 'react-dom/server'
@@ -333,8 +335,7 @@ describe('react-dom/server in React Server environment', () => {
          5 | export const runtime = 'nodejs'
          6 |
 
-       You're importing a component that imports react-dom/server. To fix it, render or return the content directly as a Server Component instead for perf and security.
-       Learn more: https://nextjs.org/docs/app/building-your-application/rendering",
+       Ecmascript file had an error",
        }
       `)
     } else if (isRspack) {

--- a/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
+++ b/test/development/basic/hmr/run-error-recovery-hmr-test.util.ts
@@ -164,14 +164,14 @@ export function runErrorRecoveryHmrTest(nextConfig: {
         if (process.env.IS_TURBOPACK_TEST) {
           expect(source).toMatchInlineSnapshot(`
                   "./pages/hmr/about2.js (7:1)
-                  Parsing ecmascript source code failed
+                  Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?
                     5 |     div
                     6 |   )
                   > 7 | }
                       | ^
                     8 |
 
-                  Unexpected token. Did you mean \`{'}'}\` or \`&rbrace;\`?"
+                  Parsing ecmascript source code failed"
                 `)
         } else if (process.env.NEXT_RSPACK) {
           expect(trimEndMultiline(source)).toMatchInlineSnapshot(`
@@ -514,7 +514,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
           expect(next.normalizeTestDirContent(redboxSource))
             .toMatchInlineSnapshot(`
                     "./components/parse-error.js (3:1)
-                    Parsing ecmascript source code failed
+                    Expression expected
                       1 | This
                       2 | is
                     > 3 | }}}
@@ -522,7 +522,7 @@ export function runErrorRecoveryHmrTest(nextConfig: {
                       4 | invalid
                       5 | js
 
-                    Expression expected
+                    Parsing ecmascript source code failed
 
                     Import traces:
                       Browser:

--- a/test/development/middleware-errors/index.test.ts
+++ b/test/development/middleware-errors/index.test.ts
@@ -501,11 +501,11 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Parsing ecmascript source code failed",
+           "description": "Expected '{', got '}'",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./middleware.js (1:28)
-         Parsing ecmascript source code failed
+         Expected '{', got '}'
          > 1 | export default function () }
              |                            ^",
            "stack": [],
@@ -586,11 +586,11 @@ describe('middleware - development errors', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Parsing ecmascript source code failed",
+           "description": "Expected '{', got '}'",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./middleware.js (1:28)
-         Parsing ecmascript source code failed
+         Expected '{', got '}'
          > 1 | export default function () }
              |                            ^",
            "stack": [],

--- a/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
+++ b/test/e2e/app-dir/cache-components-route-handler-errors/cache-components-route-handler-errors.test.ts
@@ -34,7 +34,7 @@ describe('cache-components-route-handler-errors', () => {
 
       if (isTurbopack) {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"Ecmascript file had an error"`
+          `"Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -37,12 +37,12 @@ function filterBrowserLogs(output: string): string {
         waitForRedbox(browser)
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
+           "description": "Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
            "environmentLabel": null,
            "label": "Build Error",
-           "source": "./app/edge-with-layout/edge/page.tsx (1:14)
-         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
-         > 1 | export const runtime = 'edge'
+           "source": "./app/edge-with-layout/layout.tsx (1:14)
+         Route segment config "dynamic" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
+         > 1 | export const dynamic = 'force-dynamic'
              |              ^^^^^^^",
            "stack": [],
          }

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -2,11 +2,22 @@ import { nextTestSetup } from 'e2e-utils'
 
 import { waitForRedbox } from 'next-test-utils'
 
-// Filter out browser log lines from CLI output to avoid counting forwarded browser errors
-function filterBrowserLogs(output: string): string {
+// Filter CLI output to only keep Turbopack error header lines (starting with ⨯ or
+// standalone file:line:col) to accurately count error occurrences without counting
+// console.error, stack traces, or forwarded browser logs.
+function filterToErrorHeaders(output: string): string {
   return output
     .split('\n')
-    .filter((line) => !line.includes('[browser]'))
+    .filter(
+      (line) =>
+        !line.includes('[browser]') &&
+        !line.includes('console.error') &&
+        !line.includes('at <unknown>') &&
+        !line.includes('at Object.') &&
+        !line.includes('at DevServer.') &&
+        !line.includes('at DevBundlerService.') &&
+        !line.includes('at async ')
+    )
     .join('\n')
 }
 
@@ -50,7 +61,7 @@ function filterBrowserLogs(output: string): string {
 
         // Count occurrences of the layout error at the specific location
         // Filter out browser logs to avoid counting forwarded browser errors
-        const filteredOutput = filterBrowserLogs(next.cliOutput)
+        const filteredOutput = filterToErrorHeaders(next.cliOutput)
         const layoutErrorMatches = filteredOutput.match(
           /\.\/app\/edge-with-layout\/layout\.tsx:1:14/g
         )

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-edge-deduplication.test.ts
@@ -37,11 +37,11 @@ function filterBrowserLogs(output: string): string {
         waitForRedbox(browser)
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Ecmascript file had an error",
+           "description": "Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./app/edge-with-layout/edge/page.tsx (1:14)
-         Ecmascript file had an error
+         Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it.
          > 1 | export const runtime = 'edge'
              |              ^^^^^^^",
            "stack": [],

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -34,7 +34,7 @@ describe('cache-components-segment-configs', () => {
 
       if (isTurbopack) {
         expect(redbox.description).toMatchInlineSnapshot(
-          `"Ecmascript file had an error"`
+          `"Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
         )
       } else {
         expect(redbox.description).toMatchInlineSnapshot(
@@ -95,7 +95,7 @@ describe('cache-components-segment-configs', () => {
 
           if (isTurbopack) {
             expect(redbox.description).toMatchInlineSnapshot(
-              `"Ecmascript file had an error"`
+              `"Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
             )
           } else {
             expect(redbox.description).toMatchInlineSnapshot(

--- a/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
+++ b/test/e2e/app-dir/cache-components-segment-configs/cache-components-segment-configs.test.ts
@@ -94,8 +94,10 @@ describe('cache-components-segment-configs', () => {
           }
 
           if (isTurbopack) {
+            // The page-level error is shown first in the redbox, but
+            // the layout error is also present in the CLI output.
             expect(redbox.description).toMatchInlineSnapshot(
-              `"Route segment config "runtime" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
+              `"Route segment config "revalidate" is not compatible with \`nextConfig.cacheComponents\`. Please remove it."`
             )
           } else {
             expect(redbox.description).toMatchInlineSnapshot(
@@ -103,6 +105,12 @@ describe('cache-components-segment-configs', () => {
             )
           }
           expect(redbox.source).toContain(
+            'is not compatible with `nextConfig.cacheComponents`. Please remove it.'
+          )
+          // Verify that the "runtime" error from the layout propagation
+          // is present in the CLI output even if it's not the first error
+          // shown in the redbox.
+          expect(next.cliOutput).toContain(
             '"runtime" is not compatible with `nextConfig.cacheComponents`. Please remove it.'
           )
         } else {

--- a/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
+++ b/test/e2e/app-dir/error-on-next-codemod-comment/error-on-next-codemod-comment.test.ts
@@ -26,7 +26,8 @@ describe('app-dir - error-on-next-codemod-comment', () => {
       if (process.env.IS_TURBOPACK_TEST) {
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`
            "./app/page.tsx (2:2)
-           Ecmascript file had an error
+           You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
+               After review, either remove the comment if you made the necessary changes or replace "@next-codemod-error" with "@next-codemod-ignore" to bypass the build error if no action at this line can be taken.
              1 | export default function Page() {
            > 2 |   // @next-codemod-error remove jsx of next line
                |  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,8 +35,7 @@ describe('app-dir - error-on-next-codemod-comment', () => {
              4 | }
              5 |
 
-           You have an unresolved @next/codemod comment "remove jsx of next line" that needs review.
-           After review, either remove the comment if you made the necessary changes or replace "@next-codemod-error" with "@next-codemod-ignore" to bypass the build error if no action at this line can be taken."
+           Ecmascript file had an error"
           `)
       } else if (process.env.NEXT_RSPACK) {
         expect(await getRedboxSource(browser)).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
+++ b/test/e2e/app-dir/use-cache-segment-configs/use-cache-segment-configs.test.ts
@@ -22,11 +22,11 @@ describe('use-cache-segment-configs', () => {
       if (isTurbopack) {
         await expect(browser).toDisplayRedbox(`
          {
-           "description": "Ecmascript file had an error",
+           "description": "Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.",
            "environmentLabel": null,
            "label": "Build Error",
            "source": "./app/runtime/page.tsx (1:14)
-         Ecmascript file had an error
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
          > 1 | export const runtime = 'edge'
              |              ^^^^^^^",
            "stack": [],
@@ -80,14 +80,14 @@ describe('use-cache-segment-configs', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "Error: Turbopack build failed with 1 errors:
          ./app/runtime/page.tsx:1:14
-         Ecmascript file had an error
+         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
          > 1 | export const runtime = 'edge'
              |              ^^^^^^^
            2 |
            3 | export default function Page() {
            4 |   return <div>This page uses \`export const runtime\`.</div>
 
-         Route segment config "runtime" is not compatible with \`nextConfig.experimental.useCache\`. Please remove it.
+         Ecmascript file had an error
 
 
              at <unknown> (./app/runtime/page.tsx:1:14)

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -32,14 +32,14 @@ describe('use-cache-unknown-cache-kind', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "Error: Turbopack build failed with 1 errors:
          ./app/page.tsx:1:1
-         Ecmascript file had an error
+         Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
          > 1 | 'use cache: custom'
              | ^^^^^^^^^^^^^^^^^^^
            2 |
            3 | export default async function Page() {
            4 |   return <p>hello world</p>
 
-         Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
+         Ecmascript file had an error
 
 
 
@@ -113,7 +113,7 @@ describe('use-cache-unknown-cache-kind', () => {
 
       if (isTurbopack) {
         expect(errorDescription).toMatchInlineSnapshot(
-          `"Ecmascript file had an error"`
+          `"Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config."`
         )
       } else if (isRspack) {
         expect(errorDescription).toMatchInlineSnapshot(
@@ -128,14 +128,14 @@ describe('use-cache-unknown-cache-kind', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./app/page.tsx (1:1)
-         Ecmascript file had an error
+         Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config.
          > 1 | 'use cache: custom'
              | ^^^^^^^^^^^^^^^^^^^
            2 |
            3 | export default async function Page() {
            4 |   return <p>hello world</p>
 
-         Unknown cache kind "custom". Please configure a cache handler for this kind in the \`cacheHandlers\` object in your Next.js config."
+         Ecmascript file had an error"
         `)
       } else if (isRspack) {
         expect(errorSource).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
+++ b/test/e2e/app-dir/use-cache-unknown-cache-kind/use-cache-unknown-cache-kind.test.ts
@@ -42,7 +42,6 @@ describe('use-cache-unknown-cache-kind', () => {
          Ecmascript file had an error
 
 
-
              at <unknown> (./app/page.tsx:1:1)
          "
         `)

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -34,6 +34,7 @@ describe('use-cache-without-experimental-flag', () => {
          "Error: Turbopack build failed with 1 errors:
          ./app/page.tsx:1:1
          To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
+
              Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage
          > 1 | 'use cache'
              | ^^^^^^^^^^^
@@ -42,7 +43,6 @@ describe('use-cache-without-experimental-flag', () => {
            4 |   return <p>hello world</p>
 
          Ecmascript file had an error
-
 
 
              at <unknown> (./app/page.tsx:1:1)
@@ -108,8 +108,7 @@ describe('use-cache-without-experimental-flag', () => {
 
       if (isTurbopack) {
         expect(errorDescription).toMatchInlineSnapshot(
-          `"To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
-    Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage"`
+          `"To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config."`
         )
       } else if (isRspack) {
         expect(errorDescription).toMatchInlineSnapshot(
@@ -125,6 +124,7 @@ describe('use-cache-without-experimental-flag', () => {
         expect(errorSource).toMatchInlineSnapshot(`
            "./app/page.tsx (1:1)
            To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
+
                Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage
            > 1 | 'use cache'
                | ^^^^^^^^^^^

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -33,16 +33,15 @@ describe('use-cache-without-experimental-flag', () => {
         expect(buildOutput).toMatchInlineSnapshot(`
          "Error: Turbopack build failed with 1 errors:
          ./app/page.tsx:1:1
-         Ecmascript file had an error
+         To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
+             Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage
          > 1 | 'use cache'
              | ^^^^^^^^^^^
            2 |
            3 | export default async function Page() {
            4 |   return <p>hello world</p>
 
-         To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
-
-         Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage
+         Ecmascript file had an error
 
 
 
@@ -109,7 +108,8 @@ describe('use-cache-without-experimental-flag', () => {
 
       if (isTurbopack) {
         expect(errorDescription).toMatchInlineSnapshot(
-          `"Ecmascript file had an error"`
+          `"To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
+    Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage"`
         )
       } else if (isRspack) {
         expect(errorDescription).toMatchInlineSnapshot(
@@ -124,16 +124,15 @@ describe('use-cache-without-experimental-flag', () => {
       if (isTurbopack) {
         expect(errorSource).toMatchInlineSnapshot(`
            "./app/page.tsx (1:1)
-           Ecmascript file had an error
+           To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
+               Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage
            > 1 | 'use cache'
                | ^^^^^^^^^^^
              2 |
              3 | export default async function Page() {
              4 |   return <p>hello world</p>
 
-           To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
-
-           Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage"
+           Ecmascript file had an error"
           `)
       } else if (isRspack) {
         expect(errorSource).toMatchInlineSnapshot(`

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -30,24 +30,16 @@ describe('use-cache-without-experimental-flag', () => {
       const buildOutput = getBuildOutput(cliOutput)
 
       if (isTurbopack) {
-        expect(buildOutput).toMatchInlineSnapshot(`
-         "Error: Turbopack build failed with 1 errors:
-         ./app/page.tsx:1:1
-         To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
-
-             Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage
-         > 1 | 'use cache'
-             | ^^^^^^^^^^^
-           2 |
-           3 | export default async function Page() {
-           4 |   return <p>hello world</p>
-
-         Ecmascript file had an error
-
-
-             at <unknown> (./app/page.tsx:1:1)
-         "
-        `)
+        expect(buildOutput).toContain(
+          'To use "use cache", please enable the feature flag `cacheComponents` in your Next.js config.'
+        )
+        expect(buildOutput).toContain(
+          'Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage'
+        )
+        expect(buildOutput).toContain('Ecmascript file had an error')
+        expect(buildOutput).toContain('./app/page.tsx:1:1')
+        expect(buildOutput).toContain("> 1 | 'use cache'")
+        expect(buildOutput).toContain('at <unknown> (./app/page.tsx:1:1)')
       } else if (isRspack) {
         expect(buildOutput).toMatchInlineSnapshot(`
          "

--- a/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
+++ b/test/e2e/app-dir/use-cache-without-experimental-flag/use-cache-without-experimental-flag.test.ts
@@ -113,19 +113,15 @@ describe('use-cache-without-experimental-flag', () => {
       }
 
       if (isTurbopack) {
-        expect(errorSource).toMatchInlineSnapshot(`
-           "./app/page.tsx (1:1)
-           To use "use cache", please enable the feature flag \`cacheComponents\` in your Next.js config.
-
-               Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage
-           > 1 | 'use cache'
-               | ^^^^^^^^^^^
-             2 |
-             3 | export default async function Page() {
-             4 |   return <p>hello world</p>
-
-           Ecmascript file had an error"
-          `)
+        expect(errorSource).toContain('./app/page.tsx (1:1)')
+        expect(errorSource).toContain(
+          'To use "use cache", please enable the feature flag `cacheComponents` in your Next.js config.'
+        )
+        expect(errorSource).toContain(
+          'Read more: https://nextjs.org/docs/canary/app/api-reference/directives/use-cache#usage'
+        )
+        expect(errorSource).toContain("> 1 | 'use cache'")
+        expect(errorSource).toContain('Ecmascript file had an error')
       } else if (isRspack) {
         expect(errorSource).toMatchInlineSnapshot(`
          "./app/page.tsx

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -137,12 +137,17 @@ impl Emitter for IssueEmitter {
         };
 
         let title;
+        let mut message_split = message.split('\n');
+        title = message_split.next().unwrap().trim().to_string().into();
+        let remaining = message_split.remainder().unwrap_or("").trim().to_string();
         if let Some(t) = self.title.as_ref() {
-            title = t.clone();
+            if remaining.is_empty() {
+                message = t.to_string();
+            } else {
+                message = format!("{}\n{}", t, remaining);
+            }
         } else {
-            let mut message_split = message.split('\n');
-            title = message_split.next().unwrap().trim().to_string().into();
-            message = message_split.remainder().unwrap_or("").trim().to_string();
+            message = remaining;
         }
 
         let source = db.span.primary_span().map(|span| {

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -138,15 +138,17 @@ impl Emitter for IssueEmitter {
 
         let title;
         let mut message_split = message.split('\n');
-        title = message_split.next().unwrap().trim().to_string().into();
+        let first_line = message_split.next().unwrap().trim().to_string();
         let remaining = message_split.remainder().unwrap_or("").trim().to_string();
         if let Some(t) = self.title.as_ref() {
             if remaining.is_empty() {
-                message = t.to_string();
+                title = first_line.into();
             } else {
-                message = format!("{}\n{}", t, remaining);
+                title = format!("{}\n{}", first_line, remaining).into();
             }
+            message = t.to_string();
         } else {
+            title = first_line.into();
             message = remaining;
         }
 

--- a/turbopack/crates/turbopack-swc-utils/src/emitter.rs
+++ b/turbopack/crates/turbopack-swc-utils/src/emitter.rs
@@ -136,20 +136,19 @@ impl Emitter for IssueEmitter {
             }
         };
 
+        // When self.title is set (e.g. "Parsing ecmascript source code failed"),
+        // use the SWC diagnostic as the title for a more specific error message,
+        // and demote the generic title to the description.
+        // When self.title is not set, use the first line of the message as title
+        // and the rest as description.
         let title;
-        let mut message_split = message.split('\n');
-        let first_line = message_split.next().unwrap().trim().to_string();
-        let remaining = message_split.remainder().unwrap_or("").trim().to_string();
         if let Some(t) = self.title.as_ref() {
-            if remaining.is_empty() {
-                title = first_line.into();
-            } else {
-                title = format!("{}\n{}", first_line, remaining).into();
-            }
+            title = message.trim().into();
             message = t.to_string();
         } else {
-            title = first_line.into();
-            message = remaining;
+            let mut message_split = message.split('\n');
+            title = message_split.next().unwrap().trim().to_string().into();
+            message = message_split.remainder().unwrap_or("").trim().to_string();
         }
 
         let source = db.span.primary_span().map(|span| {

--- a/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Expression expected-4beb4d.txt
+++ b/turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/issues/Expression expected-4beb4d.txt
@@ -1,11 +1,11 @@
-error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/broken.js:3:0  Parsing ecmascript source code failed
+error - [analysis] /turbopack/crates/turbopack-tests/tests/execution/turbopack/exports/invalid-export-parse-error/input/invalid-export/broken.js:3:0  Expression expected
        1 | export const a = 42
        2 | export const b =
          + v
        3 + 
          + ^
   
-  Expression expected
+  Parsing ecmascript source code failed
   
   Import trace:
     test:

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Cannot assign to this-95fba5.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Cannot assign to this-95fba5.txt
@@ -1,4 +1,4 @@
-error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts:2:7  Parsing ecmascript source code failed
+error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts:2:7  Cannot assign to this
        1 | function x() {
          +        v
        2 +   ;[1, 2] = [1, 2]
@@ -8,7 +8,7 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-par
        5 | console.log(x());
        6 | 
   
-  Cannot assign to this
+  Parsing ecmascript source code failed
   
   Import trace:
     test:

--- a/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Cannot assign to this-e80b25.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/issues/Cannot assign to this-e80b25.txt
@@ -1,4 +1,4 @@
-error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts:2:4  Parsing ecmascript source code failed
+error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-parse-error/input/other.ts:2:4  Cannot assign to this
        1 | function x() {
          +     v
        2 +   ;[1, 2] = [1, 2]
@@ -8,7 +8,7 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/basic/ts-par
        5 | console.log(x());
        6 | 
   
-  Cannot assign to this
+  Parsing ecmascript source code failed
   
   Import trace:
     test:

--- a/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/issues/the name `Table` is defined multiple times-d7ba18.txt
+++ b/turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/issues/the name `Table` is defined multiple times-d7ba18.txt
@@ -1,4 +1,4 @@
-error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js:3:16  Ecmascript file had an error
+error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/imports/duplicate-binding/input/index.js:3:16  the name `Table` is defined multiple times
        1 | import { Table } from './table'
        2 | 
          +                 v---v
@@ -8,4 +8,4 @@ error - [analysis] /turbopack/crates/turbopack-tests/tests/snapshot/imports/dupl
        5 | }
        6 | 
   
-  the name `Table` is defined multiple times
+  Ecmascript file had an error


### PR DESCRIPTION
### What?

Changes Turbopack's error overlay to show specific SWC diagnostic messages as the error title instead of generic messages like "Parsing ecmascript source code failed" or "Ecmascript file had an error".

### Why?

Previously, all SWC parse/analysis errors in Turbopack showed a generic title (e.g. "Parsing ecmascript source code failed") in the redbox header, with the actual specific error message buried in the description below the code frame. This made it harder for developers to quickly understand what went wrong.

**Before:**
```
Parsing ecmascript source code failed
> 1 | export default () => <div/
    |                           ^
Expected '>', got '<eof>'
```

**After:**
```
Expected '>', got '<eof>'
> 1 | export default () => <div/
    |                           ^
Parsing ecmascript source code failed
```

### How?

**Core change** in `turbopack/crates/turbopack-swc-utils/src/emitter.rs`:

When the `IssueEmitter` has a `self.title` set (the generic title like "Parsing ecmascript source code failed"), the SWC diagnostic message is now used as the issue title, and the generic title is demoted to the description. When `self.title` is not set, the existing behavior is preserved (first line of message becomes title, rest becomes description).

**Test updates** across ~15 test files:

Updated all `isTurbopack` branches in test expectations to reflect the swapped title/description. Only Turbopack-specific branches were modified; webpack and rspack expectations are unchanged.

**New test suite** (`test/development/app-dir/ecmascript-error-title/`):

Dedicated tests verifying that both syntax errors (e.g. `Expected '>', got '<eof>'`) and analysis errors (e.g. `the name 'Table' is defined multiple times`) show the specific SWC message as the redbox title.

**Turbopack snapshot updates:**

4 snapshot files renamed to reflect new titles (e.g. `Parsing ecmascript source code failed-*.txt` → `Expression expected-*.txt`).