### PR TITLE
Route Handlers: Fix incorrect devRequestTimingInternalsEnd

### DIFF
--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -36,8 +36,6 @@ import {
   type ResponseGenerator,
 } from '../../server/response-cache'
 
-import * as userland from 'VAR_USERLAND'
-
 // These are injected by the loader afterwards. This is injected as a variable
 // instead of a replacement because this could also be `undefined` instead of
 // an empty string.
@@ -59,7 +57,7 @@ const routeModule = new AppRouteRouteModule({
   relativeProjectDir: process.env.__NEXT_RELATIVE_PROJECT_DIR || '',
   resolvedPagePath: 'VAR_RESOLVED_PAGE_PATH',
   nextConfigOutput,
-  userland,
+  userland: () => require('VAR_USERLAND') as typeof import('VAR_USERLAND'),
 })
 
 // Pull out the exports that we need to expose from the module. This should

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -177,7 +177,9 @@ export interface AppRouteRouteModuleOptions
     RouteModuleOptions<AppRouteRouteDefinition, AppRouteUserlandModule>,
     'userland'
   > {
-  readonly userland: AppRouteUserlandModule | (() => AppRouteUserlandModule)
+  readonly userland:
+    | AppRouteUserlandModule
+    | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
   readonly resolvedPagePath: string
   readonly nextConfigOutput: NextConfig['output']
 }
@@ -216,18 +218,45 @@ export class AppRouteRouteModule extends RouteModule<
   public readonly resolvedPagePath: string
   public readonly nextConfigOutput: NextConfig['output'] | undefined
 
-  private _loadUserland: (() => AppRouteUserlandModule) | null
+  private _loadUserland:
+    | (() => AppRouteUserlandModule | Promise<AppRouteUserlandModule>)
+    | null
+  private _pendingUserland: Promise<void> | null = null
   private _methods!: Record<HTTP_METHOD, AppRouteHandlerFn>
   private _hasNonStaticMethods!: boolean
   private _dynamic!: AppRouteUserlandModule['dynamic']
 
   override get userland(): AppRouteUserlandModule {
     if (this._loadUserland) {
-      this._userland = this._loadUserland()
+      const result = this._loadUserland()
       this._loadUserland = null
-      this._initFromUserland()
+      if (result instanceof Promise) {
+        // The userland module uses top-level await (async module). Store the
+        // promise so ensureUserland() can await it before the first request.
+        this._pendingUserland = result.then((mod) => {
+          this._userland = mod
+          this._pendingUserland = null
+          this._initFromUserland()
+        })
+      } else {
+        this._userland = result
+        this._initFromUserland()
+      }
     }
     return this._userland
+  }
+
+  /**
+   * Ensures the userland module is fully loaded before handling a request.
+   * This is needed when the route file uses top-level await (async module),
+   * in which case require() returns a Promise instead of the module directly.
+   */
+  private async ensureUserland(): Promise<void> {
+    // Trigger lazy loading if not yet started.
+    void this.userland
+    if (this._pendingUserland) {
+      await this._pendingUserland
+    }
   }
 
   constructor({
@@ -324,9 +353,6 @@ export class AppRouteRouteModule extends RouteModule<
   private resolve(method: string): AppRouteHandlerFn {
     // Ensure that the requested method is a valid method (to prevent RCE's).
     if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
-
-    // Trigger lazy initialization of userland if needed.
-    void this.userland
 
     return this._methods[method]
   }
@@ -723,6 +749,10 @@ export class AppRouteRouteModule extends RouteModule<
     req: NextRequest,
     context: AppRouteRouteHandlerContext
   ): Promise<Response> {
+    // Ensure the userland module is fully loaded (handles async modules with
+    // top-level await, where require() returns a Promise).
+    await this.ensureUserland()
+
     // Get the handler function for the given method.
     const handler = this.resolve(req.method)
 

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -173,7 +173,11 @@ export type AppRouteUserlandModule = AppRouteHandlers &
  * module from the bundled code.
  */
 export interface AppRouteRouteModuleOptions
-  extends RouteModuleOptions<AppRouteRouteDefinition, AppRouteUserlandModule> {
+  extends Omit<
+    RouteModuleOptions<AppRouteRouteDefinition, AppRouteUserlandModule>,
+    'userland'
+  > {
+  readonly userland: AppRouteUserlandModule | (() => AppRouteUserlandModule)
   readonly resolvedPagePath: string
   readonly nextConfigOutput: NextConfig['output']
 }
@@ -212,9 +216,19 @@ export class AppRouteRouteModule extends RouteModule<
   public readonly resolvedPagePath: string
   public readonly nextConfigOutput: NextConfig['output'] | undefined
 
-  private readonly methods: Record<HTTP_METHOD, AppRouteHandlerFn>
-  private readonly hasNonStaticMethods: boolean
-  private readonly dynamic: AppRouteUserlandModule['dynamic']
+  private _loadUserland: (() => AppRouteUserlandModule) | null
+  private _methods!: Record<HTTP_METHOD, AppRouteHandlerFn>
+  private _hasNonStaticMethods!: boolean
+  private _dynamic!: AppRouteUserlandModule['dynamic']
+
+  override get userland(): AppRouteUserlandModule {
+    if (this._loadUserland) {
+      this._userland = this._loadUserland()
+      this._loadUserland = null
+      this._initFromUserland()
+    }
+    return this._userland
+  }
 
   constructor({
     userland,
@@ -224,31 +238,46 @@ export class AppRouteRouteModule extends RouteModule<
     resolvedPagePath,
     nextConfigOutput,
   }: AppRouteRouteModuleOptions) {
-    super({ userland, definition, distDir, relativeProjectDir })
+    const isLazy = typeof userland === 'function'
+    super({
+      userland: (isLazy ? undefined! : userland) as AppRouteUserlandModule,
+      definition,
+      distDir,
+      relativeProjectDir,
+    })
 
     this.resolvedPagePath = resolvedPagePath
     this.nextConfigOutput = nextConfigOutput
+    this._loadUserland = isLazy ? userland : null
+
+    if (!isLazy) {
+      this._initFromUserland()
+    }
+  }
+
+  private _initFromUserland(): void {
+    const userland = this._userland
 
     // Automatically implement some methods if they aren't implemented by the
     // userland module.
-    this.methods = autoImplementMethods(userland)
+    this._methods = autoImplementMethods(userland)
 
     // Get the non-static methods for this route.
-    this.hasNonStaticMethods = hasNonStaticMethods(userland)
+    this._hasNonStaticMethods = hasNonStaticMethods(userland)
 
     // Get the dynamic property from the userland module.
-    this.dynamic = this.userland.dynamic
+    this._dynamic = userland.dynamic
     if (this.nextConfigOutput === 'export') {
-      if (this.dynamic === 'force-dynamic') {
+      if (this._dynamic === 'force-dynamic') {
         throw new Error(
-          `export const dynamic = "force-dynamic" on page "${definition.pathname}" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
+          `export const dynamic = "force-dynamic" on page "${this.definition.pathname}" cannot be used with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
         )
-      } else if (!isStaticGenEnabled(this.userland) && this.userland['GET']) {
+      } else if (!isStaticGenEnabled(userland) && userland['GET']) {
         throw new Error(
-          `export const dynamic = "force-static"/export const revalidate not configured on route "${definition.pathname}" with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
+          `export const dynamic = "force-static"/export const revalidate not configured on route "${this.definition.pathname}" with "output: export". See more info here: https://nextjs.org/docs/advanced-features/static-html-export`
         )
       } else {
-        this.dynamic = 'error'
+        this._dynamic = 'error'
       }
     }
 
@@ -259,7 +288,7 @@ export class AppRouteRouteModule extends RouteModule<
       // uppercase handlers are supported.
       const lowercased = HTTP_METHODS.map((method) => method.toLowerCase())
       for (const method of lowercased) {
-        if (method in this.userland) {
+        if (method in userland) {
           Log.error(
             `Detected lowercase method '${method}' in '${
               this.resolvedPagePath
@@ -270,7 +299,7 @@ export class AppRouteRouteModule extends RouteModule<
 
       // Print error if the module exports a default handler, they must use named
       // exports for each HTTP method.
-      if ('default' in this.userland) {
+      if ('default' in userland) {
         Log.error(
           `Detected default export in '${this.resolvedPagePath}'. Export a named export for each HTTP method instead.`
         )
@@ -278,7 +307,7 @@ export class AppRouteRouteModule extends RouteModule<
 
       // If there is no methods exported by this module, then return a not found
       // response.
-      if (!HTTP_METHODS.some((method) => method in this.userland)) {
+      if (!HTTP_METHODS.some((method) => method in userland)) {
         Log.error(
           `No HTTP methods exported in '${this.resolvedPagePath}'. Export a named export for each HTTP method.`
         )
@@ -296,8 +325,10 @@ export class AppRouteRouteModule extends RouteModule<
     // Ensure that the requested method is a valid method (to prevent RCE's).
     if (!isHTTPMethod(method)) return () => new Response(null, { status: 400 })
 
-    // Return the handler.
-    return this.methods[method]
+    // Trigger lazy initialization of userland if needed.
+    void this.userland
+
+    return this._methods[method]
   }
 
   private async do(
@@ -738,7 +769,7 @@ export class AppRouteRouteModule extends RouteModule<
           this.workAsyncStorage.run(workStore, async () => {
             // Check to see if we should bail out of static generation based on
             // having non-static methods.
-            if (this.hasNonStaticMethods) {
+            if (this._hasNonStaticMethods) {
               if (workStore.isStaticGeneration) {
                 const err = new DynamicServerError(
                   'Route is configured with methods that cannot be statically generated.'
@@ -754,7 +785,7 @@ export class AppRouteRouteModule extends RouteModule<
             let request = req
 
             // Update the static generation store based on the dynamic property.
-            switch (this.dynamic) {
+            switch (this._dynamic) {
               case 'force-dynamic': {
                 // Routes of generated paths should be dynamic
                 workStore.forceDynamic = true
@@ -790,7 +821,7 @@ export class AppRouteRouteModule extends RouteModule<
                 request = proxyNextRequest(req, workStore)
                 break
               default:
-                this.dynamic satisfies never
+                this._dynamic satisfies never
             }
 
             const tracer = getTracer()

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -108,10 +108,13 @@ export abstract class RouteModule<
 > {
   /**
    * The userland module. This is the module that is exported from the user's
-   * code. This is marked as readonly to ensure that the module is not mutated
-   * because the module (when compiled) only provides getters.
+   * code. Exposed as a getter so subclasses can override with lazy loading.
    */
-  public readonly userland: Readonly<U>
+  protected _userland: Readonly<U>
+
+  get userland(): Readonly<U> {
+    return this._userland
+  }
 
   /**
    * The definition of the route.
@@ -135,7 +138,7 @@ export abstract class RouteModule<
     distDir,
     relativeProjectDir,
   }: RouteModuleOptions<D, U>) {
-    this.userland = userland
+    this._userland = userland
     this.definition = definition
     this.isDev = !!process.env.__NEXT_DEV_SERVER
     this.distDir = distDir


### PR DESCRIPTION
### What?

Lazy initialization of the userland module in the app-route template.

### Why?

The `import * as userland from 'VAR_USERLAND'` in `app-route.ts` was a static ESM import that eagerly loaded and executed the user's route module at module load time. This happened **before** `devRequestTimingInternalsEnd` was recorded in the `handler()` function, which meant user module initialization time was incorrectly counted as "framework time" instead of "application-code time" in dev request logging.

### How?

Three files changed:

1. **`packages/next/src/server/route-modules/route-module.ts`** — Changed the `userland` property on the base `RouteModule` class from a direct data property (`public readonly userland`) to a getter backed by `protected _userland`. This allows subclasses to override the getter for lazy loading.
2. **`packages/next/src/server/route-modules/app-route/module.ts`** — `AppRouteRouteModule` now accepts `userland` as either a direct module or a `() => AppRouteUserlandModule` loader function. When a loader is provided, the `userland` getter lazily resolves it on first access and runs `_initFromUserland()` which performs all the work previously done eagerly in the constructor (computing `methods`, `hasNonStaticMethods`, `dynamic`, config validation, dev warnings).
3. **`packages/next/src/build/templates/app-route.ts`** — Replaced the static `import * as userland from 'VAR_USERLAND'` with a lazy `() => require('VAR_USERLAND')` function passed to the route module constructor. The `require()` is still traced by webpack/turbopack so the dependency is included in the bundle, but execution is deferred until the first request accesses `this.userland` — which happens after `devRequestTimingInternalsEnd` is recorded.