### PR TITLE
Turbopack: rename CSS module structs for clarity

### DIFF
--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{GraphTraversalAction, ModuleGraph, ModuleGraphLayer},
 };
-use turbopack_css::{CssModuleAsset, ModuleCssAsset};
+use turbopack_css::{CssModule, ModuleCssAsset};
 
 use crate::{
     client_references::{ClientManifestEntryType, ClientReferenceData, map_client_references},
@@ -809,8 +809,7 @@ async fn validate_pages_css_imports_individual(
 
             // If the module being imported isn't a global css module, there is nothing to
             // validate.
-            let module_is_global_css =
-                ResolvedVc::try_downcast_type::<CssModuleAsset>(module).is_some();
+            let module_is_global_css = ResolvedVc::try_downcast_type::<CssModule>(module).is_some();
 
             if !module_is_global_css {
                 return Ok(GraphTraversalAction::Continue);
@@ -818,7 +817,7 @@ async fn validate_pages_css_imports_individual(
 
             let parent_is_css_module =
                 ResolvedVc::try_downcast_type::<ModuleCssAsset>(parent_module).is_some()
-                    || ResolvedVc::try_downcast_type::<CssModuleAsset>(parent_module).is_some();
+                    || ResolvedVc::try_downcast_type::<CssModule>(parent_module).is_some();
 
             // We also always allow .module css/scss/sass files to import global css files as
             // well.

--- a/crates/next-api/src/module_graph.rs
+++ b/crates/next-api/src/module_graph.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
     module::Module,
     module_graph::{GraphTraversalAction, ModuleGraph, ModuleGraphLayer},
 };
-use turbopack_css::{CssModule, ModuleCssAsset};
+use turbopack_css::{CssModule, EcmascriptCssModule};
 
 use crate::{
     client_references::{ClientManifestEntryType, ClientReferenceData, map_client_references},
@@ -816,7 +816,7 @@ async fn validate_pages_css_imports_individual(
             }
 
             let parent_is_css_module =
-                ResolvedVc::try_downcast_type::<ModuleCssAsset>(parent_module).is_some()
+                ResolvedVc::try_downcast_type::<EcmascriptCssModule>(parent_module).is_some()
                     || ResolvedVc::try_downcast_type::<CssModule>(parent_module).is_some();
 
             // We also always allow .module css/scss/sass files to import global css files as

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -60,7 +60,7 @@ pub async fn get_next_server_transforms_rules(
 
     if !matches!(context_ty, ServerContextType::AppRSC { .. }) {
         rules.extend([
-            // Ignore the inner ModuleCssAsset -> CssModule references
+            // Ignore the inner EcmascriptCssModule -> CssModule references
             // The CSS Module module itself (and the Analyze reference) is still needed to generate
             // the class names object.
             ModuleRule::new(

--- a/crates/next-core/src/next_server/transforms.rs
+++ b/crates/next-core/src/next_server/transforms.rs
@@ -60,7 +60,7 @@ pub async fn get_next_server_transforms_rules(
 
     if !matches!(context_ty, ServerContextType::AppRSC { .. }) {
         rules.extend([
-            // Ignore the inner ModuleCssAsset -> CssModuleAsset references
+            // Ignore the inner ModuleCssAsset -> CssModule references
             // The CSS Module module itself (and the Analyze reference) is still needed to generate
             // the class names object.
             ModuleRule::new(

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -221,7 +221,7 @@ pub enum CssReferenceSubType {
     /// Reference from ModuleCssAsset to an imported ModuleCssAsset for retrieving the composed
     /// class name
     Compose,
-    /// Reference from ModuleCssAsset to the CssModuleAsset
+    /// Reference from ModuleCssAsset to the CssModule
     Inner,
     /// Used for generating the list of classes in a ModuleCssAsset
     Analyze,

--- a/turbopack/crates/turbopack-core/src/reference_type.rs
+++ b/turbopack/crates/turbopack-core/src/reference_type.rs
@@ -218,12 +218,12 @@ impl ImportContext {
 )]
 pub enum CssReferenceSubType {
     AtImport(Option<ResolvedVc<ImportContext>>),
-    /// Reference from ModuleCssAsset to an imported ModuleCssAsset for retrieving the composed
-    /// class name
+    /// Reference from EcmascriptCssModule to an imported EcmascriptCssModule for retrieving the
+    /// composed class name
     Compose,
-    /// Reference from ModuleCssAsset to the CssModule
+    /// Reference from EcmascriptCssModule to the CssModule
     Inner,
-    /// Used for generating the list of classes in a ModuleCssAsset
+    /// Used for generating the list of classes in a EcmascriptCssModule
     Analyze,
     Custom(u8),
     #[default]

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -32,7 +32,8 @@ use crate::{
 
 #[turbo_tasks::value]
 #[derive(Clone)]
-/// A global CSS asset. Notably not a `.module.css` module, which is [`ModuleCssAsset`] instead.
+/// A global CSS asset. Notably not a `.module.css` module, which is [`EcmascriptCssModule`]
+/// instead.
 pub struct CssModule {
     source: ResolvedVc<Box<dyn Source>>,
     asset_context: ResolvedVc<Box<dyn AssetContext>>,

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -18,7 +18,7 @@ use turbopack_core::{
 };
 
 use crate::{
-    CssModuleAssetType, LightningCssFeatureFlags,
+    CssModuleType, LightningCssFeatureFlags,
     chunk::{CssChunkItem, CssChunkItemContent, CssChunkPlaceable, CssChunkType, CssImport},
     code_gen::CodeGenerateable,
     process::{
@@ -33,28 +33,28 @@ use crate::{
 #[turbo_tasks::value]
 #[derive(Clone)]
 /// A global CSS asset. Notably not a `.module.css` module, which is [`ModuleCssAsset`] instead.
-pub struct CssModuleAsset {
+pub struct CssModule {
     source: ResolvedVc<Box<dyn Source>>,
     asset_context: ResolvedVc<Box<dyn AssetContext>>,
     import_context: Option<ResolvedVc<ImportContext>>,
-    ty: CssModuleAssetType,
+    ty: CssModuleType,
     environment: Option<ResolvedVc<Environment>>,
     lightningcss_features: LightningCssFeatureFlags,
 }
 
 #[turbo_tasks::value_impl]
-impl CssModuleAsset {
+impl CssModule {
     /// Creates a new CSS asset.
     #[turbo_tasks::function]
     pub fn new(
         source: ResolvedVc<Box<dyn Source>>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
-        ty: CssModuleAssetType,
+        ty: CssModuleType,
         import_context: Option<ResolvedVc<ImportContext>>,
         environment: Option<ResolvedVc<Environment>>,
         lightningcss_features: LightningCssFeatureFlags,
     ) -> Vc<Self> {
-        Self::cell(CssModuleAsset {
+        Self::cell(CssModule {
             source,
             asset_context,
             import_context,
@@ -72,7 +72,7 @@ impl CssModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl ParseCss for CssModuleAsset {
+impl ParseCss for CssModule {
     #[turbo_tasks::function]
     async fn parse_css(self: Vc<Self>) -> Result<Vc<ParseCssResult>> {
         let this = self.await?;
@@ -89,7 +89,7 @@ impl ParseCss for CssModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl ProcessCss for CssModuleAsset {
+impl ProcessCss for CssModule {
     #[turbo_tasks::function]
     async fn get_css_with_placeholder(self: Vc<Self>) -> Result<Vc<CssWithPlaceholderResult>> {
         let this = self.await?;
@@ -128,7 +128,7 @@ impl ProcessCss for CssModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Module for CssModuleAsset {
+impl Module for CssModule {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         let mut ident = self
@@ -166,18 +166,18 @@ impl Module for CssModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl StyleModule for CssModuleAsset {
+impl StyleModule for CssModule {
     #[turbo_tasks::function]
     fn style_type(&self) -> Vc<StyleType> {
         match self.ty {
-            CssModuleAssetType::Default => StyleType::GlobalStyle.cell(),
-            CssModuleAssetType::Module => StyleType::IsolatedStyle.cell(),
+            CssModuleType::Default => StyleType::GlobalStyle.cell(),
+            CssModuleType::Module => StyleType::IsolatedStyle.cell(),
         }
     }
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkableModule for CssModuleAsset {
+impl ChunkableModule for CssModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
@@ -193,10 +193,10 @@ impl ChunkableModule for CssModuleAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl CssChunkPlaceable for CssModuleAsset {}
+impl CssChunkPlaceable for CssModule {}
 
 #[turbo_tasks::value_impl]
-impl ResolveOrigin for CssModuleAsset {
+impl ResolveOrigin for CssModule {
     #[turbo_tasks::function]
     fn origin_path(&self) -> Vc<FileSystemPath> {
         self.source.ident().path()
@@ -210,7 +210,7 @@ impl ResolveOrigin for CssModuleAsset {
 
 #[turbo_tasks::value]
 struct CssModuleChunkItem {
-    module: ResolvedVc<CssModuleAsset>,
+    module: ResolvedVc<CssModule>,
     module_graph: ResolvedVc<ModuleGraph>,
     chunking_context: ResolvedVc<Box<dyn ChunkingContext>>,
 }

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -18,7 +18,7 @@ use bincode::{Decode, Encode};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 
 use crate::references::import::ImportAssetReference;
-pub use crate::{asset::CssModule, module_asset::ModuleCssAsset, process::*};
+pub use crate::{asset::CssModule, module_asset::EcmascriptCssModule, process::*};
 
 #[derive(
     PartialOrd,

--- a/turbopack/crates/turbopack-css/src/lib.rs
+++ b/turbopack/crates/turbopack-css/src/lib.rs
@@ -18,7 +18,7 @@ use bincode::{Decode, Encode};
 use turbo_tasks::{NonLocalValue, TaskInput, trace::TraceRawVcs};
 
 use crate::references::import::ImportAssetReference;
-pub use crate::{asset::CssModuleAsset, module_asset::ModuleCssAsset, process::*};
+pub use crate::{asset::CssModule, module_asset::ModuleCssAsset, process::*};
 
 #[derive(
     PartialOrd,
@@ -36,7 +36,7 @@ pub use crate::{asset::CssModuleAsset, module_asset::ModuleCssAsset, process::*}
     Encode,
     Decode,
 )]
-pub enum CssModuleAssetType {
+pub enum CssModuleType {
     /// Default parsing mode.
     #[default]
     Default,

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -39,19 +39,19 @@ use crate::{
 #[turbo_tasks::value]
 #[derive(Clone)]
 /// A CSS Module asset, as in `.module.css`. For a global CSS module, see [`CssModule`].
-pub struct ModuleCssAsset {
+pub struct EcmascriptCssModule {
     pub source: ResolvedVc<Box<dyn Source>>,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,
 }
 
 #[turbo_tasks::value_impl]
-impl ModuleCssAsset {
+impl EcmascriptCssModule {
     #[turbo_tasks::function]
     pub fn new(
         source: ResolvedVc<Box<dyn Source>>,
         asset_context: ResolvedVc<Box<dyn AssetContext>>,
     ) -> Vc<Self> {
-        Self::cell(ModuleCssAsset {
+        Self::cell(EcmascriptCssModule {
             source,
             asset_context,
         })
@@ -59,7 +59,7 @@ impl ModuleCssAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl Module for ModuleCssAsset {
+impl Module for EcmascriptCssModule {
     #[turbo_tasks::function]
     async fn ident(&self) -> Result<Vc<AssetIdent>> {
         Ok(self
@@ -164,7 +164,7 @@ struct ModuleCssClasses(
 );
 
 #[turbo_tasks::value_impl]
-impl ModuleCssAsset {
+impl EcmascriptCssModule {
     #[turbo_tasks::function]
     pub fn inner(&self, ty: ReferenceType) -> Vc<ProcessResult> {
         self.asset_context.process(*self.source, ty)
@@ -244,7 +244,7 @@ impl ModuleCssAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl ChunkableModule for ModuleCssAsset {
+impl ChunkableModule for EcmascriptCssModule {
     #[turbo_tasks::function]
     fn as_chunk_item(
         self: ResolvedVc<Self>,
@@ -256,7 +256,7 @@ impl ChunkableModule for ModuleCssAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl EcmascriptChunkPlaceable for ModuleCssAsset {
+impl EcmascriptChunkPlaceable for EcmascriptCssModule {
     #[turbo_tasks::function]
     fn get_exports(&self) -> Vc<EcmascriptExports> {
         EcmascriptExports::Value.cell()
@@ -303,7 +303,7 @@ impl EcmascriptChunkPlaceable for ModuleCssAsset {
                         };
 
                         let Some(css_module) =
-                            ResolvedVc::try_downcast_type::<ModuleCssAsset>(*resolved_module)
+                            ResolvedVc::try_downcast_type::<EcmascriptCssModule>(*resolved_module)
                         else {
                             CssModuleComposesIssue {
                                 severity: IssueSeverity::Error,
@@ -371,7 +371,7 @@ impl EcmascriptChunkPlaceable for ModuleCssAsset {
 }
 
 #[turbo_tasks::value_impl]
-impl ResolveOrigin for ModuleCssAsset {
+impl ResolveOrigin for EcmascriptCssModule {
     #[turbo_tasks::function]
     fn origin_path(&self) -> Vc<FileSystemPath> {
         self.source.ident().path()

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -38,7 +38,7 @@ use crate::{
 
 #[turbo_tasks::value]
 #[derive(Clone)]
-/// A CSS Module asset, as in `.module.css`. For a global CSS module, see [`CssModuleAsset`].
+/// A CSS Module asset, as in `.module.css`. For a global CSS module, see [`CssModule`].
 pub struct ModuleCssAsset {
     pub source: ResolvedVc<Box<dyn Source>>,
     pub asset_context: ResolvedVc<Box<dyn AssetContext>>,

--- a/turbopack/crates/turbopack-css/src/process.rs
+++ b/turbopack/crates/turbopack-css/src/process.rs
@@ -35,7 +35,7 @@ use turbopack_core::{
 };
 
 use crate::{
-    CssModuleAssetType, LightningCssFeatureFlags,
+    CssModuleType, LightningCssFeatureFlags,
     lifetime_util::stylesheet_into_static,
     references::{
         analyze_references,
@@ -363,7 +363,7 @@ pub async fn parse_css(
     source: ResolvedVc<Box<dyn Source>>,
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     import_context: Option<ResolvedVc<ImportContext>>,
-    ty: CssModuleAssetType,
+    ty: CssModuleType,
     environment: Option<ResolvedVc<Environment>>,
     feature_flags: LightningCssFeatureFlags,
 ) -> Result<Vc<ParseCssResult>> {
@@ -409,7 +409,7 @@ async fn process_content(
     source: ResolvedVc<Box<dyn Source>>,
     origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     import_context: Option<ResolvedVc<ImportContext>>,
-    ty: CssModuleAssetType,
+    ty: CssModuleType,
     environment: Option<ResolvedVc<Environment>>,
     feature_flags: LightningCssFeatureFlags,
 ) -> Result<Vc<ParseCssResult>> {
@@ -427,7 +427,7 @@ async fn process_content(
 
     let config = ParserOptions {
         css_modules: match ty {
-            CssModuleAssetType::Module => Some(lightningcss::css_modules::Config {
+            CssModuleType::Module => Some(lightningcss::css_modules::Config {
                 pattern: Pattern {
                     segments: smallvec![
                         Segment::Name,
@@ -461,7 +461,7 @@ async fn process_content(
             },
         ) {
             Ok(mut ss) => {
-                if matches!(ty, CssModuleAssetType::Module) {
+                if matches!(ty, CssModuleType::Module) {
                     let mut validator = CssValidator { errors: Vec::new() };
                     ss.visit(&mut validator).unwrap();
 

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -43,7 +43,7 @@ use turbopack_core::{
     source::Source,
     source_transform::SourceTransforms,
 };
-use turbopack_css::{CssModuleAsset, ModuleCssAsset};
+use turbopack_css::{CssModule, ModuleCssAsset};
 use turbopack_ecmascript::{
     AnalyzeMode, EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptModuleAssetType,
     EcmascriptOptions, TreeShakingMode,
@@ -259,7 +259,7 @@ async fn apply_module_type(
             environment,
             lightningcss_features,
         } => ResolvedVc::upcast(
-            CssModuleAsset::new(
+            CssModule::new(
                 *source,
                 Vc::upcast(module_asset_context),
                 *ty,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -43,7 +43,7 @@ use turbopack_core::{
     source::Source,
     source_transform::SourceTransforms,
 };
-use turbopack_css::{CssModule, ModuleCssAsset};
+use turbopack_css::{CssModule, EcmascriptCssModule};
 use turbopack_ecmascript::{
     AnalyzeMode, EcmascriptInputTransforms, EcmascriptModuleAsset, EcmascriptModuleAssetType,
     EcmascriptOptions, TreeShakingMode,
@@ -249,7 +249,7 @@ async fn apply_module_type(
             ResolvedVc::upcast(NodeAddonModule::new(*source).to_resolved().await?)
         }
         ModuleType::CssModule => ResolvedVc::upcast(
-            ModuleCssAsset::new(*source, Vc::upcast(module_asset_context))
+            EcmascriptCssModule::new(*source, Vc::upcast(module_asset_context))
                 .to_resolved()
                 .await?,
         ),

--- a/turbopack/crates/turbopack/src/module_options/mod.rs
+++ b/turbopack/crates/turbopack/src/module_options/mod.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
     },
     resolve::options::{ImportMap, ImportMapping},
 };
-use turbopack_css::CssModuleAssetType;
+use turbopack_css::CssModuleType;
 use turbopack_ecmascript::{
     AnalyzeMode, EcmascriptInputTransform, EcmascriptInputTransforms, EcmascriptOptions,
     SpecifiedModuleType, bytes_source_transform::BytesSourceTransform,
@@ -819,7 +819,7 @@ impl ModuleOptions {
                 ModuleRule::new(
                     module_css_condition.clone(),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Module,
+                        ty: CssModuleType::Module,
                         environment,
                         lightningcss_features,
                     })],
@@ -830,7 +830,7 @@ impl ModuleOptions {
                         RuleCondition::ContentTypeStartsWith("text/css".to_string()),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Default,
+                        ty: CssModuleType::Default,
                         environment,
                         lightningcss_features,
                     })],
@@ -894,7 +894,7 @@ impl ModuleOptions {
                         ))),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Module,
+                        ty: CssModuleType::Module,
                         environment,
                         lightningcss_features,
                     })],
@@ -908,7 +908,7 @@ impl ModuleOptions {
                         ))),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Module,
+                        ty: CssModuleType::Module,
                         environment,
                         lightningcss_features,
                     })],
@@ -922,7 +922,7 @@ impl ModuleOptions {
                         ))),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Module,
+                        ty: CssModuleType::Module,
                         environment,
                         lightningcss_features,
                     })],
@@ -937,7 +937,7 @@ impl ModuleOptions {
                         RuleCondition::ContentTypeStartsWith("text/css".to_string()),
                     ]),
                     vec![ModuleRuleEffect::ModuleType(ModuleType::Css {
-                        ty: CssModuleAssetType::Default,
+                        ty: CssModuleType::Default,
                         environment,
                         lightningcss_features,
                     })],

--- a/turbopack/crates/turbopack/src/module_options/module_rule.rs
+++ b/turbopack/crates/turbopack/src/module_options/module_rule.rs
@@ -9,7 +9,7 @@ use turbopack_core::{
     environment::Environment, reference_type::ReferenceType, source::Source,
     source_transform::SourceTransforms,
 };
-use turbopack_css::CssModuleAssetType;
+use turbopack_css::CssModuleType;
 use turbopack_ecmascript::{
     EcmascriptInputTransforms, EcmascriptOptions, bytes_source_transform::BytesSourceTransform,
     json_source_transform::JsonSourceTransform,
@@ -140,7 +140,7 @@ pub enum ModuleType {
     NodeAddon,
     CssModule,
     Css {
-        ty: CssModuleAssetType,
+        ty: CssModuleType,
         environment: Option<ResolvedVc<Environment>>,
         lightningcss_features: turbopack_css::LightningCssFeatureFlags,
     },
@@ -264,7 +264,7 @@ impl ConfiguredModuleType {
                 })
             }
             ConfiguredModuleType::Css => ModuleRuleEffect::ModuleType(ModuleType::Css {
-                ty: CssModuleAssetType::Default,
+                ty: CssModuleType::Default,
                 environment,
                 lightningcss_features,
             }),


### PR DESCRIPTION
- The actual CSS: `CssModule`, formerly known as `CssModuleAsset`
- The module representing the codegen-d JS object for a CSS Module: `EcmascriptCssModule`, formerly known as `ModuleCssAsset`