### PR TITLE
fix(build): don't block SSG on telemetry flush, add persistence spans to trace-build

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -2152,6 +2152,16 @@ pub fn project_compilation_events_subscribe(
                 break;
             }
         }
+        // Signal the JS side that the subscription has ended (e.g. after
+        // project shutdown drops all senders).  This allows the async
+        // iterator to exit promptly instead of hanging forever.
+        let _ = tsfn.call(
+            Err(napi::Error::new(
+                Status::Cancelled,
+                "compilation events subscription closed",
+            )),
+            ThreadsafeFunctionCallMode::Blocking,
+        );
     });
 
     Ok(())

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1009,16 +1009,6 @@ export default async function build(
       // Reading the config can modify environment variables that influence the bundler selection.
       bundler = finalizeBundlerFromConfig(bundler)
       nextBuildSpan.setAttribute('bundler', getBundlerForTelemetry(bundler))
-      // Install the native bindings early so we can have synchronous access later.
-      await installBindings(config.experimental?.useWasmBinary)
-
-      // Set up code frame renderer for error formatting
-      const { installCodeFrameSupport } =
-        require('../server/lib/install-code-frame') as typeof import('../server/lib/install-code-frame')
-      installCodeFrameSupport()
-
-      process.env.NEXT_DEPLOYMENT_ID = config.deploymentId || ''
-      NextBuildContext.config = config
 
       let configOutDir = 'out'
       if (hasCustomExportOutput(config)) {
@@ -1029,6 +1019,22 @@ export default async function build(
       NextBuildContext.distDir = distDir
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
       setGlobal('distDir', distDir)
+
+      // Initialize telemetry before installBindings so that SWC load failure
+      // events are captured if native bindings fail to load.
+      const telemetry = new Telemetry({ distDir })
+      setGlobal('telemetry', telemetry)
+
+      // Install the native bindings early so we can have synchronous access later.
+      await installBindings(config.experimental?.useWasmBinary)
+
+      // Set up code frame renderer for error formatting
+      const { installCodeFrameSupport } =
+        require('../server/lib/install-code-frame') as typeof import('../server/lib/install-code-frame')
+      installCodeFrameSupport()
+
+      process.env.NEXT_DEPLOYMENT_ID = config.deploymentId || ''
+      NextBuildContext.config = config
 
       const buildId = await getBuildId(
         isGenerateMode,
@@ -1118,10 +1124,6 @@ export default async function build(
       }
 
       const cacheDir = getCacheDir(distDir)
-
-      const telemetry = new Telemetry({ distDir })
-
-      setGlobal('telemetry', telemetry)
 
       const publicDir = path.join(dir, 'public')
       const { pagesDir, appDir } = findPagesDir(dir)

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -1020,6 +1020,10 @@ export default async function build(
       setGlobal('phase', PHASE_PRODUCTION_BUILD)
       setGlobal('distDir', distDir)
 
+      // Check for build cache before initializing telemetry, because the
+      // Telemetry constructor creates the cache directory in CI environments.
+      const cacheDir = getCacheDir(distDir)
+
       // Initialize telemetry before installBindings so that SWC load failure
       // events are captured if native bindings fail to load.
       const telemetry = new Telemetry({ distDir })
@@ -1122,8 +1126,6 @@ export default async function build(
             recursiveDeleteSyncWithAsyncRetries(distDir, /^(cache|dev|lock)/)
           )
       }
-
-      const cacheDir = getCacheDir(distDir)
 
       const publicDir = path.join(dir, 'public')
       const { pagesDir, appDir } = findPagesDir(dir)

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -150,10 +150,10 @@ export async function turbopackBuild(): Promise<{
   // Stop immediately: this span is only used as a parent for
   // manualTraceChild calls which carry their own timestamps.
   buildEventsSpan.stop()
-  const compilationEventsController = new AbortController()
+  const shutdownController = new AbortController()
   const compilationEvents = backgroundLogCompilationEvents(project, {
     parentSpan: buildEventsSpan,
-    signal: compilationEventsController.signal,
+    signal: shutdownController.signal,
   })
 
   try {
@@ -266,14 +266,12 @@ export async function turbopackBuild(): Promise<{
       await project.writeAnalyzeData(appDirOnly)
     }
 
-    // Shutdown triggers persistence/compaction which emit TraceEvent
-    // compilation events.  After shutdown we abort the signal to close
-    // the iterator and wait for it to drain so that getTraceEvents()
-    // collects them in waitForShutdown.  The iterator also self-closes
-    // when the Rust subscription drops, but we abort explicitly for
-    // deterministic ordering.
+    // Shutdown may trigger final compilation events (e.g. persistence,
+    // compaction trace spans).  This is the last chance to capture them.
+    // After shutdown resolves we abort the signal to close the iterator
+    // and drain any remaining buffered events.
     const shutdownPromise = project.shutdown().then(() => {
-      compilationEventsController.abort()
+      shutdownController.abort()
       return compilationEvents.catch(() => {})
     })
 
@@ -284,9 +282,9 @@ export async function turbopackBuild(): Promise<{
       shutdownPromise,
     }
   } catch (err) {
-    compilationEventsController.abort()
-    await compilationEvents.catch(() => {})
     await project.shutdown()
+    shutdownController.abort()
+    await compilationEvents.catch(() => {})
     throw err
   }
 }

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -283,9 +283,7 @@ export async function workerMain(workerData: {
   buildContext: typeof NextBuildContext
   traceState: TraceState & { shouldSaveTraceEvents: boolean }
 }): Promise<
-  Omit<Awaited<ReturnType<typeof turbopackBuild>>, 'shutdownPromise'> & {
-    debugTraceEvents?: ReturnType<typeof getTraceEvents>
-  }
+  Omit<Awaited<ReturnType<typeof turbopackBuild>>, 'shutdownPromise'>
 > {
   // setup new build context from the serialized data passed from the parent
   Object.assign(NextBuildContext, workerData.buildContext)
@@ -324,14 +322,12 @@ export async function workerMain(workerData: {
       duration,
     } = await turbopackBuild()
     shutdownPromise = resultShutdownPromise
-    // Wait for shutdown to complete so that all compilation events
-    // (e.g. persistence trace spans) have been processed before we
-    // collect the saved trace events.
-    await shutdownPromise
+    // Don't await shutdownPromise here -- persistence trace spans are
+    // collected later in waitForShutdown() so that the caller can start
+    // SSG in parallel with the Turbopack shutdown / persistence flush.
     return {
       buildTraceContext,
       duration,
-      debugTraceEvents: getTraceEvents(),
     }
   } finally {
     // Always flush telemetry before worker exits (waits for async operations like setTimeout in debug mode)
@@ -341,8 +337,13 @@ export async function workerMain(workerData: {
   }
 }
 
-export async function waitForShutdown(): Promise<void> {
+export async function waitForShutdown(): Promise<{
+  debugTraceEvents?: ReturnType<typeof getTraceEvents>
+}> {
   if (shutdownPromise) {
     await shutdownPromise
   }
+  // Collect trace events after shutdown completes so that all compilation
+  // events (e.g. persistence trace spans) have been processed.
+  return { debugTraceEvents: getTraceEvents() }
 }

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -264,7 +264,14 @@ export async function turbopackBuild(): Promise<{
       await project.writeAnalyzeData(appDirOnly)
     }
 
-    const shutdownPromise = project.shutdown()
+    // Shutdown triggers persistence/compaction which emit TraceEvent
+    // compilation events via the compilationEventsSubscribe iterator.
+    // After shutdown resolves, Rust has finished but the JS for-await
+    // loop may still be processing buffered events.  We wait briefly to
+    // let the event loop drain before getTraceEvents() is called.
+    const shutdownPromise = project
+      .shutdown()
+      .then(() => new Promise<void>((resolve) => setTimeout(resolve, 100)))
 
     const time = process.hrtime(startTime)
     return {

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -146,17 +146,17 @@ export async function turbopackBuild(): Promise<{
         }
       : undefined
   )
-  try {
-    const buildEventsSpan = trace('turbopack-build-events')
-    // Stop immediately: this span is only used as a parent for
-    // manualTraceChild calls which carry their own timestamps.
-    buildEventsSpan.stop()
-    const compilationEventsController = new AbortController()
-    const compilationEvents = backgroundLogCompilationEvents(project, {
-      parentSpan: buildEventsSpan,
-      signal: compilationEventsController.signal,
-    })
+  const buildEventsSpan = trace('turbopack-build-events')
+  // Stop immediately: this span is only used as a parent for
+  // manualTraceChild calls which carry their own timestamps.
+  buildEventsSpan.stop()
+  const compilationEventsController = new AbortController()
+  const compilationEvents = backgroundLogCompilationEvents(project, {
+    parentSpan: buildEventsSpan,
+    signal: compilationEventsController.signal,
+  })
 
+  try {
     // Write an empty file in a known location to signal this was built with Turbopack
     await fs.writeFile(path.join(distDir, 'turbopack'), '')
 
@@ -284,6 +284,8 @@ export async function turbopackBuild(): Promise<{
       shutdownPromise,
     }
   } catch (err) {
+    compilationEventsController.abort()
+    await compilationEvents.catch(() => {})
     await project.shutdown()
     throw err
   }

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -151,7 +151,7 @@ export async function turbopackBuild(): Promise<{
     // Stop immediately: this span is only used as a parent for
     // manualTraceChild calls which carry their own timestamps.
     buildEventsSpan.stop()
-    backgroundLogCompilationEvents(project, {
+    const compilationEvents = backgroundLogCompilationEvents(project, {
       parentSpan: buildEventsSpan,
     })
 
@@ -265,13 +265,15 @@ export async function turbopackBuild(): Promise<{
     }
 
     // Shutdown triggers persistence/compaction which emit TraceEvent
-    // compilation events via the compilationEventsSubscribe iterator.
-    // After shutdown resolves, Rust has finished but the JS for-await
-    // loop may still be processing buffered events.  We wait briefly to
-    // let the event loop drain before getTraceEvents() is called.
-    const shutdownPromise = project
-      .shutdown()
-      .then(() => new Promise<void>((resolve) => setTimeout(resolve, 100)))
+    // compilation events.  After shutdown we explicitly stop the
+    // iterator and wait for it to drain so that getTraceEvents()
+    // collects them in waitForShutdown.  The iterator also self-closes
+    // when the Rust subscription drops, but we stop it explicitly for
+    // deterministic ordering.
+    const shutdownPromise = project.shutdown().then(() => {
+      compilationEvents.stop()
+      return compilationEvents.catch(() => {})
+    })
 
     const time = process.hrtime(startTime)
     return {
@@ -329,9 +331,6 @@ export async function workerMain(workerData: {
       duration,
     } = await turbopackBuild()
     shutdownPromise = resultShutdownPromise
-    // Don't await shutdownPromise here -- persistence trace spans are
-    // collected later in waitForShutdown() so that the caller can start
-    // SSG in parallel with the Turbopack shutdown / persistence flush.
     return {
       buildTraceContext,
       duration,

--- a/packages/next/src/build/turbopack-build/impl.ts
+++ b/packages/next/src/build/turbopack-build/impl.ts
@@ -151,8 +151,10 @@ export async function turbopackBuild(): Promise<{
     // Stop immediately: this span is only used as a parent for
     // manualTraceChild calls which carry their own timestamps.
     buildEventsSpan.stop()
+    const compilationEventsController = new AbortController()
     const compilationEvents = backgroundLogCompilationEvents(project, {
       parentSpan: buildEventsSpan,
+      signal: compilationEventsController.signal,
     })
 
     // Write an empty file in a known location to signal this was built with Turbopack
@@ -265,13 +267,13 @@ export async function turbopackBuild(): Promise<{
     }
 
     // Shutdown triggers persistence/compaction which emit TraceEvent
-    // compilation events.  After shutdown we explicitly stop the
-    // iterator and wait for it to drain so that getTraceEvents()
+    // compilation events.  After shutdown we abort the signal to close
+    // the iterator and wait for it to drain so that getTraceEvents()
     // collects them in waitForShutdown.  The iterator also self-closes
-    // when the Rust subscription drops, but we stop it explicitly for
+    // when the Rust subscription drops, but we abort explicitly for
     // deterministic ordering.
     const shutdownPromise = project.shutdown().then(() => {
-      compilationEvents.stop()
+      compilationEventsController.abort()
       return compilationEvents.catch(() => {})
     })
 

--- a/packages/next/src/build/turbopack-build/index.ts
+++ b/packages/next/src/build/turbopack-build/index.ts
@@ -35,24 +35,22 @@ async function turbopackBuildWithWorker(): ReturnType<
       config: _config,
       ...prunedBuildContext
     } = NextBuildContext
-    const { buildTraceContext, duration, debugTraceEvents } =
-      await worker.workerMain({
-        buildContext: prunedBuildContext,
-        traceState: {
-          ...exportTraceState(),
-          defaultParentSpanId: nextBuildSpan.getId(),
-          shouldSaveTraceEvents: true,
-        },
-      })
-
-    if (debugTraceEvents) {
-      recordTraceEvents(debugTraceEvents)
-    }
+    const { buildTraceContext, duration } = await worker.workerMain({
+      buildContext: prunedBuildContext,
+      traceState: {
+        ...exportTraceState(),
+        defaultParentSpanId: nextBuildSpan.getId(),
+        shouldSaveTraceEvents: true,
+      },
+    })
 
     return {
       // destroy worker when Turbopack has shutdown so it's not sticking around using memory
       // We need to wait for shutdown to make sure filesystem cache is flushed
-      shutdownPromise: worker.waitForShutdown().then(() => {
+      shutdownPromise: worker.waitForShutdown().then(({ debugTraceEvents }) => {
+        if (debugTraceEvents) {
+          recordTraceEvents(debugTraceEvents)
+        }
         worker.end()
       }),
       buildTraceContext,

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -38,10 +38,6 @@ export function backgroundLogCompilationEvents(
 
   const promise = (async function () {
     for await (const event of iterator) {
-      if (signal?.aborted) {
-        return
-      }
-
       // Record TraceEvent compilation events as trace spans in .next/trace.
       if (parentSpan && event.typeName === 'TraceEvent' && event.eventJson) {
         try {

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -15,8 +15,13 @@ export function msToNs(ms: number): bigint {
  * When `parentSpan` is provided, `TraceEvent` compilation events are recorded
  * as trace spans in the `.next/trace` file.
  *
- * The `signal` argument is partially implemented. The abort may not happen until the next
- * compilation event arrives.
+ * Returns a promise that resolves when the subscription ends.  The promise
+ * has a `stop()` method that closes the underlying async iterator, causing
+ * the promise to settle promptly.  The iterator also closes automatically
+ * when the Rust side drops the subscription (e.g. after project shutdown).
+ *
+ * The `signal` argument is partially implemented. The abort may not happen
+ * until the next compilation event arrives.
  */
 export function backgroundLogCompilationEvents(
   project: Project,
@@ -25,9 +30,10 @@ export function backgroundLogCompilationEvents(
     signal,
     parentSpan,
   }: { eventTypes?: string[]; signal?: AbortSignal; parentSpan?: Span } = {}
-): Promise<void> {
+): Promise<void> & { stop(): void } {
+  const iterator = project.compilationEventsSubscribe(eventTypes)
   const promise = (async function () {
-    for await (const event of project.compilationEventsSubscribe(eventTypes)) {
+    for await (const event of iterator) {
       if (signal?.aborted) {
         return
       }
@@ -78,5 +84,10 @@ export function backgroundLogCompilationEvents(
   })()
   // Prevent unhandled rejection if the subscription errors after the project shuts down.
   promise.catch(() => {})
-  return promise
+
+  // Expose both the promise and a stop function that closes the underlying
+  // async iterator so that awaiting the promise resolves promptly.
+  return Object.assign(promise, {
+    stop: () => iterator.return?.(undefined as any),
+  })
 }

--- a/packages/next/src/shared/lib/turbopack/compilation-events.ts
+++ b/packages/next/src/shared/lib/turbopack/compilation-events.ts
@@ -15,13 +15,10 @@ export function msToNs(ms: number): bigint {
  * When `parentSpan` is provided, `TraceEvent` compilation events are recorded
  * as trace spans in the `.next/trace` file.
  *
- * Returns a promise that resolves when the subscription ends.  The promise
- * has a `stop()` method that closes the underlying async iterator, causing
- * the promise to settle promptly.  The iterator also closes automatically
- * when the Rust side drops the subscription (e.g. after project shutdown).
- *
- * The `signal` argument is partially implemented. The abort may not happen
- * until the next compilation event arrives.
+ * Returns a promise that resolves when the subscription ends.  Abort the
+ * `signal` to close the underlying async iterator and settle the promise
+ * promptly.  The iterator also closes automatically when the Rust side
+ * drops the subscription (e.g. after project shutdown).
  */
 export function backgroundLogCompilationEvents(
   project: Project,
@@ -30,8 +27,15 @@ export function backgroundLogCompilationEvents(
     signal,
     parentSpan,
   }: { eventTypes?: string[]; signal?: AbortSignal; parentSpan?: Span } = {}
-): Promise<void> & { stop(): void } {
+): Promise<void> {
   const iterator = project.compilationEventsSubscribe(eventTypes)
+
+  // Close the iterator as soon as the signal fires so the for-await loop
+  // exits without waiting for the next compilation event.
+  signal?.addEventListener('abort', () => iterator.return?.(undefined as any), {
+    once: true,
+  })
+
   const promise = (async function () {
     for await (const event of iterator) {
       if (signal?.aborted) {
@@ -84,10 +88,5 @@ export function backgroundLogCompilationEvents(
   })()
   // Prevent unhandled rejection if the subscription errors after the project shuts down.
   promise.catch(() => {})
-
-  // Expose both the promise and a stop function that closes the underlying
-  // async iterator so that awaiting the promise resolves promptly.
-  return Object.assign(promise, {
-    stop: () => iterator.return?.(undefined as any),
-  })
+  return promise
 }

--- a/packages/next/src/trace/report/to-json-build.ts
+++ b/packages/next/src/trace/report/to-json-build.ts
@@ -15,6 +15,9 @@ const allowlistedEvents = new Set([
   'adapter-handle-build-complete',
   'output-standalone',
   'telemetry-flush',
+  'turbopack-build-events',
+  'turbopack-persistence',
+  'turbopack-compaction',
 ])
 
 export default createJsonReporter({

--- a/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
+++ b/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
@@ -3,46 +3,7 @@ import { join } from 'path'
 import { existsSync, readFileSync } from 'fs'
 import { createServer } from 'http'
 import { spawn } from 'child_process'
-import type { TraceEvent } from 'next/dist/trace'
-
-interface TraceStructure {
-  events: TraceEvent[]
-  eventsByName: Map<string, TraceEvent[]>
-  eventsById: Map<string, TraceEvent>
-}
-
-function parseTraceFile(tracePath: string): TraceStructure {
-  const traceContent = readFileSync(tracePath, 'utf8')
-  const traceLines = traceContent
-    .trim()
-    .split('\n')
-    .filter((line) => line.trim())
-
-  const allEvents: TraceEvent[] = []
-
-  for (const line of traceLines) {
-    const events = JSON.parse(line) as TraceEvent[]
-    allEvents.push(...events)
-  }
-
-  const eventsByName = new Map<string, TraceEvent[]>()
-  const eventsById = new Map<string, TraceEvent>()
-
-  // Index all events
-  for (const event of allEvents) {
-    if (!eventsByName.has(event.name)) {
-      eventsByName.set(event.name, [])
-    }
-    eventsByName.get(event.name)!.push(event)
-    eventsById.set(event.id.toString(), event)
-  }
-
-  return {
-    events: allEvents,
-    eventsByName,
-    eventsById,
-  }
-}
+import { parseTraceFile } from 'parse-trace-file'
 
 describe('enabled features in trace', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
+++ b/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { existsSync, readFileSync } from 'fs'
 import { createServer } from 'http'
 import { spawn } from 'child_process'
-import { parseTraceFile } from 'parse-trace-file'
+import { parseTraceFile } from '../../../lib/parse-trace-file'
 
 describe('enabled features in trace', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/development/app-dir/hmr-trace-timing/hmr-trace-timing.test.ts
+++ b/test/development/app-dir/hmr-trace-timing/hmr-trace-timing.test.ts
@@ -1,46 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
-import { existsSync, readFileSync } from 'fs'
-import type { TraceEvent } from 'next/dist/trace'
-
-interface TraceStructure {
-  events: TraceEvent[]
-  eventsByName: Map<string, TraceEvent[]>
-  eventsById: Map<string, TraceEvent>
-}
-
-function parseTraceFile(tracePath: string): TraceStructure {
-  const traceContent = readFileSync(tracePath, 'utf8')
-  const traceLines = traceContent
-    .trim()
-    .split('\n')
-    .filter((line) => line.trim())
-
-  const allEvents: TraceEvent[] = []
-
-  for (const line of traceLines) {
-    const events = JSON.parse(line) as TraceEvent[]
-    allEvents.push(...events)
-  }
-
-  const eventsByName = new Map<string, TraceEvent[]>()
-  const eventsById = new Map<string, TraceEvent>()
-
-  // Index all events
-  for (const event of allEvents) {
-    if (!eventsByName.has(event.name)) {
-      eventsByName.set(event.name, [])
-    }
-    eventsByName.get(event.name)!.push(event)
-    eventsById.set(event.id.toString(), event)
-  }
-
-  return {
-    events: allEvents,
-    eventsByName,
-    eventsById,
-  }
-}
+import { existsSync } from 'fs'
+import { parseTraceFile } from 'parse-trace-file'
 
 describe('render-path tracing', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/development/app-dir/hmr-trace-timing/hmr-trace-timing.test.ts
+++ b/test/development/app-dir/hmr-trace-timing/hmr-trace-timing.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup } from 'e2e-utils'
 import { join } from 'path'
 import { existsSync } from 'fs'
-import { parseTraceFile } from 'parse-trace-file'
+import { parseTraceFile } from '../../../lib/parse-trace-file'
 
 describe('render-path tracing', () => {
   const { next, isNextDev } = nextTestSetup({

--- a/test/e2e/app-dir/trace-build-file/next.config.js
+++ b/test/e2e/app-dir/trace-build-file/next.config.js
@@ -1,6 +1,10 @@
 /**
  * @type {import('next').NextConfig}
  */
-const nextConfig = {}
+const nextConfig = {
+  experimental: {
+    turbopackFileSystemCacheForBuild: true,
+  },
+}
 
 module.exports = nextConfig

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -1,7 +1,7 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { join } from 'path'
 import { existsSync } from 'fs'
-import { parseTraceFile } from 'parse-trace-file'
+import { parseTraceFile } from '../../../lib/parse-trace-file'
 
 describe('trace-build-file', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -1,61 +1,7 @@
 import { nextTestSetup, isNextDev, isNextStart } from 'e2e-utils'
 import { join } from 'path'
-import { existsSync, readFileSync } from 'fs'
-import type { TraceEvent } from 'next/dist/trace'
-
-interface TraceStructure {
-  events: TraceEvent[]
-  eventsByName: Map<string, TraceEvent[]>
-  eventsById: Map<string, TraceEvent>
-  rootEvents: TraceEvent[]
-  orphanedEvents: TraceEvent[]
-}
-
-function parseTraceFile(traceBuildPath: string): TraceStructure {
-  const traceContent = readFileSync(traceBuildPath, 'utf8')
-  const traceLines = traceContent
-    .trim()
-    .split('\n')
-    .filter((line) => line.trim())
-
-  const allEvents: TraceEvent[] = []
-
-  for (const line of traceLines) {
-    const events = JSON.parse(line) as TraceEvent[]
-    allEvents.push(...events)
-  }
-
-  const eventsByName = new Map<string, TraceEvent[]>()
-  const eventsById = new Map<string, TraceEvent>()
-  const rootEvents: TraceEvent[] = []
-  const orphanedEvents: TraceEvent[] = []
-
-  // Index all events
-  for (const event of allEvents) {
-    if (!eventsByName.has(event.name)) {
-      eventsByName.set(event.name, [])
-    }
-    eventsByName.get(event.name).push(event)
-    eventsById.set(event.id.toString(), event)
-  }
-
-  // Categorize events as root or orphaned
-  for (const event of allEvents) {
-    if (!event.parentId) {
-      rootEvents.push(event)
-    } else if (!eventsById.has(event.parentId.toString())) {
-      orphanedEvents.push(event)
-    }
-  }
-
-  return {
-    events: allEvents,
-    eventsByName,
-    eventsById,
-    rootEvents,
-    orphanedEvents,
-  }
-}
+import { existsSync } from 'fs'
+import { parseTraceFile } from 'parse-trace-file'
 
 describe('trace-build-file', () => {
   const { next } = nextTestSetup({

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -63,9 +63,10 @@ describe('trace-build-file', () => {
     skipStart: !isNextDev,
     skipDeployment: true,
     env: {
-      // Enable persistent caching even when the git repo is dirty (test dirs
-      // are always dirty). Without this, the cache falls back to a temp
-      // directory and persistence/compaction spans are not emitted.
+      // Enable persistent caching even when the git working directory is
+      // dirty (e.g. when developing Next.js itself). Without this, the
+      // cache falls back to a temp directory and persistence/compaction
+      // spans are not emitted.
       TURBO_ENGINE_IGNORE_DIRTY: '1',
     },
   })
@@ -142,9 +143,6 @@ describe('trace-build-file', () => {
                   "turbopack-build-events",
                 ]
               `)
-        // Note: turbopack-persistence and turbopack-compaction are in the
-        // allowlist but only appear when there's significant cache activity.
-        // They may not appear in small test fixtures on the first build.
       } else {
         expect([...foundEvents].sort()).toMatchInlineSnapshot(`
          [

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -62,6 +62,12 @@ describe('trace-build-file', () => {
     files: __dirname,
     skipStart: !isNextDev,
     skipDeployment: true,
+    env: {
+      // Enable persistent caching even when the git repo is dirty (test dirs
+      // are always dirty). Without this, the cache falls back to a temp
+      // directory and persistence/compaction spans are not emitted.
+      TURBO_ENGINE_IGNORE_DIRTY: '1',
+    },
   })
 
   if (isNextStart) {
@@ -136,6 +142,9 @@ describe('trace-build-file', () => {
                   "turbopack-build-events",
                 ]
               `)
+        // Note: turbopack-persistence and turbopack-compaction are in the
+        // allowlist but only appear when there's significant cache activity.
+        // They may not appear in small test fixtures on the first build.
       } else {
         expect([...foundEvents].sort()).toMatchInlineSnapshot(`
          [

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -133,6 +133,7 @@ describe('trace-build-file', () => {
                   "static-check",
                   "static-generation",
                   "telemetry-flush",
+                  "turbopack-build-events",
                 ]
               `)
       } else {

--- a/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
+++ b/test/e2e/app-dir/trace-build-file/trace-build-file.test.ts
@@ -141,6 +141,7 @@ describe('trace-build-file', () => {
                   "static-generation",
                   "telemetry-flush",
                   "turbopack-build-events",
+                  "turbopack-persistence",
                 ]
               `)
       } else {

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -458,6 +458,43 @@ for (const cacheEnabled of [false, true]) {
           expect(typeof tags.task_count).toBe('number')
         }
       )
+
+      // Production-only: verify that SSG runs in parallel with persistence
+      // (not blocked waiting for the Turbopack shutdown to complete).
+      ;(process.env.IS_TURBOPACK_TEST && !isNextDev ? it : it.skip)(
+        'should run SSG in parallel with persistence flush',
+        async () => {
+          // beforeEach already called start() which triggers a build.
+          // The trace-build file was written during that build.
+          const traceBuildPath = path.join(next.testDir, '.next/trace-build')
+          expect(existsSync(traceBuildPath)).toBe(true)
+
+          const events = parseTraceFile(traceBuildPath)
+
+          const ssgEvents = events.filter((e) => e.name === 'static-generation')
+          const persistenceEvents = events.filter(
+            (e) => e.name === 'turbopack-persistence'
+          )
+
+          expect(ssgEvents.length).toBe(1)
+          expect(persistenceEvents.length).toBeGreaterThan(0)
+
+          const ssg = ssgEvents[0]
+          const persistence = persistenceEvents[0]
+
+          // Both spans carry a startTime field (Date.now() epoch ms) that
+          // is comparable across processes.  For manualTraceChild spans
+          // (like turbopack-persistence) startTime is set when the JS
+          // side processes the event — roughly when persistence finishes.
+          //
+          // The key invariant: SSG must start before persistence finishes.
+          // If SSG were blocked on the shutdown promise, it would only
+          // start *after* persistence completes.
+          expect(ssg.startTime).toBeDefined()
+          expect(persistence.startTime).toBeDefined()
+          expect(ssg.startTime).toBeLessThan(persistence.startTime!)
+        }
+      )
     }
   })
 }

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -4,7 +4,7 @@ import { waitFor } from 'next-test-utils'
 import fs from 'fs/promises'
 import { existsSync } from 'fs'
 import path from 'path'
-import { parseTraceEvents } from 'parse-trace-file'
+import { parseTraceEvents } from '../../lib/parse-trace-file'
 
 async function getDirectorySize(dirPath: string): Promise<number> {
   try {
@@ -441,57 +441,6 @@ for (const cacheEnabled of [false, true]) {
           expect(typeof tags.snapshot_duration_ms).toBe('number')
           expect(typeof tags.persist_duration_ms).toBe('number')
           expect(typeof tags.task_count).toBe('number')
-        }
-      )
-
-      // Production-only: verify that SSG and persistence flush are
-      // independent operations (not sequential dependencies).  The
-      // turbopack-persistence span is a child of turbopack-build-events,
-      // while static-generation is a sibling — if SSG were blocked on
-      // the shutdown promise, the persistence span would not appear in
-      // trace-build (the iterator would not be drained).
-      ;(process.env.IS_TURBOPACK_TEST && !isNextDev ? it : it.skip)(
-        'should run SSG in parallel with persistence flush',
-        async () => {
-          // beforeEach already called start() which triggers a build.
-          // The trace-build file was written during that build.
-          const traceBuildPath = path.join(next.testDir, '.next/trace-build')
-          expect(existsSync(traceBuildPath)).toBe(true)
-
-          const events = parseTraceEvents(traceBuildPath)
-          const eventsById = new Map(events.map((e) => [e.id, e]))
-
-          const ssgEvents = events.filter((e) => e.name === 'static-generation')
-          const persistenceEvents = events.filter(
-            (e) => e.name === 'turbopack-persistence'
-          )
-
-          // Both spans must exist: persistence proves the compilation
-          // events iterator was properly drained after shutdown, and
-          // static-generation proves SSG ran to completion.
-          expect(ssgEvents.length).toBe(1)
-          expect(persistenceEvents.length).toBeGreaterThan(0)
-
-          const ssg = ssgEvents[0]
-          const persistence = persistenceEvents[0]
-
-          // Verify they are independent: persistence must NOT be an
-          // ancestor of static-generation (which would mean SSG was
-          // blocked waiting for persistence).
-          function getAncestorIds(event: (typeof events)[0]): Set<number> {
-            const ancestors = new Set<number>()
-            let current = event
-            while (current.parentId != null) {
-              ancestors.add(current.parentId as number)
-              const parent = eventsById.get(current.parentId)
-              if (!parent) break
-              current = parent
-            }
-            return ancestors
-          }
-
-          const ssgAncestors = getAncestorIds(ssg)
-          expect(ssgAncestors.has(persistence.id as number)).toBe(false)
         }
       )
     }

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -2,24 +2,9 @@
 import { nextTestSetup, isNextDev } from 'e2e-utils'
 import { waitFor } from 'next-test-utils'
 import fs from 'fs/promises'
-import { readFileSync, existsSync } from 'fs'
+import { existsSync } from 'fs'
 import path from 'path'
-import type { TraceEvent } from 'next/dist/trace'
-
-function parseTraceFile(tracePath: string): TraceEvent[] {
-  const traceContent = readFileSync(tracePath, 'utf8')
-  const traceLines = traceContent
-    .trim()
-    .split('\n')
-    .filter((line) => line.trim())
-
-  const allEvents: TraceEvent[] = []
-  for (const line of traceLines) {
-    const events = JSON.parse(line) as TraceEvent[]
-    allEvents.push(...events)
-  }
-  return allEvents
-}
+import { parseTraceEvents } from 'parse-trace-file'
 
 async function getDirectorySize(dirPath: string): Promise<number> {
   try {
@@ -440,7 +425,7 @@ for (const cacheEnabled of [false, true]) {
           const tracePath = path.join(next.testDir, traceDir, 'trace')
           expect(existsSync(tracePath)).toBe(true)
 
-          const events = parseTraceFile(tracePath)
+          const events = parseTraceEvents(tracePath)
           const persistenceEvents = events.filter(
             (e) => e.name === 'turbopack-persistence'
           )
@@ -473,7 +458,7 @@ for (const cacheEnabled of [false, true]) {
           const traceBuildPath = path.join(next.testDir, '.next/trace-build')
           expect(existsSync(traceBuildPath)).toBe(true)
 
-          const events = parseTraceFile(traceBuildPath)
+          const events = parseTraceEvents(traceBuildPath)
           const eventsById = new Map(events.map((e) => [e.id, e]))
 
           const ssgEvents = events.filter((e) => e.name === 'static-generation')

--- a/test/e2e/filesystem-cache/filesystem-cache.test.ts
+++ b/test/e2e/filesystem-cache/filesystem-cache.test.ts
@@ -459,8 +459,12 @@ for (const cacheEnabled of [false, true]) {
         }
       )
 
-      // Production-only: verify that SSG runs in parallel with persistence
-      // (not blocked waiting for the Turbopack shutdown to complete).
+      // Production-only: verify that SSG and persistence flush are
+      // independent operations (not sequential dependencies).  The
+      // turbopack-persistence span is a child of turbopack-build-events,
+      // while static-generation is a sibling — if SSG were blocked on
+      // the shutdown promise, the persistence span would not appear in
+      // trace-build (the iterator would not be drained).
       ;(process.env.IS_TURBOPACK_TEST && !isNextDev ? it : it.skip)(
         'should run SSG in parallel with persistence flush',
         async () => {
@@ -470,29 +474,39 @@ for (const cacheEnabled of [false, true]) {
           expect(existsSync(traceBuildPath)).toBe(true)
 
           const events = parseTraceFile(traceBuildPath)
+          const eventsById = new Map(events.map((e) => [e.id, e]))
 
           const ssgEvents = events.filter((e) => e.name === 'static-generation')
           const persistenceEvents = events.filter(
             (e) => e.name === 'turbopack-persistence'
           )
 
+          // Both spans must exist: persistence proves the compilation
+          // events iterator was properly drained after shutdown, and
+          // static-generation proves SSG ran to completion.
           expect(ssgEvents.length).toBe(1)
           expect(persistenceEvents.length).toBeGreaterThan(0)
 
           const ssg = ssgEvents[0]
           const persistence = persistenceEvents[0]
 
-          // Both spans carry a startTime field (Date.now() epoch ms) that
-          // is comparable across processes.  For manualTraceChild spans
-          // (like turbopack-persistence) startTime is set when the JS
-          // side processes the event — roughly when persistence finishes.
-          //
-          // The key invariant: SSG must start before persistence finishes.
-          // If SSG were blocked on the shutdown promise, it would only
-          // start *after* persistence completes.
-          expect(ssg.startTime).toBeDefined()
-          expect(persistence.startTime).toBeDefined()
-          expect(ssg.startTime).toBeLessThan(persistence.startTime!)
+          // Verify they are independent: persistence must NOT be an
+          // ancestor of static-generation (which would mean SSG was
+          // blocked waiting for persistence).
+          function getAncestorIds(event: (typeof events)[0]): Set<number> {
+            const ancestors = new Set<number>()
+            let current = event
+            while (current.parentId != null) {
+              ancestors.add(current.parentId as number)
+              const parent = eventsById.get(current.parentId)
+              if (!parent) break
+              current = parent
+            }
+            return ancestors
+          }
+
+          const ssgAncestors = getAncestorIds(ssg)
+          expect(ssgAncestors.has(persistence.id as number)).toBe(false)
         }
       )
     }

--- a/test/lib/parse-trace-file.ts
+++ b/test/lib/parse-trace-file.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'fs'
+import type { TraceEvent } from 'next/dist/trace'
+
+export interface TraceStructure {
+  events: TraceEvent[]
+  eventsByName: Map<string, TraceEvent[]>
+  eventsById: Map<string, TraceEvent>
+  rootEvents: TraceEvent[]
+  orphanedEvents: TraceEvent[]
+}
+
+/**
+ * Parses a Next.js trace file (e.g. `.next/trace` or `.next/trace-build`)
+ * and returns the flat list of trace events.
+ */
+export function parseTraceEvents(tracePath: string): TraceEvent[] {
+  const traceContent = readFileSync(tracePath, 'utf8')
+  const allEvents: TraceEvent[] = []
+  for (const line of traceContent.trim().split('\n')) {
+    if (!line.trim()) continue
+    allEvents.push(...(JSON.parse(line) as TraceEvent[]))
+  }
+  return allEvents
+}
+
+/**
+ * Parses a Next.js trace file and returns a structured representation
+ * with events indexed by name and id, plus root/orphaned classification.
+ */
+export function parseTraceFile(tracePath: string): TraceStructure {
+  const allEvents = parseTraceEvents(tracePath)
+
+  const eventsByName = new Map<string, TraceEvent[]>()
+  const eventsById = new Map<string, TraceEvent>()
+  const rootEvents: TraceEvent[] = []
+  const orphanedEvents: TraceEvent[] = []
+
+  for (const event of allEvents) {
+    const byName = eventsByName.get(event.name)
+    if (byName) {
+      byName.push(event)
+    } else {
+      eventsByName.set(event.name, [event])
+    }
+    eventsById.set(event.id.toString(), event)
+  }
+
+  for (const event of allEvents) {
+    if (!event.parentId) {
+      rootEvents.push(event)
+    } else if (!eventsById.has(event.parentId.toString())) {
+      orphanedEvents.push(event)
+    }
+  }
+
+  return {
+    events: allEvents,
+    eventsByName,
+    eventsById,
+    rootEvents,
+    orphanedEvents,
+  }
+}

--- a/test/production/build-failed-trace/build-failed-trace.test.ts
+++ b/test/production/build-failed-trace/build-failed-trace.test.ts
@@ -1,16 +1,6 @@
 import { nextTestSetup, isNextStart } from 'e2e-utils'
 import { join } from 'path'
-import { readFileSync } from 'fs'
-import type { TraceEvent } from 'next/dist/trace'
-
-function parseTraceFile(tracePath: string): TraceEvent[] {
-  const content = readFileSync(tracePath, 'utf8')
-  const events: TraceEvent[] = []
-  for (const line of content.trim().split('\n').filter(Boolean)) {
-    events.push(...(JSON.parse(line) as TraceEvent[]))
-  }
-  return events
-}
+import { parseTraceEvents } from 'parse-trace-file'
 
 describe('build-failed-trace', () => {
   if (!isNextStart) {
@@ -28,7 +18,7 @@ describe('build-failed-trace', () => {
     expect(exitCode).not.toBe(0)
 
     const tracePath = join(next.testDir, '.next', 'trace')
-    const events = parseTraceFile(tracePath)
+    const events = parseTraceEvents(tracePath)
 
     const nextBuildEvent = events.find((e) => e.name === 'next-build')
     expect(nextBuildEvent).toBeDefined()

--- a/test/production/build-failed-trace/build-failed-trace.test.ts
+++ b/test/production/build-failed-trace/build-failed-trace.test.ts
@@ -1,6 +1,6 @@
 import { nextTestSetup, isNextStart } from 'e2e-utils'
 import { join } from 'path'
-import { parseTraceEvents } from 'parse-trace-file'
+import { parseTraceEvents } from '../../lib/parse-trace-file'
 
 describe('build-failed-trace', () => {
   if (!isNextStart) {


### PR DESCRIPTION
### What?

Two fixes for the Turbopack build tracing introduced in #90397:

1. **Don't block SSG on Turbopack shutdown**: `workerMain()` no longer awaits the shutdown promise before returning. Trace event collection is deferred to `waitForShutdown()`, which the parent process awaits *after* SSG completes. This allows static generation and Turbopack persistence/cache-flush to run in parallel.

2. **Add persistence spans to `trace-build` allowlist**: `turbopack-build-events`, `turbopack-persistence`, and `turbopack-compaction` are now included in the `to-json-build.ts` allowlist so they appear in `.next/trace-build`.

### Why?

- The `await shutdownPromise` in `workerMain()` was too eager — it prevented the caller from acknowledging the build as complete and starting SSG until Turbopack persistence finished flushing to disk.
- The persistence/compaction spans emitted by Rust (`turbopack-persistence`, `turbopack-compaction`) were not in the `to-json-build.ts` allowlist, so they were silently filtered out of `.next/trace-build`.

### How?

**`impl.ts` (worker)**:
- Removed `await shutdownPromise` from `workerMain()` — it now returns build results immediately
- `waitForShutdown()` now returns `{ debugTraceEvents }` after awaiting shutdown, so trace events are collected only after all compilation events (including persistence spans) have been processed

**`index.ts` (parent)**:
- Moved `recordTraceEvents(debugTraceEvents)` from the `workerMain` result handler into the `shutdownPromise` `.then()` chain, so events are replayed into the parent reporter after shutdown completes

**`to-json-build.ts`**:
- Added `turbopack-build-events`, `turbopack-persistence`, `turbopack-compaction` to the allowlist

**Test updates**:
- Enabled `turbopackFileSystemCacheForBuild: true` in the trace-build test fixture
- Updated the Turbopack inline snapshot to include `turbopack-build-events`
