### PR TITLE
[test] Current behavior for request APIs in `generateStaticParams`

### DIFF
--- a/test/production/app-dir/generate-static-params-errors/app/[lang]/connection/[slug]/page.tsx
+++ b/test/production/app-dir/generate-static-params-errors/app/[lang]/connection/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { connection } from 'next/server'
+
+export default function Page() {
+  return <p>connection</p>
+}
+
+export async function generateStaticParams() {
+  await connection()
+  return [{ slug: 'test' }]
+}

--- a/test/production/app-dir/generate-static-params-errors/app/[lang]/cookies/[slug]/page.tsx
+++ b/test/production/app-dir/generate-static-params-errors/app/[lang]/cookies/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { cookies } from 'next/headers'
+
+export default function Page() {
+  return <p>cookies</p>
+}
+
+export async function generateStaticParams() {
+  await cookies()
+  return [{ slug: 'test' }]
+}

--- a/test/production/app-dir/generate-static-params-errors/app/[lang]/draft-mode/[slug]/page.tsx
+++ b/test/production/app-dir/generate-static-params-errors/app/[lang]/draft-mode/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { draftMode } from 'next/headers'
+
+export default function Page() {
+  return <p>draft-mode</p>
+}
+
+export async function generateStaticParams() {
+  await draftMode()
+  return [{ slug: 'test' }]
+}

--- a/test/production/app-dir/generate-static-params-errors/app/[lang]/headers/[slug]/page.tsx
+++ b/test/production/app-dir/generate-static-params-errors/app/[lang]/headers/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { headers } from 'next/headers'
+
+export default function Page() {
+  return <p>headers</p>
+}
+
+export async function generateStaticParams() {
+  await headers()
+  return [{ slug: 'test' }]
+}

--- a/test/production/app-dir/generate-static-params-errors/app/[lang]/layout.tsx
+++ b/test/production/app-dir/generate-static-params-errors/app/[lang]/layout.tsx
@@ -1,0 +1,11 @@
+export default function Root({ children }: { children: React.ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export async function generateStaticParams() {
+  return [{ lang: 'en' }]
+}

--- a/test/production/app-dir/generate-static-params-errors/app/[lang]/root-params/[slug]/page.tsx
+++ b/test/production/app-dir/generate-static-params-errors/app/[lang]/root-params/[slug]/page.tsx
@@ -1,0 +1,10 @@
+import { lang } from 'next/root-params'
+
+export default function Page() {
+  return <p>root-params</p>
+}
+
+export async function generateStaticParams() {
+  await lang()
+  return [{ slug: 'test' }]
+}

--- a/test/production/app-dir/generate-static-params-errors/generate-static-params-errors.test.ts
+++ b/test/production/app-dir/generate-static-params-errors/generate-static-params-errors.test.ts
@@ -1,0 +1,56 @@
+import { nextTestSetup } from 'e2e-utils'
+
+describe('generate-static-params-errors', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+  })
+
+  let cliOutputLength: number
+
+  afterEach(async () => {
+    await next.stop()
+  })
+
+  const buildRoute = async (routePath: string) => {
+    cliOutputLength = next.cliOutput.length
+    await next.build({ args: ['--debug-build-paths', routePath] })
+  }
+
+  const getCliOutput = () => next.cliOutput.slice(cliOutputLength)
+
+  it('should error when cookies() is called inside generateStaticParams', async () => {
+    await buildRoute('app/[lang]/cookies/[slug]/page.tsx')
+    expect(getCliOutput()).toContain(
+      'Error: `cookies` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context'
+    )
+  })
+
+  it('should error when headers() is called inside generateStaticParams', async () => {
+    await buildRoute('app/[lang]/headers/[slug]/page.tsx')
+    expect(getCliOutput()).toContain(
+      'Error: `headers` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context'
+    )
+  })
+
+  it('should error when connection() is called inside generateStaticParams', async () => {
+    await buildRoute('app/[lang]/connection/[slug]/page.tsx')
+    expect(getCliOutput()).toContain(
+      'Error: `connection` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context'
+    )
+  })
+
+  it('should error when draftMode() is called inside generateStaticParams', async () => {
+    await buildRoute('app/[lang]/draft-mode/[slug]/page.tsx')
+    expect(getCliOutput()).toContain(
+      'Error: `draftMode` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context'
+    )
+  })
+
+  it('should error when root params are accessed inside generateStaticParams', async () => {
+    await buildRoute('app/[lang]/root-params/[slug]/page.tsx')
+    expect(getCliOutput()).toContain(
+      "Error: Route /[lang]/root-params/[slug] used `import('next/root-params').lang()` outside of a Server Component. This is not allowed."
+    )
+  })
+})

--- a/test/production/app-dir/generate-static-params-errors/next.config.ts
+++ b/test/production/app-dir/generate-static-params-errors/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: { rootParams: true },
+}
+
+export default nextConfig


### PR DESCRIPTION
Adds a dedicated test suite that asserts on the errors thrown when `cookies`, `headers`, `connection`, `draftMode`, and `next/root-params` are called inside `generateStaticParams`. Currently, these all fail because `generateStaticParams` runs without a work unit store.

Each route is built individually using `--debug-build-paths` so we can capture and assert on the error for each API independently.