### PR TITLE
Development: Add experimental flag to run generateStaticParams without worker

### DIFF
--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -405,6 +405,7 @@ export const experimentalSchema = {
   runtimeServerDeploymentId: z.boolean().optional(),
   immutableAssetToken: z.string().optional(),
   devCacheControlNoCache: z.boolean().optional(),
+  devGetStaticPathsInProcess: z.boolean().optional(),
   deferredEntries: z.array(z.string()).optional(),
   onBeforeDeferredEntries: z.function().returns(z.promise(z.void())).optional(),
   reportSystemEnvInlining: z.enum(['warn', 'error']).optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1823,7 +1823,7 @@ export const defaultConfig = Object.freeze({
     turbopackInferModuleSideEffects: true,
     turbopackPluginRuntimeStrategy: 'childProcesses',
     devCacheControlNoCache: false,
-    devGetStaticPathsInProcess: false,
+    devGetStaticPathsInProcess: true,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1052,6 +1052,16 @@ export interface ExperimentalConfig {
   devCacheControlNoCache?: boolean
 
   /**
+   * When enabled, `getStaticPaths` / `generateStaticParams` is called
+   * in-process during `next dev` instead of forking a separate worker.
+   * This reduces per-request overhead but allows side-effects to leak
+   * between invocations.
+   *
+   * @default false
+   */
+  devGetStaticPathsInProcess?: boolean
+
+  /**
    * An array of paths in app or pages directories that should wait to be processed
    * until all other entries have been processed. This is useful for deferring
    * compilation of certain routes during development and build.
@@ -1813,6 +1823,7 @@ export const defaultConfig = Object.freeze({
     turbopackInferModuleSideEffects: true,
     turbopackPluginRuntimeStrategy: 'childProcesses',
     devCacheControlNoCache: false,
+    devGetStaticPathsInProcess: false,
   },
   htmlLimitedBots: undefined,
   bundlePagesRouterDependencies: false,

--- a/packages/next/src/server/dev/next-dev-server.ts
+++ b/packages/next/src/server/dev/next-dev-server.ts
@@ -790,37 +790,46 @@ export default class DevServer extends Server {
     const __getStaticPaths = async () => {
       const { configFileName, httpAgentOptions } = this.nextConfig
       const { locales, defaultLocale } = this.nextConfig.i18n || {}
+
+      const args = {
+        dir: this.dir,
+        distDir: this.distDir,
+        pathname,
+        config: {
+          pprConfig: this.nextConfig.experimental.ppr,
+          partialFallbacks:
+            this.nextConfig.experimental.partialFallbacks === true,
+          configFileName,
+          cacheComponents: Boolean(this.nextConfig.cacheComponents),
+        },
+        httpAgentOptions,
+        locales,
+        defaultLocale,
+        page,
+        isAppPath,
+        requestHeaders,
+        cacheHandler: this.nextConfig.cacheHandler,
+        cacheHandlers: this.nextConfig.cacheHandlers,
+        cacheLifeProfiles: this.nextConfig.cacheLife,
+        fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
+        isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
+        cacheMaxMemorySize: this.nextConfig.cacheMaxMemorySize,
+        nextConfigOutput: this.nextConfig.output,
+        buildId: this.buildId,
+        authInterrupts: Boolean(this.nextConfig.experimental.authInterrupts),
+        sriEnabled: Boolean(this.nextConfig.experimental.sri?.algorithm),
+      }
+
+      if (this.nextConfig.experimental.devGetStaticPathsInProcess) {
+        const { loadStaticPaths } =
+          require('./static-paths-worker') as typeof import('./static-paths-worker')
+        return loadStaticPaths(args)
+      }
+
       const staticPathsWorker = this.getStaticPathsWorker()
 
       try {
-        const pathsResult = await staticPathsWorker.loadStaticPaths({
-          dir: this.dir,
-          distDir: this.distDir,
-          pathname,
-          config: {
-            pprConfig: this.nextConfig.experimental.ppr,
-            partialFallbacks:
-              this.nextConfig.experimental.partialFallbacks === true,
-            configFileName,
-            cacheComponents: Boolean(this.nextConfig.cacheComponents),
-          },
-          httpAgentOptions,
-          locales,
-          defaultLocale,
-          page,
-          isAppPath,
-          requestHeaders,
-          cacheHandler: this.nextConfig.cacheHandler,
-          cacheHandlers: this.nextConfig.cacheHandlers,
-          cacheLifeProfiles: this.nextConfig.cacheLife,
-          fetchCacheKeyPrefix: this.nextConfig.experimental.fetchCacheKeyPrefix,
-          isrFlushToDisk: this.nextConfig.experimental.isrFlushToDisk,
-          cacheMaxMemorySize: this.nextConfig.cacheMaxMemorySize,
-          nextConfigOutput: this.nextConfig.output,
-          buildId: this.buildId,
-          authInterrupts: Boolean(this.nextConfig.experimental.authInterrupts),
-          sriEnabled: Boolean(this.nextConfig.experimental.sri?.algorithm),
-        })
+        const pathsResult = await staticPathsWorker.loadStaticPaths(args)
         return pathsResult
       } finally {
         // we don't re-use workers so destroy the used one


### PR DESCRIPTION
### What?

Adds an experimental flag `devGetStaticPathsInProcess` that runs `getStaticPaths` / `generateStaticParams` directly in the development server process instead of forking a jest-worker child process on every invocation.

### Why?

During `next dev`, each call to `getStaticPaths` (Pages Router) or `generateStaticParams` (App Router) currently forks a new child process via jest-worker, sends the arguments over IPC, waits for the result, and then destroys the worker. Requiring the code in the static paths worker is similar to a cold boot, even when generateStaticParams is not used.

While this check happens out-of-band it adds overhead on the first request to a dynamic route, even if the dynamic route does not use generateStaticParams/getStaticPaths.

The worker isolation exists to prevent module scope from being reused between invocations in dev, so this is gated behind an experimental flag, need to consider if the perf win is worth the tradeoff of running in the same process.

### How?

- Added `experimental.devGetStaticPathsInProcess` (`boolean`, default `true`) to `ExperimentalConfig` in `config-shared.ts` with zod validation in `config-schema.ts`
- In `DevServer.getStaticPaths()` (`next-dev-server.ts`), when the flag is enabled, `loadStaticPaths` from `static-paths-worker.ts` is called directly via `require()` instead of through a jest-worker child process
- When the flag is disabled, the original worker-based behavior is preserved unchanged