### PR TITLE
Perf: Only instrument clientComponentLoadTimes when used

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -2206,9 +2206,10 @@ export type BinaryStreamOf<T> = AnyStream
  */
 function installGlobalModuleLoadingHandlers(
   ComponentMod: AppPageModule,
-  cacheComponents: boolean
+  cacheComponents: boolean,
+  isTracingEnabled: boolean
 ) {
-  const instrumented = wrapClientComponentLoader(ComponentMod)
+  const instrumented = wrapClientComponentLoader(ComponentMod, isTracingEnabled)
 
   // When we are prerendering if there is a cacheSignal for tracking
   // cache reads we track calls to `loadChunk` and `require`. This allows us
@@ -2310,7 +2311,13 @@ async function renderToHTMLOrFlightImpl(
   // We need to expose the bundled `require` API globally for
   // react-server-dom-webpack. This is a hack until we find a better way.
   if (ComponentMod.__next_app__) {
-    installGlobalModuleLoadingHandlers(ComponentMod, cacheComponents)
+    const isTracingEnabled =
+      getTracer().getActiveScopeSpan()?.isRecording() ?? false
+    installGlobalModuleLoadingHandlers(
+      ComponentMod,
+      cacheComponents,
+      isTracingEnabled
+    )
   }
 
   if (process.env.__NEXT_DEV_SERVER && setIsrStatus && !cacheComponents) {

--- a/packages/next/src/server/client-component-renderer-logger.ts
+++ b/packages/next/src/server/client-component-renderer-logger.ts
@@ -5,10 +5,13 @@ let clientComponentLoadStart = 0
 let clientComponentLoadTimes = 0
 let clientComponentLoadCount = 0
 
+const HAS_CLIENT_COMPONENT_METRICS_ENABLED =
+  'performance' in globalThis && process.env.NEXT_OTEL_PERFORMANCE_PREFIX
+
 export function wrapClientComponentLoader(
   ComponentMod: AppPageModule
 ): AppPageModule['__next_app__'] {
-  if (!('performance' in globalThis)) {
+  if (!HAS_CLIENT_COMPONENT_METRICS_ENABLED) {
     return ComponentMod.__next_app__
   }
 

--- a/packages/next/src/server/client-component-renderer-logger.ts
+++ b/packages/next/src/server/client-component-renderer-logger.ts
@@ -5,13 +5,14 @@ let clientComponentLoadStart = 0
 let clientComponentLoadTimes = 0
 let clientComponentLoadCount = 0
 
-const HAS_CLIENT_COMPONENT_METRICS_ENABLED =
-  'performance' in globalThis && process.env.NEXT_OTEL_PERFORMANCE_PREFIX
-
 export function wrapClientComponentLoader(
-  ComponentMod: AppPageModule
+  ComponentMod: AppPageModule,
+  isTracingEnabled: boolean
 ): AppPageModule['__next_app__'] {
-  if (!HAS_CLIENT_COMPONENT_METRICS_ENABLED) {
+  if (
+    !('performance' in globalThis) ||
+    (!process.env.NEXT_OTEL_PERFORMANCE_PREFIX && !isTracingEnabled)
+  ) {
     return ComponentMod.__next_app__
   }
 

--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -14,6 +14,9 @@ export function isAbortError(e: any): e is Error & { name: 'AbortError' } {
   return e?.name === 'AbortError' || e?.name === ResponseAbortedName
 }
 
+const HAS_CLIENT_COMPONENT_METRICS_ENABLED =
+  'performance' in globalThis && process.env.NEXT_OTEL_PERFORMANCE_PREFIX
+
 function createWriterFromResponse(
   res: ServerResponse,
   waitUntilForEnd?: Promise<unknown>
@@ -51,10 +54,7 @@ function createWriterFromResponse(
       if (!started) {
         started = true
 
-        if (
-          'performance' in globalThis &&
-          process.env.NEXT_OTEL_PERFORMANCE_PREFIX
-        ) {
+        if (HAS_CLIENT_COMPONENT_METRICS_ENABLED) {
           const metrics = getClientComponentLoaderMetrics()
           if (metrics) {
             performance.measure(


### PR DESCRIPTION
## What?

Currently time spent requiring client components is always tracked, but if the instrumentation hook for it is disabled it's not relevant, so skipping the instrumentation is better.