### PR TITLE
Turbopack: `require(/* turbopackChunkingType: parallel */`

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -5,12 +5,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_core::{
     atoms::Wtf8Atom,
-    common::{
-        BytePos, Span, Spanned, SyntaxContext,
-        comments::Comments,
-        errors::{DiagnosticId, HANDLER},
-        source_map::SmallPos,
-    },
+    common::{BytePos, Span, Spanned, SyntaxContext, comments::Comments, source_map::SmallPos},
     ecma::{
         ast::*,
         atoms::{Atom, atom},
@@ -20,15 +15,14 @@ use swc_core::{
 };
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{FxIndexMap, FxIndexSet, ResolvedVc};
-use turbopack_core::{
-    chunk::ChunkingType, issue::IssueSource, loader::WebpackLoaderItem, source::Source,
-};
+use turbopack_core::{issue::IssueSource, loader::WebpackLoaderItem, source::Source};
 
 use super::{JsValue, ModuleValue, top_level_await::has_top_level_await};
 use crate::{
     SpecifiedModuleType,
     analyzer::{ConstantValue, ObjectPart},
     magic_identifier,
+    references::util::{SpecifiedChunkingType, parse_chunking_type_annotation},
     tree_shake::{PartId, find_turbopack_part_id_in_asserts},
 };
 
@@ -46,15 +40,12 @@ pub struct ImportAnnotations {
     turbopack_loader: Option<WebpackLoaderItem>,
     turbopack_rename_as: Option<RcStr>,
     turbopack_module_type: Option<RcStr>,
+    chunking_type: Option<SpecifiedChunkingType>,
 }
 
 /// Enables a specified transition for the annotated import
 static ANNOTATION_TRANSITION: Lazy<Wtf8Atom> =
     Lazy::new(|| crate::annotations::ANNOTATION_TRANSITION.into());
-
-/// Changes the chunking type for the annotated import
-static ANNOTATION_CHUNKING_TYPE: Lazy<Wtf8Atom> =
-    Lazy::new(|| crate::annotations::ANNOTATION_CHUNKING_TYPE.into());
 
 /// Changes the type of the resolved module (only "json" is supported currently)
 static ATTRIBUTE_MODULE_TYPE: Lazy<Wtf8Atom> = Lazy::new(|| atom!("type").into());
@@ -69,6 +60,7 @@ impl ImportAnnotations {
             serde_json::Map::new();
         let mut turbopack_rename_as: Option<RcStr> = None;
         let mut turbopack_module_type: Option<RcStr> = None;
+        let mut chunking_type: Option<SpecifiedChunkingType> = None;
 
         for prop in &with.props {
             let Some(kv) = prop.as_prop().and_then(|p| p.as_key_value()) else {
@@ -76,13 +68,13 @@ impl ImportAnnotations {
             };
 
             let key_str = match &kv.key {
-                PropName::Ident(ident) => ident.sym.to_string(),
-                PropName::Str(str) => str.value.to_string_lossy().into_owned(),
+                PropName::Ident(ident) => Cow::Borrowed(ident.sym.as_str()),
+                PropName::Str(str) => str.value.to_string_lossy(),
                 _ => continue,
             };
 
             // All turbopack* keys are extracted as string values (per TC39 import attributes spec)
-            match key_str.as_str() {
+            match &*key_str {
                 "turbopackLoader" => {
                     if let Some(Lit::Str(s)) = kv.value.as_lit() {
                         turbopack_loader_name =
@@ -110,6 +102,14 @@ impl ImportAnnotations {
                             Some(RcStr::from(s.value.to_string_lossy().into_owned()));
                     }
                 }
+                "turbopack-chunking-type" => {
+                    if let Some(Lit::Str(s)) = kv.value.as_lit() {
+                        chunking_type = parse_chunking_type_annotation(
+                            kv.value.span(),
+                            &s.value.to_string_lossy(),
+                        );
+                    }
+                }
                 _ => {
                     // For all other keys, only accept string values (per spec)
                     if let Some(Lit::Str(str)) = kv.value.as_lit() {
@@ -118,23 +118,6 @@ impl ImportAnnotations {
                             PropName::Str(s) => s.value.clone(),
                             _ => continue,
                         };
-                        // Validate known annotation values
-                        if key == *ANNOTATION_CHUNKING_TYPE {
-                            let value = str.value.to_string_lossy();
-                            if value != "parallel" && value != "none" {
-                                HANDLER.with(|handler| {
-                                    handler.span_warn_with_code(
-                                        kv.value.span(),
-                                        &format!(
-                                            "unknown turbopack-chunking-type: \"{value}\", \
-                                             expected \"parallel\" or \"none\""
-                                        ),
-                                        DiagnosticId::Error("turbopack-chunking-type".into()),
-                                    );
-                                });
-                                continue;
-                            }
-                        }
                         map.insert(key, str.value.clone());
                     }
                 }
@@ -150,12 +133,14 @@ impl ImportAnnotations {
             || turbopack_loader.is_some()
             || turbopack_rename_as.is_some()
             || turbopack_module_type.is_some()
+            || chunking_type.is_some()
         {
             Some(ImportAnnotations {
                 map,
                 turbopack_loader,
                 turbopack_rename_as,
                 turbopack_module_type,
+                chunking_type,
             })
         } else {
             None
@@ -193,6 +178,7 @@ impl ImportAnnotations {
                 turbopack_loader: None,
                 turbopack_rename_as: None,
                 turbopack_module_type: None,
+                chunking_type: None,
             })
         } else {
             None
@@ -205,23 +191,9 @@ impl ImportAnnotations {
             .map(|v| v.to_string_lossy())
     }
 
-    /// Returns the chunking type override from the `turbopack-chunking-type` annotation.
-    ///
-    /// - `None` — no annotation present
-    /// - `Some(None)` — annotation is `"none"` (opt out of chunking)
-    /// - `Some(Some(..))` — explicit chunking type (e.g. `"parallel"`)
-    ///
-    /// Unknown values are rejected during [`ImportAnnotations::parse`] and omitted.
-    pub fn chunking_type(&self) -> Option<Option<ChunkingType>> {
-        let chunking_type = self.get(&ANNOTATION_CHUNKING_TYPE)?;
-        if chunking_type == "none" {
-            Some(None)
-        } else {
-            Some(Some(ChunkingType::Parallel {
-                inherit_async: true,
-                hoisted: true,
-            }))
-        }
+    /// Returns the content on the chunking-type annotation
+    pub fn chunking_type(&self) -> Option<SpecifiedChunkingType> {
+        self.chunking_type
     }
 
     /// Returns the content on the type attribute
@@ -362,6 +334,15 @@ pub struct ImportAttributes {
     /// const { b } = await import(/* turbopackExports: "b" */ "module");
     /// ```
     pub export_names: Option<SmallVec<[RcStr; 1]>>,
+    /// Whether to use a specific chunking type for this import.
+    //
+    /// This is set by using a or `turbopackChunkingType` comment.
+    ///
+    /// Example:
+    /// ```js
+    /// const a = require(/* turbopackChunkingType: parallel */ "a");
+    /// ```
+    pub chunking_type: Option<SpecifiedChunkingType>,
 }
 
 impl ImportAttributes {
@@ -370,6 +351,7 @@ impl ImportAttributes {
             ignore: false,
             optional: false,
             export_names: None,
+            chunking_type: None,
         }
     }
 
@@ -942,12 +924,13 @@ fn parse_directives(
     comments: &dyn Comments,
     value: Option<&ExprOrSpread>,
 ) -> Option<ImportAttributes> {
-    let comment_pos = value.map(|arg| arg.span_lo())?;
-    let leading_comments = comments.get_leading(comment_pos)?;
+    let value = value?;
+    let leading_comments = comments.get_leading(value.span_lo())?;
 
     let mut ignore = None;
     let mut optional = None;
     let mut export_names = None;
+    let mut chunking_type = None;
 
     // Process all comments, last one wins for each directive type
     for comment in leading_comments.iter() {
@@ -967,17 +950,21 @@ fn parse_directives(
                 "webpackExports" | "turbopackExports" => {
                     export_names = Some(parse_export_names(val));
                 }
+                "turbopackChunkingType" => {
+                    chunking_type = parse_chunking_type_annotation(value.span(), val);
+                }
                 _ => {} // ignore anything else
             }
         }
     }
 
     // Return Some only if at least one directive was found
-    if ignore.is_some() || optional.is_some() || export_names.is_some() {
+    if ignore.is_some() || optional.is_some() || export_names.is_some() || chunking_type.is_some() {
         Some(ImportAttributes {
             ignore: ignore.unwrap_or(false),
             optional: optional.unwrap_or(false),
             export_names,
+            chunking_type,
         })
     } else {
         None

--- a/turbopack/crates/turbopack-ecmascript/src/annotations.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/annotations.rs
@@ -9,14 +9,6 @@ pub const ANNOTATION_CHUNKING_TYPE: &str = "turbopack-chunking-type";
 /// Enables a specified transition for the annotated import
 pub const ANNOTATION_TRANSITION: &str = "turbopack-transition";
 
-pub fn with_chunking_type(chunking_type: &str) -> Box<ObjectLit> {
-    with_clause(&[(ANNOTATION_CHUNKING_TYPE, chunking_type)])
-}
-
-pub fn with_transition(transition_name: &str) -> Box<ObjectLit> {
-    with_clause(&[(ANNOTATION_TRANSITION, transition_name)])
-}
-
 pub fn with_clause<'a>(
     entries: impl IntoIterator<Item = &'a (&'a str, &'a str)>,
 ) -> Box<ObjectLit> {

--- a/turbopack/crates/turbopack-ecmascript/src/errors.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/errors.rs
@@ -19,5 +19,6 @@ pub mod failed_to_analyze {
         pub const NEW_WORKER: &str = "TP1203";
         pub const MODULE_HOT_ACCEPT: &str = "TP1204";
         pub const MODULE_HOT_DECLINE: &str = "TP1205";
+        pub const CHUNKING_TYPE: &str = "TP1206";
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/cjs.rs
@@ -23,6 +23,7 @@ use crate::{
     references::{
         AstPath,
         pattern_mapping::{PatternMapping, ResolveType},
+        util::SpecifiedChunkingType,
     },
     runtime_functions::TURBOPACK_CACHE,
 };
@@ -80,10 +81,11 @@ impl ModuleReference for CjsAssetReference {
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("require {request}")]
 pub struct CjsRequireAssetReference {
-    pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-    pub request: ResolvedVc<Request>,
-    pub issue_source: IssueSource,
-    pub error_mode: ResolveErrorMode,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    request: ResolvedVc<Request>,
+    issue_source: IssueSource,
+    error_mode: ResolveErrorMode,
+    chunking_type_attribute: Option<SpecifiedChunkingType>,
 }
 
 impl CjsRequireAssetReference {
@@ -92,12 +94,14 @@ impl CjsRequireAssetReference {
         request: ResolvedVc<Request>,
         issue_source: IssueSource,
         error_mode: ResolveErrorMode,
+        chunking_type_attribute: Option<SpecifiedChunkingType>,
     ) -> Self {
         CjsRequireAssetReference {
             origin,
             request,
             issue_source,
             error_mode,
+            chunking_type_attribute,
         }
     }
 }
@@ -116,10 +120,15 @@ impl ModuleReference for CjsRequireAssetReference {
     }
 
     fn chunking_type(&self) -> Option<ChunkingType> {
-        Some(ChunkingType::Parallel {
-            inherit_async: false,
-            hoisted: false,
-        })
+        self.chunking_type_attribute.map_or_else(
+            || {
+                Some(ChunkingType::Parallel {
+                    inherit_async: false,
+                    hoisted: false,
+                })
+            },
+            |c| c.as_chunking_type(false, false),
+        )
     }
 }
 
@@ -202,10 +211,11 @@ impl CjsRequireAssetReferenceCodeGen {
 #[derive(Hash, Debug, ValueToString)]
 #[value_to_string("require.resolve {request}")]
 pub struct CjsRequireResolveAssetReference {
-    pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
-    pub request: ResolvedVc<Request>,
-    pub issue_source: IssueSource,
-    pub error_mode: ResolveErrorMode,
+    origin: ResolvedVc<Box<dyn ResolveOrigin>>,
+    request: ResolvedVc<Request>,
+    issue_source: IssueSource,
+    error_mode: ResolveErrorMode,
+    chunking_type_attribute: Option<SpecifiedChunkingType>,
 }
 
 impl CjsRequireResolveAssetReference {
@@ -214,12 +224,14 @@ impl CjsRequireResolveAssetReference {
         request: ResolvedVc<Request>,
         issue_source: IssueSource,
         error_mode: ResolveErrorMode,
+        chunking_type_attribute: Option<SpecifiedChunkingType>,
     ) -> Self {
         CjsRequireResolveAssetReference {
             origin,
             request,
             issue_source,
             error_mode,
+            chunking_type_attribute,
         }
     }
 }
@@ -238,10 +250,15 @@ impl ModuleReference for CjsRequireResolveAssetReference {
     }
 
     fn chunking_type(&self) -> Option<ChunkingType> {
-        Some(ChunkingType::Parallel {
-            inherit_async: false,
-            hoisted: false,
-        })
+        self.chunking_type_attribute.map_or_else(
+            || {
+                Some(ChunkingType::Parallel {
+                    inherit_async: false,
+                    hoisted: false,
+                })
+            },
+            |c| c.as_chunking_type(false, false),
+        )
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -46,7 +46,7 @@ use crate::{
             EsmExport,
             export::{all_known_export_names, is_export_missing},
         },
-        util::throw_module_not_found_expr,
+        util::{SpecifiedChunkingType, throw_module_not_found_expr},
     },
     runtime_functions::{TURBOPACK_EXTERNAL_IMPORT, TURBOPACK_EXTERNAL_REQUIRE, TURBOPACK_IMPORT},
     tree_shake::{TURBOPACK_PART_IMPORT_SOURCE, part::module::EcmascriptModulePartAsset},
@@ -509,10 +509,15 @@ impl ModuleReference for EsmAssetReference {
         self.annotations
             .as_ref()
             .and_then(|a| a.chunking_type())
-            .unwrap_or(Some(ChunkingType::Parallel {
-                inherit_async: true,
-                hoisted: true,
-            }))
+            .map_or_else(
+                || {
+                    Some(ChunkingType::Parallel {
+                        inherit_async: true,
+                        hoisted: true,
+                    })
+                },
+                |c| c.as_chunking_type(true, true),
+            )
     }
 
     fn binding_usage(&self) -> BindingUsage {
@@ -544,10 +549,12 @@ impl EsmAssetReference {
         }
 
         // only chunked references can be imported
-        if !matches!(
-            this.annotations.as_ref().and_then(|a| a.chunking_type()),
-            Some(None)
-        ) {
+        if this
+            .annotations
+            .as_ref()
+            .and_then(|a| a.chunking_type())
+            .is_none_or(|v| v != SpecifiedChunkingType::None)
+        {
             let import_externals = this.import_externals;
             let referenced_asset = self.get_referenced_asset().await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -1515,10 +1515,15 @@ async fn analyze_ecmascript_module_internal(
                             .annotations
                             .as_ref()
                             .and_then(|a| a.chunking_type())
-                            .unwrap_or(Some(ChunkingType::Parallel {
-                                inherit_async: true,
-                                hoisted: true,
-                            }));
+                            .map_or_else(
+                                || {
+                                    Some(ChunkingType::Parallel {
+                                        inherit_async: true,
+                                        hoisted: true,
+                                    })
+                                },
+                                |c| c.as_chunking_type(true, true),
+                            );
                         analysis.add_reference_code_gen(
                             EsmModuleIdAssetReference::new(*r, chunking_type),
                             ast_path.into(),
@@ -2262,6 +2267,7 @@ where
                         Request::parse(pat).to_resolved().await?,
                         issue_source(source, span),
                         error_mode,
+                        attributes.chunking_type,
                     ),
                     ast_path.to_vec().into(),
                 );
@@ -2315,6 +2321,7 @@ where
                         Request::parse(pat).to_resolved().await?,
                         issue_source(source, span),
                         error_mode,
+                        attributes.chunking_type,
                     ),
                     ast_path.to_vec().into(),
                 );

--- a/turbopack/crates/turbopack-ecmascript/src/references/util.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/util.rs
@@ -1,16 +1,27 @@
 use anyhow::Result;
-use swc_core::{ecma::ast::Expr, quote};
+use bincode::{Decode, Encode};
+use swc_core::{
+    common::{
+        Span,
+        errors::{DiagnosticId, HANDLER},
+    },
+    ecma::ast::Expr,
+    quote,
+};
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{ResolvedVc, Vc, turbofmt};
+use turbo_tasks::{NonLocalValue, ResolvedVc, Vc, trace::TraceRawVcs, turbofmt};
 use turbo_tasks_fs::FileSystemPath;
 use turbopack_core::{
     self,
+    chunk::ChunkingType,
     issue::{
         Issue, IssueExt, IssueSeverity, IssueSource, IssueStage, OptionIssueSource,
         OptionStyledString, StyledString,
     },
     resolve::{ModuleResolveResult, parse::Request, pattern::Pattern},
 };
+
+use crate::errors;
 
 /// Creates a IIFE expression that throws a "Cannot find module" error for the
 /// given request string
@@ -130,5 +141,54 @@ impl Issue for TooManyMatchesWarning {
     #[turbo_tasks::function]
     fn source(&self) -> Vc<OptionIssueSource> {
         Vc::cell(Some(self.source))
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Encode, Decode, TraceRawVcs, NonLocalValue)]
+pub enum SpecifiedChunkingType {
+    Parallel,
+    Shared,
+    None,
+}
+
+impl SpecifiedChunkingType {
+    pub fn as_chunking_type(&self, inherit_async: bool, hoisted: bool) -> Option<ChunkingType> {
+        match self {
+            SpecifiedChunkingType::Parallel => Some(ChunkingType::Parallel {
+                inherit_async,
+                hoisted,
+            }),
+            SpecifiedChunkingType::Shared => Some(ChunkingType::Shared {
+                inherit_async,
+                merge_tag: None,
+            }),
+            SpecifiedChunkingType::None => None,
+        }
+    }
+}
+
+pub fn parse_chunking_type_annotation(
+    span: Span,
+    chunking_type_annotation: &str,
+) -> Option<SpecifiedChunkingType> {
+    match chunking_type_annotation {
+        "parallel" => Some(SpecifiedChunkingType::Parallel),
+        "shared" => Some(SpecifiedChunkingType::Shared),
+        "none" => Some(SpecifiedChunkingType::None),
+        _ => {
+            HANDLER.with(|handler| {
+                handler.span_err_with_code(
+                    span,
+                    &format!(
+                        "Unknown specified chunking-type: \"{chunking_type_annotation}\", \
+                         expected \"parallel\", \"shared\" or \"none\""
+                    ),
+                    DiagnosticId::Error(
+                        errors::failed_to_analyze::ecmascript::CHUNKING_TYPE.into(),
+                    ),
+                );
+            });
+            None
+        }
     }
 }


### PR DESCRIPTION
1. Add the CJS version of `import ... with {"turbopack-chunking-type: "parallel"`
2. Allow `shared` as a chunking type
3. Improve error message for invalid values:

<img width="718" height="455" alt="Bildschirmfoto 2026-03-13 um 15 07 06" src="https://github.com/user-attachments/assets/bc1efb43-4cc1-4885-b253-49c1e58b3add" />
