### PR TITLE
fix(hmr): reconnect WebSocket after sleep/wake

### DIFF
--- a/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
+++ b/packages/next/src/client/dev/hot-reloader/app/web-socket.ts
@@ -121,7 +121,7 @@ export function createWebSocket(
       newWebSocket.close()
       reconnections++
 
-      // After 25 reconnects we'll want to reload the page as it indicates the dev server is no longer running.
+      // After WEB_SOCKET_MAX_RECONNECTIONS reconnects we'll want to reload the page as it indicates the dev server is no longer running.
       if (reconnections > WEB_SOCKET_MAX_RECONNECTIONS) {
         reloading = true
         window.location.reload()
@@ -141,6 +141,28 @@ export function createWebSocket(
     webSocket = newWebSocket
     return newWebSocket
   }
+
+  function handleVisibilityChange() {
+    if (
+      document.visibilityState === 'visible' &&
+      webSocket.readyState !== WebSocket.OPEN
+    ) {
+      reconnections = 0
+      clearTimeout(timer)
+      init()
+    }
+  }
+
+  function handleOnlineEvent() {
+    if (webSocket.readyState !== WebSocket.OPEN) {
+      reconnections = 0
+      clearTimeout(timer)
+      init()
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+  window.addEventListener('online', handleOnlineEvent)
 
   return init()
 }

--- a/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
+++ b/packages/next/src/client/dev/hot-reloader/pages/websocket.ts
@@ -74,7 +74,7 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
       source.onclose = null
       source.close()
       reconnections++
-      // After 25 reconnects we'll want to reload the page as it indicates the dev server is no longer running.
+      // After WEB_SOCKET_MAX_RECONNECTIONS reconnects we'll want to reload the page as it indicates the dev server is no longer running.
       if (reconnections > WEB_SOCKET_MAX_RECONNECTIONS) {
         reloading = true
         window.location.reload()
@@ -94,6 +94,28 @@ export function connectHMR(options: { path: string; assetPrefix: string }) {
     source.onclose = handleDisconnect
     source.onmessage = handleMessage
   }
+
+  function handleVisibilityChange() {
+    if (
+      document.visibilityState === 'visible' &&
+      source.readyState !== WebSocket.OPEN
+    ) {
+      reconnections = 0
+      clearTimeout(timer)
+      init()
+    }
+  }
+
+  function handleOnlineEvent() {
+    if (source.readyState !== WebSocket.OPEN) {
+      reconnections = 0
+      clearTimeout(timer)
+      init()
+    }
+  }
+
+  document.addEventListener('visibilitychange', handleVisibilityChange)
+  window.addEventListener('online', handleOnlineEvent)
 
   init()
 }


### PR DESCRIPTION
## Summary

When a computer sleeps and wakes, the `/_next/hmr` WebSocket connection can silently become stale. The current code relies entirely on `onclose`/`onerror` events, but:

- `onclose` may fire late or not at all after sleep/wake — the TCP connection is dead but the browser hasn't detected it yet
- `setTimeout` timers freeze during sleep, so queued retries can fire at once after wake, rapidly exhausting the 12-reconnect limit and triggering a spurious full-page reload

This PR adds `visibilitychange` and `online` event listeners to both the App Router and Pages Router HMR WebSocket clients. When the page becomes visible again or the browser regains connectivity, the WebSocket state is checked and a reconnection is triggered immediately if it's no longer open. The reconnection counter is reset since sleep-induced disconnections are not indicative of the dev server being down.

## How it works

- **`visibilitychange`**: When the document becomes `visible`, check `webSocket.readyState`. If not `OPEN`, reset the reconnection counter, clear any pending retry timer, and call `init()` to reconnect immediately.
- **`online`**: Same logic — when the browser fires the `online` event after regaining network connectivity.

This matches the approach recommended by the Socket.IO team and other WebSocket libraries for handling sleep/wake reconnection.

## Test plan

- Manual: open a Next.js dev app, put the computer to sleep (or simulate by disabling/re-enabling the network interface), verify the WebSocket reconnects and logs `[HMR] connected` when the tab is re-focused
- Verified: `pnpm --filter=next types` passes with no errors