### PR TITLE
Remove sequential madvise for compressed blocks in StaticSortedFile

### DIFF
--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -541,17 +541,6 @@ impl StaticSortedFile {
             return Ok(self.mmap_slice_to_arc_bytes(block));
         }
 
-        // Advise Sequential only here: we're about to linearly scan the block
-        // through the decompressor. For uncompressed blocks (returned above)
-        // and lazy medium values (which call get_raw_block directly without
-        // decompressing), the file-level Random advice applies.
-        #[cfg(unix)]
-        let _ = self.mmap.advise_range(
-            memmap2::Advice::Sequential,
-            block.as_ptr() as usize - self.mmap.as_ptr() as usize,
-            block.len(),
-        );
-
         let buffer = decompress_into_arc(uncompressed_length, block).with_context(|| {
             format!(
                 "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",


### PR DESCRIPTION
## Summary

Remove the per-block `madvise(MADV_SEQUENTIAL)` call before decompression in `StaticSortedFile`.

The primary motivation is that the kernel splits mmap regions internally when they receive different `madvise` hints. Each per-block `MADV_SEQUENTIAL` call fragments the VMA (Virtual Memory Area) for the file mapping. For larger builds with many compressed blocks, this causes the process to hit the `vm.max_map_count` limit, leading to failures.

Additionally, the file-level `MADV_RANDOM` advice is sufficient on its own — the sequential hint for individual compressed blocks adds syscall overhead without meaningful benefit, since the decompressor already performs a linear scan in userspace and the blocks are already mapped in memory.

## Changes

- Removed the `madvise(Sequential)` call in `StaticSortedFile::get_block()` for compressed blocks (`turbopack/crates/turbo-persistence/src/static_sorted_file.rs`)

## Test Plan

- Existing turbo-persistence tests continue to pass
- This is a performance-only change with no functional impact