### PR TITLE
Perf: Don't require watchpack in production

### DIFF
--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -16,7 +16,6 @@ import http from 'http'
 import https from 'https'
 import os from 'os'
 import { exec } from 'child_process'
-import Watchpack from 'next/dist/compiled/watchpack'
 import * as Log from '../../build/output/log'
 import setupDebug from 'next/dist/compiled/debug'
 import { RESTART_EXIT_CODE } from './utils'
@@ -548,7 +547,8 @@ export async function startServer(
     }
 
     const configFiles = CONFIG_FILES.map((file) => path.join(dir, file))
-
+    const Watchpack =
+      require('next/dist/compiled/watchpack') as typeof import('next/dist/compiled/watchpack').default
     const wp = new Watchpack()
     wp.watch({
       files: configFiles,


### PR DESCRIPTION
## What?

Watchpack is only used in development. Avoid requiring it for build/start