### PR TITLE
fix: include file path in segment config validation error

### DIFF
--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -2213,7 +2213,7 @@ export default async function build(
                   : undefined
 
                 if (staticInfo?.hadUnsupportedValue) {
-                  errorFromUnsupportedSegmentConfig()
+                  errorFromUnsupportedSegmentConfig(pageFilePath)
                 }
 
                 // If there's any thing that would contribute to the functions
@@ -2575,7 +2575,7 @@ export default async function build(
         })
 
         if (staticInfo.hadUnsupportedValue) {
-          errorFromUnsupportedSegmentConfig()
+          errorFromUnsupportedSegmentConfig(path.join(dir, middlewareFile))
         }
 
         if (staticInfo.runtime === 'nodejs' || isProxyFile(page)) {
@@ -4240,9 +4240,12 @@ export default async function build(
   }
 }
 
-function errorFromUnsupportedSegmentConfig(): never {
+function errorFromUnsupportedSegmentConfig(pageFilePath?: string): never {
   Log.error(
-    `Invalid segment configuration export detected. This can cause unexpected behavior from the configs not being applied. You should see the relevant failures in the logs above. Please fix them to continue.`
+    `Invalid segment configuration export detected` +
+      (pageFilePath ? ` in "${pageFilePath}"` : '') +
+      `. The exported \`config\` must use statically analyzable values. Dynamic expressions like \`String.raw\`, template literals with variables, or function calls are not supported.\n` +
+      `Read More - https://nextjs.org/docs/messages/invalid-page-config`
   )
   process.exit(1)
 }

--- a/test/production/exported-runtimes-value-validation/index.test.ts
+++ b/test/production/exported-runtimes-value-validation/index.test.ts
@@ -55,6 +55,15 @@ describe('Exported runtimes value validation', () => {
         )
       )
     }
+
+    // Verify the final error message includes the file path
+    expect(result.stderr).toEqual(
+      expect.stringContaining('Invalid segment configuration export detected')
+    )
+    expect(result.stderr).toEqual(expect.stringContaining('middleware'))
+    expect(result.stderr).toEqual(
+      expect.stringContaining('statically analyzable')
+    )
   })
 
   test('fails the build on unrecognized runtimes value', async () => {


### PR DESCRIPTION
## Summary

- The generic "Invalid segment configuration export detected" error now includes the specific file path that has the issue
- Added a hint about static analyzability requirements (e.g., `String.raw`, template literals with variables, function calls are not supported)
- Added a link to the `invalid-page-config` docs page for more context

**Before:**
```
⨯ Invalid segment configuration export detected. This can cause unexpected behavior from the configs not being applied. You should see the relevant failures in the logs above. Please fix them to continue.
```

**After:**
```
⨯ Invalid segment configuration export detected in "src/proxy.ts". The exported `config` must use statically analyzable values. Dynamic expressions like `String.raw`, template literals with variables, or function calls are not supported.
Read More - https://nextjs.org/docs/messages/invalid-page-config
```

Fixes #89937

## Test plan

- [x] Updated existing test in `test/production/exported-runtimes-value-validation/` to verify the improved error message includes:
  - The "Invalid segment configuration export detected" text
  - The middleware file reference
  - The "statically analyzable" hint

This contribution was developed with AI assistance (Claude Code).