### PR TITLE
fix: preserve middleware Vary header in app pages

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -548,7 +548,30 @@ export async function handler(
       resolvedPathname,
       interceptionRoutePatterns
     )
-    res.setHeader('Vary', varyHeader)
+    // Merge with any existing Vary values (e.g. from middleware) to avoid
+    // overwriting them. Uses a Set for case-insensitive deduplication.
+    const existingVary = res.getHeader('Vary')
+    const existingValues =
+      typeof existingVary === 'string'
+        ? existingVary.split(',').map((v) => v.trim())
+        : Array.isArray(existingVary)
+          ? existingVary.flatMap((v) =>
+              String(v)
+                .split(',')
+                .map((s) => s.trim())
+            )
+          : []
+    const newValues = varyHeader.split(',').map((v) => v.trim())
+    const seen = new Set<string>()
+    const merged: string[] = []
+    for (const value of [...existingValues, ...newValues]) {
+      const lower = value.toLowerCase()
+      if (value && !seen.has(lower)) {
+        seen.add(lower)
+        merged.push(value)
+      }
+    }
+    res.setHeader('Vary', merged.join(', '))
     let parentSpan: Span | undefined
     const invokeRouteModule = async (
       span: Span | undefined,

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -235,32 +235,45 @@ async function requestHandler(
       headers.set('Vary', varyHeader)
     }
 
-    // Add existing headers, merging multi-value headers like Vary to avoid
-    // overwriting values set above (e.g. from middleware).
-    for (const [key, value] of Object.entries({
-      ...baseRes.getHeaders(),
-      ...metadata.headers,
-    })) {
-      if (value !== undefined) {
-        if (Array.isArray(value)) {
-          for (const v of value) {
-            headers.append(key, String(v))
+    // Add existing headers from both sources, iterating separately to avoid
+    // spread shadowing (where metadata.headers would overwrite baseRes values
+    // for the same key, e.g. Vary).
+    const headerSources = [baseRes.getHeaders(), metadata.headers]
+    for (const source of headerSources) {
+      if (!source) continue
+      for (const [key, value] of Object.entries(source)) {
+        if (value === undefined) continue
+        if (key.toLowerCase() === 'vary') {
+          // Merge Vary values to preserve any previously set entries,
+          // handling both string and array values with case-insensitive dedup.
+          const existing = headers.get('Vary') || ''
+          const existingValues = new Set(
+            existing.split(',').map((v) => v.trim().toLowerCase())
+          )
+          const newValues = Array.isArray(value) ? value : [value]
+          const additions: string[] = []
+          for (const v of newValues) {
+            const items = String(v)
+              .split(',')
+              .map((i) => i.trim())
+            for (const item of items) {
+              if (item && !existingValues.has(item.toLowerCase())) {
+                existingValues.add(item.toLowerCase())
+                additions.push(item)
+              }
+            }
           }
-        } else if (key.toLowerCase() === 'vary') {
-          // Merge Vary values to preserve any previously set entries
-          const existing = headers.get('Vary')
-          const existingValues = existing
-            ? existing.split(',').map((v) => v.trim().toLowerCase())
-            : []
-          const additions = String(value)
-            .split(',')
-            .map((v) => v.trim())
-            .filter((v) => v && !existingValues.includes(v.toLowerCase()))
           if (additions.length > 0) {
             headers.set(
               'Vary',
-              existing ? `${existing}, ${additions.join(', ')}` : additions.join(', ')
+              existing
+                ? `${existing}, ${additions.join(', ')}`
+                : additions.join(', ')
             )
+          }
+        } else if (Array.isArray(value)) {
+          for (const v of value) {
+            headers.append(key, String(v))
           }
         } else {
           headers.set(key, String(value))

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -235,16 +235,32 @@ async function requestHandler(
       headers.set('Vary', varyHeader)
     }
 
-    // Add existing headers
+    // Add existing headers, merging multi-value headers like Vary to avoid
+    // overwriting values set above (e.g. from middleware).
     for (const [key, value] of Object.entries({
       ...baseRes.getHeaders(),
       ...metadata.headers,
     })) {
       if (value !== undefined) {
         if (Array.isArray(value)) {
-          // Handle multiple header values
           for (const v of value) {
             headers.append(key, String(v))
+          }
+        } else if (key.toLowerCase() === 'vary') {
+          // Merge Vary values to preserve any previously set entries
+          const existing = headers.get('Vary')
+          const existingValues = existing
+            ? existing.split(',').map((v) => v.trim().toLowerCase())
+            : []
+          const additions = String(value)
+            .split(',')
+            .map((v) => v.trim())
+            .filter((v) => v && !existingValues.includes(v.toLowerCase()))
+          if (additions.length > 0) {
+            headers.set(
+              'Vary',
+              existing ? `${existing}, ${additions.join(', ')}` : additions.join(', ')
+            )
           }
         } else {
           headers.set(key, String(value))

--- a/test/e2e/vary-header/app/app/layout.js
+++ b/test/e2e/vary-header/app/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/vary-header/app/app/page-test/page.js
+++ b/test/e2e/vary-header/app/app/page-test/page.js
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Hello from app page</p>
+}

--- a/test/e2e/vary-header/test/index.test.ts
+++ b/test/e2e/vary-header/test/index.test.ts
@@ -47,4 +47,23 @@ describe('Vary Header Tests', () => {
       'next-router-prefetch',
     ])
   })
+
+  it('should preserve middleware vary header in app pages', async () => {
+    const res = await next.fetch('/page-test')
+    const varyHeader = res.headers.get('vary')
+    const customHeader = res.headers.get('my-custom-header')
+
+    // Middleware header is set
+    expect(customHeader).toBe('test')
+
+    // Middleware vary header is preserved
+    expectVaryHeaderToContain(varyHeader, ['my-custom-header'])
+
+    // Next.js internal headers are still present
+    expectVaryHeaderToContain(varyHeader, [
+      'rsc',
+      'next-router-state-tree',
+      'next-router-prefetch',
+    ])
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #85999

The `handler` function in the app page template (`app-page.ts`) used `res.setHeader('Vary', varyHeader)` which **overwrote** any Vary headers previously set by middleware or by `base-server.ts`'s `setVaryHeader()`. This caused CDN cache issues because custom Vary values added by middleware (e.g. `Vary: X-Foo`) were silently discarded, leading to incorrect cache behavior.

### Root Cause

The request lifecycle for app pages is:

1. **Middleware** sets custom Vary headers (e.g. `Vary: X-Foo`) via `response.headers.append('vary', ...)`
2. **`base-server.ts:setVaryHeader()`** correctly uses `res.appendHeader('vary', ...)` to add RSC headers without overwriting
3. **`app-page.ts:handler()`** calls `res.setHeader('Vary', varyHeader)` which **overwrites everything** from steps 1 and 2

The handler receives the raw `ServerResponse` (not `NodeNextResponse`), so `setHeader` is a complete replacement.

### Fix

Instead of blindly overwriting, the fix reads the existing Vary header, merges it with the RSC values using case-insensitive deduplication (via `Set`), and sets the combined result. This follows the same pattern used in `send-response.ts` which already treats `vary` as a multi-value header, and the deduplication pattern from `patch-set-header.ts` for Set-Cookie.

The same fix is applied to `edge-ssr-app.ts` which had an equivalent issue with `headers.set('Vary', varyHeader)`.

### Changes

- **`packages/next/src/build/templates/app-page.ts`**: Replace `res.setHeader('Vary', varyHeader)` with read-merge-set logic that preserves existing Vary values
- **`packages/next/src/build/templates/edge-ssr-app.ts`**: Add Vary-aware merging in the existing headers loop to avoid overwriting RSC Vary values
- **`test/e2e/vary-header/`**: Add app page test fixture and test case verifying middleware Vary headers are preserved in app pages

### Before (broken)

```
Middleware sets: Vary: X-Foo
base-server appends: Vary: X-Foo, RSC, Next-Router-State-Tree, ...
app-page.ts overwrites: Vary: RSC, Next-Router-State-Tree, ...  ← X-Foo lost!
```

### After (fixed)

```
Middleware sets: Vary: X-Foo
base-server appends: Vary: X-Foo, RSC, Next-Router-State-Tree, ...
app-page.ts merges: Vary: X-Foo, RSC, Next-Router-State-Tree, ...  ← X-Foo preserved!
```