### PR TITLE
Add snapshot test for parallel slot flight router state

### DIFF
--- a/test/e2e/app-dir/parallel-routes-flight-router-state/app/@slot/default.tsx
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/app/@slot/default.tsx
@@ -1,0 +1,3 @@
+export default function SlotDefault() {
+  return null
+}

--- a/test/e2e/app-dir/parallel-routes-flight-router-state/app/@slot/nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/app/@slot/nested/page.tsx
@@ -1,0 +1,3 @@
+export default function NestedSlotPage() {
+  return <p>Nested slot content</p>
+}

--- a/test/e2e/app-dir/parallel-routes-flight-router-state/app/@slot/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/app/@slot/page.tsx
@@ -1,0 +1,3 @@
+export default function SlotPage() {
+  return <p>Slot content</p>
+}

--- a/test/e2e/app-dir/parallel-routes-flight-router-state/app/layout.tsx
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/app/layout.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react'
+export default function Root({
+  children,
+  slot,
+}: {
+  children: ReactNode
+  slot: ReactNode
+}) {
+  return (
+    <html>
+      <body>
+        <div id="children">{children}</div>
+        <div id="slot">{slot}</div>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/parallel-routes-flight-router-state/app/nested/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/app/nested/page.tsx
@@ -1,0 +1,3 @@
+export default function NestedPage() {
+  return <p>Nested main page</p>
+}

--- a/test/e2e/app-dir/parallel-routes-flight-router-state/app/page.tsx
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>Main page</p>
+}

--- a/test/e2e/app-dir/parallel-routes-flight-router-state/next.config.js
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/next.config.js
@@ -1,0 +1,6 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/parallel-routes-flight-router-state/parallel-routes-flight-router-state.test.ts
+++ b/test/e2e/app-dir/parallel-routes-flight-router-state/parallel-routes-flight-router-state.test.ts
@@ -1,0 +1,104 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('parallel-routes-flight-router-state', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+  })
+
+  function extractFlightRouterState(html: string) {
+    // The flight router state is embedded in the RSC payload as the "f" field
+    // in the initial chunk (row 0). It's inside script tags like:
+    //   self.__next_f.push([1,"0:{\"P\":...\"f\":[[...]],...}"])
+    // The data may be split across multiple push calls, so we need to find
+    // the chunk starting with "0:" that contains the "f" field.
+    const regex = /self\.__next_f\.push\(\[1,"(0:\{.*?)"]\)/gs
+    let match
+    while ((match = regex.exec(html)) !== null) {
+      const chunk = match[1]
+      // Unescape the JSON-in-JS string
+      const unescaped = chunk
+        .replace(/\\"/g, '"')
+        .replace(/\\n/g, '\n')
+        .replace(/\\\\/g, '\\')
+      // Parse as RSC row: "0:{json}"
+      const jsonStr = unescaped.slice(2) // strip "0:"
+      try {
+        const data = JSON.parse(jsonStr)
+        if (data.f) {
+          // data.f is the FlightRouterState: [[tree, seedData, head, ...]]
+          // We only care about the tree (first element of the first array)
+          return data.f[0][0]
+        }
+      } catch {
+        // If parsing fails, continue to next match
+      }
+    }
+    throw new Error('Could not extract flight router state from HTML')
+  }
+
+  it('should have correct flight router state for / (direct slot page)', async () => {
+    const html = await next.render('/')
+    const tree = extractFlightRouterState(html)
+    expect(tree).toMatchInlineSnapshot(`
+     [
+       "",
+       {
+         "children": [
+           "__PAGE__",
+           {},
+         ],
+         "slot": [
+           "(slot)",
+           {
+             "children": [
+               "__PAGE__",
+               {},
+             ],
+           },
+         ],
+       },
+       "$undefined",
+       "$undefined",
+       16,
+     ]
+    `)
+  })
+
+  it('should have correct flight router state for /nested (nested slot page)', async () => {
+    const html = await next.render('/nested')
+    const tree = extractFlightRouterState(html)
+    expect(tree).toMatchInlineSnapshot(`
+     [
+       "",
+       {
+         "children": [
+           "nested",
+           {
+             "children": [
+               "__PAGE__",
+               {},
+             ],
+           },
+         ],
+         "slot": [
+           "(slot)",
+           {
+             "children": [
+               "nested",
+               {
+                 "children": [
+                   "__PAGE__",
+                   {},
+                 ],
+               },
+             ],
+           },
+         ],
+       },
+       "$undefined",
+       "$undefined",
+       16,
+     ]
+    `)
+  })
+})


### PR DESCRIPTION
### What?

Adds an e2e snapshot test that captures the flight router state tree produced for parallel routes using `@slot`.

### Why?

There is a discrepancy between Turbopack and Webpack in how they represent parallel slot segments in the flight router state:

- **`@slot/page.tsx` (direct page)**: Turbopack produces `"(slot)"` as the segment, while Webpack produces `"__PAGE__"`.
- **`@slot/nested/page.tsx` (nested page)**: Both bundlers agree on `"(slot)"`.

**Root cause:**
- **Webpack** (`next-app-loader/index.ts`): When `@slot/page.tsx` exists directly (line 752-757), it matches as `[PAGE_SEGMENT]` which gets normalized to `__PAGE__`. Only nested parallel routes trigger `PARALLEL_VIRTUAL_SEGMENT` → `(slot)`.
- **Turbopack** (`app_structure.rs`): Unconditionally sets `tree.segment = "(slot)"` for any `@parallel` directory (line 1264-1268), regardless of nesting.

This test captures the current Turbopack behavior in inline snapshots so the discrepancy is visible and trackable.

### How?

New test at `test/e2e/app-dir/parallel-routes-flight-router-state/`:

**Fixture:**
```
app/
  layout.tsx          # Root layout accepting children + slot
  page.tsx            # Main page
  nested/page.tsx     # Nested main page
  @slot/
    page.tsx          # Direct page in slot
    default.tsx       # Default fallback
    nested/page.tsx   # Nested page in slot
```

**Tests:**
1. Fetches HTML for `/` and `/nested`
2. Extracts the flight router state tree from the RSC payload (`__next_f` script tags)
3. Inline snapshot asserts the tree structure

**Current results:**
- Turbopack (dev + start): 2/2 pass
- Webpack (start): 1/2 fail — the `/` route snapshot differs (`__PAGE__` vs `(slot)`)