### PR TITLE
Avoid `undefined` outer work unit store in `"use cache"`

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1132,5 +1132,6 @@
   "1131": "createServerParamsForRoute should not be called inside generateStaticParams.",
   "1132": "Route %s used \\`draftMode()\\` inside \\`generateStaticParams\\`. This is not supported because \\`generateStaticParams\\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
   "1133": "createSearchParamsFromClient should not be called inside generateStaticParams.",
-  "1134": "Route %s used \\`headers()\\` inside \\`generateStaticParams\\`. This is not supported because \\`generateStaticParams\\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context"
+  "1134": "Route %s used \\`headers()\\` inside \\`generateStaticParams\\`. This is not supported because \\`generateStaticParams\\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
+  "1135": "\"use cache\" cannot be used outside of App Router. Expected a WorkUnitStore."
 }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -79,14 +79,17 @@ interface PrivateCacheContext {
     | RequestStore
     | PrivateUseCacheStore
     | PrerenderStoreModernRuntime
+  readonly skipPropagation: boolean
 }
 
 interface PublicCacheContext {
   readonly kind: 'public'
   // TODO: We should probably forbid nesting "use cache" inside unstable_cache.
-  readonly outerWorkUnitStore:
-    | Exclude<WorkUnitStore, PrerenderStoreModernClient | ValidationStoreClient>
-    | undefined
+  readonly outerWorkUnitStore: Exclude<
+    WorkUnitStore,
+    PrerenderStoreModernClient | ValidationStoreClient
+  >
+  readonly skipPropagation: boolean
 }
 
 type CacheContext = PrivateCacheContext | PublicCacheContext
@@ -234,29 +237,27 @@ function createUseCacheStore(
     let useCacheOrRequestStore: RequestStore | UseCacheStore | undefined
     const outerWorkUnitStore = cacheContext.outerWorkUnitStore
 
-    if (outerWorkUnitStore) {
-      switch (outerWorkUnitStore?.type) {
-        case 'cache':
-        case 'private-cache':
-        case 'request':
-          useCacheOrRequestStore = outerWorkUnitStore
-          break
-        case 'prerender-runtime':
-        case 'prerender':
-        case 'prerender-ppr':
-        case 'prerender-legacy':
-        case 'unstable-cache':
-        case 'generate-static-params':
-          break
-        default:
-          outerWorkUnitStore satisfies never
-      }
+    switch (outerWorkUnitStore.type) {
+      case 'cache':
+      case 'private-cache':
+      case 'request':
+        useCacheOrRequestStore = outerWorkUnitStore
+        break
+      case 'prerender-runtime':
+      case 'prerender':
+      case 'prerender-ppr':
+      case 'prerender-legacy':
+      case 'unstable-cache':
+      case 'generate-static-params':
+        break
+      default:
+        outerWorkUnitStore satisfies never
     }
 
     return {
       type: 'cache',
       phase: 'render',
-      implicitTags: outerWorkUnitStore?.implicitTags,
+      implicitTags: outerWorkUnitStore.implicitTags,
       revalidate: defaultCacheLife.revalidate,
       expire: defaultCacheLife.expire,
       stale: defaultCacheLife.stale,
@@ -264,15 +265,15 @@ function createUseCacheStore(
       explicitExpire: undefined,
       explicitStale: undefined,
       tags: null,
-      hmrRefreshHash:
-        outerWorkUnitStore && getHmrRefreshHash(outerWorkUnitStore),
+      hmrRefreshHash: getHmrRefreshHash(outerWorkUnitStore),
       isHmrRefresh: useCacheOrRequestStore?.isHmrRefresh ?? false,
       serverComponentsHmrCache:
         useCacheOrRequestStore?.serverComponentsHmrCache,
       forceRevalidate: shouldForceRevalidate(workStore, outerWorkUnitStore),
-      draftMode:
-        outerWorkUnitStore &&
-        getDraftModeProviderForCacheScope(workStore, outerWorkUnitStore),
+      draftMode: getDraftModeProviderForCacheScope(
+        workStore,
+        outerWorkUnitStore
+      ),
     }
   }
 }
@@ -387,7 +388,7 @@ function propagateCacheLifeAndTags(
         cacheContext.outerWorkUnitStore satisfies never
     }
   } else {
-    switch (cacheContext.outerWorkUnitStore?.type) {
+    switch (cacheContext.outerWorkUnitStore.type) {
       case 'cache':
       case 'private-cache':
       case 'prerender':
@@ -407,7 +408,6 @@ function propagateCacheLifeAndTags(
         break
       case 'unstable-cache':
       case 'generate-static-params':
-      case undefined:
         break
       default:
         cacheContext.outerWorkUnitStore satisfies never
@@ -509,7 +509,7 @@ async function collectResult(
     tags: collectedTags === null ? [] : collectedTags,
   }
 
-  if (cacheContext.outerWorkUnitStore) {
+  if (!cacheContext.skipPropagation) {
     const outerWorkUnitStore = cacheContext.outerWorkUnitStore
 
     // Propagate cache life & tags to the outer context if appropriate.
@@ -603,38 +603,35 @@ async function generateCacheEntryImpl(
                 yield entry
               }
 
-              if (outerWorkUnitStore) {
-                switch (outerWorkUnitStore.type) {
-                  case 'prerender-runtime':
-                  case 'prerender':
-                    // The encoded arguments might contain hanging promises. In
-                    // this case we don't want to reject with "Error: Connection
-                    // closed.", so we intentionally keep the iterable alive.
-                    // This is similar to the halting trick that we do while
-                    // rendering.
-                    await new Promise<void>((resolve) => {
-                      if (outerWorkUnitStore.renderSignal.aborted) {
-                        resolve()
-                      } else {
-                        outerWorkUnitStore.renderSignal.addEventListener(
-                          'abort',
-                          () => resolve(),
-                          { once: true }
-                        )
-                      }
-                    })
-                    break
-                  case 'prerender-ppr':
-                  case 'prerender-legacy':
-                  case 'request':
-                  case 'cache':
-                  case 'private-cache':
-                  case 'unstable-cache':
-                  case 'generate-static-params':
-                    break
-                  default:
-                    outerWorkUnitStore satisfies never
-                }
+              switch (outerWorkUnitStore.type) {
+                case 'prerender-runtime':
+                case 'prerender':
+                  // The encoded arguments might contain hanging promises. In
+                  // this case we don't want to reject with "Error: Connection
+                  // closed.", so we intentionally keep the iterable alive. This
+                  // is similar to the halting trick that we do while rendering.
+                  await new Promise<void>((resolve) => {
+                    if (outerWorkUnitStore.renderSignal.aborted) {
+                      resolve()
+                    } else {
+                      outerWorkUnitStore.renderSignal.addEventListener(
+                        'abort',
+                        () => resolve(),
+                        { once: true }
+                      )
+                    }
+                  })
+                  break
+                case 'prerender-ppr':
+                case 'prerender-legacy':
+                case 'request':
+                case 'cache':
+                case 'private-cache':
+                case 'unstable-cache':
+                case 'generate-static-params':
+                  break
+                default:
+                  outerWorkUnitStore satisfies never
               }
             },
           },
@@ -677,7 +674,7 @@ async function generateCacheEntryImpl(
 
   let stream: ReadableStream<Uint8Array>
 
-  switch (outerWorkUnitStore?.type) {
+  switch (outerWorkUnitStore.type) {
     case 'prerender-runtime':
     case 'prerender':
       const timeoutAbortController = new AbortController()
@@ -772,7 +769,6 @@ async function generateCacheEntryImpl(
     case 'private-cache':
     case 'unstable-cache':
     case 'generate-static-params':
-    case undefined:
       stream = renderToReadableStream(
         resultPromise,
         clientReferenceManifest.clientModules,
@@ -951,6 +947,12 @@ export async function cache(
   }
 
   const workUnitStore = workUnitAsyncStorage.getStore()
+  if (workUnitStore === undefined) {
+    throw new InvariantError(
+      '"use cache" cannot be used outside of App Router. Expected a WorkUnitStore.'
+    )
+  }
+
   const name = originalFn.name
   let fn = originalFn
   let cacheContext: CacheContext
@@ -958,7 +960,7 @@ export async function cache(
   if (isPrivate) {
     const expression = '"use cache: private"'
 
-    switch (workUnitStore?.type) {
+    switch (workUnitStore.type) {
       // "use cache: private" is dynamic in prerendering contexts.
       case 'prerender':
         return makeHangingPromise(
@@ -1007,10 +1009,10 @@ export async function cache(
         cacheContext = {
           kind: 'private',
           outerWorkUnitStore: workUnitStore,
+          skipPropagation: false,
         }
         break
       case 'generate-static-params':
-      case undefined:
         throw wrapAsInvalidDynamicUsageError(
           new Error(
             // TODO: Add a link to an error documentation page when we have one.
@@ -1025,7 +1027,7 @@ export async function cache(
         throw new InvariantError(`Unexpected work unit store.`)
     }
   } else {
-    switch (workUnitStore?.type) {
+    switch (workUnitStore.type) {
       case 'prerender-client':
       case 'validation-client':
         const expression = '"use cache"'
@@ -1043,10 +1045,10 @@ export async function cache(
       // unstable_cache. (fallthrough)
       case 'unstable-cache':
       case 'generate-static-params':
-      case undefined:
         cacheContext = {
           kind: 'public',
           outerWorkUnitStore: workUnitStore,
+          skipPropagation: false,
         }
         break
       default:
@@ -1072,11 +1074,9 @@ export async function cache(
   // components have been edited. This is a very coarse approach. But it's
   // also only a temporary solution until Action IDs are unique per
   // implementation. Remove this once Action IDs hash the implementation.
-  const hmrRefreshHash = workUnitStore && getHmrRefreshHash(workUnitStore)
+  const hmrRefreshHash = getHmrRefreshHash(workUnitStore)
 
-  const hangingInputAbortSignal = workUnitStore
-    ? createHangingInputAbortSignal(workUnitStore)
-    : undefined
+  const hangingInputAbortSignal = createHangingInputAbortSignal(workUnitStore)
 
   if (cacheContext.kind === 'private') {
     const { outerWorkUnitStore } = cacheContext
@@ -1248,7 +1248,7 @@ export async function cache(
 
   let encodedCacheKeyParts: FormData | string
 
-  switch (workUnitStore?.type) {
+  switch (workUnitStore.type) {
     case 'prerender-runtime':
     // We're currently only using `dynamicAccessAsyncStorage` for params,
     // which are always available in a runtime prerender, so they will never hang,
@@ -1312,15 +1312,13 @@ export async function cache(
   let stream: undefined | ReadableStream = undefined
 
   // Get an immutable and mutable versions of the resume data cache.
-  const prerenderResumeDataCache = workUnitStore
-    ? getPrerenderResumeDataCache(workUnitStore)
-    : null
-  const renderResumeDataCache = workUnitStore
-    ? getRenderResumeDataCache(workUnitStore)
-    : null
+  const prerenderResumeDataCache = getPrerenderResumeDataCache(workUnitStore)
+  const renderResumeDataCache = getRenderResumeDataCache(workUnitStore)
+
+  const implicitTags = workUnitStore.implicitTags?.tags ?? []
 
   if (renderResumeDataCache) {
-    const cacheSignal = workUnitStore ? getCacheSignal(workUnitStore) : null
+    const cacheSignal = getCacheSignal(workUnitStore)
 
     if (cacheSignal) {
       cacheSignal.beginRead()
@@ -1333,7 +1331,6 @@ export async function cache(
       // When a server action calls updateTag(), the re-render should see fresh data
       // instead of stale RDC data.
       if (existingResult !== undefined) {
-        const implicitTags = workUnitStore?.implicitTags?.tags ?? []
         if (
           existingResult.entry.tags.some((tag) =>
             isRecentlyRevalidatedTag(tag, workStore)
@@ -1348,7 +1345,7 @@ export async function cache(
         }
       }
 
-      if (workUnitStore !== undefined && existingResult !== undefined) {
+      if (existingResult !== undefined) {
         if (
           existingResult.entry.revalidate === 0 ||
           existingResult.entry.expire < DYNAMIC_EXPIRE
@@ -1545,50 +1542,47 @@ export async function cache(
         cacheSignal.endRead()
       }
 
-      if (workUnitStore) {
-        switch (workUnitStore.type) {
-          case 'prerender':
-            // If `allowEmptyStaticShell` is true, and thus a prefilled
-            // resume data cache was provided, then a cache miss means that
-            // params were part of the cache key. In this case, we can make
-            // this cache function a dynamic hole in the shell (or produce
-            // an empty shell if there's no parent suspense boundary).
-            // Currently, this also includes layouts and pages that don't
-            // read params, which will be improved when we implement
-            // NAR-136. Otherwise, we assume that if params are passed
-            // explicitly into a "use cache" function, that the params are
-            // also accessed. This allows us to abort early, and treat the
-            // function as dynamic, instead of waiting for the timeout to be
-            // reached. Compared to the instrumentation-based params bailout
-            // we do here, this also covers the case where params are
-            // transformed with an async function, before being passed into
-            // the "use cache" function, which escapes the instrumentation.
-            if (workUnitStore.allowEmptyStaticShell) {
-              return makeHangingPromise(
-                workUnitStore.renderSignal,
-                workStore.route,
-                'dynamic "use cache"'
-              )
-            }
-            break
-          case 'prerender-runtime':
-          case 'prerender-ppr':
-          case 'prerender-legacy':
-          case 'request':
-          case 'cache':
-          case 'private-cache':
-          case 'unstable-cache':
-          case 'generate-static-params':
-            break
-          default:
-            workUnitStore satisfies never
-        }
+      switch (workUnitStore.type) {
+        case 'prerender':
+          // If `allowEmptyStaticShell` is true, and thus a prefilled resume
+          // data cache was provided, then a cache miss means that params were
+          // part of the cache key. In this case, we can make this cache
+          // function a dynamic hole in the shell (or produce an empty shell if
+          // there's no parent suspense boundary). Currently, this also includes
+          // layouts and pages that don't read params, which will be improved
+          // when we implement NAR-136. Otherwise, we assume that if params are
+          // passed explicitly into a "use cache" function, that the params are
+          // also accessed. This allows us to abort early, and treat the
+          // function as dynamic, instead of waiting for the timeout to be
+          // reached. Compared to the instrumentation-based params bailout we do
+          // here, this also covers the case where params are transformed with
+          // an async function, before being passed into the "use cache"
+          // function, which escapes the instrumentation.
+          if (workUnitStore.allowEmptyStaticShell) {
+            return makeHangingPromise(
+              workUnitStore.renderSignal,
+              workStore.route,
+              'dynamic "use cache"'
+            )
+          }
+          break
+        case 'prerender-runtime':
+        case 'prerender-ppr':
+        case 'prerender-legacy':
+        case 'request':
+        case 'cache':
+        case 'private-cache':
+        case 'unstable-cache':
+        case 'generate-static-params':
+          break
+        default:
+          workUnitStore satisfies never
       }
     }
   }
 
   if (stream === undefined) {
-    const cacheSignal = workUnitStore ? getCacheSignal(workUnitStore) : null
+    const cacheSignal = getCacheSignal(workUnitStore)
     if (cacheSignal) {
       // Either the cache handler or the generation can be using I/O at this point.
       // We need to track when they start and when they complete.
@@ -1605,17 +1599,13 @@ export async function cache(
 
     // We ignore existing cache entries when force revalidating.
     if (cacheHandler && !shouldForceRevalidate(workStore, workUnitStore)) {
-      entry = await cacheHandler.get(
-        serializedCacheKey,
-        workUnitStore?.implicitTags?.tags ?? []
-      )
+      entry = await cacheHandler.get(serializedCacheKey, implicitTags)
     }
 
     if (entry) {
-      const implicitTags = workUnitStore?.implicitTags?.tags ?? []
       let implicitTagsExpiration = 0
 
-      if (workUnitStore?.implicitTags) {
+      if (workUnitStore.implicitTags) {
         const lazyExpiration =
           workUnitStore.implicitTags.expirationsByCacheKind.get(kind)
 
@@ -1651,7 +1641,6 @@ export async function cache(
 
     const currentTime = performance.timeOrigin + performance.now()
     if (
-      workUnitStore !== undefined &&
       entry !== undefined &&
       (entry.revalidate === 0 || entry.expire < DYNAMIC_EXPIRE)
     ) {
@@ -1839,8 +1828,14 @@ export async function cache(
         // revalidated entry.
         const result = await generateCacheEntry(
           workStore,
-          // This is not running within the context of this unit.
-          { kind: cacheContext.kind, outerWorkUnitStore: undefined },
+          // The background revalidation preserves the outer store for reading
+          // (e.g. implicitTags) but skips propagation of cache life and tags
+          // back to the outer scope.
+          {
+            kind: cacheContext.kind,
+            outerWorkUnitStore: cacheContext.outerWorkUnitStore,
+            skipPropagation: true,
+          },
           clientReferenceManifest,
           encodedCacheKeyParts,
           fn,
@@ -1941,13 +1936,13 @@ function isLayoutSegmentFunction(
 
 function shouldForceRevalidate(
   workStore: WorkStore,
-  workUnitStore: WorkUnitStore | undefined
+  workUnitStore: WorkUnitStore
 ): boolean {
   if (workStore.isOnDemandRevalidate || workStore.isDraftMode) {
     return true
   }
 
-  if (process.env.__NEXT_DEV_SERVER && workUnitStore) {
+  if (process.env.__NEXT_DEV_SERVER) {
     switch (workUnitStore.type) {
       case 'request':
         return workUnitStore.headers.get('cache-control') === 'no-cache'
@@ -1974,7 +1969,7 @@ function shouldForceRevalidate(
 function shouldDiscardCacheEntry(
   entry: CacheEntry,
   workStore: WorkStore,
-  workUnitStore: WorkUnitStore | undefined,
+  workUnitStore: WorkUnitStore,
   implicitTags: string[],
   implicitTagsExpiration: number
 ): boolean {
@@ -1996,24 +1991,22 @@ function shouldDiscardCacheEntry(
   // the affected cache entries, and we don't want to discard those again during
   // the prerender validation. During build-time prerendering, there will never
   // be any pending revalidated tags.
-  if (workUnitStore) {
-    switch (workUnitStore.type) {
-      case 'prerender':
-        return false
-      case 'prerender-runtime':
-      case 'prerender-client':
-      case 'validation-client':
-      case 'prerender-ppr':
-      case 'prerender-legacy':
-      case 'request':
-      case 'cache':
-      case 'private-cache':
-      case 'unstable-cache':
-      case 'generate-static-params':
-        break
-      default:
-        workUnitStore satisfies never
-    }
+  switch (workUnitStore.type) {
+    case 'prerender':
+      return false
+    case 'prerender-runtime':
+    case 'prerender-client':
+    case 'validation-client':
+    case 'prerender-ppr':
+    case 'prerender-legacy':
+    case 'request':
+    case 'cache':
+    case 'private-cache':
+    case 'unstable-cache':
+    case 'generate-static-params':
+      break
+    default:
+      workUnitStore satisfies never
   }
 
   // If the cache entry contains revalidated tags that the cache handler might

--- a/test/e2e/app-dir/use-cache-swr/app/layout.tsx
+++ b/test/e2e/app-dir/use-cache-swr/app/layout.tsx
@@ -1,0 +1,12 @@
+import { Suspense } from 'react'
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <head />
+      <body>
+        <Suspense>{children}</Suspense>
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/use-cache-swr/app/page.tsx
+++ b/test/e2e/app-dir/use-cache-swr/app/page.tsx
@@ -1,0 +1,31 @@
+import { cacheLife } from 'next/cache'
+import { connection } from 'next/server'
+
+async function getInnerData(id: string) {
+  'use cache'
+
+  return new Date().toISOString()
+}
+
+async function getOuterData(id: string) {
+  'use cache'
+
+  cacheLife({ revalidate: 5 })
+
+  const innerData = await getInnerData('inner')
+
+  return { outer: new Date().toISOString(), inner: innerData }
+}
+
+export default async function Page() {
+  await connection()
+
+  const data = await getOuterData('outer')
+
+  return (
+    <main>
+      <p id="outer-data">{data.outer}</p>
+      <p id="inner-data">{data.inner}</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/use-cache-swr/handler.js
+++ b/test/e2e/app-dir/use-cache-swr/handler.js
@@ -1,0 +1,81 @@
+// @ts-check
+
+/**
+ * A persistent cache handler that does NOT drop entries at revalidate time.
+ * This allows the framework's SWR code path to trigger, unlike the default
+ * in-memory handler which expires entries at revalidate time.
+ */
+
+/** @type {Map<string, import('next/dist/server/lib/cache-handlers/types').CacheEntry>} */
+const store = new Map()
+
+/** @type {Map<string, Promise<void>>} */
+const pendingSets = new Map()
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  async get(cacheKey, softTags) {
+    const pendingPromise = pendingSets.get(cacheKey)
+    if (pendingPromise) {
+      await pendingPromise
+    }
+
+    const entry = store.get(cacheKey)
+    if (!entry) {
+      console.log('PersistentCacheHandler::get', cacheKey, softTags, '-> miss')
+      return undefined
+    }
+
+    const [returnStream, savedStream] = entry.value.tee()
+    entry.value = savedStream
+
+    console.log(
+      'PersistentCacheHandler::get',
+      cacheKey,
+      softTags,
+      '-> hit, revalidate:',
+      entry.revalidate
+    )
+
+    return { ...entry, value: returnStream }
+  },
+
+  async set(cacheKey, pendingEntry) {
+    /** @type {() => void} */
+    let resolvePending = () => {}
+    const pendingPromise = new Promise((resolve) => {
+      resolvePending = /** @type {() => void} */ (resolve)
+    })
+    pendingSets.set(cacheKey, pendingPromise)
+
+    try {
+      const entry = await pendingEntry
+      const [value, clonedValue] = entry.value.tee()
+      entry.value = value
+
+      // Consume the cloned stream to ensure the entry is fully resolved.
+      const reader = clonedValue.getReader()
+      while (!(await reader.read()).done) {}
+
+      store.set(cacheKey, entry)
+      console.log('PersistentCacheHandler::set', cacheKey)
+    } catch (err) {
+      console.log('PersistentCacheHandler::set', cacheKey, 'failed', err)
+    } finally {
+      resolvePending()
+      pendingSets.delete(cacheKey)
+    }
+  },
+
+  async refreshTags() {},
+
+  async getExpiration(_tags) {
+    return Infinity
+  },
+
+  async updateTags(_tags) {},
+}
+
+module.exports = cacheHandler

--- a/test/e2e/app-dir/use-cache-swr/next.config.js
+++ b/test/e2e/app-dir/use-cache-swr/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  cacheHandlers: {
+    default: require.resolve('./handler.js'),
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
+++ b/test/e2e/app-dir/use-cache-swr/use-cache-swr.test.ts
@@ -1,0 +1,81 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('use-cache-swr', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) return
+
+  let outputIndex: number
+
+  beforeEach(() => {
+    outputIndex = next.cliOutput.length
+  })
+
+  it('should serve stale data and then pre-warmed data on subsequent request', async () => {
+    const browser = await next.browser('/')
+    const initialOuter = await browser.elementById('outer-data').text()
+    expect(initialOuter).toBeDateString()
+
+    // Wait for the outer cache to go stale (revalidate: 5).
+    await new Promise((resolve) => setTimeout(resolve, 6000))
+
+    // This request should trigger SWR: the handler returns the stale entry,
+    // the framework serves it to the client, and kicks off a background regen.
+    await browser.refresh()
+    const afterStale = await browser.elementById('outer-data').text()
+
+    // The stale data should be the same as the initial data.
+    expect(afterStale).toBe(initialOuter)
+
+    // Wait for the background regen to complete by polling for its set log.
+    await retry(() => {
+      const regenOutput = next.cliOutput.slice(outputIndex)
+      expect(regenOutput).toMatch(/PersistentCacheHandler::set.*"outer"/)
+    })
+
+    // Reset output index to capture only the next request's handler logs.
+    outputIndex = next.cliOutput.length
+
+    // Refresh again. The pre-warmed entry from the SWR regen should be served.
+    await browser.refresh()
+    const afterRegen = await browser.elementById('outer-data').text()
+
+    // The data should now be fresh (different from the stale data).
+    expect(afterRegen).not.toBe(initialOuter)
+
+    // Verify this was served from the pre-warmed cache (get hit, no set).
+    const cliOutput = next.cliOutput.slice(outputIndex)
+    expect(cliOutput).toMatch(/PersistentCacheHandler::get.*"outer".*-> hit/)
+    expect(cliOutput).not.toMatch(/PersistentCacheHandler::set.*"outer"/)
+  })
+
+  it('should pass implicit tags to cache handler get() for nested caches during SWR', async () => {
+    const browser = await next.browser('/')
+    await browser.elementById('outer-data').text()
+
+    // Wait for the outer cache to go stale (revalidate: 5).
+    await new Promise((resolve) => setTimeout(resolve, 6000))
+
+    // Reset output index to capture only the SWR-related logs.
+    outputIndex = next.cliOutput.length
+
+    // This triggers SWR: stale outer is served, background regen starts.
+    // During regen, the outer fn re-executes and calls the inner "use cache".
+    // The inner cache's get() should receive the page's implicit tags.
+    await browser.refresh()
+
+    // Wait for the background regen to complete.
+    await new Promise((resolve) => setTimeout(resolve, 1000))
+
+    const cliOutput = next.cliOutput.slice(outputIndex)
+
+    // The inner cache's get() during SWR regen should include the page's
+    // implicit tags (softTags), not an empty array. We identify the inner
+    // cache by its "inner" sentinel argument in the key.
+    expect(cliOutput).toMatch(/PersistentCacheHandler::get.*"inner".*_N_T_\//)
+  })
+})


### PR DESCRIPTION
The `outerWorkUnitStore` in the public cache context could previously be `undefined`, which was needed when `"use cache"` was called without a `WorkUnitStore` (e.g. inside `generateStaticParams`) and during background revalidation of stale cache entries (SWR). With the previous commit providing a `GenerateStaticParamsStore` for `generateStaticParams`, the only remaining source of `undefined` was the SWR background revalidation path, which intentionally discarded the store to prevent cache life and tags from propagating back to the outer scope.

A `skipPropagation` flag was added to `CacheContext` to decouple the propagation concern from the store reference. The SWR background regen now passes `skipPropagation: true` while keeping the outer store intact for reads (e.g. `implicitTags`). Previously, nested `"use cache"` calls during SWR regen would pass empty `softTags` to `cacheHandler.get()` because the store was `undefined`. Now they correctly receive the page's implicit tags.

With `| undefined` removed from `PublicCacheContext.outerWorkUnitStore`, all unnecessary existence checks (`?.`, `if (x)`, `case undefined:`, ternaries) were cleaned up throughout `use-cache-wrapper.ts`, and the `shouldForceRevalidate` and `shouldDiscardCacheEntry` signatures were tightened from `WorkUnitStore | undefined` to `WorkUnitStore`.

Note that module-scope `"use cache"` usage (calling a cached function at the top level of a module) was already prevented before this change by the `WorkStore` check, which throws if no `WorkStore` is present. The new `WorkUnitStore` check is an additional guard that comes after it.

This also unblocks a future change to support root params inside `"use cache"` with cache keying. Since the outer work unit store is now always defined, `rootParams` can be threaded from the outer store into the cache store. The only exception will be `UnstableCacheStore`, which doesn't carry `rootParams` and can't include them in its cache key.

A new `use-cache-swr` test suite was added with a persistent cache handler that does not drop entries at revalidate time (unlike the default in-memory handler), which enables testing the server-side SWR code path that was previously uncovered.

> [!TIP]
> Best reviewed with hidden whitespace changes.  