### PR TITLE
example: remove duplicate items in .dockerignore

### DIFF
--- a/examples/with-docker/.dockerignore
+++ b/examples/with-docker/.dockerignore
@@ -80,13 +80,6 @@ Jenkinsfile
 .parcel-cache/
 .eslintcache
 .stylelintcache
-.turbo/
-.tmp/
-# Cache directories and temporary data
-.cache/
-.parcel-cache/
-.eslintcache
-.stylelintcache
 .swc/
 .turbo/
 .tmp/


### PR DESCRIPTION
Removed duplicate entries for cache and temporary directories.

```diff
- # Cache directories and temporary data
- .cache/
- .parcel-cache/
- .eslintcache
- .stylelintcache
- .turbo/
- .tmp/
# Cache directories and temporary data
.cache/
.parcel-cache/
.eslintcache
.stylelintcache
.swc/
.turbo/
.tmp/
.temp/
```
