### PR TITLE
Fix preview tarball script to include @next/swc-linux-x64-gnu

### DIFF
--- a/scripts/patch-preview-tarball.mjs
+++ b/scripts/patch-preview-tarball.mjs
@@ -10,6 +10,7 @@ const PACKAGES_TO_PATCH = [
   '@next/mdx',
   '@next/env',
   '@next/bundle-analyzer',
+  '@next/swc-linux-x64-gnu',
 ]
 
 // --- Argument parsing ---
@@ -185,6 +186,12 @@ async function patchPackageJson(projectPath, tarballUrls) {
   for (const [name, url] of entries) {
     pkg.resolutions[name] = url
   }
+
+  // Add @next/swc-linux-x64-gnu to dependencies
+  pkg.dependencies = pkg.dependencies || {}
+  pkg.dependencies['@next/swc-linux-x64-gnu'] = tarballUrls.get(
+    '@next/swc-linux-x64-gnu'
+  )
 
   await fs.writeFile(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n')
 


### PR DESCRIPTION
### What?

Adds `@next/swc-linux-x64-gnu` to the preview tarball patching script (`scripts/patch-preview-tarball.mjs`):

1. Adds the package to the `PACKAGES_TO_PATCH` list so its tarball URL is fetched.
2. Adds the package as an explicit dependency in the patched `package.json`, in addition to the overrides/resolutions.

### Why?

The `@next/swc-linux-x64-gnu` native binary package is an optional dependency of `next` and may not be installed automatically depending on the platform/package manager. When testing preview tarballs (e.g., in CI or on Linux environments), the SWC binary needs to be explicitly present for Next.js to function correctly. Without this change, preview tarball testing on Linux x64 could fail because the native binary isn't resolved from the preview build.

Adding it as a direct dependency (not just an override/resolution) ensures the package manager actually installs it, since optional dependencies from overridden tarballs may not be auto-resolved.

### How?

- Added `'@next/swc-linux-x64-gnu'` to the `PACKAGES_TO_PATCH` array so the script fetches its tarball URL.
- After writing overrides/resolutions, the script now also adds `@next/swc-linux-x64-gnu` as an explicit entry in `pkg.dependencies` pointing to the tarball URL.