### PR TITLE
perf: skip anySegmentHasRuntimePrefetchEnabled when cacheComponents is disabled

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -551,8 +551,11 @@ async function generateDynamicRSCPayload(
       !options?.actionResult && // Only for navigations
       (await anySegmentNeedsInstantValidation(loaderTree))
 
-    const metadataIsRuntimePrefetchable =
-      await anySegmentHasRuntimePrefetchEnabled(loaderTree)
+    // unstable_instant (runtime prefetch) requires cacheComponents. Skip the
+    // expensive module-loading tree walk when cacheComponents is disabled.
+    const metadataIsRuntimePrefetchable = ctx.renderOpts.cacheComponents
+      ? await anySegmentHasRuntimePrefetchEnabled(loaderTree)
+      : false
     const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
       tree: loaderTree,
       parsedQuery: query,
@@ -1650,8 +1653,11 @@ async function getRSCPayload(
   const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
   const hasGlobalNotFound = !!tree[2]['global-not-found']
 
-  const metadataIsRuntimePrefetchable =
-    await anySegmentHasRuntimePrefetchEnabled(tree)
+  // unstable_instant (runtime prefetch) requires cacheComponents. Skip the
+  // expensive module-loading tree walk when cacheComponents is disabled.
+  const metadataIsRuntimePrefetchable = ctx.renderOpts.cacheComponents
+    ? await anySegmentHasRuntimePrefetchEnabled(tree)
+    : false
   const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
     tree,
     // When it's using global-not-found, metadata errorType is undefined, which will retrieve the
@@ -1790,8 +1796,11 @@ async function getErrorRSCPayload(
   } = ctx
 
   const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata
-  const metadataIsRuntimePrefetchable =
-    await anySegmentHasRuntimePrefetchEnabled(tree)
+  // unstable_instant (runtime prefetch) requires cacheComponents. Skip the
+  // expensive module-loading tree walk when cacheComponents is disabled.
+  const metadataIsRuntimePrefetchable = ctx.renderOpts.cacheComponents
+    ? await anySegmentHasRuntimePrefetchEnabled(tree)
+    : false
   const { Viewport, Metadata } = createMetadataComponents({
     tree,
     parsedQuery: query,


### PR DESCRIPTION
## Summary

`anySegmentHasRuntimePrefetchEnabled` recursively loads ALL layout/page modules via `getLayoutOrPageModule(tree)` to check if any segment exports `unstable_instant` with `prefetch: 'runtime'`. On cold start, this loads every module in the route tree.

The function is called 3 times per request in the main render pipeline (`generateDynamicRSCPayload`, `getRSCPayload`, `getErrorRSCPayload`), each traversing the entire route tree.

However, `unstable_instant` requires `cacheComponents` to function. When `cacheComponents` is disabled (the default), these module loads are wasted — the function always returns `false`.

**Changes:**
- Gate the 3 ungated `anySegmentHasRuntimePrefetchEnabled` call sites on `ctx.renderOpts.cacheComponents`
- The remaining 2 call sites are already inside `cacheComponents` blocks

### Evidence that this is safe

- `anySegmentNeedsInstantValidation` (companion function) is already gated on `ctx.renderOpts.cacheComponents`
- `generateStagedDynamicFlightRenderResult` (which uses the result) is only called when `cacheComponents && cachedNavigations`
- The `unstable_instant` config is only read by the async path in `createFlightRouterState`, which only runs when `cacheComponents` is enabled

### Impact

On a 500+ segment app, eliminates 3 full tree traversals with module loading per request when `cacheComponents` is disabled (the default).

## Test plan

- [x] TypeScript compilation passes
- [x] Prettier and ESLint pass (pre-commit hooks)
- [x] Verified all 5 call sites — 2 already gated, 3 now gated
- [x] No behavioral change for default config (`cacheComponents` disabled)
- [x] Identical behavior when `cacheComponents` is enabled


🤖 Generated with [Claude Code](https://claude.com/claude-code)