### PR TITLE
Add `unstable_dynamicStaleTime` route segment config

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1133,5 +1133,7 @@
   "1132": "Route %s used \\`draftMode()\\` inside \\`generateStaticParams\\`. This is not supported because \\`generateStaticParams\\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
   "1133": "createSearchParamsFromClient should not be called inside generateStaticParams.",
   "1134": "Route %s used \\`headers()\\` inside \\`generateStaticParams\\`. This is not supported because \\`generateStaticParams\\` runs at build time without an HTTP request. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
-  "1135": "\"use cache\" cannot be used outside of App Router. Expected a WorkUnitStore."
+  "1135": "\"use cache\" cannot be used outside of App Router. Expected a WorkUnitStore.",
+  "1136": "Page \"%s\" cannot use both \\`export const unstable_dynamicStaleTime\\` and \\`export const unstable_instant\\`.",
+  "1137": "\"%s\" cannot use \\`export const unstable_dynamicStaleTime\\`. This config is only supported in page files, not layouts."
 }

--- a/packages/next/src/build/analysis/get-page-static-info.ts
+++ b/packages/next/src/build/analysis/get-page-static-info.ts
@@ -691,6 +691,23 @@ export async function getAppPageStaticInfo({
     )
   }
 
+  // Prevent unstable_dynamicStaleTime in layouts.
+  if ('unstable_dynamicStaleTime' in config) {
+    const isLayout = /\/layout\.[^/]+$/.test(pageFilePath)
+    if (isLayout) {
+      throw new Error(
+        `"${page}" cannot use \`export const unstable_dynamicStaleTime\`. This config is only supported in page files, not layouts.`
+      )
+    }
+  }
+
+  // Prevent combining unstable_dynamicStaleTime and unstable_instant.
+  if ('unstable_dynamicStaleTime' in config && 'unstable_instant' in config) {
+    throw new Error(
+      `Page "${page}" cannot use both \`export const unstable_dynamicStaleTime\` and \`export const unstable_instant\`.`
+    )
+  }
+
   return {
     type: PAGE_TYPES.APP,
     rsc,

--- a/packages/next/src/build/segment-config/app/app-segment-config.ts
+++ b/packages/next/src/build/segment-config/app/app-segment-config.ts
@@ -146,6 +146,13 @@ const AppSegmentConfigSchema = z.object({
   unstable_instant: InstantConfigSchema.optional(),
 
   /**
+   * The stale time for dynamic responses in seconds.
+   * Controls how long the client-side router cache retains dynamic page data.
+   * Pages only — not allowed in layouts.
+   */
+  unstable_dynamicStaleTime: z.number().int().nonnegative().optional(),
+
+  /**
    * The preferred region for the page.
    */
   preferredRegion: z.union([z.string(), z.array(z.string())]).optional(),
@@ -186,6 +193,11 @@ export function parseAppSegmentConfig(
             return {
               // @TODO replace this link with a link to the docs when they are written
               message: `Invalid unstable_instant value ${JSON.stringify(ctx.data)} on "${route}", must be an object with \`prefetch: "static"\` or \`prefetch: "runtime"\`, or \`false\`. Read more at https://nextjs.org/docs/messages/invalid-instant-configuration`,
+            }
+          }
+          case 'unstable_dynamicStaleTime': {
+            return {
+              message: `Invalid unstable_dynamicStaleTime value ${JSON.stringify(ctx.data)} on "${route}", must be a non-negative number`,
             }
           }
           default:
@@ -241,6 +253,13 @@ export type AppSegmentConfig = {
    * How this segment should be prefetched.
    */
   unstable_instant?: Instant
+
+  /**
+   * The stale time for dynamic responses in seconds.
+   * Controls how long the client-side router cache retains dynamic page data.
+   * Pages only — not allowed in layouts.
+   */
+  unstable_dynamicStaleTime?: number
 
   /**
    * The preferred region for the page.

--- a/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
+++ b/packages/next/src/build/webpack/plugins/next-types-plugin/index.ts
@@ -72,6 +72,7 @@ checkFields<Diff<{
   config?: {}
   generateStaticParams?: Function
   unstable_instant?: InstantConfigForTypeCheckInternal
+  unstable_dynamicStaleTime?: number
   revalidate?: RevalidateRange<TEntry> | false
   dynamic?: 'auto' | 'force-dynamic' | 'error' | 'force-static'
   dynamicParams?: boolean

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -14,6 +14,10 @@ import {
   writeStaticStageResponseIntoCache,
 } from '../segment-cache/cache'
 import { FetchStrategy } from '../segment-cache/types'
+import {
+  UnknownDynamicStaleTime,
+  computeDynamicStaleAt,
+} from '../segment-cache/bfcache'
 import { decodeStaticStage } from './fetch-server-response'
 import { discoverKnownRoute } from '../segment-cache/optimistic-routes'
 import type { NormalizedSearch } from '../segment-cache/cache-key'
@@ -41,6 +45,7 @@ export function createInitialRouterState({
     l: initialStaticStageByteLength,
     h: initialHeadVaryParams,
     p: initialRuntimePrefetchStream,
+    d: initialDynamicStaleTimeSeconds,
   } = initialRSCPayload
 
   // When initialized on the server, the canonical URL is provided as an array of parts.
@@ -87,7 +92,11 @@ export function createInitialRouterState({
     navigatedAt,
     initialRouteTree,
     initialSeedData,
-    initialHead
+    initialHead,
+    computeDynamicStaleAt(
+      navigatedAt,
+      initialDynamicStaleTimeSeconds ?? UnknownDynamicStaleTime
+    )
   )
 
   // The following only applies in the browser (location !== null) since neither

--- a/packages/next/src/client/components/router-reducer/fetch-server-response.ts
+++ b/packages/next/src/client/components/router-reducer/fetch-server-response.ts
@@ -25,7 +25,6 @@ import {
   RSC_CONTENT_TYPE_HEADER,
   NEXT_HMR_REFRESH_HEADER,
   NEXT_DID_POSTPONE_HEADER,
-  NEXT_ROUTER_STALE_TIME_HEADER,
   NEXT_HTML_REQUEST_ID_HEADER,
   NEXT_REQUEST_ID_HEADER,
 } from '../app-router-headers'
@@ -43,6 +42,7 @@ import { getDeploymentId } from '../../../shared/lib/deployment-id'
 import { getNavigationBuildId } from '../../navigation-build-id'
 import { NEXT_NAV_DEPLOYMENT_ID_HEADER } from '../../../lib/constants'
 import { stripIsPartialByte } from '../segment-cache/cache'
+import { UnknownDynamicStaleTime } from '../segment-cache/bfcache'
 
 const createFromReadableStream =
   createFromReadableStreamBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromReadableStream']
@@ -81,7 +81,7 @@ type SpaFetchServerResponseResult = {
   couldBeIntercepted: boolean
   supportsPerSegmentPrefetching: boolean
   postponed: boolean
-  staleTime: number
+  dynamicStaleTime: number
   staticStageData: StaticStageData | null
   runtimePrefetchStream: ReadableStream<Uint8Array> | null
   responseHeaders: Headers
@@ -196,13 +196,6 @@ export async function fetchServerResponse(
     const contentType = res.headers.get('content-type') || ''
     const interception = !!res.headers.get('vary')?.includes(NEXT_URL)
     const postponed = !!res.headers.get(NEXT_DID_POSTPONE_HEADER)
-    const staleTimeHeaderSeconds = res.headers.get(
-      NEXT_ROUTER_STALE_TIME_HEADER
-    )
-    const staleTime =
-      staleTimeHeaderSeconds !== null
-        ? parseInt(staleTimeHeaderSeconds, 10) * 1000
-        : -1
     let isFlightResponse = contentType.startsWith(RSC_CONTENT_TYPE_HEADER)
 
     if (process.env.NODE_ENV === 'production') {
@@ -289,7 +282,11 @@ export async function fetchServerResponse(
       couldBeIntercepted: interception,
       supportsPerSegmentPrefetching: flightResponse.S,
       postponed,
-      staleTime,
+      // The dynamicStaleTime is only present in the response body when
+      // a page exports unstable_dynamicStaleTime and this is a dynamic render.
+      // When absent (UnknownDynamicStaleTime), the client falls back to the
+      // global DYNAMIC_STALETIME_MS. The value is in seconds.
+      dynamicStaleTime: flightResponse.d ?? UnknownDynamicStaleTime,
       staticStageData,
       runtimePrefetchStream: flightResponse.p ?? null,
       responseHeaders: res.headers,

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -53,8 +53,9 @@ import {
   readFromBFCacheDuringRegularNavigation,
   writeToBFCache,
   writeHeadToBFCache,
+  updateBFCacheEntryStaleAt,
+  computeDynamicStaleAt,
 } from '../segment-cache/bfcache'
-import { DYNAMIC_STALETIME_MS } from './reducers/navigate-reducer'
 
 // This is yet another tree type that is used to track pending promises that
 // need to be fulfilled once the dynamic data is received. The terminal nodes of
@@ -132,7 +133,8 @@ export function createInitialCacheNodeForHydration(
   navigatedAt: number,
   initialTree: RouteTree,
   seedData: CacheNodeSeedData | null,
-  seedHead: HeadData
+  seedHead: HeadData,
+  seedDynamicStaleAt: number
 ): NavigationTask {
   // Create the initial cache node tree, using the data embedded into the
   // HTML document.
@@ -147,6 +149,7 @@ export function createInitialCacheNodeForHydration(
     FreshnessPolicy.Hydration,
     seedData,
     seedHead,
+    seedDynamicStaleAt,
     false,
     accumulation
   )
@@ -193,6 +196,7 @@ export function startPPRNavigation(
   freshness: FreshnessPolicy,
   seedData: CacheNodeSeedData | null,
   seedHead: HeadData | null,
+  seedDynamicStaleAt: number,
   isSamePageNavigation: boolean,
   accumulation: NavigationRequestAccumulation
 ): NavigationTask | null {
@@ -214,6 +218,7 @@ export function startPPRNavigation(
     didFindRootLayout,
     seedData,
     seedHead,
+    seedDynamicStaleAt,
     isSamePageNavigation,
     parentNeedsDynamicRequest,
     oldRootRefreshState,
@@ -233,6 +238,7 @@ function updateCacheNodeOnNavigation(
   didFindRootLayout: boolean,
   seedData: CacheNodeSeedData | null,
   seedHead: HeadData | null,
+  seedDynamicStaleAt: number,
   isSamePageNavigation: boolean,
   parentNeedsDynamicRequest: boolean,
   oldRootRefreshState: RefreshState,
@@ -290,6 +296,7 @@ function updateCacheNodeOnNavigation(
       freshness,
       seedData,
       seedHead,
+      seedDynamicStaleAt,
       parentNeedsDynamicRequest,
       accumulation
     )
@@ -356,7 +363,8 @@ function updateCacheNodeOnNavigation(
       seedRsc,
       newMetadataVaryPath,
       seedHead,
-      freshness
+      freshness,
+      seedDynamicStaleAt
     )
     newCacheNode = result.cacheNode
     needsDynamicRequest = result.needsDynamicRequest
@@ -486,6 +494,7 @@ function updateCacheNodeOnNavigation(
         childDidFindRootLayout,
         seedDataChild ?? null,
         seedHeadChild,
+        seedDynamicStaleAt,
         isSamePageNavigation,
         parentNeedsDynamicRequest || needsDynamicRequest,
         oldRootRefreshState,
@@ -600,6 +609,7 @@ function createCacheNodeOnNavigation(
   freshness: FreshnessPolicy,
   seedData: CacheNodeSeedData | null,
   seedHead: HeadData | null,
+  seedDynamicStaleAt: number,
   parentNeedsDynamicRequest: boolean,
   accumulation: NavigationRequestAccumulation
 ): NavigationTask {
@@ -625,7 +635,8 @@ function createCacheNodeOnNavigation(
     seedRsc,
     newMetadataVaryPath,
     seedHead,
-    freshness
+    freshness,
+    seedDynamicStaleAt
   )
   const newCacheNode = result.cacheNode
   const needsDynamicRequest = result.needsDynamicRequest
@@ -661,6 +672,7 @@ function createCacheNodeOnNavigation(
         freshness,
         seedDataChild ?? null,
         seedHead,
+        seedDynamicStaleAt,
         parentNeedsDynamicRequest || needsDynamicRequest,
         accumulation
       )
@@ -882,7 +894,8 @@ function createCacheNodeForSegment(
   seedRsc: React.ReactNode | null,
   metadataVaryPath: PageVaryPath | null,
   seedHead: HeadData | null,
-  freshness: FreshnessPolicy
+  freshness: FreshnessPolicy,
+  dynamicStaleAt: number
 ): { cacheNode: CacheNode; needsDynamicRequest: boolean } {
   // Construct a new CacheNode using data from the BFCache, the client's
   // Segment Cache, or seeded from a server response.
@@ -905,29 +918,23 @@ function createCacheNodeForSegment(
   // the BFCache.
   switch (freshness) {
     case FreshnessPolicy.Default: {
-      // When experimental.staleTimes.dynamic config is set, we read from the
-      // BFCache even during regular navigations. (This is not a recommended API
-      // with Cache Components, but it's supported for backwards compatibility.
-      // Use cacheLife instead.)
-
-      // This outer check isn't semantically necessary; even if the configured
-      // stale time is 0, the bfcache will return null, because any entry would
-      // have immediately expired. Just an optimization.
-      if (DYNAMIC_STALETIME_MS > 0) {
-        const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
-          now,
-          tree.varyPath
-        )
-        if (bfcacheEntry !== null) {
-          return {
-            cacheNode: createCacheNode(
-              bfcacheEntry.rsc,
-              bfcacheEntry.prefetchRsc,
-              bfcacheEntry.head,
-              bfcacheEntry.prefetchHead
-            ),
-            needsDynamicRequest: false,
-          }
+      // Check BFCache during regular navigations. The entry's staleAt
+      // determines whether it's still fresh. This is used when
+      // staleTimes.dynamic is configured globally or when a page exports
+      // unstable_dynamicStaleTime for per-page control.
+      const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
+        now,
+        tree.varyPath
+      )
+      if (bfcacheEntry !== null) {
+        return {
+          cacheNode: createCacheNode(
+            bfcacheEntry.rsc,
+            bfcacheEntry.prefetchRsc,
+            bfcacheEntry.head,
+            bfcacheEntry.prefetchHead
+          ),
+          needsDynamicRequest: false,
         }
       }
       break
@@ -953,9 +960,23 @@ function createCacheNodeForSegment(
       const prefetchRsc = null
       const head = isPage ? seedHead : null
       const prefetchHead = null
-      writeToBFCache(now, tree.varyPath, rsc, prefetchRsc, head, prefetchHead)
+      writeToBFCache(
+        now,
+        tree.varyPath,
+        rsc,
+        prefetchRsc,
+        head,
+        prefetchHead,
+        dynamicStaleAt
+      )
       if (isPage && metadataVaryPath !== null) {
-        writeHeadToBFCache(now, metadataVaryPath, head, prefetchHead)
+        writeHeadToBFCache(
+          now,
+          metadataVaryPath,
+          head,
+          prefetchHead,
+          dynamicStaleAt
+        )
       }
       return {
         cacheNode: createCacheNode(rsc, prefetchRsc, head, prefetchHead),
@@ -1180,9 +1201,23 @@ function createCacheNodeForSegment(
   // Skip BFCache writes for optimistic navigations since they are transient
   // and will be replaced by the canonical navigation.
   if (freshness !== FreshnessPolicy.Gesture) {
-    writeToBFCache(now, tree.varyPath, rsc, prefetchRsc, head, prefetchHead)
+    writeToBFCache(
+      now,
+      tree.varyPath,
+      rsc,
+      prefetchRsc,
+      head,
+      prefetchHead,
+      dynamicStaleAt
+    )
     if (isPage && metadataVaryPath !== null) {
-      writeHeadToBFCache(now, metadataVaryPath, head, prefetchHead)
+      writeHeadToBFCache(
+        now,
+        metadataVaryPath,
+        head,
+        prefetchHead,
+        dynamicStaleAt
+      )
     }
   }
 
@@ -1583,10 +1618,14 @@ async function fetchMissingDynamicData(
         seed: null,
       }
     }
+    const now = Date.now()
+
     const seed = convertServerPatchToFullTree(
+      now,
       task.route,
       result.flightData,
-      result.renderedSearch
+      result.renderedSearch,
+      result.dynamicStaleTime
     )
 
     // If the navigation lock is active, wait for it to be released before
@@ -1595,8 +1634,6 @@ async function fetchMissingDynamicData(
     if (process.env.__NEXT_EXPOSE_TESTING_API) {
       await waitForNavigationLock()
     }
-
-    const now = Date.now()
 
     if (routeCacheEntry !== null && result.staticStageData !== null) {
       const { response: staticStageResponse, isResponsePartial } =
@@ -1653,11 +1690,16 @@ async function fetchMissingDynamicData(
         })
     }
 
+    // result.dynamicStaleTime is in seconds (from the server's `d` field).
+    // Convert to an absolute timestamp using the centralized helper.
+    const dynamicStaleAt = computeDynamicStaleAt(now, result.dynamicStaleTime)
+
     const didReceiveUnknownParallelRoute = writeDynamicDataIntoNavigationTask(
       task,
       seed.routeTree,
       seed.data,
       seed.head,
+      dynamicStaleAt,
       result.debugInfo
     )
 
@@ -1685,11 +1727,19 @@ function writeDynamicDataIntoNavigationTask(
   serverRouteTree: RouteTree,
   dynamicData: CacheNodeSeedData | null,
   dynamicHead: HeadData,
+  dynamicStaleAt: number,
   debugInfo: Array<any> | null
 ): boolean {
   if (task.status === NavigationTaskStatus.Pending && dynamicData !== null) {
     task.status = NavigationTaskStatus.Fulfilled
     finishPendingCacheNode(task.node, dynamicData, dynamicHead, debugInfo)
+
+    // Update the BFCache entry's staleAt for this segment with the value
+    // from the dynamic response. This applies the per-page
+    // unstable_dynamicStaleTime if set, or the default DYNAMIC_STALETIME_MS.
+    // We only update segments that received dynamic data — static segments
+    // are unaffected.
+    updateBFCacheEntryStaleAt(serverRouteTree.varyPath, dynamicStaleAt)
   }
 
   const taskChildren = task.children
@@ -1740,6 +1790,7 @@ function writeDynamicDataIntoNavigationTask(
                 serverRouteTreeChild,
                 dynamicDataChild,
                 dynamicHead,
+                dynamicStaleAt,
                 debugInfo
               )
             if (childDidReceiveUnknownParallelRoute) {

--- a/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/refresh-reducer.ts
@@ -11,7 +11,10 @@ import {
 import { invalidateSegmentCacheEntries } from '../../segment-cache/cache'
 import { hasInterceptionRouteInCurrentTree } from './has-interception-route-in-current-tree'
 import { FreshnessPolicy } from '../ppr-navigations'
-import { invalidateBfCache } from '../../segment-cache/bfcache'
+import {
+  invalidateBfCache,
+  UnknownDynamicStaleTime,
+} from '../../segment-cache/bfcache'
 
 export function refreshReducer(
   state: ReadonlyReducerState,
@@ -63,13 +66,17 @@ export function refreshDynamicData(
   // TODO: Eventually we will store this type directly on the state object
   // instead of reconstructing it on demand. Part of a larger series of
   // refactors to unify the various tree types that the client deals with.
+  const now = Date.now()
+  // TODO: Store the dynamic stale time on the top-level state so it's known
+  // during restores and refreshes.
   const refreshSeed = convertServerPatchToFullTree(
+    now,
     currentFlightRouterState,
     null,
-    currentRenderedSearch
+    currentRenderedSearch,
+    UnknownDynamicStaleTime
   )
 
-  const now = Date.now()
   const navigateType = 'replace'
   return navigateToKnownRoute(
     now,

--- a/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/restore-reducer.ts
@@ -16,6 +16,7 @@ import {
   completeTraverseNavigation,
   convertServerPatchToFullTree,
 } from '../../segment-cache/navigation'
+import { UnknownDynamicStaleTime } from '../../segment-cache/bfcache'
 
 export function restoreReducer(
   state: ReadonlyReducerState,
@@ -44,14 +45,18 @@ export function restoreReducer(
     extractPathFromFlightRouterState(treeToRestore) ?? restoredUrl.pathname
 
   const now = Date.now()
+  // TODO: Store the dynamic stale time on the top-level state so it's known
+  // during restores and refreshes.
   const accumulation: NavigationRequestAccumulation = {
     separateRefreshUrls: null,
     scrollRef: null,
   }
   const restoreSeed = convertServerPatchToFullTree(
+    now,
     treeToRestore,
     null,
-    renderedSearch
+    renderedSearch,
+    UnknownDynamicStaleTime
   )
   const task = startPPRNavigation(
     now,
@@ -64,6 +69,7 @@ export function restoreReducer(
     FreshnessPolicy.HistoryTraversal,
     null,
     null,
+    restoreSeed.dynamicStaleAt,
     false,
     accumulation
   )

--- a/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
+++ b/packages/next/src/client/components/router-reducer/reducers/server-action-reducer.ts
@@ -68,7 +68,10 @@ import {
 import { isExternalURL } from '../../app-router-utils'
 import { FreshnessPolicy } from '../ppr-navigations'
 import { processFetch } from '../fetch-server-response'
-import { invalidateBfCache } from '../../segment-cache/bfcache'
+import {
+  invalidateBfCache,
+  UnknownDynamicStaleTime,
+} from '../../segment-cache/bfcache'
 
 const createFromFetch =
   createFromFetchBrowser as (typeof import('react-server-dom-webpack/client.browser'))['createFromFetch']
@@ -437,12 +440,16 @@ export function serverActionReducer(
         // subset of the data needed to render the new page, we'll initiate a
         // new fetch, like we would for a normal navigation.
         const redirectCanonicalUrl = createHrefFromUrl(redirectUrl)
+        const now = Date.now()
+        // TODO: Store the dynamic stale time on the top-level state so it's
+        // known during restores and refreshes.
         const redirectSeed = convertServerPatchToFullTree(
+          now,
           currentFlightRouterState,
           flightData,
-          flightDataRenderedSearch
+          flightDataRenderedSearch,
+          UnknownDynamicStaleTime
         )
-        const now = Date.now()
 
         // Learn the route pattern so we can predict it for future navigations.
         const metadataVaryPath = redirectSeed.metadataVaryPath

--- a/packages/next/src/client/components/segment-cache/bfcache.ts
+++ b/packages/next/src/client/components/segment-cache/bfcache.ts
@@ -1,4 +1,25 @@
+import { DYNAMIC_STALETIME_MS } from '../router-reducer/reducers/navigate-reducer'
 import type { SegmentVaryPath } from './vary-path'
+
+/**
+ * Sentinel value indicating that no per-page dynamic stale time was provided.
+ * When this is the dynamicStaleTime, the default DYNAMIC_STALETIME_MS is used.
+ */
+export const UnknownDynamicStaleTime = -1
+
+/**
+ * Converts a dynamic stale time (in seconds, as sent by the server in the `d`
+ * field of the Flight response) to an absolute staleAt timestamp. When the
+ * value is unknown, falls back to the global DYNAMIC_STALETIME_MS.
+ */
+export function computeDynamicStaleAt(
+  now: number,
+  dynamicStaleTimeSeconds: number
+): number {
+  return dynamicStaleTimeSeconds !== UnknownDynamicStaleTime
+    ? now + dynamicStaleTimeSeconds * 1000
+    : now + DYNAMIC_STALETIME_MS
+}
 import {
   setInCacheMap,
   getFromCacheMap,
@@ -6,7 +27,6 @@ import {
   type CacheMap,
   createCacheMap,
 } from './cache-map'
-import { DYNAMIC_STALETIME_MS } from '../router-reducer/reducers/navigate-reducer'
 
 export type BFCacheEntry = {
   rsc: React.ReactNode | null
@@ -16,6 +36,12 @@ export type BFCacheEntry = {
 
   ref: UnknownMapEntry | null
   size: number
+  // The time at which this data was received. Used to compute the stale time
+  // for dynamic prefetches (which use STATIC_STALETIME_MS instead of
+  // DYNAMIC_STALETIME_MS). Stored explicitly because staleAt may be
+  // overridden by a per-page unstable_dynamicStaleTime, which would break
+  // any reverse calculation from staleAt.
+  navigatedAt: number
   staleAt: number
   version: number
 }
@@ -37,7 +63,8 @@ export function writeToBFCache(
   rsc: React.ReactNode,
   prefetchRsc: React.ReactNode,
   head: React.ReactNode,
-  prefetchHead: React.ReactNode
+  prefetchHead: React.ReactNode,
+  dynamicStaleAt: number
 ): void {
   if (typeof window === 'undefined') {
     return
@@ -60,9 +87,12 @@ export function writeToBFCache(
     // entirely and use memory pressure events instead.
     size: 100,
 
+    navigatedAt: now,
+
     // A back/forward navigation will disregard the stale time. This field is
-    // only relevant when staleTimes.dynamic is enabled.
-    staleAt: now + DYNAMIC_STALETIME_MS,
+    // only relevant when staleTimes.dynamic is enabled or unstable_dynamicStaleTime
+    // is exported by a page.
+    staleAt: dynamicStaleAt,
     version: currentBfCacheVersion,
   }
   const isRevalidation = false
@@ -73,10 +103,38 @@ export function writeHeadToBFCache(
   now: number,
   varyPath: SegmentVaryPath,
   head: React.ReactNode,
-  prefetchHead: React.ReactNode
+  prefetchHead: React.ReactNode,
+  dynamicStaleAt: number
 ): void {
   // Read the special "segment" that represents the head data.
-  writeToBFCache(now, varyPath, head, prefetchHead, null, null)
+  writeToBFCache(now, varyPath, head, prefetchHead, null, null, dynamicStaleAt)
+}
+
+/**
+ * Update the staleAt of an existing BFCache entry. Used after a dynamic
+ * response arrives with a per-page stale time from `unstable_dynamicStaleTime`.
+ * The per-page value is authoritative — it overrides whatever staleAt was set
+ * by the default DYNAMIC_STALETIME_MS.
+ */
+export function updateBFCacheEntryStaleAt(
+  varyPath: SegmentVaryPath,
+  newStaleAt: number
+): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+  const isRevalidation = false
+  // Read with staleness bypass (-1) so we can update even stale entries
+  const entry = getFromCacheMap(
+    -1,
+    currentBfCacheVersion,
+    bfcacheMap,
+    varyPath,
+    isRevalidation
+  )
+  if (entry !== null) {
+    entry.staleAt = newStaleAt
+  }
 }
 
 export function readFromBFCache(

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -99,15 +99,12 @@ import {
   normalizeFlightData,
   prepareFlightRouterStateForRequest,
 } from '../../flight-data-helpers'
-import {
-  DYNAMIC_STALETIME_MS,
-  STATIC_STALETIME_MS,
-} from '../router-reducer/reducers/navigate-reducer'
+import { STATIC_STALETIME_MS } from '../router-reducer/reducers/navigate-reducer'
 import { pingVisibleLinks } from '../links'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
-import { readFromBFCacheDuringRegularNavigation } from './bfcache'
+import { readFromBFCache, UnknownDynamicStaleTime } from './bfcache'
 import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
 import { convertServerPatchToFullTree, type NavigationSeed } from './navigation'
 import { getNavigationBuildId } from '../../navigation-build-id'
@@ -951,23 +948,20 @@ export function attemptToFulfillDynamicSegmentFromBFCache(
   // regular navigation.
   const varyPath = tree.varyPath
 
-  // The stale time for dynamic prefetches (default: 5 mins) is different from
-  // the stale time for regular navigations (default: 0 secs). We adjust the
-  // current timestamp to account for the difference.
-  const adjustedCurrentTime = now - STATIC_STALETIME_MS + DYNAMIC_STALETIME_MS
-  const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
-    adjustedCurrentTime,
-    varyPath
-  )
+  // Read from the BFCache without expiring it (pass -1). We check freshness
+  // ourselves using navigatedAt, because the BFCache's staleAt may have been
+  // overridden by a per-page unstable_dynamicStaleTime and can't be used to
+  // derive the original request time.
+  const bfcacheEntry = readFromBFCache(varyPath)
   if (bfcacheEntry !== null) {
-    // Fulfill the prefetch using the bfcache entry.
-
-    // As explained above, the stale time of this prefetch entry is different
-    // than the one for the bfcache. Calculate when it was originally requested
-    // by subtracting the stale time used by the bfcache.
-    const requestedAt = bfcacheEntry.staleAt - DYNAMIC_STALETIME_MS
-    // Now add the stale time used by dynamic prefetches.
-    const dynamicPrefetchStaleAt = requestedAt + STATIC_STALETIME_MS
+    // The stale time for dynamic prefetches (default: 5 mins) is different
+    // from the stale time for regular navigations (default: 0 secs). Use
+    // navigatedAt to compute the correct expiry for prefetch purposes.
+    const dynamicPrefetchStaleAt =
+      bfcacheEntry.navigatedAt + STATIC_STALETIME_MS
+    if (now > dynamicPrefetchStaleAt) {
+      return null
+    }
 
     const pendingSegment = upgradeToPendingSegment(segment, FetchStrategy.Full)
     const isPartial = false
@@ -992,14 +986,13 @@ export function attemptToUpgradeSegmentFromBFCache(
   tree: RouteTree
 ): FulfilledSegmentCacheEntry | null {
   const varyPath = tree.varyPath
-  const adjustedCurrentTime = now - STATIC_STALETIME_MS + DYNAMIC_STALETIME_MS
-  const bfcacheEntry = readFromBFCacheDuringRegularNavigation(
-    adjustedCurrentTime,
-    varyPath
-  )
+  const bfcacheEntry = readFromBFCache(varyPath)
   if (bfcacheEntry !== null) {
-    const requestedAt = bfcacheEntry.staleAt - DYNAMIC_STALETIME_MS
-    const dynamicPrefetchStaleAt = requestedAt + STATIC_STALETIME_MS
+    const dynamicPrefetchStaleAt =
+      bfcacheEntry.navigatedAt + STATIC_STALETIME_MS
+    if (now > dynamicPrefetchStaleAt) {
+      return null
+    }
     const pendingSegment = upgradeToPendingSegment(
       createDetachedSegmentCacheEntry(now),
       FetchStrategy.Full
@@ -2292,9 +2285,12 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       return null
     }
     const navigationSeed = convertServerPatchToFullTree(
+      now,
       dynamicRequestTree,
       flightDatas,
-      renderedSearch
+      renderedSearch,
+      // Not needed for prefetch responses; pass unknown to use the default.
+      UnknownDynamicStaleTime
     )
     fulfilledEntries = writeDynamicRenderResponseIntoCache(
       now,
@@ -2395,9 +2391,11 @@ function writeDynamicTreeResponseIntoCache(
   // enabled everywhere. Tree prefetches should never include segment data.  We
   // can delete it. Leaving for a subsequent PR.
   const navigationSeed = convertServerPatchToFullTree(
+    now,
     flightRouterState,
     normalizedFlightDataResult,
-    renderedSearch
+    renderedSearch,
+    UnknownDynamicStaleTime
   )
   const buildId =
     response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ?? serverData.b
@@ -2921,9 +2919,11 @@ export function writeStaticStageResponseIntoCache(
     return
   }
   const navigationSeed = convertServerPatchToFullTree(
+    now,
     baseTree,
     flightDatas,
-    renderedSearch
+    renderedSearch,
+    UnknownDynamicStaleTime
   )
   writeDynamicRenderResponseIntoCache(
     now,
@@ -2979,9 +2979,11 @@ export async function processRuntimePrefetchStream(
     return null
   }
   const navigationSeed = convertServerPatchToFullTree(
+    now,
     baseTree,
     flightDatas,
-    renderedSearch
+    renderedSearch,
+    UnknownDynamicStaleTime
   )
 
   return {

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -38,6 +38,7 @@ import type { AppRouterState } from '../router-reducer/router-reducer-types'
 import { ScrollBehavior } from '../router-reducer/router-reducer-types'
 import { computeChangedPath } from '../router-reducer/compute-changed-path'
 import { isJavaScriptURLString } from '../../lib/javascript-url'
+import { UnknownDynamicStaleTime, computeDynamicStaleAt } from './bfcache'
 
 /**
  * Navigate to a new URL, using the Segment Cache to construct a response.
@@ -258,6 +259,7 @@ export function navigateToKnownRoute(
     freshnessPolicy,
     navigationSeed.data,
     navigationSeed.head,
+    navigationSeed.dynamicStaleAt,
     isSamePageNavigation,
     accumulation
   )
@@ -314,6 +316,7 @@ function navigateUsingPrefetchedRouteTree(
     metadataVaryPath: route.metadata.varyPath as any,
     data: null,
     head: null,
+    dynamicStaleAt: computeDynamicStaleAt(now, UnknownDynamicStaleTime),
   }
   return navigateToKnownRoute(
     now,
@@ -406,6 +409,7 @@ async function navigateToUnknownRoute(
     renderedSearch,
     couldBeIntercepted,
     supportsPerSegmentPrefetching,
+    dynamicStaleTime,
     staticStageData,
     runtimePrefetchStream,
     responseHeaders,
@@ -416,9 +420,11 @@ async function navigateToUnknownRoute(
   // different, we'll need to massage the data a bit. Create FlightRouterState
   // tree that simulates what we'd receive as the result of a prefetch.
   const navigationSeed = convertServerPatchToFullTree(
+    now,
     currentFlightRouterState,
     flightData,
-    renderedSearch
+    renderedSearch,
+    dynamicStaleTime
   )
 
   // Learn the route pattern so we can predict it for future navigations.
@@ -736,12 +742,15 @@ export type NavigationSeed = {
   metadataVaryPath: PageVaryPath | null
   data: CacheNodeSeedData | null
   head: HeadData | null
+  dynamicStaleAt: number
 }
 
 export function convertServerPatchToFullTree(
+  now: number,
   currentTree: FlightRouterState,
   flightData: Array<NormalizedFlightData> | null,
-  renderedSearch: string
+  renderedSearch: string,
+  dynamicStaleTimeSeconds: number
 ): NavigationSeed {
   // During a client navigation or prefetch, the server sends back only a patch
   // for the parts of the tree that have changed.
@@ -806,6 +815,7 @@ export function convertServerPatchToFullTree(
     data: baseData,
     renderedSearch,
     head,
+    dynamicStaleAt: computeDynamicStaleAt(now, dynamicStaleTimeSeconds),
   }
 }
 

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -260,7 +260,10 @@ import {
   createValidationBoundaryTracking,
   type ValidationBoundaryTracking,
 } from './instant-validation/boundary-tracking'
-import type { InstantSample } from '../../build/segment-config/app/app-segment-config'
+import type {
+  AppSegmentConfig,
+  InstantSample,
+} from '../../build/segment-config/app/app-segment-config'
 import { ResponseCookies } from '../web/spec-extension/cookies'
 import { isInstantValidationError } from './instant-validation/instant-validation-error'
 
@@ -429,6 +432,48 @@ function parseRequestHeaders(
     requestId,
     htmlRequestId,
   }
+}
+
+/**
+ * Walks the loader tree to find the minimum `unstable_dynamicStaleTime` exported by
+ * any page module. Returns null if no page exports the config.
+ *
+ * This only reads static exports from page modules — it does not render any
+ * server components, so it's cheap to call.
+ *
+ * TODO: Move this to the prefetch hints file so we don't have to walk the
+ * tree on every render.
+ */
+async function getDynamicStaleTime(tree: LoaderTree): Promise<number | null> {
+  const { page, parallelRoutes } = parseLoaderTree(tree)
+
+  let result: number | null = null
+
+  // Only pages (not layouts) can export unstable_dynamicStaleTime.
+  if (typeof page !== 'undefined') {
+    const pageMod = await page[0]()
+    if (
+      pageMod &&
+      typeof (pageMod as AppSegmentConfig).unstable_dynamicStaleTime ===
+        'number'
+    ) {
+      const value = (pageMod as AppSegmentConfig).unstable_dynamicStaleTime!
+      result = result !== null ? Math.min(result, value) : value
+    }
+  }
+
+  const childPromises: Promise<number | null>[] = []
+  for (const parallelRouteKey in parallelRoutes) {
+    childPromises.push(getDynamicStaleTime(parallelRoutes[parallelRouteKey]))
+  }
+  const childResults = await Promise.all(childPromises)
+  for (const childResult of childResults) {
+    if (childResult !== null) {
+      result = result !== null ? Math.min(result, childResult) : childResult
+    }
+  }
+
+  return result
 }
 
 function createNotFoundLoaderTree(loaderTree: LoaderTree): LoaderTree {
@@ -666,6 +711,20 @@ async function generateDynamicRSCPayload(
 
   if (options?.runtimePrefetchStream !== undefined) {
     baseResponse.p = options.runtimePrefetchStream
+  }
+
+  // Include the per-page dynamic stale time from unstable_dynamicStaleTime, but only
+  // for dynamic renders (not prerenders/static generation). The client treats
+  // its presence as authoritative.
+  // TODO: Move this to the prefetch hints file so we don't have to walk the
+  // tree on every render.
+  if (!workStore.isStaticGeneration) {
+    const dynamicStaleTime = await getDynamicStaleTime(
+      ctx.componentMod.routeModule.userland.loaderTree
+    )
+    if (dynamicStaleTime !== null) {
+      baseResponse.d = dynamicStaleTime
+    }
   }
 
   return baseResponse
@@ -1789,6 +1848,14 @@ async function getRSCPayload(
     s: staleTimeIterable,
     l: staticStageByteLengthPromise,
     p: runtimePrefetchStream,
+    // Include the per-page dynamic stale time from unstable_dynamicStaleTime, but
+    // only for dynamic renders. The client treats its presence as
+    // authoritative.
+    // TODO: Move this to the prefetch hints file so we don't have to walk
+    // the tree on every render.
+    d: !workStore.isStaticGeneration
+      ? ((await getDynamicStaleTime(tree)) ?? undefined)
+      : undefined,
   })
 }
 

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -357,6 +357,48 @@ async function createComponentTreeInternal(
     }
   }
 
+  // Read unstable_dynamicStaleTime from page modules (not layouts) and track it on
+  // the store's stale field. This affects the segment cache stale time via
+  // the StaleTimeIterable.
+  if (
+    isPage &&
+    typeof layoutOrPageMod?.unstable_dynamicStaleTime === 'number'
+  ) {
+    const pageStaleTime = layoutOrPageMod.unstable_dynamicStaleTime
+    const workUnitStore = workUnitAsyncStorage.getStore()
+
+    if (workUnitStore) {
+      switch (workUnitStore.type) {
+        case 'prerender':
+        case 'prerender-runtime':
+        case 'prerender-legacy':
+        case 'prerender-ppr':
+          if (workUnitStore.stale > pageStaleTime) {
+            workUnitStore.stale = pageStaleTime
+          }
+          break
+        case 'request':
+          if (
+            workUnitStore.stale === undefined ||
+            workUnitStore.stale > pageStaleTime
+          ) {
+            workUnitStore.stale = pageStaleTime
+          }
+          break
+        // createComponentTree is not called for these stores:
+        case 'cache':
+        case 'private-cache':
+        case 'prerender-client':
+        case 'validation-client':
+        case 'unstable-cache':
+        case 'generate-static-params':
+          break
+        default:
+          workUnitStore satisfies never
+      }
+    }
+  }
+
   const isStaticGeneration = workStore.isStaticGeneration
 
   // Assume the segment we're rendering contains only partial data if PPR is

--- a/packages/next/src/server/typescript/rules/config.ts
+++ b/packages/next/src/server/typescript/rules/config.ts
@@ -156,6 +156,17 @@ const API_DOCS: Record<
     // `getSemanticDiagnosticsForExportVariableStatement` below, and only provide hover a tooltip + autocomplete.
     insertText: 'unstable_instant = { prefetch: "static" };',
   },
+  unstable_dynamicStaleTime: {
+    description: `Controls how long the client-side router cache retains dynamic page data (in seconds). Pages only — not allowed in layouts. Cannot be combined with \`unstable_instant\`.`,
+    link: '(docs coming soon)',
+    type: 'number',
+    isValid: (value: string) => {
+      return Number(value.replace(/_/g, '')) >= 0
+    },
+    getHint: (value: any) => {
+      return `Set the dynamic stale time to \`${value}\` seconds.`
+    },
+  },
 }
 
 type FullAppSegmentConfig = Required<AppSegmentConfig>

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -314,6 +314,14 @@ export type InitialRSCPayload = {
   l?: Promise<number>
   /** runtimePrefetchStream — Embedded runtime prefetch Flight stream. */
   p?: ReadableStream<Uint8Array>
+  /**
+   * dynamicStaleTime — Per-page BFCache stale time in seconds, from
+   * `unstable_dynamicStaleTime`. Only included for dynamic renders. Controls
+   * how long the client router cache retains dynamic navigation data. This is
+   * distinct from the `s` field, which controls segment cache (prefetch)
+   * staleness.
+   */
+  d?: number
 }
 
 // Response from `createFromFetch` for normal rendering
@@ -336,6 +344,14 @@ export type NavigationFlightResponse = {
   h: VaryParamsThenable | null
   /** runtimePrefetchStream — Embedded runtime prefetch Flight stream. */
   p?: ReadableStream<Uint8Array>
+  /**
+   * dynamicStaleTime — Per-page BFCache stale time in seconds, from
+   * `unstable_dynamicStaleTime`. Only included for dynamic renders. Controls
+   * how long the client router cache retains dynamic navigation data. This is
+   * distinct from the `s` field, which controls segment cache (prefetch)
+   * staleness.
+   */
+  d?: number
 }
 
 // Response from `createFromFetch` for server actions. Action's flight data can be null

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/dynamic-stale-10/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/dynamic-stale-10/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export const unstable_dynamicStaleTime = 10
+
+async function Content() {
+  await connection()
+  return (
+    <div id="dynamic-stale-10-content">Dynamic content (stale time 10s)</div>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/dynamic-stale-60/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/dynamic-stale-60/page.tsx
@@ -1,0 +1,19 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export const unstable_dynamicStaleTime = 60
+
+async function Content() {
+  await connection()
+  return (
+    <div id="dynamic-stale-60-content">Dynamic content (stale time 60s)</div>
+  )
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/layout.tsx
@@ -1,0 +1,3 @@
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return children
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/page.tsx
@@ -1,0 +1,30 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function Page() {
+  return (
+    <>
+      <p>
+        This page tests per-page dynamic stale time configuration via{' '}
+        <code>export const unstable_dynamicStaleTime</code>.
+      </p>
+      <ul>
+        <li>
+          <LinkAccordion href="/per-page-config/dynamic-stale-60">
+            Dynamic page with stale time of 60 seconds
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/per-page-config/dynamic-stale-10">
+            Dynamic page with stale time of 10 seconds
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/per-page-config/parallel-slots">
+            Parallel routes with slots having different stale times (60s and
+            15s)
+          </LinkAccordion>
+        </li>
+      </ul>
+    </>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/@slotA/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/@slotA/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export const unstable_dynamicStaleTime = 60
+
+async function Content() {
+  await connection()
+  return <div id="slot-a-content">Slot A content (stale time 60s)</div>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading slot A...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/@slotB/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/@slotB/page.tsx
@@ -1,0 +1,17 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+export const unstable_dynamicStaleTime = 15
+
+async function Content() {
+  await connection()
+  return <div id="slot-b-content">Slot B content (stale time 15s)</div>
+}
+
+export default function Page() {
+  return (
+    <Suspense fallback="Loading slot B...">
+      <Content />
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/layout.tsx
@@ -1,0 +1,17 @@
+export default function Layout({
+  children,
+  slotA,
+  slotB,
+}: {
+  children: React.ReactNode
+  slotA: React.ReactNode
+  slotB: React.ReactNode
+}) {
+  return (
+    <div>
+      {children}
+      {slotA}
+      {slotB}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/page.tsx
+++ b/test/e2e/app-dir/segment-cache/staleness/app/per-page-config/parallel-slots/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return null
+}

--- a/test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
+++ b/test/e2e/app-dir/segment-cache/staleness/segment-cache-per-page-dynamic-stale-time.test.ts
@@ -1,0 +1,352 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('segment cache (per-page dynamic stale time)', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+  if (isNextDev) {
+    test('disabled in development', () => {})
+    return
+  }
+
+  async function startBrowserWithFakeClock(url: string) {
+    let page!: Playwright.Page
+    const startDate = Date.now()
+
+    const browser = await next.browser(url, {
+      async beforePageLoad(p: Playwright.Page) {
+        page = p
+        await page.clock.install()
+        await page.clock.setFixedTime(startDate)
+      },
+    })
+
+    const act = createRouterAct(page)
+
+    return { browser, page, act, startDate }
+  }
+
+  it('reuses dynamic data within the per-page stale time window', async () => {
+    const { browser, page, act, startDate } =
+      await startBrowserWithFakeClock('/per-page-config')
+
+    // Navigate to the dynamic page with unstable_dynamicStaleTime = 60
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/per-page-config/dynamic-stale-60"]'
+        )
+        await toggle.click()
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-60"]'
+        )
+        await link.click()
+      },
+      {
+        includes: 'Dynamic content (stale time 60s)',
+      }
+    )
+    expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+      'Dynamic content (stale time 60s)'
+    )
+
+    // Go back to the starting page
+    await browser.back()
+
+    // Advance to 59 seconds. The per-page stale time is 60s (which overrides
+    // the global staleTimes.dynamic of 30s), so the data should still be fresh.
+    await page.clock.setFixedTime(startDate + 59 * 1000)
+
+    await act(async () => {
+      const link = await browser.elementByCss(
+        'a[href="/per-page-config/dynamic-stale-60"]'
+      )
+      await link.click()
+      expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+        'Dynamic content (stale time 60s)'
+      )
+    }, 'no-requests')
+
+    // Go back again
+    await browser.back()
+
+    // Advance to 60 seconds. The data is now stale, so a new request
+    // should be made.
+    await page.clock.setFixedTime(startDate + 60 * 1000)
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-60"]'
+        )
+        await link.click()
+      },
+      { includes: 'Dynamic content (stale time 60s)' }
+    )
+    expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+      'Dynamic content (stale time 60s)'
+    )
+  })
+
+  it('back/forward navigation always reuses BFCache regardless of stale time', async () => {
+    const { browser, page, act, startDate } =
+      await startBrowserWithFakeClock('/per-page-config')
+
+    // Navigate to the dynamic page with unstable_dynamicStaleTime = 60
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/per-page-config/dynamic-stale-60"]'
+        )
+        await toggle.click()
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-60"]'
+        )
+        await link.click()
+      },
+      {
+        includes: 'Dynamic content (stale time 60s)',
+      }
+    )
+    expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+      'Dynamic content (stale time 60s)'
+    )
+
+    // Go back to the starting page
+    await browser.back()
+
+    // Advance time well past the 60s stale time
+    await page.clock.setFixedTime(startDate + 120 * 1000)
+
+    // Use browser.forward() to go forward. Back/forward navigation should
+    // always reuse the BFCache, regardless of stale time.
+    await act(async () => {
+      await browser.forward()
+      expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+        'Dynamic content (stale time 60s)'
+      )
+    }, 'no-requests')
+  })
+
+  it('two dynamic pages with different stale times behave independently', async () => {
+    const { browser, page, act, startDate } =
+      await startBrowserWithFakeClock('/per-page-config')
+
+    // Navigate to the dynamic page with unstable_dynamicStaleTime = 60
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/per-page-config/dynamic-stale-60"]'
+        )
+        await toggle.click()
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-60"]'
+        )
+        await link.click()
+      },
+      {
+        includes: 'Dynamic content (stale time 60s)',
+      }
+    )
+    expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+      'Dynamic content (stale time 60s)'
+    )
+
+    // Go back to the starting page
+    await browser.back()
+
+    // Navigate to the dynamic page with unstable_dynamicStaleTime = 10
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/per-page-config/dynamic-stale-10"]'
+        )
+        await toggle.click()
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-10"]'
+        )
+        await link.click()
+      },
+      {
+        includes: 'Dynamic content (stale time 10s)',
+      }
+    )
+    expect(await browser.elementById('dynamic-stale-10-content').text()).toBe(
+      'Dynamic content (stale time 10s)'
+    )
+
+    // Go back to the starting page
+    await browser.back()
+
+    // Advance to 11 seconds. The 10s page should be stale, but the 60s page
+    // should still be fresh.
+    await page.clock.setFixedTime(startDate + 11 * 1000)
+
+    // Navigate to the 10s page — should be stale, triggering a new request
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-10"]'
+        )
+        await link.click()
+      },
+      { includes: 'Dynamic content (stale time 10s)' }
+    )
+    expect(await browser.elementById('dynamic-stale-10-content').text()).toBe(
+      'Dynamic content (stale time 10s)'
+    )
+
+    // Go back to the starting page
+    await browser.back()
+
+    // Navigate to the 60s page — should still be fresh, no new request
+    await act(async () => {
+      const link = await browser.elementByCss(
+        'a[href="/per-page-config/dynamic-stale-60"]'
+      )
+      await link.click()
+      expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+        'Dynamic content (stale time 60s)'
+      )
+    }, 'no-requests')
+  })
+
+  it('per-page value overrides global staleTimes.dynamic regardless of direction', async () => {
+    // The global staleTimes.dynamic is 30s. This test verifies that a per-page
+    // value of 10s (smaller) causes the data to expire sooner, and a per-page
+    // value of 60s (larger) causes the data to last longer.
+    const { browser, page, act, startDate } =
+      await startBrowserWithFakeClock('/per-page-config')
+
+    // Navigate to the 10s page
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/per-page-config/dynamic-stale-10"]'
+        )
+        await toggle.click()
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-10"]'
+        )
+        await link.click()
+      },
+      { includes: 'Dynamic content (stale time 10s)' }
+    )
+
+    await browser.back()
+
+    // At 11s the 10s page should be stale, even though the global default
+    // is 30s. This proves a smaller per-page value overrides the global.
+    await page.clock.setFixedTime(startDate + 11 * 1000)
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-10"]'
+        )
+        await link.click()
+      },
+      { includes: 'Dynamic content (stale time 10s)' }
+    )
+
+    await browser.back()
+
+    // Now navigate to the 60s page
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/per-page-config/dynamic-stale-60"]'
+        )
+        await toggle.click()
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/dynamic-stale-60"]'
+        )
+        await link.click()
+      },
+      { includes: 'Dynamic content (stale time 60s)' }
+    )
+
+    await browser.back()
+
+    // At 42s from the 60s page's navigation (11s + 31s), the data should
+    // still be fresh — the per-page value of 60s overrides the global 30s.
+    await page.clock.setFixedTime(startDate + 42 * 1000)
+
+    await act(async () => {
+      const link = await browser.elementByCss(
+        'a[href="/per-page-config/dynamic-stale-60"]'
+      )
+      await link.click()
+      expect(await browser.elementById('dynamic-stale-60-content').text()).toBe(
+        'Dynamic content (stale time 60s)'
+      )
+    }, 'no-requests')
+  })
+
+  it('with parallel routes, uses the minimum stale time across all slots', async () => {
+    const { browser, page, act, startDate } =
+      await startBrowserWithFakeClock('/per-page-config')
+
+    // Navigate to a page with parallel routes: slot A has
+    // unstable_dynamicStaleTime = 60, slot B has
+    // unstable_dynamicStaleTime = 15. The effective stale time should be
+    // min(60, 15) = 15.
+    await act(
+      async () => {
+        const toggle = await browser.elementByCss(
+          'input[data-link-accordion="/per-page-config/parallel-slots"]'
+        )
+        await toggle.click()
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/parallel-slots"]'
+        )
+        await link.click()
+      },
+      {
+        includes: 'Slot A content',
+      }
+    )
+    expect(await browser.elementById('slot-a-content').text()).toBe(
+      'Slot A content (stale time 60s)'
+    )
+    expect(await browser.elementById('slot-b-content').text()).toBe(
+      'Slot B content (stale time 15s)'
+    )
+
+    await browser.back()
+
+    // At 14s both slots should still be fresh (min is 15s)
+    await page.clock.setFixedTime(startDate + 14 * 1000)
+
+    await act(async () => {
+      const link = await browser.elementByCss(
+        'a[href="/per-page-config/parallel-slots"]'
+      )
+      await link.click()
+      expect(await browser.elementById('slot-a-content').text()).toBe(
+        'Slot A content (stale time 60s)'
+      )
+      expect(await browser.elementById('slot-b-content').text()).toBe(
+        'Slot B content (stale time 15s)'
+      )
+    }, 'no-requests')
+
+    await browser.back()
+
+    // At 16s the data should be stale because slot B's stale time (15s)
+    // has elapsed.
+    await page.clock.setFixedTime(startDate + 16 * 1000)
+
+    await act(
+      async () => {
+        const link = await browser.elementByCss(
+          'a[href="/per-page-config/parallel-slots"]'
+        )
+        await link.click()
+      },
+      { includes: 'Slot A content' }
+    )
+  })
+})


### PR DESCRIPTION
## Background

Next.js has an existing global config, `experimental.staleTimes.dynamic`, that controls how long the client-side router cache retains data from dynamic navigation responses. By default this is 0 — meaning dynamic data is always refetched on every navigation. Some users set this to a higher value (e.g. 30 seconds) so that navigating back to a recently visited page reuses the cached response instead of making a new request.

The limitation of the global config is that it applies uniformly to every page in the app. Users have asked for the ability to set different stale times for different pages — for example, a dashboard page that should always show fresh data vs. a product listing page where it's acceptable to show slightly stale data for a smoother navigation experience.

## What this PR adds

`export const unstable_dynamicStaleTime` is a per-page version of `staleTimes.dynamic`. It accepts a number in seconds with the same unit and semantics, but scoped to a single page. When present, it overrides the global config for that page — whether the per-page value is larger or smaller than the global default. Static and cached responses are unaffected.

When parallel routes render multiple pages in a single response, the minimum value across all parallel slots wins, consistent with how stale times compose generally.

Exporting this from a layout is a build error (pages only).

## Relationship to Cache Components

The recommended way to control data freshness in Next.js is to use Cache Components (`"use cache"`) with `cacheLife`. This API exists as a simpler migration path for apps that are already using `staleTimes.dynamic` and haven't yet adopted Cache Components. It's prefixed with `unstable_` not because the implementation is unstable, but because it's not the recommended long-term idiom — apps should migrate to Cache Components for more granular and composable control over data freshness.

Based on the design from #88609.
