### PR TITLE
chore(docs): mention behavior of redirects and remotePatterns

### DIFF
--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -608,7 +608,7 @@ module.exports = {
 
 The example above will ensure the `src` property of `next/image` must start with `https://assets.example.com` and must have the exact query string `?v=1727111025337`. Any other protocol or query string will respond with `400` Bad Request.
 
-Note that any allowed `remotePatterns` that respond with a redirect will follow the redirect from the remote image server without validating `remotePatterns` again on the redirect location. You can reduce or disable redirects by configuring [maximumredirects](#maximumredirects).
+Note that any allowed `remotePatterns` that respond with a redirect will follow the redirect from the remote image server without validating `remotePatterns` again on the redirect location. You can reduce or disable redirects by configuring [maximumRedirects](#maximumredirects).
 
 #### `loaderFile`
 

--- a/docs/01-app/03-api-reference/02-components/image.mdx
+++ b/docs/01-app/03-api-reference/02-components/image.mdx
@@ -608,6 +608,8 @@ module.exports = {
 
 The example above will ensure the `src` property of `next/image` must start with `https://assets.example.com` and must have the exact query string `?v=1727111025337`. Any other protocol or query string will respond with `400` Bad Request.
 
+Note that any allowed `remotePatterns` that respond with a redirect will follow the redirect from the remote image server without validating `remotePatterns` again on the redirect location. You can reduce or disable redirects by configuring [maximumredirects](#maximumredirects).
+
 #### `loaderFile`
 
 `loaderFiles` allows you to use a custom image optimization service instead of Next.js.
@@ -826,6 +828,8 @@ module.exports = {
   },
 }
 ```
+
+For your convenience, these redirects do not need to satisfy [remotePatterns](#remotepatterns).
 
 You can configure the number of redirects to follow when fetching remote images. Setting the value to `0` will disable following redirects.
 


### PR DESCRIPTION
Some users have been confused by the relationship of `images.remotePatterns` and `images.maximumRedirects` so lets document it. 

This behavior is expected since you might allowlist something like `https://github.com/styfle.png` and that can redirect to whatever it needs to redirect to (assuming maximumRedirects > 0). For example, it currently redirects to `https://avatars.githubusercontent.com/u/229881?v=4` but you can imagine in the future if the redirect was changed, you wouldn't want your app to break.

Regardless of redirects, the final response must be an image.