### PR TITLE
Rename /_next/webpack-hmr to /_next/hmr

### DIFF
--- a/docs/02-pages/02-guides/upgrading/version-12.mdx
+++ b/docs/02-pages/02-guides/upgrading/version-12.mdx
@@ -134,6 +134,8 @@ app.all('/_next/webpack-hmr', (req, res) => {
 })
 ```
 
+> **Note:** In Next.js 16, the HMR WebSocket path was renamed from `/_next/webpack-hmr` to `/_next/hmr`.
+
 #### Webpack 4 support has been removed
 
 If you are already using webpack 5 you can skip this section.

--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -48,7 +48,7 @@ export function createWebSocket(
     }
 
     const newWebSocket = new window.WebSocket(
-      `${getSocketUrl(assetPrefix)}/_next/webpack-hmr?id=${self.__next_r}`
+      `${getSocketUrl(assetPrefix)}/_next/hmr?id=${self.__next_r}`
     )
 
     newWebSocket.binaryType = 'arraybuffer'

--- a/packages/next/src/client/page-bootstrap.ts
+++ b/packages/next/src/client/page-bootstrap.ts
@@ -17,7 +17,7 @@ import { performFullReload } from './dev/hot-reloader/pages/hot-reloader-pages'
 import { dispatcher } from 'next/dist/compiled/next-devtools'
 
 export function pageBootstrap(assetPrefix: string) {
-  connectHMR({ assetPrefix, path: '/_next/webpack-hmr' })
+  connectHMR({ assetPrefix, path: '/_next/hmr' })
 
   return hydrate({ beforeRender: displayContent }).then(() => {
     initOnDemandEntries()

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -836,7 +836,7 @@ export async function initialize(opts: {
         }
 
         const isHMRRequest = req.url.startsWith(
-          ensureLeadingSlash(`${hmrPrefix}/_next/webpack-hmr`)
+          ensureLeadingSlash(`${hmrPrefix}/_next/hmr`)
         )
 
         // only handle HMR requests if the basePath in the request

--- a/test/development/app-dir/hmr-iframe/app/page1/subscribeToHMR.ts
+++ b/test/development/app-dir/hmr-iframe/app/page1/subscribeToHMR.ts
@@ -32,9 +32,7 @@ export const subscribeToHMR = async () => {
 
   state.initialized = true
 
-  const ws = new WebSocket(
-    `ws://localhost:${process.env.PORT}/_next/webpack-hmr`
-  )
+  const ws = new WebSocket(`ws://localhost:${process.env.PORT}/_next/hmr`)
 
   ws.onmessage = (event: any) => {
     if (typeof event.data === 'string') {

--- a/test/development/basic/allowed-dev-origins.test.ts
+++ b/test/development/basic/allowed-dev-origins.test.ts
@@ -158,7 +158,7 @@ describe.each(['', '/docs'])(
               statusEl.id = 'status'
               document.querySelector('body').appendChild(statusEl)
   
-              const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/webpack-hmr')}")
+              const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/hmr')}")
               
               ws.addEventListener('error', (err) => {
                 statusEl.innerText = 'error'
@@ -183,7 +183,7 @@ describe.each(['', '/docs'])(
           })
 
           expectBlockedDevResourceMessage(next.cliOutput, {
-            resourcePath: withBasePath(basePath, '/_next/webpack-hmr'),
+            resourcePath: withBasePath(basePath, '/_next/hmr'),
             source: 'example.vercel.sh',
           })
         } finally {
@@ -286,7 +286,7 @@ describe.each(['', '/docs'])(
               statusEl.id = 'status'
               document.querySelector('body').appendChild(statusEl)
 
-              const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/webpack-hmr')}")
+              const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/hmr')}")
 
               ws.addEventListener('error', () => {
                 statusEl.innerText = 'error'
@@ -353,7 +353,7 @@ describe.each(['', '/docs'])(
               statusEl.id = 'status'
               document.querySelector('body').appendChild(statusEl)
   
-              const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/webpack-hmr')}")
+              const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/hmr')}")
               
               ws.addEventListener('error', (err) => {
                 statusEl.innerText = 'error'
@@ -484,7 +484,7 @@ describe.each(['', '/docs'])(
                     statusEl.id = 'status'
                     document.querySelector('body').appendChild(statusEl)
         
-                    const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/webpack-hmr')}")
+                    const ws = new WebSocket("${next.url}${withBasePath(basePath, '/_next/hmr')}")
                     
                     ws.addEventListener('error', (err) => {
                       statusEl.innerText = 'error'
@@ -512,7 +512,7 @@ describe.each(['', '/docs'])(
           })
 
           expectBlockedDevResourceMessage(next.cliOutput, {
-            resourcePath: withBasePath(basePath, '/_next/webpack-hmr'),
+            resourcePath: withBasePath(basePath, '/_next/hmr'),
             opaqueOrigin: true,
           })
         } finally {

--- a/test/integration/custom-routes/next.config.js
+++ b/test/integration/custom-routes/next.config.js
@@ -18,7 +18,7 @@ module.exports = {
         {
           source: '/to-websocket',
           destination:
-            'http://localhost:__EXTERNAL_PORT__/_next/webpack-hmr?page=/about',
+            'http://localhost:__EXTERNAL_PORT__/_next/hmr?page=/about',
         },
         {
           source: '/websocket-to-page',

--- a/test/integration/custom-routes/test/index.test.ts
+++ b/test/integration/custom-routes/test/index.test.ts
@@ -97,7 +97,7 @@ const runTests = (isDev = false) => {
       'success'
     )
     ws.close()
-    expect([...externalServerHits]).toEqual(['/_next/webpack-hmr?page=/about'])
+    expect([...externalServerHits]).toEqual(['/_next/hmr?page=/about'])
   })
 
   it('should successfully rewrite a WebSocket request to a page', async () => {
@@ -2134,7 +2134,7 @@ const runTests = (isDev = false) => {
          "rewrites": {
            "afterFiles": [
              {
-               "destination": "http://localhost:EXTERNAL_SERVER_PORT/_next/webpack-hmr?page=/about",
+               "destination": "http://localhost:EXTERNAL_SERVER_PORT/_next/hmr?page=/about",
                "regex": "^\\/to-websocket(?:\\/)?$",
                "source": "/to-websocket",
              },

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -202,7 +202,7 @@ impl DevServerBuilder {
                                 }
 
                                 println!("[404] {path} (WebSocket)");
-                                if path == "/_next/webpack-hmr" {
+                                if path == "/_next/hmr" {
                                     // Special-case requests to webpack-hmr as these are made by
                                     // Next.js clients built
                                     // without turbopack, which may be making requests in

--- a/turbopack/crates/turbopack-dev-server/src/lib.rs
+++ b/turbopack/crates/turbopack-dev-server/src/lib.rs
@@ -203,7 +203,7 @@ impl DevServerBuilder {
 
                                 println!("[404] {path} (WebSocket)");
                                 if path == "/_next/hmr" {
-                                    // Special-case requests to webpack-hmr as these are made by
+                                    // Special-case requests to hmr as these are made by
                                     // Next.js clients built
                                     // without turbopack, which may be making requests in
                                     // development.


### PR DESCRIPTION
## What

Rename the HMR WebSocket path from `/_next/webpack-hmr` to `/_next/hmr`.

## Why

The `webpack-hmr` name is a leftover from when webpack was the only bundler. Now that Turbopack is the default bundler for both `next dev` and `next build`, the path name is misleading. The generic `/_next/hmr` better reflects that this endpoint is bundler-agnostic.

## Changes

- **Client source** (`page-bootstrap.ts`, `web-socket.ts`): updated the WebSocket connection path
- **Server** (`router-server.ts`): updated the HMR request detection path
- **Turbopack** (`turbopack-dev-server/src/lib.rs`): updated the fallback WebSocket path check
- **Tests**: updated all test files referencing the old path
- **Docs** (`version-12.mdx`): added a note that the path was renamed to `/_next/hmr` in Next.js 16, while keeping the original v12 examples intact