### PR TITLE
fix(dev): clear stale interception rewrites on HMR update to prevent accumulation

### DIFF
--- a/packages/next/src/lib/generate-interception-routes-rewrites.ts
+++ b/packages/next/src/lib/generate-interception-routes-rewrites.ts
@@ -58,3 +58,11 @@ export function generateInterceptionRoutesRewrites(
 
   return rewrites
 }
+
+export function isInterceptionRouteRewrite(rewrite: Rewrite): boolean {
+  return Boolean(
+    rewrite.has?.some(
+      (has) => has.type === 'header' && has.key === NEXT_URL
+    )
+  )
+}

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -34,7 +34,10 @@ import { getRouteMatcher } from '../../../shared/lib/router/utils/route-matcher'
 import { normalizePathSep } from '../../../shared/lib/page-path/normalize-path-sep'
 import { createClientRouterFilter } from '../../../lib/create-client-router-filter'
 import { absolutePathToPage } from '../../../shared/lib/page-path/absolute-path-to-page'
-import { generateInterceptionRoutesRewrites } from '../../../lib/generate-interception-routes-rewrites'
+import {
+  generateInterceptionRoutesRewrites,
+  isInterceptionRouteRewrite,
+} from '../../../lib/generate-interception-routes-rewrites'
 
 import {
   CLIENT_STATIC_FILES_PATH,
@@ -529,15 +532,13 @@ async function startWatcher(
 
         const isAppPath = Boolean(
           appDir &&
-            normalizePathSep(fileName).startsWith(
-              normalizePathSep(appDir) + '/'
-            )
+          normalizePathSep(fileName).startsWith(normalizePathSep(appDir) + '/')
         )
         const isPagePath = Boolean(
           pagesDir &&
-            normalizePathSep(fileName).startsWith(
-              normalizePathSep(pagesDir) + '/'
-            )
+          normalizePathSep(fileName).startsWith(
+            normalizePathSep(pagesDir) + '/'
+          )
         )
 
         const rootFile = absolutePathToPage(fileName, {
@@ -990,6 +991,10 @@ async function startWatcher(
         )
       )
 
+      opts.fsChecker.rewrites.beforeFiles =
+        opts.fsChecker.rewrites.beforeFiles.filter(
+          (r) => !isInterceptionRouteRewrite(r)
+        )
       opts.fsChecker.rewrites.beforeFiles.push(...interceptionRoutes)
 
       const exportPathMap =

--- a/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
+++ b/test/e2e/app-dir/parallel-routes-and-interception/parallel-routes-and-interception.test.ts
@@ -1089,3 +1089,40 @@ describe('parallel-routes-and-interception-conflicting-pages', () => {
     }
   })
 })
+
+describe('parallel-routes-and-interception-hmr', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+    nextConfig,
+  })
+
+  it('should not accumulate interception rewrites in beforeFiles on repeated HMR updates', async () => {
+    if (!isNextDev) return
+
+    const filePath = 'app/[lang]/foo/page.js'
+    const fileContent = await next.readFile(filePath)
+
+    try {
+      // Simulate 3 file saves to trigger HMR aggregated event multiple times
+      // If the bug is present, interception rewrites accumulate and corrupt
+      // the pathname, throwing "Invalid interception route: /photos/(.)(.)(.)1"
+      await next.patchFile(filePath, fileContent + '\n// hmr-1')
+      await next.patchFile(filePath, fileContent + '\n// hmr-2')
+      await next.patchFile(filePath, fileContent + '\n// hmr-3')
+
+      // Navigate to the page with the interception route link
+      const browser = await next.browser('/en/foo')
+
+      // Click the link that triggers the interception route
+      await browser.elementByCss('a[href="/photos"]').click()
+
+      // The interception route should still work after multiple HMR saves
+      await check(
+        () => browser.waitForElementByCss('#intercepted').text(),
+        'intercepted'
+      )
+    } finally {
+      await next.patchFile(filePath, fileContent)
+    }
+  })
+})


### PR DESCRIPTION
## What

Fixes interception routes breaking on every HMR file save in Next.js 16.

## Why

In `setup-dev-bundler.ts`, interception route rewrites are pushed into
`beforeFiles` on every HMR `aggregated` event without clearing old entries
first. The (.) markers stacking up on every save makes dev pretty painful since you have to do a full refresh each time. This causes entries to accumulate on every save:

- Save No.1 → `[(.)users/[id]]`
- Save No.2 → `[(.)users/[id], (.)users/[id]]`
- Save No.3 → `[(.)users/[id], (.)users/[id], (.)users/[id]]`

The duplicate rewrites corrupt pathname matching, producing paths like
`/users/(.)(.)(.)1`, which then throws:
```
Error: Invalid interception route: /users/(.)(.)(.)1
```

## How

1. Added `isInterceptionRouteRewrite()` helper to
   `generate-interception-routes-rewrites.ts` — identifies rewrites
   generated from interception routes by checking for the `NEXT_URL`
   header in the `has` array.

2. In `setup-dev-bundler.ts`, filter out stale interception rewrites
   before pushing fresh ones on each HMR update.

## Testing

- Confirmed broken in 16.1.6 without fix
- Confirmed working after fix applied to node_modules
- This is a regression — Next.js 15.2.4 did not have this code path

Closes #91265