### PR TITLE
docs: clarify generateMetadata re-evaluation on navigation

### DIFF
--- a/docs/01-app/01-getting-started/14-metadata-and-og-images.mdx
+++ b/docs/01-app/01-getting-started/14-metadata-and-og-images.mdx
@@ -132,7 +132,11 @@ Learn more about [streaming metadata](/docs/app/api-reference/functions/generate
 
 ### Memoizing data requests
 
-There may be cases where you need to fetch the **same** data for metadata and the page itself. To avoid duplicate requests, you can use React's [`cache` function](https://react.dev/reference/react/cache) to memoize the return value and only fetch the data once. For example, to fetch the blog post information for both the metadata and the page:
+There may be cases where you need to fetch the **same** data for metadata and the page itself. To avoid duplicate requests, you can use React's [`cache` function](https://react.dev/reference/react/cache) to memoize the return value and only fetch the data once.
+
+> **Good to know**: React `cache()` and `fetch` memoization deduplicate requests **within a single server render**, not across navigations. Each client-side navigation triggers a new server request with a fresh React render context. This means `generateMetadata` re-runs on every navigation—even for layouts whose component tree is preserved. If you need to cache expensive data fetches across multiple navigations, use [`fetch` with `revalidate`](/docs/app/guides/caching#time-based-revalidation) or [`unstable_cache`](/docs/app/api-reference/functions/unstable_cache) at the data layer.
+
+For example, to fetch the blog post information for both the metadata and the page:
 
 ```ts filename="app/lib/data.ts" highlight={5} switcher
 import { cache } from 'react'

--- a/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
+++ b/docs/01-app/03-api-reference/04-functions/generate-metadata.mdx
@@ -1321,6 +1321,8 @@ Metadata is evaluated in order, starting from the root segment down to the segme
 2. `app/blog/layout.tsx` (Nested Blog Layout)
 3. `app/blog/[slug]/page.tsx` (Blog Page)
 
+> **Good to know**: `generateMetadata` is re-evaluated for **every navigation**, including navigations between sibling routes. Even if a layout's React component tree is preserved during navigation (e.g., navigating from `/alpha` to `/beta` under the same layout), its `generateMetadata` still runs again because metadata reflects the full route and may depend on child segments. React `cache()` and `fetch` memoization only deduplicate within a single request—they do not persist across navigations. If you need to cache expensive data fetches across navigations, use [`fetch` with `revalidate`](/docs/app/guides/caching#time-based-revalidation) or [`unstable_cache`](/docs/app/api-reference/functions/unstable_cache) instead.
+
 ### Merging
 
 Following the [evaluation order](#ordering), Metadata objects exported from multiple segments in the same route are **shallowly** merged together to form the final metadata output of a route. Duplicate keys are **replaced** based on their ordering.


### PR DESCRIPTION
### Improving Documentation

- [x] Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- [x] Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

## What?

Adds "Good to know" callouts to the metadata docs clarifying that `generateMetadata` re-evaluates on every client-side navigation, even when the layout component tree is preserved.

## Why?

Users expect that if a layout is preserved during sibling navigation (e.g., `/alpha` → `/beta`), its `generateMetadata` and any React `cache()`-wrapped fetches should also be preserved. This is not the case—metadata reflects the full route and must be re-resolved on every navigation. React `cache()` is per-request scoped, not cross-navigation.

This was reported in #91410.

## How?

Added clarifying notes in two places:

1. **`docs/01-app/03-api-reference/04-functions/generate-metadata.mdx`** — Under the "Ordering" section, a "Good to know" callout explaining re-evaluation behavior and pointing to `fetch` with `revalidate` or `unstable_cache` for cross-navigation caching.

2. **`docs/01-app/01-getting-started/14-metadata-and-og-images.mdx`** — In the "Memoizing data requests" section, a "Good to know" callout clarifying that React `cache()` and `fetch` memoization are per-request only.

Fixes #91410