### PR TITLE
[Bug Demo] Static generation runs on every request for routes with unstable_instant = false

### DIFF
--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -5566,6 +5566,14 @@ async function prerenderToStream(
   tree: LoaderTree,
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ): Promise<PrerenderToStreamResult> {
+  // [BUG DEMO LOG] This log should only appear during build or ISR
+  // revalidation. If it appears on every runtime request, it means
+  // static generation is running per-request instead of being cached.
+  console.log(
+    `[prerenderToStream] route: ${ctx.pagePath}` +
+      ` | isBuildTimePrerendering: ${ctx.renderOpts.isBuildTimePrerendering}`
+  )
+
   // When prerendering formState is always null. We still include it
   // because some shared APIs expect a formState value and this is slightly
   // more explicit than making it an optional function argument
@@ -7093,6 +7101,13 @@ async function collectSegmentData(
   pagePath: string,
   metadata: AppPageRenderResultMetadata
 ): Promise<void> {
+  // [BUG DEMO LOG] collectSegmentData should only run during build or ISR
+  // revalidation — not on every runtime request.
+  console.log(
+    `[collectSegmentData] route: ${pagePath}` +
+      ` | isBuildTimePrerendering: ${renderOpts.isBuildTimePrerendering}`
+  )
+
   // Per-segment prefetch data
   //
   // All of the segments for a page are generated simultaneously, including

--- a/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/page.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <div>
+      <h1>Home</h1>
+      <ul>
+        <li>
+          <Link href="/with-suspense">With Suspense (partial prerender)</Link>
+        </li>
+        <li>
+          <Link href="/without-suspense">
+            Without Suspense (fully dynamic — bug)
+          </Link>
+        </li>
+        <li>
+          <Link href="/suspense-around-body">
+            Suspense around body (null fallback)
+          </Link>
+        </li>
+      </ul>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/suspense-around-body/page.tsx
+++ b/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/suspense-around-body/page.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+async function DynamicContent() {
+  await connection()
+  return (
+    <div>
+      <h1>Suspense with null fallback</h1>
+      <p>Dynamic content (rendered at request time)</p>
+    </div>
+  )
+}
+
+// This uses the old pattern for fully dynamic routes: Suspense with a null
+// fallback around the entire body. This produces no static HTML shell but
+// should still allow the static generation result (segment data, route tree)
+// to be cached rather than re-computed on every request.
+export default function Page() {
+  return (
+    <Suspense fallback={null}>
+      <DynamicContent />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/with-suspense/page.tsx
+++ b/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/with-suspense/page.tsx
@@ -1,0 +1,22 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function DynamicContent() {
+  await connection()
+  return <p>Dynamic content (rendered at request time)</p>
+}
+
+// connection() is inside a Suspense boundary, so the route gets a static
+// shell at build time (partial prerender). At runtime, the static shell is
+// served from cache and only the dynamic part is computed per-request.
+// prerenderToStream should NOT run on each request for this route.
+export default function Page() {
+  return (
+    <div>
+      <h1>With Suspense</h1>
+      <Suspense fallback={<p>Loading...</p>}>
+        <DynamicContent />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/without-suspense/page.tsx
+++ b/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/app/without-suspense/page.tsx
@@ -1,0 +1,18 @@
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+// connection() is called directly without a Suspense boundary, and
+// unstable_instant = false opts out of prefetching. With Cache Components
+// enabled, the route is marked as ƒ (Dynamic). This causes
+// prerenderToStream and collectSegmentData to run on EVERY request —
+// static generation is happening per-request instead of being cached.
+export default async function Page() {
+  await connection()
+  return (
+    <div>
+      <h1>Without Suspense</h1>
+      <p>Dynamic content (rendered at request time)</p>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/next.config.js
+++ b/test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
## Summary

This is a demonstration of a bug, not a fix. The debug logs added here are intentional and meant to illustrate the issue.

When a route has `unstable_instant = false` at the root segment (i.e. `connection()` called outside a Suspense boundary), the route is marked as Dynamic in the build output. At runtime with Cache Components enabled, `prerenderToStream` and `collectSegmentData` run on every single request instead of caching the static generation result.

In contrast, when the same `connection()` call is wrapped in a Suspense boundary — either with a real fallback (partial prerender) or with a null fallback (the old "suspense around body" pattern) — neither function runs at runtime. The static generation result is served from cache as expected.

I haven't thought of a way to write a regression test for this that doesn't rely on implementation details. Logging inside a component would get de-duped by the memory cache anyway. I've demonstrated by adding logs to Next.js itself for now.

## Steps to reproduce

```sh
cd test/e2e/app-dir/segment-cache/bug-dynamic-prerender-per-request
pnpm next build
pnpm next start

# In another terminal:
curl http://localhost:3000/with-suspense
curl http://localhost:3000/suspense-around-body
curl http://localhost:3000/without-suspense
```

The build output shows `/without-suspense` as fully dynamic:

```
Route (app)
┌ ○ /
├ ○ /_not-found
├ ◐ /suspense-around-body
├ ◐ /with-suspense
└ ƒ /without-suspense

○  (Static)             prerendered as static content
◐  (Partial Prerender)  prerendered as static HTML with dynamic server-streamed content
ƒ  (Dynamic)            server-rendered on demand
```

Note that `/without-suspense` is marked as `ƒ` (Dynamic) rather than `◐` (Partial Prerender). The fact that `/suspense-around-body` — which also has no meaningful static HTML shell — is marked as `◐` is highly suggestive that `unstable_instant = false` should be treated the same way. At minimum, the inconsistency between these two routes is wrong.

**Expected:** No runtime logs for any route. Static generation results should be cached and served without re-running the prerender path on each request.

**Actual:** The `/without-suspense` request produces these logs on the server:

```
[prerenderToStream] route: /without-suspense | isBuildTimePrerendering: undefined
[collectSegmentData] route: /without-suspense | isBuildTimePrerendering: undefined
```

The `/with-suspense` and `/suspense-around-body` requests produce no logs (correct).