### PR TITLE
[test] Show decoded binary WebSocket messages in traces

### DIFF
--- a/test/lib/browsers/playwright.ts
+++ b/test/lib/browsers/playwright.ts
@@ -318,15 +318,17 @@ export class Playwright<TCurrent = undefined> {
     }
 
     page.on('websocket', (ws) => {
+      const decoder = tracePlaywright ? new TextDecoder() : null
       if (tracePlaywright) {
-        page
-          .evaluate(`console.log('connected to ws at ${ws.url()}')`)
-          .catch(() => {})
+        // We're just evaluating a string here so that it appears in Playwright
+        // traces.
+        // console.log spams CI logs. If you already have a browser open, you can
+        // see WebSocket messages in the network tab of dev tools.
+        // TODO: Revisit once https://github.com/microsoft/playwright/issues/10996 is resolved.
+        page.evaluate(`'connected to ws at ${ws.url()}'`).catch(() => {})
 
         ws.on('close', () =>
-          page
-            .evaluate(`console.log('closed websocket ${ws.url()}')`)
-            .catch(() => {})
+          page.evaluate(`'closed websocket ${ws.url()}'`).catch(() => {})
         )
       }
       ws.on('framereceived', (frame) => {
@@ -337,7 +339,7 @@ export class Playwright<TCurrent = undefined> {
           page
             // Note that passing the payload as a an argument is 2 orders of magnitude more expensive in Playwright.
             .evaluate(
-              `console.log('received ws message ${JSON.stringify(payload)}')`
+              `'received ws message ${JSON.stringify(typeof payload === 'string' ? payload : decoder!.decode(payload))}'`
             )
             .catch(() => {})
         }


### PR DESCRIPTION
Follow-up to https://github.com/vercel/next.js/pull/91266

Showing the Buffer is just noise. Now we print it decoded which shows us the Flight data from the debug channel:
<img width="1664" height="842" alt="CleanShot 2026-03-13 at 13 42 08@2x" src="https://github.com/user-attachments/assets/086198fa-e48f-4af7-bd34-9e002d4c5b84" />

I switched to just evaluating the string. It'll still show up in traces but won't show up in browser logs i.e. CI logs. Felt to spammy.
