### PR TITLE
Fix POST with form data returning 500 instead of 404

### DIFF
--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -773,11 +773,9 @@ export async function handleAction({
               // Multipart POST, but not a fetch action.
               // Potentially an MPA action, we have to try decoding it to check.
               if (areAllActionIdsValid(formData, serverModuleMap) === false) {
-                // TODO: This can be from skew or manipulated input. We should handle this case
-                // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
-                throw new Error(
-                  `Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
-                )
+                // Not a valid server action request (e.g., a regular form POST).
+                // Return null to fall through to normal routing (404).
+                return null
               }
 
               const action = await decodeAction(formData, serverModuleMap)
@@ -979,11 +977,9 @@ export async function handleAction({
               }
 
               if (areAllActionIdsValid(formData, serverModuleMap) === false) {
-                // TODO: This can be from skew or manipulated input. We should handle this case
-                // more gracefully but this preserves the prior behavior where decodeAction would throw instead.
-                throw new Error(
-                  `Failed to find Server Action. This request might be from an older or newer deployment.\nRead more: https://nextjs.org/docs/messages/failed-to-find-server-action`
-                )
+                // Not a valid server action request (e.g., a regular form POST).
+                // Return null to fall through to normal routing (404).
+                return null
               }
 
               // TODO: Refactor so it is harder to accidentally decode an action before you have validated that the

--- a/test/e2e/app-dir/post-formdata-404/app/layout.tsx
+++ b/test/e2e/app-dir/post-formdata-404/app/layout.tsx
@@ -1,0 +1,11 @@
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/post-formdata-404/app/page.tsx
+++ b/test/e2e/app-dir/post-formdata-404/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Home</p>
+}

--- a/test/e2e/app-dir/post-formdata-404/app/with-action/page.tsx
+++ b/test/e2e/app-dir/post-formdata-404/app/with-action/page.tsx
@@ -1,0 +1,10 @@
+export default function Page() {
+  async function myAction() {
+    'use server'
+  }
+  return (
+    <form action={myAction}>
+      <button type="submit">Submit</button>
+    </form>
+  )
+}

--- a/test/e2e/app-dir/post-formdata-404/next.config.js
+++ b/test/e2e/app-dir/post-formdata-404/next.config.js
@@ -1,0 +1,2 @@
+/** @type {import('next').NextConfig} */
+module.exports = {}

--- a/test/e2e/app-dir/post-formdata-404/post-formdata-404.test.ts
+++ b/test/e2e/app-dir/post-formdata-404/post-formdata-404.test.ts
@@ -1,0 +1,31 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('post-formdata-404', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  it('should return 404 for POST with multipart/form-data to a non-existent route', async () => {
+    const formData = new FormData()
+    formData.append('name', 'test')
+
+    const res = await next.fetch('/non-existent-route', {
+      method: 'POST',
+      body: formData,
+    })
+
+    expect(res.status).toBe(404)
+  })
+
+  it('should return 404 for POST with multipart/form-data to an existing route without server actions', async () => {
+    const formData = new FormData()
+    formData.append('name', 'test')
+
+    const res = await next.fetch('/', {
+      method: 'POST',
+      body: formData,
+    })
+
+    expect(res.status).toBe(404)
+  })
+})


### PR DESCRIPTION
## Summary

- When a `multipart/form-data` POST request is sent to a route that doesn't have a server action, Next.js returns a 500 error instead of 404
- The root cause is in `action-handler.ts`: when `areAllActionIdsValid()` returns false for a non-fetch multipart POST, the handler throws an error instead of returning `null` to fall through to normal routing
- Changed both occurrences (Web API path and Node.js streaming path) to return `null` instead of throwing, allowing normal 404 routing to occur

Fixes #90090

## Test plan

- Added e2e test `test/e2e/app-dir/post-formdata-404/` that verifies:
  - [ ] POST with `multipart/form-data` to a non-existent route returns 404
  - [ ] POST with `multipart/form-data` to an existing route without server actions returns 404

This contribution was developed with AI assistance (Claude Code).