### PR TITLE
perf: hoist TextEncoder singletons, pre-compile RegExp, avoid redundant Uint8Array wrap

### DIFF
--- a/improvements/011-hoist-singletons.md
+++ b/improvements/011-hoist-singletons.md
@@ -1,0 +1,46 @@
+# Improvement 011: Hoist Singletons and Pre-compile RegExp Patterns
+
+## Problem
+
+Several per-request allocations of stateless objects that should be module-scoped singletons:
+
+### 1. `new TextEncoder()` in `api-utils/web.ts`
+
+`byteLength()` creates a new TextEncoder on every call. Called per-request for payload size checks.
+
+### 2. `new TextEncoder()` in `incremental-cache/index.ts`
+
+`generateCacheKey()` creates a new TextEncoder (and TextDecoder) inside the method. The encoder is stateless and can be shared; the decoder must remain per-call because it uses streaming mode.
+
+### 3. `new TextEncoder()` in `node-web-streams-helper.ts`
+
+`createRuntimePrefetchTransformStream` creates its own TextEncoder despite the file already having a module-scoped `encoder` at line 34.
+
+### 4. `new RegExp()` in `segment-explorer-path.ts`
+
+`normalizeBoundaryFilename()` creates two RegExp objects on every call from constant strings that never change.
+
+### 5. Redundant `new Uint8Array()` in `encryption-utils.ts`
+
+`arrayBufferToString()` wraps the input in `new Uint8Array(buffer)` even when the input is already a Uint8Array.
+
+## Solution
+
+- Hoist TextEncoder instances to module scope
+- Pre-compile RegExp patterns at module scope
+- Skip Uint8Array wrapping when input is already Uint8Array
+
+## Behavioral Correctness
+
+- TextEncoder is stateless (unlike TextDecoder which is stateful when streaming) — safe to share
+- RegExp patterns from constant strings produce identical results at module scope
+- `buffer instanceof Uint8Array` check avoids redundant wrapping
+- No change in output
+
+## Files Changed
+
+- `packages/next/src/server/api-utils/web.ts` — hoist TextEncoder
+- `packages/next/src/server/lib/incremental-cache/index.ts` — hoist TextEncoder
+- `packages/next/src/server/stream-utils/node-web-streams-helper.ts` — reuse existing module encoder
+- `packages/next/src/server/app-render/segment-explorer-path.ts` — pre-compile RegExp
+- `packages/next/src/server/app-render/encryption-utils.ts` — avoid redundant Uint8Array wrap

--- a/packages/next/src/server/api-utils/web.ts
+++ b/packages/next/src/server/api-utils/web.ts
@@ -1,5 +1,7 @@
 // Buffer.byteLength polyfill in the Edge runtime, with only utf8 strings
 // supported at the moment.
+const textEncoder = new TextEncoder()
+
 export function byteLength(payload: string): number {
-  return new TextEncoder().encode(payload).buffer.byteLength
+  return textEncoder.encode(payload).buffer.byteLength
 }

--- a/packages/next/src/server/app-render/encryption-utils.ts
+++ b/packages/next/src/server/app-render/encryption-utils.ts
@@ -6,7 +6,7 @@ let __next_loaded_action_key: CryptoKey
 export function arrayBufferToString(
   buffer: ArrayBuffer | Uint8Array<ArrayBufferLike>
 ) {
-  const bytes = new Uint8Array(buffer)
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer)
   const len = bytes.byteLength
 
   // @anonrig: V8 has a limit of 65535 arguments in a function.

--- a/packages/next/src/server/app-render/segment-explorer-path.ts
+++ b/packages/next/src/server/app-render/segment-explorer-path.ts
@@ -80,10 +80,15 @@ export const isNextjsBuiltinFilePath = (filePath: string) => {
 }
 
 export const BOUNDARY_SUFFIX = '@boundary'
+
+// Pre-compiled at module scope — avoids per-call RegExp construction
+const builtinPrefixRegex = new RegExp(`^${BUILTIN_PREFIX}`)
+const boundarySuffixRegex = new RegExp(`${BOUNDARY_SUFFIX}$`)
+
 export function normalizeBoundaryFilename(filename: string) {
   return filename
-    .replace(new RegExp(`^${BUILTIN_PREFIX}`), '')
-    .replace(new RegExp(`${BOUNDARY_SUFFIX}$`), '')
+    .replace(builtinPrefixRegex, '')
+    .replace(boundarySuffixRegex, '')
 }
 
 export const BOUNDARY_PREFIX = 'boundary:'

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -37,6 +37,9 @@ import { workAsyncStorage } from '../../app-render/work-async-storage.external'
 import { DetachedPromise } from '../../../lib/detached-promise'
 import { areTagsExpired, areTagsStale } from './tags-manifest.external'
 
+// Shared TextEncoder for cache key generation — TextEncoder is stateless
+const cacheKeyEncoder = new TextEncoder()
+
 export interface CacheHandlerContext {
   fs?: CacheFs
   dev?: boolean
@@ -300,7 +303,8 @@ export class IncrementalCache implements IncrementalCacheType {
 
     const bodyChunks: string[] = []
 
-    const encoder = new TextEncoder()
+    const encoder = cacheKeyEncoder
+    // TextDecoder is stateful when streaming — must be per-call
     const decoder = new TextDecoder()
 
     if (init.body) {

--- a/packages/next/src/server/stream-utils/node-web-streams-helper.ts
+++ b/packages/next/src/server/stream-utils/node-web-streams-helper.ts
@@ -1115,13 +1115,11 @@ export function createRuntimePrefetchTransformStream(
   isPartial: boolean,
   staleTime: number
 ): TransformStream<Uint8Array, Uint8Array> {
-  const enc = new TextEncoder()
-
   // Search for: [<sentinel>]
   // Replace with: [<isPartial>,<staleTime>]
-  const search = enc.encode(`[${sentinel}]`)
+  const search = encoder.encode(`[${sentinel}]`)
   const first = search[0]
-  const replace = enc.encode(`[${isPartial},${staleTime}]`)
+  const replace = encoder.encode(`[${isPartial},${staleTime}]`)
   const searchLen = search.length
 
   let currentChunk: Uint8Array | null = null


### PR DESCRIPTION
## Summary

Several per-request allocations of stateless objects that should be module-scoped singletons:

- **`api-utils/web.ts`**: `byteLength()` creates `new TextEncoder()` on every call
- **`incremental-cache/index.ts`**: `generateCacheKey()` creates `new TextEncoder()` per call (TextDecoder kept per-call since it uses streaming mode)
- **`node-web-streams-helper.ts`**: `createRuntimePrefetchTransformStream` creates its own `TextEncoder` despite the file already having a module-scoped one at line 34
- **`segment-explorer-path.ts`**: `normalizeBoundaryFilename()` creates 2 `new RegExp()` from constant strings on every call
- **`encryption-utils.ts`**: `arrayBufferToString()` wraps input in `new Uint8Array(buffer)` even when input is already a Uint8Array

### Behavioral correctness

- TextEncoder is stateless (unlike streaming TextDecoder) — safe to share at module scope
- Pre-compiled RegExp from constant strings produces identical results
- `buffer instanceof Uint8Array` check avoids redundant wrapping
- No change in output

## Files Changed

- `packages/next/src/server/api-utils/web.ts`
- `packages/next/src/server/lib/incremental-cache/index.ts`
- `packages/next/src/server/stream-utils/node-web-streams-helper.ts`
- `packages/next/src/server/app-render/segment-explorer-path.ts`
- `packages/next/src/server/app-render/encryption-utils.ts`

## Test plan

- [ ] Verify existing tests pass
- [ ] Verify no behavioral change in SSR output