### PR TITLE
partial fallbacks: gate behind experimental flag

### DIFF
--- a/packages/next/src/build/adapter/build-complete.ts
+++ b/packages/next/src/build/adapter/build-complete.ts
@@ -1589,7 +1589,10 @@ export async function handleBuildComplete({
             (item) => item.page === dynamicRoute
           )?.routeKeys || {}
         )
+        const partialFallbacksEnabled =
+          config.experimental.partialFallbacks === true
         const partialFallback =
+          partialFallbacksEnabled &&
           isAppPage &&
           renderingMode === RenderingMode.PARTIALLY_STATIC &&
           typeof fallback === 'string' &&
@@ -1611,8 +1614,9 @@ export async function handleBuildComplete({
           // RSC shell.
           else if (meta.postponed) {
             // If there's postponed fallback content, we usually collapse to a shared shell (`[]`).
-            // For partial fallbacks in cache components, keep route allowQuery so
-            // fallback shells can be upgraded per-param instead of sharing one cache key.
+            // For opt-in partial fallbacks in cache components, keep route
+            // allowQuery so fallback shells can be upgraded per-param instead
+            // of sharing one cache key.
             htmlAllowQuery =
               partialFallback && routesManifest.rsc.clientParamParsing
                 ? allowQuery

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -979,6 +979,7 @@ export async function handler(
             if (
               !isMinimalMode &&
               isRoutePPREnabled &&
+              nextConfig.experimental.partialFallbacks === true &&
               ssgCacheKey &&
               incrementalCache &&
               !isOnDemandRevalidate &&

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -219,6 +219,7 @@ export const experimentalSchema = {
   caseSensitiveRoutes: z.boolean().optional(),
   clientParamParsingOrigins: z.array(z.string()).optional(),
   cachedNavigations: z.boolean().optional(),
+  partialFallbacks: z.boolean().optional(),
   dynamicOnHover: z.boolean().optional(),
   optimisticRouting: z.boolean().optional(),
   varyParams: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -353,6 +353,11 @@ export interface ExperimentalConfig {
    */
   clientParamParsingOrigins?: string[]
   cachedNavigations?: boolean
+  /**
+   * Enables partial fallback shells for cache-components routes while the
+   * feature stabilizes.
+   */
+  partialFallbacks?: boolean
   dynamicOnHover?: boolean
   optimisticRouting?: boolean
   varyParams?: boolean
@@ -1648,6 +1653,7 @@ export const defaultConfig = Object.freeze({
     caseSensitiveRoutes: false,
     clientParamParsingOrigins: undefined,
     cachedNavigations: false,
+    partialFallbacks: false,
     dynamicOnHover: false,
     varyParams: false,
     prefetchInlining: false,
@@ -1828,6 +1834,7 @@ export interface NextConfigRuntime {
     | 'maxPostponedStateSize'
     | 'devCacheControlNoCache'
     | 'cachedNavigations'
+    | 'partialFallbacks'
     | 'exposeTestingApiInProductionBuild'
     | 'immutableAssetToken'
   > & {
@@ -1898,6 +1905,7 @@ export function getNextConfigRuntime(
         maxPostponedStateSize: ex.maxPostponedStateSize,
         devCacheControlNoCache: ex.devCacheControlNoCache,
         cachedNavigations: ex.cachedNavigations,
+        partialFallbacks: ex.partialFallbacks,
         exposeTestingApiInProductionBuild: ex.exposeTestingApiInProductionBuild,
         immutableAssetToken: ex.immutableAssetToken,
 

--- a/test/e2e/app-dir/partial-fallback-shell-upgrade/next.config.js
+++ b/test/e2e/app-dir/partial-fallback-shell-upgrade/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    partialFallbacks: true,
+  },
 }
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
+++ b/test/e2e/app-dir/sub-shell-generation-middleware/next.config.js
@@ -4,6 +4,7 @@
 const nextConfig = {
   experimental: {
     useCache: true,
+    partialFallbacks: true,
   },
   rewrites: async () => {
     return {

--- a/test/e2e/app-dir/sub-shell-generation/next.config.js
+++ b/test/e2e/app-dir/sub-shell-generation/next.config.js
@@ -3,6 +3,9 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  experimental: {
+    partialFallbacks: true,
+  },
 }
 
 module.exports = nextConfig

--- a/test/production/adapter-config/adapter-config.test.ts
+++ b/test/production/adapter-config/adapter-config.test.ts
@@ -258,7 +258,6 @@ describe('adapter-config', () => {
     const indexPrerender = prerenderOutputs.find(
       (item) => item.pathname === '/docs'
     )
-
     expect(indexPrerender?.fallback?.initialHeaders).toEqual({
       'content-type': 'text/html; charset=utf-8',
       vary: 'rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch',


### PR DESCRIPTION
This puts the partial fallback upgrading feature introduced in https://github.com/vercel/next.js/pull/89063 behind a flag to make it easier to test the rollout/eventual stabilization in isolation.