### PR TITLE
Turbopack: don't emit polyfill chunk for API routes

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1358,45 +1358,52 @@ impl AppEndpoint {
 
         let manifest_path_prefix = &app_entry.original_name;
 
-        // polyfill-nomodule.js is a pre-compiled asset distributed as part of next
-        let next_package = get_next_package(project.project_path().owned().await?).await?;
-        let polyfill_source_path =
-            next_package.join("dist/build/polyfills/polyfill-nomodule.js")?;
-        let polyfill_source = FileSource::new(polyfill_source_path.clone());
-        let polyfill_output_path = client_chunking_context
-            .chunk_path(
-                Some(Vc::upcast(polyfill_source)),
-                polyfill_source.ident(),
-                None,
-                rcstr!(".js"),
-            )
-            .owned()
-            .await?;
+        // Only Pages need a polyfill chunk, Routes handlers don't have any inherent code that runs
+        // in the browser.
+        let polyfill_output_asset = if matches!(this.ty, AppEndpointType::Page { .. }) {
+            // polyfill-nomodule.js is a pre-compiled asset distributed as part of next
+            let next_package = get_next_package(project.project_path().owned().await?).await?;
+            let polyfill_source_path =
+                next_package.join("dist/build/polyfills/polyfill-nomodule.js")?;
+            let polyfill_source = FileSource::new(polyfill_source_path.clone());
+            let polyfill_output_path = client_chunking_context
+                .chunk_path(
+                    Some(Vc::upcast(polyfill_source)),
+                    polyfill_source.ident(),
+                    None,
+                    rcstr!(".js"),
+                )
+                .owned()
+                .await?;
 
-        let polyfill_output = SingleFileEcmascriptOutput::new(
-            polyfill_output_path.clone(),
-            polyfill_source_path,
-            Vc::upcast(polyfill_source),
-        )
-        .to_resolved()
-        .await?;
-
-        let polyfill_output_asset = ResolvedVc::upcast(polyfill_output);
-        client_assets.insert(polyfill_output_asset);
-
-        let client_source_maps = project
-            .next_config()
-            .client_source_maps(project.next_mode())
-            .await?;
-        if *client_source_maps != SourceMapsType::None {
-            let polyfill_source_map_asset = SourceMapAsset::new_fixed(
+            let polyfill_output = SingleFileEcmascriptOutput::new(
                 polyfill_output_path.clone(),
-                *ResolvedVc::upcast(polyfill_output),
+                polyfill_source_path,
+                Vc::upcast(polyfill_source),
             )
             .to_resolved()
             .await?;
-            client_assets.insert(ResolvedVc::upcast(polyfill_source_map_asset));
-        }
+
+            let polyfill_output_asset = ResolvedVc::upcast(polyfill_output);
+            client_assets.insert(polyfill_output_asset);
+
+            let client_source_maps = project
+                .next_config()
+                .client_source_maps(project.next_mode())
+                .await?;
+            if *client_source_maps != SourceMapsType::None {
+                let polyfill_source_map_asset = SourceMapAsset::new_fixed(
+                    polyfill_output_path.clone(),
+                    *ResolvedVc::upcast(polyfill_output),
+                )
+                .to_resolved()
+                .await?;
+                client_assets.insert(ResolvedVc::upcast(polyfill_source_map_asset));
+            }
+            Some(polyfill_output_asset)
+        } else {
+            None
+        };
 
         let client_assets: ResolvedVc<OutputAssets> =
             ResolvedVc::cell(client_assets.into_iter().collect::<Vec<_>>());
@@ -1437,7 +1444,7 @@ impl AppEndpoint {
                 client_relative_path: client_relative_path.clone(),
                 pages: Default::default(),
                 root_main_files: client_shared_chunks,
-                polyfill_files: vec![polyfill_output_asset],
+                polyfill_files: polyfill_output_asset.into_iter().collect(),
             };
             server_assets.insert(ResolvedVc::upcast(build_manifest.resolved_cell()));
         }


### PR DESCRIPTION
1. This is misldeading in the bundle analyzer view
2. If you have a Nextjs app consisting of only API routes, then there is no need to ever write out any polyfill chunk.