### PR TITLE
Turboopack: put import attributes behind a pointer, 23% faster analyze

### DIFF
--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/imports.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::BTreeMap, fmt::Display};
+use std::{borrow::Cow, collections::BTreeMap, fmt::Display, sync::Arc};
 
 use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -60,10 +60,8 @@ static ANNOTATION_CHUNKING_TYPE: Lazy<Wtf8Atom> =
 static ATTRIBUTE_MODULE_TYPE: Lazy<Wtf8Atom> = Lazy::new(|| atom!("type").into());
 
 impl ImportAnnotations {
-    pub fn parse(with: Option<&ObjectLit>) -> ImportAnnotations {
-        let Some(with) = with else {
-            return ImportAnnotations::default();
-        };
+    pub fn parse(with: Option<&ObjectLit>) -> Option<ImportAnnotations> {
+        let with = with?;
 
         let mut map = BTreeMap::new();
         let mut turbopack_loader_name: Option<RcStr> = None;
@@ -148,11 +146,19 @@ impl ImportAnnotations {
             options: turbopack_loader_options,
         });
 
-        ImportAnnotations {
-            map,
-            turbopack_loader,
-            turbopack_rename_as,
-            turbopack_module_type,
+        if !map.is_empty()
+            || turbopack_loader.is_some()
+            || turbopack_rename_as.is_some()
+            || turbopack_module_type.is_some()
+        {
+            Some(ImportAnnotations {
+                map,
+                turbopack_loader,
+                turbopack_rename_as,
+                turbopack_module_type,
+            })
+        } else {
+            None
         }
     }
 
@@ -181,12 +187,16 @@ impl ImportAnnotations {
             );
         }
 
-        Some(ImportAnnotations {
-            map,
-            turbopack_loader: None,
-            turbopack_rename_as: None,
-            turbopack_module_type: None,
-        })
+        if !map.is_empty() {
+            Some(ImportAnnotations {
+                map,
+                turbopack_loader: None,
+                turbopack_rename_as: None,
+                turbopack_module_type: None,
+            })
+        } else {
+            None
+        }
     }
 
     /// Returns the content on the transition annotation
@@ -395,7 +405,7 @@ pub(crate) enum ImportedSymbol {
 pub(crate) struct ImportMapReference {
     pub module_path: Wtf8Atom,
     pub imported_symbol: ImportedSymbol,
-    pub annotations: ImportAnnotations,
+    pub annotations: Option<Arc<ImportAnnotations>>,
     pub issue_source: Option<IssueSource>,
 }
 
@@ -581,7 +591,7 @@ impl Analyzer<'_> {
         span: Span,
         module_path: Wtf8Atom,
         imported_symbol: ImportedSymbol,
-        annotations: ImportAnnotations,
+        annotations: Option<ImportAnnotations>,
     ) -> Option<usize> {
         let issue_source = self
             .source
@@ -591,7 +601,7 @@ impl Analyzer<'_> {
             module_path,
             imported_symbol,
             issue_source,
-            annotations,
+            annotations: annotations.map(Arc::new),
         };
         if let Some(i) = self.data.references.get_index_of(&r) {
             Some(i)
@@ -897,11 +907,11 @@ impl Visit for Analyzer<'_> {
                 _ => None,
             };
 
-            let attributes = parse_directives(comments, n.args.first());
-
-            if let Some((callee_span, attributes)) = callee_span.zip(attributes) {
+            if let Some(callee_span) = callee_span
+                && let Some(attributes) = parse_directives(comments, n.args.first())
+            {
                 self.data.attributes.insert(callee_span.lo, attributes);
-            };
+            }
         }
 
         n.visit_children_with(self);
@@ -915,11 +925,11 @@ impl Visit for Analyzer<'_> {
                 _ => None,
             };
 
-            let attributes = parse_directives(comments, n.args.iter().flatten().next());
-
-            if let Some((callee_span, attributes)) = callee_span.zip(attributes) {
+            if let Some(callee_span) = callee_span
+                && let Some(attributes) = parse_directives(comments, n.args.iter().flatten().next())
+            {
                 self.data.attributes.insert(callee_span.lo, attributes);
-            };
+            }
         }
 
         n.visit_children_with(self);
@@ -1069,7 +1079,7 @@ mod tests {
             props: vec![kv_prop(ident_key("turbopackLoader"), str_lit("raw-loader"))],
         };
 
-        let annotations = ImportAnnotations::parse(Some(&with));
+        let annotations = ImportAnnotations::parse(Some(&with)).unwrap();
         assert!(annotations.has_turbopack_loader());
 
         let loader = annotations.turbopack_loader().unwrap();
@@ -1091,7 +1101,7 @@ mod tests {
             ],
         };
 
-        let annotations = ImportAnnotations::parse(Some(&with));
+        let annotations = ImportAnnotations::parse(Some(&with)).unwrap();
         assert!(annotations.has_turbopack_loader());
 
         let loader = annotations.turbopack_loader().unwrap();
@@ -1107,7 +1117,7 @@ mod tests {
             props: vec![kv_prop(ident_key("type"), str_lit("json"))],
         };
 
-        let annotations = ImportAnnotations::parse(Some(&with));
+        let annotations = ImportAnnotations::parse(Some(&with)).unwrap();
         assert!(!annotations.has_turbopack_loader());
         assert!(annotations.module_type().is_some());
     }
@@ -1115,7 +1125,6 @@ mod tests {
     #[test]
     fn test_parse_empty_with() {
         let annotations = ImportAnnotations::parse(None);
-        assert!(!annotations.has_turbopack_loader());
-        assert!(annotations.module_type().is_none());
+        assert!(annotations.is_none());
     }
 }

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/mod.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use anyhow::{Result, bail};
+use either::Either;
 use num_bigint::BigInt;
 use num_traits::identities::Zero;
 use once_cell::sync::Lazy;
@@ -268,7 +269,7 @@ impl Display for ConstantValue {
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub struct ModuleValue {
     pub module: Wtf8Atom,
-    pub annotations: ImportAnnotations,
+    pub annotations: Option<Arc<ImportAnnotations>>,
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -799,7 +800,16 @@ impl Display for JsValue {
                 module: name,
                 annotations,
             }) => {
-                write!(f, "Module({}, {annotations})", name.to_string_lossy())
+                write!(
+                    f,
+                    "Module({}, {})",
+                    name.to_string_lossy(),
+                    if let Some(annotations) = annotations {
+                        Either::Left(annotations)
+                    } else {
+                        Either::Right("{}")
+                    }
+                )
             }
             JsValue::Unknown { .. } => write!(f, "???"),
             JsValue::WellKnownObject(obj) => write!(f, "WellKnownObject({obj:?})"),
@@ -1618,7 +1628,15 @@ impl JsValue {
                 module: name,
                 annotations,
             }) => {
-                format!("module<{}, {annotations}>", name.to_string_lossy())
+                format!(
+                    "module<{}, {}>",
+                    name.to_string_lossy(),
+                    if let Some(annotations) = annotations {
+                        Either::Left(annotations)
+                    } else {
+                        Either::Right("{}")
+                    }
+                )
             }
             JsValue::Unknown {
                 original_value: inner,
@@ -3527,9 +3545,7 @@ pub mod test_utils {
     };
     use crate::{
         analyzer::{
-            RequireContextValue,
-            builtin::replace_builtin,
-            imports::{ImportAnnotations, ImportAttributes},
+            RequireContextValue, builtin::replace_builtin, imports::ImportAttributes,
             parse_require_context,
         },
         utils::module_value_to_well_known_object,
@@ -3557,7 +3573,7 @@ pub mod test_utils {
                 JsValue::Constant(ConstantValue::Str(v)) => {
                     JsValue::promise(JsValue::Module(ModuleValue {
                         module: v.as_atom().into_owned().into(),
-                        annotations: ImportAnnotations::default(),
+                        annotations: None,
                     }))
                 }
                 _ => v.into_unknown(true, "import() non constant"),

--- a/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/analyzer/well_known.rs
@@ -7,8 +7,7 @@ use turbopack_core::compile_time_info::CompileTimeInfo;
 use url::Url;
 
 use super::{
-    ConstantValue, JsValue, JsValueUrlKind, ModuleValue, WellKnownFunctionKind,
-    WellKnownObjectKind, imports::ImportAnnotations,
+    ConstantValue, JsValue, JsValueUrlKind, ModuleValue, WellKnownFunctionKind, WellKnownObjectKind,
 };
 use crate::analyzer::RequireContextValue;
 
@@ -359,7 +358,7 @@ pub fn import(args: Vec<JsValue>) -> JsValue {
         [JsValue::Constant(ConstantValue::Str(v))] => {
             JsValue::promise(JsValue::Module(ModuleValue {
                 module: v.as_atom().into_owned().into(),
-                annotations: ImportAnnotations::default(),
+                annotations: None,
             }))
         }
         _ => JsValue::unknown(
@@ -380,7 +379,7 @@ fn require(args: Vec<JsValue>) -> JsValue {
         if let Some(s) = args[0].as_str() {
             JsValue::Module(ModuleValue {
                 module: s.into(),
-                annotations: ImportAnnotations::default(),
+                annotations: None,
             })
         } else {
             JsValue::unknown(
@@ -448,7 +447,7 @@ fn require_context_require(val: RequireContextValue, args: Vec<JsValue>) -> Resu
 
     Ok(JsValue::Module(ModuleValue {
         module: m.to_string().into(),
-        annotations: ImportAnnotations::default(),
+        annotations: None,
     }))
 }
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/esm/base.rs
@@ -322,13 +322,13 @@ impl EsmAssetReferences {
 
 #[turbo_tasks::value(shared)]
 #[derive(Hash, Debug, ValueToString)]
-#[value_to_string("import {request} with {annotations}")]
+#[value_to_string("import {request}")]
 pub struct EsmAssetReference {
     pub module: ResolvedVc<EcmascriptModuleAsset>,
     pub origin: ResolvedVc<Box<dyn ResolveOrigin>>,
     // Request is a string to avoid eagerly parsing into a `Request` VC
     pub request: RcStr,
-    pub annotations: ImportAnnotations,
+    pub annotations: Option<ImportAnnotations>,
     pub issue_source: IssueSource,
     pub export_name: Option<ModulePart>,
     pub import_usage: ImportUsage,
@@ -339,7 +339,7 @@ pub struct EsmAssetReference {
 
 impl EsmAssetReference {
     fn get_origin(&self) -> Vc<Box<dyn ResolveOrigin>> {
-        if let Some(transition) = self.annotations.transition() {
+        if let Some(transition) = self.annotations.as_ref().and_then(|a| a.transition()) {
             self.origin.with_transition(transition.into())
         } else {
             *self.origin
@@ -353,7 +353,7 @@ impl EsmAssetReference {
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: RcStr,
         issue_source: IssueSource,
-        annotations: ImportAnnotations,
+        annotations: Option<ImportAnnotations>,
         export_name: Option<ModulePart>,
         import_usage: ImportUsage,
         import_externals: bool,
@@ -378,7 +378,7 @@ impl EsmAssetReference {
         origin: ResolvedVc<Box<dyn ResolveOrigin>>,
         request: RcStr,
         issue_source: IssueSource,
-        annotations: ImportAnnotations,
+        annotations: Option<ImportAnnotations>,
         export_name: Option<ModulePart>,
         import_usage: ImportUsage,
         import_externals: bool,
@@ -406,7 +406,8 @@ impl EsmAssetReference {
 impl ModuleReference for EsmAssetReference {
     #[turbo_tasks::function]
     async fn resolve_reference(&self) -> Result<Vc<ModuleResolveResult>> {
-        let ty = if let Some(loader) = self.annotations.turbopack_loader() {
+        let ty = if let Some(loader) = self.annotations.as_ref().and_then(|a| a.turbopack_loader())
+        {
             // Resolve the loader path relative to the importing file
             let origin = self.get_origin();
             let origin_path = origin.origin_path().await?;
@@ -428,10 +429,18 @@ impl ModuleReference for EsmAssetReference {
                     loader: loader_fs_path,
                     options: loader.options.clone(),
                 },
-                rename_as: self.annotations.turbopack_rename_as().cloned(),
-                module_type: self.annotations.turbopack_module_type().cloned(),
+                rename_as: self
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.turbopack_rename_as())
+                    .cloned(),
+                module_type: self
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.turbopack_module_type())
+                    .cloned(),
             }
-        } else if let Some(module_type) = self.annotations.module_type() {
+        } else if let Some(module_type) = self.annotations.as_ref().and_then(|a| a.module_type()) {
             EcmaScriptModulesReferenceSubType::ImportWithType(RcStr::from(
                 &*module_type.to_string_lossy(),
             ))
@@ -498,7 +507,8 @@ impl ModuleReference for EsmAssetReference {
 
     fn chunking_type(&self) -> Option<ChunkingType> {
         self.annotations
-            .chunking_type()
+            .as_ref()
+            .and_then(|a| a.chunking_type())
             .unwrap_or(Some(ChunkingType::Parallel {
                 inherit_async: true,
                 hoisted: true,
@@ -534,7 +544,10 @@ impl EsmAssetReference {
         }
 
         // only chunked references can be imported
-        if !matches!(this.annotations.chunking_type(), Some(None)) {
+        if !matches!(
+            this.annotations.as_ref().and_then(|a| a.chunking_type()),
+            Some(None)
+        ) {
             let import_externals = this.import_externals;
             let referenced_asset = self.get_referenced_asset().await?;
 

--- a/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
+++ b/turbopack/crates/turbopack-ecmascript/src/references/mod.rs
@@ -820,7 +820,7 @@ async fn analyze_ecmascript_module_internal(
                 RcStr::from(&*r.module_path.to_string_lossy()),
                 r.issue_source
                     .unwrap_or_else(|| IssueSource::from_source_only(source)),
-                r.annotations.clone(),
+                r.annotations.as_ref().map(|a| (**a).clone()),
                 match &r.imported_symbol {
                     ImportedSymbol::ModuleEvaluation => {
                         should_add_evaluation = true;
@@ -1510,12 +1510,15 @@ async fn analyze_ecmascript_module_internal(
                     };
 
                     if let Some("__turbopack_module_id__") = export.as_deref() {
-                        let chunking_type = r.await?.annotations.chunking_type().unwrap_or(Some(
-                            ChunkingType::Parallel {
+                        let chunking_type = r
+                            .await?
+                            .annotations
+                            .as_ref()
+                            .and_then(|a| a.chunking_type())
+                            .unwrap_or(Some(ChunkingType::Parallel {
                                 inherit_async: true,
                                 hoisted: true,
-                            },
-                        ));
+                            }));
                         analysis.add_reference_code_gen(
                             EsmModuleIdAssetReference::new(*r, chunking_type),
                             ast_path.into(),
@@ -4264,7 +4267,7 @@ pub static TURBOPACK_HELPER_WTF8: Lazy<Wtf8Atom> =
 pub fn is_turbopack_helper_import(import: &ImportDecl) -> bool {
     let annotations = ImportAnnotations::parse(import.with.as_deref());
 
-    annotations.get(&TURBOPACK_HELPER_WTF8).is_some()
+    annotations.is_some_and(|a| a.get(&TURBOPACK_HELPER_WTF8).is_some())
 }
 
 pub fn is_swc_helper_import(import: &ImportDecl) -> bool {

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/class_super/graph-effects.snapshot
@@ -121,12 +121,7 @@
                                 Module(
                                     ModuleValue {
                                         module: "./module.js",
-                                        annotations: ImportAnnotations {
-                                            map: {},
-                                            turbopack_loader: None,
-                                            turbopack_rename_as: None,
-                                            turbopack_module_type: None,
-                                        },
+                                        annotations: None,
                                     },
                                 ),
                                 Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/createRequire/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/createRequire/graph-effects.snapshot
@@ -95,12 +95,7 @@
         obj: Module(
             ModuleValue {
                 module: "node:module",
-                annotations: ImportAnnotations {
-                    map: {},
-                    turbopack_loader: None,
-                    turbopack_rename_as: None,
-                    turbopack_module_type: None,
-                },
+                annotations: None,
             },
         ),
         prop: Constant(
@@ -308,12 +303,7 @@
         obj: Module(
             ModuleValue {
                 module: "node:module",
-                annotations: ImportAnnotations {
-                    map: {},
-                    turbopack_loader: None,
-                    turbopack_rename_as: None,
-                    turbopack_module_type: None,
-                },
+                annotations: None,
             },
         ),
         prop: Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/createRequire/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/createRequire/graph.snapshot
@@ -58,12 +58,7 @@
             Module(
                 ModuleValue {
                     module: "node:module",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/default-args/graph.snapshot
@@ -58,12 +58,7 @@
                     Module(
                         ModuleValue {
                             module: "./module.js",
-                            annotations: ImportAnnotations {
-                                map: {},
-                                turbopack_loader: None,
-                                turbopack_rename_as: None,
-                                turbopack_module_type: None,
-                            },
+                            annotations: None,
                         },
                     ),
                     Constant(
@@ -102,12 +97,7 @@
                     Module(
                         ModuleValue {
                             module: "./module.js",
-                            annotations: ImportAnnotations {
-                                map: {},
-                                turbopack_loader: None,
-                                turbopack_rename_as: None,
-                                turbopack_module_type: None,
-                            },
+                            annotations: None,
                         },
                     ),
                     Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/imports/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/imports/graph.snapshot
@@ -6,12 +6,7 @@
             Module(
                 ModuleValue {
                     module: "x2",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -30,12 +25,7 @@
             Module(
                 ModuleValue {
                     module: "x1",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -52,12 +42,7 @@
         Module(
             ModuleValue {
                 module: "x3",
-                annotations: ImportAnnotations {
-                    map: {},
-                    turbopack_loader: None,
-                    turbopack_rename_as: None,
-                    turbopack_module_type: None,
-                },
+                annotations: None,
             },
         ),
     ),

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/graph-effects.snapshot
@@ -71,12 +71,7 @@
             Module(
                 ModuleValue {
                     module: "react",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -579,12 +574,7 @@
             Module(
                 ModuleValue {
                     module: "https://esm.sh/preact/jsx-runtime",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -958,12 +948,7 @@
                                 Module(
                                     ModuleValue {
                                         module: "./external",
-                                        annotations: ImportAnnotations {
-                                            map: {},
-                                            turbopack_loader: None,
-                                            turbopack_rename_as: None,
-                                            turbopack_module_type: None,
-                                        },
+                                        annotations: None,
                                     },
                                 ),
                                 Constant(
@@ -1084,12 +1069,7 @@
                                             Module(
                                                 ModuleValue {
                                                     module: "./external",
-                                                    annotations: ImportAnnotations {
-                                                        map: {},
-                                                        turbopack_loader: None,
-                                                        turbopack_rename_as: None,
-                                                        turbopack_module_type: None,
-                                                    },
+                                                    annotations: None,
                                                 },
                                             ),
                                             Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-75938/graph.snapshot
@@ -70,12 +70,7 @@
                     Module(
                         ModuleValue {
                             module: "https://esm.sh/preact/jsx-runtime",
-                            annotations: ImportAnnotations {
-                                map: {},
-                                turbopack_loader: None,
-                                turbopack_rename_as: None,
-                                turbopack_module_type: None,
-                            },
+                            annotations: None,
                         },
                     ),
                     Constant(
@@ -151,12 +146,7 @@
                 Module(
                     ModuleValue {
                         module: "react",
-                        annotations: ImportAnnotations {
-                            map: {},
-                            turbopack_loader: None,
-                            turbopack_rename_as: None,
-                            turbopack_module_type: None,
-                        },
+                        annotations: None,
                     },
                 ),
                 Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/issue-77083/graph-effects.snapshot
@@ -83,12 +83,7 @@
                             Module(
                                 ModuleValue {
                                     module: "./assert",
-                                    annotations: ImportAnnotations {
-                                        map: {},
-                                        turbopack_loader: None,
-                                        turbopack_rename_as: None,
-                                        turbopack_module_type: None,
-                                    },
+                                    annotations: None,
                                 },
                             ),
                             Constant(
@@ -374,12 +369,7 @@
             Module(
                 ModuleValue {
                     module: "./assert",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -526,12 +516,7 @@
             Module(
                 ModuleValue {
                     module: "./assert",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/pack-2236/graph.snapshot
@@ -40,12 +40,7 @@
                 Module(
                     ModuleValue {
                         module: "@upstash/redis",
-                        annotations: ImportAnnotations {
-                            map: {},
-                            turbopack_loader: None,
-                            turbopack_rename_as: None,
-                            turbopack_module_type: None,
-                        },
+                        annotations: None,
                     },
                 ),
                 Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph-effects.snapshot
@@ -1028,12 +1028,7 @@
             Module(
                 ModuleValue {
                     module: "path",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/path-join/graph.snapshot
@@ -81,12 +81,7 @@
                 Module(
                     ModuleValue {
                         module: "path",
-                        annotations: ImportAnnotations {
-                            map: {},
-                            turbopack_loader: None,
-                            turbopack_rename_as: None,
-                            turbopack_module_type: None,
-                        },
+                        annotations: None,
                     },
                 ),
                 Constant(
@@ -113,12 +108,7 @@
             Module(
                 ModuleValue {
                     module: "path",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(

--- a/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-effects.snapshot
+++ b/turbopack/crates/turbopack-ecmascript/tests/analyzer/graph/unreachable-break/graph-effects.snapshot
@@ -60,12 +60,7 @@
             Module(
                 ModuleValue {
                     module: "foo",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -230,12 +225,7 @@
             Module(
                 ModuleValue {
                     module: "foo",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -365,12 +355,7 @@
             Module(
                 ModuleValue {
                     module: "foo",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -549,12 +534,7 @@
             Module(
                 ModuleValue {
                     module: "foo",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -684,12 +664,7 @@
             Module(
                 ModuleValue {
                     module: "foo",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(
@@ -868,12 +843,7 @@
             Module(
                 ModuleValue {
                     module: "foo",
-                    annotations: ImportAnnotations {
-                        map: {},
-                        turbopack_loader: None,
-                        turbopack_rename_as: None,
-                        turbopack_module_type: None,
-                    },
+                    annotations: None,
                 },
             ),
             Constant(


### PR DESCRIPTION
The JS analyze microbenchmark got 23% faster:

Only a tiny fraction of imports have annotations, be it `import ... with {...}` or `require(/*webpackIgnore: true*/...)`, so a `Option<Pointer<Struct>>` mkes sense here.
```
canary:
references/jsonwebtoken.js/full
                        time:   [63.250 ms 63.918 ms 64.752 ms]
                        change: [-5.2380% -3.0074% -0.8753%] (p = 0.01 < 0.05)
                        Change within noise threshold.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe


now:
references/jsonwebtoken.js/full
                        time:   [49.070 ms 49.166 ms 49.273 ms]
                        change: [-24.097% -23.079% -22.237%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
````

This came up in https://github.com/vercel/next.js/pull/91278#issuecomment-4058275943, which added another (tiny) field to ImportAttributes. But it caused a 6% regression in the microbenchmark anyway.