### PR TITLE
refactor: consolidate prerender stream continuation functions

### DIFF
--- a/bench/BENCHMARKING.md
+++ b/bench/BENCHMARKING.md
@@ -86,7 +86,7 @@ Micro benchmark output includes cases for:
 - `teeNodeReadable`
 - `createBufferedTransformNode`
 - `createInlinedDataNodeStream`
-- `continueStaticPrerender` / `continueDynamicPrerender` / `continueDynamicHTMLResume`
+- `continuePrerenderStream` / `continueDynamicPrerender`
 
 Flight payload mode toggles:
 

--- a/bench/render-pipeline/benchmark.ts
+++ b/bench/render-pipeline/benchmark.ts
@@ -21,9 +21,8 @@ import {
   createBufferedTransformNode,
 } from '../../packages/next/src/server/stream-utils/node-stream-helpers'
 import {
-  continueDynamicHTMLResume,
+  continuePrerenderStream,
   continueDynamicPrerender,
-  continueStaticPrerender,
 } from '../../packages/next/src/server/stream-utils/node-web-streams-helper'
 
 const REPO_ROOT = fileURLToPath(new URL('../..', import.meta.url))
@@ -579,7 +578,7 @@ function buildMicroBenchCases(
       },
     },
     {
-      name: 'Web continueStaticPrerender',
+      name: 'Web continuePrerenderStream',
       group: 'integration',
       run: async () => {
         const renderStream = createWebStream(webHtmlChunks)
@@ -588,7 +587,7 @@ function buildMicroBenchCases(
           undefined,
           null
         )
-        const stream = await continueStaticPrerender(renderStream, {
+        const stream = await continuePrerenderStream(renderStream, {
           inlinedDataStream,
           getServerInsertedHTML: async () => '',
           getServerInsertedMetadata: async () => '',
@@ -611,7 +610,7 @@ function buildMicroBenchCases(
       },
     },
     {
-      name: 'Web continueDynamicHTMLResume',
+      name: 'Web continuePrerenderStream (delay=false)',
       group: 'integration',
       run: async () => {
         const renderStream = createWebStream(webHtmlChunks)
@@ -620,7 +619,7 @@ function buildMicroBenchCases(
           undefined,
           null
         )
-        const stream = await continueDynamicHTMLResume(renderStream, {
+        const stream = await continuePrerenderStream(renderStream, {
           inlinedDataStream,
           delayDataUntilFirstHtmlChunk: false,
           getServerInsertedHTML: async () => '',
@@ -631,7 +630,7 @@ function buildMicroBenchCases(
       },
     },
     {
-      name: `Web continueDynamicHTMLResume (${secondaryFlightLabel})`,
+      name: `Web continuePrerenderStream (${secondaryFlightLabel}, delay=false)`,
       group: 'integration',
       run: async () => {
         const renderStream = createWebStream(webHtmlChunks)
@@ -640,7 +639,7 @@ function buildMicroBenchCases(
           undefined,
           null
         )
-        const stream = await continueDynamicHTMLResume(renderStream, {
+        const stream = await continuePrerenderStream(renderStream, {
           inlinedDataStream,
           delayDataUntilFirstHtmlChunk: false,
           getServerInsertedHTML: async () => '',

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -41,9 +41,7 @@ import {
   chainStreams,
   continueFizzStream,
   continueDynamicPrerender,
-  continueStaticPrerender,
-  continueDynamicHTMLResume,
-  continueStaticFallbackPrerender,
+  continuePrerenderStream,
   streamToBuffer,
   streamToString,
   createInlinedDataStream,
@@ -3349,7 +3347,7 @@ async function renderToStream(
             if (renderSpan.isRecording()) renderSpan.end()
           })
 
-          return await continueDynamicHTMLResume(htmlStream, {
+          return await continuePrerenderStream(htmlStream, {
             delayDataUntilFirstHtmlChunk:
               preludeState === DynamicHTMLPreludeState.Empty,
             inlinedDataStream: createInlinedDataStream(
@@ -6575,7 +6573,8 @@ async function prerenderToStream(
                 onError: serverComponentsErrorHandler,
               })
             )
-          finalStream = await continueStaticFallbackPrerender(htmlStream, {
+          finalStream = await continuePrerenderStream(htmlStream, {
+            insertClientResumeScript: true,
             inlinedDataStream: createInlinedDataStream(
               emptyReactServerResult.consumeAsStream(),
               nonce,
@@ -6587,7 +6586,7 @@ async function prerenderToStream(
           })
         } else {
           // Normal static prerender case, no fallback param handling needed
-          finalStream = await continueStaticPrerender(htmlStream, {
+          finalStream = await continuePrerenderStream(htmlStream, {
             inlinedDataStream: createInlinedDataStream(
               reactServerResult.consumeAsStream(),
               nonce,
@@ -6841,7 +6840,7 @@ async function prerenderToStream(
         return {
           digestErrorsMap: reactServerErrorsByDigest,
           ssrErrors: allCapturedErrors,
-          stream: await continueStaticPrerender(htmlStream, {
+          stream: await continuePrerenderStream(htmlStream, {
             inlinedDataStream: createInlinedDataStream(
               reactServerResult.consumeAsStream(),
               nonce,

--- a/packages/next/src/server/app-render/stream-ops.ts
+++ b/packages/next/src/server/app-render/stream-ops.ts
@@ -7,9 +7,8 @@
 export type {
   AnyStream,
   ContinueFizzStreamOptions,
-  ContinueStaticPrerenderOptions,
+  ContinuePrerenderStreamOptions,
   ContinueStreamSharedOptions,
-  ContinueDynamicHTMLResumeOptions,
   FlightComponentMod,
   ServerPrerenderComponentMod,
   FlightPayload,
@@ -20,10 +19,8 @@ export type {
 
 export {
   continueFizzStream,
-  continueStaticPrerender,
+  continuePrerenderStream,
   continueDynamicPrerender,
-  continueStaticFallbackPrerender,
-  continueDynamicHTMLResume,
   streamToBuffer,
   chainStreams,
   createDocumentClosingStream,

--- a/packages/next/src/server/app-render/stream-ops.web.ts
+++ b/packages/next/src/server/app-render/stream-ops.web.ts
@@ -41,13 +41,10 @@ export type ContinueFizzStreamOptions = ContinueStreamSharedOptions & {
   suffix?: string
 }
 
-export type ContinueStaticPrerenderOptions = ContinueStreamSharedOptions & {
+export type ContinuePrerenderStreamOptions = ContinueStreamSharedOptions & {
   inlinedDataStream: AnyStream
-}
-
-export type ContinueDynamicHTMLResumeOptions = ContinueStreamSharedOptions & {
-  inlinedDataStream: AnyStream
-  delayDataUntilFirstHtmlChunk: boolean
+  insertClientResumeScript?: boolean
+  delayDataUntilFirstHtmlChunk?: boolean
 }
 
 export type FlightComponentMod = {
@@ -73,10 +70,8 @@ export type FizzStreamResult = {
 // ---------------------------------------------------------------------------
 
 export {
-  continueStaticPrerender,
+  continuePrerenderStream,
   continueDynamicPrerender,
-  continueStaticFallbackPrerender,
-  continueDynamicHTMLResume,
   streamToBuffer,
   chainStreams,
   createDocumentClosingStream,

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -1021,51 +1021,26 @@ export async function continueDynamicPrerender(
   ])
 }
 
-type ContinueStaticPrerenderOptions = {
+type ContinuePrerenderStreamOptions = {
   inlinedDataStream: ReadableStream<Uint8Array>
   getServerInsertedHTML: () => Promise<string>
   getServerInsertedMetadata: () => Promise<string>
   deploymentId: string | undefined
+  insertClientResumeScript?: boolean
+  delayDataUntilFirstHtmlChunk?: boolean
 }
 
-export async function continueStaticPrerender(
+export async function continuePrerenderStream(
   prerenderStream: ReadableStream<Uint8Array>,
   {
     inlinedDataStream,
     getServerInsertedHTML,
     getServerInsertedMetadata,
     deploymentId,
-  }: ContinueStaticPrerenderOptions
+    insertClientResumeScript = false,
+    delayDataUntilFirstHtmlChunk = true,
+  }: ContinuePrerenderStreamOptions
 ) {
-  return chainTransformers(prerenderStream, [
-    // Buffer everything to avoid flushing too frequently
-    createBufferedTransformStream(),
-    // Add build id comment to start of the HTML document (in export mode)
-    // Insert data-dpl-id attribute on the html tag
-    deploymentId ? createHtmlDataDplIdTransformStream(deploymentId) : null,
-    // Insert generated tags to head
-    createHeadInsertionTransformStream(getServerInsertedHTML),
-    // Transform metadata
-    createMetadataTransformStream(getServerInsertedMetadata),
-    // Insert the inlined data (Flight data, form state, etc.) stream into the HTML
-    createFlightDataInjectionTransformStream(inlinedDataStream, true),
-    // Close tags should always be deferred to the end
-    createMoveSuffixStream(),
-  ])
-}
-
-export async function continueStaticFallbackPrerender(
-  prerenderStream: ReadableStream<Uint8Array>,
-  {
-    inlinedDataStream,
-    getServerInsertedHTML,
-    getServerInsertedMetadata,
-    deploymentId,
-  }: ContinueStaticPrerenderOptions
-) {
-  // Same as `continueStaticPrerender`, but also inserts an additional script
-  // to instruct the client to start fetching the hydration data as early
-  // as possible.
   return chainTransformers(prerenderStream, [
     // Buffer everything to avoid flushing too frequently
     createBufferedTransformStream(),
@@ -1074,41 +1049,9 @@ export async function continueStaticFallbackPrerender(
     // Insert generated tags to head
     createHeadInsertionTransformStream(getServerInsertedHTML),
     // Insert the client resume script into the head
-    createClientResumeScriptInsertionTransformStream(),
-    // Transform metadata
-    createMetadataTransformStream(getServerInsertedMetadata),
-    // Insert the inlined data (Flight data, form state, etc.) stream into the HTML
-    createFlightDataInjectionTransformStream(inlinedDataStream, true),
-    // Close tags should always be deferred to the end
-    createMoveSuffixStream(),
-  ])
-}
-
-type ContinueResumeOptions = {
-  inlinedDataStream: ReadableStream<Uint8Array>
-  getServerInsertedHTML: () => Promise<string>
-  getServerInsertedMetadata: () => Promise<string>
-  delayDataUntilFirstHtmlChunk: boolean
-  deploymentId: string | undefined
-}
-
-export async function continueDynamicHTMLResume(
-  renderStream: ReadableStream<Uint8Array>,
-  {
-    delayDataUntilFirstHtmlChunk,
-    inlinedDataStream,
-    getServerInsertedHTML,
-    getServerInsertedMetadata,
-    deploymentId,
-  }: ContinueResumeOptions
-) {
-  return chainTransformers(renderStream, [
-    // Buffer everything to avoid flushing too frequently
-    createBufferedTransformStream(),
-    // Insert data-dpl-id attribute on the html tag
-    deploymentId ? createHtmlDataDplIdTransformStream(deploymentId) : null,
-    // Insert generated tags to head
-    createHeadInsertionTransformStream(getServerInsertedHTML),
+    insertClientResumeScript
+      ? createClientResumeScriptInsertionTransformStream()
+      : null,
     // Transform metadata
     createMetadataTransformStream(getServerInsertedMetadata),
     // Insert the inlined data (Flight data, form state, etc.) stream into the HTML


### PR DESCRIPTION
## Summary

Merges three nearly-identical stream continuation functions (`continueStaticPrerender`, `continueStaticFallbackPrerender`, `continueDynamicHTMLResume`) into a single `continuePrerenderStream`.

The three functions shared the same transformer pipeline and differed only in:
- Whether a client resume script was inserted (only `continueStaticFallbackPrerender`)
- Whether `delayDataUntilFirstHtmlChunk` was configurable or hardcoded to `true`

These differences are now captured as optional parameters with defaults that match the previous static prerender behavior (`insertClientResumeScript = false`, `delayDataUntilFirstHtmlChunk = true`).

No behavioral changes.