### PR TITLE
Turbopack: use camel case for import attributes

### DIFF
--- a/crates/next-core/src/app_page_loader_tree.rs
+++ b/crates/next-core/src/app_page_loader_tree.rs
@@ -224,7 +224,7 @@ impl AppPageLoaderTreeBuilder {
         let inner_module_id = format!("METADATA_{i}");
         let helper_import = rcstr!(
             "import { fillMetadataSegment } from 'next/dist/lib/metadata/get-metadata-route' with \
-             { 'turbopack-transition': 'next-server-utility' }"
+             { 'turbopackTransition': 'next-server-utility' }"
         );
 
         if !self.base.imports.contains(&helper_import) {

--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -579,7 +579,7 @@ fn with_transition(transition_name: &str) -> ObjectLit {
 fn with_transition_chunking_type(transition_name: &str, chunking_type: &str) -> Box<ObjectLit> {
     Box::new(with_clause(&[
         ("turbopack-transition", transition_name),
-        ("turbopack-chunking-type", chunking_type),
+        ("turbopackChunkingType", chunking_type),
     ]))
 }
 

--- a/crates/next-custom-transforms/src/transforms/dynamic.rs
+++ b/crates/next-custom-transforms/src/transforms/dynamic.rs
@@ -375,7 +375,7 @@ impl VisitMut for NextDynamicPatcher {
 
                         expr.args[0] = side_effect_free_loader_arg.as_arg();
                     } else {
-                        // Add `{with:{turbopack-transition: ...}}` to the dynamic import
+                        // Add `{with:{turbopackTransition: ...}}` to the dynamic import
                         let mut visitor = DynamicImportTransitionAdder {
                             transition_name: dynamic_transition_name,
                         };
@@ -404,7 +404,7 @@ impl VisitMut for NextDynamicPatcher {
 struct DynamicImportTransitionAdder<'a> {
     transition_name: &'a str,
 }
-// Add `{with:{turbopack-transition: <self.transition_name>}}` to any dynamic imports
+// Add `{with:{turbopackTransition: <self.transition_name>}}` to any dynamic imports
 impl VisitMut for DynamicImportTransitionAdder<'_> {
     fn visit_mut_call_expr(&mut self, expr: &mut CallExpr) {
         if let Callee::Import(..) = &expr.callee {
@@ -573,12 +573,12 @@ fn rel_filename(base: Option<&Path>, file: &FileName) -> String {
 }
 
 fn with_transition(transition_name: &str) -> ObjectLit {
-    with_clause(&[("turbopack-transition", transition_name)])
+    with_clause(&[("turbopackTransition", transition_name)])
 }
 
 fn with_transition_chunking_type(transition_name: &str, chunking_type: &str) -> Box<ObjectLit> {
     Box::new(with_clause(&[
-        ("turbopack-transition", transition_name),
+        ("turbopackTransition", transition_name),
         ("turbopackChunkingType", chunking_type),
     ]))
 }

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-dev.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-dev.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-prod.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-prod.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server-client-layer.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic-app-dir/no-ssr/output-turbo-server.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-dev.js
@@ -1,10 +1,10 @@
 import { __turbopack_module_id__ as id } from "../components/hello1" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic1 from 'next/dynamic';
 import dynamic2 from 'next/dynamic';

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-dev.js
@@ -1,16 +1,16 @@
 import { __turbopack_module_id__ as id } from "../components/hello1" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic1 from 'next/dynamic';
 import dynamic2 from 'next/dynamic';
 const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -21,7 +21,7 @@ const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
 });
 const DynamicComponent2 = dynamic2(()=>import('../components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-prod.js
@@ -1,10 +1,10 @@
 import { __turbopack_module_id__ as id } from "../components/hello1" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic1 from 'next/dynamic';
 import dynamic2 from 'next/dynamic';

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-prod.js
@@ -1,16 +1,16 @@
 import { __turbopack_module_id__ as id } from "../components/hello1" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic1 from 'next/dynamic';
 import dynamic2 from 'next/dynamic';
 const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -21,7 +21,7 @@ const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
 });
 const DynamicComponent2 = dynamic2(()=>import('../components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
@@ -1,10 +1,10 @@
 import { __turbopack_module_id__ as id } from "../components/hello1" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic1 from 'next/dynamic';
 import dynamic2 from 'next/dynamic';

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/duplicated-imports/output-turbo-server.js
@@ -1,16 +1,16 @@
 import { __turbopack_module_id__ as id } from "../components/hello1" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello2" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic1 from 'next/dynamic';
 import dynamic2 from 'next/dynamic';
 const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -21,7 +21,7 @@ const DynamicComponent1 = dynamic1(()=>import('../components/hello1', {
 });
 const DynamicComponent2 = dynamic2(()=>import('../components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-dev.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-dev.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-prod.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-prod.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/issue-48098/output-turbo-server.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../text-dynamic-no-ssr-server" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 export const NextDynamicNoSSRServerComponent = dynamic(()=>import('../text-dynamic-no-ssr-server', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-dev.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 import somethingElse from 'something-else';

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-dev.js
@@ -1,12 +1,12 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 import somethingElse from 'something-else';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-prod.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 import somethingElse from 'something-else';

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-prod.js
@@ -1,12 +1,12 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 import somethingElse from 'something-else';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 import somethingElse from 'something-else';

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/member-with-same-name/output-turbo-server.js
@@ -1,12 +1,12 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 import somethingElse from 'something-else';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-dev.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-dev.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import('../components/hello', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-prod.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-prod.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import('../components/hello', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/no-options/output-turbo-server.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import('../components/hello', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-dev.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import(`../components/hello`, {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-dev.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import(`../components/hello`, {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-prod.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import(`../components/hello`, {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-prod.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import(`../components/hello`, {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
@@ -1,11 +1,11 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import(`../components/hello`, {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/template-literal/output-turbo-server.js
@@ -1,6 +1,6 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent = dynamic(()=>import(`../components/hello`, {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-dev.js
@@ -1,19 +1,19 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id2 } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -25,7 +25,7 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hell
 });
 const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -37,7 +37,7 @@ const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
 });
 const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-dev.js
@@ -1,14 +1,14 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id2 } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-prod.js
@@ -1,19 +1,19 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id2 } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -25,7 +25,7 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hell
 });
 const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -37,7 +37,7 @@ const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
 });
 const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-prod.js
@@ -1,14 +1,14 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id2 } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
@@ -1,19 +1,19 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id2 } from "../components/hello" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -25,7 +25,7 @@ const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hell
 });
 const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {
@@ -37,7 +37,7 @@ const DynamicClientOnlyComponent = dynamic(()=>import('../components/hello', {
 });
 const DynamicClientOnlyComponentWithSuspense = dynamic(()=>import('../components/hello', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }), {
     loadableGenerated: {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/with-options/output-turbo-server.js
@@ -1,14 +1,14 @@
 import { __turbopack_module_id__ as id } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id2 } from "../components/hello" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponentWithCustomLoading = dynamic(()=>import('../components/hello', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-dev.js
@@ -1,10 +1,10 @@
 import { __turbopack_module_id__ as id } from "./components/hello1" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-dev.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-dev.js
@@ -1,15 +1,15 @@
 import { __turbopack_module_id__ as id } from "./components/hello1" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     })), {
     loadableGenerated: {
@@ -22,7 +22,7 @@ const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1',
 });
 const DynamicComponent2 = dynamic(()=>import('./components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }).then((mod)=>{
         return mod.Button;

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-prod.js
@@ -1,10 +1,10 @@
 import { __turbopack_module_id__ as id } from "./components/hello1" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-prod.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-prod.js
@@ -1,15 +1,15 @@
 import { __turbopack_module_id__ as id } from "./components/hello1" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     })), {
     loadableGenerated: {
@@ -22,7 +22,7 @@ const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1',
 });
 const DynamicComponent2 = dynamic(()=>import('./components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }).then((mod)=>{
         return mod.Button;

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
@@ -1,10 +1,10 @@
 import { __turbopack_module_id__ as id } from "./components/hello1" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
     "turbopack-transition": "next-client-dynamic",
-    "turbopack-chunking-type": "none"
+    "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {

--- a/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
+++ b/crates/next-custom-transforms/tests/fixture/next-dynamic/wrapped-import/output-turbo-server.js
@@ -1,15 +1,15 @@
 import { __turbopack_module_id__ as id } from "./components/hello1" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import { __turbopack_module_id__ as id1 } from "./components/hello2" with {
-    "turbopack-transition": "next-client-dynamic",
+    "turbopackTransition": "next-client-dynamic",
     "turbopackChunkingType": "none"
 };
 import dynamic from 'next/dynamic';
 const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     })), {
     loadableGenerated: {
@@ -22,7 +22,7 @@ const DynamicComponent1 = dynamic(()=>handleImport(import('./components/hello1',
 });
 const DynamicComponent2 = dynamic(()=>import('./components/hello2', {
         with: {
-            "turbopack-transition": "next-dynamic"
+            "turbopackTransition": "next-dynamic"
         }
     }).then((mod)=>{
         return mod.Button;

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -5,9 +5,9 @@ import type { FallbackRouteParam } from '../static-paths/types'
 import {
   AppPageRouteModule,
   type AppPageRouteHandlerContext,
-} from '../../server/route-modules/app-page/module.compiled' with { 'turbopack-transition': 'next-ssr' }
+} from '../../server/route-modules/app-page/module.compiled' with { turbopackTransition: 'next-ssr' }
 
-import { RouteKind } from '../../server/route-kind' with { 'turbopack-transition': 'next-server-utility' }
+import { RouteKind } from '../../server/route-kind' with { turbopackTransition: 'next-server-utility' }
 
 import { getRevalidateReason } from '../../server/instrumentation/utils'
 import { getTracer, SpanKind, type Span } from '../../server/lib/trace/tracer'
@@ -97,7 +97,7 @@ export const __next_app__ = {
   loadChunk: __next_app_load_chunk__,
 }
 
-import * as entryBase from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
+import * as entryBase from '../../server/app-render/entry-base' with { turbopackTransition: 'next-server-utility' }
 import { RedirectStatusCode } from '../../client/components/redirect-status-code'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import { scheduleOnNextTick } from '../../lib/scheduler'
@@ -107,7 +107,7 @@ import {
   getSegmentParam,
 } from '../../shared/lib/router/utils/get-segment-param'
 
-export * from '../../server/app-render/entry-base' with { 'turbopack-transition': 'next-server-utility' }
+export * from '../../server/app-render/entry-base' with { turbopackTransition: 'next-server-utility' }
 
 // Create and export the route module that will be consumed.
 export const routeModule = new AppPageRouteModule({

--- a/packages/next/src/server/app-render/action-async-storage.external.ts
+++ b/packages/next/src/server/app-render/action-async-storage.external.ts
@@ -1,7 +1,7 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 
 // Share the instance module in the next-shared layer
-import { actionAsyncStorageInstance } from './action-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { actionAsyncStorageInstance } from './action-async-storage-instance' with { turbopackTransition: 'next-shared' }
 export interface ActionStore {
   readonly isAction?: boolean
   readonly isAppRoute?: boolean

--- a/packages/next/src/server/app-render/after-task-async-storage.external.ts
+++ b/packages/next/src/server/app-render/after-task-async-storage.external.ts
@@ -1,7 +1,7 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 
 // Share the instance module in the next-shared layer
-import { afterTaskAsyncStorageInstance as afterTaskAsyncStorage } from './after-task-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { afterTaskAsyncStorageInstance as afterTaskAsyncStorage } from './after-task-async-storage-instance' with { turbopackTransition: 'next-shared' }
 import type { WorkUnitStore } from './work-unit-async-storage.external'
 
 export interface AfterTaskStore {

--- a/packages/next/src/server/app-render/console-async-storage.external.ts
+++ b/packages/next/src/server/app-render/console-async-storage.external.ts
@@ -1,7 +1,7 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 
 // Share the instance module in the next-shared layer
-import { consoleAsyncStorageInstance } from './console-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { consoleAsyncStorageInstance } from './console-async-storage-instance' with { turbopackTransition: 'next-shared' }
 
 export interface ConsoleStore {
   /**

--- a/packages/next/src/server/app-render/dynamic-access-async-storage.external.ts
+++ b/packages/next/src/server/app-render/dynamic-access-async-storage.external.ts
@@ -1,7 +1,7 @@
 import type { AsyncLocalStorage } from 'async_hooks'
 
 // Share the instance module in the next-shared layer
-import { dynamicAccessAsyncStorageInstance } from './dynamic-access-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { dynamicAccessAsyncStorageInstance } from './dynamic-access-async-storage-instance' with { turbopackTransition: 'next-shared' }
 
 export interface DynamicAccessAsyncStore {
   readonly abortController: AbortController

--- a/packages/next/src/server/app-render/module-loading/track-module-loading.external.ts
+++ b/packages/next/src/server/app-render/module-loading/track-module-loading.external.ts
@@ -6,6 +6,6 @@ import {
   trackPendingChunkLoad,
   trackPendingImport,
   trackPendingModules,
-} from './track-module-loading.instance' with { 'turbopack-transition': 'next-shared' }
+} from './track-module-loading.instance' with { turbopackTransition: 'next-shared' }
 
 export { trackPendingChunkLoad, trackPendingImport, trackPendingModules }

--- a/packages/next/src/server/app-render/work-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-async-storage.external.ts
@@ -7,7 +7,7 @@ import type { AfterContext } from '../after/after-context'
 import type { CacheLife } from '../use-cache/cache-life'
 
 // Share the instance module in the next-shared layer
-import { workAsyncStorageInstance } from './work-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { workAsyncStorageInstance } from './work-async-storage-instance' with { turbopackTransition: 'next-shared' }
 import type { LazyResult } from '../lib/lazy-result'
 import type { DigestedError } from './create-error-handler'
 import type { ActionRevalidationKind } from '../../shared/lib/action-revalidation-kind'

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -9,7 +9,7 @@ import type { DynamicTrackingState } from './dynamic-rendering'
 import type { OpaqueFallbackRouteParams } from '../request/fallback-params'
 
 // Share the instance module in the next-shared layer
-import { workUnitAsyncStorageInstance } from './work-unit-async-storage-instance' with { 'turbopack-transition': 'next-shared' }
+import { workUnitAsyncStorageInstance } from './work-unit-async-storage-instance' with { turbopackTransition: 'next-shared' }
 import type { ServerComponentsHmrCache } from '../response-cache'
 import type {
   RenderResumeDataCache,

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -102,7 +102,7 @@ impl ImportAnnotations {
                             Some(RcStr::from(s.value.to_string_lossy().into_owned()));
                     }
                 }
-                "turbopack-chunking-type" => {
+                "turbopackChunkingType" => {
                     if let Some(Lit::Str(s)) = kv.value.as_lit() {
                         chunking_type = parse_chunking_type_annotation(
                             kv.value.span(),

--- a/turbopack/crates/turbopack-ecmascript/src/annotations.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/annotations.rs
@@ -7,7 +7,7 @@ use swc_core::{
 pub const ANNOTATION_CHUNKING_TYPE: &str = "turbopackChunkingType";
 
 /// Enables a specified transition for the annotated import
-pub const ANNOTATION_TRANSITION: &str = "turbopack-transition";
+pub const ANNOTATION_TRANSITION: &str = "turbopackTransition";
 
 pub fn with_clause<'a>(
     entries: impl IntoIterator<Item = &'a (&'a str, &'a str)>,

--- a/turbopack/crates/turbopack-ecmascript/src/annotations.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/annotations.rs
@@ -4,7 +4,7 @@ use swc_core::{
 };
 
 /// Changes the chunking type for the annotated import
-pub const ANNOTATION_CHUNKING_TYPE: &str = "turbopack-chunking-type";
+pub const ANNOTATION_CHUNKING_TYPE: &str = "turbopackChunkingType";
 
 /// Enables a specified transition for the annotated import
 pub const ANNOTATION_TRANSITION: &str = "turbopack-transition";


### PR DESCRIPTION
We already use `turbopackLoaderOptions`, so let's do the same for `turbopack-transition` and `turbopack-chunking-type`