### PR TITLE
docs: fix params type and add missing notFound import in error handling

### DIFF
--- a/docs/01-app/01-getting-started/10-error-handling.mdx
+++ b/docs/01-app/01-getting-started/10-error-handling.mdx
@@ -151,8 +151,9 @@ You can call the [`notFound`](/docs/app/api-reference/functions/not-found) funct
 
 ```tsx filename="app/blog/[slug]/page.tsx" switcher
 import { getPostBySlug } from '@/lib/posts'
+import { notFound } from 'next/navigation'
 
-export default async function Page({ params }: { params: { slug: string } }) {
+export default async function Page({ params }: { params: Promise<{ slug: string }> }) {
   const { slug } = await params
   const post = getPostBySlug(slug)
 
@@ -166,6 +167,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
 
 ```jsx filename="app/blog/[slug]/page.js" switcher
 import { getPostBySlug } from '@/lib/posts'
+import { notFound } from 'next/navigation'
 
 export default async function Page({ params }) {
   const { slug } = await params


### PR DESCRIPTION
## Summary
  - Added missing `import { notFound } from 'next/navigation'` to both TypeScript and JavaScript examples in the "Not found" section
  - Fixed `params` type from `{ slug: string }` to `Promise<{ slug: string }>`  to match the async params pattern in Next.js 15+

## Context
The rest of the error handling page and other docs pages already use the correct `Promise` type for params. These examples were inconsistent.