### PR TITLE
fix(scripts): guard DEPLOY_ENVIRONMENT in deploy-docs.sh under set -u

### DIFF
--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -35,7 +35,7 @@ npm i -g vercel@latest 1>&2
 echo "Linking Vercel project..." >&2
 vercel link --cwd "$CWD" --scope vercel --project "$PROJECT" --token "$VERCEL_API_TOKEN" --yes 1>&2
 
-echo "Pulling env for $DEPLOY_ENVIRONMENT..." >&2
+echo "Pulling env for ${DEPLOY_ENVIRONMENT:-preview}..." >&2
 vercel pull --cwd "$CWD" --yes --environment="${DEPLOY_ENVIRONMENT:-preview}" --token="$VERCEL_API_TOKEN" 1>&2
 
 echo "Building locally with Vercel..." >&2


### PR DESCRIPTION
### What?
Fix `scripts/deploy-docs.sh` to avoid unbound-variable failure when `DEPLOY_ENVIRONMENT` is unset.

### Why?
The script runs with `set -euo pipefail` and mostly treats `DEPLOY_ENVIRONMENT` as optional using `${DEPLOY_ENVIRONMENT:-preview}`.  
One `echo` used `$DEPLOY_ENVIRONMENT` directly, which can crash with `set -u`.

### How?
Use `${DEPLOY_ENVIRONMENT:-preview}` in the log line as well, matching the rest of the script behavior.