### PR TITLE
Turbopack: Pass hmr_enabled to ImportMetaBinding

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/meta.rs
@@ -31,11 +31,12 @@ use crate::{
 )]
 pub struct ImportMetaBinding {
     path: FileSystemPath,
+    hmr_enabled: bool,
 }
 
 impl ImportMetaBinding {
-    pub fn new(path: FileSystemPath) -> Self {
-        ImportMetaBinding { path }
+    pub fn new(path: FileSystemPath, hmr_enabled: bool) -> Self {
+        ImportMetaBinding { path, hmr_enabled }
     }
 
     pub async fn code_generation(
@@ -63,7 +64,7 @@ impl ImportMetaBinding {
             },
         );
 
-        let hmr_enabled = *chunking_context.is_hot_module_replacement_enabled().await?;
+        let hmr_enabled = self.hmr_enabled;
 
         // [NOTE] url property is lazy-evaluated, as it should be computed once
         // turbopack_runtime injects a function to calculate an absolute path.

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1585,6 +1585,9 @@ async fn analyze_ecmascript_module_internal(
                         analysis_state.first_import_meta = false;
                         analysis.add_code_gen(ImportMetaBinding::new(
                             source.ident().path().owned().await?,
+                            analysis_state
+                                .compile_time_info_ref
+                                .hot_module_replacement_enabled,
                         ));
                     }
 


### PR DESCRIPTION
`is_hot_module_replacement_enabled` was removed from ChunkingContexts. Instead, pass it through from CompileTimeInfo when constructing ImportMetaBinding during analysis.

Test Plan: CI
