### PR TITLE
Unify CacheNode RSC rendering and spawn dynamic requests during instant test hydration

### DIFF
--- a/packages/next/src/client/components/app-router.tsx
+++ b/packages/next/src/client/components/app-router.tsx
@@ -3,7 +3,6 @@ import React, {
   useMemo,
   startTransition,
   useInsertionEffect,
-  useDeferredValue,
 } from 'react'
 import {
   AppRouterContext,
@@ -30,6 +29,7 @@ import { AppRouterAnnouncer } from './app-router-announcer'
 import { RedirectBoundary } from './redirect-boundary'
 import { findHeadInCache } from './router-reducer/reducers/find-head-in-cache'
 import { unresolvedThenable } from './unresolved-thenable'
+import { useCacheNodeRsc } from './layout-router'
 import { removeBasePath } from '../remove-base-path'
 import { hasBasePath } from '../has-base-path'
 import {
@@ -130,22 +130,17 @@ function copyNextJsInternalHistoryState(data: any) {
 function Head({
   headCacheNode,
 }: {
-  headCacheNode: CacheNode | null
+  headCacheNode: CacheNode
 }): React.ReactNode {
-  // If this segment has a `prefetchHead`, it's the statically prefetched data.
-  // We should use that on initial render instead of `head`. Then we'll switch
-  // to `head` when the dynamic response streams in.
-  const head = headCacheNode !== null ? headCacheNode.head : null
-  const prefetchHead =
-    headCacheNode !== null ? headCacheNode.prefetchHead : null
+  return useCacheNodeRsc(headCacheNode.head, headCacheNode.prefetchHead)
+}
 
-  // If no prefetch data is available, then we go straight to rendering `head`.
-  const resolvedPrefetchRsc = prefetchHead !== null ? prefetchHead : head
-
-  // We use `useDeferredValue` to handle switching between the prefetched and
-  // final values. The second argument is returned on initial render, then it
-  // re-renders with the first argument.
-  return useDeferredValue(head, resolvedPrefetchRsc)
+function RootTreeSegment({
+  cacheNode,
+}: {
+  cacheNode: CacheNode
+}): React.ReactNode {
+  return useCacheNodeRsc(cacheNode.rsc, cacheNode.prefetchRsc)
 }
 
 /**
@@ -484,14 +479,27 @@ function Router({
     head = null
   }
 
+  let devtoolsRouteStateNode: React.ReactNode = null
+  if (process.env.NODE_ENV !== 'production') {
+    // Render SegmentViewStateNode at the root level so the devtools overlay
+    // receives the route tree immediately, without waiting for the full
+    // segment tree to mount (which may be delayed by deferred rendering).
+    const { SegmentViewStateNode } =
+      require('../../next-devtools/userspace/app/segment-explorer-node') as typeof import('../../next-devtools/userspace/app/segment-explorer-node')
+    devtoolsRouteStateNode = <SegmentViewStateNode page={pathname} />
+  }
+
   let content = (
     <RedirectBoundary>
       {head}
       {/* RootLayoutBoundary enables detection of Suspense boundaries around the root layout.
           When users wrap their layout in <Suspense>, this creates the component stack pattern
           "Suspense -> RootLayoutBoundary" which dynamic-rendering.ts uses to allow dynamic rendering. */}
-      <RootLayoutBoundary>{cache.rsc}</RootLayoutBoundary>
+      <RootLayoutBoundary>
+        <RootTreeSegment cacheNode={cache} />
+      </RootLayoutBoundary>
       <AppRouterAnnouncer tree={tree} />
+      {devtoolsRouteStateNode}
     </RedirectBoundary>
   )
 

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -405,6 +405,47 @@ function ScrollAndMaybeFocusHandler({
 }
 
 /**
+ * Resolves the RSC content for a CacheNode field (segment rsc, head, etc.),
+ * using `useDeferredValue` to show prefetched (static) content on initial render
+ * and switch to the final (dynamic) content when it becomes available.
+ *
+ * This is the single codepath for rendering any CacheNode field that may arrive
+ * in two phases: a prefetch phase (static/partial data) and a dynamic phase
+ * (full server response). The root segment, child segments, and head all use
+ * this same hook — they are conceptually identical, even though the root was
+ * historically rendered without `useDeferredValue`.
+ *
+ * If the resolved value is a deferred RSC promise, it is unwrapped with `use()`.
+ * If the final value is `null` (meaning the server did not provide data for this
+ * field), the component suspends indefinitely until the router fills it in.
+ */
+export function useCacheNodeRsc(
+  rsc: React.ReactNode,
+  prefetchRsc: React.ReactNode
+): React.ReactNode {
+  const resolvedPrefetchRsc = prefetchRsc !== null ? prefetchRsc : rsc
+  const resolved = useDeferredValue(rsc, resolvedPrefetchRsc)
+
+  if (isDeferredRsc(resolved)) {
+    const unwrapped = use(resolved)
+    if (unwrapped === null) {
+      // The promise resolved to `null`, meaning data for this field was not
+      // returned by the server. Suspend indefinitely until the router fills it
+      // in with a new state update.
+      use(unresolvedThenable) as never
+    }
+    return unwrapped
+  }
+
+  if (resolved === null) {
+    // No data available. Suspend indefinitely.
+    use(unresolvedThenable) as never
+  }
+
+  return resolved
+}
+
+/**
  * InnerLayoutRouter handles rendering the provided segment based on the cache.
  */
 function InnerLayoutRouter({
@@ -445,42 +486,7 @@ function InnerLayoutRouter({
         (use(unresolvedThenable) as never)
 
   // `rsc` represents the renderable node for this segment.
-
-  // If this segment has a `prefetchRsc`, it's the statically prefetched data.
-  // We should use that on initial render instead of `rsc`. Then we'll switch
-  // to `rsc` when the dynamic response streams in.
-  //
-  // If no prefetch data is available, then we go straight to rendering `rsc`.
-  const resolvedPrefetchRsc =
-    cacheNode.prefetchRsc !== null ? cacheNode.prefetchRsc : cacheNode.rsc
-
-  // We use `useDeferredValue` to handle switching between the prefetched and
-  // final values. The second argument is returned on initial render, then it
-  // re-renders with the first argument.
-  const rsc: any = useDeferredValue(cacheNode.rsc, resolvedPrefetchRsc)
-
-  // `rsc` is either a React node or a promise for a React node, except we
-  // special case `null` to represent that this segment's data is missing. If
-  // it's a promise, we need to unwrap it so we can determine whether or not the
-  // data is missing.
-  let resolvedRsc: React.ReactNode
-  if (isDeferredRsc(rsc)) {
-    const unwrappedRsc = use(rsc)
-    if (unwrappedRsc === null) {
-      // If the promise was resolved to `null`, it means the data for this
-      // segment was not returned by the server. Suspend indefinitely. When this
-      // happens, the router is responsible for triggering a new state update to
-      // un-suspend this segment.
-      use(unresolvedThenable) as never
-    }
-    resolvedRsc = unwrappedRsc
-  } else {
-    // This is not a deferred RSC promise. Don't need to unwrap it.
-    if (rsc === null) {
-      use(unresolvedThenable) as never
-    }
-    resolvedRsc = rsc
-  }
+  const resolvedRsc = useCacheNodeRsc(cacheNode.rsc, cacheNode.prefetchRsc)
 
   // In dev, we create a NavigationPromisesContext containing the instrumented promises that provide
   // `useSelectedLayoutSegment` and `useSelectedLayoutSegments`.

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -5,7 +5,12 @@ import { extractPathFromFlightRouterState } from './compute-changed-path'
 
 import type { AppRouterState } from './router-reducer-types'
 import { getFlightDataPartsFromPath } from '../../flight-data-helpers'
-import { createInitialCacheNodeForHydration } from './ppr-navigations'
+import {
+  createInitialCacheNodeForHydration,
+  createInitialCacheNodeForInstantTest,
+  FreshnessPolicy,
+  spawnDynamicRequests,
+} from './ppr-navigations'
 import {
   convertRootFlightRouterStateToRouteTree,
   getStaleAt,
@@ -83,12 +88,42 @@ export function createInitialRouterState({
     acc
   )
   const metadataVaryPath = acc.metadataVaryPath
-  const initialTask = createInitialCacheNodeForHydration(
-    navigatedAt,
-    initialRouteTree,
-    initialSeedData,
-    initialHead
-  )
+  const isInstantTest =
+    typeof window !== 'undefined' && !!self.__next_instant_test
+
+  const initialTask = isInstantTest
+    ? createInitialCacheNodeForInstantTest(
+        navigatedAt,
+        initialRouteTree,
+        initialSeedData,
+        initialHead
+      )
+    : createInitialCacheNodeForHydration(
+        navigatedAt,
+        initialRouteTree,
+        initialSeedData,
+        initialHead
+      )
+
+  // The Next-URL of the referrer, used for interception, is always null during
+  // the initial render, because we never intercept the initial navigation.
+  const initialNextUrl = null
+
+  // During instant navigation testing, spawn dynamic requests immediately.
+  // The dynamic data fetch starts right away but is blocked by the navigation
+  // lock (waitForNavigationLockIfActive in fetchMissingDynamicData). When the
+  // lock releases, the data writes into the cache nodes and the UI updates.
+  if (isInstantTest && location !== null) {
+    spawnDynamicRequests(
+      initialTask,
+      new URL(location.href),
+      initialNextUrl,
+      FreshnessPolicy.InstantTest,
+      { scrollableSegments: null, separateRefreshUrls: null },
+      null, // routeCacheEntry
+      'replace' // navigateType
+    )
+  }
 
   // The following only applies in the browser (location !== null) since neither
   // route learning nor segment cache state persists from SSR to client.
@@ -97,7 +132,7 @@ export function createInitialRouterState({
     discoverKnownRoute(
       Date.now(),
       location.pathname,
-      null, // nextUrl — initial render is never an interception
+      initialNextUrl,
       null, // No pending entry
       initialRouteTree,
       metadataVaryPath,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -88,6 +88,7 @@ export const enum FreshnessPolicy {
   RefreshAll,
   HMRRefresh,
   Gesture,
+  InstantTest,
 }
 
 const enum NavigationTaskStatus {
@@ -141,6 +142,34 @@ export function createInitialCacheNodeForHydration(
     initialTree,
     null,
     FreshnessPolicy.Hydration,
+    seedData,
+    seedHead,
+    null,
+    null,
+    false,
+    accumulation
+  )
+  return task
+}
+
+export function createInitialCacheNodeForInstantTest(
+  navigatedAt: number,
+  initialTree: RouteTree,
+  seedData: CacheNodeSeedData | null,
+  seedHead: HeadData
+): NavigationTask {
+  // Like createInitialCacheNodeForHydration, but uses FreshnessPolicy.InstantTest.
+  // This allows segments with partial/missing data to be marked as
+  // needsDynamicRequest, so that spawnDynamicRequests will fetch dynamic data.
+  const accumulation: NavigationRequestAccumulation = {
+    scrollableSegments: null,
+    separateRefreshUrls: null,
+  }
+  const task = createCacheNodeOnNavigation(
+    navigatedAt,
+    initialTree,
+    null,
+    FreshnessPolicy.InstantTest,
     seedData,
     seedHead,
     null,
@@ -333,6 +362,7 @@ function updateCacheNodeOnNavigation(
     case FreshnessPolicy.HistoryTraversal:
     case FreshnessPolicy.Hydration: // <- shouldn't happen during client nav
     case FreshnessPolicy.Gesture:
+    case FreshnessPolicy.InstantTest:
       // We should never drop dynamic data in shared layouts, except during
       // a refresh.
       shouldRefreshDynamicData = false
@@ -952,6 +982,27 @@ function createCacheNodeForSegment(
         cacheNode: createCacheNode(rsc, prefetchRsc, head, prefetchHead),
         needsDynamicRequest: false,
       }
+    }
+    case FreshnessPolicy.InstantTest: {
+      if (process.env.__NEXT_EXPOSE_TESTING_API) {
+        // Instant navigation test: the server served a static shell, so the
+        // seed data only contains static content. Use the seed as prefetchRsc
+        // (the partial state shown immediately) and create a deferred RSC for
+        // the full dynamic data that will be fetched from the server.
+        const prefetchRsc: React.ReactNode = seedRsc
+        const rsc: React.ReactNode = createDeferredRsc()
+        const prefetchHead: HeadData | null = isPage ? seedHead : null
+        const head: HeadData | null = isPage ? createDeferredRsc() : null
+        writeToBFCache(now, tree.varyPath, rsc, prefetchRsc, head, prefetchHead)
+        if (isPage && metadataVaryPath !== null) {
+          writeHeadToBFCache(now, metadataVaryPath, head, prefetchHead)
+        }
+        return {
+          cacheNode: createCacheNode(rsc, prefetchRsc, head, prefetchHead),
+          needsDynamicRequest: true,
+        }
+      }
+      break
     }
     case FreshnessPolicy.HistoryTraversal:
       const bfcacheEntry = readFromBFCache(tree.varyPath)

--- a/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
+++ b/packages/next/src/client/components/segment-cache/navigation-testing-lock.ts
@@ -18,7 +18,6 @@
 
 import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 import { NEXT_INSTANT_TEST_COOKIE } from '../app-router-headers'
-import { refreshOnInstantNavigationUnlock } from '../use-action-queue'
 
 type InstantNavCookieState = 'pending' | 'mpa' | 'spa'
 
@@ -131,7 +130,6 @@ export function startListeningForInstantNavigationCookie(): void {
       for (const cookie of event.deleted) {
         if (cookie.name === NEXT_INSTANT_TEST_COOKIE) {
           releaseLock()
-          refreshOnInstantNavigationUnlock()
           return
         }
       }

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -379,6 +379,7 @@ async function navigateToUnknownRoute(
     case FreshnessPolicy.Hydration: // <- shouldn't happen during client nav
     case FreshnessPolicy.RefreshAll:
     case FreshnessPolicy.HMRRefresh:
+    case FreshnessPolicy.InstantTest:
       dynamicRequestTree = DynamicRequestTreeForEntireRoute
       break
     default:

--- a/packages/next/src/client/components/use-action-queue.ts
+++ b/packages/next/src/client/components/use-action-queue.ts
@@ -2,33 +2,16 @@ import type { Dispatch } from 'react'
 import React, { use, useMemo, useOptimistic } from 'react'
 import { isThenable } from '../../shared/lib/is-thenable'
 import type { AppRouterActionQueue } from './app-router-instance'
-import {
-  ACTION_REFRESH,
-  type AppRouterState,
-  type ReducerActions,
-  type ReducerState,
+import type {
+  AppRouterState,
+  ReducerActions,
+  ReducerState,
 } from './router-reducer/router-reducer-types'
 
 // The app router state lives outside of React, so we can import the dispatch
 // method directly wherever we need it, rather than passing it around via props
 // or context.
 let dispatch: Dispatch<ReducerActions> | null = null
-
-/**
- * Called when the instant navigation test lock is released. If the router
- * is initialized, dispatches a soft refresh to fetch dynamic data. If not
- * (e.g. the lock was released before hydration finished), falls back to a
- * hard reload.
- */
-export function refreshOnInstantNavigationUnlock() {
-  if (process.env.__NEXT_EXPOSE_TESTING_API) {
-    if (dispatch !== null) {
-      dispatch({ type: ACTION_REFRESH, bypassCacheInvalidation: true })
-    } else {
-      window.location.reload()
-    }
-  }
-}
 
 export function dispatchAppRouterAction(action: ReducerActions) {
   if (dispatch === null) {

--- a/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
+++ b/packages/next/src/next-devtools/dev-overlay/components/instant-navs/instant-navs-panel.tsx
@@ -64,9 +64,9 @@ export function InstantNavsPanel() {
 
   function handleContinueRendering() {
     // Delete the cookie to release the lock. The CookieStore change
-    // event triggers refreshOnInstantNavigationUnlock which does a
-    // soft refresh to fetch dynamic data. The panel stays open so
-    // the user can start another capture.
+    // event releases the navigation lock, which unblocks any in-flight
+    // dynamic requests spawned during hydration. The panel stays open
+    // so the user can start another capture.
     if (typeof cookieStore !== 'undefined') {
       cookieStore.delete(COOKIE_NAME)
     }


### PR DESCRIPTION
## Summary

- **Unify CacheNode RSC rendering with `useCacheNodeRsc` hook**: The root segment, child segments, and head are all the same concept — RSC content that may arrive in two phases (prefetch then dynamic). Previously, each was rendered differently: the root rendered `cache.rsc` directly, child segments used `useDeferredValue` inline in `InnerLayoutRouter`, and head used `useDeferredValue` inline in `Head`. This extracts all three into a shared `useCacheNodeRsc` hook with consistent behavior. Also renders `SegmentViewStateNode` at the root level in `Router` so the devtools overlay receives the route tree immediately without waiting for the full segment tree to mount.

- **Spawn dynamic requests during instant test hydration**: Instead of waiting for the lock to release and then doing a full `router.refresh`, spawn the dynamic data fetch immediately during `createInitialRouterState`. The fetch runs in parallel with hydration — the response arrives and is held by `waitForNavigationLockIfActive` until the user clicks "Continue rendering" in the devtools panel. When the lock releases, the fetched data is written directly into the CacheNode tree's deferred RSC promises, and React picks up the resolved values without a separate router action.

Follows up on #91207.

## Test plan

- Verified no hydration errors on normal and locked page loads
- Verified clicking "Continue rendering" in the devtools panel works (deletes cookie, panel transitions, page updates)
- Verified root `isDehydrated` is `false` after hydration on locked pages
- Verified no shimmer on the route label in the instant navs panel
- Verified `.click()` events work on the locked page (no event blocking)