### PR TITLE
[Instant] Show owner stack for validation-blocking errors

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1115,5 +1115,6 @@
   "1114": "Route \"%s\" accessed root param \"%s\" which is not defined in the \\`samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`params\\` object.",
   "1115": "Route \"%s\" accessed cookie \"%s\" which is not defined in the \\`samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`cookies\\` array, or \\`{ name: \"%s\", value: null }\\` if it should be absent.",
   "1116": "Route \"%s\" accessed header \"%s\" which is not defined in the \\`samples\\` of \\`unstable_instant\\`. Add it to the sample's \\`headers\\` array, or \\`[\"%s\", null]\\` if it should be absent.",
-  "1117": "Instant validation boundaries should never appear in browser bundles."
+  "1117": "Instant validation boundaries should never appear in browser bundles.",
+  "1118": "An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing."
 }

--- a/packages/next/src/lib/is-error.ts
+++ b/packages/next/src/lib/is-error.ts
@@ -6,7 +6,7 @@ export interface NextError extends Error {
   page?: string
   code?: string | number
   cancelled?: boolean
-  digest?: number
+  digest?: string
 }
 
 /**

--- a/packages/next/src/server/app-render/dynamic-rendering.ts
+++ b/packages/next/src/server/app-render/dynamic-rendering.ts
@@ -947,7 +947,7 @@ export function trackDynamicHoleInNavigation(
 export function trackThrownErrorInNavigation(
   workStore: WorkStore,
   dynamicValidation: InstantValidationState,
-  thrownError: unknown,
+  thrownValue: unknown,
   componentStack: string
 ) {
   const boundaryLocation =
@@ -955,7 +955,20 @@ export function trackThrownErrorInNavigation(
   if (!boundaryLocation) {
     // There's no validation boundary on the component stack.
     // This error may have blocked a boundary from rendering.
-    dynamicValidation.thrownErrorsOutsideBoundary.push(thrownError)
+
+    // Wrap the error to provide component context.
+    // This helps for errors from node_modules which would otherwise
+    // have no useful stack information due to ignore-listing,
+    // e.g. next/dynamic with `ssr: false`.
+    const error = addErrorContext(
+      new Error(
+        'An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.',
+        { cause: thrownValue }
+      ),
+      componentStack,
+      null
+    )
+    dynamicValidation.thrownErrorsOutsideBoundary.push(error)
   } else {
     // There's validation boundary on the component stack,
     // so we know this error didn't block a validation boundary from rendering.
@@ -975,7 +988,7 @@ export function trackThrownErrorInNavigation(
     }
     const message = `Route "${workStore.route}": Could not validate \`unstable_instant\` because an error prevented the target segment from rendering.`
     const error = addErrorContext(
-      new Error(message, { cause: thrownError }),
+      new Error(message, { cause: thrownValue }),
       componentStack,
       null // TODO(instant-validation-build): conflicting use of cause
     )

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/page.tsx
@@ -127,6 +127,12 @@ export default async function Page() {
           <DebugLinks href="/suspense-in-root/static/invalid-client-error-in-parent-blocks-children" />
         </li>
         <li>
+          <DebugLinks href="/suspense-in-root/static/invalid-csr-bailout-blocks-children" />
+        </li>
+        <li>
+          <DebugLinks href="/suspense-in-root/static/invalid-error-in-node-modules-blocks-children" />
+        </li>
+        <li>
           <DebugLinks href="/suspense-in-root/static/invalid-client-error-in-parent-sibling" />
         </li>
         <li>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/layout.tsx
@@ -1,11 +1,13 @@
 import { Suspense, type ReactNode } from 'react'
 import { ErrorInSSR } from './client'
+import { connection } from 'next/server'
 
 // Make sure that the holes from this layout aren't factored in for validation
 // (otherwise, we'd check a navigation into it from the root layout and fail)
 export const unstable_instant = false
 
-export default function Layout({ children }: { children: ReactNode }) {
+export default async function Layout({ children }: { children: ReactNode }) {
+  await connection() // Prevent the error from failing the prerender in build
   return (
     <>
       <div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-client-error-in-parent-sibling/layout.tsx
@@ -1,11 +1,13 @@
 import { type ReactNode } from 'react'
 import { ErrorInSSR } from './client'
+import { connection } from 'next/server'
 
 // Make sure that the holes from this layout aren't factored in for validation
 // (otherwise, we'd check a navigation into it from the root layout and fail)
 export const unstable_instant = false
 
-export default function Layout({ children }: { children: ReactNode }) {
+export default async function Layout({ children }: { children: ReactNode }) {
+  await connection() // Prevent the error from failing the prerender in build
   return (
     <>
       <div>

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/client.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/client.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { ReactNode } from 'react'
+
+export function ClientWrapper({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <p>Hello from a client wrapper</p>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/layout.tsx
@@ -1,5 +1,5 @@
-import { Suspense, type ReactNode } from 'react'
-import { ErrorInSSR } from './client'
+import type { ReactNode } from 'react'
+import { LazyClientWrapperWithNoSSR } from './lazy-client'
 import { connection } from 'next/server'
 
 // Make sure that the holes from this layout aren't factored in for validation
@@ -12,14 +12,11 @@ export default async function Layout({ children }: { children: ReactNode }) {
     <>
       <div>
         <p>
-          This layout errors in SSR, but the error is wrapped in Suspense and
-          does not block the children slot, so it does not prevent us from
-          validating the page.
+          This layout renders a component wrapped in next/dynamic with ssr:
+          false around the children slot. This blocks the children slot so it
+          prevents validation.
         </p>
-        <Suspense>
-          <ErrorInSSR />
-        </Suspense>
-        {children}
+        <LazyClientWrapperWithNoSSR>{children}</LazyClientWrapperWithNoSSR>
       </div>
     </>
   )

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/lazy-client.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/lazy-client.tsx
@@ -1,0 +1,8 @@
+'use client'
+
+import dynamic from 'next/dynamic'
+
+export const LazyClientWrapperWithNoSSR = dynamic(
+  () => import('./client').then((mod) => mod.ClientWrapper),
+  { ssr: false }
+)

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx
@@ -1,0 +1,11 @@
+export const unstable_instant = {
+  prefetch: 'static',
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p>This page is static, so it should pass instant validation</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/layout.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/layout.tsx
@@ -1,5 +1,5 @@
 import { Suspense, type ReactNode } from 'react'
-import { ErrorInSSR } from './client'
+import { ErrorInSSRFromPackage } from 'my-pkg'
 import { connection } from 'next/server'
 
 // Make sure that the holes from this layout aren't factored in for validation
@@ -12,14 +12,14 @@ export default async function Layout({ children }: { children: ReactNode }) {
     <>
       <div>
         <p>
-          This layout errors in SSR, but the error is wrapped in Suspense and
-          does not block the children slot, so it does not prevent us from
-          validating the page.
+          This layout errors in SSR, and the errors is caught by a Suspense
+          boundary, but it blocks the children slot so it prevents validation.
+          The error is thrown in a component from node_modules, which means that
+          the component is ignore-listed away.
         </p>
         <Suspense>
-          <ErrorInSSR />
+          <ErrorInSSRFromPackage>{children}</ErrorInSSRFromPackage>
         </Suspense>
-        {children}
       </div>
     </>
   )

--- a/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
+++ b/test/e2e/app-dir/instant-validation/app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx
@@ -1,0 +1,11 @@
+export const unstable_instant = {
+  prefetch: 'static',
+}
+
+export default function Page() {
+  return (
+    <main>
+      <p>This page is static, so it should pass instant validation</p>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/instant-validation/instant-validation.test.ts
+++ b/test/e2e/app-dir/instant-validation/instant-validation.test.ts
@@ -1778,35 +1778,33 @@ describe('instant validation', () => {
       })
     })
 
-    if (isNextDev) {
-      // The errors we throw in these tests are recoverable in dev,
-      // but fail the prerender in prod, so we don't get to validating.
-      describe('client errors', () => {
-        function removeExpectedError(
-          errors: RedboxSnapshot,
-          shouldRemove: (error: ErrorSnapshot) => boolean
-        ): ErrorSnapshot[] {
-          if (!Array.isArray(errors)) {
-            throw new Error('Expected to receive multiple errors to filter')
-          }
-          let found = false
-          const result = errors.filter((err) => {
-            if (shouldRemove(err)) {
-              found = true
-              return false
-            } else {
-              return true
-            }
-          })
-          if (!found) {
-            throw new Error(
-              `Did not find expected error in errors array: ${JSON.stringify(errors, null, 2)}`
-            )
-          }
-          return result
+    describe('client errors', () => {
+      function removeExpectedError(
+        errors: RedboxSnapshot,
+        shouldRemove: (error: ErrorSnapshot) => boolean
+      ): ErrorSnapshot[] {
+        if (!Array.isArray(errors)) {
+          throw new Error('Expected to receive multiple errors to filter')
         }
+        let found = false
+        const result = errors.filter((err) => {
+          if (shouldRemove(err)) {
+            found = true
+            return false
+          } else {
+            return true
+          }
+        })
+        if (!found) {
+          throw new Error(
+            `Did not find expected error in errors array: ${JSON.stringify(errors, null, 2)}`
+          )
+        }
+        return result
+      }
 
-        it('unable to validate - client error in parent blocks children', async () => {
+      it('unable to validate - client error in parent blocks children', async () => {
+        if (isNextDev) {
           const browser = await navigateTo(
             '/suspense-in-root/static/invalid-client-error-in-parent-blocks-children'
           )
@@ -1831,34 +1829,237 @@ describe('instant validation', () => {
           }
 
           expect(errors).toMatchInlineSnapshot(`
-            [
-              {
-                "description": "Route "/suspense-in-root/static/invalid-client-error-in-parent-blocks-children": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.",
-                "environmentLabel": "Server",
-                "label": "Console Error",
-                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33) @ unstable_instant
-            > 1 | export const unstable_instant = {
-                |                                 ^",
-                "stack": [
-                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33)",
-                ],
-              },
-              {
-                "description": "No SSR please",
-                "environmentLabel": "Server",
-                "label": "Console Error",
-                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/client.tsx (5:11) @ ErrorInSSR
-            > 5 |     throw new Error('No SSR please')
+           [
+             {
+               "description": "Route "/suspense-in-root/static/invalid-client-error-in-parent-blocks-children": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = {
+               |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/page.tsx (1:33)",
+               ],
+             },
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Error",
+                   "message": "No SSR please",
+                   "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/client.tsx (5:11) @ ErrorInSSR
+           > 5 |     throw new Error('No SSR please')
+               |           ^",
+                   "stack": [
+                     "ErrorInSSR app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/client.tsx (5:11)",
+                   ],
+                 },
+               ],
+               "code": "E1118",
+               "description": "An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/layout.tsx (19:11) @ Layout
+           > 19 |           <ErrorInSSR>{children}</ErrorInSSR>
                 |           ^",
-                "stack": [
-                  "ErrorInSSR app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/client.tsx (5:11)",
-                ],
-              },
-            ]
+               "stack": [
+                 "Layout app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/layout.tsx (19:11)",
+               ],
+             },
+           ]
           `)
-        })
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/static/invalid-client-error-in-parent-blocks-children'
+          )
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/static/invalid-client-error-in-parent-blocks-children": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.
+               at ignore-listed frames
+           Error: An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.
+               at <unknown> (app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/client.tsx:3:30)
+               at a (<anonymous>)
+               at div (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at b (<anonymous>)
+             1 | 'use client'
+             2 |
+           > 3 | export function ErrorInSSR({ children }) {
+               |                              ^
+             4 |   if (typeof window === 'undefined') {
+             5 |     throw new Error('No SSR please')
+             6 |   } {
+             [cause]: Error: No SSR please
+                 at <unknown> (app/suspense-in-root/static/invalid-client-error-in-parent-blocks-children/client.tsx:5:11)
+               3 | export function ErrorInSSR({ children }) {
+               4 |   if (typeof window === 'undefined') {
+             > 5 |     throw new Error('No SSR please')
+                 |           ^
+               6 |   }
+               7 |   return <>{children}</>
+               8 | }
+           }
+           Build-time instant validation failed for route "/suspense-in-root/static/invalid-client-error-in-parent-blocks-children".
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      })
 
-        it('unable to validate - client error from sibling of children slot without suspense', async () => {
+      it('unable to validate - client error in component from node_modules blocks children', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/suspense-in-root/static/invalid-error-in-node-modules-blocks-children'
+          )
+          // We expect a collapsed redbox. We need to open it to assert on the messages.
+          await openRedbox(browser)
+
+          let errors = await createRedboxSnapshot(browser, next)
+
+          if (!isClientNav) {
+            // In SSR, we expect a "Switched to client rendering ..." error because we deliberately throw in a client component.
+            // However, the timing of when it appears is inconsistent -- sometimes it's before validation errors,
+            // and sometimes it's after.
+            // To avoid flakiness, we filter it out (but assert that it appears in the redbox)
+            errors = removeExpectedError(errors, (err) => {
+              return (
+                err.label === 'Recoverable Error' &&
+                err.description.startsWith(
+                  'Switched to client rendering because the server rendering errored:\n\nError from node_modules'
+                )
+              )
+            })
+          }
+
+          expect(errors).toMatchInlineSnapshot(`
+           [
+             {
+               "description": "Route "/suspense-in-root/static/invalid-error-in-node-modules-blocks-children": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = {
+               |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/page.tsx (1:33)",
+               ],
+             },
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Error",
+                   "message": "Error from node_modules",
+                   "source": null,
+                   "stack": [],
+                 },
+               ],
+               "code": "E1118",
+               "description": "An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/layout.tsx (21:11) @ Layout
+           > 21 |           <ErrorInSSRFromPackage>{children}</ErrorInSSRFromPackage>
+                |           ^",
+               "stack": [
+                 "Layout app/suspense-in-root/static/invalid-error-in-node-modules-blocks-children/layout.tsx (21:11)",
+               ],
+             },
+           ]
+          `)
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/static/invalid-error-in-node-modules-blocks-children'
+          )
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/static/invalid-error-in-node-modules-blocks-children": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.
+               at ignore-listed frames
+           Error: An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.
+               at a (<anonymous>)
+               at div (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at b (<anonymous>) {
+             [cause]: Error: Error from node_modules
+                 at ignore-listed frames
+           }
+           Build-time instant validation failed for route "/suspense-in-root/static/invalid-error-in-node-modules-blocks-children".
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      })
+
+      it('unable to validate - CSR bailout from next/dynamic blocks children', async () => {
+        if (isNextDev) {
+          const browser = await navigateTo(
+            '/suspense-in-root/static/invalid-csr-bailout-blocks-children'
+          )
+          await expect(browser).toDisplayCollapsedRedbox(`
+           [
+             {
+               "description": "Route "/suspense-in-root/static/invalid-csr-bailout-blocks-children": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = {
+               |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/invalid-csr-bailout-blocks-children/page.tsx (1:33)",
+               ],
+             },
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Error",
+                   "message": "Bail out to client-side rendering: next/dynamic",
+                   "source": null,
+                   "stack": [],
+                 },
+               ],
+               "code": "E1118",
+               "description": "An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-csr-bailout-blocks-children/layout.tsx (19:9) @ Layout
+           > 19 |         <LazyClientWrapperWithNoSSR>{children}</LazyClientWrapperWithNoSSR>
+                |         ^",
+               "stack": [
+                 "Layout app/suspense-in-root/static/invalid-csr-bailout-blocks-children/layout.tsx (19:9)",
+               ],
+             },
+           ]
+          `)
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/static/invalid-csr-bailout-blocks-children'
+          )
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/static/invalid-csr-bailout-blocks-children": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.
+               at ignore-listed frames
+           Error: An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.
+               at a (<anonymous>)
+               at b (<anonymous>)
+               at div (<anonymous>)
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at c (<anonymous>) {
+             [cause]: Error: Bail out to client-side rendering: next/dynamic
+                 at ignore-listed frames {
+               reason: 'next/dynamic',
+               digest: 'BAILOUT_TO_CLIENT_SIDE_RENDERING'
+             }
+           }
+           Build-time instant validation failed for route "/suspense-in-root/static/invalid-csr-bailout-blocks-children".
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      })
+
+      it('unable to validate - client error from sibling of children slot without suspense', async () => {
+        if (isNextDev) {
           const browser = await navigateTo(
             '/suspense-in-root/static/invalid-client-error-in-parent-sibling'
           )
@@ -1888,34 +2089,83 @@ describe('instant validation', () => {
           }
 
           expect(errors).toMatchInlineSnapshot(`
-            [
-              {
-                "description": "Route "/suspense-in-root/static/invalid-client-error-in-parent-sibling": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.",
-                "environmentLabel": "Server",
-                "label": "Console Error",
-                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33) @ unstable_instant
-            > 1 | export const unstable_instant = {
-                |                                 ^",
-                "stack": [
-                  "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33)",
-                ],
-              },
-              {
-                "description": "No SSR please",
-                "environmentLabel": "Server",
-                "label": "Console Error",
-                "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/client.tsx (5:11) @ ErrorInSSR
-            > 5 |     throw new Error('No SSR please')
-                |           ^",
-                "stack": [
-                  "ErrorInSSR app/suspense-in-root/static/invalid-client-error-in-parent-sibling/client.tsx (5:11)",
-                ],
-              },
-            ]
+           [
+             {
+               "description": "Route "/suspense-in-root/static/invalid-client-error-in-parent-sibling": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33) @ unstable_instant
+           > 1 | export const unstable_instant = {
+               |                                 ^",
+               "stack": [
+                 "unstable_instant app/suspense-in-root/static/invalid-client-error-in-parent-sibling/page.tsx (1:33)",
+               ],
+             },
+             {
+               "cause": [
+                 {
+                   "label": "Caused by: Error",
+                   "message": "No SSR please",
+                   "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/client.tsx (5:11) @ ErrorInSSR
+           > 5 |     throw new Error('No SSR please')
+               |           ^",
+                   "stack": [
+                     "ErrorInSSR app/suspense-in-root/static/invalid-client-error-in-parent-sibling/client.tsx (5:11)",
+                   ],
+                 },
+               ],
+               "code": "E1118",
+               "description": "An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.",
+               "environmentLabel": "Server",
+               "label": "Console Error",
+               "source": "app/suspense-in-root/static/invalid-client-error-in-parent-sibling/layout.tsx (20:7) @ Layout
+           > 20 |       <ErrorInSSR />
+                |       ^",
+               "stack": [
+                 "Layout app/suspense-in-root/static/invalid-client-error-in-parent-sibling/layout.tsx (20:7)",
+               ],
+             },
+           ]
           `)
-        })
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/static/invalid-client-error-in-parent-sibling'
+          )
+          expect(extractBuildValidationError(result.cliOutput))
+            .toMatchInlineSnapshot(`
+           "Error: Route "/suspense-in-root/static/invalid-client-error-in-parent-sibling": Could not validate \`unstable_instant\` because the target segment was prevented from rendering, likely due to the following error.
+               at ignore-listed frames
+           Error: An error occurred while attempting to validate instant UI. This error may be preventing the validation from completing.
+               at <unknown> (app/suspense-in-root/static/invalid-client-error-in-parent-sibling/client.tsx:5:11)
+               at body (<anonymous>)
+               at html (<anonymous>)
+               at a (<anonymous>)
+             3 | export function ErrorInSSR() {
+             4 |   if (typeof window === 'undefined') {
+           > 5 |     throw new Error('No SSR please')
+               |           ^
+             6 |   }
+             7 |   return <div>Hello, browser!</div>
+             8 | } {
+             [cause]: Error: No SSR please
+                 at <unknown> (app/suspense-in-root/static/invalid-client-error-in-parent-sibling/client.tsx:5:11)
+               3 | export function ErrorInSSR() {
+               4 |   if (typeof window === 'undefined') {
+             > 5 |     throw new Error('No SSR please')
+                 |           ^
+               6 |   }
+               7 |   return <div>Hello, browser!</div>
+               8 | }
+           }
+           Build-time instant validation failed for route "/suspense-in-root/static/invalid-client-error-in-parent-sibling".
+           Stopping prerender due to instant validation errors."
+          `)
+          expect(result.exitCode).toBe(1)
+        }
+      })
 
-        it('valid - client error from sibling of children slot with suspense', async () => {
+      it('valid - client error from sibling of children slot with suspense', async () => {
+        if (isNextDev) {
           const browser = await navigateTo(
             '/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation'
           )
@@ -1926,24 +2176,29 @@ describe('instant validation', () => {
           } else {
             // In SSR, we expect to only see the error coming from react.
             await expect(browser).toDisplayCollapsedRedbox(`
-                         {
-                           "description": "Switched to client rendering because the server rendering errored:
+              {
+                "description": "Switched to client rendering because the server rendering errored:
 
-                         No SSR please",
-                           "environmentLabel": null,
-                           "label": "Recoverable Error",
-                           "source": "app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/client.tsx (5:11) @ ErrorInSSR
-                         > 5 |     throw new Error('No SSR please')
-                             |           ^",
-                           "stack": [
-                             "ErrorInSSR app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/client.tsx (5:11)",
-                           ],
-                         }
-                      `)
+              No SSR please",
+                "environmentLabel": null,
+                "label": "Recoverable Error",
+                "source": "app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/client.tsx (5:11) @ ErrorInSSR
+              > 5 |     throw new Error('No SSR please')
+                  |           ^",
+                "stack": [
+                  "ErrorInSSR app/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation/client.tsx (5:11)",
+                ],
+              }
+          `)
           }
-        })
+        } else {
+          const result = await prerender(
+            '/suspense-in-root/static/valid-client-error-in-parent-does-not-block-validation'
+          )
+          expectNoBuildValidationErrors(result)
+        }
       })
-    }
+    })
 
     describe('head', () => {
       it('valid - runtime prefetch - dynamic generateMetadata does not block navigation', async () => {

--- a/test/e2e/app-dir/instant-validation/node_modules/my-pkg/index.js
+++ b/test/e2e/app-dir/instant-validation/node_modules/my-pkg/index.js
@@ -1,0 +1,8 @@
+'use client'
+
+export function ErrorInSSRFromPackage({ children }) {
+  if (typeof window === 'undefined') {
+    throw new Error('Error from node_modules')
+  }
+  return children
+}

--- a/test/e2e/app-dir/instant-validation/node_modules/my-pkg/package.json
+++ b/test/e2e/app-dir/instant-validation/node_modules/my-pkg/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "my-pkg",
+  "type": "module",
+  "exports": {
+    ".": "./index.js"
+  }
+}


### PR DESCRIPTION
Adds extra context to errors that we think may have prevented validation:

<img width="816" height="765" alt="Screenshot 2026-03-12 at 22 07 40" src="https://github.com/user-attachments/assets/35ce60d0-4840-496e-b91e-62ada4096f64" />

This is particularly useful for errors where the component comes from node_modules, so it gets ignore-listed. previously, all we got is the message with no stack, no we at least get a location. One notable case of this is `next/dynamic` with `ssr: false`.

<img width="802" height="556" alt="Screenshot 2026-03-12 at 22 08 30" src="https://github.com/user-attachments/assets/b1240732-3346-4056-89b2-9a864a3166f2" />
