### PR TITLE
perf: memoize getRenderedSearch per query object

### DIFF
--- a/improvements/008-memoize-rendered-search.md
+++ b/improvements/008-memoize-rendered-search.md
@@ -1,0 +1,45 @@
+# Improvement 008: Memoize getRenderedSearch per Query Object
+
+## Problem
+
+`getRenderedSearch(query)` is called 4 times per SSR request with the same `query` object:
+
+- Line 631 — `generateDynamicRSCPayload` (navigation requests)
+- Line 641 — `generateDynamicRSCPayload` (navigation requests)
+- Line 1749 — `getRSCPayload`
+- Line 1886 — `getRSCPayload`
+
+Each call iterates over all query parameters, calling `encodeURIComponent()` on every key and value, then joins them with `&`. For a URL with 5 query parameters, that's 10 `encodeURIComponent` calls × 4 invocations = 40 redundant encoding operations per request.
+
+### Impact on throughput
+
+The query object is the same reference for all calls within a request — the result is always identical. For pages with many search parameters (e.g., filter-heavy e-commerce), the redundant encoding adds measurable overhead.
+
+## Solution
+
+Memoize using a WeakMap keyed by the query object:
+
+```typescript
+const renderedSearchCache = new WeakMap<NextParsedUrlQuery, string>()
+
+function getRenderedSearch(query: NextParsedUrlQuery): string {
+  const cached = renderedSearchCache.get(query)
+  if (cached !== undefined) return cached
+
+  // ... compute result ...
+
+  renderedSearchCache.set(query, result)
+  return result
+}
+```
+
+## Behavioral Correctness
+
+- `getRenderedSearch` is a pure function of the query object — memoization produces identical output
+- WeakMap keyed by the per-request query object — no cross-request leakage
+- After the request completes and the query object is GC'd, the cache entry is also collected
+- No change in rendered output or search string format
+
+## Files Changed
+
+- `packages/next/src/server/app-render/app-render.tsx` — memoize `getRenderedSearch` with WeakMap

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -1573,7 +1573,13 @@ function prepareInitialCanonicalUrl(url: RequestStore['url']) {
   return (url.pathname + url.search).split('/')
 }
 
+// Memoize per query object — called 4 times per request with the same object
+const renderedSearchCache = new WeakMap<NextParsedUrlQuery, string>()
+
 function getRenderedSearch(query: NextParsedUrlQuery): string {
+  const cached = renderedSearchCache.get(query)
+  if (cached !== undefined) return cached
+
   // Inlined implementation of querystring.encode, which is not available in
   // the Edge runtime.
   const pairs = []
@@ -1598,12 +1604,17 @@ function getRenderedSearch(query: NextParsedUrlQuery): string {
   // TODO: We're a bit inconsistent about this. The x-nextjs-rewritten-query
   // header omits the leading question mark. Should refactor to always do
   // that instead.
+  let result: string
   if (pairs.length === 0) {
     // If the search string is empty, return an empty string.
-    return ''
+    result = ''
+  } else {
+    // Prepend '?' to the search params string.
+    result = '?' + pairs.join('&')
   }
-  // Prepend '?' to the search params string.
-  return '?' + pairs.join('&')
+
+  renderedSearchCache.set(query, result)
+  return result
 }
 
 // This is the data necessary to render <AppRouter /> when no SSR errors are encountered


### PR DESCRIPTION
## Summary

`getRenderedSearch(query)` is called **4 times per SSR request** with the same `query` object reference. Each call iterates all query parameters calling `encodeURIComponent()` on every key and value, then joins them. For a URL with 5 query parameters, that's 40 redundant encoding operations per request.

This PR memoizes the result using a `WeakMap` keyed by the `query` object. After the request completes and the query object is GC'd, the cache entry is also collected.

### Behavioral correctness

- `getRenderedSearch` is a pure function of the query object
- WeakMap keyed by the per-request query object — no cross-request leakage
- No change in rendered output or search string format

## Files Changed

- `packages/next/src/server/app-render/app-render.tsx` — memoize `getRenderedSearch` with WeakMap

## Test plan

- [ ] Verify existing tests pass
- [ ] Verify SSR output is identical before/after