### PR TITLE
[ci] Disable test-level retries during flakiness detection

### DIFF
--- a/scripts/test-new-tests.mjs
+++ b/scripts/test-new-tests.mjs
@@ -160,6 +160,7 @@ async function main() {
           NEXT_TEST_MODE: testMode,
           NEXT_TEST_VERSION: nextTestVersion,
           NEXT_EXTERNAL_TESTS_FILTERS,
+          NEXT_FLAKE_DETECTION: '1',
           IS_TURBOPACK_TEST: '1',
           TURBOPACK_BUILD:
             testMode === 'start' || testMode === 'deploy' ? '1' : undefined,

--- a/test/lib/e2e-utils/index.ts
+++ b/test/lib/e2e-utils/index.ts
@@ -126,7 +126,7 @@ if (!e2eGlobal.__NEXT_E2E_TEST_CONFIG_PATCHED__) {
       global.test = wrapJestTestFn(global.test) as jest.It
     }
 
-    if (process.env.NEXT_TEST_CI) {
+    if (process.env.NEXT_TEST_CI && !process.env.NEXT_FLAKE_DETECTION) {
       jest.retryTimes(1)
     }
   }


### PR DESCRIPTION

Previously, test-level retries (`jest.retryTimes(1)`) were active during flakiness detection in `start` and `deploy` modes. This allowed flaky tests that failed once but passed on retry to be marked as passing, silently hiding intermittent failures and defeating the purpose of flakiness detection.

We now disable test-level retries during flakiness detection.

[Cursor thread](https://cursor.com/agents/bc-240f7a2c-66b5-4014-8d53-6b56da738a94)
