### PR TITLE
Turbopack: introduce `ReferenceTypeCondition`

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -63,7 +63,7 @@ use turbopack_core::{
     },
     output::{OutputAsset, OutputAssets, OutputAssetsWithReferenced},
     reference::all_assets_from_entries,
-    reference_type::{CommonJsReferenceSubType, CssReferenceSubType, ReferenceType},
+    reference_type::{CommonJsReferenceSubType, CssReferenceSubType, ReferenceTypeCondition},
     resolve::{ResolveErrorMode, origin::PlainResolveOrigin, parse::Request, pattern::Pattern},
     source::Source,
     source_map::SourceMapAsset,
@@ -388,9 +388,9 @@ impl AppProject {
                 // CSS Module to the actual CSS
                 TransitionRule::new(
                     RuleCondition::all(vec![
-                        RuleCondition::ReferenceType(ReferenceType::Css(
+                        RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
                             CssReferenceSubType::Inner,
-                        )),
+                        ))),
                         module_styles_rule_condition(),
                     ]),
                     self.css_client_reference_transition().to_resolved().await?,
@@ -399,9 +399,9 @@ impl AppProject {
                 // the list of CSS module classes.
                 TransitionRule::new(
                     RuleCondition::all(vec![
-                        RuleCondition::ReferenceType(ReferenceType::Css(
+                        RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
                             CssReferenceSubType::Analyze,
-                        )),
+                        ))),
                         module_styles_rule_condition(),
                     ]),
                     ResolvedVc::upcast(self.client_transition().to_resolved().await?),
@@ -664,9 +664,9 @@ impl AppProject {
                     // Change context, this is used to determine the list of CSS module classes.
                     TransitionRule::new(
                         RuleCondition::all(vec![
-                            RuleCondition::ReferenceType(ReferenceType::Css(
+                            RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
                                 CssReferenceSubType::Analyze,
-                            )),
+                            ))),
                             module_styles_rule_condition(),
                         ]),
                         ResolvedVc::upcast(self.client_transition().to_resolved().await?),
@@ -736,9 +736,9 @@ impl AppProject {
                     // Change context, this is used to determine the list of CSS module classes.
                     TransitionRule::new(
                         RuleCondition::all(vec![
-                            RuleCondition::ReferenceType(ReferenceType::Css(
+                            RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
                                 CssReferenceSubType::Analyze,
-                            )),
+                            ))),
                             module_styles_rule_condition(),
                         ]),
                         ResolvedVc::upcast(self.client_transition().to_resolved().await?),

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -9,7 +9,7 @@ use turbo_tasks_fs::{
 };
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
-    reference_type::{EcmaScriptModulesReferenceSubType, ReferenceType},
+    reference_type::{ReferenceType, ReferenceTypeCondition},
     resolve::{
         ExternalTraced, ExternalType, FindContextFileResult, ResolveResult, ResolveResultItem,
         ResolveResultOption, find_context_file,
@@ -155,8 +155,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         };
 
         let is_esm = self.import_externals
-            && ReferenceType::EcmaScriptModules(EcmaScriptModulesReferenceSubType::Undefined)
-                .includes(&reference_type);
+            && ReferenceTypeCondition::EcmaScriptModules(None).includes(&reference_type);
 
         #[derive(Debug, Copy, Clone)]
         enum FileType {

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -4,7 +4,7 @@ use turbo_rcstr::RcStr;
 use turbo_tasks::{ResolvedVc, Vc};
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, RuleCondition};
 use turbopack_core::reference_type::{
-    CssReferenceSubType, EntryReferenceSubType, ReferenceType, UrlReferenceSubType,
+    CssReferenceSubType, EntryReferenceSubType, ReferenceTypeCondition,
 };
 
 use crate::{
@@ -65,7 +65,9 @@ pub async fn get_next_server_transforms_rules(
             // the class names object.
             ModuleRule::new(
                 RuleCondition::all(vec![
-                    RuleCondition::ReferenceType(ReferenceType::Css(CssReferenceSubType::Inner)),
+                    RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
+                        CssReferenceSubType::Inner,
+                    ))),
                     module_styles_rule_condition(),
                 ]),
                 vec![ModuleRuleEffect::Ignore],
@@ -90,8 +92,8 @@ pub async fn get_next_server_transforms_rules(
                     pages_dir.clone(),
                     ExportFilter::StripDefaultExport,
                     mdx_rs,
-                    vec![RuleCondition::ReferenceType(ReferenceType::Entry(
-                        EntryReferenceSubType::PageData,
+                    vec![RuleCondition::ReferenceType(ReferenceTypeCondition::Entry(
+                        Some(EntryReferenceSubType::PageData),
                     ))],
                     &page_extensions,
                 )?);
@@ -209,8 +211,8 @@ pub async fn get_next_server_transforms_rules(
             // (i.e. for pages), while still allowing `new URL(..., import.meta.url)`
             rules.push(ModuleRule::new(
                 RuleCondition::all(vec![
-                    RuleCondition::not(RuleCondition::ReferenceType(ReferenceType::Url(
-                        UrlReferenceSubType::Undefined,
+                    RuleCondition::not(RuleCondition::ReferenceType(ReferenceTypeCondition::Url(
+                        None,
                     ))),
                     RuleCondition::any(vec![
                         RuleCondition::ResourcePathEndsWith(".apng".to_string()),

--- a/crates/next-core/src/next_shared/transforms/mod.rs
+++ b/crates/next-core/src/next_shared/transforms/mod.rs
@@ -34,7 +34,7 @@ pub use server_actions::get_server_actions_transform_rule;
 use turbo_tasks::ResolvedVc;
 use turbo_tasks_fs::FileSystemPath;
 use turbopack::module_options::{ModuleRule, ModuleRuleEffect, ModuleType, RuleCondition};
-use turbopack_core::reference_type::{ReferenceType, UrlReferenceSubType};
+use turbopack_core::reference_type::ReferenceTypeCondition;
 use turbopack_ecmascript::{CustomTransformer, EcmascriptInputTransform};
 
 use crate::next_image::{StructuredImageModuleType, module::BlurPlaceholderMode};
@@ -44,8 +44,8 @@ pub async fn get_next_image_rule() -> Result<ModuleRule> {
         RuleCondition::All(vec![
             // avoid urlAssetReference to be affected by this rule, since urlAssetReference
             // requires raw module to have its paths in the export
-            RuleCondition::not(RuleCondition::ReferenceType(ReferenceType::Url(
-                UrlReferenceSubType::Undefined,
+            RuleCondition::not(RuleCondition::ReferenceType(ReferenceTypeCondition::Url(
+                None,
             ))),
             RuleCondition::any(vec![
                 RuleCondition::ResourcePathEndsWith(".jpg".to_string()),
@@ -108,8 +108,8 @@ fn match_js_extension(enable_mdx_rs: bool) -> RuleCondition {
 /// condition for custom ecma specific transforms.
 pub(crate) fn module_rule_match_js_no_url(enable_mdx_rs: bool) -> RuleCondition {
     RuleCondition::all(vec![
-        RuleCondition::not(RuleCondition::ReferenceType(ReferenceType::Url(
-            UrlReferenceSubType::Undefined,
+        RuleCondition::not(RuleCondition::ReferenceType(ReferenceTypeCondition::Url(
+            None,
         ))),
         match_js_extension(enable_mdx_rs),
     ])

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -351,53 +351,6 @@ impl Display for ReferenceType {
 }
 
 impl ReferenceType {
-    pub fn includes(&self, other: &Self) -> bool {
-        if self == other {
-            return true;
-        }
-        match self {
-            ReferenceType::CommonJs(sub_type) => {
-                matches!(other, ReferenceType::CommonJs(_))
-                    && matches!(sub_type, CommonJsReferenceSubType::Undefined)
-            }
-            ReferenceType::EcmaScriptModules(sub_type) => {
-                matches!(other, ReferenceType::EcmaScriptModules(_))
-                    && matches!(sub_type, EcmaScriptModulesReferenceSubType::Undefined)
-            }
-            ReferenceType::Css(CssReferenceSubType::AtImport(_)) => {
-                // For condition matching, treat any AtImport pair as identical.
-                matches!(other, ReferenceType::Css(CssReferenceSubType::AtImport(_)))
-            }
-            ReferenceType::Css(sub_type) => {
-                matches!(other, ReferenceType::Css(_))
-                    && matches!(sub_type, CssReferenceSubType::Undefined)
-            }
-            ReferenceType::Url(sub_type) => {
-                matches!(other, ReferenceType::Url(_))
-                    && matches!(sub_type, UrlReferenceSubType::Undefined)
-            }
-            ReferenceType::TypeScript(sub_type) => {
-                matches!(other, ReferenceType::TypeScript(_))
-                    && matches!(sub_type, TypeScriptReferenceSubType::Undefined)
-            }
-            ReferenceType::Worker(sub_type) => {
-                matches!(other, ReferenceType::Worker(_))
-                    && matches!(sub_type, WorkerReferenceSubType::Undefined)
-            }
-            ReferenceType::Entry(sub_type) => {
-                matches!(other, ReferenceType::Entry(_))
-                    && matches!(sub_type, EntryReferenceSubType::Undefined)
-            }
-            ReferenceType::Runtime => matches!(other, ReferenceType::Runtime),
-            ReferenceType::Internal(_) => matches!(other, ReferenceType::Internal(_)),
-            ReferenceType::Loader => matches!(other, ReferenceType::Loader),
-            ReferenceType::Custom(_) => {
-                todo!()
-            }
-            ReferenceType::Undefined => true,
-        }
-    }
-
     /// Returns true if this reference type is internal. This will be used in
     /// combination with [`ModuleRuleCondition::Internal`] to determine if a
     /// rule should be applied to an internal asset/reference.
@@ -406,5 +359,86 @@ impl ReferenceType {
             self,
             ReferenceType::Internal(_) | ReferenceType::Runtime | ReferenceType::Loader
         )
+    }
+}
+
+/// A type to match [`ReferenceType`] against. This is used in conditions to determine if a rule
+/// should be applied to a reference of a given type. It allows
+/// - to match against a ReferenceType, e.g. with `ReferenceTypeCondition::Url(None)` matching any
+///   `ReferenceType::Url(_)`, or
+/// - to match against a specific subtype, e.g. with
+///   `ReferenceTypeCondition::Url(Some(UrlReferenceSubType::EcmaScriptNewUrl))` matching
+///   `ReferenceType::Url(UrlReferenceSubType::EcmaScriptNewUrl)`
+#[derive(
+    PartialEq, Eq, TraceRawVcs, NonLocalValue, Debug, Clone, Hash, TaskInput, Encode, Decode,
+)]
+pub enum ReferenceTypeCondition {
+    CommonJs(Option<CommonJsReferenceSubType>),
+    EcmaScriptModules(Option<EcmaScriptModulesReferenceSubType>),
+    Css(Option<CssReferenceSubType>),
+    Url(Option<UrlReferenceSubType>),
+    TypeScript(Option<TypeScriptReferenceSubType>),
+    Worker(Option<WorkerReferenceSubType>),
+    Entry(Option<EntryReferenceSubType>),
+    Runtime,
+    Internal,
+    Loader,
+    Custom(u8),
+}
+
+impl ReferenceTypeCondition {
+    pub fn includes(&self, other: &ReferenceType) -> bool {
+        if matches!(
+            self,
+            ReferenceTypeCondition::Css(Some(CssReferenceSubType::AtImport(_)))
+        ) && matches!(other, ReferenceType::Css(CssReferenceSubType::AtImport(_)))
+        {
+            // For condition matching, treat any AtImport pair as identical.
+            return true;
+        }
+
+        if matches!(self, ReferenceTypeCondition::Custom(_)) {
+            todo!()
+        }
+
+        macro_rules! match_condition_includes {
+            (
+                $self:expr, $other:expr,
+                optional: [$($opt:ident),* $(,)?],
+                unit: [$($unit:ident),* $(,)?],
+                value: [$($val:ident),* $(,)?]
+                $(,)?
+            ) => {
+                match $self {
+                    $(
+                        ReferenceTypeCondition::$opt(sub_type) => {
+                            if let ReferenceType::$opt(other_sub_type) = $other {
+                                return sub_type.as_ref().is_none_or(|s| s == other_sub_type);
+                            }
+                        }
+                    )*
+                    $(
+                        ReferenceTypeCondition::$unit => {
+                            return matches!($other, ReferenceType::$unit { .. });
+                        }
+                    )*
+                    $(
+                        ReferenceTypeCondition::$val(v) => {
+                            if let ReferenceType::$val(ov) = $other {
+                                return v == ov;
+                            }
+                        }
+                    )*
+                }
+            };
+        }
+        match_condition_includes!(
+            self, other,
+            optional: [CommonJs, EcmaScriptModules, Css, Url, TypeScript, Worker, Entry],
+            unit: [Runtime, Loader, Internal],
+            value: [Custom],
+        );
+
+        false
     }
 }

--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -50,7 +50,7 @@ use turbopack_core::{
         chunk_group_info::{ChunkGroup, ChunkGroupEntry},
     },
     output::{OutputAsset, OutputAssets, OutputAssetsReference, OutputAssetsWithReferenced},
-    reference_type::{EntryReferenceSubType, ReferenceType, UrlReferenceSubType},
+    reference_type::{EntryReferenceSubType, ReferenceType, ReferenceTypeCondition},
 };
 use turbopack_ecmascript::{
     AnalyzeMode, EcmascriptInputTransform, TreeShakingMode, chunk::EcmascriptChunkType,
@@ -347,8 +347,8 @@ async fn run_test_operation(resource: RcStr) -> Result<Vc<FileSystemPath>> {
         .await?;
 
     let conditions = RuleCondition::All(vec![
-        RuleCondition::not(RuleCondition::ReferenceType(ReferenceType::Url(
-            UrlReferenceSubType::Undefined,
+        RuleCondition::not(RuleCondition::ReferenceType(ReferenceTypeCondition::Url(
+            None,
         ))),
         RuleCondition::any(vec![
             RuleCondition::ResourcePathEndsWith(".js".into()),

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -20,7 +20,8 @@ use turbopack_core::{
     chunk::SourceMapsType,
     ident::Layer,
     reference_type::{
-        CssReferenceSubType, EcmaScriptModulesReferenceSubType, ReferenceType, UrlReferenceSubType,
+        CssReferenceSubType, EcmaScriptModulesReferenceSubType, ReferenceTypeCondition,
+        UrlReferenceSubType,
     },
     resolve::options::{ImportMap, ImportMapping},
 };
@@ -286,8 +287,12 @@ impl ModuleOptions {
         // So only if this is not a CSS module, or one of the special reference type constraints.
         let module_css_external_transform_conditions = RuleCondition::Any(vec![
             RuleCondition::not(module_css_condition.clone()),
-            RuleCondition::ReferenceType(ReferenceType::Css(CssReferenceSubType::Inner)),
-            RuleCondition::ReferenceType(ReferenceType::Css(CssReferenceSubType::Analyze)),
+            RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
+                CssReferenceSubType::Inner,
+            ))),
+            RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
+                CssReferenceSubType::Analyze,
+            ))),
         ]);
 
         let mut ecma_preprocess = vec![];
@@ -374,9 +379,9 @@ impl ModuleOptions {
         // and should override any file-pattern-based config rules.
         if enable_import_as_bytes {
             rules.push(ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::EcmaScriptModules(
+                RuleCondition::ReferenceType(ReferenceTypeCondition::EcmaScriptModules(Some(
                     EcmaScriptModulesReferenceSubType::ImportWithType("bytes".into()),
-                )),
+                ))),
                 if is_tracing {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Raw)]
                 } else {
@@ -389,9 +394,9 @@ impl ModuleOptions {
 
         if enable_import_as_text {
             rules.push(ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::EcmaScriptModules(
+                RuleCondition::ReferenceType(ReferenceTypeCondition::EcmaScriptModules(Some(
                     EcmaScriptModulesReferenceSubType::ImportWithType("text".into()),
-                )),
+                ))),
                 if is_tracing {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Raw)]
                 } else {
@@ -545,29 +550,33 @@ impl ModuleOptions {
         // Rules that apply for certains references
         rules.extend([
             ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::Url(UrlReferenceSubType::CssUrl)),
+                RuleCondition::ReferenceType(ReferenceTypeCondition::Url(Some(
+                    UrlReferenceSubType::CssUrl,
+                ))),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlCss {
                     tag: static_url_tag.clone(),
                 })],
             ),
             ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::Url(UrlReferenceSubType::Undefined)),
+                RuleCondition::ReferenceType(ReferenceTypeCondition::Url(Some(
+                    UrlReferenceSubType::Undefined,
+                ))),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlJs {
                     tag: static_url_tag.clone(),
                 })],
             ),
             ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::Url(
+                RuleCondition::ReferenceType(ReferenceTypeCondition::Url(Some(
                     UrlReferenceSubType::EcmaScriptNewUrl,
-                )),
+                ))),
                 vec![ModuleRuleEffect::ModuleType(ModuleType::StaticUrlJs {
                     tag: static_url_tag.clone(),
                 })],
             ),
             ModuleRule::new(
-                RuleCondition::ReferenceType(ReferenceType::EcmaScriptModules(
+                RuleCondition::ReferenceType(ReferenceTypeCondition::EcmaScriptModules(Some(
                     EcmaScriptModulesReferenceSubType::ImportWithType("json".into()),
-                )),
+                ))),
                 if is_tracing {
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Raw)]
                 } else {
@@ -874,9 +883,9 @@ impl ModuleOptions {
                     RuleCondition::all(vec![
                         module_css_condition.clone(),
                         // Create a normal CSS asset if `@import`ed from CSS already.
-                        RuleCondition::ReferenceType(ReferenceType::Css(
+                        RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
                             CssReferenceSubType::AtImport(None),
-                        )),
+                        ))),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleAssetType::Module,
@@ -887,9 +896,9 @@ impl ModuleOptions {
                 ModuleRule::new(
                     RuleCondition::all(vec![
                         module_css_condition.clone(),
-                        RuleCondition::ReferenceType(ReferenceType::Css(
+                        RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
                             CssReferenceSubType::Inner,
-                        )),
+                        ))),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleAssetType::Module,
@@ -900,9 +909,9 @@ impl ModuleOptions {
                 ModuleRule::new(
                     RuleCondition::all(vec![
                         module_css_condition.clone(),
-                        RuleCondition::ReferenceType(ReferenceType::Css(
+                        RuleCondition::ReferenceType(ReferenceTypeCondition::Css(Some(
                             CssReferenceSubType::Analyze,
-                        )),
+                        ))),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
                         ty: CssModuleAssetType::Module,

--- a/turbopack/crates/turbopack/src/module_options/rule_condition.rs
+++ b/turbopack/crates/turbopack/src/module_options/rule_condition.rs
@@ -11,7 +11,10 @@ use turbo_esregex::EsRegex;
 use turbo_tasks::{NonLocalValue, ReadRef, ResolvedVc, trace::TraceRawVcs};
 use turbo_tasks_fs::{FileContent, FileSystemPath, glob::Glob};
 use turbopack_core::{
-    asset::Asset, reference_type::ReferenceType, source::Source, virtual_source::VirtualSource,
+    asset::Asset,
+    reference_type::{ReferenceType, ReferenceTypeCondition},
+    source::Source,
+    virtual_source::VirtualSource,
 };
 
 #[derive(Debug, Clone, TraceRawVcs, PartialEq, Eq, NonLocalValue, Encode, Decode)]
@@ -21,7 +24,7 @@ pub enum RuleCondition {
     Not(Box<RuleCondition>),
     True,
     False,
-    ReferenceType(ReferenceType),
+    ReferenceType(ReferenceTypeCondition),
     ResourceIsVirtualSource,
     ResourcePathEquals(FileSystemPath),
     ResourcePathHasNoExtension,
@@ -500,7 +503,7 @@ pub mod tests {
                 .await?;
 
         {
-            let condition = RuleCondition::ReferenceType(ReferenceType::Runtime);
+            let condition = RuleCondition::ReferenceType(ReferenceTypeCondition::Runtime);
             assert!(
                 condition
                     .matches(virtual_source, &virtual_path, &ReferenceType::Runtime)


### PR DESCRIPTION
Previously, we used `RuleCondition::ReferenceType(ReferenceType)`. But there are some problem with using the type itself as a matcher:

1. the sub types' Undefined variant (like `CssReferenceSubType::Undefined`) always matched all possible variants. So it was actually impossible to match exactly `CssReferenceSubType::Undefined`
2. variants with more complex types were also impossible to match against, like `ReferenceType::Inner(ResolvedVc<...>)`
