### PR TITLE
fix: add hidden attribute to Activity wrapper for :has() CSS compatibility

### DIFF
--- a/packages/next/src/client/components/layout-router.tsx
+++ b/packages/next/src/client/components/layout-router.tsx
@@ -866,14 +866,16 @@ export default function OuterLayoutRouter({
     }
 
     if (process.env.__NEXT_CACHE_COMPONENTS) {
+      const isHidden = stateKey !== activeStateKey
       child = (
-        <Activity
-          name={debugNameToDisplay}
-          key={stateKey}
-          mode={stateKey === activeStateKey ? 'visible' : 'hidden'}
-        >
-          {child}
-        </Activity>
+        <div key={stateKey} hidden={isHidden}>
+          <Activity
+            name={debugNameToDisplay}
+            mode={isHidden ? 'hidden' : 'visible'}
+          >
+            {child}
+          </Activity>
+        </div>
       )
     }
 

--- a/test/e2e/app-dir/activity-has-css/activity-has-css.test.ts
+++ b/test/e2e/app-dir/activity-has-css/activity-has-css.test.ts
@@ -1,0 +1,33 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+
+describe('Activity :has() CSS', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (process.env.__NEXT_CACHE_COMPONENTS !== 'true') {
+    it('is skipped when cacheComponents is disabled', () => {})
+    return
+  }
+
+  it('does not apply :has() rule to page B when navigating from page A', async () => {
+    const browser = await next.browser('/page-a')
+
+    await retry(async () => {
+      const bgColor = await browser.eval(
+        `window.getComputedStyle(document.querySelector('[data-testid="status-banner"]')).backgroundColor`
+      )
+      expect(bgColor).toMatch(/rgb\(185,\s*28,\s*28\)|#b91c1c/)
+    })
+
+    await browser.elementByCss('a[href="/page-b"]').click()
+
+    await retry(async () => {
+      const bgColor = await browser.eval(
+        `window.getComputedStyle(document.querySelector('[data-testid="status-banner"]')).backgroundColor`
+      )
+      expect(bgColor).not.toMatch(/rgb\(185,\s*28,\s*28\)|#b91c1c/)
+    })
+  })
+})

--- a/test/e2e/app-dir/activity-has-css/app/globals.css
+++ b/test/e2e/app-dir/activity-has-css/app/globals.css
@@ -1,0 +1,10 @@
+.status-banner {
+  padding: 8px 12px;
+  background: #dbeafe;
+  color: #1e3a8a;
+}
+
+body:has([data-page='a']):not(:has([hidden] [data-page='a'])) .status-banner {
+  background: #b91c1c;
+  color: #fff7ed;
+}

--- a/test/e2e/app-dir/activity-has-css/app/layout.tsx
+++ b/test/e2e/app-dir/activity-has-css/app/layout.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+import { ReactNode } from 'react'
+
+import './globals.css'
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>
+        <nav>
+          <Link href="/page-a" prefetch={false}>
+            Page A
+          </Link>
+          <Link href="/page-b" prefetch={false}>
+            Page B
+          </Link>
+        </nav>
+        <div className="status-banner" data-testid="status-banner">
+          Layout status
+        </div>
+        {children}
+      </body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/activity-has-css/app/page-a/page.tsx
+++ b/test/e2e/app-dir/activity-has-css/app/page-a/page.tsx
@@ -1,0 +1,7 @@
+export default function PageA() {
+  return (
+    <main data-page="a">
+      <h1>Page A</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/activity-has-css/app/page-b/page.tsx
+++ b/test/e2e/app-dir/activity-has-css/app/page-b/page.tsx
@@ -1,0 +1,7 @@
+export default function PageB() {
+  return (
+    <main data-page="b">
+      <h1>Page B</h1>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/activity-has-css/app/page.tsx
+++ b/test/e2e/app-dir/activity-has-css/app/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Home</h1>
+      <nav>
+        <Link href="/page-a" prefetch={false}>
+          Page A
+        </Link>
+        <Link href="/page-b" prefetch={false}>
+          Page B
+        </Link>
+      </nav>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/activity-has-css/next.config.js
+++ b/test/e2e/app-dir/activity-has-css/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
fix : #91359 

### Summary
- Add `hidden` attribute to the Activity wrapper when the segment is inactive so `:has()` can ignore hidden bfcache content.

### Changes
- Wrap Activity in a `div` with `hidden` when `mode !== 'visible'`
- Add e2e test for `:has()` behavior with cacheComponents

### Why
- Activity hides inactive bfcache content with `display: none`, but `:has()` still matches it. The `hidden` attribute lets users exclude hidden content via `:not(:has([hidden] .selector))`.

### Usage
- body:has([data-page='a']):not(:has([hidden] [data-page='a'])) .status-banner { ... }
