### PR TITLE
Wire cache handlers in edge paths and add e2e regression coverage

### DIFF
--- a/crates/next-api/src/middleware.rs
+++ b/crates/next-api/src/middleware.rs
@@ -90,6 +90,7 @@ impl MiddlewareEndpoint {
             self.project.project_path().owned().await?,
             userland_module,
             is_proxy,
+            self.project.next_config(),
         );
 
         if matches!(self.runtime, NextRuntime::NodeJs) {

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -885,6 +885,7 @@ impl PageEndpoint {
                     self.source(),
                     this.original_name.clone(),
                     *this.pages_structure,
+                    this.pages_project.project().next_config(),
                     runtime,
                 )
                 .await?;

--- a/crates/next-core/src/middleware.rs
+++ b/crates/next-core/src/middleware.rs
@@ -4,13 +4,14 @@ use turbo_tasks::{ResolvedVc, Vc, fxindexmap};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     context::AssetContext,
+    file_source::FileSource,
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
     module::Module,
     reference_type::ReferenceType,
 };
 use turbopack_ecmascript::chunk::{EcmascriptChunkPlaceable, EcmascriptExports};
 
-use crate::util::load_next_js_template;
+use crate::{next_config::NextConfig, util::load_next_js_template};
 
 #[turbo_tasks::function]
 pub async fn middleware_files(page_extensions: Vc<Vec<RcStr>>) -> Result<Vc<Vec<RcStr>>> {
@@ -33,6 +34,7 @@ pub async fn get_middleware_module(
     project_root: FileSystemPath,
     userland_module: ResolvedVc<Box<dyn Module>>,
     is_proxy: bool,
+    next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_MIDDLEWARE_MODULE";
 
@@ -86,6 +88,26 @@ pub async fn get_middleware_module(
     }
     // If we can't cast to EcmascriptChunkPlaceable, continue without validation
     // (might be a special module type that doesn't support export checking)
+    let mut incremental_cache_handler_import = None;
+    let mut cache_handler_inner_assets = fxindexmap! {};
+
+    for cache_handler_path in next_config
+        .cache_handler(project_root.clone())
+        .await?
+        .into_iter()
+    {
+        let cache_handler_inner = rcstr!("INNER_INCREMENTAL_CACHE_HANDLER");
+        incremental_cache_handler_import = Some(cache_handler_inner.clone());
+        let cache_handler_module = asset_context
+            .process(
+                Vc::upcast(FileSource::new(cache_handler_path.clone())),
+                ReferenceType::Undefined,
+            )
+            .module()
+            .to_resolved()
+            .await?;
+        cache_handler_inner_assets.insert(cache_handler_inner, cache_handler_module);
+    }
 
     // Load the file from the next.js codebase.
     let source = load_next_js_template(
@@ -93,13 +115,17 @@ pub async fn get_middleware_module(
         project_root,
         [("VAR_USERLAND", INNER), ("VAR_DEFINITION_PAGE", page_path)],
         [],
-        [],
+        [(
+            "incrementalCacheHandler",
+            incremental_cache_handler_import.as_deref(),
+        )],
     )
     .await?;
 
-    let inner_assets = fxindexmap! {
+    let mut inner_assets = fxindexmap! {
         rcstr!(INNER) => userland_module
     };
+    inner_assets.extend(cache_handler_inner_assets);
 
     let module = asset_context
         .process(

--- a/crates/next-core/src/next_app/app_page_entry.rs
+++ b/crates/next-core/src/next_app/app_page_entry.rs
@@ -8,6 +8,7 @@ use turbopack::ModuleAssetContext;
 use turbopack_core::{
     asset::{Asset, AssetContent},
     context::AssetContext,
+    file_source::FileSource,
     module::Module,
     reference_type::ReferenceType,
     source::Source,
@@ -113,6 +114,7 @@ pub async fn get_app_page_entry(
             project_root.clone(),
             rsc_entry,
             page,
+            next_config,
         );
     };
 
@@ -131,21 +133,78 @@ async fn wrap_edge_page(
     project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     page: AppPage,
+    next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn Module>>> {
     const INNER: &str = "INNER_PAGE_ENTRY";
+    let mut cache_handler_imports = String::new();
+    let mut cache_handler_registration = String::new();
+    let mut incremental_cache_handler_import = None;
+    let mut cache_handler_inner_assets = fxindexmap! {};
+
+    let cache_handlers = next_config.cache_handlers_map().owned().await?;
+    for (index, (kind, handler_path)) in cache_handlers.iter().enumerate() {
+        let cache_handler_inner: RcStr = format!("INNER_CACHE_HANDLER_{index}").into();
+        let cache_handler_var = format!("cacheHandler{index}");
+        cache_handler_imports.push_str(&format!(
+            "import {cache_handler_var} from {};\n",
+            serde_json::to_string(&*cache_handler_inner)?
+        ));
+        cache_handler_registration.push_str(&format!(
+            "  cacheHandlers.setCacheHandler({}, {cache_handler_var});\n",
+            serde_json::to_string(kind.as_str())?
+        ));
+
+        let cache_handler_module = asset_context
+            .process(
+                Vc::upcast(FileSource::new(project_root.join(handler_path)?)),
+                ReferenceType::Undefined,
+            )
+            .module()
+            .to_resolved()
+            .await?;
+        cache_handler_inner_assets.insert(cache_handler_inner, cache_handler_module);
+    }
+
+    for cache_handler_path in next_config
+        .cache_handler(project_root.clone())
+        .await?
+        .into_iter()
+    {
+        let cache_handler_inner: RcStr = "INNER_INCREMENTAL_CACHE_HANDLER".into();
+        incremental_cache_handler_import = Some(cache_handler_inner.clone());
+        let cache_handler_module = asset_context
+            .process(
+                Vc::upcast(FileSource::new(cache_handler_path.clone())),
+                ReferenceType::Undefined,
+            )
+            .module()
+            .to_resolved()
+            .await?;
+        cache_handler_inner_assets.insert(cache_handler_inner, cache_handler_module);
+    }
 
     let source = load_next_js_template(
         "edge-ssr-app.js",
         project_root.clone(),
         [("VAR_USERLAND", INNER), ("VAR_PAGE", &page.to_string())],
-        [],
-        [("incrementalCacheHandler", None)],
+        [
+            ("cacheHandlerImports", cache_handler_imports.as_str()),
+            (
+                "cacheHandlerRegistration",
+                cache_handler_registration.as_str(),
+            ),
+        ],
+        [(
+            "incrementalCacheHandler",
+            incremental_cache_handler_import.as_deref(),
+        )],
     )
     .await?;
 
-    let inner_assets = fxindexmap! {
+    let mut inner_assets = fxindexmap! {
         INNER.into() => entry
     };
+    inner_assets.extend(cache_handler_inner_assets);
 
     let wrapped = asset_context
         .process(

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -5,6 +5,7 @@ use turbo_tasks_fs::FileSystemPath;
 use turbopack::ModuleAssetContext;
 use turbopack_core::{
     context::AssetContext,
+    file_source::FileSource,
     module::Module,
     reference_type::{EntryReferenceSubType, ReferenceType},
     source::Source,
@@ -113,6 +114,7 @@ pub async fn get_app_route_entry(
             project_root,
             rsc_entry,
             page,
+            next_config,
         );
     }
 
@@ -131,21 +133,75 @@ async fn wrap_edge_route(
     project_root: FileSystemPath,
     entry: ResolvedVc<Box<dyn Module>>,
     page: AppPage,
+    next_config: Vc<NextConfig>,
 ) -> Result<Vc<Box<dyn Module>>> {
     let inner = rcstr!("INNER_ROUTE_ENTRY");
+    let mut cache_handler_imports = String::new();
+    let mut cache_handler_map_entries = String::new();
+    let mut incremental_cache_handler_import = None;
+    let mut cache_handler_inner_assets = fxindexmap! {};
+
+    let cache_handlers = next_config.cache_handlers_map().owned().await?;
+    for (index, (kind, handler_path)) in cache_handlers.iter().enumerate() {
+        let cache_handler_inner: RcStr = format!("INNER_CACHE_HANDLER_{index}").into();
+        let cache_handler_var = format!("cacheHandler{index}");
+        cache_handler_imports.push_str(&format!(
+            "import {cache_handler_var} from {};\n",
+            serde_json::to_string(&*cache_handler_inner)?
+        ));
+        cache_handler_map_entries.push_str(&format!(
+            "  {}: {cache_handler_var},\n",
+            serde_json::to_string(kind.as_str())?
+        ));
+
+        let cache_handler_module = asset_context
+            .process(
+                Vc::upcast(FileSource::new(project_root.join(handler_path)?)),
+                ReferenceType::Undefined,
+            )
+            .module()
+            .to_resolved()
+            .await?;
+        cache_handler_inner_assets.insert(cache_handler_inner, cache_handler_module);
+    }
+
+    for cache_handler_path in next_config
+        .cache_handler(project_root.clone())
+        .await?
+        .into_iter()
+    {
+        let cache_handler_inner: RcStr = "INNER_INCREMENTAL_CACHE_HANDLER".into();
+        incremental_cache_handler_import = Some(cache_handler_inner.clone());
+        let cache_handler_module = asset_context
+            .process(
+                Vc::upcast(FileSource::new(cache_handler_path.clone())),
+                ReferenceType::Undefined,
+            )
+            .module()
+            .to_resolved()
+            .await?;
+        cache_handler_inner_assets.insert(cache_handler_inner, cache_handler_module);
+    }
 
     let source = load_next_js_template(
         "edge-app-route.js",
         project_root.clone(),
         [("VAR_USERLAND", &*inner), ("VAR_PAGE", &page.to_string())],
-        [],
-        [],
+        [
+            ("cacheHandlerImports", cache_handler_imports.as_str()),
+            ("cacheHandlerMapEntries", cache_handler_map_entries.as_str()),
+        ],
+        [(
+            "incrementalCacheHandler",
+            incremental_cache_handler_import.as_deref(),
+        )],
     )
     .await?;
 
-    let inner_assets = fxindexmap! {
+    let mut inner_assets = fxindexmap! {
         inner => entry
     };
+    inner_assets.extend(cache_handler_inner_assets);
 
     let wrapped = asset_context
         .process(

--- a/crates/next-core/src/next_app/app_route_entry.rs
+++ b/crates/next-core/src/next_app/app_route_entry.rs
@@ -189,7 +189,10 @@ async fn wrap_edge_route(
         [("VAR_USERLAND", &*inner), ("VAR_PAGE", &page.to_string())],
         [
             ("cacheHandlerImports", cache_handler_imports.as_str()),
-            ("cacheHandlerMapEntries", cache_handler_map_entries.as_str()),
+            (
+                "edgeCacheHandlersRegistration",
+                cache_handler_map_entries.as_str(),
+            ),
         ],
         [(
             "incrementalCacheHandler",

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -70,6 +70,9 @@ impl Default for CacheKinds {
     }
 }
 
+#[turbo_tasks::value(transparent)]
+pub struct CacheHandlersMap(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, RcStr>);
+
 #[turbo_tasks::value(eq = "manual")]
 #[derive(Clone, Debug, Default, PartialEq, Deserialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -1839,6 +1842,11 @@ impl NextConfig {
         } else {
             Ok(Vc::cell(vec![]))
         }
+    }
+
+    #[turbo_tasks::function]
+    pub fn cache_handlers_map(&self) -> Vc<CacheHandlersMap> {
+        Vc::cell(self.cache_handlers.clone().unwrap_or_default())
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_pages/page_entry.rs
+++ b/crates/next-core/src/next_pages/page_entry.rs
@@ -16,6 +16,7 @@ use turbopack_core::{
 };
 
 use crate::{
+    next_config::NextConfig,
     next_edge::entry::wrap_edge_entry,
     pages_structure::{PagesStructure, PagesStructureItem},
     util::{NextRuntime, file_content_rope, load_next_js_template, pages_function_name},
@@ -37,6 +38,7 @@ pub async fn create_page_ssr_entry_module(
     source: Vc<Box<dyn Source>>,
     next_original_name: RcStr,
     pages_structure: Vc<PagesStructure>,
+    next_config: Vc<NextConfig>,
     runtime: NextRuntime,
 ) -> Result<Vc<PageSsrEntryModule>> {
     let definition_page = next_original_name;
@@ -95,6 +97,56 @@ pub async fn create_page_ssr_entry_module(
     }
 
     let pages_structure_ref = pages_structure.await?;
+    let mut cache_handler_inner_assets = fxindexmap! {};
+    let mut cache_handler_imports = String::new();
+    let mut cache_handler_registration = String::new();
+    let mut incremental_cache_handler_import = None;
+
+    if runtime == NextRuntime::Edge {
+        if is_page {
+            let cache_handlers = next_config.cache_handlers_map().owned().await?;
+            for (index, (kind, handler_path)) in cache_handlers.iter().enumerate() {
+                let cache_handler_inner: RcStr = format!("INNER_CACHE_HANDLER_{index}").into();
+                let cache_handler_var = format!("cacheHandler{index}");
+                cache_handler_imports.push_str(&format!(
+                    "import {cache_handler_var} from {};\n",
+                    serde_json::to_string(&*cache_handler_inner)?
+                ));
+                cache_handler_registration.push_str(&format!(
+                    "  cacheHandlers.setCacheHandler({}, {cache_handler_var});\n",
+                    serde_json::to_string(kind.as_str())?
+                ));
+
+                let cache_handler_module = ssr_module_context
+                    .process(
+                        Vc::upcast(FileSource::new(project_root.join(handler_path)?)),
+                        ReferenceType::Undefined,
+                    )
+                    .module()
+                    .to_resolved()
+                    .await?;
+                cache_handler_inner_assets.insert(cache_handler_inner, cache_handler_module);
+            }
+        }
+
+        for cache_handler_path in next_config
+            .cache_handler(project_root.clone())
+            .await?
+            .into_iter()
+        {
+            let cache_handler_inner = rcstr!("INNER_INCREMENTAL_CACHE_HANDLER");
+            incremental_cache_handler_import = Some(cache_handler_inner.clone());
+            let cache_handler_module = ssr_module_context
+                .process(
+                    Vc::upcast(FileSource::new(cache_handler_path.clone())),
+                    ReferenceType::Undefined,
+                )
+                .module()
+                .to_resolved()
+                .await?;
+            cache_handler_inner_assets.insert(cache_handler_inner, cache_handler_module);
+        }
+    }
 
     let (injections, imports) = if is_page && runtime == NextRuntime::Edge {
         let injections = vec![
@@ -116,16 +168,24 @@ pub async fn create_page_ssr_entry_module(
                 "user500RouteModuleOptions",
                 serde_json::to_string(&get_route_module_options(rcstr!("/500"), rcstr!("/500")))?,
             ),
+            ("cacheHandlerImports", cache_handler_imports),
+            ("cacheHandlerRegistration", cache_handler_registration),
         ];
         let imports = vec![
-            // TODO
-            ("incrementalCacheHandler", None),
+            ("incrementalCacheHandler", incremental_cache_handler_import),
             (
                 "userland500Page",
-                pages_structure_ref.error_500.map(|_| &*inner_error_500),
+                pages_structure_ref
+                    .error_500
+                    .map(|_| inner_error_500.clone()),
             ),
         ];
         (injections, imports)
+    } else if runtime == NextRuntime::Edge {
+        (
+            vec![],
+            vec![("incrementalCacheHandler", incremental_cache_handler_import)],
+        )
     } else {
         (vec![], vec![])
     };
@@ -136,7 +196,9 @@ pub async fn create_page_ssr_entry_module(
         project_root.clone(),
         replacements,
         injections.iter().map(|(k, v)| (*k, &**v)),
-        imports,
+        imports
+            .iter()
+            .map(|(k, v)| (*k, v.as_ref().map(|value| value.as_str()))),
     )
     .await?;
 
@@ -167,6 +229,7 @@ pub async fn create_page_ssr_entry_module(
     let mut inner_assets = fxindexmap! {
         inner => ssr_module,
     };
+    inner_assets.extend(cache_handler_inner_assets);
 
     // for PagesData we apply a ?server-data query parameter to avoid conflicts with the Page
     // module.

--- a/crates/next-taskless/src/lib.rs
+++ b/crates/next-taskless/src/lib.rs
@@ -174,16 +174,39 @@ fn expand_next_js_template_inner<'a>(
         )
     }
 
-    // Replace the injections.
+    // Replace the raw injections.
     let mut missing_injections = Vec::new();
     for (key, injection) in injections {
+        let mut used = false;
+        let full_raw = format!("// INJECT_RAW:{key}");
+
+        if content.contains(&full_raw) {
+            content = content.replace(&full_raw, injection);
+            used = true;
+        }
+
         let full = format!("// INJECT:{key}");
 
         if content.contains(&full) {
             content = content.replace(&full, &format!("const {key} = {injection}"));
-        } else {
+            used = true;
+        }
+
+        if !used {
             missing_injections.push(key);
         }
+    }
+
+    // Check to see if there's any remaining raw injections.
+    static INJECT_RAW_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new("// INJECT_RAW:[A-Za-z0-9_]+").unwrap());
+    let mut matches = INJECT_RAW_RE.find_iter(&content).peekable();
+
+    if matches.peek().is_some() {
+        bail!(
+            "Invariant: Expected to inject all injections, found {}",
+            matches.map(|m| m.as_str()).collect::<Vec<_>>().join(", "),
+        )
     }
 
     // Check to see if there's any remaining injections.
@@ -276,6 +299,7 @@ mod tests {
             import * as userlandPage from 'VAR_USERLAND'
             // OPTIONAL_IMPORT:* as userland500Page
             // OPTIONAL_IMPORT:incrementalCacheHandler
+            // INJECT_RAW:extraImports
 
             // INJECT:nextConfig
             const srcPage = 'VAR_PAGE'
@@ -286,6 +310,7 @@ mod tests {
             import * as userlandPage from "INNER_PAGE_ENTRY"
             import * as userland500Page from "INNER_ERROR_500"
             const incrementalCacheHandler = null
+            import handlerX from "INNER_HANDLER"
 
             const nextConfig = {}
             const srcPage = "./some/path.js"
@@ -299,7 +324,10 @@ mod tests {
                 ("VAR_USERLAND", "INNER_PAGE_ENTRY"),
                 ("VAR_PAGE", "./some/path.js"),
             ],
-            [("nextConfig", "{}")],
+            [
+                ("nextConfig", "{}"),
+                ("extraImports", r#"import handlerX from "INNER_HANDLER""#),
+            ],
             [
                 ("incrementalCacheHandler", None),
                 ("userland500Page", Some("INNER_ERROR_500")),

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -166,6 +166,8 @@ export function getEdgeServerEntry(opts: {
   preferredRegion: string | string[] | undefined
   middlewareConfig?: ProxyConfig
 }) {
+  const cacheHandler = opts.config.cacheHandler || undefined
+
   if (
     opts.pagesType === 'app' &&
     isAppRouteRoute(opts.page) &&
@@ -179,8 +181,8 @@ export function getEdgeServerEntry(opts: {
       middlewareConfig: Buffer.from(
         JSON.stringify(opts.middlewareConfig || {})
       ).toString('base64'),
-      cacheHandler: opts.config.cacheHandler,
       cacheHandlers: JSON.stringify(opts.config.cacheHandlers || {}),
+      ...(cacheHandler ? { cacheHandler } : {}),
     }
 
     return {
@@ -201,7 +203,7 @@ export function getEdgeServerEntry(opts: {
       middlewareConfig: Buffer.from(
         JSON.stringify(opts.middlewareConfig || {})
       ).toString('base64'),
-      cacheHandler: opts.config.cacheHandler,
+      ...(cacheHandler ? { cacheHandler } : {}),
     }
 
     return {
@@ -220,7 +222,7 @@ export function getEdgeServerEntry(opts: {
       middlewareConfig: Buffer.from(
         JSON.stringify(opts.middlewareConfig || {})
       ).toString('base64'),
-      cacheHandler: opts.config.cacheHandler,
+      ...(cacheHandler ? { cacheHandler } : {}),
     }
 
     return {
@@ -241,13 +243,13 @@ export function getEdgeServerEntry(opts: {
     pagesType: opts.pagesType,
     appDirLoader: Buffer.from(opts.appDirLoader || '').toString('base64'),
     sriEnabled: !opts.isDev && !!opts.config.experimental.sri?.algorithm,
-    cacheHandler: opts.config.cacheHandler,
     preferredRegion: opts.preferredRegion,
     middlewareConfig: Buffer.from(
       JSON.stringify(opts.middlewareConfig || {})
     ).toString('base64'),
     serverActions: opts.config.experimental.serverActions,
     cacheHandlers: JSON.stringify(opts.config.cacheHandlers || {}),
+    ...(cacheHandler ? { cacheHandler } : {}),
   }
 
   return {

--- a/packages/next/src/build/entries.ts
+++ b/packages/next/src/build/entries.ts
@@ -179,6 +179,7 @@ export function getEdgeServerEntry(opts: {
       middlewareConfig: Buffer.from(
         JSON.stringify(opts.middlewareConfig || {})
       ).toString('base64'),
+      cacheHandler: opts.config.cacheHandler,
       cacheHandlers: JSON.stringify(opts.config.cacheHandlers || {}),
     }
 
@@ -200,6 +201,7 @@ export function getEdgeServerEntry(opts: {
       middlewareConfig: Buffer.from(
         JSON.stringify(opts.middlewareConfig || {})
       ).toString('base64'),
+      cacheHandler: opts.config.cacheHandler,
     }
 
     return {
@@ -218,6 +220,7 @@ export function getEdgeServerEntry(opts: {
       middlewareConfig: Buffer.from(
         JSON.stringify(opts.middlewareConfig || {})
       ).toString('base64'),
+      cacheHandler: opts.config.cacheHandler,
     }
 
     return {

--- a/packages/next/src/build/templates/edge-app-route.ts
+++ b/packages/next/src/build/templates/edge-app-route.ts
@@ -27,9 +27,8 @@ if (rscManifest && rscServerManifest) {
 
 export const ComponentMod = module
 
-const edgeCacheHandlers = {
-  // INJECT_RAW:cacheHandlerMapEntries
-}
+const edgeCacheHandlers: any = {}
+// INJECT_RAW:edgeCacheHandlersRegistration
 
 const internalHandler: EdgeHandler = EdgeRouteModuleWrapper.wrap(
   module.routeModule,

--- a/packages/next/src/build/templates/edge-app-route.ts
+++ b/packages/next/src/build/templates/edge-app-route.ts
@@ -8,6 +8,9 @@ import * as module from 'VAR_USERLAND'
 import { toNodeOutgoingHttpHeaders } from '../../server/web/utils'
 
 // injected by the loader afterwards.
+declare const incrementalCacheHandler: any
+// OPTIONAL_IMPORT:incrementalCacheHandler
+// INJECT_RAW:cacheHandlerImports
 
 const maybeJSONParse = (str?: string) => (str ? JSON.parse(str) : undefined)
 
@@ -24,10 +27,16 @@ if (rscManifest && rscServerManifest) {
 
 export const ComponentMod = module
 
+const edgeCacheHandlers = {
+  // INJECT_RAW:cacheHandlerMapEntries
+}
+
 const internalHandler: EdgeHandler = EdgeRouteModuleWrapper.wrap(
   module.routeModule,
   {
     page: 'VAR_PAGE',
+    cacheHandlers: edgeCacheHandlers,
+    incrementalCacheHandler,
   }
 )
 

--- a/packages/next/src/build/templates/edge-ssr-app.ts
+++ b/packages/next/src/build/templates/edge-ssr-app.ts
@@ -9,7 +9,7 @@ import { IncrementalCache } from '../../server/lib/incremental-cache'
 import * as pageMod from 'VAR_USERLAND'
 
 import { setManifestsSingleton } from '../../server/app-render/manifests-singleton'
-import { initializeCacheHandlers } from '../../server/use-cache/handlers'
+import * as cacheHandlers from '../../server/use-cache/handlers'
 import { BaseServerSpan } from '../../server/lib/trace/constants'
 import { getTracer, SpanKind, type Span } from '../../server/lib/trace/tracer'
 import { WebNextRequest, WebNextResponse } from '../../server/base-http/web'
@@ -32,6 +32,7 @@ import type { RequestMeta } from '../../server/request-meta'
 
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:incrementalCacheHandler
+// INJECT_RAW:cacheHandlerImports
 
 const maybeJSONParse = (str?: string) => (str ? JSON.parse(str) : undefined)
 
@@ -89,7 +90,8 @@ async function requestHandler(
   } = prepareResult
 
   // Initialize the cache handlers interface.
-  initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
+  cacheHandlers.initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
+  // INJECT_RAW:cacheHandlerRegistration
 
   const isPossibleServerAction = getIsPossibleServerAction(req)
   const botType = getBotType(req.headers.get('User-Agent') || '')

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -5,7 +5,7 @@ import {
   type NextRequestHint,
 } from '../../server/web/adapter'
 import { IncrementalCache } from '../../server/lib/incremental-cache'
-import { initializeCacheHandlers } from '../../server/use-cache/handlers'
+import * as cacheHandlers from '../../server/use-cache/handlers'
 
 import Document from 'VAR_MODULE_DOCUMENT'
 import * as appMod from 'VAR_MODULE_APP'
@@ -16,6 +16,7 @@ declare const userland500Page: any
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:* as userland500Page
 // OPTIONAL_IMPORT:incrementalCacheHandler
+// INJECT_RAW:cacheHandlerImports
 
 import RouteModule, {
   type PagesRouteHandlerContext,
@@ -120,7 +121,8 @@ async function requestHandler(
     clientAssetToken,
   } = prepareResult
 
-  initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
+  cacheHandlers.initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
+  // INJECT_RAW:cacheHandlerRegistration
 
   const renderContext: PagesRouteHandlerContext = {
     page: srcPage,

--- a/packages/next/src/build/templates/edge-ssr.ts
+++ b/packages/next/src/build/templates/edge-ssr.ts
@@ -16,7 +16,6 @@ declare const userland500Page: any
 declare const incrementalCacheHandler: any
 // OPTIONAL_IMPORT:* as userland500Page
 // OPTIONAL_IMPORT:incrementalCacheHandler
-// INJECT_RAW:cacheHandlerImports
 
 import RouteModule, {
   type PagesRouteHandlerContext,
@@ -39,6 +38,7 @@ declare const user500RouteModuleOptions: any
 // INJECT:pageRouteModuleOptions
 // INJECT:errorRouteModuleOptions
 // INJECT:user500RouteModuleOptions
+// INJECT_RAW:cacheHandlerImports
 
 const pageMod = {
   ...userlandPage,

--- a/packages/next/src/build/templates/middleware.ts
+++ b/packages/next/src/build/templates/middleware.ts
@@ -4,6 +4,8 @@ import '../../server/web/globals'
 
 import { adapter } from '../../server/web/adapter'
 import { IncrementalCache } from '../../server/lib/incremental-cache'
+declare const incrementalCacheHandler: any
+// OPTIONAL_IMPORT:incrementalCacheHandler
 
 // Import the userland code.
 import * as _mod from 'VAR_USERLAND'
@@ -76,6 +78,7 @@ const internalHandler: EdgeHandler = (opts) => {
   return adapter({
     ...opts,
     IncrementalCache,
+    incrementalCacheHandler,
     page,
     handler: errorHandledHandler(handlerUserland),
   })

--- a/packages/next/src/build/templates/pages-edge-api.ts
+++ b/packages/next/src/build/templates/pages-edge-api.ts
@@ -5,6 +5,8 @@ import '../../server/web/globals'
 import { adapter } from '../../server/web/adapter'
 import { IncrementalCache } from '../../server/lib/incremental-cache'
 import { wrapApiHandler } from '../../server/api-utils'
+declare const incrementalCacheHandler: any
+// OPTIONAL_IMPORT:incrementalCacheHandler
 
 // Import the userland code.
 import handlerUserland from 'VAR_USERLAND'
@@ -23,6 +25,7 @@ const internalHandler: EdgeHandler = (opts) => {
   return adapter({
     ...opts,
     IncrementalCache,
+    incrementalCacheHandler,
     page: 'VAR_DEFINITION_PATHNAME',
     handler: wrapApiHandler(page, handlerUserland),
   })

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -19,12 +19,10 @@ export type EdgeAppRouteLoaderQuery = {
 function getCacheHandlersSetup(
   cacheHandlersStringified: string,
   contextifyImportPath: (path: string) => string
-):
-  | {
-      cacheHandlerImports: string
-      edgeCacheHandlersRegistration: string
-    }
-  | undefined {
+): {
+  cacheHandlerImports: string
+  edgeCacheHandlersRegistration: string
+} {
   const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}') as Record<
     string,
     string | undefined
@@ -32,10 +30,6 @@ function getCacheHandlersSetup(
   const definedCacheHandlers = Object.entries(cacheHandlers).filter(
     (entry): entry is [string, string] => Boolean(entry[1])
   )
-
-  if (definedCacheHandlers.length === 0) {
-    return undefined
-  }
 
   const cacheHandlerImports: string[] = []
   const edgeCacheHandlersRegistration: string[] = []
@@ -54,8 +48,9 @@ function getCacheHandlersSetup(
   }
 
   return {
-    cacheHandlerImports: cacheHandlerImports.join('\n'),
-    edgeCacheHandlersRegistration: edgeCacheHandlersRegistration.join('\n'),
+    cacheHandlerImports: cacheHandlerImports.join('\n') || '\n',
+    edgeCacheHandlersRegistration:
+      edgeCacheHandlersRegistration.join('\n') || '\n',
   }
 }
 

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -19,10 +19,12 @@ export type EdgeAppRouteLoaderQuery = {
 function getCacheHandlersSetup(
   cacheHandlersStringified: string,
   contextifyImportPath: (path: string) => string
-): {
-  cacheHandlerImports: string
-  cacheHandlerMapEntries: string
-} {
+):
+  | {
+      cacheHandlerImports: string
+      edgeCacheHandlersRegistration: string
+    }
+  | undefined {
   const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}') as Record<
     string,
     string | undefined
@@ -30,8 +32,13 @@ function getCacheHandlersSetup(
   const definedCacheHandlers = Object.entries(cacheHandlers).filter(
     (entry): entry is [string, string] => Boolean(entry[1])
   )
+
+  if (definedCacheHandlers.length === 0) {
+    return undefined
+  }
+
   const cacheHandlerImports: string[] = []
-  const cacheHandlerMapEntries: string[] = []
+  const edgeCacheHandlersRegistration: string[] = []
 
   for (const [index, [kind, handlerPath]] of definedCacheHandlers.entries()) {
     const cacheHandlerVarName = `edgeCacheHandler_${index}`
@@ -41,14 +48,14 @@ function getCacheHandlersSetup(
         cacheHandlerImportPath
       )}`
     )
-    cacheHandlerMapEntries.push(
-      `  ${JSON.stringify(kind)}: ${cacheHandlerVarName},`
+    edgeCacheHandlersRegistration.push(
+      `edgeCacheHandlers[${JSON.stringify(kind)}] = ${cacheHandlerVarName}`
     )
   }
 
   return {
     cacheHandlerImports: cacheHandlerImports.join('\n'),
-    cacheHandlerMapEntries: cacheHandlerMapEntries.join('\n'),
+    edgeCacheHandlersRegistration: edgeCacheHandlersRegistration.join('\n'),
   }
 }
 
@@ -69,10 +76,14 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
       Buffer.from(middlewareConfigBase64, 'base64').toString()
     )
 
-    const { cacheHandlerImports, cacheHandlerMapEntries } =
-      getCacheHandlersSetup(cacheHandlersStringified, (handlerPath) =>
+    const cacheHandlersSetup = getCacheHandlersSetup(
+      cacheHandlersStringified,
+      (handlerPath) =>
         this.utils.contextify(this.context || this.rootContext, handlerPath)
-      )
+    )
+    const incrementalCacheHandler = cacheHandler
+      ? this.utils.contextify(this.context || this.rootContext, cacheHandler)
+      : null
 
     // Ensure we only run this loader for as a module.
     if (!this._module) throw new Error('This loader is only usable as a module')
@@ -103,12 +114,9 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
         VAR_USERLAND: modulePath,
         VAR_PAGE: page,
       },
+      cacheHandlersSetup,
       {
-        cacheHandlerImports,
-        cacheHandlerMapEntries,
-      },
-      {
-        incrementalCacheHandler: cacheHandler ?? null,
+        incrementalCacheHandler,
       }
     )
   }

--- a/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-app-route-loader/index.ts
@@ -12,7 +12,44 @@ export type EdgeAppRouteLoaderQuery = {
   appDirLoader: string
   preferredRegion: string | string[] | undefined
   middlewareConfig: string
+  cacheHandler?: string
   cacheHandlers: string
+}
+
+function getCacheHandlersSetup(
+  cacheHandlersStringified: string,
+  contextifyImportPath: (path: string) => string
+): {
+  cacheHandlerImports: string
+  cacheHandlerMapEntries: string
+} {
+  const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}') as Record<
+    string,
+    string | undefined
+  >
+  const definedCacheHandlers = Object.entries(cacheHandlers).filter(
+    (entry): entry is [string, string] => Boolean(entry[1])
+  )
+  const cacheHandlerImports: string[] = []
+  const cacheHandlerMapEntries: string[] = []
+
+  for (const [index, [kind, handlerPath]] of definedCacheHandlers.entries()) {
+    const cacheHandlerVarName = `edgeCacheHandler_${index}`
+    const cacheHandlerImportPath = contextifyImportPath(handlerPath)
+    cacheHandlerImports.push(
+      `import ${cacheHandlerVarName} from ${JSON.stringify(
+        cacheHandlerImportPath
+      )}`
+    )
+    cacheHandlerMapEntries.push(
+      `  ${JSON.stringify(kind)}: ${cacheHandlerVarName},`
+    )
+  }
+
+  return {
+    cacheHandlerImports: cacheHandlerImports.join('\n'),
+    cacheHandlerMapEntries: cacheHandlerMapEntries.join('\n'),
+  }
 }
 
 const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQuery> =
@@ -23,6 +60,7 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
       preferredRegion,
       appDirLoader: appDirLoaderBase64 = '',
       middlewareConfig: middlewareConfigBase64 = '',
+      cacheHandler,
       cacheHandlers: cacheHandlersStringified,
     } = this.getOptions()
 
@@ -31,13 +69,10 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
       Buffer.from(middlewareConfigBase64, 'base64').toString()
     )
 
-    const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}')
-
-    if (!cacheHandlers.default) {
-      cacheHandlers.default = require.resolve(
-        '../../../../server/lib/cache-handlers/default.external'
+    const { cacheHandlerImports, cacheHandlerMapEntries } =
+      getCacheHandlersSetup(cacheHandlersStringified, (handlerPath) =>
+        this.utils.contextify(this.context || this.rootContext, handlerPath)
       )
-    }
 
     // Ensure we only run this loader for as a module.
     if (!this._module) throw new Error('This loader is only usable as a module')
@@ -68,7 +103,13 @@ const EdgeAppRouteLoader: webpack.LoaderDefinitionFunction<EdgeAppRouteLoaderQue
         VAR_USERLAND: modulePath,
         VAR_PAGE: page,
       },
-      {}
+      {
+        cacheHandlerImports,
+        cacheHandlerMapEntries,
+      },
+      {
+        incrementalCacheHandler: cacheHandler ?? null,
+      }
     )
   }
 

--- a/packages/next/src/build/webpack/loaders/next-edge-function-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-function-loader.ts
@@ -9,6 +9,7 @@ export type EdgeFunctionLoaderOptions = {
   rootDir: string
   preferredRegion: string | string[] | undefined
   middlewareConfig: string
+  cacheHandler?: string
 }
 
 const nextEdgeFunctionLoader: webpack.LoaderDefinitionFunction<EdgeFunctionLoaderOptions> =
@@ -19,8 +20,12 @@ const nextEdgeFunctionLoader: webpack.LoaderDefinitionFunction<EdgeFunctionLoade
       rootDir,
       preferredRegion,
       middlewareConfig: middlewareConfigBase64,
+      cacheHandler,
     }: EdgeFunctionLoaderOptions = this.getOptions()
     const stringifiedPagePath = stringifyRequest(this, absolutePagePath)
+    const stringifiedCacheHandlerPath = cacheHandler
+      ? stringifyRequest(this, cacheHandler)
+      : null
     const buildInfo = getModuleBuildInfo(this._module as any)
     const middlewareConfig: ProxyConfig = JSON.parse(
       Buffer.from(middlewareConfigBase64, 'base64').toString()
@@ -41,6 +46,11 @@ const nextEdgeFunctionLoader: webpack.LoaderDefinitionFunction<EdgeFunctionLoade
         import { adapter } from 'next/dist/esm/server/web/adapter'
         import { IncrementalCache } from 'next/dist/esm/server/lib/incremental-cache'
         import { wrapApiHandler } from 'next/dist/esm/server/api-utils'
+        ${
+          stringifiedCacheHandlerPath
+            ? `import incrementalCacheHandler from ${stringifiedCacheHandlerPath}`
+            : 'const incrementalCacheHandler = null'
+        }
 
         import handler from ${stringifiedPagePath}
 
@@ -52,6 +62,7 @@ const nextEdgeFunctionLoader: webpack.LoaderDefinitionFunction<EdgeFunctionLoade
           return adapter({
               ...opts,
               IncrementalCache,
+              incrementalCacheHandler,
               page: ${JSON.stringify(page)},
               handler: wrapApiHandler(${JSON.stringify(page)}, handler),
           })

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -65,12 +65,10 @@ function getRouteModuleOptions(page: string) {
 function getCacheHandlersSetup(
   cacheHandlersStringified: string | undefined,
   contextifyImportPath: (path: string) => string
-):
-  | {
-      cacheHandlerImports: string
-      cacheHandlerRegistration: string
-    }
-  | undefined {
+): {
+  cacheHandlerImports: string
+  cacheHandlerRegistration: string
+} {
   const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}') as Record<
     string,
     string | undefined
@@ -78,10 +76,6 @@ function getCacheHandlersSetup(
   const definedCacheHandlers = Object.entries(cacheHandlers).filter(
     (entry): entry is [string, string] => Boolean(entry[1])
   )
-
-  if (definedCacheHandlers.length === 0) {
-    return undefined
-  }
 
   const cacheHandlerImports: string[] = []
   const cacheHandlerRegistration: string[] = []
@@ -102,8 +96,8 @@ function getCacheHandlersSetup(
   }
 
   return {
-    cacheHandlerImports: cacheHandlerImports.join('\n'),
-    cacheHandlerRegistration: cacheHandlerRegistration.join('\n'),
+    cacheHandlerImports: cacheHandlerImports.join('\n') || '\n',
+    cacheHandlerRegistration: cacheHandlerRegistration.join('\n') || '\n',
   }
 }
 

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -62,6 +62,44 @@ function getRouteModuleOptions(page: string) {
   return options
 }
 
+function getCacheHandlersSetup(
+  cacheHandlersStringified: string | undefined,
+  contextifyImportPath: (path: string) => string
+): {
+  cacheHandlerImports: string
+  cacheHandlerRegistration: string
+} {
+  const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}') as Record<
+    string,
+    string | undefined
+  >
+  const definedCacheHandlers = Object.entries(cacheHandlers).filter(
+    (entry): entry is [string, string] => Boolean(entry[1])
+  )
+  const cacheHandlerImports: string[] = []
+  const cacheHandlerRegistration: string[] = []
+
+  for (const [index, [kind, handlerPath]] of definedCacheHandlers.entries()) {
+    const cacheHandlerVarName = `edgeCacheHandler_${index}`
+    const cacheHandlerImportPath = contextifyImportPath(handlerPath)
+    cacheHandlerImports.push(
+      `import ${cacheHandlerVarName} from ${JSON.stringify(
+        cacheHandlerImportPath
+      )}`
+    )
+    cacheHandlerRegistration.push(
+      `  cacheHandlers.setCacheHandler(${JSON.stringify(
+        kind
+      )}, ${cacheHandlerVarName})`
+    )
+  }
+
+  return {
+    cacheHandlerImports: cacheHandlerImports.join('\n'),
+    cacheHandlerRegistration: cacheHandlerRegistration.join('\n'),
+  }
+}
+
 const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
   async function edgeSSRLoader(this) {
     const {
@@ -80,13 +118,10 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       middlewareConfig: middlewareConfigBase64,
     } = this.getOptions()
 
-    const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}')
-
-    if (!cacheHandlers.default) {
-      cacheHandlers.default = require.resolve(
-        '../../../../server/lib/cache-handlers/default.external'
+    const { cacheHandlerImports, cacheHandlerRegistration } =
+      getCacheHandlersSetup(cacheHandlersStringified, (handlerPath) =>
+        this.utils.contextify(this.context || this.rootContext, handlerPath)
       )
-    }
 
     const middlewareConfig: ProxyConfig = JSON.parse(
       Buffer.from(middlewareConfigBase64, 'base64').toString()
@@ -154,7 +189,10 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
           VAR_USERLAND: pageModPath,
           VAR_PAGE: page,
         },
-        {},
+        {
+          cacheHandlerImports,
+          cacheHandlerRegistration,
+        },
         {
           incrementalCacheHandler: cacheHandler ?? null,
         }
@@ -177,6 +215,8 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
           user500RouteModuleOptions: JSON.stringify(
             getRouteModuleOptions('/500')
           ),
+          cacheHandlerImports,
+          cacheHandlerRegistration,
         },
         {
           userland500Page: userland500Path,

--- a/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
+++ b/packages/next/src/build/webpack/loaders/next-edge-ssr-loader/index.ts
@@ -65,10 +65,12 @@ function getRouteModuleOptions(page: string) {
 function getCacheHandlersSetup(
   cacheHandlersStringified: string | undefined,
   contextifyImportPath: (path: string) => string
-): {
-  cacheHandlerImports: string
-  cacheHandlerRegistration: string
-} {
+):
+  | {
+      cacheHandlerImports: string
+      cacheHandlerRegistration: string
+    }
+  | undefined {
   const cacheHandlers = JSON.parse(cacheHandlersStringified || '{}') as Record<
     string,
     string | undefined
@@ -76,6 +78,11 @@ function getCacheHandlersSetup(
   const definedCacheHandlers = Object.entries(cacheHandlers).filter(
     (entry): entry is [string, string] => Boolean(entry[1])
   )
+
+  if (definedCacheHandlers.length === 0) {
+    return undefined
+  }
+
   const cacheHandlerImports: string[] = []
   const cacheHandlerRegistration: string[] = []
 
@@ -118,10 +125,14 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
       middlewareConfig: middlewareConfigBase64,
     } = this.getOptions()
 
-    const { cacheHandlerImports, cacheHandlerRegistration } =
-      getCacheHandlersSetup(cacheHandlersStringified, (handlerPath) =>
+    const cacheHandlersSetup = getCacheHandlersSetup(
+      cacheHandlersStringified,
+      (handlerPath) =>
         this.utils.contextify(this.context || this.rootContext, handlerPath)
-      )
+    )
+    const incrementalCacheHandler = cacheHandler
+      ? this.utils.contextify(this.context || this.rootContext, cacheHandler)
+      : null
 
     const middlewareConfig: ProxyConfig = JSON.parse(
       Buffer.from(middlewareConfigBase64, 'base64').toString()
@@ -189,12 +200,9 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
           VAR_USERLAND: pageModPath,
           VAR_PAGE: page,
         },
+        cacheHandlersSetup,
         {
-          cacheHandlerImports,
-          cacheHandlerRegistration,
-        },
-        {
-          incrementalCacheHandler: cacheHandler ?? null,
+          incrementalCacheHandler,
         }
       )
     } else {
@@ -215,12 +223,11 @@ const edgeSSRLoader: webpack.LoaderDefinitionFunction<EdgeSSRLoaderQuery> =
           user500RouteModuleOptions: JSON.stringify(
             getRouteModuleOptions('/500')
           ),
-          cacheHandlerImports,
-          cacheHandlerRegistration,
+          ...(cacheHandlersSetup ?? {}),
         },
         {
           userland500Page: userland500Path,
-          incrementalCacheHandler: cacheHandler ?? null,
+          incrementalCacheHandler,
         }
       )
     }

--- a/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
+++ b/packages/next/src/build/webpack/loaders/next-middleware-loader.ts
@@ -16,6 +16,7 @@ export type MiddlewareLoaderOptions = {
   matchers?: string
   preferredRegion: string | string[] | undefined
   middlewareConfig: string
+  cacheHandler?: string
 }
 
 // matchers can have special characters that break the loader params
@@ -38,6 +39,7 @@ export default async function middlewareLoader(this: any) {
     matchers: encodedMatchers,
     preferredRegion,
     middlewareConfig: middlewareConfigBase64,
+    cacheHandler,
   }: MiddlewareLoaderOptions = this.getOptions()
   const matchers = encodedMatchers ? decodeMatchers(encodedMatchers) : undefined
   const pagePath = this.utils.contextify(
@@ -67,8 +69,17 @@ export default async function middlewareLoader(this: any) {
     middlewareConfig,
   }
 
-  return await loadEntrypoint('middleware', {
-    VAR_USERLAND: pagePath,
-    VAR_DEFINITION_PAGE: page,
-  })
+  return await loadEntrypoint(
+    'middleware',
+    {
+      VAR_USERLAND: pagePath,
+      VAR_DEFINITION_PAGE: page,
+    },
+    {},
+    {
+      incrementalCacheHandler: cacheHandler
+        ? this.utils.contextify(this.context || this.rootContext, cacheHandler)
+        : null,
+    }
+  )
 }

--- a/packages/next/src/server/web/edge-route-module-wrapper.ts
+++ b/packages/next/src/server/web/edge-route-module-wrapper.ts
@@ -6,7 +6,12 @@ import type {
 import './globals'
 
 import { adapter, type NextRequestHint, type EdgeHandler } from './adapter'
-import { IncrementalCache } from '../lib/incremental-cache'
+import {
+  IncrementalCache,
+  type CacheHandler as IncrementalCacheHandler,
+} from '../lib/incremental-cache'
+import type { CacheHandler } from '../lib/cache-handlers/types'
+import { initializeCacheHandlers, setCacheHandler } from '../use-cache/handlers'
 import { RouteMatcher } from '../route-matchers/route-matcher'
 import type { NextFetchEvent } from './spec-extension/fetch-event'
 import { internal_getCurrentFunctionWaitUntil } from './internal-edge-wait-until'
@@ -18,6 +23,8 @@ import { WebNextRequest } from '../../server/base-http/web'
 
 export interface WrapOptions {
   page: string
+  cacheHandlers?: Record<string, CacheHandler>
+  incrementalCacheHandler?: typeof IncrementalCacheHandler
 }
 
 /**
@@ -34,7 +41,10 @@ export class EdgeRouteModuleWrapper {
    *
    * @param routeModule the route module to wrap
    */
-  private constructor(private readonly routeModule: AppRouteRouteModule) {
+  private constructor(
+    private readonly routeModule: AppRouteRouteModule,
+    private readonly cacheHandlers: Record<string, CacheHandler>
+  ) {
     // TODO: (wyattjoh) possibly allow the module to define it's own matcher
     this.matcher = new RouteMatcher(routeModule.definition)
   }
@@ -53,13 +63,17 @@ export class EdgeRouteModuleWrapper {
     options: WrapOptions
   ): EdgeHandler {
     // Create the module wrapper.
-    const wrapper = new EdgeRouteModuleWrapper(routeModule)
+    const wrapper = new EdgeRouteModuleWrapper(
+      routeModule,
+      options.cacheHandlers ?? {}
+    )
 
     // Return the wrapping function.
     return (opts) => {
       return adapter({
         ...opts,
         IncrementalCache,
+        incrementalCacheHandler: options.incrementalCacheHandler,
         // Bind the handler method to the wrapper so it still has context.
         handler: wrapper.handler.bind(wrapper),
         page: options.page,
@@ -84,6 +98,10 @@ export class EdgeRouteModuleWrapper {
     const { nextConfig } = this.routeModule.getNextConfigEdge(
       new WebNextRequest(request)
     )
+    initializeCacheHandlers(nextConfig.cacheMaxMemorySize)
+    for (const [kind, cacheHandler] of Object.entries(this.cacheHandlers)) {
+      setCacheHandler(kind, cacheHandler)
+    }
 
     const { params } = utils.normalizeDynamicRouteParams(
       searchParamsToUrlQuery(request.nextUrl.searchParams),

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/app/api/edge-route/route.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/app/api/edge-route/route.js
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export async function GET() {
+  return Response.json({ ok: true })
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/app/edge-page/page.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/app/edge-page/page.js
@@ -1,0 +1,5 @@
+export const runtime = 'edge'
+
+export default function Page() {
+  return <div id="edge-page">edge page</div>
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/app/layout.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/incremental-cache-handler.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/incremental-cache-handler.js
@@ -1,0 +1,10 @@
+const {
+  default: FileSystemCache,
+} = require('next/dist/server/lib/incremental-cache/file-system-cache')
+
+module.exports = class IncrementalCacheHandler extends FileSystemCache {
+  constructor(options) {
+    super(options)
+    console.log('WiringIncrementalCacheHandler::constructor')
+  }
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/next.config.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/edge-without-cache-components/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheHandler: require.resolve('./incremental-cache-handler'),
+}
+
+module.exports = nextConfig

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/layout.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/layout.js
@@ -1,0 +1,7 @@
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/page.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/page.js
@@ -1,0 +1,13 @@
+import { cacheTag } from 'next/cache'
+
+async function getCachedValue() {
+  'use cache: custom'
+  cacheTag('custom-tag')
+  return Date.now().toString()
+}
+
+export default async function Page() {
+  const value = await getCachedValue()
+
+  return <div id="value">{value}</div>
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/revalidate-actions/page.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/revalidate-actions/page.js
@@ -1,0 +1,24 @@
+import { revalidatePath, revalidateTag } from 'next/cache'
+
+async function revalidateTagAction() {
+  'use server'
+  revalidateTag('custom-tag', 'max')
+}
+
+async function revalidatePathAction() {
+  'use server'
+  revalidatePath('/revalidate-target')
+}
+
+export default function Page() {
+  return (
+    <>
+      <form action={revalidateTagAction}>
+        <button id="revalidate-tag">revalidate tag</button>
+      </form>
+      <form action={revalidatePathAction}>
+        <button id="revalidate-path">revalidate path</button>
+      </form>
+    </>
+  )
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/revalidate-target/page.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/app/revalidate-target/page.js
@@ -1,0 +1,13 @@
+import { cacheTag } from 'next/cache'
+
+async function getCachedValue() {
+  'use cache: custom'
+  cacheTag('custom-tag')
+  return Date.now().toString()
+}
+
+export default async function Page() {
+  const value = await getCachedValue()
+
+  return <div id="revalidate-target">{value}</div>
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/modern-cache-handler.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/modern-cache-handler.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+const defaultCacheHandler =
+  require('next/dist/server/lib/cache-handlers/default.external').default
+
+/**
+ * @type {import('next/dist/server/lib/cache-handlers/types').CacheHandler}
+ */
+const cacheHandler = {
+  async get(cacheKey, softTags) {
+    console.log('WiringModernCacheHandler::get', cacheKey, softTags)
+    return defaultCacheHandler.get(cacheKey, softTags)
+  },
+
+  async set(cacheKey, pendingEntry) {
+    console.log('WiringModernCacheHandler::set', cacheKey)
+    return defaultCacheHandler.set(cacheKey, pendingEntry)
+  },
+
+  async refreshTags() {
+    console.log('WiringModernCacheHandler::refreshTags')
+    return defaultCacheHandler.refreshTags()
+  },
+
+  async getExpiration(tags) {
+    console.log('WiringModernCacheHandler::getExpiration', JSON.stringify(tags))
+    return Infinity
+  },
+
+  async updateTags(tags) {
+    console.log('WiringModernCacheHandler::updateTags', JSON.stringify(tags))
+    return defaultCacheHandler.updateTags(tags)
+  },
+}
+
+module.exports = cacheHandler

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/next.config.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/non-edge-cache-components/next.config.js
@@ -1,0 +1,12 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  cacheHandlers: {
+    default: require.resolve('./modern-cache-handler'),
+    custom: require.resolve('./modern-cache-handler'),
+  },
+}
+
+module.exports = nextConfig

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/incremental-cache-handler.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/incremental-cache-handler.js
@@ -1,0 +1,18 @@
+const {
+  default: FileSystemCache,
+} = require('next/dist/server/lib/incremental-cache/file-system-cache')
+
+module.exports = class IncrementalCacheHandler extends FileSystemCache {
+  constructor(options) {
+    super(options)
+    console.log('WiringPagesIncrementalCacheHandler::constructor')
+  }
+
+  async revalidateTag(tags) {
+    console.log(
+      'WiringPagesIncrementalCacheHandler::revalidateTag',
+      JSON.stringify(tags)
+    )
+    return super.revalidateTag(tags)
+  }
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/next.config.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheHandler: require.resolve('./incremental-cache-handler'),
+}
+
+module.exports = nextConfig

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/pages/api/revalidate.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/pages/api/revalidate.js
@@ -1,0 +1,4 @@
+export default async function handler(req, res) {
+  await res.revalidate('/isr')
+  return res.status(200).json({ revalidated: true })
+}

--- a/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/pages/isr.js
+++ b/test/e2e/cache-handlers-upstream-wiring/fixtures/pages-router-non-edge/pages/isr.js
@@ -1,0 +1,12 @@
+export async function getStaticProps() {
+  return {
+    props: {
+      now: Date.now().toString(),
+    },
+    revalidate: 3600,
+  }
+}
+
+export default function Page({ now }) {
+  return <p id="now">{now}</p>
+}

--- a/test/e2e/cache-handlers-upstream-wiring/index.test.ts
+++ b/test/e2e/cache-handlers-upstream-wiring/index.test.ts
@@ -1,0 +1,133 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { join } from 'path'
+
+describe('cache-handlers-upstream-wiring', () => {
+  describe('pages router non-edge', () => {
+    const { next, skipped, isNextDev } = nextTestSetup({
+      files: join(__dirname, 'fixtures/pages-router-non-edge'),
+      skipDeployment: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    let outputIndex = 0
+
+    beforeEach(() => {
+      outputIndex = next.cliOutput.length
+    })
+
+    it('wires res.revalidate() through the configured custom cacheHandler', async () => {
+      const initialHtml = await next.render$('/isr')
+      const initialValue = initialHtml('#now').text()
+      outputIndex = next.cliOutput.length
+
+      const revalidateResponse = await next.fetch('/api/revalidate')
+      expect(revalidateResponse.status).toBe(200)
+      expect(await revalidateResponse.json()).toEqual({ revalidated: true })
+
+      if (!isNextDev) {
+        await retry(async () => {
+          const htmlAfterRevalidate = await next.render$('/isr')
+          const valueAfterRevalidate = htmlAfterRevalidate('#now').text()
+          expect(valueAfterRevalidate).not.toBe(initialValue)
+        })
+      }
+
+      await next.render$('/isr')
+
+      await retry(async () => {
+        const output = next.cliOutput.slice(outputIndex)
+        const constructorLogs =
+          output.match(/WiringPagesIncrementalCacheHandler::constructor/g) ?? []
+        const sawRevalidateTag = output.includes(
+          'WiringPagesIncrementalCacheHandler::revalidateTag'
+        )
+
+        expect(sawRevalidateTag || constructorLogs.length > 0).toBe(true)
+      })
+    })
+  })
+
+  describe('cacheComponents enabled, non-edge app router', () => {
+    const { next, skipped } = nextTestSetup({
+      files: join(__dirname, 'fixtures/non-edge-cache-components'),
+      skipDeployment: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    let outputIndex = 0
+
+    beforeEach(() => {
+      outputIndex = next.cliOutput.length
+    })
+
+    it('uses configured cacheHandlers for custom app-router cache kind', async () => {
+      const pageResponse = await next.fetch('/')
+      expect(pageResponse.status).toBe(200)
+
+      await retry(async () => {
+        const output = next.cliOutput.slice(outputIndex)
+        expect(output).toContain('WiringModernCacheHandler::set')
+        expect(output).toContain('WiringModernCacheHandler::get')
+      })
+    })
+
+    it('wires revalidateTag and revalidatePath to the custom cache handler', async () => {
+      const seedResponse = await next.fetch('/revalidate-target')
+      expect(seedResponse.status).toBe(200)
+
+      const browser = await next.browser('/revalidate-actions')
+      await browser.elementById('revalidate-tag').click()
+      await browser.elementById('revalidate-path').click()
+
+      await retry(async () => {
+        const output = next.cliOutput.slice(outputIndex)
+        const updateTagLogs =
+          output.match(/WiringModernCacheHandler::updateTags/g) ?? []
+
+        expect(updateTagLogs.length).toBeGreaterThanOrEqual(2)
+        expect(output).toContain('custom-tag')
+      })
+    })
+  })
+
+  describe('cacheComponents disabled, edge app router', () => {
+    const { next, skipped } = nextTestSetup({
+      files: join(__dirname, 'fixtures/edge-without-cache-components'),
+      skipDeployment: true,
+    })
+
+    if (skipped) {
+      return
+    }
+
+    let outputIndex = 0
+
+    beforeEach(() => {
+      outputIndex = next.cliOutput.length
+    })
+
+    it('uses configured cacheHandler for edge app page and edge app route', async () => {
+      const edgePageResponse = await next.fetch('/edge-page')
+      expect(edgePageResponse.status).toBe(200)
+
+      const edgeRouteResponse = await next.fetch('/api/edge-route')
+      expect(edgeRouteResponse.status).toBe(200)
+      expect(await edgeRouteResponse.json()).toEqual({ ok: true })
+
+      await retry(async () => {
+        const output = next.cliOutput.slice(outputIndex)
+        const constructorLogs =
+          output.match(/WiringIncrementalCacheHandler::constructor/g) ?? []
+
+        expect(constructorLogs.length).toBeGreaterThanOrEqual(2)
+      })
+    })
+  })
+})

--- a/test/e2e/cache-handlers-upstream-wiring/index.test.ts
+++ b/test/e2e/cache-handlers-upstream-wiring/index.test.ts
@@ -52,7 +52,7 @@ describe('cache-handlers-upstream-wiring', () => {
   })
 
   describe('cacheComponents enabled, non-edge app router', () => {
-    const { next, skipped } = nextTestSetup({
+    const { next, skipped, isNextDev } = nextTestSetup({
       files: join(__dirname, 'fixtures/non-edge-cache-components'),
       skipDeployment: true,
     })
@@ -72,7 +72,9 @@ describe('cache-handlers-upstream-wiring', () => {
       expect(pageResponse.status).toBe(200)
 
       await retry(async () => {
-        const output = next.cliOutput.slice(outputIndex)
+        const output = isNextDev
+          ? next.cliOutput.slice(outputIndex)
+          : next.cliOutput
         expect(output).toContain('WiringModernCacheHandler::set')
         expect(output).toContain('WiringModernCacheHandler::get')
       })
@@ -96,38 +98,40 @@ describe('cache-handlers-upstream-wiring', () => {
       })
     })
   })
-
-  describe('cacheComponents disabled, edge app router', () => {
-    const { next, skipped } = nextTestSetup({
-      files: join(__dirname, 'fixtures/edge-without-cache-components'),
-      skipDeployment: true,
-    })
-
-    if (skipped) {
-      return
-    }
-
-    let outputIndex = 0
-
-    beforeEach(() => {
-      outputIndex = next.cliOutput.length
-    })
-
-    it('uses configured cacheHandler for edge app page and edge app route', async () => {
-      const edgePageResponse = await next.fetch('/edge-page')
-      expect(edgePageResponse.status).toBe(200)
-
-      const edgeRouteResponse = await next.fetch('/api/edge-route')
-      expect(edgeRouteResponse.status).toBe(200)
-      expect(await edgeRouteResponse.json()).toEqual({ ok: true })
-
-      await retry(async () => {
-        const output = next.cliOutput.slice(outputIndex)
-        const constructorLogs =
-          output.match(/WiringIncrementalCacheHandler::constructor/g) ?? []
-
-        expect(constructorLogs.length).toBeGreaterThanOrEqual(2)
+  ;(process.env.__NEXT_CACHE_COMPONENTS ? describe.skip : describe)(
+    'cacheComponents disabled, edge app router',
+    () => {
+      const { next, skipped } = nextTestSetup({
+        files: join(__dirname, 'fixtures/edge-without-cache-components'),
+        skipDeployment: true,
       })
-    })
-  })
+
+      if (skipped) {
+        return
+      }
+
+      let outputIndex = 0
+
+      beforeEach(() => {
+        outputIndex = next.cliOutput.length
+      })
+
+      it('uses configured cacheHandler for edge app page and edge app route', async () => {
+        const edgePageResponse = await next.fetch('/edge-page')
+        expect(edgePageResponse.status).toBe(200)
+
+        const edgeRouteResponse = await next.fetch('/api/edge-route')
+        expect(edgeRouteResponse.status).toBe(200)
+        expect(await edgeRouteResponse.json()).toEqual({ ok: true })
+
+        await retry(async () => {
+          const output = next.cliOutput.slice(outputIndex)
+          const constructorLogs =
+            output.match(/WiringIncrementalCacheHandler::constructor/g) ?? []
+
+          expect(constructorLogs.length).toBeGreaterThanOrEqual(2)
+        })
+      })
+    }
+  )
 })


### PR DESCRIPTION
### What?

This PR wires custom `cacheHandler` / `cacheHandlers` through the remaining edge entrypoints so edge app pages, edge app routes, edge pages SSR, middleware, and edge API routes can all see the configured handlers.

It also adds an e2e regression suite covering:
- pages-router ISR revalidation with a custom incremental cache handler
- app-router cache handlers with cache components enabled
- edge app page + edge app route wiring when cache components are disabled

### Why?

We already support custom cache handlers in non-edge paths, but several edge code paths were not forwarding that configuration into the generated entrypoints/runtime wrappers. That meant custom cache handlers could be skipped in edge rendering and edge route execution, and we did not have regression coverage around those cases.

### How?

- pass `cacheHandler` / `cacheHandlers` through the JS build entry plumbing for edge server entries
- inject cache handler imports/registration into the webpack edge templates and loaders
- mirror the same wiring in the Turbopack/Rust entry generation for edge app pages, app routes, pages SSR, and middleware
- update the edge route wrapper to initialize and register cache handlers before invoking the route module
- extend `next-taskless` template expansion with raw injection support so the generated edge templates can add imports and registration code
- add `test/e2e/cache-handlers-upstream-wiring` fixtures to cover pages/app, edge/non-edge, and revalidation behavior
