### PR TITLE
Remove unused layer from server actions manifest

### DIFF
--- a/crates/next-api/src/server_actions.rs
+++ b/crates/next-api/src/server_actions.rs
@@ -198,7 +198,7 @@ async fn build_manifest(
     }
 
     // Now create the manifest entries
-    for (hash_id, (layer, name, filename)) in &action_metadata {
+    for (hash_id, (_layer, name, filename)) in &action_metadata {
         let entry = mapping.entry(hash_id.as_str()).or_default();
         entry.workers.insert(
             &key,
@@ -211,7 +211,6 @@ async fn build_manifest(
                 filename: filename.as_str(),
             },
         );
-        entry.layer.insert(&key, *layer);
 
         // Hoist the filename and exported_name to the entry level
         entry.exported_name = name.as_str();

--- a/crates/next-core/src/next_manifests/mod.rs
+++ b/crates/next-core/src/next_manifests/mod.rs
@@ -385,8 +385,6 @@ pub struct ActionManifestEntry<'a> {
     /// module that exports it.
     pub workers: FxIndexMap<&'a str, ActionManifestWorkerEntry<'a>>,
 
-    pub layer: FxIndexMap<&'a str, ActionLayer>,
-
     #[serde(rename = "exportedName")]
     pub exported_name: &'a str,
 

--- a/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
+++ b/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts
@@ -74,8 +74,12 @@ type Actions = {
         async: boolean
       }
     }
-    // Record which layer the action is in (rsc or sc_action), in the specific entry.
-    layer: {
+    // Record which layer the action is in (rsc or sc_action), in the specific entry
+    //
+    // This is only used by Webpack to correctly output the manifest. It's value shouldn't be relied
+    // upon externally. It's possible that the same action can be in different layers in a single
+    // page, which cannot be modelled with this API anyway.
+    layer?: {
       [name: string]: string
     }
   }
@@ -1016,7 +1020,7 @@ export class FlightClientEntryPlugin {
           async: false,
         }
 
-        currentCompilerServerActions[id].layer[bundlePath] = fromClient
+        currentCompilerServerActions[id].layer![bundlePath] = fromClient
           ? WEBPACK_LAYERS.actionBrowser
           : WEBPACK_LAYERS.reactServerComponents
       }
@@ -1124,13 +1128,11 @@ export class FlightClientEntryPlugin {
     })
 
     for (let id in pluginState.serverActions) {
-      const action = pluginState.serverActions[id]
+      const { layer, ...action } = pluginState.serverActions[id]
       for (let name in action.workers) {
         const modId =
           pluginState.serverActionModules[name][
-            action.layer[name] === WEBPACK_LAYERS.actionBrowser
-              ? 'client'
-              : 'server'
+            layer![name] === WEBPACK_LAYERS.actionBrowser ? 'client' : 'server'
           ]
         action.workers[name] = modId!
       }
@@ -1138,13 +1140,11 @@ export class FlightClientEntryPlugin {
     }
 
     for (let id in pluginState.edgeServerActions) {
-      const action = pluginState.edgeServerActions[id]
+      const { layer, ...action } = pluginState.edgeServerActions[id]
       for (let name in action.workers) {
         const modId =
           pluginState.edgeServerActionModules[name][
-            action.layer[name] === WEBPACK_LAYERS.actionBrowser
-              ? 'client'
-              : 'server'
+            layer![name] === WEBPACK_LAYERS.actionBrowser ? 'client' : 'server'
           ]
         action.workers[name] = modId!
       }

--- a/packages/next/src/shared/lib/turbopack/manifest-loader.ts
+++ b/packages/next/src/shared/lib/turbopack/manifest-loader.ts
@@ -273,12 +273,10 @@ export class TurbopackManifestLoader {
       for (const key in other) {
         const action = (actionEntries[key] ??= {
           workers: {},
-          layer: {},
         })
         action.filename = other[key].filename
         action.exportedName = other[key].exportedName
         Object.assign(action.workers, other[key].workers)
-        Object.assign(action.layer, other[key].layer)
       }
     }
 
@@ -289,12 +287,10 @@ export class TurbopackManifestLoader {
     for (const key in manifest.node) {
       const entry = manifest.node[key]
       entry.workers = sortObjectByKey(entry.workers)
-      entry.layer = sortObjectByKey(entry.layer)
     }
     for (const key in manifest.edge) {
       const entry = manifest.edge[key]
       entry.workers = sortObjectByKey(entry.workers)
-      entry.layer = sortObjectByKey(entry.layer)
     }
 
     return manifest

--- a/test/production/app-dir/actions-tree-shaking/_testing/utils.ts
+++ b/test/production/app-dir/actions-tree-shaking/_testing/utils.ts
@@ -12,9 +12,6 @@ type Actions = {
         async: boolean
       }
     }
-    layer: {
-      [name: string]: string
-    }
   }
 }
 
@@ -50,9 +47,7 @@ export function nextTestSetupActionTreeShaking(opts) {
 }
 
 type ActionState = {
-  [route: string]: {
-    [layer: string]: string[]
-  }
+  [route: string]: string[]
 }
 
 function getActionsRoutesState(actionsMappingOfRuntime: Actions): ActionState {
@@ -61,12 +56,7 @@ function getActionsRoutesState(actionsMappingOfRuntime: Actions): ActionState {
     const action = actionsMappingOfRuntime[actionId]
     for (const routePath in action.workers) {
       if (!state[routePath]) {
-        state[routePath] = {}
-      }
-      const layer = action.layer[routePath]
-
-      if (!state[routePath][layer]) {
-        state[routePath][layer] = []
+        state[routePath] = []
       }
 
       // Normalize when NEXT_SKIP_ISOLATE=1
@@ -75,14 +65,12 @@ function getActionsRoutesState(actionsMappingOfRuntime: Actions): ActionState {
             action.filename.indexOf('/', 'test/tmp/next-test-'.length) + 1
           )
         : action.filename
-      state[routePath][layer].push(`${filename}#${action.exportedName}`)
+      state[routePath].push(`${filename}#${action.exportedName}`)
     }
   }
 
-  for (const layer of Object.values(state)) {
-    for (const list of Object.values(layer)) {
-      list.sort()
-    }
+  for (const page of Object.values(state)) {
+    page.sort()
   }
 
   return state

--- a/test/production/app-dir/actions-tree-shaking/basic/basic.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/basic/basic.test.ts
@@ -15,23 +15,17 @@ import {
       const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
       expect(actionsRoutesState).toMatchInlineSnapshot(`
        {
-         "app/client/page": {
-           "action-browser": [
-             "app/actions.js#clientComponentAction",
-           ],
-         },
-         "app/inline/page": {
-           "rsc": [
-             "app/inline/page.js#$$RSC_SERVER_ACTION_0",
-           ],
-         },
-         "app/server/page": {
-           "rsc": [
-             "app/actions.js#clientComponentAction",
-             "app/actions.js#serverComponentAction",
-             "app/actions.js#unusedExportedAction",
-           ],
-         },
+         "app/client/page": [
+           "app/actions.js#clientComponentAction",
+         ],
+         "app/inline/page": [
+           "app/inline/page.js#$$RSC_SERVER_ACTION_0",
+         ],
+         "app/server/page": [
+           "app/actions.js#clientComponentAction",
+           "app/actions.js#serverComponentAction",
+           "app/actions.js#unusedExportedAction",
+         ],
        }
       `)
     })

--- a/test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/mixed-module-actions/mixed-module-actions.test.ts
@@ -15,20 +15,16 @@ import {
       const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
       expect(actionsRoutesState).toMatchInlineSnapshot(`
        {
-         "app/mixed-module/cjs/page": {
-           "rsc": [
-             "app/mixed-module/cjs/actions.js#cjsModuleTypeAction",
-             "app/mixed-module/cjs/actions.js#esmModuleTypeAction",
-             "app/mixed-module/cjs/actions.js#unusedModuleTypeAction1",
-           ],
-         },
-         "app/mixed-module/esm/page": {
-           "rsc": [
-             "app/mixed-module/esm/actions.js#cjsModuleTypeAction",
-             "app/mixed-module/esm/actions.js#esmModuleTypeAction",
-             "app/mixed-module/esm/actions.js#unusedModuleTypeAction1",
-           ],
-         },
+         "app/mixed-module/cjs/page": [
+           "app/mixed-module/cjs/actions.js#cjsModuleTypeAction",
+           "app/mixed-module/cjs/actions.js#esmModuleTypeAction",
+           "app/mixed-module/cjs/actions.js#unusedModuleTypeAction1",
+         ],
+         "app/mixed-module/esm/page": [
+           "app/mixed-module/esm/actions.js#cjsModuleTypeAction",
+           "app/mixed-module/esm/actions.js#esmModuleTypeAction",
+           "app/mixed-module/esm/actions.js#unusedModuleTypeAction1",
+         ],
        }
       `)
     })

--- a/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/reexport/reexport.test.ts
@@ -18,43 +18,31 @@ import { retry } from 'next-test-utils'
 
       expect(actionsRoutesState).toMatchInlineSnapshot(`
        {
-         "app/named-reexport/client/page": {
-           "action-browser": [
-             "app/named-reexport/client/actions.js#sharedClientLayerAction",
-           ],
-         },
-         "app/named-reexport/server/page": {
-           "rsc": [
-             "app/named-reexport/server/actions.js#sharedServerLayerAction",
-             "app/named-reexport/server/actions.js#unusedServerLayerAction1",
-             "app/named-reexport/server/actions.js#unusedServerLayerAction2",
-           ],
-         },
-         "app/namespace-reexport-2/client/page": {
-           "action-browser": [
-             "app/namespace-reexport-2/actions/action-modules.js#action",
-             "app/namespace-reexport-2/nested.js#getFoo",
-           ],
-         },
-         "app/namespace-reexport-2/server/page": {
-           "rsc": [
-             "app/namespace-reexport-2/actions/action-modules.js#action",
-             "app/namespace-reexport-2/nested.js#foo",
-             "app/namespace-reexport-2/nested.js#getFoo",
-           ],
-         },
-         "app/namespace-reexport/client/page": {
-           "action-browser": [
-             "app/namespace-reexport/client/actions.js#sharedClientLayerAction",
-           ],
-         },
-         "app/namespace-reexport/server/page": {
-           "rsc": [
-             "app/namespace-reexport/server/actions.js#sharedServerLayerAction",
-             "app/namespace-reexport/server/actions.js#unusedServerLayerAction1",
-             "app/namespace-reexport/server/actions.js#unusedServerLayerAction2",
-           ],
-         },
+         "app/named-reexport/client/page": [
+           "app/named-reexport/client/actions.js#sharedClientLayerAction",
+         ],
+         "app/named-reexport/server/page": [
+           "app/named-reexport/server/actions.js#sharedServerLayerAction",
+           "app/named-reexport/server/actions.js#unusedServerLayerAction1",
+           "app/named-reexport/server/actions.js#unusedServerLayerAction2",
+         ],
+         "app/namespace-reexport-2/client/page": [
+           "app/namespace-reexport-2/actions/action-modules.js#action",
+           "app/namespace-reexport-2/nested.js#getFoo",
+         ],
+         "app/namespace-reexport-2/server/page": [
+           "app/namespace-reexport-2/actions/action-modules.js#action",
+           "app/namespace-reexport-2/nested.js#foo",
+           "app/namespace-reexport-2/nested.js#getFoo",
+         ],
+         "app/namespace-reexport/client/page": [
+           "app/namespace-reexport/client/actions.js#sharedClientLayerAction",
+         ],
+         "app/namespace-reexport/server/page": [
+           "app/namespace-reexport/server/actions.js#sharedServerLayerAction",
+           "app/namespace-reexport/server/actions.js#unusedServerLayerAction1",
+           "app/namespace-reexport/server/actions.js#unusedServerLayerAction2",
+         ],
        }
       `)
     })

--- a/test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/shared-module-actions/shared-module-actions.test.ts
@@ -15,30 +15,22 @@ import {
       const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
       expect(actionsRoutesState).toMatchInlineSnapshot(`
        {
-         "app/client/one/page": {
-           "action-browser": [
-             "app/client/actions.js#sharedClientLayerAction",
-           ],
-         },
-         "app/client/two/page": {
-           "action-browser": [
-             "app/client/actions.js#sharedClientLayerAction",
-           ],
-         },
-         "app/server/one/page": {
-           "rsc": [
-             "app/server/actions.js#sharedServerLayerAction",
-             "app/server/actions.js#unusedServerLayerAction1",
-             "app/server/actions.js#unusedServerLayerAction2",
-           ],
-         },
-         "app/server/two/page": {
-           "rsc": [
-             "app/server/actions.js#sharedServerLayerAction",
-             "app/server/actions.js#unusedServerLayerAction1",
-             "app/server/actions.js#unusedServerLayerAction2",
-           ],
-         },
+         "app/client/one/page": [
+           "app/client/actions.js#sharedClientLayerAction",
+         ],
+         "app/client/two/page": [
+           "app/client/actions.js#sharedClientLayerAction",
+         ],
+         "app/server/one/page": [
+           "app/server/actions.js#sharedServerLayerAction",
+           "app/server/actions.js#unusedServerLayerAction1",
+           "app/server/actions.js#unusedServerLayerAction2",
+         ],
+         "app/server/two/page": [
+           "app/server/actions.js#sharedServerLayerAction",
+           "app/server/actions.js#unusedServerLayerAction1",
+           "app/server/actions.js#unusedServerLayerAction2",
+         ],
        }
       `)
     })

--- a/test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions.test.ts
+++ b/test/production/app-dir/actions-tree-shaking/use-effect-actions/use-effect-actions.test.ts
@@ -12,13 +12,11 @@ describe('actions-tree-shaking - use-effect-actions', () => {
     const actionsRoutesState = await getActionsRoutesStateByRuntime(next)
     expect(actionsRoutesState).toMatchInlineSnapshot(`
      {
-       "app/mixed/page": {
-         "action-browser": [
-           "app/mixed/actions.ts#action1",
-           "app/mixed/actions.ts#action2",
-           "app/mixed/actions.ts#action3",
-         ],
-       },
+       "app/mixed/page": [
+         "app/mixed/actions.ts#action1",
+         "app/mixed/actions.ts#action2",
+         "app/mixed/actions.ts#action3",
+       ],
      }
     `)
   })


### PR DESCRIPTION
```
    // This is only used by Webpack to correctly output the manifest. It's value shouldn't be relied
    // upon externally. It's possible that the same action can be in different layers in a single
    // page, which cannot be modelled with this API anyway.
```