### PR TITLE
fix(unstable_cache): avoid undefined coercion in invocation cache key

### DIFF
--- a/packages/next/src/server/web/spec-extension/unstable-cache.ts
+++ b/packages/next/src/server/web/spec-extension/unstable-cache.ts
@@ -131,7 +131,9 @@ export function unstable_cache<T extends Callback>(
       // Construct the complete cache key for this function invocation
       // @TODO stringify is likely not safe here. We will coerce undefined to null which will make
       // the keyspace smaller than the execution space
-      const invocationKey = `${fixedKey}-${JSON.stringify(args)}`
+      const invocationKey = `${fixedKey}-${JSON.stringify(args, (_, value) =>
+        value === undefined ? '__undefined__' : value
+      )}`
       const cacheKey = await incrementalCache.generateCacheKey(invocationKey)
       // $urlWithPath,$sortedQueryStringKeys,$hashOfEveryThingElse
       const fetchUrl = `unstable_cache ${fetchUrlPrefix} ${cb.name ? ` ${cb.name}` : cacheKey}`


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide
- 
This pull request updates the cache key generation logic in the `unstable_cache` function to handle `undefined` values more safely. Now, when serializing arguments for the cache key, any `undefined` values are explicitly replaced with the string `'__undefined__'`. This prevents different argument lists that only differ by `undefined` from being treated as identical cache keys.

- Cache key generation improvement:
  * `unstable_cache` in `unstable-cache.ts`: Modified the `JSON.stringify` call to replace `undefined` values with `'__undefined__'`, ensuring better cache key uniqueness and preventing accidental key collisions.
### Problem

`unstable_cache` builds the invocation key using:

```ts
JSON.stringify(args)

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs)
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
