### PR TITLE
Simplify scroll restoration with shared ScrollRef on CacheNode

### DIFF
--- a/packages/next/src/client/app-dir/link.tsx
+++ b/packages/next/src/client/app-dir/link.tsx
@@ -8,6 +8,7 @@ import { useMergedRef } from '../use-merged-ref'
 import { isAbsoluteUrl } from '../../shared/lib/utils'
 import { addBasePath } from '../add-base-path'
 import { warnOnce } from '../../shared/lib/utils/warn-once'
+import { ScrollBehavior } from '../components/router-reducer/router-reducer-types'
 import type { PENDING_LINK_STATUS } from '../components/links'
 import {
   IDLE_LINK_STATUS,
@@ -307,7 +308,7 @@ function linkClicked(
       dispatchNavigateAction(
         href,
         replace ? 'replace' : 'push',
-        scroll ?? true,
+        scroll === false ? ScrollBehavior.NoScroll : ScrollBehavior.Default,
         linkInstanceRef.current,
         transitionTypes
       )

--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -9,6 +9,7 @@ import {
   type NavigateAction,
   ACTION_HMR_REFRESH,
   PrefetchKind,
+  ScrollBehavior,
   type AppHistoryState,
 } from './router-reducer/router-reducer-types'
 import { reducer } from './router-reducer/router-reducer'
@@ -277,7 +278,7 @@ function getProfilingHookForOnNavigationStart() {
 export function dispatchNavigateAction(
   href: string,
   navigateType: NavigateAction['navigateType'],
-  shouldScroll: boolean,
+  scrollBehavior: ScrollBehavior,
   linkInstanceRef: LinkInstance | null,
   transitionTypes: string[] | undefined
 ): void {
@@ -307,7 +308,7 @@ export function dispatchNavigateAction(
     url,
     isExternalUrl: isExternalURL(url),
     locationSearch: location.search,
-    shouldScroll,
+    scrollBehavior,
     navigateType,
   })
 }
@@ -356,7 +357,10 @@ function gesturePush(href: string, options?: NavigateOptions): void {
 
     // Fork the router state for the duration of the gesture transition.
     const currentUrl = new URL(state.canonicalUrl, location.href)
-    const shouldScroll = options?.scroll ?? true
+    const scrollBehavior =
+      options?.scroll === false
+        ? ScrollBehavior.NoScroll
+        : ScrollBehavior.Default
     // This is a special freshness policy that prevents dynamic requests from
     // being spawned. During the gesture, we should only show the cached
     // prefetched UI, not dynamic data.
@@ -373,7 +377,7 @@ function gesturePush(href: string, options?: NavigateOptions): void {
       state.tree,
       state.nextUrl,
       freshnessPolicy,
-      shouldScroll,
+      scrollBehavior,
       'push'
     )
     dispatchGestureState(forkedGestureState)
@@ -442,7 +446,9 @@ export const publicAppRouterInstance: AppRouterInstance = {
       dispatchNavigateAction(
         href,
         'replace',
-        options?.scroll ?? true,
+        options?.scroll === false
+          ? ScrollBehavior.NoScroll
+          : ScrollBehavior.Default,
         null,
         options?.transitionTypes
       )
@@ -458,7 +464,9 @@ export const publicAppRouterInstance: AppRouterInstance = {
       dispatchNavigateAction(
         href,
         'push',
-        options?.scroll ?? true,
+        options?.scroll === false
+          ? ScrollBehavior.NoScroll
+          : ScrollBehavior.Default,
         null,
         options?.transitionTypes
       )

--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -30,7 +30,6 @@ import {
 } from '../../shared/lib/app-router-context.shared-runtime'
 import { unresolvedThenable } from './unresolved-thenable'
 import { ErrorBoundary } from './error-boundary'
-import { matchSegment } from './match-segments'
 import { disableSmoothScrollDuringRouteTransition } from '../../shared/lib/router/utils/disable-smooth-scroll'
 import { RedirectBoundary } from './redirect-boundary'
 import { HTTPAccessFallbackBoundary } from './http-access-fallback/error-boundary'
@@ -142,114 +141,102 @@ function getHashFragmentDomNode(hashFragment: string) {
 interface ScrollAndMaybeFocusHandlerProps {
   focusAndScrollRef: FocusAndScrollRef
   children: React.ReactNode
-  segmentPath: FlightSegmentPath
+  cacheNode: CacheNode
 }
 class InnerScrollAndFocusHandlerOld extends React.Component<ScrollAndMaybeFocusHandlerProps> {
   handlePotentialScroll = () => {
     // Handle scroll and focus, it's only applied once.
-    const { focusAndScrollRef, segmentPath } = this.props
+    const { focusAndScrollRef, cacheNode } = this.props
 
-    if (focusAndScrollRef.apply) {
-      // segmentPaths is an array of segment paths that should be scrolled to
-      // if the current segment path is not in the array, the scroll is not applied
-      // unless the array is empty, in which case the scroll is always applied
-      if (
-        focusAndScrollRef.segmentPaths.length !== 0 &&
-        !focusAndScrollRef.segmentPaths.some((scrollRefSegmentPath) =>
-          segmentPath.every((segment, index) =>
-            matchSegment(segment, scrollRefSegmentPath[index])
-          )
-        )
-      ) {
-        return
-      }
+    const scrollRef = focusAndScrollRef.forceScroll
+      ? focusAndScrollRef.scrollRef
+      : cacheNode.scrollRef
+    if (scrollRef === null || !scrollRef.current) return
 
-      let domNode:
-        | ReturnType<typeof getHashFragmentDomNode>
-        | ReturnType<typeof findDOMNode> = null
-      const hashFragment = focusAndScrollRef.hashFragment
+    let domNode:
+      | ReturnType<typeof getHashFragmentDomNode>
+      | ReturnType<typeof findDOMNode> = null
+    const hashFragment = focusAndScrollRef.hashFragment
 
-      if (hashFragment) {
-        domNode = getHashFragmentDomNode(hashFragment)
-      }
+    if (hashFragment) {
+      domNode = getHashFragmentDomNode(hashFragment)
+    }
 
-      // `findDOMNode` is tricky because it returns just the first child if the component is a fragment.
-      // This already caused a bug where the first child was a <link/> in head.
-      if (!domNode) {
-        domNode = findDOMNode(this)
-      }
+    // `findDOMNode` is tricky because it returns just the first child if the component is a fragment.
+    // This already caused a bug where the first child was a <link/> in head.
+    if (!domNode) {
+      domNode = findDOMNode(this)
+    }
 
-      // If there is no DOM node this layout-router level is skipped. It'll be handled higher-up in the tree.
-      if (!(domNode instanceof Element)) {
-        return
-      }
+    // If there is no DOM node this layout-router level is skipped. It'll be handled higher-up in the tree.
+    if (!(domNode instanceof Element)) {
+      return
+    }
 
-      // Verify if the element is a HTMLElement and if we want to consider it for scroll behavior.
-      // If the element is skipped, try to select the next sibling and try again.
-      while (!(domNode instanceof HTMLElement) || shouldSkipElement(domNode)) {
-        if (process.env.NODE_ENV !== 'production') {
-          if (domNode.parentElement?.localName === 'head') {
-            // We enter this state when metadata was rendered as part of the page or via Next.js.
-            // This is always a bug in Next.js and caused by React hoisting metadata.
-            // Fixed with `experimental.appNewScrollHandler`
-          }
+    // Verify if the element is a HTMLElement and if we want to consider it for scroll behavior.
+    // If the element is skipped, try to select the next sibling and try again.
+    while (!(domNode instanceof HTMLElement) || shouldSkipElement(domNode)) {
+      if (process.env.NODE_ENV !== 'production') {
+        if (domNode.parentElement?.localName === 'head') {
+          // We enter this state when metadata was rendered as part of the page or via Next.js.
+          // This is always a bug in Next.js and caused by React hoisting metadata.
+          // Fixed with `experimental.appNewScrollHandler`
         }
+      }
 
-        // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
-        if (domNode.nextElementSibling === null) {
+      // No siblings found that match the criteria are found, so handle scroll higher up in the tree instead.
+      if (domNode.nextElementSibling === null) {
+        return
+      }
+      domNode = domNode.nextElementSibling
+    }
+
+    // Mark as scrolled so no other segment scrolls for this navigation.
+    scrollRef.current = false
+
+    disableSmoothScrollDuringRouteTransition(
+      () => {
+        // In case of hash scroll, we only need to scroll the element into view
+        if (hashFragment) {
+          domNode.scrollIntoView()
+
           return
         }
-        domNode = domNode.nextElementSibling
-      }
+        // Store the current viewport height because reading `clientHeight` causes a reflow,
+        // and it won't change during this function.
+        const htmlElement = document.documentElement
+        const viewportHeight = htmlElement.clientHeight
 
-      // State is mutated to ensure that the focus and scroll is applied only once.
-      focusAndScrollRef.apply = false
-      focusAndScrollRef.hashFragment = null
-      focusAndScrollRef.segmentPaths = []
-
-      disableSmoothScrollDuringRouteTransition(
-        () => {
-          // In case of hash scroll, we only need to scroll the element into view
-          if (hashFragment) {
-            domNode.scrollIntoView()
-
-            return
-          }
-          // Store the current viewport height because reading `clientHeight` causes a reflow,
-          // and it won't change during this function.
-          const htmlElement = document.documentElement
-          const viewportHeight = htmlElement.clientHeight
-
-          // If the element's top edge is already in the viewport, exit early.
-          if (topOfElementInViewport(domNode, viewportHeight)) {
-            return
-          }
-
-          // Otherwise, try scrolling go the top of the document to be backward compatible with pages
-          // scrollIntoView() called on `<html/>` element scrolls horizontally on chrome and firefox (that shouldn't happen)
-          // We could use it to scroll horizontally following RTL but that also seems to be broken - it will always scroll left
-          // scrollLeft = 0 also seems to ignore RTL and manually checking for RTL is too much hassle so we will scroll just vertically
-          htmlElement.scrollTop = 0
-
-          // Scroll to domNode if domNode is not in viewport when scrolled to top of document
-          if (!topOfElementInViewport(domNode, viewportHeight)) {
-            // Scroll into view doesn't scroll horizontally by default when not needed
-            domNode.scrollIntoView()
-          }
-        },
-        {
-          // We will force layout by querying domNode position
-          dontForceLayout: true,
-          onlyHashChange: focusAndScrollRef.onlyHashChange,
+        // If the element's top edge is already in the viewport, exit early.
+        if (topOfElementInViewport(domNode, viewportHeight)) {
+          return
         }
-      )
 
-      // Mutate after scrolling so that it can be read by `disableSmoothScrollDuringRouteTransition`
-      focusAndScrollRef.onlyHashChange = false
+        // Otherwise, try scrolling go the top of the document to be backward compatible with pages
+        // scrollIntoView() called on `<html/>` element scrolls horizontally on chrome and firefox (that shouldn't happen)
+        // We could use it to scroll horizontally following RTL but that also seems to be broken - it will always scroll left
+        // scrollLeft = 0 also seems to ignore RTL and manually checking for RTL is too much hassle so we will scroll just vertically
+        htmlElement.scrollTop = 0
 
-      // Set focus on the element
-      domNode.focus()
-    }
+        // Scroll to domNode if domNode is not in viewport when scrolled to top of document
+        if (!topOfElementInViewport(domNode, viewportHeight)) {
+          // Scroll into view doesn't scroll horizontally by default when not needed
+          domNode.scrollIntoView()
+        }
+      },
+      {
+        // We will force layout by querying domNode position
+        dontForceLayout: true,
+        onlyHashChange: focusAndScrollRef.onlyHashChange,
+      }
+    )
+
+    // Mutate after scrolling so that it can be read by `disableSmoothScrollDuringRouteTransition`
+    focusAndScrollRef.onlyHashChange = false
+    focusAndScrollRef.hashFragment = null
+
+    // Set focus on the element
+    domNode.focus()
   }
 
   componentDidMount() {
@@ -274,101 +261,88 @@ function InnerScrollHandlerNew(props: ScrollAndMaybeFocusHandlerProps) {
 
   useLayoutEffect(
     () => {
-      const { focusAndScrollRef, segmentPath } = props
-      // Handle scroll and focus, it's only applied once in the first useEffect that triggers that changed.
+      const { focusAndScrollRef, cacheNode } = props
 
-      if (focusAndScrollRef.apply) {
-        // segmentPaths is an array of segment paths that should be scrolled to
-        // if the current segment path is not in the array, the scroll is not applied
-        // unless the array is empty, in which case the scroll is always applied
-        if (
-          focusAndScrollRef.segmentPaths.length !== 0 &&
-          !focusAndScrollRef.segmentPaths.some((scrollRefSegmentPath) =>
-            segmentPath.every((segment, index) =>
-              matchSegment(segment, scrollRefSegmentPath[index])
-            )
-          )
-        ) {
-          return
-        }
+      const scrollRef = focusAndScrollRef.forceScroll
+        ? focusAndScrollRef.scrollRef
+        : cacheNode.scrollRef
+      if (scrollRef === null || !scrollRef.current) return
 
-        let instance: FragmentInstance | HTMLElement | null = null
-        const hashFragment = focusAndScrollRef.hashFragment
+      let instance: FragmentInstance | HTMLElement | null = null
+      const hashFragment = focusAndScrollRef.hashFragment
 
-        if (hashFragment) {
-          instance = getHashFragmentDomNode(hashFragment)
-        }
-
-        if (!instance) {
-          instance = childrenRef.current
-        }
-
-        // If there is no DOM node this layout-router level is skipped. It'll be handled higher-up in the tree.
-        if (instance === null) {
-          return
-        }
-
-        // State is mutated to ensure that the focus and scroll is applied only once.
-        focusAndScrollRef.apply = false
-        focusAndScrollRef.hashFragment = null
-        focusAndScrollRef.segmentPaths = []
-
-        const activeElement = document.activeElement
-        if (
-          activeElement !== null &&
-          'blur' in activeElement &&
-          typeof activeElement.blur === 'function'
-        ) {
-          // Trying to match hard navigations.
-          // Ideally we'd move the internal focus cursor either to the top
-          // or at least before the segment. But there's no DOM API to do that,
-          // so we just blur.
-          // We could workaround this by moving focus to a temporary element in
-          // the body. But adding elements might trigger layout or other effects
-          // so it should be well motivated.
-          activeElement.blur()
-        }
-
-        disableSmoothScrollDuringRouteTransition(
-          () => {
-            // In case of hash scroll, we only need to scroll the element into view
-            if (hashFragment) {
-              instance.scrollIntoView()
-
-              return
-            }
-            // Store the current viewport height because reading `clientHeight` causes a reflow,
-            // and it won't change during this function.
-            const htmlElement = document.documentElement
-            const viewportHeight = htmlElement.clientHeight
-
-            // If the element's top edge is already in the viewport, exit early.
-            if (topOfElementInViewport(instance, viewportHeight)) {
-              return
-            }
-
-            // Otherwise, try scrolling go the top of the document to be backward compatible with pages
-            // scrollIntoView() called on `<html/>` element scrolls horizontally on chrome and firefox (that shouldn't happen)
-            // We could use it to scroll horizontally following RTL but that also seems to be broken - it will always scroll left
-            // scrollLeft = 0 also seems to ignore RTL and manually checking for RTL is too much hassle so we will scroll just vertically
-            htmlElement.scrollTop = 0
-
-            // Scroll to domNode if domNode is not in viewport when scrolled to top of document
-            if (!topOfElementInViewport(instance, viewportHeight)) {
-              // Scroll into view doesn't scroll horizontally by default when not needed
-              instance.scrollIntoView()
-            }
-          },
-          {
-            // We will force layout by querying domNode position
-            dontForceLayout: true,
-            onlyHashChange: focusAndScrollRef.onlyHashChange,
-          }
-        )
-
-        // Mutate after scrolling so that it can be read by `disableSmoothScrollDuringRouteTransition`
-        focusAndScrollRef.onlyHashChange = false
+      if (hashFragment) {
+        instance = getHashFragmentDomNode(hashFragment)
       }
+
+      if (!instance) {
+        instance = childrenRef.current
+      }
+
+      // If there is no DOM node this layout-router level is skipped. It'll be handled higher-up in the tree.
+      if (instance === null) {
+        return
+      }
+
+      // Mark as scrolled so no other segment scrolls for this navigation.
+      scrollRef.current = false
+
+      const activeElement = document.activeElement
+      if (
+        activeElement !== null &&
+        'blur' in activeElement &&
+        typeof activeElement.blur === 'function'
+      ) {
+        // Trying to match hard navigations.
+        // Ideally we'd move the internal focus cursor either to the top
+        // or at least before the segment. But there's no DOM API to do that,
+        // so we just blur.
+        // We could workaround this by moving focus to a temporary element in
+        // the body. But adding elements might trigger layout or other effects
+        // so it should be well motivated.
+        activeElement.blur()
+      }
+
+      disableSmoothScrollDuringRouteTransition(
+        () => {
+          // In case of hash scroll, we only need to scroll the element into view
+          if (hashFragment) {
+            instance.scrollIntoView()
+
+            return
+          }
+          // Store the current viewport height because reading `clientHeight` causes a reflow,
+          // and it won't change during this function.
+          const htmlElement = document.documentElement
+          const viewportHeight = htmlElement.clientHeight
+
+          // If the element's top edge is already in the viewport, exit early.
+          if (topOfElementInViewport(instance, viewportHeight)) {
+            return
+          }
+
+          // Otherwise, try scrolling go the top of the document to be backward compatible with pages
+          // scrollIntoView() called on `<html/>` element scrolls horizontally on chrome and firefox (that shouldn't happen)
+          // We could use it to scroll horizontally following RTL but that also seems to be broken - it will always scroll left
+          // scrollLeft = 0 also seems to ignore RTL and manually checking for RTL is too much hassle so we will scroll just vertically
+          htmlElement.scrollTop = 0
+
+          // Scroll to domNode if domNode is not in viewport when scrolled to top of document
+          if (!topOfElementInViewport(instance, viewportHeight)) {
+            // Scroll into view doesn't scroll horizontally by default when not needed
+            instance.scrollIntoView()
+          }
+        },
+        {
+          // We will force layout by querying domNode position
+          dontForceLayout: true,
+          onlyHashChange: focusAndScrollRef.onlyHashChange,
+        }
+      )
+
+      // Mutate after scrolling so that it can be read by `disableSmoothScrollDuringRouteTransition`
+      focusAndScrollRef.onlyHashChange = false
+      focusAndScrollRef.hashFragment = null
     },
     // Used to run on every commit. We may be able to be smarter about this
     // but be prepared for lots of manual testing.
@@ -383,11 +357,11 @@ const InnerScrollAndMaybeFocusHandler = enableNewScrollHandler
   : InnerScrollAndFocusHandlerOld
 
 function ScrollAndMaybeFocusHandler({
-  segmentPath,
   children,
+  cacheNode,
 }: {
-  segmentPath: FlightSegmentPath
   children: React.ReactNode
+  cacheNode: CacheNode
 }) {
   const context = useContext(GlobalLayoutRouterContext)
   if (!context) {
@@ -396,8 +370,8 @@ function ScrollAndMaybeFocusHandler({
 
   return (
     <InnerScrollAndMaybeFocusHandler
-      segmentPath={segmentPath}
       focusAndScrollRef={context.focusAndScrollRef}
+      cacheNode={cacheNode}
     >
       {children}
     </InnerScrollAndMaybeFocusHandler>
@@ -787,7 +761,7 @@ export default function OuterLayoutRouter({
     const debugNameToDisplay = isVirtual ? undefined : debugNameContext
 
     let templateValue = (
-      <ScrollAndMaybeFocusHandler segmentPath={segmentPath}>
+      <ScrollAndMaybeFocusHandler cacheNode={cacheNode}>
         <ErrorBoundary
           errorComponent={error}
           errorStyles={errorStyles}

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -233,10 +233,10 @@ export function createInitialRouterState({
       preserveCustomHistoryState: true,
     },
     focusAndScrollRef: {
-      apply: false,
+      scrollRef: null,
+      forceScroll: false,
       onlyHashChange: false,
       hashFragment: null,
-      segmentPaths: [],
     },
     canonicalUrl,
     renderedSearch: initialRenderedSearch,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1,11 +1,10 @@
 import type {
   CacheNodeSeedData,
   FlightRouterState,
-  FlightSegmentPath,
   Segment,
 } from '../../../shared/lib/app-router-types'
 import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type { HeadData } from '../../../shared/lib/app-router-types'
+import type { HeadData, ScrollRef } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
 import {
   PAGE_SEGMENT_KEY,
@@ -118,8 +117,13 @@ const enum NavigationTaskExitStatus {
 }
 
 export type NavigationRequestAccumulation = {
-  scrollableSegments: Array<FlightSegmentPath> | null
   separateRefreshUrls: Set<string> | null
+  /**
+   * Set when a navigation creates new leaf segments that should be
+   * scrolled to. Stays null when no new segments are created (e.g.
+   * during a refresh where the route structure didn't change).
+   */
+  scrollRef: ScrollRef | null
 }
 
 const noop = () => {}
@@ -133,8 +137,8 @@ export function createInitialCacheNodeForHydration(
   // Create the initial cache node tree, using the data embedded into the
   // HTML document.
   const accumulation: NavigationRequestAccumulation = {
-    scrollableSegments: null,
     separateRefreshUrls: null,
+    scrollRef: null,
   }
   const task = createCacheNodeOnNavigation(
     navigatedAt,
@@ -143,8 +147,6 @@ export function createInitialCacheNodeForHydration(
     FreshnessPolicy.Hydration,
     seedData,
     seedHead,
-    null,
-    null,
     false,
     accumulation
   )
@@ -213,8 +215,6 @@ export function startPPRNavigation(
     seedData,
     seedHead,
     isSamePageNavigation,
-    null,
-    null,
     parentNeedsDynamicRequest,
     oldRootRefreshState,
     parentRefreshState,
@@ -234,8 +234,6 @@ function updateCacheNodeOnNavigation(
   seedData: CacheNodeSeedData | null,
   seedHead: HeadData | null,
   isSamePageNavigation: boolean,
-  parentSegmentPath: FlightSegmentPath | null,
-  parentParallelRouteKey: string | null,
   parentNeedsDynamicRequest: boolean,
   oldRootRefreshState: RefreshState,
   parentRefreshState: RefreshState | null,
@@ -285,12 +283,6 @@ function updateCacheNodeOnNavigation(
     ) {
       return null
     }
-    if (parentSegmentPath === null || parentParallelRouteKey === null) {
-      // The root should never mismatch. If it does, it suggests an internal
-      // Next.js error, or a malformed server response. Trigger a full-
-      // page navigation.
-      return null
-    }
     return createCacheNodeOnNavigation(
       navigatedAt,
       newRouteTree,
@@ -298,23 +290,10 @@ function updateCacheNodeOnNavigation(
       freshness,
       seedData,
       seedHead,
-      parentSegmentPath,
-      parentParallelRouteKey,
       parentNeedsDynamicRequest,
       accumulation
     )
   }
-
-  // TODO: The segment paths are tracked so that LayoutRouter knows which
-  // segments to scroll to after a navigation. But we should just mark this
-  // information on the CacheNode directly. It used to be necessary to do this
-  // separately because CacheNodes were created lazily during render, not when
-  // rather than when creating the route tree.
-  const segmentPath =
-    parentParallelRouteKey !== null && parentSegmentPath !== null
-      ? parentSegmentPath.concat([parentParallelRouteKey, newSegment])
-      : // NOTE: The root segment is intentionally omitted from the segment path
-        []
 
   const newSlots = newRouteTree.slots
   const oldRouterStateChildren = oldRouterState[1]
@@ -331,10 +310,8 @@ function updateCacheNodeOnNavigation(
   switch (freshness) {
     case FreshnessPolicy.Default:
     case FreshnessPolicy.HistoryTraversal:
-    case FreshnessPolicy.Hydration: // <- shouldn't happen during client nav
+    case FreshnessPolicy.Hydration:
     case FreshnessPolicy.Gesture:
-      // We should never drop dynamic data in shared layouts, except during
-      // a refresh.
       shouldRefreshDynamicData = false
       break
     case FreshnessPolicy.RefreshAll:
@@ -383,6 +360,15 @@ function updateCacheNodeOnNavigation(
     )
     newCacheNode = result.cacheNode
     needsDynamicRequest = result.needsDynamicRequest
+
+    // Carry forward the old node's scrollRef. This preserves scroll
+    // intent when a prior navigation's cache node is replaced by a
+    // refresh before the scroll handler has had a chance to fire —
+    // e.g. when router.push() and router.refresh() are called in the
+    // same startTransition batch.
+    if (oldCacheNode !== undefined) {
+      newCacheNode.scrollRef = oldCacheNode.scrollRef
+    }
   }
 
   // During a refresh navigation, there's a special case that happens when
@@ -501,8 +487,6 @@ function updateCacheNodeOnNavigation(
         seedDataChild ?? null,
         seedHeadChild,
         isSamePageNavigation,
-        segmentPath,
-        parallelRouteKey,
         parentNeedsDynamicRequest || needsDynamicRequest,
         oldRootRefreshState,
         refreshState,
@@ -565,6 +549,50 @@ function updateCacheNodeOnNavigation(
   }
 }
 
+/**
+ * Assigns a ScrollRef to a new leaf CacheNode so the scroll handler
+ * knows to scroll to it after navigation. All leaves in the same
+ * navigation share the same ScrollRef — the first segment to scroll
+ * consumes it, preventing others from also scrolling.
+ *
+ * This is only called inside `createCacheNodeOnNavigation`, which only
+ * runs when segments diverge from the previous route. So for a refresh
+ * where the route structure stays the same, segments match, the update
+ * path is taken, and this function is never called — no scroll ref is
+ * assigned. A scroll ref is only assigned when the route actually
+ * changed (e.g. a redirect, or a dynamic condition on the server that
+ * produces a different route).
+ *
+ * Skipped during hydration (initial render should not scroll) and
+ * history traversal (scroll restoration is handled separately).
+ */
+function accumulateScrollRef(
+  freshness: FreshnessPolicy,
+  cacheNode: CacheNode,
+  accumulation: NavigationRequestAccumulation
+): void {
+  switch (freshness) {
+    case FreshnessPolicy.Default:
+    case FreshnessPolicy.Gesture:
+    case FreshnessPolicy.RefreshAll:
+    case FreshnessPolicy.HMRRefresh:
+      if (accumulation.scrollRef === null) {
+        accumulation.scrollRef = { current: true }
+      }
+      cacheNode.scrollRef = accumulation.scrollRef
+      break
+    case FreshnessPolicy.Hydration:
+      // Initial render — no scroll.
+      break
+    case FreshnessPolicy.HistoryTraversal:
+      // Back/forward — scroll restoration is handled separately.
+      break
+    default:
+      freshness satisfies never
+      break
+  }
+}
+
 function createCacheNodeOnNavigation(
   navigatedAt: number,
   newRouteTree: RouteTree,
@@ -572,8 +600,6 @@ function createCacheNodeOnNavigation(
   freshness: FreshnessPolicy,
   seedData: CacheNodeSeedData | null,
   seedHead: HeadData | null,
-  parentSegmentPath: FlightSegmentPath | null,
-  parentParallelRouteKey: string | null,
   parentNeedsDynamicRequest: boolean,
   accumulation: NavigationRequestAccumulation
 ): NavigationTask {
@@ -588,32 +614,9 @@ function createCacheNodeOnNavigation(
   // diverges, which is why we keep them separate.
 
   const newSegment = createSegmentFromRouteTree(newRouteTree)
-  const segmentPath =
-    parentParallelRouteKey !== null && parentSegmentPath !== null
-      ? parentSegmentPath.concat([parentParallelRouteKey, newSegment])
-      : // NOTE: The root segment is intentionally omitted from the segment path
-        []
 
   const newSlots = newRouteTree.slots
   const seedDataChildren = seedData !== null ? seedData[1] : null
-
-  const isLeafSegment = newSlots === null
-
-  if (isLeafSegment) {
-    // The segment path of every leaf segment (i.e. page) is collected into
-    // a result array. This is used by the LayoutRouter to scroll to ensure that
-    // new pages are visible after a navigation.
-    //
-    // This only happens for new pages, not for refreshed pages.
-    //
-    // TODO: We should use a string to represent the segment path instead of
-    // an array. We already use a string representation for the path when
-    // accessing the Segment Cache, so we can use the same one.
-    if (accumulation.scrollableSegments === null) {
-      accumulation.scrollableSegments = []
-    }
-    accumulation.scrollableSegments.push(segmentPath)
-  }
 
   const seedRsc = seedData !== null ? seedData[0] : null
   const result = createCacheNodeForSegment(
@@ -626,6 +629,11 @@ function createCacheNodeOnNavigation(
   )
   const newCacheNode = result.cacheNode
   const needsDynamicRequest = result.needsDynamicRequest
+
+  const isLeafSegment = newSlots === null
+  if (isLeafSegment) {
+    accumulateScrollRef(freshness, newCacheNode, accumulation)
+  }
 
   let patchedRouterStateChildren: {
     [parallelRouteKey: string]: FlightRouterState
@@ -653,8 +661,6 @@ function createCacheNodeOnNavigation(
         freshness,
         seedDataChild ?? null,
         seedHead,
-        segmentPath,
-        parallelRouteKey,
         parentNeedsDynamicRequest || needsDynamicRequest,
         accumulation
       )
@@ -858,12 +864,15 @@ function reuseSharedCacheNode(
   dropPrefetchRsc: boolean,
   existingCacheNode: CacheNode
 ): CacheNode {
-  // Clone the CacheNode that was already present in the previous tree
+  // Clone the CacheNode that was already present in the previous tree.
+  // Carry forward the scrollRef so scroll intent from a prior navigation
+  // survives tree rebuilds (e.g. push + refresh in the same batch).
   return createCacheNode(
     existingCacheNode.rsc,
     dropPrefetchRsc ? null : existingCacheNode.prefetchRsc,
     existingCacheNode.head,
-    dropPrefetchRsc ? null : existingCacheNode.prefetchHead
+    dropPrefetchRsc ? null : existingCacheNode.prefetchHead,
+    existingCacheNode.scrollRef
   )
 }
 
@@ -1191,7 +1200,8 @@ function createCacheNode(
   rsc: React.ReactNode | null,
   prefetchRsc: React.ReactNode | null,
   head: React.ReactNode | null,
-  prefetchHead: HeadData | null
+  prefetchHead: HeadData | null,
+  scrollRef: ScrollRef | null = null
 ): CacheNode {
   return {
     rsc,
@@ -1199,6 +1209,7 @@ function createCacheNode(
     head,
     prefetchHead,
     slots: null,
+    scrollRef,
   }
 }
 

--- a/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/navigate-reducer.ts
@@ -24,7 +24,7 @@ export function navigateReducer(
   state: ReadonlyReducerState,
   action: NavigateAction
 ): ReducerState {
-  const { url, isExternalUrl, navigateType, shouldScroll } = action
+  const { url, isExternalUrl, navigateType, scrollBehavior } = action
 
   if (isExternalUrl) {
     return completeHardNavigation(state, url, navigateType)
@@ -50,7 +50,7 @@ export function navigateReducer(
     state.tree,
     state.nextUrl,
     FreshnessPolicy.Default,
-    shouldScroll,
+    scrollBehavior,
     navigateType
   )
 }

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -3,6 +3,7 @@ import type {
   ReducerState,
   RefreshAction,
 } from '../router-reducer-types'
+import { ScrollBehavior } from '../router-reducer-types'
 import {
   convertServerPatchToFullTree,
   navigateToKnownRoute,
@@ -56,7 +57,7 @@ export function refreshDynamicData(
   const currentUrl = new URL(currentCanonicalUrl, location.origin)
   const currentRenderedSearch = state.renderedSearch
   const currentFlightRouterState = state.tree
-  const shouldScroll = false
+  const scrollBehavior = ScrollBehavior.NoScroll
 
   // Create a NavigationSeed from the current FlightRouterState.
   // TODO: Eventually we will store this type directly on the state object
@@ -82,7 +83,7 @@ export function refreshDynamicData(
     currentFlightRouterState,
     freshnessPolicy,
     nextUrlForRefresh,
-    shouldScroll,
+    scrollBehavior,
     navigateType,
     null,
     // Refresh navigations don't use route prediction, so there's no route

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -45,8 +45,8 @@ export function restoreReducer(
 
   const now = Date.now()
   const accumulation: NavigationRequestAccumulation = {
-    scrollableSegments: null,
     separateRefreshUrls: null,
+    scrollRef: null,
   }
   const restoreSeed = convertServerPatchToFullTree(
     treeToRestore,

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -29,6 +29,7 @@ import type {
   ReducerState,
   ServerActionAction,
 } from '../router-reducer-types'
+import { ScrollBehavior } from '../router-reducer-types'
 import { assignLocation } from '../../../assign-location'
 import { createHrefFromUrl } from '../create-href-from-url'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
@@ -416,7 +417,7 @@ export function serverActionReducer(
       const redirectUrl =
         redirectLocation !== undefined ? redirectLocation : currentUrl
       const currentFlightRouterState = state.tree
-      const shouldScroll = true
+      const scrollBehavior = ScrollBehavior.Default
 
       // If the action triggered a revalidation of the cache, we should also
       // refresh all the dynamic data.
@@ -472,7 +473,7 @@ export function serverActionReducer(
           currentFlightRouterState,
           freshnessPolicy,
           nextUrl,
-          shouldScroll,
+          scrollBehavior,
           navigateType,
           null,
           // Server action redirects don't use route prediction - we already
@@ -494,7 +495,7 @@ export function serverActionReducer(
         currentFlightRouterState,
         nextUrl,
         freshnessPolicy,
-        shouldScroll,
+        scrollBehavior,
         navigateType
       )
     },

--- a/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-patch-reducer.ts
@@ -4,6 +4,7 @@ import {
   type ServerPatchAction,
   type ReducerState,
   type ReadonlyReducerState,
+  ScrollBehavior,
 } from '../router-reducer-types'
 import {
   completeHardNavigation,
@@ -41,7 +42,7 @@ export function serverPatchReducer(
   // using the tree we just received from the server.
   const retryCanonicalUrl = createHrefFromUrl(retryUrl)
   const retryNextUrl = action.nextUrl
-  const shouldScroll = true
+  const scrollBehavior = ScrollBehavior.Default
   const now = Date.now()
   return navigateToKnownRoute(
     now,
@@ -55,7 +56,7 @@ export function serverPatchReducer(
     state.tree,
     FreshnessPolicy.RefreshAll,
     retryNextUrl,
-    shouldScroll,
+    scrollBehavior,
     navigateType,
     null,
     // Server patch (retry) navigations don't use route prediction. This is

--- a/packages/next/src/client/components/router-reducer/router-reducer-types.ts
+++ b/packages/next/src/client/components/router-reducer/router-reducer-types.ts
@@ -1,8 +1,5 @@
-import type { CacheNode } from '../../../shared/lib/app-router-types'
-import type {
-  FlightRouterState,
-  FlightSegmentPath,
-} from '../../../shared/lib/app-router-types'
+import type { CacheNode, ScrollRef } from '../../../shared/lib/app-router-types'
+import type { FlightRouterState } from '../../../shared/lib/app-router-types'
 import type { NavigationSeed } from '../segment-cache/navigation'
 import type { FetchServerResponseResult } from './fetch-server-response'
 
@@ -94,7 +91,7 @@ export interface NavigateAction {
   isExternalUrl: boolean
   locationSearch: Location['search']
   navigateType: 'push' | 'replace'
-  shouldScroll: boolean
+  scrollBehavior: ScrollBehavior
 }
 
 /**
@@ -163,19 +160,37 @@ export interface PushRef {
   preserveCustomHistoryState: boolean
 }
 
+/**
+ * Controls the scroll behavior for a navigation.
+ */
+export const enum ScrollBehavior {
+  /** Use per-node ScrollRef to decide whether to scroll. */
+  Default = 0,
+  /** Suppress scroll entirely (e.g. scroll={false} on Link or router.push). */
+  NoScroll = 1,
+}
+
 export type FocusAndScrollRef = {
   /**
-   * If focus and scroll should be set in the layout-router's useEffect()
+   * The scroll ref from the most recent navigation. Set to whatever was
+   * accumulated during tree construction (or null if nothing was
+   * accumulated). On the next navigation, if new scroll targets are
+   * created, the previous scrollRef is invalidated by setting
+   * `current = false`.
    */
-  apply: boolean
+  scrollRef: ScrollRef | null
+  /**
+   * When true, the scroll handler uses `focusAndScrollRef.scrollRef`
+   * for every segment regardless of per-node state. Used for hash-only
+   * navigations where every segment should be treated as a scroll
+   * target. When false, the handler checks `cacheNode.scrollRef`
+   * instead (per-node), so only segments that actually navigated scroll.
+   */
+  forceScroll: boolean
   /**
    * The hash fragment that should be scrolled to.
    */
   hashFragment: string | null
-  /**
-   * The paths of the segments that should be focused.
-   */
-  segmentPaths: FlightSegmentPath[]
   /**
    * If only the URLs hash fragment changed
    */

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -2,6 +2,7 @@ import type {
   CacheNodeSeedData,
   FlightRouterState,
   FlightSegmentPath,
+  ScrollRef,
 } from '../../../shared/lib/app-router-types'
 import type { CacheNode } from '../../../shared/lib/app-router-types'
 import type { HeadData } from '../../../shared/lib/app-router-types'
@@ -34,6 +35,7 @@ import { PrefetchPriority, FetchStrategy } from './types'
 import { getLinkForCurrentNavigation } from '../links'
 import type { PageVaryPath } from './vary-path'
 import type { AppRouterState } from '../router-reducer/router-reducer-types'
+import { ScrollBehavior } from '../router-reducer/router-reducer-types'
 import { computeChangedPath } from '../router-reducer/compute-changed-path'
 import { isJavaScriptURLString } from '../../lib/javascript-url'
 
@@ -54,7 +56,7 @@ export function navigate(
   currentFlightRouterState: FlightRouterState,
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
-  shouldScroll: boolean,
+  scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): AppRouterState | Promise<AppRouterState> {
   // Instant Navigation Testing API: when the lock is active, ensure a
@@ -76,7 +78,7 @@ export function navigate(
         currentFlightRouterState,
         nextUrl,
         freshnessPolicy,
-        shouldScroll,
+        scrollBehavior,
         navigateType
       )
     }
@@ -91,7 +93,7 @@ export function navigate(
     currentFlightRouterState,
     nextUrl,
     freshnessPolicy,
-    shouldScroll,
+    scrollBehavior,
     navigateType
   )
 }
@@ -105,7 +107,7 @@ function navigateImpl(
   currentFlightRouterState: FlightRouterState,
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
-  shouldScroll: boolean,
+  scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): AppRouterState | Promise<AppRouterState> {
   const now = Date.now()
@@ -125,7 +127,7 @@ function navigateImpl(
       currentCacheNode,
       currentFlightRouterState,
       freshnessPolicy,
-      shouldScroll,
+      scrollBehavior,
       navigateType,
       route
     )
@@ -161,7 +163,7 @@ function navigateImpl(
           currentCacheNode,
           currentFlightRouterState,
           freshnessPolicy,
-          shouldScroll,
+          scrollBehavior,
           navigateType,
           optimisticRoute
         )
@@ -184,7 +186,7 @@ function navigateImpl(
     currentCacheNode,
     currentFlightRouterState,
     freshnessPolicy,
-    shouldScroll,
+    scrollBehavior,
     navigateType
   ).catch(() => {
     // If the navigation fails, return the current state
@@ -204,7 +206,7 @@ export function navigateToKnownRoute(
   currentFlightRouterState: FlightRouterState,
   freshnessPolicy: FreshnessPolicy,
   nextUrl: string | null,
-  shouldScroll: boolean,
+  scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
   debugInfo: Array<unknown> | null,
   // The route cache entry used for this navigation, if it came from route
@@ -223,8 +225,8 @@ export function navigateToKnownRoute(
   // A version of navigate() that accepts the target route tree as an argument
   // rather than reading it from the prefetch cache.
   const accumulation: NavigationRequestAccumulation = {
-    scrollableSegments: null,
     separateRefreshUrls: null,
+    scrollRef: null,
   }
   // We special case navigations to the exact same URL as the current location.
   // It's a common UI pattern for apps to refresh when you click a link to the
@@ -280,8 +282,8 @@ export function navigateToKnownRoute(
       navigationSeed.renderedSearch,
       canonicalUrl,
       navigateType,
-      shouldScroll,
-      accumulation.scrollableSegments,
+      scrollBehavior,
+      accumulation.scrollRef,
       debugInfo
     )
   }
@@ -299,7 +301,7 @@ function navigateUsingPrefetchedRouteTree(
   currentCacheNode: CacheNode | null,
   currentFlightRouterState: FlightRouterState,
   freshnessPolicy: FreshnessPolicy,
-  shouldScroll: boolean,
+  scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace',
   route: FulfilledRouteCacheEntry
 ): AppRouterState {
@@ -325,7 +327,7 @@ function navigateUsingPrefetchedRouteTree(
     currentFlightRouterState,
     freshnessPolicy,
     nextUrl,
-    shouldScroll,
+    scrollBehavior,
     navigateType,
     null,
     route
@@ -354,7 +356,7 @@ async function navigateToUnknownRoute(
   currentCacheNode: CacheNode | null,
   currentFlightRouterState: FlightRouterState,
   freshnessPolicy: FreshnessPolicy,
-  shouldScroll: boolean,
+  scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): Promise<AppRouterState> {
   // Runs when a navigation happens but there's no cached prefetch we can use.
@@ -509,7 +511,7 @@ async function navigateToUnknownRoute(
     currentFlightRouterState,
     freshnessPolicy,
     nextUrl,
-    shouldScroll,
+    scrollBehavior,
     navigateType,
     debugInfo,
     // Unknown route navigations don't use route prediction - the route tree
@@ -564,8 +566,8 @@ export function completeSoftNavigation(
   renderedSearch: string,
   canonicalUrl: string,
   navigateType: 'push' | 'replace',
-  shouldScroll: boolean,
-  scrollableSegments: Array<FlightSegmentPath> | null,
+  scrollBehavior: ScrollBehavior,
+  scrollRef: ScrollRef | null,
   collectedDebugInfo: Array<unknown> | null
 ) {
   // The "Next-Url" is a special representation of the URL that Next.js
@@ -594,20 +596,72 @@ export function completeSoftNavigation(
     url.search === oldUrl.search &&
     url.hash !== oldUrl.hash
 
-  // During a hash-only change, setting scrollableSegments to an empty
-  // array triggers a scroll for all new and updated segments. See
-  // `ScrollAndFocusHandler` for more details.
+  // Determine whether and how the page should scroll after this
+  // navigation.
   //
-  // TODO: Given the previous comment, I don't know why shouldScroll =
-  // false sets this to an empty array. Seems like an accident. I'm just
-  // preserving the logic that was already here. Clean this up when we
-  // move the per-segment scroll state to the CacheNode.
-  const segmentPathsToScrollTo =
-    onlyHashChange || !shouldScroll
-      ? []
-      : scrollableSegments !== null
-        ? scrollableSegments
-        : oldState.focusAndScrollRef.segmentPaths
+  // By default, we scroll to the segments that were navigated to — i.e.
+  // segments in the new part of the route, as opposed to shared segments
+  // that were already part of the previous route. All newly navigated
+  // segments share a single ScrollRef. When they mount, the first one
+  // to mount initiates the scroll. They share a ref so that only one
+  // scroll happens per navigation.
+  //
+  // If a subsequent navigation produces new segments, those supersede
+  // any pending scroll from the previous navigation by invalidating its
+  // ScrollRef. If a navigation doesn't produce any new segments (e.g.
+  // a refresh where the route structure didn't change), any pending
+  // scrolls from previous navigations are unaffected.
+  //
+  // The branches below handle special cases layered on top of this
+  // default model.
+  let activeScrollRef: ScrollRef | null
+  let forceScroll: boolean
+  if (scrollBehavior === ScrollBehavior.NoScroll) {
+    // The user explicitly opted out of scrolling (e.g. scroll={false}
+    // on a Link or router.push).
+    //
+    // If this navigation created new scroll targets (scrollRef !== null),
+    // neutralize them. If it didn't, any prior scroll targets carried
+    // forward on the cache nodes via reuseSharedCacheNode remain active.
+    if (scrollRef !== null) {
+      scrollRef.current = false
+    }
+    activeScrollRef = oldState.focusAndScrollRef.scrollRef
+    forceScroll = false
+  } else if (onlyHashChange) {
+    // Hash-only navigations should scroll regardless of per-node state.
+    // Create a fresh ref so the first segment to scroll consumes it.
+    //
+    // Invalidate any scroll ref from a prior navigation that hasn't
+    // been consumed yet.
+    const oldScrollRef = oldState.focusAndScrollRef.scrollRef
+    if (oldScrollRef !== null) {
+      oldScrollRef.current = false
+    }
+    // Also invalidate any per-node refs that were accumulated during
+    // this navigation's tree construction — the hash-only ref
+    // supersedes them.
+    if (scrollRef !== null) {
+      scrollRef.current = false
+    }
+    activeScrollRef = { current: true }
+    forceScroll = true
+  } else {
+    // Default case. Use the accumulated scrollRef (may be null if no
+    // new segments were created). The handler checks per-node refs, so
+    // unchanged parallel route slots won't scroll.
+    activeScrollRef = scrollRef
+
+    // If this navigation created new scroll targets, invalidate any
+    // pending scroll from a previous navigation.
+    if (scrollRef !== null) {
+      const oldScrollRef = oldState.focusAndScrollRef.scrollRef
+      if (oldScrollRef !== null) {
+        oldScrollRef.current = false
+      }
+    }
+    forceScroll = false
+  }
 
   const newState: AppRouterState = {
     canonicalUrl,
@@ -618,13 +672,8 @@ export function completeSoftNavigation(
       preserveCustomHistoryState: false,
     },
     focusAndScrollRef: {
-      // TODO: We should track all the per-segment scroll state on the CacheNode
-      // instead of using the paths.
-      apply: shouldScroll
-        ? segmentPathsToScrollTo !== null
-          ? true
-          : oldState.focusAndScrollRef.apply
-        : oldState.focusAndScrollRef.apply,
+      scrollRef: activeScrollRef,
+      forceScroll,
       onlyHashChange,
       hashFragment:
         // Remove leading # and decode hash to make non-latin hashes work.
@@ -633,10 +682,9 @@ export function completeSoftNavigation(
         // view. #top is handled in layout-router.
         //
         // Refer to `ScrollAndFocusHandler` for details on how this is used.
-        shouldScroll && url.hash !== ''
+        scrollBehavior !== ScrollBehavior.NoScroll && url.hash !== ''
           ? decodeURIComponent(url.hash.slice(1))
           : oldState.focusAndScrollRef.hashFragment,
-      segmentPaths: segmentPathsToScrollTo,
     },
     cache,
     tree,
@@ -887,7 +935,7 @@ async function ensurePrefetchThenNavigate(
   currentFlightRouterState: FlightRouterState,
   nextUrl: string | null,
   freshnessPolicy: FreshnessPolicy,
-  shouldScroll: boolean,
+  scrollBehavior: ScrollBehavior,
   navigateType: 'push' | 'replace'
 ): Promise<AppRouterState> {
   const link = getLinkForCurrentNavigation()
@@ -926,7 +974,7 @@ async function ensurePrefetchThenNavigate(
     currentFlightRouterState,
     nextUrl,
     freshnessPolicy,
-    shouldScroll,
+    scrollBehavior,
     navigateType
   )
 

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -49,7 +49,24 @@ export type CacheNode = {
   head: HeadData
 
   slots: Record<string, CacheNode> | null
+
+  /**
+   * A shared mutable ref that tracks whether this segment should be scrolled
+   * to. All new segments created during a single navigation share the same
+   * ref. When any segment's scroll handler fires, it sets `current` to
+   * `false` so no other segment scrolls for the same navigation.
+   *
+   * `null` means this segment is not a scroll target (e.g., a reused shared
+   * layout segment).
+   */
+  scrollRef: ScrollRef | null
 }
+
+/**
+ * A mutable ref shared across all new segments created during a single
+ * navigation. Used to ensure that only one segment scrolls per navigation.
+ */
+export type ScrollRef = { current: boolean }
 
 export type DynamicParamTypes =
   | 'catchall'

--- a/test/development/browser-logs/browser-logs.test.ts
+++ b/test/development/browser-logs/browser-logs.test.ts
@@ -336,8 +336,8 @@ describe(`Terminal Logging (${bundlerName})`, () => {
 
          ...
            <RenderFromTemplateContext>
-             <ScrollAndMaybeFocusHandler segmentPath={[...]}>
-               <${innerScrollAndMaybeFocusHandlerName} segmentPath={[...]} focusAndScrollRef={{apply:false, ...}}>
+             <ScrollAndMaybeFocusHandler cacheNode={{rsc:{...}, ...}}>
+               <${innerScrollAndMaybeFocusHandlerName} focusAndScrollRef={{scrollRef:null, ...}} cacheNode={{rsc:{...}, ...}}>
                  <ErrorBoundary errorComponent={undefined} errorStyles={undefined} errorScripts={undefined}>
                    <LoadingBoundary name="hydration-..." loading={null}>
                      <HTTPAccessFallbackBoundary notFound={undefined} forbidden={undefined} unauthorized={undefined}>

--- a/test/e2e/app-dir/router-autoscroll/app/server-action-refresh/actions.ts
+++ b/test/e2e/app-dir/router-autoscroll/app/server-action-refresh/actions.ts
@@ -1,0 +1,7 @@
+'use server'
+
+import { refresh } from 'next/cache'
+
+export async function refreshAction() {
+  refresh()
+}

--- a/test/e2e/app-dir/router-autoscroll/app/server-action-refresh/page.tsx
+++ b/test/e2e/app-dir/router-autoscroll/app/server-action-refresh/page.tsx
@@ -1,0 +1,21 @@
+import { refreshAction } from './actions'
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+
+  const timestamp = Date.now()
+
+  return (
+    <>
+      <div style={{ height: '200vh' }} />
+      <form action={refreshAction}>
+        <button id="refresh-button" type="submit">
+          Refresh
+        </button>
+      </form>
+      <div id="server-timestamp">{timestamp}</div>
+      <div style={{ height: '200vh' }} />
+    </>
+  )
+}

--- a/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
+++ b/test/e2e/app-dir/router-autoscroll/router-autoscroll.test.ts
@@ -173,6 +173,33 @@ describe('router autoscrolling on navigation', () => {
     )
   })
 
+  describe('server action refresh', () => {
+    it('should not scroll when refresh() is called from a server action', async () => {
+      const browser = await next.browser('/server-action-refresh')
+
+      const initialTimestamp = await browser
+        .elementByCss('#server-timestamp')
+        .text()
+
+      // Scroll down past the first spacer div
+      await scrollTo(browser, { x: 0, y: 1000 })
+
+      // Click the refresh button which calls refresh() via a server action
+      await browser.elementByCss('#refresh-button').click()
+
+      // Wait for the action to complete by checking the server timestamp
+      await retry(async () => {
+        const newTimestamp = await browser
+          .elementByCss('#server-timestamp')
+          .text()
+        expect(newTimestamp).not.toBe(initialTimestamp)
+      })
+
+      // Scroll position should be preserved
+      await waitForScrollToComplete(browser, { x: 0, y: 1000 })
+    })
+  })
+
   describe('bugs', () => {
     it('Should scroll to the top of the layout when the first child is display none', async () => {
       const browser = await next.browser('/')


### PR DESCRIPTION
Replaces the segment-path-matching scroll system with a simpler model based on a shared mutable ScrollRef on CacheNode.

The old system accumulated segment paths during navigation and matched them in layout-router to decide which segments should scroll. This was necessary when CacheNodes were created lazily during render. Now that we construct the entire CacheNode tree immediately upon navigation, we can assign a shared ScrollRef directly to each new leaf node. When any segment scrolls, it flips the ref to false, preventing other segments from also scrolling. This removes all the segment path accumulation and matching logic.

Fixes a regression where calling `refresh()` from a server action scrolled the page to the top. The old system had a semantic gap between `null` (no segments) and `[]` (scroll everything) — a server action refresh with no new segments fell through to a path that scrolled unconditionally. The new model avoids this: refresh creates no new CacheNodes, so no ScrollRef is assigned, and nothing scrolls.

Repro: https://github.com/stipsan/nextjs-refresh-regression-repro

There is extensive existing test coverage for scroll restoration behavior. This adds one additional test for the server action refresh bug.