### PR TITLE
fix(app-router): discard queued server actions on navigation

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -192,12 +192,15 @@ function dispatchAction(
     payload.type === ACTION_RESTORE
   ) {
     // Navigations (including back/forward) take priority over any pending actions.
-    // Mark the pending action as discarded (so the state is never applied) and start the navigation action immediately.
-    actionQueue.pending.discarded = true
+    // Discard all currently queued actions so stale server actions cannot
+    // commit updates that were started for the previous route.
+    let pendingAction: ActionQueueNode | null = actionQueue.pending
+    while (pendingAction !== null) {
+      pendingAction.discarded = true
+      pendingAction = pendingAction.next
+    }
 
-    // The rest of the current queue should still execute after this navigation.
-    // (Note that it can't contain any earlier navigations, because we always put those into `actionQueue.pending` by calling `runAction`)
-    newAction.next = actionQueue.pending.next
+    actionQueue.last = newAction
 
     runAction({
       actionQueue,

--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1949,6 +1949,28 @@ describe('app-dir action handling', () => {
   describe('action discarding', () => {
     // TODO: Investigate flaky behavior when deployed
     if (!isNextDeploy) {
+      it('should discard queued server actions when navigating away', async () => {
+        let browser = await next.browser('/action-discarding')
+        await browser.waitForIdleNetwork()
+
+        // Queue up multiple server actions from the current page.
+        for (let i = 0; i < 5; i++) {
+          await browser.elementByCss('#slow-action').click()
+        }
+
+        // Navigate away while actions are still in-flight/queued.
+        await browser.elementByCss('#navigate-destination').click()
+
+        // Wait for all queued actions to settle.
+        await waitFor(2500)
+
+        await retry(async () => {
+          expect(await browser.url()).toContain(
+            '/action-discarding/destination'
+          )
+        })
+      })
+
       it('should not trigger a refresh for a server action that gets discarded due to a navigation (without revalidation)', async () => {
         let browser = await next.browser('/action-discarding')
         await browser.waitForIdleNetwork()


### PR DESCRIPTION
### What?

Discard all queued server actions when a navigation/restore is dispatched so stale queued actions cannot commit state after a route change.

### Why?

Issue #90467 reports queued server actions racing with navigation and clobbering `state.canonicalUrl` (and related router state). Previously only the *currently pending* action was discarded; queued actions could still run after navigation and overwrite the new route state.

### How?

- Mark every queued action as `discarded` when a navigation/restore is dispatched.
- Keep the navigation action as the last queued action so subsequent actions queue behind it.
- Added an e2e regression test that queues multiple actions, navigates away, and asserts we remain on the destination page.

Fixes #90467

### Tests

- `pnpm lint-eslint packages/next/src/client/components/app-router-instance.ts test/e2e/app-dir/actions/app-action.test.ts`
- Unable to run `pnpm testonly-start-webpack ...` locally because `packages/next/dist/build/jest/jest` was missing (build not generated in this environment).
