### PR TITLE
perf: use Buffer.from for base64 encoding of binary Flight data

### DIFF
--- a/packages/next/src/server/app-render/use-flight-response.tsx
+++ b/packages/next/src/server/app-render/use-flight-response.tsx
@@ -241,7 +241,14 @@ function writeFlightDataInstruction(
     // Instead let's inline it in base64.
     // Credits to Devon Govett (devongovett) for the technique.
     // https://github.com/devongovett/rsc-html-stream
-    const base64 = btoa(String.fromCodePoint(...chunk))
+    const base64 =
+      typeof Buffer !== 'undefined'
+        ? Buffer.from(
+            chunk.buffer,
+            chunk.byteOffset,
+            chunk.byteLength
+          ).toString('base64')
+        : btoa(String.fromCodePoint(...chunk))
     htmlInlinedData = htmlEscapeJsonString(
       JSON.stringify([INLINE_FLIGHT_PAYLOAD_BINARY, base64])
     )


### PR DESCRIPTION
## Summary

Replace `btoa(String.fromCodePoint(...chunk))` with `Buffer.from().toString('base64')` for encoding binary Flight data chunks in `writeFlightDataInstruction`.

The spread operator `...chunk` converts the entire Uint8Array into individual arguments on the call stack. For a 64KB binary chunk, this creates 65,536 arguments — causing:
- Significant call stack pressure (V8's argument limit is ~65K)
- Temporary JS string allocation from `String.fromCodePoint`
- The entire chunk must be converted to a JS string before base64 encoding

`Buffer.from().toString('base64')` performs base64 encoding natively in C++ without any intermediate string allocation or argument spreading.

**Edge runtime compatibility**: Falls back to the original `btoa` path where `Buffer` is unavailable.

## Test plan

- [x] TypeScript compilation passes
- [x] Prettier and ESLint pass (pre-commit hooks)
- [x] Produces identical base64 output
- [x] Edge runtime falls back to original path (no `Buffer` available)
- [x] Node.js runtime uses `Buffer.from` for native encoding


🤖 Generated with [Claude Code](https://claude.com/claude-code)