### PR TITLE
fix: use normalizePathSep for app route path normalization

### DIFF
--- a/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
+++ b/packages/next/src/build/webpack/loaders/next-app-loader/create-app-route-code.ts
@@ -11,6 +11,7 @@ import { AppPathnameNormalizer } from '../../../../server/normalizers/built/app/
 import { loadEntrypoint } from '../../../load-entrypoint'
 import type { PageExtensions } from '../../../page-extensions-type'
 import { getFilenameAndExtension } from '../next-metadata-route-loader'
+import { normalizePathSep } from '../../../../shared/lib/page-path/normalize-path-sep'
 
 export async function createAppRouteCode({
   appDir,
@@ -33,7 +34,7 @@ export async function createAppRouteCode({
 }): Promise<string> {
   // routePath is the path to the route handler file,
   // but could be aliased e.g. private-next-app-dir/favicon.ico
-  const routePath = pagePath.replace(/[\\/]/, '/')
+  const routePath = normalizePathSep(pagePath)
 
   // This, when used with the resolver will give us the pathname to the built
   // route handler file.


### PR DESCRIPTION
### What?

Fixes the path separator normalization in `create-app-route-code.ts` where the regex `/[\\/]/` was missing the global (`g`) flag, causing only the first backslash to be replaced on Windows.

### Why?

On Windows, `pagePath` arrives with backslash separators (e.g., `app\api\nested\route`). Without the `g` flag, `String.prototype.replace` only replaces the first occurrence, producing `app/api\nested\route` instead of `app/api/nested/route`. This causes `resolveAppRoute` to fail for any nested app route.

Every other path separator normalization in the codebase uses either `/\\/g` (with global flag) or the `normalizePathSep` utility. This was the only instance missing the global flag.

### How?

Replaced the buggy inline regex with the existing `normalizePathSep` utility from `shared/lib/page-path/normalize-path-sep`, which is already imported and used in the sibling `index.ts` file in the same loader directory.

fixes #91312

### Checklist

- [x] Related issues linked using `fixes #number`
- [ ] Tests added
- [x] Errors have a helpful link attached, see [`contributing.md`](https://github.com/vercel/next.js/blob/canary/contributing.md)
- [ ] Linter, currentTests, TypeScript compiler passed