### PR TITLE
[Instant] fix instant config suggested by editor plugin

### DIFF
--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -154,7 +154,7 @@ const API_DOCS: Record<
     // with the way this plugin is currently structured.
     // For now, since we don't provide an `options` here, we won't do any validation in
     // `getSemanticDiagnosticsForExportVariableStatement` below, and only provide hover a tooltip + autocomplete.
-    insertText: 'unstable_instant = { mode: "static" };',
+    insertText: 'unstable_instant = { prefetch: "static" };',
   },
 }
 


### PR DESCRIPTION
We forgot to update the autocomplete hint when we changed it from `mode` to `prefetch`.