### PR TITLE
Remove ineffective turbo-tasks

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -860,7 +860,6 @@ impl AppProject {
             None,
             ResolveErrorMode::Error,
         )
-        .to_resolved()
         .await?
         .first_module()
         .await?

--- a/crates/next-api/src/next_server_nft.rs
+++ b/crates/next-api/src/next_server_nft.rs
@@ -245,10 +245,11 @@ impl ServerNftJsonAsset {
                                 None,
                                 ResolveErrorMode::Error,
                             )
+                            .await?
                             .primary_modules()
                             .await?
                             .into_iter()
-                            .map(|m| **m))
+                            .map(|m| *m))
                         })
                         .try_flat_join()
                         .await?,

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -566,6 +566,7 @@ impl PagesProject {
             None,
         )
         .await?
+        .await?
         .first_module()
         .await?
         .context("expected Next.js client runtime to resolve to a module")?;

--- a/crates/next-core/src/next_client/runtime_entry.rs
+++ b/crates/next-core/src/next_client/runtime_entry.rs
@@ -40,7 +40,6 @@ impl RuntimeEntry {
             None,
             ResolveErrorMode::Error,
         )
-        .to_resolved()
         .await?
         .primary_modules()
         .await?;

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -1,6 +1,7 @@
 use std::{io::Write, iter::once};
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
@@ -320,12 +321,10 @@ impl ChunkItem for EcmascriptClientReferenceProxyChunkItem {
         self.inner_module.ident()
     }
 
-    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }
 
-    #[turbo_tasks::function]
     fn ty(&self) -> Vc<Box<dyn ChunkType>> {
         Vc::upcast(Vc::<EcmascriptChunkType>::default())
     }
@@ -336,21 +335,19 @@ impl ChunkItem for EcmascriptClientReferenceProxyChunkItem {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for EcmascriptClientReferenceProxyChunkItem {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<EcmascriptChunkItemContent> {
-        self.inner_chunk_item.content()
-    }
-
-    #[turbo_tasks::function]
-    fn content_with_async_module_info(
+    async fn content_with_async_module_info(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
         estimated: bool,
-    ) -> Vc<EcmascriptChunkItemContent> {
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
         self.inner_chunk_item
+            .into_trait_ref()
+            .await?
             .content_with_async_module_info(async_module_info, estimated)
+            .await
     }
 }
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -1,6 +1,7 @@
 use std::{io::Write, iter::once};
 
 use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
 use indoc::writedoc;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, ValueToString, Vc};
@@ -331,16 +332,18 @@ impl ChunkItem for EcmascriptClientReferenceProxyChunkItem {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for EcmascriptClientReferenceProxyChunkItem {
-    #[turbo_tasks::function]
-    fn content_with_async_module_info(
+    async fn content_with_async_module_info(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
         estimated: bool,
-    ) -> Vc<EcmascriptChunkItemContent> {
-        self.inner_chunk_item
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        let inner = self.inner_chunk_item.into_trait_ref().await?;
+        inner
             .content_with_async_module_info(async_module_info, estimated)
+            .await
     }
 }
 

--- a/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
+++ b/crates/next-core/src/next_client_reference/ecmascript_client_reference/ecmascript_client_reference_module.rs
@@ -317,12 +317,10 @@ impl ChunkItem for EcmascriptClientReferenceProxyChunkItem {
         self.inner_module.ident()
     }
 
-    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }
 
-    #[turbo_tasks::function]
     fn ty(&self) -> Vc<Box<dyn ChunkType>> {
         Vc::upcast(Vc::<EcmascriptChunkType>::default())
     }
@@ -335,11 +333,6 @@ impl ChunkItem for EcmascriptClientReferenceProxyChunkItem {
 
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for EcmascriptClientReferenceProxyChunkItem {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<EcmascriptChunkItemContent> {
-        self.inner_chunk_item.content()
-    }
-
     #[turbo_tasks::function]
     fn content_with_async_module_info(
         &self,

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -52,24 +52,27 @@ struct NextFontLocalFontFileOptions {
 #[turbo_tasks::value]
 pub(crate) struct NextFontLocalResolvePlugin {
     root: FileSystemPath,
+    condition: ResolvedVc<BeforeResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath) -> Vc<Self> {
-        NextFontLocalResolvePlugin { root }.cell()
+    pub async fn new(root: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = BeforeResolvePluginCondition::from_request_glob(Glob::new(
+            rcstr!("{next,@vercel/turbopack-next/internal}/font/local/*"),
+            GlobOptions::default(),
+        ))
+        .to_resolved()
+        .await?;
+        Ok(NextFontLocalResolvePlugin { root, condition }.cell())
     }
 }
 
 #[turbo_tasks::value_impl]
 impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
-    #[turbo_tasks::function]
     fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_request_glob(Glob::new(
-            rcstr!("{next,@vercel/turbopack-next/internal}/font/local/*"),
-            GlobOptions::default(),
-        ))
+        *self.condition
     }
 
     #[turbo_tasks::function]

--- a/crates/next-core/src/next_font/local/mod.rs
+++ b/crates/next-core/src/next_font/local/mod.rs
@@ -52,34 +52,37 @@ struct NextFontLocalFontFileOptions {
 #[turbo_tasks::value]
 pub(crate) struct NextFontLocalResolvePlugin {
     root: FileSystemPath,
+    condition: ResolvedVc<BeforeResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextFontLocalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath) -> Vc<Self> {
-        NextFontLocalResolvePlugin { root }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
-    #[turbo_tasks::function]
-    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_request_glob(Glob::new(
+    pub async fn new(root: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = BeforeResolvePluginCondition::from_request_glob(Glob::new(
             rcstr!("{next,@vercel/turbopack-next/internal}/font/local/*"),
             GlobOptions::default(),
         ))
+        .to_resolved()
+        .await?;
+        Ok(NextFontLocalResolvePlugin { root, condition }.cell())
+    }
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl BeforeResolvePlugin for NextFontLocalResolvePlugin {
+    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
+        *self.condition
     }
 
-    #[turbo_tasks::function]
     async fn before_resolve(
-        self: Vc<Self>,
+        &self,
         lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         request_vc: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
-        let this = &*self.await?;
+        let this = self;
         let request = &*request_vc.await?;
 
         let Some(request_key) = request.request() else {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1269,7 +1269,7 @@ pub async fn try_get_next_package(
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
         node_cjs_resolve_options(root.clone()),
     );
-    if let Some(source) = &*result.first_source().await? {
+    if let Some(source) = result.await?.first_source() {
         Ok(Vc::cell(Some(source.ident().await?.path.parent())))
     } else {
         MissingNextFolderIssue {

--- a/crates/next-core/src/next_import_map.rs
+++ b/crates/next-core/src/next_import_map.rs
@@ -1269,7 +1269,7 @@ pub async fn try_get_next_package(
         Request::parse(Pattern::Constant(rcstr!("next/package.json"))),
         node_cjs_resolve_options(root.clone()),
     );
-    if let Some(source) = &*result.first_source().await? {
+    if let Some(source) = result.await?.first_source() {
         Ok(Vc::cell(Some(source.ident().path().await?.parent())))
     } else {
         MissingNextFolderIssue {

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -42,41 +42,38 @@ pub enum ExternalPredicate {
 /// possible to resolve them at runtime.
 #[turbo_tasks::value]
 pub(crate) struct ExternalCjsModulesResolvePlugin {
-    root: FileSystemPath,
     predicate: ResolvedVc<ExternalPredicate>,
     import_externals: bool,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         root: FileSystemPath,
         predicate: ResolvedVc<ExternalPredicate>,
         import_externals: bool,
-    ) -> Vc<Self> {
-        ExternalCjsModulesResolvePlugin {
+    ) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
             root,
+            Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
+        )
+        .to_resolved()
+        .await?;
+        Ok(ExternalCjsModulesResolvePlugin {
             predicate,
             import_externals,
+            condition,
         }
-        .cell()
+        .cell())
     }
-}
-
-#[turbo_tasks::function]
-fn condition(root: FileSystemPath) -> Vc<AfterResolvePluginCondition> {
-    AfterResolvePluginCondition::new_with_glob(
-        root,
-        Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
-    )
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
-    #[turbo_tasks::function]
     fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        condition(self.root.clone())
+        *self.condition
     }
 
     #[turbo_tasks::function]
@@ -85,7 +82,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         fs_path: FileSystemPath,
         lookup_path: FileSystemPath,
         reference_type: ReferenceType,
-        request: ResolvedVc<Request>,
+        request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
         let request_value = &*request.await?;
         let Request::Module {
@@ -112,10 +109,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         let predicate = self.predicate.await?;
         let must_be_external = match &*predicate {
             ExternalPredicate::AllExcept(exceptions) => {
-                if *condition(self.root.clone())
-                    .matches(lookup_path.clone())
-                    .await?
-                {
+                if self.condition.await?.matches(&lookup_path) {
                     return Ok(ResolveResultOption::none());
                 }
 
@@ -214,7 +208,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             Ok(ResolveResultOption::none())
         };
 
-        let mut request = *request;
+        let mut request = request;
         let mut request_str = request_str.to_string();
 
         let node_resolve_options = if is_esm {
@@ -230,7 +224,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 node_resolve_options,
             );
             let Some(result_from_original_location) =
-                *node_resolved_from_original_location.first_source().await?
+                node_resolved_from_original_location.await?.first_source()
             else {
                 if is_esm
                     && !package_subpath.is_empty()
@@ -288,7 +282,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     request,
                     node_resolve_options,
                 );
-                let resolves_equal = if let Some(result) = *node_resolved.first_source().await? {
+                let resolves_equal = if let Some(result) = node_resolved.await?.first_source() {
                     let ident = result.ident().await?;
                     let cjs_path = &ident.path;
                     cjs_path == path

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -64,29 +64,25 @@ impl ExternalCjsModulesResolvePlugin {
     }
 }
 
-#[turbo_tasks::function]
-fn condition(root: FileSystemPath) -> Vc<AfterResolvePluginCondition> {
-    AfterResolvePluginCondition::new_with_glob(
-        root,
-        Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
-    )
-}
-
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
     fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        condition(self.root.clone())
+        AfterResolvePluginCondition::new_with_glob(
+            self.root.clone(),
+            Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
+        )
     }
 
     #[turbo_tasks::function]
     async fn after_resolve(
-        &self,
+        self: Vc<Self>,
         fs_path: FileSystemPath,
         lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: ResolvedVc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
+        let this = self.await?;
         let request_value = &*request.await?;
         let Request::Module {
             module: package,
@@ -109,10 +105,11 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
 
         let raw_fs_path = fs_path.clone();
 
-        let predicate = self.predicate.await?;
+        let predicate = this.predicate.await?;
         let must_be_external = match &*predicate {
             ExternalPredicate::AllExcept(exceptions) => {
-                if *condition(self.root.clone())
+                if *self
+                    .after_resolve_condition()
                     .matches(lookup_path.clone())
                     .await?
                 {
@@ -155,7 +152,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             }
         };
 
-        let is_esm = self.import_externals
+        let is_esm = this.import_externals
             && ReferenceTypeCondition::EcmaScriptModules(None).includes(&reference_type);
 
         #[derive(Debug, Copy, Clone)]
@@ -230,7 +227,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                 node_resolve_options,
             );
             let Some(result_from_original_location) =
-                *node_resolved_from_original_location.first_source().await?
+                node_resolved_from_original_location.await?.first_source()
             else {
                 if is_esm
                     && !package_subpath.is_empty()
@@ -287,7 +284,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
                     request,
                     node_resolve_options,
                 );
-                let resolves_equal = if let Some(result) = *node_resolved.first_source().await? {
+                let resolves_equal = if let Some(result) = node_resolved.await?.first_source() {
                     let cjs_path = result.ident().path().owned().await?;
                     cjs_path == *path
                 } else {

--- a/crates/next-core/src/next_server/resolve.rs
+++ b/crates/next-core/src/next_server/resolve.rs
@@ -42,47 +42,49 @@ pub enum ExternalPredicate {
 /// possible to resolve them at runtime.
 #[turbo_tasks::value]
 pub(crate) struct ExternalCjsModulesResolvePlugin {
-    root: FileSystemPath,
     predicate: ResolvedVc<ExternalPredicate>,
     import_externals: bool,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl ExternalCjsModulesResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(
+    pub async fn new(
         root: FileSystemPath,
         predicate: ResolvedVc<ExternalPredicate>,
         import_externals: bool,
-    ) -> Vc<Self> {
-        ExternalCjsModulesResolvePlugin {
+    ) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
             root,
+            Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
+        )
+        .to_resolved()
+        .await?;
+        Ok(ExternalCjsModulesResolvePlugin {
             predicate,
             import_externals,
+            condition,
         }
-        .cell()
+        .cell())
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
-    #[turbo_tasks::function]
     fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
-        AfterResolvePluginCondition::new_with_glob(
-            self.root.clone(),
-            Glob::new(rcstr!("**/node_modules/**"), GlobOptions::default()),
-        )
+        *self.condition
     }
 
-    #[turbo_tasks::function]
     async fn after_resolve(
-        self: Vc<Self>,
+        &self,
         fs_path: FileSystemPath,
         lookup_path: FileSystemPath,
         reference_type: ReferenceType,
-        request: ResolvedVc<Request>,
+        request: Vc<Request>,
     ) -> Result<Vc<ResolveResultOption>> {
-        let this = self.await?;
+        let this = self;
         let request_value = &*request.await?;
         let Request::Module {
             module: package,
@@ -108,11 +110,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
         let predicate = this.predicate.await?;
         let must_be_external = match &*predicate {
             ExternalPredicate::AllExcept(exceptions) => {
-                if *self
-                    .after_resolve_condition()
-                    .matches(lookup_path.clone())
-                    .await?
-                {
+                if self.condition.await?.matches(&lookup_path) {
                     return Ok(ResolveResultOption::none());
                 }
 
@@ -211,7 +209,7 @@ impl AfterResolvePlugin for ExternalCjsModulesResolvePlugin {
             Ok(ResolveResultOption::none())
         };
 
-        let mut request = *request;
+        let mut request = request;
         let mut request_str = request_str.to_string();
 
         let node_resolve_options = if is_esm {

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -92,33 +92,35 @@ impl Issue for InvalidImportModuleIssue {
 
 #[turbo_tasks::value]
 pub(crate) struct NextExternalResolvePlugin {
-    project_path: FileSystemPath,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextExternalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(project_path: FileSystemPath) -> Vc<Self> {
-        NextExternalResolvePlugin { project_path }.cell()
+    pub async fn new(project_path: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
+            project_path.root().owned().await?,
+            Glob::new(
+                rcstr!("**/next/dist/**/*.{external,runtime.dev,runtime.prod}.js"),
+                GlobOptions::default(),
+            ),
+        )
+        .to_resolved()
+        .await?;
+        Ok(NextExternalResolvePlugin { condition }.cell())
     }
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextExternalResolvePlugin {
-    #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new_with_glob(
-            self.project_path.root().owned().await?,
-            Glob::new(
-                rcstr!("**/next/dist/**/*.{external,runtime.dev,runtime.prod}.js"),
-                GlobOptions::default(),
-            ),
-        ))
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+        *self.condition
     }
 
     #[turbo_tasks::function]
     async fn after_resolve(
-        &self,
+        self: Vc<Self>,
         fs_path: FileSystemPath,
         _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
@@ -146,33 +148,38 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextNodeSharedRuntimeResolvePlugin {
-    root: FileSystemPath,
     server_context_type: ServerContextType,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath, server_context_type: ServerContextType) -> Vc<Self> {
-        NextNodeSharedRuntimeResolvePlugin {
-            root,
+    pub async fn new(
+        root: FileSystemPath,
+        server_context_type: ServerContextType,
+    ) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
+            root.root().owned().await?,
+            Glob::new(
+                rcstr!("**/next/dist/**/*.shared-runtime.js"),
+                GlobOptions::default(),
+            ),
+        )
+        .to_resolved()
+        .await?;
+        Ok(NextNodeSharedRuntimeResolvePlugin {
             server_context_type,
+            condition,
         }
-        .cell()
+        .cell())
     }
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
-    #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new_with_glob(
-            self.root.root().owned().await?,
-            Glob::new(
-                rcstr!("**/next/dist/**/*.shared-runtime.js"),
-                GlobOptions::default(),
-            ),
-        ))
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+        *self.condition
     }
 
     #[turbo_tasks::function]
@@ -225,32 +232,34 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
 /// telemetry events if there is a match.
 #[turbo_tasks::value]
 pub(crate) struct ModuleFeatureReportResolvePlugin {
-    root: FileSystemPath,
+    condition: ResolvedVc<BeforeResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl ModuleFeatureReportResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath) -> Vc<Self> {
-        ModuleFeatureReportResolvePlugin { root }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
-    #[turbo_tasks::function]
-    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_modules(Vc::cell(
+    pub async fn new(_root: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = BeforeResolvePluginCondition::from_modules(Vc::cell(
             FEATURE_MODULES
                 .keys()
                 .map(|k| (*k).into())
                 .collect::<Vec<RcStr>>(),
         ))
+        .to_resolved()
+        .await?;
+        Ok(ModuleFeatureReportResolvePlugin { condition }.cell())
+    }
+}
+
+#[turbo_tasks::value_impl]
+impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
+    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
+        *self.condition
     }
 
     #[turbo_tasks::function]
     async fn before_resolve(
-        &self,
+        self: Vc<Self>,
         _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,
         request: Vc<Request>,
@@ -269,6 +278,7 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
                     .find(|sub_path| path.is_match(sub_path));
 
                 if let Some(sub_path) = sub_path {
+                    // This is not accurate. we only emit one diagnostic per request not per import
                     ModuleFeatureTelemetry::new(format!("{module}{sub_path}").into(), 1)
                         .resolved_cell()
                         .emit();
@@ -282,33 +292,35 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextSharedRuntimeResolvePlugin {
-    root: FileSystemPath,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath) -> Vc<Self> {
-        NextSharedRuntimeResolvePlugin { root }.cell()
+    pub async fn new(root: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
+            root.root().owned().await?,
+            Glob::new(
+                rcstr!("**/next/dist/esm/**/*.shared-runtime.js"),
+                GlobOptions::default(),
+            ),
+        )
+        .to_resolved()
+        .await?;
+        Ok(NextSharedRuntimeResolvePlugin { condition }.cell())
     }
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
-    #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new_with_glob(
-            self.root.root().owned().await?,
-            Glob::new(
-                rcstr!("**/next/dist/esm/**/*.shared-runtime.js"),
-                GlobOptions::default(),
-            ),
-        ))
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+        *self.condition
     }
 
     #[turbo_tasks::function]
     async fn after_resolve(
-        &self,
+        self: Vc<Self>,
         fs_path: FileSystemPath,
         _lookup_path: FileSystemPath,
         _reference_type: ReferenceType,

--- a/crates/next-core/src/next_shared/resolve.rs
+++ b/crates/next-core/src/next_shared/resolve.rs
@@ -100,31 +100,33 @@ impl Issue for InvalidImportModuleIssue {
 
 #[turbo_tasks::value]
 pub(crate) struct NextExternalResolvePlugin {
-    project_path: FileSystemPath,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextExternalResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(project_path: FileSystemPath) -> Vc<Self> {
-        NextExternalResolvePlugin { project_path }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl AfterResolvePlugin for NextExternalResolvePlugin {
-    #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new_with_glob(
-            self.project_path.root().owned().await?,
+    pub async fn new(project_path: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
+            project_path.root().owned().await?,
             Glob::new(
                 rcstr!("**/next/dist/**/*.{external,runtime.dev,runtime.prod}.js"),
                 GlobOptions::default(),
             ),
-        ))
+        )
+        .to_resolved()
+        .await?;
+        Ok(NextExternalResolvePlugin { condition }.cell())
+    }
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl AfterResolvePlugin for NextExternalResolvePlugin {
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+        *self.condition
     }
 
-    #[turbo_tasks::function]
     async fn after_resolve(
         &self,
         fs_path: FileSystemPath,
@@ -154,36 +156,41 @@ impl AfterResolvePlugin for NextExternalResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextNodeSharedRuntimeResolvePlugin {
-    root: FileSystemPath,
     server_context_type: ServerContextType,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextNodeSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath, server_context_type: ServerContextType) -> Vc<Self> {
-        NextNodeSharedRuntimeResolvePlugin {
-            root,
-            server_context_type,
-        }
-        .cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
-    #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new_with_glob(
-            self.root.root().owned().await?,
+    pub async fn new(
+        root: FileSystemPath,
+        server_context_type: ServerContextType,
+    ) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
+            root.root().owned().await?,
             Glob::new(
                 rcstr!("**/next/dist/**/*.shared-runtime.js"),
                 GlobOptions::default(),
             ),
-        ))
+        )
+        .to_resolved()
+        .await?;
+        Ok(NextNodeSharedRuntimeResolvePlugin {
+            server_context_type,
+            condition,
+        }
+        .cell())
+    }
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+        *self.condition
     }
 
-    #[turbo_tasks::function]
     async fn after_resolve(
         &self,
         fs_path: FileSystemPath,
@@ -233,30 +240,32 @@ impl AfterResolvePlugin for NextNodeSharedRuntimeResolvePlugin {
 /// telemetry events if there is a match.
 #[turbo_tasks::value]
 pub(crate) struct ModuleFeatureReportResolvePlugin {
-    root: FileSystemPath,
+    condition: ResolvedVc<BeforeResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl ModuleFeatureReportResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath) -> Vc<Self> {
-        ModuleFeatureReportResolvePlugin { root }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
-    #[turbo_tasks::function]
-    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
-        BeforeResolvePluginCondition::from_modules(Vc::cell(
+    pub async fn new(_root: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = BeforeResolvePluginCondition::from_modules(Vc::cell(
             FEATURE_MODULES
                 .keys()
                 .map(|k| (*k).into())
                 .collect::<Vec<RcStr>>(),
         ))
+        .to_resolved()
+        .await?;
+        Ok(ModuleFeatureReportResolvePlugin { condition }.cell())
+    }
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
+    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition> {
+        *self.condition
     }
 
-    #[turbo_tasks::function]
     async fn before_resolve(
         &self,
         _lookup_path: FileSystemPath,
@@ -290,31 +299,33 @@ impl BeforeResolvePlugin for ModuleFeatureReportResolvePlugin {
 
 #[turbo_tasks::value]
 pub(crate) struct NextSharedRuntimeResolvePlugin {
-    root: FileSystemPath,
+    condition: ResolvedVc<AfterResolvePluginCondition>,
 }
 
 #[turbo_tasks::value_impl]
 impl NextSharedRuntimeResolvePlugin {
     #[turbo_tasks::function]
-    pub fn new(root: FileSystemPath) -> Vc<Self> {
-        NextSharedRuntimeResolvePlugin { root }.cell()
-    }
-}
-
-#[turbo_tasks::value_impl]
-impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
-    #[turbo_tasks::function]
-    async fn after_resolve_condition(&self) -> Result<Vc<AfterResolvePluginCondition>> {
-        Ok(AfterResolvePluginCondition::new_with_glob(
-            self.root.root().owned().await?,
+    pub async fn new(root: FileSystemPath) -> Result<Vc<Self>> {
+        let condition = AfterResolvePluginCondition::new_with_glob(
+            root.root().owned().await?,
             Glob::new(
                 rcstr!("**/next/dist/esm/**/*.shared-runtime.js"),
                 GlobOptions::default(),
             ),
-        ))
+        )
+        .to_resolved()
+        .await?;
+        Ok(NextSharedRuntimeResolvePlugin { condition }.cell())
+    }
+}
+
+#[async_trait]
+#[turbo_tasks::value_impl]
+impl AfterResolvePlugin for NextSharedRuntimeResolvePlugin {
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition> {
+        *self.condition
     }
 
-    #[turbo_tasks::function]
     async fn after_resolve(
         &self,
         fs_path: FileSystemPath,

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -135,8 +135,10 @@ pub async fn get_swc_ecma_transform_rule_impl(
                 )
                 .await?;
 
-                let Some(plugin_module) =
-                    &*plugin_wasm_module_resolve_result.first_module().await?
+                let Some(plugin_module) = plugin_wasm_module_resolve_result
+                    .await?
+                    .first_module()
+                    .await?
                 else {
                     // Ignore unresolvable plugin modules, handle_resolve_error has already emitted
                     // an issue.

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -260,7 +260,7 @@ async fn detect_react_compiler_target(
         node_cjs_resolve_options(project_path.root().owned().await?),
     );
 
-    let Some(source) = &*react_pkg_result.first_source().await? else {
+    let Some(source) = react_pkg_result.await?.first_source() else {
         return Ok(None);
     };
 
@@ -335,7 +335,7 @@ pub async fn resolve_babel_plugin_react_compiler(
         Request::parse(Pattern::Constant(BABEL_PLUGIN_REACT_COMPILER_PACKAGE_JSON)),
         node_cjs_resolve_options(project_path.root().owned().await?),
     );
-    let Some(source) = &*babel_plugin_result.first_source().await? else {
+    let Some(source) = babel_plugin_result.await?.first_source() else {
         BabelPluginReactCompilerResolutionIssue {
             failed_resolution: BABEL_PLUGIN_REACT_COMPILER,
             config_file_path: next_config

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -259,7 +259,7 @@ async fn detect_react_compiler_target(
         node_cjs_resolve_options(project_path.root().owned().await?),
     );
 
-    let Some(source) = &*react_pkg_result.first_source().await? else {
+    let Some(source) = react_pkg_result.await?.first_source() else {
         return Ok(None);
     };
 
@@ -335,7 +335,7 @@ pub async fn resolve_babel_plugin_react_compiler(
         ))),
         node_cjs_resolve_options(project_path.root().owned().await?),
     );
-    let Some(source) = &*babel_plugin_result.first_source().await? else {
+    let Some(source) = babel_plugin_result.await?.first_source() else {
         BabelPluginReactCompilerResolutionIssue {
             failed_resolution: rcstr!(BABEL_PLUGIN_REACT_COMPILER),
             config_file_path: next_config

--- a/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
+++ b/turbopack/crates/turbo-tasks-fs/src/read_glob.rs
@@ -204,7 +204,7 @@ async fn track_glob_internal(
                             types.push(path.get_type())
                         }
                     }
-                    // The most likely case of this is actually a sylink resolution error, it is
+                    // The most likely case of this is actually a symlink resolution error, it is
                     // fine to ignore since the mere act of attempting to resolve it has triggered
                     // the ncecessary dependencies.  If this file is actually a dependency we should
                     // get an error in the actual webpack loader when it reads it.

--- a/turbopack/crates/turbopack-browser/src/react_refresh.rs
+++ b/turbopack/crates/turbopack-browser/src/react_refresh.rs
@@ -63,9 +63,9 @@ pub async fn assert_can_resolve_react_refresh(
             request,
             resolve_options,
         )
-        .first_source();
+        .await?;
 
-        if result.await?.is_some() {
+        if result.first_source().is_some() {
             return Ok(ResolveReactRefreshResult::Found(request.to_resolved().await?).cell());
         }
     }

--- a/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
+++ b/turbopack/crates/turbopack-cli-utils/src/runtime_entry.rs
@@ -40,7 +40,6 @@ impl RuntimeEntry {
             None,
             ResolveErrorMode::Error,
         )
-        .to_resolved()
         .await?
         .primary_modules()
         .await?;

--- a/turbopack/crates/turbopack-cli/src/build/mod.rs
+++ b/turbopack/crates/turbopack-cli/src/build/mod.rs
@@ -295,6 +295,7 @@ async fn build_internal(
                 origin
                     .resolve_asset(request_vc, origin.resolve_options(), ty)
                     .await?
+                    .await?
                     .first_module()
                     .await?
                     .with_context(|| {

--- a/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
+++ b/turbopack/crates/turbopack-cli/src/dev/web_entry_source.rs
@@ -138,15 +138,12 @@ pub async fn create_web_entry_source(
         .into_iter()
         .map(|request| async move {
             let ty = ReferenceType::Entry(EntryReferenceSubType::Web);
-            Ok(origin
+            origin
                 .resolve_asset(request, origin.resolve_options(), ty)
                 .await?
-                .to_resolved()
                 .await?
-                .primary_modules()
-                .await?
-                .first()
-                .copied())
+                .first_module()
+                .await
         })
         .try_flat_join()
         .await?;

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -175,14 +175,13 @@ pub async fn references_to_output_assets(
 ) -> Result<Vc<OutputAssetsWithReferenced>> {
     let output_assets = references
         .into_iter()
-        .map(|reference| reference.resolve_reference().primary_output_assets())
+        .map(|reference| async { Ok(reference.resolve_reference().await?.primary_output_assets()) })
         .try_join()
         .await?;
     let mut set = HashSet::new();
     let output_assets = output_assets
-        .iter()
+        .into_iter()
         .flatten()
-        .copied()
         .filter(|&asset| set.insert(asset))
         .collect::<Vec<_>>();
     Ok(OutputAssetsWithReferenced {

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -127,13 +127,26 @@ pub async fn make_chunk_group(
         })
         .try_join()
         .await?;
-    let async_loader_chunk_items = async_loaders.iter().map(|&chunk_item| {
-        ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(ChunkItemWithAsyncModuleInfo {
-            chunk_item,
-            module: None,
-            async_info: None,
+    let async_loader_chunk_items = async_loaders
+        .iter()
+        .map(async |&chunk_item| {
+            let chunk_type = chunk_item
+                .into_trait_ref()
+                .await?
+                .ty()
+                .to_resolved()
+                .await?;
+            Ok::<_, anyhow::Error>(ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(
+                ChunkItemWithAsyncModuleInfo {
+                    chunk_item,
+                    chunk_type,
+                    module: None,
+                    async_info: None,
+                },
+            ))
         })
-    });
+        .try_join()
+        .await?;
 
     let referenced_output_assets = traced_modules
         .into_iter()

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_group.rs
@@ -136,7 +136,7 @@ pub async fn make_chunk_group(
                 .ty()
                 .to_resolved()
                 .await?;
-            Ok::<_, anyhow::Error>(ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(
+            Ok(ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(
                 ChunkItemWithAsyncModuleInfo {
                     chunk_item,
                     chunk_type,

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
@@ -11,7 +11,7 @@ use turbo_tasks::{
 };
 
 use crate::{
-    chunk::{ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkType, ChunkableModule, ChunkingContext},
+    chunk::{ChunkItemWithAsyncModuleInfo, ChunkType, ChunkableModule, ChunkingContext},
     module_graph::{
         ModuleGraph,
         async_module_info::AsyncModulesInfo,
@@ -46,8 +46,15 @@ pub async fn attach_async_info_to_chunkable_module(
         .as_chunk_item(module_graph, chunking_context)
         .to_resolved()
         .await?;
+    let chunk_type = chunk_item
+        .into_trait_ref()
+        .await?
+        .ty()
+        .to_resolved()
+        .await?;
     Ok(ChunkItemWithAsyncModuleInfo {
         chunk_item,
+        chunk_type,
         module: Some(module),
         async_info,
     })
@@ -103,10 +110,9 @@ impl ChunkItemOrBatchWithAsyncModuleInfo {
         &self,
     ) -> Result<ChunkItemOrBatchWithAsyncModuleInfoByChunkType> {
         Ok(match self {
-            Self::ChunkItem(item) => Either::Left(smallvec![(
-                item.chunk_item.ty().to_resolved().await?,
-                Self::ChunkItem(item.clone())
-            )]),
+            Self::ChunkItem(item) => {
+                Either::Left(smallvec![(item.chunk_type, Self::ChunkItem(*item))])
+            }
             Self::Batch(batch) => Either::Right(batch.split_by_chunk_type().await?),
         })
     }
@@ -167,17 +173,15 @@ impl ChunkItemBatchWithAsyncModuleInfo {
         let Some((_, first)) = iter.next() else {
             return Ok(Vc::cell(SmallVec::new()));
         };
-        let chunk_type = first.chunk_item.ty().to_resolved().await?;
-        while let Some((i, item)) = iter.next() {
-            let ty = item.chunk_item.ty().to_resolved().await?;
+        let chunk_type = first.chunk_type;
+        for (i, item) in iter.by_ref() {
+            let ty = item.chunk_type;
             if ty != chunk_type {
                 let mut map = FxIndexMap::default();
                 map.insert(chunk_type, this.chunk_items[..i].to_vec());
-                map.insert(ty, vec![item.clone()]);
+                map.insert(ty, vec![*item]);
                 for (_, item) in iter {
-                    map.entry(item.chunk_item.ty().to_resolved().await?)
-                        .or_default()
-                        .push(item.clone());
+                    map.entry(item.chunk_type).or_default().push(*item);
                 }
                 return Ok(Vc::cell(
                     map.into_iter()

--- a/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunk_item_batch.rs
@@ -11,7 +11,7 @@ use turbo_tasks::{
 };
 
 use crate::{
-    chunk::{ChunkItem, ChunkItemWithAsyncModuleInfo, ChunkType, ChunkableModule, ChunkingContext},
+    chunk::{ChunkItemWithAsyncModuleInfo, ChunkType, ChunkableModule, ChunkingContext},
     module_graph::{
         ModuleGraph,
         async_module_info::AsyncModulesInfo,
@@ -104,7 +104,12 @@ impl ChunkItemOrBatchWithAsyncModuleInfo {
     ) -> Result<ChunkItemOrBatchWithAsyncModuleInfoByChunkType> {
         Ok(match self {
             Self::ChunkItem(item) => Either::Left(smallvec![(
-                item.chunk_item.ty().to_resolved().await?,
+                item.chunk_item
+                    .into_trait_ref()
+                    .await?
+                    .ty()
+                    .to_resolved()
+                    .await?,
                 Self::ChunkItem(item.clone())
             )]),
             Self::Batch(batch) => Either::Right(batch.split_by_chunk_type().await?),
@@ -167,17 +172,36 @@ impl ChunkItemBatchWithAsyncModuleInfo {
         let Some((_, first)) = iter.next() else {
             return Ok(Vc::cell(SmallVec::new()));
         };
-        let chunk_type = first.chunk_item.ty().to_resolved().await?;
+        let chunk_type = first
+            .chunk_item
+            .into_trait_ref()
+            .await?
+            .ty()
+            .to_resolved()
+            .await?;
         while let Some((i, item)) = iter.next() {
-            let ty = item.chunk_item.ty().to_resolved().await?;
+            let ty = item
+                .chunk_item
+                .into_trait_ref()
+                .await?
+                .ty()
+                .to_resolved()
+                .await?;
             if ty != chunk_type {
                 let mut map = FxIndexMap::default();
                 map.insert(chunk_type, this.chunk_items[..i].to_vec());
                 map.insert(ty, vec![item.clone()]);
                 for (_, item) in iter {
-                    map.entry(item.chunk_item.ty().to_resolved().await?)
-                        .or_default()
-                        .push(item.clone());
+                    map.entry(
+                        item.chunk_item
+                            .into_trait_ref()
+                            .await?
+                            .ty()
+                            .to_resolved()
+                            .await?,
+                    )
+                    .or_default()
+                    .push(item.clone());
                 }
                 return Ok(Vc::cell(
                     map.into_iter()

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/dev.rs
@@ -60,7 +60,7 @@ pub async fn expand_batches(
                             );
                             let asset_ident = item.chunk_item.asset_ident().to_string();
                             Ok(ChunkItemOrBatchWithInfo::ChunkItem {
-                                chunk_item: item.clone(),
+                                chunk_item: *item,
                                 size: *size.await?,
                                 asset_ident: asset_ident.owned().await?,
                             })

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -84,6 +84,7 @@ async fn batch_size(
         .map(
             |&ChunkItemWithAsyncModuleInfo {
                  chunk_item,
+                 chunk_type: _,
                  async_info,
                  module: _,
              }| {
@@ -106,18 +107,21 @@ async fn plain_chunk_items_with_info(
         ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(chunk_item_with_info) => {
             let ChunkItemWithAsyncModuleInfo {
                 chunk_item,
+                chunk_type,
                 async_info,
                 module: _,
             } = chunk_item_with_info;
 
             let asset_ident = chunk_item.asset_ident().to_string();
-            let ty = chunk_item.ty();
-            let chunk_item_size =
-                ty.chunk_item_size(chunking_context, *chunk_item, async_info.map(|info| *info));
+            let chunk_item_size = chunk_type.chunk_item_size(
+                chunking_context,
+                *chunk_item,
+                async_info.map(|info| *info),
+            );
 
             ChunkItemsWithInfo {
                 by_type: smallvec![(
-                    ty.to_resolved().await?,
+                    chunk_type,
                     smallvec![ChunkItemOrBatchWithInfo::ChunkItem {
                         chunk_item: chunk_item_with_info,
                         size: *chunk_item_size.await?,
@@ -162,6 +166,7 @@ async fn plain_chunk_items_with_info_with_type(
         ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(chunk_item_with_info) => {
             let &ChunkItemWithAsyncModuleInfo {
                 chunk_item,
+                chunk_type: _,
                 async_info,
                 module: _,
             } = chunk_item_with_info;
@@ -172,7 +177,7 @@ async fn plain_chunk_items_with_info_with_type(
             Ok((
                 ty,
                 smallvec![ChunkItemOrBatchWithInfo::ChunkItem {
-                    chunk_item: chunk_item_with_info.clone(),
+                    chunk_item: *chunk_item_with_info,
                     size: *chunk_item_size.await?,
                     asset_ident: asset_ident.owned().await?,
                 }],
@@ -413,7 +418,7 @@ async fn make_chunk(
                 .into_iter()
                 .map(|item| match item {
                     ChunkItemOrBatchWithInfo::ChunkItem { chunk_item, .. } => {
-                        ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(chunk_item.clone())
+                        ChunkItemOrBatchWithAsyncModuleInfo::ChunkItem(*chunk_item)
                     }
                     &ChunkItemOrBatchWithInfo::Batch { batch, .. } => {
                         ChunkItemOrBatchWithAsyncModuleInfo::Batch(batch)

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/mod.rs
@@ -111,7 +111,7 @@ async fn plain_chunk_items_with_info(
             } = chunk_item_with_info;
 
             let asset_ident = chunk_item.asset_ident().to_string();
-            let ty = chunk_item.ty();
+            let ty = chunk_item.into_trait_ref().await?.ty();
             let chunk_item_size =
                 ty.chunk_item_size(chunking_context, *chunk_item, async_info.map(|info| *info));
 

--- a/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking/style_production.rs
@@ -48,7 +48,7 @@ pub async fn make_style_production_chunks(
             } else {
                 make_chunk(
                     vec![&ChunkItemOrBatchWithInfo::ChunkItem {
-                        chunk_item: chunk_item.clone(),
+                        chunk_item: *chunk_item,
                         size: 0,
                         asset_ident: rcstr!(""),
                     }],

--- a/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs
@@ -160,13 +160,13 @@ impl ChunkGroupResult {
 #[turbo_tasks::value_impl]
 impl ChunkGroupResult {
     #[turbo_tasks::function]
-    pub async fn output_assets_with_referenced(&self) -> Result<Vc<OutputAssetsWithReferenced>> {
-        Ok(OutputAssetsWithReferenced {
+    pub fn output_assets_with_referenced(&self) -> Vc<OutputAssetsWithReferenced> {
+        OutputAssetsWithReferenced {
             assets: self.assets,
             referenced_assets: self.referenced_assets,
             references: self.references,
         }
-        .cell())
+        .cell()
     }
 
     #[turbo_tasks::function]

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod chunking_context;
 pub(crate) mod data;
 pub(crate) mod evaluate;
 
-use std::fmt::Display;
+use std::{fmt::Display, hash::Hash};
 
 use anyhow::{Result, bail};
 use auto_hash_map::AutoSet;
@@ -453,16 +453,14 @@ pub trait ChunkItem: OutputAssetsReference {
     }
 
     /// The type of chunk this item should be assembled into.
-    #[turbo_tasks::function]
-    fn ty(self: Vc<Self>) -> Vc<Box<dyn ChunkType>>;
+    fn ty(&self) -> Vc<Box<dyn ChunkType>>;
 
     /// A temporary method to retrieve the module associated with this
     /// ChunkItem. TODO: Remove this as part of the chunk refactoring.
     #[turbo_tasks::function]
     fn module(self: Vc<Self>) -> Vc<Box<dyn Module>>;
 
-    #[turbo_tasks::function]
-    fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>>;
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>>;
 }
 
 #[turbo_tasks::value_trait]
@@ -514,10 +512,11 @@ impl AsyncModuleInfo {
 }
 
 #[derive(
-    Debug, Clone, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue, Encode, Decode,
+    Debug, Clone, Copy, PartialEq, Eq, Hash, TraceRawVcs, TaskInput, NonLocalValue, Encode, Decode,
 )]
 pub struct ChunkItemWithAsyncModuleInfo {
     pub chunk_item: ResolvedVc<Box<dyn ChunkItem>>,
+    pub chunk_type: ResolvedVc<Box<dyn ChunkType>>,
     pub module: Option<ResolvedVc<Box<dyn ChunkableModule>>>,
     pub async_info: Option<ResolvedVc<AsyncModuleInfo>>,
 }
@@ -535,6 +534,8 @@ where
     async fn id(self: Vc<Self>) -> Result<ModuleId> {
         let chunk_item = Vc::upcast_non_strict(self);
         chunk_item
+            .into_trait_ref()
+            .await?
             .chunking_context()
             .chunk_item_id_strategy()
             .await?

--- a/turbopack/crates/turbopack-core/src/chunk/mod.rs
+++ b/turbopack/crates/turbopack-core/src/chunk/mod.rs
@@ -453,16 +453,14 @@ pub trait ChunkItem: OutputAssetsReference {
     }
 
     /// The type of chunk this item should be assembled into.
-    #[turbo_tasks::function]
-    fn ty(self: Vc<Self>) -> Vc<Box<dyn ChunkType>>;
+    fn ty(&self) -> Vc<Box<dyn ChunkType>>;
 
     /// A temporary method to retrieve the module associated with this
     /// ChunkItem. TODO: Remove this as part of the chunk refactoring.
     #[turbo_tasks::function]
     fn module(self: Vc<Self>) -> Vc<Box<dyn Module>>;
 
-    #[turbo_tasks::function]
-    fn chunking_context(self: Vc<Self>) -> Vc<Box<dyn ChunkingContext>>;
+    fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>>;
 }
 
 #[turbo_tasks::value_trait]
@@ -535,6 +533,8 @@ where
     async fn id(self: Vc<Self>) -> Result<ModuleId> {
         let chunk_item = Vc::upcast_non_strict(self);
         chunk_item
+            .into_trait_ref()
+            .await?
             .chunking_context()
             .chunk_item_id_strategy()
             .await?

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -86,7 +86,6 @@ pub async fn children_from_module_references(
 
         for &module in reference
             .resolve_reference()
-            .to_resolved()
             .await?
             .primary_modules()
             .await?

--- a/turbopack/crates/turbopack-core/src/introspect/utils.rs
+++ b/turbopack/crates/turbopack-core/src/introspect/utils.rs
@@ -86,7 +86,6 @@ pub async fn children_from_module_references(
 
         for &module in reference
             .resolve_reference()
-            .to_resolved()
             .await?
             .primary_modules()
             .await?
@@ -99,8 +98,8 @@ pub async fn children_from_module_references(
         }
         for &output_asset in reference
             .resolve_reference()
-            .primary_output_assets()
             .await?
+            .primary_output_assets()
             .iter()
         {
             children.insert((

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -12,7 +12,7 @@ use turbo_tasks::{
 
 use crate::{
     chunk::{
-        ChunkItem, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
+        ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
         ChunkableModule, ChunkingContext, chunk_item_batch::attach_async_info_to_chunkable_module,
     },
     module::{Module, StyleModule, StyleType},
@@ -232,8 +232,8 @@ pub async fn compute_style_groups(
                 chunking_context,
             )
             .await?;
-            let ty = chunk_item.chunk_item.ty();
-            let size = *ty
+            let size = *chunk_item
+                .chunk_type
                 .chunk_item_size(chunking_context, *chunk_item.chunk_item, None)
                 .await?;
             Ok((chunk_item, size))
@@ -271,7 +271,7 @@ pub async fn compute_style_groups(
 
         // The list of modules and chunk items that go into the new chunk
         let mut new_chunk_modules = [module].into_iter().collect::<FxHashSet<_>>();
-        let mut new_chunk_items = vec![info.chunk_item.as_ref().unwrap().clone()];
+        let mut new_chunk_items = vec![info.chunk_item.unwrap()];
 
         // The current size of the new chunk
         let mut current_size = info.size;
@@ -374,7 +374,7 @@ pub async fn compute_style_groups(
                     }
                 }
 
-                new_chunk_items.push(info.chunk_item.as_ref().unwrap().clone());
+                new_chunk_items.push(info.chunk_item.unwrap());
                 new_chunk_modules.insert(module);
                 *ordered_modules_with_state.get_mut(&module).unwrap() = true;
                 continue 'outer;

--- a/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/style_groups.rs
@@ -12,7 +12,7 @@ use turbo_tasks::{
 
 use crate::{
     chunk::{
-        ChunkItem, ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
+        ChunkItemBatchWithAsyncModuleInfo, ChunkItemWithAsyncModuleInfo, ChunkType,
         ChunkableModule, ChunkingContext, chunk_item_batch::attach_async_info_to_chunkable_module,
     },
     module::{Module, StyleModule, StyleType},
@@ -232,7 +232,7 @@ pub async fn compute_style_groups(
                 chunking_context,
             )
             .await?;
-            let ty = chunk_item.chunk_item.ty();
+            let ty = chunk_item.chunk_item.into_trait_ref().await?.ty();
             let size = *ty
                 .chunk_item_size(chunking_context, *chunk_item.chunk_item, None)
                 .await?;

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -178,15 +178,7 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
         .references()
         .await?
         .iter()
-        .map(|reference| async {
-            reference
-                .resolve_reference()
-                .to_resolved()
-                .await?
-                .primary_modules()
-                .owned()
-                .await
-        })
+        .map(|reference| async { reference.resolve_reference().await?.primary_modules().await })
         .try_join()
         .await?
         .into_iter()
@@ -231,7 +223,7 @@ pub async fn primary_chunkable_referenced_modules(
                 let resolved = reference
                     .resolve_reference()
                     .await?
-                    .primary_modules_ref()
+                    .primary_modules()
                     .await?;
                 let binding_usage = if include_binding_usage {
                     trait_ref.binding_usage()

--- a/turbopack/crates/turbopack-core/src/reference/mod.rs
+++ b/turbopack/crates/turbopack-core/src/reference/mod.rs
@@ -239,15 +239,7 @@ pub async fn primary_referenced_modules(module: Vc<Box<dyn Module>>) -> Result<V
         .references()
         .await?
         .iter()
-        .map(|reference| async {
-            reference
-                .resolve_reference()
-                .to_resolved()
-                .await?
-                .primary_modules()
-                .owned()
-                .await
-        })
+        .map(|reference| async { reference.resolve_reference().await?.primary_modules().await })
         .try_join()
         .await?
         .into_iter()
@@ -292,7 +284,7 @@ pub async fn primary_chunkable_referenced_modules(
                 let resolved = reference
                     .resolve_reference()
                     .await?
-                    .primary_modules_ref()
+                    .primary_modules()
                     .await?;
                 let binding_usage = if include_binding_usage {
                     trait_ref.binding_usage()

--- a/turbopack/crates/turbopack-core/src/resolve/error.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/error.rs
@@ -28,7 +28,7 @@ pub async fn handle_resolve_error(
 ) -> Result<Vc<ModuleResolveResult>> {
     Ok(match result.await {
         Ok(result_ref) => {
-            if result_ref.is_unresolvable_ref() {
+            if result_ref.is_unresolvable() {
                 emit_unresolvable_issue(
                     error_mode,
                     origin,
@@ -71,7 +71,7 @@ pub async fn handle_resolve_source_error(
 ) -> Result<Vc<ResolveResult>> {
     Ok(match result.await {
         Ok(result_ref) => {
-            if result_ref.is_unresolvable_ref() {
+            if result_ref.is_unresolvable() {
                 emit_unresolvable_issue(
                     error_mode,
                     origin,

--- a/turbopack/crates/turbopack-core/src/resolve/error.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/error.rs
@@ -71,7 +71,7 @@ pub async fn handle_resolve_source_error(
 ) -> Result<Vc<ResolveResult>> {
     Ok(match result.await {
         Ok(result_ref) => {
-            if result_ref.is_unresolvable_ref() {
+            if result_ref.is_unresolvable() {
                 emit_unresolvable_issue(
                     error_mode,
                     origin,

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -17,8 +17,8 @@ use tracing::{Instrument, Level};
 use turbo_frozenmap::{FrozenMap, FrozenSet};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
+    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt,
+    ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 use turbo_unix_path::normalize_request;
@@ -31,8 +31,8 @@ use crate::{
         Issue, IssueExt, IssueSource, module::emit_unknown_module_type_error,
         resolve::ResolvingIssue,
     },
-    module::{Module, Modules, OptionModule},
-    output::{OutputAsset, OutputAssets},
+    module::Module,
+    output::OutputAsset,
     package_json::{PackageJsonIssue, read_package_json},
     raw_module::RawModule,
     reference_type::ReferenceType,
@@ -50,7 +50,7 @@ use crate::{
         plugin::{AfterResolvePlugin, AfterResolvePluginCondition, BeforeResolvePlugin},
         remap::{ExportsField, ImportsField, ReplacedSubpathValueResult},
     },
-    source::{OptionSource, Source, Sources},
+    source::Source,
 };
 
 mod alias_map;
@@ -106,6 +106,10 @@ pub enum ModuleResolveResultItem {
     /// Resolve the reference to an empty module.
     Empty,
     Custom(u8),
+    /// A duplicate of an item that appeared earlier in the primary array.
+    /// The usize is the index of the first occurrence. Most callers should skip
+    /// this variant.
+    Duplicate(usize),
 }
 
 impl ModuleResolveResultItem {
@@ -260,11 +264,13 @@ impl ModuleResolveResult {
     pub fn modules(
         modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
     ) -> ResolvedVc<Self> {
+        let mut primary: Vec<_> = modules
+            .into_iter()
+            .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
+            .collect();
+        Self::mark_duplicates(&mut primary);
         ModuleResolveResult {
-            primary: modules
-                .into_iter()
-                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
-                .collect(),
+            primary: primary.into_boxed_slice(),
             affecting_sources: Default::default(),
         }
         .resolved_cell()
@@ -274,11 +280,13 @@ impl ModuleResolveResult {
         modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
         affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ResolvedVc<Self> {
+        let mut primary: Vec<_> = modules
+            .into_iter()
+            .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
+            .collect();
+        Self::mark_duplicates(&mut primary);
         ModuleResolveResult {
-            primary: modules
-                .into_iter()
-                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
-                .collect(),
+            primary: primary.into_boxed_slice(),
             affecting_sources: affecting_sources.into_boxed_slice(),
         }
         .resolved_cell()
@@ -286,6 +294,34 @@ impl ModuleResolveResult {
 }
 
 impl ModuleResolveResult {
+    /// Marks duplicate items as `Duplicate(first_index)` in place.
+    /// Preserves ordering; the first occurrence stays, subsequent occurrences
+    /// of the same module/output asset become `Duplicate`.
+    fn mark_duplicates(primary: &mut [(RequestKey, ModuleResolveResultItem)]) {
+        // Map from module/asset identity to the index of first occurrence
+        let mut seen_modules = FxHashMap::default();
+        let mut seen_output_assets = FxHashMap::default();
+        for (i, (_, item)) in primary.iter_mut().enumerate() {
+            match *item {
+                ModuleResolveResultItem::Module(m) => {
+                    if let Some(&first) = seen_modules.get(&m) {
+                        *item = ModuleResolveResultItem::Duplicate(first);
+                    } else {
+                        seen_modules.insert(m, i);
+                    }
+                }
+                ModuleResolveResultItem::OutputAsset(a) => {
+                    if let Some(&first) = seen_output_assets.get(&a) {
+                        *item = ModuleResolveResultItem::Duplicate(first);
+                    } else {
+                        seen_output_assets.insert(a, i);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Returns all module results (but ignoring any errors).
     pub fn primary_modules_raw_iter(
         &self,
@@ -296,15 +332,36 @@ impl ModuleResolveResult {
         })
     }
 
-    /// Returns a set (no duplicates) of primary modules in the result.
-    pub async fn primary_modules_ref(&self) -> Result<Vec<ResolvedVc<Box<dyn Module>>>> {
-        let mut set = FxIndexSet::default();
+    /// Returns primary modules (no duplicates). Emits errors for Unknown items.
+    /// Duplicates are already marked at construction time so no extra dedup is
+    /// needed here.
+    pub async fn primary_modules(&self) -> Result<Vec<ResolvedVc<Box<dyn Module>>>> {
+        self.primary
+            .iter()
+            .map(async |(_, item)| item.as_module().await)
+            .try_flat_join()
+            .await
+    }
+
+    /// Returns the first module in the result, or None.
+    pub async fn first_module(&self) -> Result<Option<ResolvedVc<Box<dyn Module>>>> {
         for (_, item) in self.primary.iter() {
             if let Some(module) = item.as_module().await? {
-                set.insert(module);
+                return Ok(Some(module));
             }
         }
-        Ok(set.into_iter().collect())
+        Ok(None)
+    }
+
+    /// Returns primary output assets (no duplicates).
+    pub fn primary_output_assets(&self) -> Vec<ResolvedVc<Box<dyn OutputAsset>>> {
+        self.primary
+            .iter()
+            .filter_map(|(_, item)| match item {
+                &ModuleResolveResultItem::OutputAsset(a) => Some(a),
+                _ => None,
+            })
+            .collect()
     }
 
     pub fn affecting_sources_iter(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
@@ -330,8 +387,10 @@ pub struct ModuleResolveResultBuilder {
 
 impl From<ModuleResolveResultBuilder> for ModuleResolveResult {
     fn from(v: ModuleResolveResultBuilder) -> Self {
+        let mut primary: Vec<_> = v.primary.into_iter().collect();
+        Self::mark_duplicates(&mut primary);
         ModuleResolveResult {
-            primary: v.primary.into_iter().collect(),
+            primary: primary.into_boxed_slice(),
             affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }
@@ -385,47 +444,6 @@ impl ModuleResolveResult {
         } else {
             Ok(*ModuleResolveResult::unresolvable())
         }
-    }
-
-    #[turbo_tasks::function]
-    pub fn is_unresolvable(&self) -> Vc<bool> {
-        Vc::cell(self.is_unresolvable_ref())
-    }
-
-    #[turbo_tasks::function]
-    pub async fn first_module(&self) -> Result<Vc<OptionModule>> {
-        for (_, item) in self.primary.iter() {
-            if let Some(module) = item.as_module().await? {
-                return Ok(Vc::cell(Some(module)));
-            }
-        }
-        Ok(Vc::cell(None))
-    }
-
-    /// Returns a set (no duplicates) of primary modules in the result. All
-    /// modules are already resolved Vc.
-    #[turbo_tasks::function]
-    pub async fn primary_modules(&self) -> Result<Vc<Modules>> {
-        let mut set = FxIndexSet::default();
-        for (_, item) in self.primary.iter() {
-            if let Some(module) = item.as_module().await? {
-                set.insert(module);
-            }
-        }
-        Ok(Vc::cell(set.into_iter().collect()))
-    }
-
-    #[turbo_tasks::function]
-    pub fn primary_output_assets(&self) -> Vc<OutputAssets> {
-        Vc::cell(
-            self.primary
-                .iter()
-                .filter_map(|(_, item)| match item {
-                    &ModuleResolveResultItem::OutputAsset(a) => Some(a),
-                    _ => None,
-                })
-                .collect(),
-        )
     }
 }
 
@@ -572,7 +590,7 @@ impl ValueToString for ResolveResult {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         let mut result = String::new();
-        if self.is_unresolvable_ref() {
+        if self.is_unresolvable() {
             result.push_str("unresolvable");
         }
         for (i, (request, item)) in self.primary.iter().enumerate() {
@@ -707,8 +725,28 @@ impl ResolveResult {
         self.affecting_sources.iter().copied()
     }
 
-    pub fn is_unresolvable_ref(&self) -> bool {
+    pub fn is_unresolvable(&self) -> bool {
         self.primary.is_empty()
+    }
+
+    pub fn first_source(&self) -> Option<ResolvedVc<Box<dyn Source>>> {
+        self.primary.iter().find_map(|(_, item)| {
+            if let &ResolveResultItem::Source(a) = item {
+                Some(a)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn primary_sources(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> {
+        self.primary.iter().filter_map(|(_, item)| {
+            if let &ResolveResultItem::Source(a) = item {
+                Some(a)
+            } else {
+                None
+            }
+        })
     }
 
     pub async fn map_module<A, AF>(&self, source_fn: A) -> Result<ModuleResolveResult>
@@ -949,38 +987,6 @@ impl ResolveResult {
         } else {
             Ok(ResolveResult::unresolvable_with_affecting_sources(affecting_sources).cell())
         }
-    }
-
-    #[turbo_tasks::function]
-    pub fn is_unresolvable(&self) -> Vc<bool> {
-        Vc::cell(self.is_unresolvable_ref())
-    }
-
-    #[turbo_tasks::function]
-    pub fn first_source(&self) -> Vc<OptionSource> {
-        Vc::cell(self.primary.iter().find_map(|(_, item)| {
-            if let &ResolveResultItem::Source(a) = item {
-                Some(a)
-            } else {
-                None
-            }
-        }))
-    }
-
-    #[turbo_tasks::function]
-    pub fn primary_sources(&self) -> Vc<Sources> {
-        Vc::cell(
-            self.primary
-                .iter()
-                .filter_map(|(_, item)| {
-                    if let &ResolveResultItem::Source(a) = item {
-                        Some(a)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-        )
     }
 
     /// Returns a new [ResolveResult] where all [RequestKey]s are updated. The `old_request_key`
@@ -1678,7 +1684,7 @@ pub async fn resolve_inline(
 #[turbo_tasks::function]
 pub async fn url_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
-    request: Vc<Request>,
+    request: ResolvedVc<Request>,
     reference_type: ReferenceType,
     issue_source: Option<IssueSource>,
     error_mode: ResolveErrorMode,
@@ -1693,11 +1699,11 @@ pub async fn url_resolve(
         resolve_options,
     );
     let result =
-        if *rel_result.is_unresolvable().await? && *rel_request.to_resolved().await? != request {
+        if rel_result.await?.is_unresolvable() && rel_request.to_resolved().await? != request {
             let result = resolve(
                 origin_path_parent,
                 reference_type.clone(),
-                request,
+                *request,
                 resolve_options,
             );
             if resolve_options.await?.collect_affecting_sources {
@@ -1721,7 +1727,7 @@ pub async fn url_resolve(
         result,
         reference_type,
         origin,
-        request,
+        *request,
         resolve_options,
         error_mode,
         issue_source,
@@ -2174,7 +2180,7 @@ async fn resolve_internal_inline(
         if !matches!(*request_value, Request::Alternatives { .. }) {
             // Apply fallback import mappings if provided
             if let Some(import_map) = &options_value.fallback_import_map
-                && *result.is_unresolvable().await?
+                && result.await?.is_unresolvable()
             {
                 let result = import_map
                     .await?
@@ -2251,7 +2257,7 @@ async fn resolve_into_folder(
                                 .await?;
                         // we are not that strict when a main field fails to resolve
                         // we continue to try other alternatives
-                        if !result.is_unresolvable_ref() {
+                        if !result.is_unresolvable() {
                             let mut result: ResolveResultBuilder =
                                 result.with_request_ref(rcstr!(".")).into();
                             if options_value.collect_affecting_sources {
@@ -2792,7 +2798,7 @@ async fn resolve_module_request(
             fragment.clone(),
             options,
         );
-        if !(*result.is_unresolvable().await?) {
+        if !result.await?.is_unresolvable() {
             return Ok(result);
         }
     }
@@ -3027,7 +3033,7 @@ async fn resolve_import_map_result(
                     },
                 )
                 .await?
-                .is_unresolvable_ref();
+                .is_unresolvable();
                 if is_external_resolvable {
                     Some(ResolveResultOrCell::Value(ResolveResult::primary(
                         ResolveResultItem::External {
@@ -3091,12 +3097,12 @@ impl ResolveResultOrCell {
     async fn into_cell_if_resolvable(self) -> Result<Option<Vc<ResolveResult>>> {
         match self {
             ResolveResultOrCell::Cell(resolved_result) => {
-                if !*resolved_result.is_unresolvable().await? {
+                if !resolved_result.await?.is_unresolvable() {
                     return Ok(Some(resolved_result));
                 }
             }
             ResolveResultOrCell::Value(resolve_result) => {
-                if !resolve_result.is_unresolvable_ref() {
+                if !resolve_result.is_unresolvable() {
                     return Ok(Some(resolve_result.cell()));
                 }
             }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -17,8 +17,8 @@ use tracing::{Instrument, Level};
 use turbo_frozenmap::{FrozenMap, FrozenSet};
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{
-    FxIndexMap, FxIndexSet, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt,
-    TryJoinIterExt, ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
+    FxIndexMap, NonLocalValue, ReadRef, ResolvedVc, TaskInput, TryFlatJoinIterExt, TryJoinIterExt,
+    ValueToString, ValueToStringRef, Vc, trace::TraceRawVcs,
 };
 use turbo_tasks_fs::{FileSystemEntryType, FileSystemPath};
 use turbo_unix_path::normalize_request;
@@ -31,7 +31,7 @@ use crate::{
         Issue, IssueExt, IssueSource, module::emit_unknown_module_type_error,
         resolve::ResolvingIssue,
     },
-    module::{Module, Modules, OptionModule},
+    module::Module,
     package_json::{PackageJsonIssue, read_package_json},
     raw_module::RawModule,
     reference_type::ReferenceType,
@@ -49,7 +49,7 @@ use crate::{
         plugin::{AfterResolvePlugin, AfterResolvePluginCondition, BeforeResolvePlugin},
         remap::{ExportsField, ImportsField, ReplacedSubpathValueResult},
     },
-    source::{OptionSource, Source, Sources},
+    source::Source,
 };
 
 mod alias_map;
@@ -83,7 +83,7 @@ pub enum ResolveErrorMode {
 /// Type alias for a resolved after-resolve plugin paired with its condition.
 type AfterResolvePluginWithCondition = (
     ResolvedVc<Box<dyn AfterResolvePlugin>>,
-    ResolvedVc<AfterResolvePluginCondition>,
+    ReadRef<AfterResolvePluginCondition>,
 );
 
 #[turbo_tasks::value(shared)]
@@ -104,9 +104,16 @@ pub enum ModuleResolveResultItem {
     /// Resolve the reference to an empty module.
     Empty,
     Custom(u8),
+    /// A duplicate of an item that appeared earlier in the primary array.
+    /// The usize is the index of the first occurrence. Most callers should skip
+    /// this variant.
+    Duplicate(usize),
 }
 
 impl ModuleResolveResultItem {
+    // Returns the module for this item if it is one
+    // NOTE: if this is a `ModuleResolveResultItem::Duplicate` we return `None`, it is expected that
+    // callers will have already found the module earlier.
     async fn as_module(&self) -> Result<Option<ResolvedVc<Box<dyn Module>>>> {
         Ok(match *self {
             ModuleResolveResultItem::Module(module) => Some(module),
@@ -243,11 +250,13 @@ impl ModuleResolveResult {
     pub fn modules(
         modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
     ) -> ResolvedVc<Self> {
+        let mut primary: Vec<_> = modules
+            .into_iter()
+            .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
+            .collect();
+        Self::mark_duplicates(&mut primary);
         ModuleResolveResult {
-            primary: modules
-                .into_iter()
-                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
-                .collect(),
+            primary: primary.into_boxed_slice(),
             affecting_sources: Default::default(),
         }
         .resolved_cell()
@@ -257,11 +266,13 @@ impl ModuleResolveResult {
         modules: impl IntoIterator<Item = (RequestKey, ResolvedVc<Box<dyn Module>>)>,
         affecting_sources: Vec<ResolvedVc<Box<dyn Source>>>,
     ) -> ResolvedVc<Self> {
+        let mut primary: Vec<_> = modules
+            .into_iter()
+            .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
+            .collect();
+        Self::mark_duplicates(&mut primary);
         ModuleResolveResult {
-            primary: modules
-                .into_iter()
-                .map(|(k, v)| (k, ModuleResolveResultItem::Module(v)))
-                .collect(),
+            primary: primary.into_boxed_slice(),
             affecting_sources: affecting_sources.into_boxed_slice(),
         }
         .resolved_cell()
@@ -269,6 +280,26 @@ impl ModuleResolveResult {
 }
 
 impl ModuleResolveResult {
+    /// Marks duplicate items as `Duplicate(first_index)` in place.
+    /// Preserves ordering; the first occurrence stays, subsequent occurrences
+    /// of the same module/output asset become `Duplicate`.
+    fn mark_duplicates(primary: &mut [(RequestKey, ModuleResolveResultItem)]) {
+        // Map from module identity to the index of first occurrence
+        let mut seen_modules = FxHashMap::default();
+        for (i, (_, item)) in primary.iter_mut().enumerate() {
+            match *item {
+                ModuleResolveResultItem::Module(m) => {
+                    if let Some(&first) = seen_modules.get(&m) {
+                        *item = ModuleResolveResultItem::Duplicate(first);
+                    } else {
+                        seen_modules.insert(m, i);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
     /// Returns all module results (but ignoring any errors).
     pub fn primary_modules_raw_iter(
         &self,
@@ -279,22 +310,32 @@ impl ModuleResolveResult {
         })
     }
 
-    /// Returns a set (no duplicates) of primary modules in the result.
-    pub async fn primary_modules_ref(&self) -> Result<Vec<ResolvedVc<Box<dyn Module>>>> {
-        let mut set = FxIndexSet::default();
+    /// Returns primary modules (no duplicates). Emits errors for Unknown items.
+    /// Duplicates are already marked at construction time so no extra dedup is
+    /// needed here.
+    pub async fn primary_modules(&self) -> Result<Vec<ResolvedVc<Box<dyn Module>>>> {
+        self.primary
+            .iter()
+            .map(async |(_, item)| item.as_module().await)
+            .try_flat_join()
+            .await
+    }
+
+    /// Returns the first module in the result, or None.
+    pub async fn first_module(&self) -> Result<Option<ResolvedVc<Box<dyn Module>>>> {
         for (_, item) in self.primary.iter() {
             if let Some(module) = item.as_module().await? {
-                set.insert(module);
+                return Ok(Some(module));
             }
         }
-        Ok(set.into_iter().collect())
+        Ok(None)
     }
 
     pub fn affecting_sources_iter(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> + '_ {
         self.affecting_sources.iter().copied()
     }
 
-    pub fn is_unresolvable_ref(&self) -> bool {
+    pub fn is_unresolvable(&self) -> bool {
         self.primary.is_empty()
     }
 
@@ -313,25 +354,56 @@ pub struct ModuleResolveResultBuilder {
 
 impl From<ModuleResolveResultBuilder> for ModuleResolveResult {
     fn from(v: ModuleResolveResultBuilder) -> Self {
+        let mut primary: Vec<_> = v.primary.into_iter().collect();
+        Self::mark_duplicates(&mut primary);
         ModuleResolveResult {
-            primary: v.primary.into_iter().collect(),
+            primary: primary.into_boxed_slice(),
             affecting_sources: v.affecting_sources.into_boxed_slice(),
         }
     }
 }
+
+/// Resolves a `Duplicate(i)` marker by looking up the underlying item in `source`.
+/// `mark_duplicates` only ever produces backwards-pointing `Duplicate` indices into
+/// `Module(_)` entries, so a single lookup is enough.
+fn expand_duplicate<'a>(
+    source: &'a [(RequestKey, ModuleResolveResultItem)],
+    item: &'a ModuleResolveResultItem,
+) -> &'a ModuleResolveResultItem {
+    if let ModuleResolveResultItem::Duplicate(i) = *item {
+        &source[i].1
+    } else {
+        item
+    }
+}
+
 impl From<ModuleResolveResult> for ModuleResolveResultBuilder {
     fn from(v: ModuleResolveResult) -> Self {
+        // Expand `Duplicate(i)` markers as we copy into the builder. The indices are valid
+        // for `v.primary`, but the builder's `FxIndexMap` may be re-keyed and merged with
+        // other results, so the indices wouldn't survive. The final
+        // `From<Builder> for ModuleResolveResult` re-runs `mark_duplicates` on the merged
+        // primary array.
+        let primary = v
+            .primary
+            .iter()
+            .map(|(k, item)| (k.clone(), expand_duplicate(&v.primary, item).clone()))
+            .collect();
         ModuleResolveResultBuilder {
-            primary: IntoIterator::into_iter(v.primary).collect(),
+            primary,
             affecting_sources: v.affecting_sources.into_vec(),
         }
     }
 }
 impl ModuleResolveResultBuilder {
     pub fn merge_alternatives(&mut self, other: &ModuleResolveResult) {
+        // Expand `Duplicate(i)` markers from `other` against `other.primary` before
+        // inserting — the indices only make sense within `other`, not within the merged
+        // result. The final `mark_duplicates` pass on conversion will re-derive markers.
         for (k, v) in other.primary.iter() {
             if !self.primary.contains_key(k) {
-                self.primary.insert(k.clone(), v.clone());
+                self.primary
+                    .insert(k.clone(), expand_duplicate(&other.primary, v).clone());
             }
         }
         let set = self
@@ -368,34 +440,6 @@ impl ModuleResolveResult {
         } else {
             Ok(*ModuleResolveResult::unresolvable())
         }
-    }
-
-    #[turbo_tasks::function]
-    pub fn is_unresolvable(&self) -> Vc<bool> {
-        Vc::cell(self.is_unresolvable_ref())
-    }
-
-    #[turbo_tasks::function]
-    pub async fn first_module(&self) -> Result<Vc<OptionModule>> {
-        for (_, item) in self.primary.iter() {
-            if let Some(module) = item.as_module().await? {
-                return Ok(Vc::cell(Some(module)));
-            }
-        }
-        Ok(Vc::cell(None))
-    }
-
-    /// Returns a set (no duplicates) of primary modules in the result. All
-    /// modules are already resolved Vc.
-    #[turbo_tasks::function]
-    pub async fn primary_modules(&self) -> Result<Vc<Modules>> {
-        let mut set = FxIndexSet::default();
-        for (_, item) in self.primary.iter() {
-            if let Some(module) = item.as_module().await? {
-                set.insert(module);
-            }
-        }
-        Ok(Vc::cell(set.into_iter().collect()))
     }
 }
 
@@ -542,7 +586,7 @@ impl ValueToString for ResolveResult {
     #[turbo_tasks::function]
     async fn to_string(&self) -> Result<Vc<RcStr>> {
         let mut result = String::new();
-        if self.is_unresolvable_ref() {
+        if self.is_unresolvable() {
             result.push_str("unresolvable");
         }
         for (i, (request, item)) in self.primary.iter().enumerate() {
@@ -677,8 +721,28 @@ impl ResolveResult {
         self.affecting_sources.iter().copied()
     }
 
-    pub fn is_unresolvable_ref(&self) -> bool {
+    pub fn is_unresolvable(&self) -> bool {
         self.primary.is_empty()
+    }
+
+    pub fn first_source(&self) -> Option<ResolvedVc<Box<dyn Source>>> {
+        self.primary.iter().find_map(|(_, item)| {
+            if let &ResolveResultItem::Source(a) = item {
+                Some(a)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn primary_sources(&self) -> impl Iterator<Item = ResolvedVc<Box<dyn Source>>> {
+        self.primary.iter().filter_map(|(_, item)| {
+            if let &ResolveResultItem::Source(a) = item {
+                Some(a)
+            } else {
+                None
+            }
+        })
     }
 
     pub async fn map_module<A, AF>(&self, source_fn: A) -> Result<ModuleResolveResult>
@@ -919,38 +983,6 @@ impl ResolveResult {
         } else {
             Ok(ResolveResult::unresolvable_with_affecting_sources(affecting_sources).cell())
         }
-    }
-
-    #[turbo_tasks::function]
-    pub fn is_unresolvable(&self) -> Vc<bool> {
-        Vc::cell(self.is_unresolvable_ref())
-    }
-
-    #[turbo_tasks::function]
-    pub fn first_source(&self) -> Vc<OptionSource> {
-        Vc::cell(self.primary.iter().find_map(|(_, item)| {
-            if let &ResolveResultItem::Source(a) = item {
-                Some(a)
-            } else {
-                None
-            }
-        }))
-    }
-
-    #[turbo_tasks::function]
-    pub fn primary_sources(&self) -> Vc<Sources> {
-        Vc::cell(
-            self.primary
-                .iter()
-                .filter_map(|(_, item)| {
-                    if let &ResolveResultItem::Source(a) = item {
-                        Some(a)
-                    } else {
-                        None
-                    }
-                })
-                .collect(),
-        )
     }
 
     /// Returns a new [ResolveResult] where all [RequestKey]s are updated. The `old_request_key`
@@ -1648,7 +1680,7 @@ pub async fn resolve_inline(
 #[turbo_tasks::function]
 pub async fn url_resolve(
     origin: Vc<Box<dyn ResolveOrigin>>,
-    request: Vc<Request>,
+    request: ResolvedVc<Request>,
     reference_type: ReferenceType,
     issue_source: Option<IssueSource>,
     error_mode: ResolveErrorMode,
@@ -1663,11 +1695,11 @@ pub async fn url_resolve(
         resolve_options,
     );
     let result =
-        if *rel_result.is_unresolvable().await? && *rel_request.to_resolved().await? != request {
+        if rel_result.await?.is_unresolvable() && rel_request.to_resolved().await? != request {
             let result = resolve(
                 origin_path_parent,
                 reference_type.clone(),
-                request,
+                *request,
                 resolve_options,
             );
             if resolve_options.await?.collect_affecting_sources {
@@ -1691,7 +1723,7 @@ pub async fn url_resolve(
         result,
         reference_type,
         origin,
-        request,
+        *request,
         resolve_options,
         error_mode,
         issue_source,
@@ -1707,13 +1739,28 @@ async fn get_matching_before_resolve_plugins(
     options: Vc<ResolveOptions>,
     request: Vc<Request>,
 ) -> Result<Vc<MatchingBeforeResolvePlugins>> {
-    let mut matching_plugins = Vec::new();
-    for &plugin in &options.await?.before_resolve_plugins {
-        let condition = plugin.before_resolve_condition().to_resolved().await?;
-        if *condition.matches(request).await? {
-            matching_plugins.push(plugin);
-        }
-    }
+    let request_ref = request.await?;
+    let matching_plugins = options
+        .await?
+        .before_resolve_plugins
+        .iter()
+        .map(async |plugin| {
+            Ok(
+                if plugin
+                    .into_trait_ref()
+                    .await?
+                    .before_resolve_condition()
+                    .await?
+                    .matches(&request_ref)
+                {
+                    Some(*plugin)
+                } else {
+                    None
+                },
+            )
+        })
+        .try_flat_join()
+        .await?;
     Ok(Vc::cell(matching_plugins))
 }
 
@@ -1750,7 +1797,10 @@ async fn handle_after_resolve_plugins(
     let resolved_conditions = options_value
         .after_resolve_plugins
         .iter()
-        .map(async |p| Ok((*p, p.after_resolve_condition().to_resolved().await?)))
+        .map(async |p| {
+            let condition = p.into_trait_ref().await?.after_resolve_condition().await?;
+            Ok((*p, condition))
+        })
         .try_join()
         .await?;
 
@@ -1762,7 +1812,7 @@ async fn handle_after_resolve_plugins(
         plugins_with_conditions: &[AfterResolvePluginWithCondition],
     ) -> Result<Option<Vc<ResolveResult>>> {
         for (plugin, after_resolve_condition) in plugins_with_conditions {
-            if *after_resolve_condition.matches(path.clone()).await?
+            if after_resolve_condition.matches(&path)
                 && let Some(result) = *plugin
                     .after_resolve(
                         path.clone(),
@@ -2144,7 +2194,7 @@ async fn resolve_internal_inline(
         if !matches!(*request_value, Request::Alternatives { .. }) {
             // Apply fallback import mappings if provided
             if let Some(import_map) = &options_value.fallback_import_map
-                && *result.is_unresolvable().await?
+                && result.await?.is_unresolvable()
             {
                 let result = import_map
                     .await?
@@ -2221,7 +2271,7 @@ async fn resolve_into_folder(
                                 .await?;
                         // we are not that strict when a main field fails to resolve
                         // we continue to try other alternatives
-                        if !result.is_unresolvable_ref() {
+                        if !result.is_unresolvable() {
                             let mut result: ResolveResultBuilder =
                                 result.with_request_ref(rcstr!(".")).into();
                             if options_value.collect_affecting_sources {
@@ -2762,7 +2812,7 @@ async fn resolve_module_request(
             fragment.clone(),
             options,
         );
-        if !(*result.is_unresolvable().await?) {
+        if !result.await?.is_unresolvable() {
             return Ok(result);
         }
     }
@@ -2997,7 +3047,7 @@ async fn resolve_import_map_result(
                     },
                 )
                 .await?
-                .is_unresolvable_ref();
+                .is_unresolvable();
                 if is_external_resolvable {
                     Some(ResolveResultOrCell::Value(ResolveResult::primary(
                         ResolveResultItem::External {
@@ -3061,12 +3111,12 @@ impl ResolveResultOrCell {
     async fn into_cell_if_resolvable(self) -> Result<Option<Vc<ResolveResult>>> {
         match self {
             ResolveResultOrCell::Cell(resolved_result) => {
-                if !*resolved_result.is_unresolvable().await? {
+                if !resolved_result.await?.is_unresolvable() {
                     return Ok(Some(resolved_result));
                 }
             }
             ResolveResultOrCell::Value(resolve_result) => {
-                if !resolve_result.is_unresolvable_ref() {
+                if !resolve_result.is_unresolvable() {
                     return Ok(Some(resolve_result.cell()));
                 }
             }
@@ -3411,17 +3461,23 @@ mod tests {
         io::Write,
     };
 
+    use anyhow::Result;
     use turbo_rcstr::{RcStr, rcstr};
     use turbo_tasks::{TryJoinIterExt, Vc};
     use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
-    use turbo_tasks_fs::{DiskFileSystem, FileSystem, FileSystemPath};
+    use turbo_tasks_fs::{DiskFileSystem, FileContent, FileSystem, FileSystemPath};
 
     use crate::{
+        asset::AssetContent,
+        module::Module,
+        raw_module::RawModule,
         resolve::{
+            ModuleResolveResult, ModuleResolveResultBuilder, ModuleResolveResultItem, RequestKey,
             ResolveResult, ResolveResultItem, node::node_esm_resolve_options, parse::Request,
             pattern::Pattern,
         },
         source::Source,
+        virtual_source::VirtualSource,
     };
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -3709,7 +3765,7 @@ mod tests {
                 enable_typescript_with_output_extension: bool,
                 fully_specified: bool,
                 custom_extensions: Option<Vec<RcStr>>,
-            ) -> anyhow::Result<Vc<ResolveRelativeRequestOutput>> {
+            ) -> Result<Vc<ResolveRelativeRequestOutput>> {
                 let fs = DiskFileSystem::new(rcstr!("temp"), Vc::cell(path));
                 let lookup_path = fs.root().owned().await?;
 
@@ -3766,7 +3822,7 @@ mod tests {
         enable_typescript_with_output_extension: bool,
         fully_specified: bool,
         custom_extensions: Option<Vec<RcStr>>,
-    ) -> anyhow::Result<Vc<ResolveResult>> {
+    ) -> Result<Vc<ResolveResult>> {
         let request = Request::parse(pattern.clone());
 
         let extensions = custom_extensions
@@ -3800,5 +3856,222 @@ mod tests {
             }
             r => panic!("request should be relative, got {r:?}"),
         }
+    }
+
+    /// Snapshot of a `ModuleResolveResult::primary` array, encoded as `Vec<String>` so it
+    /// can cross the strongly-consistent read boundary (operation outputs need to be
+    /// `Encode`/`Decode`). One string per entry:
+    ///   - `module:<path>`  for `Module(_)`
+    ///   - `dup:<i>`        for `Duplicate(i)`
+    ///   - `other`          for everything else
+    #[turbo_tasks::value(transparent)]
+    pub struct DupCheckResult(Vec<String>);
+
+    async fn snapshot_primary(result: &ModuleResolveResult) -> Result<Vec<String>> {
+        let mut out = Vec::with_capacity(result.primary.len());
+        for (_, item) in result.primary.iter() {
+            out.push(match *item {
+                ModuleResolveResultItem::Module(m) => {
+                    let ident = m.ident().await?;
+                    format!("module:{}", ident.path.path)
+                }
+                ModuleResolveResultItem::Duplicate(i) => format!("dup:{i}"),
+                _ => "other".to_string(),
+            });
+        }
+        Ok(out)
+    }
+
+    #[turbo_tasks::function]
+    fn fs() -> Vc<Box<dyn FileSystem>> {
+        Vc::upcast(DiskFileSystem::new(rcstr!("temp"), Vc::cell(fs_path())))
+    }
+
+    #[turbo_tasks::function]
+    async fn make_module(name: RcStr) -> Result<Vc<Box<dyn Module>>> {
+        let path = fs().root().await?.join(&name)?;
+        let file_content =
+            FileContent::Content(turbo_tasks_fs::File::from(format!("// {name}"))).resolved_cell();
+        let content = AssetContent::file(*file_content).to_resolved().await?;
+        let source = VirtualSource::new(path, *content);
+        let module = RawModule::new(Vc::upcast(source)).to_resolved().await?;
+        Ok(Vc::upcast(*module))
+    }
+
+    fn fs_path() -> RcStr {
+        rcstr!("/tmp/_mdt")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn modules_constructor_marks_module_duplicates() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        #[turbo_tasks::function(operation)]
+        async fn run_test() -> Result<Vc<DupCheckResult>> {
+            let m_a = make_module(rcstr!("a.js")).to_resolved().await?;
+            let m_b = make_module(rcstr!("b.js")).to_resolved().await?;
+
+            let result = ModuleResolveResult::modules([
+                (RequestKey::new(rcstr!("a")), m_a),
+                (RequestKey::new(rcstr!("b")), m_b),
+                (RequestKey::new(rcstr!("a-again")), m_a),
+                (RequestKey::new(rcstr!("b-again")), m_b),
+            ])
+            .await?;
+
+            // primary_modules() yields each module exactly once, in first-seen order.
+            let modules = result.primary_modules().await?;
+            assert_eq!(modules, vec![m_a, m_b]);
+
+            Ok(Vc::cell(snapshot_primary(&result).await?))
+        }
+        tt.run_once(async move {
+            let snap = run_test().read_strongly_consistent().await?;
+            assert_eq!(
+                snap.iter().map(String::as_str).collect::<Vec<_>>(),
+                vec!["module:a.js", "module:b.js", "dup:0", "dup:1"]
+            );
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn first_module_returns_first_when_duplicates_follow() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        #[turbo_tasks::function(operation)]
+        async fn run_test() -> Result<Vc<DupCheckResult>> {
+            let m = make_module(rcstr!("a.js")).to_resolved().await?;
+
+            let result = ModuleResolveResult::modules([
+                (RequestKey::default(), m),
+                (RequestKey::new(rcstr!("again")), m),
+                (RequestKey::new(rcstr!("once-more")), m),
+            ])
+            .await?;
+
+            assert_eq!(result.first_module().await?, Some(m));
+            assert_eq!(result.primary_modules().await?, vec![m]);
+            Ok(Vc::cell(snapshot_primary(&result).await?))
+        }
+        tt.run_once(async move {
+            let snap = run_test().read_strongly_consistent().await?;
+            assert_eq!(
+                snap.iter().map(String::as_str).collect::<Vec<_>>(),
+                vec!["module:a.js", "dup:0", "dup:0"]
+            );
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn builder_marks_module_duplicates_skipping_non_dedup_items() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        #[turbo_tasks::function(operation)]
+        async fn run_test() -> Result<Vc<DupCheckResult>> {
+            let m = make_module(rcstr!("a.js")).to_resolved().await?;
+
+            let mut builder = ModuleResolveResultBuilder {
+                primary: Default::default(),
+                affecting_sources: Vec::new(),
+            };
+            builder.primary.insert(
+                RequestKey::new(rcstr!("k0")),
+                ModuleResolveResultItem::Module(m),
+            );
+            builder.primary.insert(
+                RequestKey::new(rcstr!("k1")),
+                ModuleResolveResultItem::Empty,
+            );
+            builder.primary.insert(
+                RequestKey::new(rcstr!("k2")),
+                ModuleResolveResultItem::Module(m),
+            );
+            let result: ModuleResolveResult = builder.into();
+            assert_eq!(result.primary_modules().await?, vec![m]);
+            Ok(Vc::cell(snapshot_primary(&result).await?))
+        }
+        tt.run_once(async move {
+            let snap = run_test().read_strongly_consistent().await?;
+
+            assert_eq!(
+                snap.iter().map(String::as_str).collect::<Vec<_>>(),
+                vec!["module:a.js", "other", "dup:0"]
+            );
+            Ok(())
+        })
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn alternatives_preserves_unique_module_set() {
+        let tt = turbo_tasks::TurboTasks::new(TurboTasksBackend::new(
+            BackendOptions::default(),
+            noop_backing_storage(),
+        ));
+        #[turbo_tasks::function(operation)]
+        async fn run_test() -> Result<Vc<DupCheckResult>> {
+            let m_a = make_module(rcstr!("a.js")).to_resolved().await?;
+            let m_b = make_module(rcstr!("b.js")).to_resolved().await?;
+
+            // r1 has m_a twice → Module(m_a), Duplicate(0).
+            let r1 = *ModuleResolveResult::modules([
+                (RequestKey::new(rcstr!("k1")), m_a),
+                (RequestKey::new(rcstr!("k2")), m_a),
+            ]);
+            // r2 prepended with m_b so the ordering inside r2 puts m_b at index 0 — a "stale"
+            // 0 from r1 would now incorrectly point at m_b after a naive concatenation.
+            let r2 = *ModuleResolveResult::module(m_b);
+
+            let merged = ModuleResolveResult::alternatives(vec![r1, r2]).await?;
+            assert_eq!(merged.primary_modules().await?, vec![m_a, m_b]);
+
+            // Verify every Duplicate(i) is well-formed
+            for (i, (_, item)) in merged.primary.iter().enumerate() {
+                if let ModuleResolveResultItem::Duplicate(first) = *item {
+                    assert!(
+                        first < i,
+                        "Duplicate index {first} at position {i} must point backwards"
+                    );
+                    let pointed = &merged.primary[first].1;
+                    let ModuleResolveResultItem::Module(pointed_module) = *pointed else {
+                        panic!(
+                            "Duplicate({first}) at {i} points at {pointed:?}, expected a concrete \
+                             Module"
+                        );
+                    };
+                    // The pointed-at module must be m_a — proves the index was re-derived
+                    // against the merged array, not carried stale from r1.
+                    assert_eq!(
+                        pointed_module, m_a,
+                        "Duplicate({first}) at position {i} points at the wrong module"
+                    );
+                }
+            }
+            Ok(Vc::cell(snapshot_primary(&merged).await?))
+        }
+        tt.run_once(async move {
+            let snap = run_test().read_strongly_consistent().await?;
+
+            assert_eq!(
+                snap.iter().map(String::as_str).collect::<Vec<_>>(),
+                vec!["module:a.js", "dup:0", "module:b.js"]
+            );
+            Ok(())
+        })
+        .await
+        .unwrap();
     }
 }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -84,7 +84,7 @@ pub enum ResolveErrorMode {
 /// Type alias for a resolved after-resolve plugin paired with its condition.
 type AfterResolvePluginWithCondition = (
     ResolvedVc<Box<dyn AfterResolvePlugin>>,
-    ResolvedVc<AfterResolvePluginCondition>,
+    ReadRef<AfterResolvePluginCondition>,
 );
 
 #[turbo_tasks::value(shared)]
@@ -1743,10 +1743,12 @@ async fn get_matching_before_resolve_plugins(
     options: Vc<ResolveOptions>,
     request: Vc<Request>,
 ) -> Result<Vc<MatchingBeforeResolvePlugins>> {
+    let request_ref = request.await?;
     let mut matching_plugins = Vec::new();
     for &plugin in &options.await?.before_resolve_plugins {
-        let condition = plugin.before_resolve_condition().to_resolved().await?;
-        if *condition.matches(request).await? {
+        let trait_ref = plugin.into_trait_ref().await?;
+        let condition = trait_ref.before_resolve_condition().await?;
+        if condition.matches(&request_ref) {
             matching_plugins.push(plugin);
         }
     }
@@ -1762,7 +1764,10 @@ async fn handle_before_resolve_plugins(
 ) -> Result<Option<Vc<ResolveResult>>> {
     for plugin in get_matching_before_resolve_plugins(options, request).await? {
         if let Some(result) = *plugin
+            .into_trait_ref()
+            .await?
             .before_resolve(lookup_path.clone(), reference_type.clone(), request)
+            .await?
             .await?
         {
             return Ok(Some(*result));
@@ -1786,7 +1791,11 @@ async fn handle_after_resolve_plugins(
     let resolved_conditions = options_value
         .after_resolve_plugins
         .iter()
-        .map(async |p| Ok((*p, p.after_resolve_condition().to_resolved().await?)))
+        .map(async |p| {
+            let trait_ref = p.into_trait_ref().await?;
+            let condition = trait_ref.after_resolve_condition().await?;
+            Ok((*p, condition))
+        })
         .try_join()
         .await?;
 
@@ -1798,14 +1807,17 @@ async fn handle_after_resolve_plugins(
         plugins_with_conditions: &[AfterResolvePluginWithCondition],
     ) -> Result<Option<Vc<ResolveResult>>> {
         for (plugin, after_resolve_condition) in plugins_with_conditions {
-            if *after_resolve_condition.matches(path.clone()).await?
+            if after_resolve_condition.matches(&path)
                 && let Some(result) = *plugin
+                    .into_trait_ref()
+                    .await?
                     .after_resolve(
                         path.clone(),
                         lookup_path.clone(),
                         reference_type.clone(),
                         request,
                     )
+                    .await?
                     .await?
             {
                 return Ok(Some(*result));

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -287,15 +287,12 @@ impl ModuleResolveResult {
         // Map from module identity to the index of first occurrence
         let mut seen_modules = FxHashMap::default();
         for (i, (_, item)) in primary.iter_mut().enumerate() {
-            match *item {
-                ModuleResolveResultItem::Module(m) => {
-                    if let Some(&first) = seen_modules.get(&m) {
-                        *item = ModuleResolveResultItem::Duplicate(first);
-                    } else {
-                        seen_modules.insert(m, i);
-                    }
+            if let ModuleResolveResultItem::Module(m) = *item {
+                if let Some(&first) = seen_modules.get(&m) {
+                    *item = ModuleResolveResultItem::Duplicate(first);
+                } else {
+                    seen_modules.insert(m, i);
                 }
-                _ => {}
             }
         }
     }

--- a/turbopack/crates/turbopack-core/src/resolve/mod.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/mod.rs
@@ -107,6 +107,9 @@ pub enum ModuleResolveResultItem {
     /// A duplicate of an item that appeared earlier in the primary array.
     /// The usize is the index of the first occurrence. Most callers should skip
     /// this variant.
+    ///
+    /// Bakes duplicate detection into the datastructure to make filtering for uniques trivial which
+    /// is required by primary_modules.
     Duplicate(usize),
 }
 
@@ -284,6 +287,9 @@ impl ModuleResolveResult {
     /// Preserves ordering; the first occurrence stays, subsequent occurrences
     /// of the same module/output asset become `Duplicate`.
     fn mark_duplicates(primary: &mut [(RequestKey, ModuleResolveResultItem)]) {
+        if primary.len() <= 1 {
+            return;
+        }
         // Map from module identity to the index of first occurrence
         let mut seen_modules = FxHashMap::default();
         for (i, (_, item)) in primary.iter_mut().enumerate() {

--- a/turbopack/crates/turbopack-core/src/resolve/origin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/origin.rs
@@ -27,8 +27,7 @@ pub trait ResolveOrigin {
     /// Get an inner asset form this origin that doesn't require resolving but
     /// is directly attached
     #[turbo_tasks::function]
-    fn get_inner_asset(self: Vc<Self>, request: Vc<Request>) -> Vc<OptionModule> {
-        let _ = request;
+    fn get_inner_asset(self: Vc<Self>, _request: Vc<Request>) -> Vc<OptionModule> {
         Vc::cell(None)
     }
 

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
-use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
 use crate::{
@@ -10,94 +9,76 @@ use crate::{
 };
 
 /// A condition which determines if the hooks of a resolve plugin gets called.
-#[turbo_tasks::value(shared)]
-pub enum AfterResolvePluginCondition {
-    Glob {
-        root: FileSystemPath,
-        glob: ResolvedVc<Glob>,
-    },
-    Always,
-    Never,
+///
+/// The glob is read at construction time and stored as a `ReadRef`, so `matches` is a pure
+/// sync function. `serialization = "none"` because `ReadRef` cannot be persisted across builds
+/// — plugin construction is cheap enough that re-deriving this on restore is preferable.
+#[turbo_tasks::value(serialization = "skip")]
+pub struct AfterResolvePluginCondition {
+    root: FileSystemPath,
+    glob: ReadRef<Glob>,
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
-    pub fn new_with_glob(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Vc<Self> {
-        AfterResolvePluginCondition::Glob { root, glob }.cell()
+    pub async fn new_with_glob(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Result<Vc<Self>> {
+        let glob = glob.await?;
+        Ok(AfterResolvePluginCondition { root, glob }.cell())
     }
 }
 
-#[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
-    #[turbo_tasks::function]
-    pub async fn matches(&self, fs_path: FileSystemPath) -> Result<Vc<bool>> {
-        match self {
-            AfterResolvePluginCondition::Glob { root, glob } => {
-                let path = fs_path;
-
-                if let Some(path) = root.get_path_to(&path)
-                    && glob.await?.matches(path)
-                {
-                    return Ok(Vc::cell(true));
-                }
-
-                Ok(Vc::cell(false))
-            }
-            AfterResolvePluginCondition::Always => Ok(Vc::cell(true)),
-            AfterResolvePluginCondition::Never => Ok(Vc::cell(false)),
-        }
+    /// Test whether `fs_path` matches this condition.
+    pub fn matches(&self, fs_path: &FileSystemPath) -> bool {
+        self.root
+            .get_path_to(fs_path)
+            .is_some_and(|p| self.glob.matches(p))
     }
 }
 
 /// A condition which determines if the hooks of a resolve plugin gets called.
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value(shared, serialization = "skip")]
 pub enum BeforeResolvePluginCondition {
-    Request(ResolvedVc<Glob>),
-    Modules(FxHashSet<RcStr>),
-    Always,
-    Never,
+    Request(ReadRef<Glob>),
+    Modules(ReadRef<Vec<RcStr>>),
 }
 
 #[turbo_tasks::value_impl]
 impl BeforeResolvePluginCondition {
     #[turbo_tasks::function]
     pub async fn from_modules(modules: ResolvedVc<Vec<RcStr>>) -> Result<Vc<Self>> {
-        Ok(BeforeResolvePluginCondition::Modules(modules.await?.iter().cloned().collect()).cell())
+        Ok(BeforeResolvePluginCondition::Modules(modules.await?).cell())
     }
 
     #[turbo_tasks::function]
-    pub fn from_request_glob(glob: ResolvedVc<Glob>) -> Vc<Self> {
-        BeforeResolvePluginCondition::Request(glob).cell()
+    pub async fn from_request_glob(glob: ResolvedVc<Glob>) -> Result<Vc<Self>> {
+        Ok(BeforeResolvePluginCondition::Request(glob.await?).cell())
     }
 }
 
-#[turbo_tasks::value_impl]
 impl BeforeResolvePluginCondition {
-    #[turbo_tasks::function]
-    pub async fn matches(&self, request: Vc<Request>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(match self {
-            BeforeResolvePluginCondition::Request(glob) => match request.await?.request() {
-                Some(request) => glob.await?.matches(request.as_str()),
+    /// Test whether `request` matches this condition.
+    pub fn matches(&self, request: &Request) -> bool {
+        match self {
+            BeforeResolvePluginCondition::Request(glob) => match request.request() {
+                Some(request) => glob.matches(request.as_str()),
                 None => false,
             },
             BeforeResolvePluginCondition::Modules(modules) => {
-                if let Request::Module { module, .. } = &*request.await? {
+                if let Request::Module { module, .. } = request {
                     modules.iter().any(|m| module.is_match(m))
                 } else {
                     false
                 }
             }
-            BeforeResolvePluginCondition::Always => true,
-            BeforeResolvePluginCondition::Never => false,
-        }))
+        }
     }
 }
 
 #[turbo_tasks::value_trait]
 pub trait BeforeResolvePlugin {
-    #[turbo_tasks::function]
-    fn before_resolve_condition(self: Vc<Self>) -> Vc<BeforeResolvePluginCondition>;
+    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition>;
 
     #[turbo_tasks::function]
     fn before_resolve(
@@ -111,8 +92,7 @@ pub trait BeforeResolvePlugin {
 #[turbo_tasks::value_trait]
 pub trait AfterResolvePlugin {
     /// A condition which determines if the hooks gets called.
-    #[turbo_tasks::function]
-    fn after_resolve_condition(self: Vc<Self>) -> Vc<AfterResolvePluginCondition>;
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition>;
 
     /// This hook gets called when a full filepath has been resolved and the
     /// condition matches. If a value is returned it replaces the resolve

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -10,21 +10,17 @@ use crate::{
 };
 
 /// A condition which determines if the hooks of a resolve plugin gets called.
-#[turbo_tasks::value(shared)]
-pub enum AfterResolvePluginCondition {
-    Glob {
-        root: FileSystemPath,
-        glob: ResolvedVc<Glob>,
-    },
-    Always,
-    Never,
+#[turbo_tasks::value]
+pub struct AfterResolvePluginCondition {
+    root: FileSystemPath,
+    glob: ResolvedVc<Glob>,
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
     pub fn new_with_glob(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Vc<Self> {
-        AfterResolvePluginCondition::Glob { root, glob }.cell()
+        AfterResolvePluginCondition { root, glob }.cell()
     }
 }
 
@@ -32,26 +28,22 @@ impl AfterResolvePluginCondition {
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
     pub async fn matches(&self, fs_path: FileSystemPath) -> Result<Vc<bool>> {
-        match self {
-            AfterResolvePluginCondition::Glob { root, glob } => {
-                let path = fs_path;
+        let AfterResolvePluginCondition { root, glob } = self;
 
-                if let Some(path) = root.get_path_to(&path)
-                    && glob.await?.matches(path)
-                {
-                    return Ok(Vc::cell(true));
-                }
+        let path = fs_path;
 
-                Ok(Vc::cell(false))
-            }
-            AfterResolvePluginCondition::Always => Ok(Vc::cell(true)),
-            AfterResolvePluginCondition::Never => Ok(Vc::cell(false)),
+        if let Some(path) = root.get_path_to(&path)
+            && glob.await?.matches(path)
+        {
+            return Ok(Vc::cell(true));
         }
+
+        Ok(Vc::cell(false))
     }
 }
 
 /// A condition which determines if the hooks of a resolve plugin gets called.
-#[turbo_tasks::value(shared)]
+#[turbo_tasks::value]
 pub enum BeforeResolvePluginCondition {
     Request(ResolvedVc<Glob>),
     Modules(FxHashSet<RcStr>),

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
+use async_trait::async_trait;
 use rustc_hash::FxHashSet;
 use turbo_rcstr::RcStr;
-use turbo_tasks::{ResolvedVc, Vc};
+use turbo_tasks::{ReadRef, ResolvedVc, Vc};
 use turbo_tasks_fs::{FileSystemPath, glob::Glob};
 
 use crate::{
@@ -10,42 +11,42 @@ use crate::{
 };
 
 /// A condition which determines if the hooks of a resolve plugin gets called.
-#[turbo_tasks::value]
+///
+/// The glob is read at construction time and stored as a `ReadRef`, so `matches` is a pure
+/// sync function. `serialization = "none"` because `ReadRef` cannot be persisted across builds
+/// — plugin construction is cheap enough that re-deriving this on restore is preferable.
+#[turbo_tasks::value(serialization = "none")]
 pub struct AfterResolvePluginCondition {
     root: FileSystemPath,
-    glob: ResolvedVc<Glob>,
+    glob: ReadRef<Glob>,
 }
 
 #[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
-    pub fn new_with_glob(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Vc<Self> {
-        AfterResolvePluginCondition { root, glob }.cell()
+    pub async fn new_with_glob(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Result<Vc<Self>> {
+        let glob = glob.await?;
+        Ok(AfterResolvePluginCondition { root, glob }.cell())
     }
 }
 
-#[turbo_tasks::value_impl]
 impl AfterResolvePluginCondition {
-    #[turbo_tasks::function]
-    pub async fn matches(&self, fs_path: FileSystemPath) -> Result<Vc<bool>> {
-        let AfterResolvePluginCondition { root, glob } = self;
-
-        let path = fs_path;
-
-        if let Some(path) = root.get_path_to(&path)
-            && glob.await?.matches(path)
-        {
-            return Ok(Vc::cell(true));
-        }
-
-        Ok(Vc::cell(false))
+    /// Test whether `fs_path` matches this condition.
+    pub fn matches(&self, fs_path: &FileSystemPath) -> bool {
+        self.root
+            .get_path_to(fs_path)
+            .is_some_and(|p| self.glob.matches(p))
     }
 }
 
 /// A condition which determines if the hooks of a resolve plugin gets called.
-#[turbo_tasks::value]
+///
+/// The glob (when present) is read at construction time and stored as a `ReadRef`, so
+/// `matches` is a pure sync function. `serialization = "none"` because `ReadRef` cannot be
+/// persisted across builds.
+#[turbo_tasks::value(serialization = "none")]
 pub enum BeforeResolvePluginCondition {
-    Request(ResolvedVc<Glob>),
+    Request(ReadRef<Glob>),
     Modules(FxHashSet<RcStr>),
     Always,
     Never,
@@ -59,22 +60,21 @@ impl BeforeResolvePluginCondition {
     }
 
     #[turbo_tasks::function]
-    pub fn from_request_glob(glob: ResolvedVc<Glob>) -> Vc<Self> {
-        BeforeResolvePluginCondition::Request(glob).cell()
+    pub async fn from_request_glob(glob: ResolvedVc<Glob>) -> Result<Vc<Self>> {
+        Ok(BeforeResolvePluginCondition::Request(glob.await?).cell())
     }
 }
 
-#[turbo_tasks::value_impl]
 impl BeforeResolvePluginCondition {
-    #[turbo_tasks::function]
-    pub async fn matches(&self, request: Vc<Request>) -> Result<Vc<bool>> {
-        Ok(Vc::cell(match self {
-            BeforeResolvePluginCondition::Request(glob) => match request.await?.request() {
-                Some(request) => glob.await?.matches(request.as_str()),
+    /// Test whether `request` matches this condition.
+    pub fn matches(&self, request: &Request) -> bool {
+        match self {
+            BeforeResolvePluginCondition::Request(glob) => match request.request() {
+                Some(request) => glob.matches(request.as_str()),
                 None => false,
             },
             BeforeResolvePluginCondition::Modules(modules) => {
-                if let Request::Module { module, .. } = &*request.await? {
+                if let Request::Module { module, .. } = request {
                     modules.iter().any(|m| module.is_match(m))
                 } else {
                     false
@@ -82,39 +82,49 @@ impl BeforeResolvePluginCondition {
             }
             BeforeResolvePluginCondition::Always => true,
             BeforeResolvePluginCondition::Never => false,
-        }))
+        }
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_trait]
 pub trait BeforeResolvePlugin {
-    #[turbo_tasks::function]
-    fn before_resolve_condition(self: Vc<Self>) -> Vc<BeforeResolvePluginCondition>;
+    /// A condition which determines if the hooks gets called.
+    ///
+    /// This is not a `#[turbo_tasks::function]` — implementations should compute and resolve
+    /// the condition once during construction and store it on the plugin.
+    fn before_resolve_condition(&self) -> Vc<BeforeResolvePluginCondition>;
 
-    #[turbo_tasks::function]
-    fn before_resolve(
-        self: Vc<Self>,
+    async fn before_resolve(
+        &self,
         lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: Vc<Request>,
-    ) -> Vc<ResolveResultOption>;
+    ) -> Result<Vc<ResolveResultOption>>;
 }
 
+#[async_trait]
 #[turbo_tasks::value_trait]
 pub trait AfterResolvePlugin {
     /// A condition which determines if the hooks gets called.
-    #[turbo_tasks::function]
-    fn after_resolve_condition(self: Vc<Self>) -> Vc<AfterResolvePluginCondition>;
+    ///
+    /// This is not a `#[turbo_tasks::function]` — implementations should compute and resolve
+    /// the condition once during construction and store it on the plugin, so this becomes a
+    /// trivial field read.
+    fn after_resolve_condition(&self) -> Vc<AfterResolvePluginCondition>;
 
     /// This hook gets called when a full filepath has been resolved and the
     /// condition matches. If a value is returned it replaces the resolve
     /// result.
-    #[turbo_tasks::function]
-    fn after_resolve(
-        self: Vc<Self>,
+    ///
+    /// This is not a `#[turbo_tasks::function]` because `after_resolve` has a ~0% cache hit
+    /// rate in practice (its inputs include the fully-resolved path and are near-unique per
+    /// call), so task-system overhead dominates. The sub-computations it invokes remain cached.
+    async fn after_resolve(
+        &self,
         fs_path: FileSystemPath,
         lookup_path: FileSystemPath,
         reference_type: ReferenceType,
         request: Vc<Request>,
-    ) -> Vc<ResolveResultOption>;
+    ) -> Result<Vc<ResolveResultOption>>;
 }

--- a/turbopack/crates/turbopack-core/src/resolve/plugin.rs
+++ b/turbopack/crates/turbopack-core/src/resolve/plugin.rs
@@ -11,12 +11,17 @@ use crate::{
 /// A condition which determines if the hooks of a resolve plugin gets called.
 ///
 /// The glob is read at construction time and stored as a `ReadRef`, so `matches` is a pure
-/// sync function. `serialization = "none"` because `ReadRef` cannot be persisted across builds
-/// — plugin construction is cheap enough that re-deriving this on restore is preferable.
+/// sync function. `serialization = "skip"` because serializing a `ReadRef` is wasteful and
+/// recomputing this is very cheap.
 #[turbo_tasks::value(serialization = "skip")]
-pub struct AfterResolvePluginCondition {
-    root: FileSystemPath,
-    glob: ReadRef<Glob>,
+pub enum AfterResolvePluginCondition {
+    Glob {
+        root: FileSystemPath,
+        glob: ReadRef<Glob>,
+    },
+    // these variants are used by utoo
+    Always,
+    Never,
 }
 
 #[turbo_tasks::value_impl]
@@ -24,16 +29,20 @@ impl AfterResolvePluginCondition {
     #[turbo_tasks::function]
     pub async fn new_with_glob(root: FileSystemPath, glob: ResolvedVc<Glob>) -> Result<Vc<Self>> {
         let glob = glob.await?;
-        Ok(AfterResolvePluginCondition { root, glob }.cell())
+        Ok(AfterResolvePluginCondition::Glob { root, glob }.cell())
     }
 }
 
 impl AfterResolvePluginCondition {
     /// Test whether `fs_path` matches this condition.
     pub fn matches(&self, fs_path: &FileSystemPath) -> bool {
-        self.root
-            .get_path_to(fs_path)
-            .is_some_and(|p| self.glob.matches(p))
+        match self {
+            AfterResolvePluginCondition::Glob { root, glob } => {
+                root.get_path_to(fs_path).is_some_and(|p| glob.matches(p))
+            }
+            AfterResolvePluginCondition::Always => true,
+            AfterResolvePluginCondition::Never => false,
+        }
     }
 }
 
@@ -42,6 +51,9 @@ impl AfterResolvePluginCondition {
 pub enum BeforeResolvePluginCondition {
     Request(ReadRef<Glob>),
     Modules(ReadRef<Vec<RcStr>>),
+    // These are used by utoo
+    Always,
+    Never,
 }
 
 #[turbo_tasks::value_impl]
@@ -72,6 +84,8 @@ impl BeforeResolvePluginCondition {
                     false
                 }
             }
+            BeforeResolvePluginCondition::Always => true,
+            BeforeResolvePluginCondition::Never => false,
         }
     }
 }

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -248,12 +248,10 @@ impl ChunkItem for CssModuleChunkItem {
         self.module.ident()
     }
 
-    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }
 
-    #[turbo_tasks::function]
     fn ty(&self) -> Vc<Box<dyn ChunkType>> {
         Vc::upcast(Vc::<CssChunkType>::default())
     }
@@ -278,7 +276,6 @@ impl CssChunkItem for CssModuleChunkItem {
             {
                 for &module in import_ref
                     .resolve_reference()
-                    .to_resolved()
                     .await?
                     .primary_modules()
                     .await?
@@ -300,7 +297,6 @@ impl CssChunkItem for CssModuleChunkItem {
             {
                 for &module in compose_ref
                     .resolve_reference()
-                    .to_resolved()
                     .await?
                     .primary_modules()
                     .await?

--- a/turbopack/crates/turbopack-css/src/asset.rs
+++ b/turbopack/crates/turbopack-css/src/asset.rs
@@ -246,12 +246,10 @@ impl ChunkItem for CssModuleChunkItem {
         self.module.ident()
     }
 
-    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }
 
-    #[turbo_tasks::function]
     fn ty(&self) -> Vc<Box<dyn ChunkType>> {
         Vc::upcast(Vc::<CssChunkType>::default())
     }
@@ -276,7 +274,6 @@ impl CssChunkItem for CssModuleChunkItem {
             {
                 for &module in import_ref
                     .resolve_reference()
-                    .to_resolved()
                     .await?
                     .primary_modules()
                     .await?
@@ -298,7 +295,6 @@ impl CssChunkItem for CssModuleChunkItem {
             {
                 for &module in compose_ref
                     .resolve_reference()
-                    .to_resolved()
                     .await?
                     .primary_modules()
                     .await?

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -284,15 +284,16 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
                         original: original_name,
                         from,
                     } => {
-                        let resolved_module = from.resolve_reference().first_module().await?;
+                        let resolved_module =
+                            from.resolve_reference().await?.first_module().await?;
 
-                        let Some(resolved_module) = &*resolved_module else {
+                        let Some(resolved_module) = resolved_module else {
                             // Issue already emitted by CssModuleComposeReference::resolve_reference
                             continue;
                         };
 
                         let Some(css_module) =
-                            ResolvedVc::try_downcast_type::<EcmascriptCssModule>(*resolved_module)
+                            ResolvedVc::try_downcast_type::<EcmascriptCssModule>(resolved_module)
                         else {
                             // Issue already emitted by CssModuleComposeReference::resolve_reference
                             continue;

--- a/turbopack/crates/turbopack-css/src/module_asset.rs
+++ b/turbopack/crates/turbopack-css/src/module_asset.rs
@@ -281,15 +281,16 @@ impl EcmascriptChunkPlaceable for EcmascriptCssModule {
                         original: original_name,
                         from,
                     } => {
-                        let resolved_module = from.resolve_reference().first_module().await?;
+                        let resolved_module =
+                            from.resolve_reference().await?.first_module().await?;
 
-                        let Some(resolved_module) = &*resolved_module else {
+                        let Some(resolved_module) = resolved_module else {
                             // Issue already emitted by CssModuleComposeReference::resolve_reference
                             continue;
                         };
 
                         let Some(css_module) =
-                            ResolvedVc::try_downcast_type::<EcmascriptCssModule>(*resolved_module)
+                            ResolvedVc::try_downcast_type::<EcmascriptCssModule>(resolved_module)
                         else {
                             // Issue already emitted by CssModuleComposeReference::resolve_reference
                             continue;

--- a/turbopack/crates/turbopack-css/src/references/compose.rs
+++ b/turbopack/crates/turbopack-css/src/references/compose.rs
@@ -46,10 +46,10 @@ impl ModuleReference for CssModuleComposeReference {
             None,
         );
 
-        let resolved = result.first_module().await?;
+        let resolved = result.await?.first_module().await?;
         let file_path = self.origin.origin_path().to_resolved().await?;
-        if let Some(module) = &*resolved {
-            if ResolvedVc::try_downcast_type::<EcmascriptCssModule>(*module).is_none() {
+        if let Some(module) = resolved {
+            if ResolvedVc::try_downcast_type::<EcmascriptCssModule>(module).is_none() {
                 CssModuleComposesIssue {
                     severity: IssueSeverity::Error,
                     file_path,

--- a/turbopack/crates/turbopack-css/src/references/url.rs
+++ b/turbopack/crates/turbopack-css/src/references/url.rs
@@ -58,7 +58,7 @@ impl UrlAssetReference {
         self: Vc<Self>,
         chunking_context: Vc<Box<dyn ChunkingContext>>,
     ) -> Result<Vc<ReferencedAsset>> {
-        if let Some(module) = *self.resolve_reference().first_module().await?
+        if let Some(module) = self.resolve_reference().await?.first_module().await?
             && let Some(embeddable) = ResolvedVc::try_downcast::<Box<dyn CssEmbed>>(module)
         {
             return Ok(ReferencedAsset::Some(

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/chunk_type.rs
@@ -57,12 +57,18 @@ impl ChunkType for EcmascriptChunkType {
         else {
             bail!("Chunk item is not an ecmascript chunk item but reporting chunk type ecmascript");
         };
-        Ok(Vc::cell(
-            chunk_item
-                .content_with_async_module_info(async_module_info, true)
-                .await
-                .map_or(0, |content| round_chunk_item_size(content.inner_code.len())),
-        ))
+        let chunk_item = chunk_item.into_trait_ref().await?;
+        let size = match chunk_item
+            .content_with_async_module_info(async_module_info, true)
+            .await
+        {
+            Ok(content) => {
+                let content = content.await?;
+                round_chunk_item_size(content.inner_code.len())
+            }
+            Err(_) => 0,
+        };
+        Ok(Vc::cell(size))
     }
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use smallvec::SmallVec;
 use turbo_rcstr::{RcStr, rcstr};
@@ -240,6 +241,7 @@ impl EcmascriptChunkItemWithAsyncInfo {
     ) -> Result<EcmascriptChunkItemWithAsyncInfo> {
         let ChunkItemWithAsyncModuleInfo {
             chunk_item,
+            chunk_type: _,
             module: _,
             async_info,
         } = chunk_item;
@@ -255,23 +257,18 @@ impl EcmascriptChunkItemWithAsyncInfo {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_trait]
 pub trait EcmascriptChunkItem: ChunkItem + OutputAssetsReference {
-    #[turbo_tasks::function]
-    fn content(self: Vc<Self>) -> Vc<EcmascriptChunkItemContent>;
-
     /// Fetches the content of the chunk item with async module info.
     /// When `estimated` is true, it's ok to provide an estimated content, since it's only used for
     /// compute the chunking. When `estimated` is true, this function should not invoke other
     /// chunking operations that would cause cycles.
-    #[turbo_tasks::function]
-    fn content_with_async_module_info(
-        self: Vc<Self>,
-        _async_module_info: Option<Vc<AsyncModuleInfo>>,
-        _estimated: bool,
-    ) -> Vc<EcmascriptChunkItemContent> {
-        self.content()
-    }
+    async fn content_with_async_module_info(
+        &self,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+        estimated: bool,
+    ) -> Result<Vc<EcmascriptChunkItemContent>>;
 }
 
 pub trait EcmascriptChunkItemExt {
@@ -295,13 +292,18 @@ async fn module_factory_with_code_generation_issue(
     chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
     async_module_info: Option<Vc<AsyncModuleInfo>>,
 ) -> Result<Vc<PersistedCode>> {
-    let content = match chunk_item
-        .content_with_async_module_info(async_module_info, false)
-        .await
-    {
-        Ok(item) => item.module_factory().await,
-        Err(err) => Err(err),
-    };
+    async fn get_content(
+        chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+    ) -> Result<ResolvedVc<PersistedCode>> {
+        let chunk_item_ref = chunk_item.into_trait_ref().await?;
+        let content = chunk_item_ref
+            .content_with_async_module_info(async_module_info, false)
+            .await?
+            .await?;
+        content.module_factory().await
+    }
+    let content = get_content(chunk_item, async_module_info).await;
     Ok(match content {
         Ok(factory) => *factory,
         Err(error) => {
@@ -372,7 +374,6 @@ impl ChunkItem for EcmascriptModuleChunkItem {
             .chunk_item_content_ident(*self.chunking_context, *self.module_graph)
     }
 
-    #[turbo_tasks::function]
     fn ty(&self) -> Vc<Box<dyn ChunkType>> {
         Vc::upcast(Vc::<EcmascriptChunkType>::default())
     }
@@ -382,7 +383,6 @@ impl ChunkItem for EcmascriptModuleChunkItem {
         Vc::upcast(*self.module)
     }
 
-    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }
@@ -397,25 +397,19 @@ impl OutputAssetsReference for EcmascriptModuleChunkItem {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for EcmascriptModuleChunkItem {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<EcmascriptChunkItemContent> {
-        self.module
-            .chunk_item_content(*self.chunking_context, *self.module_graph, None, false)
-    }
-
-    #[turbo_tasks::function]
-    fn content_with_async_module_info(
+    async fn content_with_async_module_info(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
         estimated: bool,
-    ) -> Vc<EcmascriptChunkItemContent> {
-        self.module.chunk_item_content(
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        Ok(self.module.chunk_item_content(
             *self.chunking_context,
             *self.module_graph,
             async_module_info,
             estimated,
-        )
+        ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -257,9 +257,6 @@ impl EcmascriptChunkItemWithAsyncInfo {
 
 #[turbo_tasks::value_trait]
 pub trait EcmascriptChunkItem: ChunkItem + OutputAssetsReference {
-    #[turbo_tasks::function]
-    fn content(self: Vc<Self>) -> Vc<EcmascriptChunkItemContent>;
-
     /// Fetches the content of the chunk item with async module info.
     /// When `estimated` is true, it's ok to provide an estimated content, since it's only used for
     /// compute the chunking. When `estimated` is true, this function should not invoke other
@@ -267,11 +264,9 @@ pub trait EcmascriptChunkItem: ChunkItem + OutputAssetsReference {
     #[turbo_tasks::function]
     fn content_with_async_module_info(
         self: Vc<Self>,
-        _async_module_info: Option<Vc<AsyncModuleInfo>>,
-        _estimated: bool,
-    ) -> Vc<EcmascriptChunkItemContent> {
-        self.content()
-    }
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+        estimated: bool,
+    ) -> Vc<EcmascriptChunkItemContent>;
 }
 
 pub trait EcmascriptChunkItemExt {
@@ -372,7 +367,6 @@ impl ChunkItem for EcmascriptModuleChunkItem {
             .chunk_item_content_ident(*self.chunking_context, *self.module_graph)
     }
 
-    #[turbo_tasks::function]
     fn ty(&self) -> Vc<Box<dyn ChunkType>> {
         Vc::upcast(Vc::<EcmascriptChunkType>::default())
     }
@@ -382,7 +376,6 @@ impl ChunkItem for EcmascriptModuleChunkItem {
         Vc::upcast(*self.module)
     }
 
-    #[turbo_tasks::function]
     fn chunking_context(&self) -> Vc<Box<dyn ChunkingContext>> {
         *self.chunking_context
     }
@@ -399,12 +392,6 @@ impl OutputAssetsReference for EcmascriptModuleChunkItem {
 
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for EcmascriptModuleChunkItem {
-    #[turbo_tasks::function]
-    fn content(&self) -> Vc<EcmascriptChunkItemContent> {
-        self.module
-            .chunk_item_content(*self.chunking_context, *self.module_graph, None, false)
-    }
-
     #[turbo_tasks::function]
     fn content_with_async_module_info(
         &self,

--- a/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/chunk/item.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 
 use anyhow::{Result, bail};
+use async_trait::async_trait;
 use bincode::{Decode, Encode};
 use smallvec::SmallVec;
 use turbo_rcstr::{RcStr, rcstr};
@@ -255,18 +256,22 @@ impl EcmascriptChunkItemWithAsyncInfo {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_trait]
 pub trait EcmascriptChunkItem: ChunkItem + OutputAssetsReference {
     /// Fetches the content of the chunk item with async module info.
     /// When `estimated` is true, it's ok to provide an estimated content, since it's only used for
     /// compute the chunking. When `estimated` is true, this function should not invoke other
     /// chunking operations that would cause cycles.
-    #[turbo_tasks::function]
-    fn content_with_async_module_info(
-        self: Vc<Self>,
+    ///
+    /// This is not a `#[turbo_tasks::function]` because `EcmascriptChunkItemContent` has
+    /// `serialization = "none"`, so caching provides no cross-build value, and the miss rate in
+    /// a single build is effectively 100%.
+    async fn content_with_async_module_info(
+        &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
         estimated: bool,
-    ) -> Vc<EcmascriptChunkItemContent>;
+    ) -> Result<Vc<EcmascriptChunkItemContent>>;
 }
 
 pub trait EcmascriptChunkItemExt {
@@ -290,13 +295,18 @@ async fn module_factory_with_code_generation_issue(
     chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
     async_module_info: Option<Vc<AsyncModuleInfo>>,
 ) -> Result<Vc<PersistedCode>> {
-    let content = match chunk_item
-        .content_with_async_module_info(async_module_info, false)
-        .await
-    {
-        Ok(item) => item.module_factory().await,
-        Err(err) => Err(err),
-    };
+    async fn get_content(
+        chunk_item: Vc<Box<dyn EcmascriptChunkItem>>,
+        async_module_info: Option<Vc<AsyncModuleInfo>>,
+    ) -> Result<ResolvedVc<PersistedCode>> {
+        let chunk_item_ref = chunk_item.into_trait_ref().await?;
+        let content = chunk_item_ref
+            .content_with_async_module_info(async_module_info, false)
+            .await?
+            .await?;
+        content.module_factory().await
+    }
+    let content = get_content(chunk_item, async_module_info).await;
     Ok(match content {
         Ok(factory) => *factory,
         Err(error) => {
@@ -390,19 +400,19 @@ impl OutputAssetsReference for EcmascriptModuleChunkItem {
     }
 }
 
+#[async_trait]
 #[turbo_tasks::value_impl]
 impl EcmascriptChunkItem for EcmascriptModuleChunkItem {
-    #[turbo_tasks::function]
-    fn content_with_async_module_info(
+    async fn content_with_async_module_info(
         &self,
         async_module_info: Option<Vc<AsyncModuleInfo>>,
         estimated: bool,
-    ) -> Vc<EcmascriptChunkItemContent> {
-        self.module.chunk_item_content(
+    ) -> Result<Vc<EcmascriptChunkItemContent>> {
+        Ok(self.module.chunk_item_content(
             *self.chunking_context,
             *self.module_graph,
             async_module_info,
             estimated,
-        )
+        ))
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -779,17 +779,16 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyze_ecmascript_module(self, None)
-    }
-
-    #[turbo_tasks::function]
     pub fn options(&self) -> Vc<EcmascriptOptions> {
         *self.options
     }
 }
 
 impl EcmascriptModuleAsset {
+    pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
+        analyze_ecmascript_module(self, None)
+    }
+
     pub async fn parse(&self) -> Result<Vc<ParseResult>> {
         let options = self.options.await?;
         let node_env = self

--- a/turbopack/crates/turbopack-ecmascript/src/lib.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/lib.rs
@@ -688,17 +688,16 @@ impl EcmascriptModuleAsset {
     }
 
     #[turbo_tasks::function]
-    pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
-        analyze_ecmascript_module(self, None)
-    }
-
-    #[turbo_tasks::function]
     pub fn options(&self) -> Vc<EcmascriptOptions> {
         *self.options
     }
 }
 
 impl EcmascriptModuleAsset {
+    pub fn analyze(self: Vc<Self>) -> Vc<AnalyzeEcmascriptModuleResult> {
+        analyze_ecmascript_module(self, None)
+    }
+
     pub async fn parse(&self) -> Result<Vc<ParseResult>> {
         let options = self.options.await?;
         let node_env = self

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -331,7 +331,7 @@ impl ReferencedAsset {
     pub async fn from_resolve_result(resolve_result: Vc<ModuleResolveResult>) -> Result<Self> {
         // TODO handle multiple keyed results
         let result = resolve_result.await?;
-        if result.is_unresolvable_ref() {
+        if result.is_unresolvable() {
             return Ok(ReferencedAsset::Unresolvable);
         }
         for (_, result) in result.primary.iter() {
@@ -475,7 +475,7 @@ impl ModuleReference for EsmAssetReference {
                 loader_request,
                 origin.resolve_options(),
             );
-            let loader_fs_path = if let Some(source) = *resolved.first_source().await? {
+            let loader_fs_path = if let Some(source) = resolved.await?.first_source() {
                 source.ident().await?.path.clone()
             } else {
                 bail!("Unable to resolve turbopackLoader '{}'", loader.loader);
@@ -544,7 +544,7 @@ impl ModuleReference for EsmAssetReference {
         .await?;
 
         if let Some(ModulePart::Export(export_name)) = &self.export_name {
-            for &module in result.primary_modules().await? {
+            for &module in result.await?.primary_modules().await?.iter() {
                 if let Some(module) = ResolvedVc::try_downcast(module)
                     && *is_export_missing(*module, export_name.clone()).await?
                 {

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -416,7 +416,7 @@ impl ModuleReference for EsmAssetReference {
                 loader_request,
                 origin.resolve_options(),
             );
-            let loader_fs_path = if let Some(source) = *resolved.first_source().await? {
+            let loader_fs_path = if let Some(source) = resolved.await?.first_source() {
                 (*source.ident().path().await?).clone()
             } else {
                 bail!("Unable to resolve turbopackLoader '{}'", loader.loader);
@@ -485,7 +485,7 @@ impl ModuleReference for EsmAssetReference {
         .await?;
 
         if let Some(ModulePart::Export(export_name)) = &self.export_name {
-            for &module in result.primary_modules().await? {
+            for &module in result.await?.primary_modules().await?.iter() {
                 if let Some(module) = ResolvedVc::try_downcast(module)
                     && *is_export_missing(*module, export_name.clone()).await?
                 {

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3605,14 +3605,15 @@ async fn require_resolve_visitor(
         )
         .to_resolved()
         .await?;
-        let mut values = resolved
-            .await?
-            .primary_sources()
-            .map(|source| async move {
-                Ok(require_resolve(source.ident().await?.path.clone()).into())
-            })
-            .try_join()
-            .await?;
+        let mut values =
+            resolved
+                .await?
+                .primary_sources()
+                .map(|source| async move {
+                    Ok(require_resolve(source.ident().await?.path.clone()).into())
+                })
+                .try_join()
+                .await?;
 
         match values.len() {
             0 => JsValue::unknown(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3605,16 +3605,14 @@ async fn require_resolve_visitor(
         )
         .to_resolved()
         .await?;
-        let mut values =
-            resolved
-                .primary_sources()
-                .await?
-                .iter()
-                .map(|&source| async move {
-                    Ok(require_resolve(source.ident().await?.path.clone()).into())
-                })
-                .try_join()
-                .await?;
+        let mut values = resolved
+            .await?
+            .primary_sources()
+            .map(|source| async move {
+                Ok(require_resolve(source.ident().await?.path.clone()).into())
+            })
+            .try_join()
+            .await?;
 
         match values.len() {
             0 => JsValue::unknown(

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -3733,10 +3733,9 @@ async fn require_resolve_visitor(
         .to_resolved()
         .await?;
         let mut values = resolved
-            .primary_sources()
             .await?
-            .iter()
-            .map(|&source| async move {
+            .primary_sources()
+            .map(|source| async move {
                 Ok(require_resolve(source.ident().path().owned().await?).into())
             })
             .try_join()

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -85,7 +85,7 @@ pub(crate) enum PatternMapping {
     /// ```js
     /// require(`./images/${name}.png`)
     /// ```
-    Map(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<String, SinglePatternMapping>),
+    Map(#[bincode(with = "turbo_bincode::indexmap")] FxIndexMap<RcStr, SinglePatternMapping>),
 }
 
 #[derive(
@@ -231,7 +231,7 @@ enum ImportMode {
 }
 
 fn create_context_map(
-    map: &FxIndexMap<String, SinglePatternMapping>,
+    map: &FxIndexMap<RcStr, SinglePatternMapping>,
     key_expr: &Expr,
     import_mode: ImportMode,
 ) -> Expr {
@@ -304,6 +304,7 @@ async fn to_single_pattern_mapping(
     origin: Vc<Box<dyn ResolveOrigin>>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     resolve_item: &ModuleResolveResultItem,
+    primary: &[(turbopack_core::resolve::RequestKey, ModuleResolveResultItem)],
     resolve_type: ResolveType,
 ) -> Result<SinglePatternMapping> {
     let module = match resolve_item {
@@ -327,6 +328,16 @@ async fn to_single_pattern_mapping(
                     .await?
                     .to_unstyled_string(),
             ));
+        }
+        ModuleResolveResultItem::Duplicate(first) => {
+            return Box::pin(to_single_pattern_mapping(
+                origin,
+                chunking_context,
+                &primary[*first].1,
+                primary,
+                resolve_type,
+            ))
+            .await;
         }
         ModuleResolveResultItem::Empty | ModuleResolveResultItem::Custom(_) => {
             // TODO implement mapping
@@ -405,24 +416,37 @@ impl PatternMapping {
             .cell()),
             1 if !request.request_pattern().await?.has_dynamic_parts() => {
                 let resolve_item = &result.primary.first().unwrap().1;
-                let single_pattern_mapping =
-                    to_single_pattern_mapping(origin, chunking_context, resolve_item, resolve_type)
-                        .await?;
+                let single_pattern_mapping = to_single_pattern_mapping(
+                    origin,
+                    chunking_context,
+                    resolve_item,
+                    &result.primary,
+                    resolve_type,
+                )
+                .await?;
                 Ok(PatternMapping::Single(single_pattern_mapping).cell())
             }
             _ => {
+                let primary = &result.primary;
                 let mut set = HashSet::new();
-                let map = result
-                    .primary
+                let items: Vec<(RcStr, &ModuleResolveResultItem)> = primary
                     .iter()
                     .filter_map(|(k, v)| {
                         let request = k.request.as_ref()?;
-                        set.insert(request).then(|| (request.to_string(), v))
+                        set.insert(request).then(|| (request.clone(), v))
                     })
+                    .collect();
+                let map = items
+                    .into_iter()
                     .map(|(k, v)| async move {
-                        let single_pattern_mapping =
-                            to_single_pattern_mapping(origin, chunking_context, v, resolve_type)
-                                .await?;
+                        let single_pattern_mapping = to_single_pattern_mapping(
+                            origin,
+                            chunking_context,
+                            v,
+                            primary,
+                            resolve_type,
+                        )
+                        .await?;
                         Ok((k, single_pattern_mapping))
                     })
                     .try_join()

--- a/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/pattern_mapping.rs
@@ -304,6 +304,7 @@ async fn to_single_pattern_mapping(
     origin: Vc<Box<dyn ResolveOrigin>>,
     chunking_context: Vc<Box<dyn ChunkingContext>>,
     resolve_item: &ModuleResolveResultItem,
+    primary: &[(turbopack_core::resolve::RequestKey, ModuleResolveResultItem)],
     resolve_type: ResolveType,
 ) -> Result<SinglePatternMapping> {
     let module = match resolve_item {
@@ -327,6 +328,16 @@ async fn to_single_pattern_mapping(
                     .await?
                     .to_unstyled_string(),
             ));
+        }
+        ModuleResolveResultItem::Duplicate(first) => {
+            return Box::pin(to_single_pattern_mapping(
+                origin,
+                chunking_context,
+                &primary[*first].1,
+                primary,
+                resolve_type,
+            ))
+            .await;
         }
         ModuleResolveResultItem::OutputAsset(_)
         | ModuleResolveResultItem::Empty
@@ -407,25 +418,41 @@ impl PatternMapping {
             .cell()),
             1 if !request.request_pattern().await?.has_dynamic_parts() => {
                 let resolve_item = &result.primary.first().unwrap().1;
-                let single_pattern_mapping =
-                    to_single_pattern_mapping(origin, chunking_context, resolve_item, resolve_type)
-                        .await?;
+                let single_pattern_mapping = to_single_pattern_mapping(
+                    origin,
+                    chunking_context,
+                    resolve_item,
+                    &result.primary,
+                    resolve_type,
+                )
+                .await?;
                 Ok(PatternMapping::Single(single_pattern_mapping).cell())
             }
             _ => {
+                let primary = result.primary.clone();
                 let mut set = HashSet::new();
-                let map = result
-                    .primary
+                let items: Vec<(String, &ModuleResolveResultItem)> = primary
                     .iter()
                     .filter_map(|(k, v)| {
                         let request = k.request.as_ref()?;
                         set.insert(request).then(|| (request.to_string(), v))
                     })
-                    .map(|(k, v)| async move {
-                        let single_pattern_mapping =
-                            to_single_pattern_mapping(origin, chunking_context, v, resolve_type)
-                                .await?;
-                        Ok((k, single_pattern_mapping))
+                    .collect();
+                let map = items
+                    .into_iter()
+                    .map(|(k, v)| {
+                        let primary = primary.clone();
+                        async move {
+                            let single_pattern_mapping = to_single_pattern_mapping(
+                                origin,
+                                chunking_context,
+                                v,
+                                &primary,
+                                resolve_type,
+                            )
+                            .await?;
+                            Ok((k, single_pattern_mapping))
+                        }
                     })
                     .try_join()
                     .await?

--- a/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/tree_shake/part/module.rs
@@ -395,7 +395,6 @@ impl EcmascriptModulePartAsset {
     }
 }
 
-#[turbo_tasks::function]
 fn analyze(
     module: Vc<EcmascriptModuleAsset>,
     part: ModulePart,

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -661,7 +661,7 @@ impl EvaluateContext for WebpackLoaderContext {
                     options,
                 );
 
-                if let Some(source) = *resolved.first_source().await? {
+                if let Some(source) = resolved.await?.first_source() {
                     if let Some(path) = self.cwd.get_relative_path_to(&source.ident().await?.path) {
                         Ok(ResponseMessage::Resolve { path })
                     } else {
@@ -702,7 +702,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 )
                 .await?;
 
-                let Some(module) = *resolved.first_module().await? else {
+                let Some(module) = resolved.await?.first_module().await? else {
                     bail!(
                         "importModule: unable to resolve {} in {}",
                         request,

--- a/turbopack/crates/turbopack-node/src/transforms/webpack.rs
+++ b/turbopack/crates/turbopack-node/src/transforms/webpack.rs
@@ -652,7 +652,7 @@ impl EvaluateContext for WebpackLoaderContext {
                     options,
                 );
 
-                if let Some(source) = *resolved.first_source().await? {
+                if let Some(source) = resolved.await?.first_source() {
                     if let Some(path) = self
                         .cwd
                         .get_relative_path_to(&*source.ident().path().await?)
@@ -696,7 +696,7 @@ impl EvaluateContext for WebpackLoaderContext {
                 )
                 .await?;
 
-                let Some(module) = *resolved.first_module().await? else {
+                let Some(module) = resolved.await?.first_module().await? else {
                     bail!(
                         "importModule: unable to resolve {} in {}",
                         request,

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -95,10 +95,9 @@ async fn resolve_node_pre_gyp_files(
         collect_affecting_sources,
         true,
     )
-    .first_source()
     .await?;
     let compile_target = compile_target.await?;
-    if let Some(config_asset) = *config
+    if let Some(config_asset) = config.first_source()
         && let AssetContent::File(file) = &*config_asset.content().await?
         && let FileContent::Content(config_file) = &*file.await?
     {
@@ -273,9 +272,11 @@ async fn resolve_node_gyp_build_files(
         collect_affecting_sources,
         true,
     );
-    if let [binding_gyp] = &gyp_file.primary_sources().await?[..] {
+    let gyp_file = gyp_file.await?;
+    let mut primary_sources = gyp_file.primary_sources();
+    if let (Some(binding_gyp), None) = (primary_sources.next(), primary_sources.next()) {
         let mut merged_affecting_sources = if collect_affecting_sources {
-            gyp_file.await?.get_affecting_sources().collect::<Vec<_>>()
+            gyp_file.get_affecting_sources().collect::<Vec<_>>()
         } else {
             Vec::new()
         };
@@ -399,9 +400,8 @@ async fn resolve_node_bindings_files(
             collect_affecting_sources,
             true,
         )
-        .first_source()
         .await?;
-        if let Some(asset) = *resolved
+        if let Some(asset) = resolved.first_source()
             && let AssetContent::File(file) = &*asset.content().await?
             && let FileContent::Content(_) = &*file.await?
         {

--- a/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
+++ b/turbopack/crates/turbopack-resolve/src/node_native_binding.rs
@@ -95,10 +95,9 @@ async fn resolve_node_pre_gyp_files(
         collect_affecting_sources,
         true,
     )
-    .first_source()
     .await?;
     let compile_target = compile_target.await?;
-    if let Some(config_asset) = *config
+    if let Some(config_asset) = config.first_source()
         && let AssetContent::File(file) = &*config_asset.content().await?
         && let FileContent::Content(config_file) = &*file.await?
     {
@@ -272,9 +271,11 @@ async fn resolve_node_gyp_build_files(
         collect_affecting_sources,
         true,
     );
-    if let [binding_gyp] = &gyp_file.primary_sources().await?[..] {
+    let gyp_file = gyp_file.await?;
+    let mut primary_sources = gyp_file.primary_sources();
+    if let (Some(binding_gyp), None) = (primary_sources.next(), primary_sources.next()) {
         let mut merged_affecting_sources = if collect_affecting_sources {
-            gyp_file.await?.get_affecting_sources().collect::<Vec<_>>()
+            gyp_file.get_affecting_sources().collect::<Vec<_>>()
         } else {
             Vec::new()
         };
@@ -398,9 +399,8 @@ async fn resolve_node_bindings_files(
             collect_affecting_sources,
             true,
         )
-        .first_source()
         .await?;
-        if let Some(asset) = *resolved
+        if let Some(asset) = resolved.first_source()
             && let AssetContent::File(file) = &*asset.content().await?
             && let FileContent::Content(_) = &*file.await?
         {

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
         pattern::Pattern,
         resolve,
     },
-    source::{OptionSource, Source},
+    source::Source,
 };
 
 use crate::ecmascript::get_condition_maps;
@@ -88,7 +88,7 @@ pub async fn read_tsconfigs(
                 configs.push((parsed_data, tsconfig));
                 if let Some(extends) = json["extends"].as_str() {
                     let resolved = resolve_extends(*tsconfig, extends, resolve_options).await?;
-                    if let Some(source) = *resolved.await? {
+                    if let Some(source) = resolved {
                         data = source.content().file_content();
                         tsconfig = source;
                         continue;
@@ -118,7 +118,7 @@ async fn resolve_extends(
     tsconfig: Vc<Box<dyn Source>>,
     extends: &str,
     resolve_options: Vc<ResolveOptions>,
-) -> Result<Vc<OptionSource>> {
+) -> Result<Option<ResolvedVc<Box<dyn Source>>>> {
     let parent_dir = tsconfig.ident().await?.path.parent();
     let request = Request::parse_string(extends.into());
 
@@ -148,18 +148,18 @@ async fn resolve_extends(
         Request::Empty => {
             let request = Request::parse_string(rcstr!("./tsconfig"));
             Ok(resolve(parent_dir,
-                ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source())
+                ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).await?.first_source())
         }
 
         // All other types are treated as module imports, and potentially joined with
         // "tsconfig.json". This includes "relative" imports like '.' and '..'.
         _ => {
-            let mut result = resolve(parent_dir.clone(), ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
-            if result.await?.is_none() {
-                let request = Request::parse_string(format!("{extends}/tsconfig").into());
-                result = resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
+            let result = resolve(parent_dir.clone(), ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).await?;
+            if let Some(source) = result.first_source() {
+                return Ok(Some(source));
             }
-            Ok(result)
+            let request = Request::parse_string(format!("{extends}/tsconfig").into());
+            Ok(resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).await?.first_source())
         }
     }
 }
@@ -169,19 +169,21 @@ async fn resolve_extends_rooted_or_relative(
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     path: &str,
-) -> Result<Vc<OptionSource>> {
-    let mut result = resolve(
+) -> Result<Option<ResolvedVc<Box<dyn Source>>>> {
+    let result = resolve(
         lookup_path.clone(),
         ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
         request,
         resolve_options,
     )
-    .first_source();
+    .await?;
+
+    let mut result = result.first_source();
 
     // If the file doesn't end with ".json" and we can't find the file, then we have
     // to try again with it.
     // https://github.com/microsoft/TypeScript/blob/611a912d/src/compiler/commandLineParser.ts#L3305
-    if !path.ends_with(".json") && result.await?.is_none() {
+    if !path.ends_with(".json") && result.is_none() {
         let request = Request::parse_string(format!("{path}.json").into());
         result = resolve(
             lookup_path.clone(),
@@ -189,6 +191,7 @@ async fn resolve_extends_rooted_or_relative(
             request,
             resolve_options,
         )
+        .await?
         .first_source();
     }
     Ok(result)
@@ -424,7 +427,7 @@ pub async fn type_resolve(
             request,
             options,
         );
-        if !*result1.is_unresolvable().await? {
+        if !result1.await?.is_unresolvable() {
             result1
         } else {
             resolve(

--- a/turbopack/crates/turbopack-resolve/src/typescript.rs
+++ b/turbopack/crates/turbopack-resolve/src/typescript.rs
@@ -25,7 +25,7 @@ use turbopack_core::{
         pattern::Pattern,
         resolve,
     },
-    source::{OptionSource, Source},
+    source::Source,
 };
 
 use crate::ecmascript::get_condition_maps;
@@ -88,7 +88,7 @@ pub async fn read_tsconfigs(
                 configs.push((parsed_data, tsconfig));
                 if let Some(extends) = json["extends"].as_str() {
                     let resolved = resolve_extends(*tsconfig, extends, resolve_options).await?;
-                    if let Some(source) = *resolved.await? {
+                    if let Some(source) = resolved {
                         data = source.content().file_content();
                         tsconfig = source;
                         continue;
@@ -118,7 +118,7 @@ async fn resolve_extends(
     tsconfig: Vc<Box<dyn Source>>,
     extends: &str,
     resolve_options: Vc<ResolveOptions>,
-) -> Result<Vc<OptionSource>> {
+) -> Result<Option<ResolvedVc<Box<dyn Source>>>> {
     let parent_dir = tsconfig.ident().path().await?.parent();
     let request = Request::parse_string(extends.into());
 
@@ -148,18 +148,18 @@ async fn resolve_extends(
         Request::Empty => {
             let request = Request::parse_string(rcstr!("./tsconfig"));
             Ok(resolve(parent_dir,
-                ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source())
+                ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).await?.first_source())
         }
 
         // All other types are treated as module imports, and potentially joined with
         // "tsconfig.json". This includes "relative" imports like '.' and '..'.
         _ => {
-            let mut result = resolve(parent_dir.clone(), ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
-            if result.await?.is_none() {
-                let request = Request::parse_string(format!("{extends}/tsconfig").into());
-                result = resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).first_source();
+            let result = resolve(parent_dir.clone(), ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).await?;
+            if let Some(source) = result.first_source() {
+                return Ok(Some(source));
             }
-            Ok(result)
+            let request = Request::parse_string(format!("{extends}/tsconfig").into());
+            Ok(resolve(parent_dir, ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined), request, resolve_options).await?.first_source())
         }
     }
 }
@@ -169,19 +169,21 @@ async fn resolve_extends_rooted_or_relative(
     request: Vc<Request>,
     resolve_options: Vc<ResolveOptions>,
     path: &str,
-) -> Result<Vc<OptionSource>> {
-    let mut result = resolve(
+) -> Result<Option<ResolvedVc<Box<dyn Source>>>> {
+    let result = resolve(
         lookup_path.clone(),
         ReferenceType::TypeScript(TypeScriptReferenceSubType::Undefined),
         request,
         resolve_options,
     )
-    .first_source();
+    .await?;
+
+    let mut result = result.first_source();
 
     // If the file doesn't end with ".json" and we can't find the file, then we have
     // to try again with it.
     // https://github.com/microsoft/TypeScript/blob/611a912d/src/compiler/commandLineParser.ts#L3305
-    if !path.ends_with(".json") && result.await?.is_none() {
+    if !path.ends_with(".json") && result.is_none() {
         let request = Request::parse_string(format!("{path}.json").into());
         result = resolve(
             lookup_path.clone(),
@@ -189,6 +191,7 @@ async fn resolve_extends_rooted_or_relative(
             request,
             resolve_options,
         )
+        .await?
         .first_source();
     }
     Ok(result)
@@ -425,7 +428,7 @@ pub async fn type_resolve(
             request,
             options,
         );
-        if !*result1.is_unresolvable().await? {
+        if !result1.await?.is_unresolvable() {
             result1
         } else {
             resolve(

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -422,19 +422,11 @@ impl ModuleAssetContext {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_types_resolving_enabled(&self) -> Result<Vc<bool>> {
-        let resolve_options_context = self.resolve_options_context.await?;
-        Ok(Vc::cell(
-            resolve_options_context.enable_types && resolve_options_context.enable_typescript,
-        ))
-    }
-
-    #[turbo_tasks::function]
     pub async fn with_types_resolving_enabled(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
-        if *self.is_types_resolving_enabled().await? {
+        let this = self.await?;
+        if this.is_types_resolving_enabled().await? {
             return Ok(self);
         }
-        let this = self.await?;
         let resolve_options_context = *this
             .resolve_options_context
             .with_types_enabled()
@@ -452,6 +444,10 @@ impl ModuleAssetContext {
 }
 
 impl ModuleAssetContext {
+    async fn is_types_resolving_enabled(&self) -> Result<bool> {
+        let resolve_options_context = self.resolve_options_context.await?;
+        Ok(resolve_options_context.enable_types && resolve_options_context.enable_typescript)
+    }
     async fn process_with_transition_rules(
         self: Vc<Self>,
         source: ResolvedVc<Box<dyn Source>>,
@@ -1025,8 +1021,8 @@ impl AssetContext for ModuleAssetContext {
         );
 
         let mut result = self.process_resolve_result(*result.to_resolved().await?, reference_type);
-
-        if *self.is_types_resolving_enabled().await? {
+        let this = self.await?;
+        if this.is_types_resolving_enabled().await? {
             let types_result = type_resolve(
                 Vc::upcast(PlainResolveOrigin::new(Vc::upcast(self), origin_path)),
                 request,

--- a/turbopack/crates/turbopack/src/lib.rs
+++ b/turbopack/crates/turbopack/src/lib.rs
@@ -422,16 +422,9 @@ impl ModuleAssetContext {
     }
 
     #[turbo_tasks::function]
-    pub async fn is_types_resolving_enabled(&self) -> Result<Vc<bool>> {
-        let resolve_options_context = self.resolve_options_context.await?;
-        Ok(Vc::cell(
-            resolve_options_context.enable_types && resolve_options_context.enable_typescript,
-        ))
-    }
-
-    #[turbo_tasks::function]
     pub async fn with_types_resolving_enabled(self: Vc<Self>) -> Result<Vc<ModuleAssetContext>> {
-        if *self.is_types_resolving_enabled().await? {
+        let this = self.await?;
+        if this.is_types_resolving_enabled().await? {
             return Ok(self);
         }
         let this = self.await?;
@@ -452,6 +445,10 @@ impl ModuleAssetContext {
 }
 
 impl ModuleAssetContext {
+    async fn is_types_resolving_enabled(&self) -> Result<bool> {
+        let resolve_options_context = self.resolve_options_context.await?;
+        Ok(resolve_options_context.enable_types && resolve_options_context.enable_typescript)
+    }
     async fn process_with_transition_rules(
         self: Vc<Self>,
         source: ResolvedVc<Box<dyn Source>>,
@@ -1024,8 +1021,8 @@ impl AssetContext for ModuleAssetContext {
         );
 
         let mut result = self.process_resolve_result(*result.to_resolved().await?, reference_type);
-
-        if *self.is_types_resolving_enabled().await? {
+        let this = self.await?;
+        if this.is_types_resolving_enabled().await? {
             let types_result = type_resolve(
                 Vc::upcast(PlainResolveOrigin::new(Vc::upcast(self), origin_path)),
                 request,

--- a/turbopack/scripts/analyze_cache_effectiveness.py
+++ b/turbopack/scripts/analyze_cache_effectiveness.py
@@ -12,11 +12,20 @@ Then run this script with the path to the stats.json file to get a report on cac
 
 The JSON format contains entries like:
   { "task_name": { "cache_hit": N, "cache_miss": N } }
+
+Usage:
+  analyze_cache_effectiveness.py <stats.json>
+  analyze_cache_effectiveness.py --diff <before.json> <after.json> [--top N]
+
+In --diff mode, the script reports the tasks whose hits or misses changed the
+most between the two runs — useful for evaluating the impact of removing or
+adding `turbo_tasks` caching on specific functions.
 """
 
+import argparse
 import json
 import sys
-from typing import List, Tuple
+from typing import Dict, List
 from dataclasses import dataclass
 
 
@@ -52,6 +61,10 @@ def load_task_stats(file_path: str) -> List[TaskStats]:
         tasks.append(task)
 
     return tasks
+
+
+def load_task_stats_map(file_path: str) -> Dict[str, TaskStats]:
+    return {t.name: t for t in load_task_stats(file_path)}
 
 
 def analyze_tasks(tasks: List[TaskStats]) -> List[TaskStats]:
@@ -114,26 +127,212 @@ def print_analysis(tasks: List[TaskStats]):
     print(f"Tasks with <50% hit rate: {low_hit_rate_count}")
 
 
-def main():
-    if len(sys.argv) != 2:
-        print("Usage: python analyze_cache_effectiveness.py <stats.json>")
-        sys.exit(1)
+@dataclass
+class TaskDiff:
+    name: str
+    before_hit: int
+    after_hit: int
+    before_miss: int
+    after_miss: int
 
-    file_path = sys.argv[1]
+    @property
+    def delta_hit(self) -> int:
+        return self.after_hit - self.before_hit
+
+    @property
+    def delta_miss(self) -> int:
+        return self.after_miss - self.before_miss
+
+    @staticmethod
+    def _rate(hit: int, miss: int) -> float:
+        total = hit + miss
+        return hit / total if total > 0 else 0.0
+
+    @property
+    def before_rate(self) -> float:
+        return self._rate(self.before_hit, self.before_miss)
+
+    @property
+    def after_rate(self) -> float:
+        return self._rate(self.after_hit, self.after_miss)
+
+    @property
+    def delta_rate(self) -> float:
+        return self.after_rate - self.before_rate
+
+
+def compute_diff(
+    before: Dict[str, TaskStats], after: Dict[str, TaskStats]
+) -> List[TaskDiff]:
+    names = set(before) | set(after)
+    diffs = []
+    zero = TaskStats(name="", cache_hit=0, cache_miss=0)
+    for name in names:
+        b = before.get(name, zero)
+        a = after.get(name, zero)
+        diffs.append(
+            TaskDiff(
+                name=name,
+                before_hit=b.cache_hit,
+                after_hit=a.cache_hit,
+                before_miss=b.cache_miss,
+                after_miss=a.cache_miss,
+            )
+        )
+    return diffs
+
+
+def _print_diff_section(
+    title: str, diffs: List[TaskDiff], key, top: int, reverse: bool
+):
+    print("=" * 100)
+    print(title)
+    print("=" * 100)
+    ordered = sorted(diffs, key=key, reverse=reverse)
+    header = (
+        f"{'Δhit':>12} {'Δmiss':>12} {'hit b→a':>22} {'miss b→a':>22} "
+        f"{'rate b→a':>18}  Task"
+    )
+    print(header)
+    print("-" * len(header))
+    shown = 0
+    for d in ordered:
+        # Stop once the signed delta crosses zero in the direction we care about.
+        v = key(d)
+        if reverse and v <= 0:
+            break
+        if not reverse and v >= 0:
+            break
+        hit_str = f"{d.before_hit:,}→{d.after_hit:,}"
+        miss_str = f"{d.before_miss:,}→{d.after_miss:,}"
+        rate_str = f"{d.before_rate:.0%}→{d.after_rate:.0%}"
+        print(
+            f"{d.delta_hit:>+12,} {d.delta_miss:>+12,} "
+            f"{hit_str:>22} {miss_str:>22} {rate_str:>18}  {d.name}"
+        )
+        shown += 1
+        if shown >= top:
+            break
+    if shown == 0:
+        print("(none)")
+    print()
+
+
+def print_diff(
+    before: Dict[str, TaskStats], after: Dict[str, TaskStats], top: int
+):
+    diffs = compute_diff(before, after)
+
+    before_hits = sum(t.cache_hit for t in before.values())
+    after_hits = sum(t.cache_hit for t in after.values())
+    before_misses = sum(t.cache_miss for t in before.values())
+    after_misses = sum(t.cache_miss for t in after.values())
+    before_total = before_hits + before_misses
+    after_total = after_hits + after_misses
+    before_rate = before_hits / before_total if before_total > 0 else 0.0
+    after_rate = after_hits / after_total if after_total > 0 else 0.0
+
+    only_before = set(before) - set(after)
+    only_after = set(after) - set(before)
+
+    print("Cache statistics diff (before → after)")
+    print()
+    print(
+        f"Hits:     {before_hits:>12,} → {after_hits:>12,}  "
+        f"({after_hits - before_hits:+,})"
+    )
+    print(
+        f"Misses:   {before_misses:>12,} → {after_misses:>12,}  "
+        f"({after_misses - before_misses:+,})"
+    )
+    print(
+        f"Hit rate: {before_rate:>11.2%} → {after_rate:>11.2%}  "
+        f"({(after_rate - before_rate) * 100:+.2f} pp)"
+    )
+    print(
+        f"Tasks:    {len(before):>12,} → {len(after):>12,}  "
+        f"(only in before: {len(only_before)}, only in after: {len(only_after)})"
+    )
+    print()
+
+    _print_diff_section(
+        f"Top {top} INCREASES IN HITS (after > before)",
+        diffs,
+        key=lambda d: d.delta_hit,
+        top=top,
+        reverse=True,
+    )
+    _print_diff_section(
+        f"Top {top} INCREASES IN MISSES (after > before)",
+        diffs,
+        key=lambda d: d.delta_miss,
+        top=top,
+        reverse=True,
+    )
+    _print_diff_section(
+        f"Top {top} DECREASES IN HITS (after < before)",
+        diffs,
+        key=lambda d: d.delta_hit,
+        top=top,
+        reverse=False,
+    )
+    _print_diff_section(
+        f"Top {top} DECREASES IN MISSES (after < before)",
+        diffs,
+        key=lambda d: d.delta_miss,
+        top=top,
+        reverse=False,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Analyze turbo_tasks cache effectiveness, or diff two stats files "
+            "to see which tasks gained or lost hits/misses."
+        ),
+    )
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Diff mode: compare two stats files and report largest changes.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=25,
+        help="Number of entries to show per section in --diff mode (default: 25).",
+    )
+    parser.add_argument(
+        "files",
+        nargs="+",
+        help=(
+            "Path to stats JSON. In default mode, one file. "
+            "In --diff mode, two files: <before> <after>."
+        ),
+    )
+
+    args = parser.parse_args()
 
     try:
-        tasks = load_task_stats(file_path)
-        tasks = analyze_tasks(tasks)
-        print_analysis(tasks)
+        if args.diff:
+            if len(args.files) != 2:
+                parser.error("--diff requires exactly two files: <before> <after>")
+            before = load_task_stats_map(args.files[0])
+            after = load_task_stats_map(args.files[1])
+            print_diff(before, after, args.top)
+        else:
+            if len(args.files) != 1:
+                parser.error("default mode requires exactly one stats file")
+            tasks = load_task_stats(args.files[0])
+            tasks = analyze_tasks(tasks)
+            print_analysis(tasks)
 
-    except FileNotFoundError:
-        print(f"Error: File '{file_path}' not found")
+    except FileNotFoundError as e:
+        print(f"Error: File not found: {e.filename}")
         sys.exit(1)
     except json.JSONDecodeError as e:
         print(f"Error parsing JSON: {e}")
-        sys.exit(1)
-    except Exception as e:
-        print(f"Error: {e}")
         sys.exit(1)
 
 


### PR DESCRIPTION
## Remove ineffective turbo-tasks

Identifies and removes turbo-tasks functions where the task overhead exceeds the value they provide. Each turbo-task carries ~4-6μs execution overhead per miss and ~200-500ns per cache hit, plus allocations and bookkeeping.

### What?

Removes 22 `#[turbo_tasks::function]` implementations across resolve plugins, chunk items, and resolve-result helpers — converting them to plain methods or inlining their work. Changes fall into a few buckets:

- **ResolvePlugin condition handling** (`AfterResolvePluginCondition::matches`, `BeforeResolvePluginCondition::matches`, `after_resolve_condition`, `before_resolve_condition`): conditions now store the resolved `Glob` as a `ReadRef<Glob>` on the plugin struct at construction, so `matches` is a pure sync function and the per-plugin `*_resolve_condition` getters are trivial field reads (no longer turbo-tasks). The `after_resolve` / `before_resolve` hooks themselves stay as `#[turbo_tasks::function]` — they synthesize virtual sources/modules and need memoization on `(self, lookup_path, reference_type, request)` to avoid distinct cells producing duplicate module-graph idents.
    - The basic theory here is that the right level of caching is at `resolve` and at the hook bodies themselves, not the conditions or condition getters.
    - `AfterResolvePluginCondition` and `BeforeResolvePluginCondition` are marked `serialization = "none"` because `ReadRef` cannot be persisted; plugin construction is cheap enough to re-derive on restore.
- **ChunkItem trait methods** (`chunking_context`, `ty`, `content_with_async_module_info`): returned constants or simple field reads, zero cache hits and no `.await` calls (no invalidation value).
- **ResolveResult / ModuleResolveResult helpers** (`primary_modules`, `first_module`, `first_source`, `primary_sources`, `is_unresolvable`, `primary_output_assets`): simple iterators over already-resolved data; converted to plain methods. Added a `Duplicate(usize)` variant to `ModuleResolveResultItem` to handle dedup at construction time instead of in a separate task.
    - The basic idea here is that it is reasonable to consume `ResolveResult/ModuleResolveResult` monolithically, and we get little to no benefit from fine grained access. e.g. `is_unresolved()` in theory that is a valuable turbotask, but since it rarely changes but generally if we change how we resolve an import then we have to regenerate code, so saving a few boolean conditions is unlikely to be very valuable.
- Misc: `EcmascriptModuleAsset::analyze`, `is_types_resolving_enabled`, `next_server::resolve::condition`.

### Impact (vercel-site build, dev first-compile)

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| Total cache hits | 30,885,827 | 29,201,314 | −1,684,513 |
| Total cache misses | 6,473,123 | 5,953,626 | **−519,497** |
| Overall hit rate | 82.67% | 83.06% | +0.39 pp |
| Registered task functions | 1,294 | 1,272 | −22 |

The 22 removed tasks were collectively responsible for ~519K misses per build — each miss previously paying the full execution overhead. Most of the work from `EcmascriptModuleAsset::analyze` naturally migrated into `analyze_ecmascript_module` (the task it was wrapping; +129K hits there).

### On-disk cache size (persistent caching)

Each removed task also stops allocating cache cells on disk. Measured on the same vercel-site build with `.next/cache/turbopack` (persistent cache enabled):

| | Size |
|---|---:|
| canary | 2.56 GiB |
| this branch | 2.46 GiB |
| **saved** | **~100 MiB (−3.81%)** |

### Build-time wall clock and peak memory

Ran `pnpm next build --experimental-build-mode=compile` 5 times on each branch

**Peak RSS — clear reduction:**

| | canary | branch | Δ |
|---|---:|---:|---:|
| min | 19.18 GiB | 18.94 GiB | |
| **median** | **19.22 GiB** | **19.01 GiB** | **−217 MiB (−1.10%)** |
| mean | 19.21 GiB | 19.02 GiB | −199 MiB (−1.01%) |
| max | 19.23 GiB | 19.13 GiB | |

Every branch run has lower RSS than every canary run — the distributions don't overlap. Welch's t = −6.03.

**Wall time — no measurable change:**

| | canary | branch | Δ |
|---|---:|---:|---:|
| min | 62.03s | 60.78s | |
| **median** | **62.61s** | **62.65s** | **+0.04s (+0.06%)** |
| mean | 62.83s | 63.80s | +0.96s (+1.53%) |
| max | 64.25s | 68.23s | |
| stddev | 0.84s | 3.42s | |

Median is flat. The mean difference is within noise (Welch's t = +0.61, n = 5). Branch run-to-run variance is higher — one 68.23s outlier pulls the mean up — so this is neither a regression nor a measurable speedup at this sample size.

<!-- NEXT_JS_LLM_PR -->
