### PR TITLE
fix: suppress NoFallbackError console.error when dynamicParams=false

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2668,6 +2668,12 @@ export default abstract class Server<
       if (err instanceof NoFallbackError && bubbleNoFallback) {
         throw err
       }
+      // NoFallbackError is internal control flow for dynamicParams=false 404s.
+      // When bubbleNoFallback is false, handle it as a 404 without logging.
+      if (err instanceof NoFallbackError) {
+        res.statusCode = 404
+        return this.renderErrorToResponse(ctx, null)
+      }
       if (err instanceof DecodeError || err instanceof NormalizeError) {
         res.statusCode = 400
         return await this.renderErrorToResponse(ctx, err)

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -690,7 +690,7 @@ export async function initialize(opts: {
         if (err instanceof DecodeError) {
           invokePath = '/400'
           invokeStatus = '400'
-        } else {
+        } else if (!(err instanceof NoFallbackError)) {
           console.error(err)
         }
         res.statusCode = Number(invokeStatus)

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -690,7 +690,10 @@ export async function initialize(opts: {
         if (err instanceof DecodeError) {
           invokePath = '/400'
           invokeStatus = '400'
-        } else if (!(err instanceof NoFallbackError)) {
+        } else if (err instanceof NoFallbackError) {
+          invokePath = '/404'
+          invokeStatus = '404'
+        } else {
           console.error(err)
         }
         res.statusCode = Number(invokeStatus)

--- a/packages/next/src/server/response-cache/index.ts
+++ b/packages/next/src/server/response-cache/index.ts
@@ -16,6 +16,7 @@ import {
   toResponseCacheEntry,
 } from './utils'
 import type { RouteKind } from '../route-kind'
+import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 
 /**
  * Parses an environment variable as a positive integer, returning the fallback
@@ -378,7 +379,13 @@ export default class ResponseCache implements ResponseCacheBase {
       // If we've already resolved the cache entry, we can't reject as we
       // already resolved the cache entry so log the error here.
       if (resolved) {
-        console.error(err)
+        // NoFallbackError is an internal control-flow mechanism used to
+        // trigger 404 responses when dynamicParams = false. It should not
+        // be logged to console.error as it triggers false-positive alerts
+        // in APM tools (Datadog, Sentry, etc.).
+        if (!(err instanceof NoFallbackError)) {
+          console.error(err)
+        }
         return null
       }
 

--- a/packages/next/src/server/response-cache/web.ts
+++ b/packages/next/src/server/response-cache/web.ts
@@ -1,5 +1,6 @@
 import { DetachedPromise } from '../../lib/detached-promise'
 import type { ResponseCacheEntry, ResponseGenerator } from './types'
+import { NoFallbackError } from '../../shared/lib/no-fallback-error.external'
 
 /**
  * In the web server, there is currently no incremental cache provided and we
@@ -115,7 +116,9 @@ export default class WebResponseCache {
         // while revalidating in the background we can't reject as
         // we already resolved the cache entry so log the error here
         if (hasResolved) {
-          console.error(err)
+          if (!(err instanceof NoFallbackError)) {
+            console.error(err)
+          }
         } else {
           rejecter(err as Error)
         }

--- a/test/e2e/app-dir/dynamic-params-no-fallback-error/app/[slug]/page.tsx
+++ b/test/e2e/app-dir/dynamic-params-no-fallback-error/app/[slug]/page.tsx
@@ -1,0 +1,14 @@
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return [{ slug: 'about' }]
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  return <p id="page-content">Page: {slug}</p>
+}

--- a/test/e2e/app-dir/dynamic-params-no-fallback-error/app/layout.tsx
+++ b/test/e2e/app-dir/dynamic-params-no-fallback-error/app/layout.tsx
@@ -1,0 +1,7 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/dynamic-params-no-fallback-error/dynamic-params-no-fallback-error.test.ts
+++ b/test/e2e/app-dir/dynamic-params-no-fallback-error/dynamic-params-no-fallback-error.test.ts
@@ -1,0 +1,23 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('dynamic-params-no-fallback-error', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  // Regression test for https://github.com/vercel/next.js/issues/90537
+  // NoFallbackError is an internal control-flow mechanism that should not
+  // be logged to console.error when dynamicParams = false rejects a param.
+  it('should not log NoFallbackError to console.error on 404', async () => {
+    // Valid param should return 200
+    const validRes = await next.fetch('/about')
+    expect(validRes.status).toBe(200)
+
+    // Invalid param should return 404 without logging NoFallbackError
+    const invalidRes = await next.fetch('/nonexistent')
+    expect(invalidRes.status).toBe(404)
+
+    // Check that NoFallbackError was not logged
+    expect(next.cliOutput).not.toContain('NoFallbackError')
+  })
+})

--- a/test/e2e/app-dir/dynamic-params-no-fallback-error/next.config.js
+++ b/test/e2e/app-dir/dynamic-params-no-fallback-error/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}


### PR DESCRIPTION
## What?

Suppresses `NoFallbackError` from being logged to `console.error` when `dynamicParams = false` correctly rejects a param with a 404 response.

## Why?

`NoFallbackError` is an internal control-flow mechanism, not an actual error. When it leaks to `console.error`, APM tools (Datadog dd-trace, Sentry, New Relic) that hook into `console.error` generate false-positive error alerts. At scale, bot traffic hitting nonexistent paths produces hundreds of these alerts per day, drowning out real errors.

## How?

Added `NoFallbackError` instance checks before `console.error` calls in four locations where the error could leak:

1. **`response-cache/index.ts`** - Background revalidation catch block that logs errors when a cache entry was already resolved
2. **`response-cache/web.ts`** - Same pattern for the web response cache
3. **`router-server.ts`** - Top-level request handler catch that logs non-`DecodeError` exceptions
4. **`base-server.ts`** `renderToResponseImpl` - When `bubbleNoFallback` is false (production bundles), handle `NoFallbackError` as a 404 instead of falling through to the generic error handler that calls `logError`

The 404 response behavior is preserved - only the spurious `console.error` output is suppressed.

Fixes #90537

This contribution was developed with AI assistance (Claude Code).