### PR TITLE
Tracing: tag spans as failed if their runner fn fails

### DIFF
--- a/packages/next/src/trace/trace.ts
+++ b/packages/next/src/trace/trace.ts
@@ -133,6 +133,9 @@ export class Span {
   traceFn<T>(fn: (span: Span) => T): T {
     try {
       return fn(this)
+    } catch (e) {
+      this.attrs['failed'] = true
+      throw e
     } finally {
       this.stop()
     }
@@ -141,6 +144,9 @@ export class Span {
   async traceAsyncFn<T>(fn: (span: Span) => T | Promise<T>): Promise<T> {
     try {
       return await fn(this)
+    } catch (e) {
+      this.attrs['failed'] = true
+      throw e
     } finally {
       this.stop()
     }

--- a/test/production/build-failed-trace/build-failed-trace.test.ts
+++ b/test/production/build-failed-trace/build-failed-trace.test.ts
@@ -1,0 +1,37 @@
+import { nextTestSetup, isNextStart } from 'e2e-utils'
+import { join } from 'path'
+import { readFileSync } from 'fs'
+import type { TraceEvent } from 'next/dist/trace'
+
+function parseTraceFile(tracePath: string): TraceEvent[] {
+  const content = readFileSync(tracePath, 'utf8')
+  const events: TraceEvent[] = []
+  for (const line of content.trim().split('\n').filter(Boolean)) {
+    events.push(...(JSON.parse(line) as TraceEvent[]))
+  }
+  return events
+}
+
+describe('build-failed-trace', () => {
+  if (!isNextStart) {
+    return
+  }
+
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  it('should mark the next-build span as failed when the build fails', async () => {
+    const { exitCode } = await next.build()
+    expect(exitCode).not.toBe(0)
+
+    const tracePath = join(next.testDir, '.next', 'trace')
+    const events = parseTraceFile(tracePath)
+
+    const nextBuildEvent = events.find((e) => e.name === 'next-build')
+    expect(nextBuildEvent).toBeDefined()
+    expect(nextBuildEvent!.tags).toMatchObject({ failed: true })
+  })
+})

--- a/test/production/build-failed-trace/next.config.js
+++ b/test/production/build-failed-trace/next.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  redirects: async () => {
+    throw new Error('intentional build failure for trace testing')
+  },
+}

--- a/test/production/build-failed-trace/pages/index.tsx
+++ b/test/production/build-failed-trace/pages/index.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}


### PR DESCRIPTION
This adds a dedicated attribute, `failed`, to a span representing if the procedure failed. It's then set if the runner function threw.

Test Plan: Added an e2e test
