### PR TITLE
Fix pr-status script missing failed jobs on page 2+ of API results

### DIFF
--- a/scripts/pr-status.js
+++ b/scripts/pr-status.js
@@ -217,34 +217,14 @@ function getRunMetadata(runId) {
 }
 
 function getFailedJobs(runId) {
-  const failedJobs = []
-  let page = 1
-
-  while (true) {
-    const jqQuery = '.jobs[] | select(.conclusion == "failure") | {id, name}'
-    let output
-    try {
-      output = exec(
-        `gh api "repos/vercel/next.js/actions/runs/${runId}/jobs?per_page=100&page=${page}" --jq '${jqQuery}'`
-      )
-    } catch {
-      break
-    }
-
-    if (!output.trim()) break
-
-    const jobs = output
-      .split('\n')
-      .filter((line) => line.trim())
-      .map((line) => JSON.parse(line))
-
-    failedJobs.push(...jobs)
-
-    if (jobs.length < 100) break
-    page++
-  }
-
-  return failedJobs
+  // Fetch all jobs first, then filter for failures in JS.
+  // We can't use jq filtering during pagination because a page full of
+  // non-failure jobs produces empty jq output, which would incorrectly
+  // stop pagination before reaching later pages that contain failures.
+  const allJobs = getAllJobs(runId)
+  return allJobs
+    .filter((j) => j.conclusion === 'failure')
+    .map((j) => ({ id: j.id, name: j.name }))
 }
 
 function getAllJobs(runId) {


### PR DESCRIPTION
## Summary

`getFailedJobs()` in `scripts/pr-status.js` used jq's `select(.conclusion == "failure")` filter during GitHub API pagination. When a page had 100 jobs but none were failures, jq returned empty output, and the `if (!output.trim()) break` check terminated the pagination loop early — never fetching page 2+ where actual failures existed.

For example, on PR #90755 (129 total jobs), all 100 jobs on page 1 were success/skipped, while the 2 failures (`test unit windows (22) / build` and `thank you, next`) were on page 2 (jobs 101-129). The script reported "Found 0 failed jobs" when there were actually 2.

## Fix

`getFailedJobs()` now delegates to `getAllJobs()` (which fetches all jobs without jq filtering, so pagination works correctly) and filters for failures in JavaScript afterward. This is simpler and avoids the class of bug where jq pre-filtering interacts badly with pagination.

## Test Plan

- Ran `node scripts/pr-status.js 90755` before fix: reported 0 failed jobs
- Ran `node scripts/pr-status.js 90755` after fix: correctly reported 2 failed jobs (`test unit windows (22) / build` and `thank you, next`)