### PR TITLE
docs: update ai-agents guide from canary to latest

### DIFF
--- a/docs/01-app/02-guides/ai-agents.mdx
+++ b/docs/01-app/02-guides/ai-agents.mdx
@@ -36,30 +36,30 @@ The `AGENTS.md` file at the root of your project tells agents to read these bund
 [`create-next-app`](/docs/app/api-reference/cli/create-next-app) generates `AGENTS.md` and `CLAUDE.md` automatically. No additional setup is needed:
 
 ```bash package="pnpm"
-pnpm create next-app@canary
+pnpm create next-app@latest
 ```
 
 ```bash package="npm"
-npx create-next-app@canary
+npx create-next-app@latest
 ```
 
 ```bash package="yarn"
-yarn create next-app@canary
+yarn create next-app@latest
 ```
 
 ```bash package="bun"
-bun create next-app@canary
+bun create next-app@latest
 ```
 
 If you don't want the agent files, pass `--no-agents-md`:
 
 ```bash
-npx create-next-app@canary --no-agents-md
+npx create-next-app@latest --no-agents-md
 ```
 
 ### Existing projects
 
-Ensure you are on Next.js `v16.2.0-canary.37` or later, then add the following files to the root of your project.
+Ensure you are on Next.js `16.2` or later, then add the following files to the root of your project.
 
 `AGENTS.md` contains the instructions that agents will read:
 

--- a/packages/next-codemod/bin/agents-md.ts
+++ b/packages/next-codemod/bin/agents-md.ts
@@ -163,6 +163,7 @@ async function promptForOptions(
         choices: [
           { title: 'CLAUDE.md', value: 'CLAUDE.md' },
           { title: 'AGENTS.md', value: 'AGENTS.md' },
+          { title: 'GEMINI.md', value: 'GEMINI.md' },
           { title: 'Custom...', value: '__custom__' },
         ],
         initial: 0,

--- a/packages/next-codemod/lib/__tests__/agents-md-e2e.test.js
+++ b/packages/next-codemod/lib/__tests__/agents-md-e2e.test.js
@@ -193,6 +193,37 @@ This is my project documentation.
     }
   })
 
+  it('creates GEMINI.md as a first-class option', async () => {
+    const originalCwd = process.cwd()
+    process.chdir(testProjectDir)
+
+    try {
+      // Run with GEMINI.md as output
+      await runAgentsMd({
+        version: '15.0.0',
+        output: 'GEMINI.md',
+      })
+
+      // Verify GEMINI.md was created (not CLAUDE.md or AGENTS.md)
+      expect(fs.existsSync(path.join(testProjectDir, 'GEMINI.md'))).toBe(true)
+      expect(fs.existsSync(path.join(testProjectDir, 'CLAUDE.md'))).toBe(false)
+      expect(fs.existsSync(path.join(testProjectDir, 'AGENTS.md'))).toBe(false)
+
+      const geminiMdContent = fs.readFileSync(
+        path.join(testProjectDir, 'GEMINI.md'),
+        'utf-8'
+      )
+
+      // Verify content structure matches other options
+      expect(geminiMdContent).toContain('<!-- NEXT-AGENTS-MD-START -->')
+      expect(geminiMdContent).toContain('<!-- NEXT-AGENTS-MD-END -->')
+      expect(geminiMdContent).toContain('[Next.js Docs Index]')
+      expect(geminiMdContent).toContain('root: ./.next-docs')
+    } finally {
+      process.chdir(originalCwd)
+    }
+  })
+
   it('works when run from a subdirectory', async () => {
     const originalCwd = process.cwd()
 


### PR DESCRIPTION
## Summary

- Update `create-next-app@canary` → `create-next-app@latest` in install commands
- Update version requirement from `v16.2.0-canary.37` to `16.2`

Now that AGENTS.md and bundled docs ship in 16.2 stable, the docs should point users to `@latest` instead of `@canary`.

Related: https://github.com/vercel/front/pull/64561