### PR TITLE
fix: add redirect: 'manual' to createRedirectRenderResult fetch

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -417,6 +417,7 @@ async function createRedirectRenderResult(
       const response = await fetch(fetchUrl, {
         method: 'GET',
         headers: forwardedHeaders,
+        redirect: 'manual',
         next: {
           // @ts-ignore
           internal: 1,

--- a/test/e2e/app-dir/server-actions-redirect-chain/app/api/redirect-chain/route.ts
+++ b/test/e2e/app-dir/server-actions-redirect-chain/app/api/redirect-chain/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+
+export async function GET() {
+  // Simulate a route that redirects externally (e.g., OAuth flow).
+  // Without redirect: 'manual', createRedirectRenderResult would follow
+  // this redirect server-side, causing latency or errors.
+  return NextResponse.redirect('https://example.com/external-redirect')
+}

--- a/test/e2e/app-dir/server-actions-redirect-chain/app/layout.tsx
+++ b/test/e2e/app-dir/server-actions-redirect-chain/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/server-actions-redirect-chain/app/page.tsx
+++ b/test/e2e/app-dir/server-actions-redirect-chain/app/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from 'next/navigation'
+
+async function redirectToApiRoute() {
+  'use server'
+  redirect('/api/redirect-chain')
+}
+
+export default function Page() {
+  return (
+    <form action={redirectToApiRoute}>
+      <button id="redirect-chain" type="submit">
+        Redirect via API
+      </button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/server-actions-redirect-chain/next.config.js
+++ b/test/e2e/app-dir/server-actions-redirect-chain/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/test/e2e/app-dir/server-actions-redirect-chain/server-actions-redirect-chain.test.ts
+++ b/test/e2e/app-dir/server-actions-redirect-chain/server-actions-redirect-chain.test.ts
@@ -1,0 +1,28 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('server-actions-redirect-chain', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Regression test for https://github.com/vercel/next.js/issues/90591
+  // createRedirectRenderResult should use redirect: 'manual' to avoid
+  // following redirect chains server-side (causing latency or errors).
+  it('should handle server action redirect to a route that itself redirects', async () => {
+    const browser = await next.browser('/')
+
+    // The server action redirects to /api/redirect-chain, which redirects
+    // externally. With the fix, the client receives the redirect header
+    // without the server following the chain.
+    await browser.elementByCss('#redirect-chain').click()
+
+    await retry(async () => {
+      const url = await browser.url()
+      // The browser should navigate to either the API route (which issues
+      // the external redirect) or directly to the external URL. Either way,
+      // the server should not error with "redirect count exceeded".
+      expect(url).toMatch(/redirect-chain|example\.com/)
+    })
+  })
+})


### PR DESCRIPTION
## What?

Adds `redirect: 'manual'` to the `fetch()` call in `createRedirectRenderResult` in `action-handler.ts`.

## Why?

Without this option, `createRedirectRenderResult` follows the entire redirect chain server-side when the redirect target itself redirects (common with OAuth/SSO flows). This causes either:
- "redirect count exceeded" errors (500) when the chain is long
- Unnecessary latency as the server fetches the external redirect target before returning the redirect response to the client

The sibling function `createForwardedActionResponse` already uses `redirect: 'manual'` (added in PR #65097), but `createRedirectRenderResult` was missed.

## How?

Added `redirect: 'manual'` to the fetch options, matching the pattern already used in `createForwardedActionResponse`. This ensures the redirect is handed back to the client via the `x-action-redirect` header without the server following it.

Fixes #90591

This contribution was developed with AI assistance (Claude Code).