### PR TITLE
Enable thin LTO for release builds

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -21,7 +21,6 @@ env:
   NAPI_CLI_VERSION: 2.18.4
   TURBO_VERSION: 2.8.11
   NODE_LTS_VERSION: 20
-  CARGO_PROFILE_RELEASE_LTO: 'true'
   TURBO_TEAM: 'vercel'
   TURBO_CACHE: 'remote:rw'
   # Without this environment variable, rust-lld will fail because some dependencies defaults to newer version of macOS by default.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ opt-level = 1
 opt-level = 3
 
 [profile.release]
+lto = "thin"
 
 [profile.release.package]
 

--- a/crates/next-napi-bindings/Cargo.toml
+++ b/crates/next-napi-bindings/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib", "rlib"]
+crate-type = ["cdylib"]
 
 [features]
 # Instead of enabling all the plugin-related functionality by default, make it


### PR DESCRIPTION
# What

Add `lto = "thin"` to the workspace-level `[profile.release]` in `Cargo.toml`.

# Why

Thin LTO enables cross-crate optimization at link time, improving runtime
performance of the final artifacts (next-napi-bindings native module,
turbopack-cli binary, and benchmarks) without the full build time cost of
fat LTO.

# How

Added `lto = "thin"` to the workspace root `[profile.release]` section.
This applies to all release-profile link targets in the workspace, including
binaries, cdylibs, and benchmarks. The `release-with-assertions` and
`release-with-debug` profiles inherit from `release`, so they also benefit.