### PR TITLE
[test] Properly log `framereceived` payload

### DIFF
--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -334,7 +334,11 @@ export class Playwright<TCurrent = undefined> {
 
         if (tracePlaywright) {
           page
-            .evaluate(`console.log('received ws message ${frame.payload}')`)
+            .evaluate(
+              (payload) =>
+                console.log('received ws message with payload: ', payload),
+              frame.payload
+            )
             .catch(() => {})
         }
       })

--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -333,11 +333,11 @@ export class Playwright<TCurrent = undefined> {
         websocketFrames.push({ payload: frame.payload })
 
         if (tracePlaywright) {
+          const { payload } = frame
           page
+            // Note that passing the payload as a an argument is 2 orders of magnitude more expensive in Playwright.
             .evaluate(
-              (payload) =>
-                console.log('received ws message with payload: ', payload),
-              frame.payload
+              `console.log('received ws message ${JSON.stringify(payload)}')`
             )
             .catch(() => {})
         }


### PR DESCRIPTION
We just stringified the value as-is which can produce invalid JS. This is only noticedable in Playwright traces where the errors are just noise.

Before: 
<img width="1382" height="400" alt="CleanShot 2026-03-12 at 16 26 17@2x" src="https://github.com/user-attachments/assets/39c2519b-b2eb-4114-b50f-2ba8e595d490" />

After:
<img width="1608" height="800" alt="CleanShot 2026-03-12 at 18 16 34@2x" src="https://github.com/user-attachments/assets/ed40ec6c-39c8-4bd1-ad92-1a38bd4b3ddb" />



I originally sent the payload as is but that seems too expensive for Playwright. Regularly saw 300+ ms when doing that instead of using upfront serialization which takes around 10-70ms. 