### PR TITLE
types: make NODE_ENV optional in ProcessEnv

### DIFF
--- a/packages/next/types/global.d.ts
+++ b/packages/next/types/global.d.ts
@@ -19,8 +19,7 @@ declare namespace NodeJS {
   }
 
   interface ProcessEnv {
-    // TODO: Should be optional and possibly undefined
-    readonly NODE_ENV: 'development' | 'production' | 'test'
+    readonly NODE_ENV?: 'development' | 'production' | 'test'
   }
 }
 


### PR DESCRIPTION
## Summary

Make `NODE_ENV` optional in the `ProcessEnv` interface.

In Node.js, environment variables accessed via `process.env` can be `undefined` if not set. The previous typing required `NODE_ENV` to always be present, which does not accurately reflect runtime behavior.

This change updates the type definition to make `NODE_ENV` optional, aligning it with how environment variables work in Node.js.

## Changes

- Make `NODE_ENV` optional in `ProcessEnv` type definition
- Remove outdated TODO comment

## Testing

Type-only change. No runtime behavior affected.