### PR TITLE
[Segment Bundling] [Scaffolding] Track which segments can be omitted from prefetch

### DIFF
--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -7,7 +7,10 @@ import type {
   HeadData,
   PrefetchHints,
 } from '../../shared/lib/app-router-types'
-import { PrefetchHint } from '../../shared/lib/app-router-types'
+import {
+  PrefetchHint,
+  StaticPrefetchDisabled,
+} from '../../shared/lib/app-router-types'
 import { readVaryParams } from '../../shared/lib/segment-cache/vary-params-decoding'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
@@ -321,8 +324,15 @@ export async function collectPrefetchHints(
   )
   const headGzipSize = await getGzipSize(headBuffer)
 
-  // Mutable accumulator: the first page leaf that can fit the head sets
-  // this to true. Once set, subsequent leaves skip the check.
+  // Mutable accumulator: the first segment that accepts the head sets this
+  // to true. Once set, subsequent segments skip the check.
+  //
+  // When the route has any runtime prefetch segment, the head is only
+  // assigned to a runtime segment (since the runtime response already
+  // includes it). Static pages are skipped to avoid duplication.
+  const rootHints = flightRouterState[4] ?? 0
+  const subtreeHasRuntimePrefetch =
+    (rootHints & PrefetchHint.SubtreeHasRuntimePrefetch) !== 0
   const headInlineState = { inlined: false }
 
   // Walk the tree with the parent-first, child-decides algorithm.
@@ -337,7 +347,8 @@ export async function collectPrefetchHints(
     maxSize,
     maxBundleSize,
     headGzipSize,
-    headInlineState
+    headInlineState,
+    subtreeHasRuntimePrefetch
   )
 
   if (!headInlineState.inlined) {
@@ -389,16 +400,28 @@ async function collectPrefetchHintsImpl(
   maxSize: number,
   maxBundleSize: number,
   headGzipSize: number,
-  headInlineState: { inlined: boolean }
+  headInlineState: { inlined: boolean },
+  routeHasRuntimePrefetch: boolean
 ): Promise<{
   node: PrefetchHints
   // Total inlined bytes accumulated along the deepest accepting path in this
   // subtree. Used by ancestors for budget checks.
   inlinedBytes: number
 }> {
-  // Render current segment and measure its gzip size.
+  // Check if static prefetching is disabled for this segment (runtime
+  // prefetch or unstable_instant = false). Such segments act as transparent
+  // pass-throughs in the bundle chain: they contribute zero bytes of their
+  // own and pass parent data through to children. However, they cannot be
+  // the terminal of a chain — if no child accepts the parent data, the
+  // parent cannot be inlined into this segment because there's no static
+  // response to carry it. See the ParentInlinedIntoSelf check below.
+  const isStaticPrefetchDisabled =
+    ((route[4] ?? 0) & StaticPrefetchDisabled) !== 0
+
+  // Render current segment and measure its gzip size. Skip measurement for
+  // segments with static prefetching disabled since they contribute nothing.
   let currentGzipSize: number | null = null
-  if (seedData !== null) {
+  if (!isStaticPrefetchDisabled && seedData !== null) {
     const varyParamsThenable = seedData[4]
     const varyParams =
       varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
@@ -415,7 +438,8 @@ async function collectPrefetchHintsImpl(
   }
 
   // Only offer this segment to its children for inlining if its gzip size
-  // is below maxSize. Segments above this get their own response.
+  // is below maxSize. Segments with static prefetching disabled have
+  // nothing to offer (their slot in the bundle is null).
   const sizeToInline =
     currentGzipSize !== null && currentGzipSize < maxSize
       ? currentGzipSize
@@ -454,6 +478,15 @@ async function collectPrefetchHintsImpl(
       createSegmentRequestKeyPart(childSegment)
     )
 
+    // Determine what size to offer children for inlining. Normally we offer
+    // our own size. But if static prefetching is disabled for this segment,
+    // it has no data of its own — instead it passes the parent's offer
+    // through to children. This allows a static grandparent to inline
+    // through a disabled intermediate segment into a static grandchild.
+    const sizeToOfferChild = isStaticPrefetchDisabled
+      ? parentGzipSize
+      : sizeToInline
+
     const childResult = await collectPrefetchHintsImpl(
       childRoute,
       buildId,
@@ -462,11 +495,12 @@ async function collectPrefetchHintsImpl(
       clientModules,
       childRequestKey,
       // Once a child has accepted us, stop offering to remaining siblings.
-      didInlineIntoChild ? null : sizeToInline,
+      didInlineIntoChild ? null : sizeToOfferChild,
       maxSize,
       maxBundleSize,
       headGzipSize,
-      headInlineState
+      headInlineState,
+      routeHasRuntimePrefetch
     )
 
     if (slots === null) {
@@ -510,27 +544,45 @@ async function collectPrefetchHintsImpl(
     ? acceptingChildInlinedBytes
     : smallestChildInlinedBytes
 
-  // Try to inline the head (metadata/viewport) into this segment's
-  // response. The head can only be inlined into a page, not a layout,
-  // because pages may access additional params (e.g. searchParams) that
-  // layouts cannot. The head is treated like an additional inlined
-  // entry — it counts against the same total budget. Only the first page
-  // that has room gets the head; subsequent pages skip via the shared
-  // headInlineState accumulator.
+  // Determine which segment is responsible for the head (metadata/viewport).
+  //
+  // When the route has any runtime prefetch segment, the head is only
+  // assigned to a runtime segment — the runtime response already includes
+  // the head, so assigning it to a static page would duplicate it.
+  //
+  // When the route has no runtime prefetch segments, the head is assigned
+  // to the first static page terminal that has budget room. Head can only
+  // be inlined into a page, not a layout, because pages may access
+  // additional params (e.g. searchParams) that layouts cannot.
+  //
+  // A disabled segment with PrefetchDisabled (instant = false) is never a
+  // valid target — it has no response at all.
+  const hasRuntimePrefetch =
+    ((route[4] ?? 0) & PrefetchHint.HasRuntimePrefetch) !== 0
+  const isBundleTerminal = !didInlineIntoChild && !isStaticPrefetchDisabled
   const segment = route[0]
   const isPageSegment =
     typeof segment === 'string'
       ? segment === PAGE_SEGMENT_KEY
       : segment[0] === PAGE_SEGMENT_KEY
-  if (isPageSegment && !headInlineState.inlined) {
-    if (inlinedBytes + headGzipSize < maxBundleSize) {
+  if (!headInlineState.inlined) {
+    if (hasRuntimePrefetch) {
+      // Runtime prefetch segment — the runtime response includes the head.
+      // No budget cost since it's already part of that response.
       hints |= PrefetchHint.HeadInlinedIntoSelf
-      inlinedBytes += headGzipSize
       headInlineState.inlined = true
+    } else if (isBundleTerminal && isPageSegment && !routeHasRuntimePrefetch) {
+      // Static page terminal — only used when no runtime segments exist.
+      // The head counts against the bundle budget.
+      if (inlinedBytes + headGzipSize < maxBundleSize) {
+        hints |= PrefetchHint.HeadInlinedIntoSelf
+        inlinedBytes += headGzipSize
+        headInlineState.inlined = true
+      }
     }
   }
 
-  // Decide whether to accept our own parent's data. Two conditions:
+  // Decide whether to accept our own parent's data. Conditions:
   //
   // 1. The parent offered us a size (parentGzipSize is not null). It's null
   //    when the parent is too large to inline or when this is the root.
@@ -540,6 +592,13 @@ async function collectPrefetchHintsImpl(
   //    longer makes sense to keep adding bytes because the combined response
   //    is unique per URL and can't be deduped.
   //
+  // 3. If this segment has static prefetching disabled, it can only accept
+  //    the parent if it has successfully inlined into a child. A disabled
+  //    segment is a transparent pass-through — it passes parent data through
+  //    to descendants. But if no descendant accepted, there's no static
+  //    response to carry the parent's data, so the parent must remain
+  //    outlined.
+  //
   // A node can be both InlinedIntoChild and ParentInlinedIntoSelf. This
   // happens in multi-level chains: GP → P → C where all are small. C
   // accepts P (P is InlinedIntoChild), then P also accepts GP (P is
@@ -547,7 +606,10 @@ async function collectPrefetchHintsImpl(
   // and GP's data. The parent's data flows through to the deepest
   // accepting descendant.
   if (parentGzipSize !== null) {
-    if (inlinedBytes + parentGzipSize < maxBundleSize) {
+    // A disabled segment can only pass through — it needs a child to
+    // ultimately accept the parent's data.
+    const canAcceptParent = !isStaticPrefetchDisabled || didInlineIntoChild
+    if (canAcceptParent && inlinedBytes + parentGzipSize < maxBundleSize) {
       hints |= PrefetchHint.ParentInlinedIntoSelf
       inlinedBytes += parentGzipSize
     }

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -212,10 +212,13 @@ export const enum PrefetchHint {
 }
 
 /**
- * Alias: this segment's static prefetch is skipped. Either because it uses
- * runtime prefetching (fetched dynamically instead) or because prefetching
- * is disabled entirely (unstable_instant = false). The segment participates
- * in the bundle chain but with null data.
+ * Bitmask for checking whether a segment's static prefetch is skipped. Matches
+ * if EITHER bit is set — i.e. the segment uses runtime prefetching
+ * (HasRuntimePrefetch) OR prefetching is disabled entirely (PrefetchDisabled,
+ * e.g. unstable_instant = false). The segment participates in the bundle chain
+ * but with null data.
+ *
+ * Usage: `(hints & StaticPrefetchDisabled) !== 0`
  */
 export const StaticPrefetchDisabled =
   PrefetchHint.HasRuntimePrefetch | PrefetchHint.PrefetchDisabled

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -26,6 +26,11 @@ export default function Page() {
           <LinkAccordion href="/test-dynamic/hello">Dynamic</LinkAccordion>
         </li>
         <li>
+          <LinkAccordion href="/test-runtime-bailout">
+            Runtime bailout
+          </LinkAccordion>
+        </li>
+        <li>
           <LinkAccordion href="/test-stale-hints/nested/deep">
             Stale hints
           </LinkAccordion>
@@ -33,6 +38,21 @@ export default function Page() {
         <li>
           <LinkAccordion href="/test-instant-false-root">
             Instant false root
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-runtime-passthrough/inner">
+            Runtime passthrough
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-instant-false-passthrough/inner">
+            Instant false passthrough
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-runtime-parallel/inner">
+            Runtime parallel
           </LinkAccordion>
         </li>
       </ul>

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/inner/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/inner/layout.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from 'react'
+
+// Small static layout below the instant:false pass-through.
+export default function InnerLayout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/inner/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/inner/page.tsx
@@ -1,0 +1,7 @@
+export default function Page() {
+  return (
+    <p id="page-instant-false-passthrough">
+      Static page below instant:false layout
+    </p>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-instant-false-passthrough/layout.tsx
@@ -1,0 +1,29 @@
+// This layout has prefetching disabled (unstable_instant = false) because it
+// performs uncached dynamic I/O (connection()). Static parents above it should
+// be able to inline through it and into the static child below, because this
+// layout acts as a transparent pass-through — its slot in the bundle is null
+// but the chain isn't broken.
+import { ReactNode, Suspense } from 'react'
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+async function DynamicContent() {
+  await connection()
+  return <p id="layout-instant-false-passthrough">Dynamic layout</p>
+}
+
+export default function InstantFalsePassthroughLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <Suspense fallback={<p>Loading...</p>}>
+        <DynamicContent />
+      </Suspense>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/layout.tsx
@@ -1,0 +1,18 @@
+import { ReactNode, Suspense } from 'react'
+
+// Small static layout. With prefetch inlining enabled, this layout's data
+// should be bundled into the child's response. But since the child page uses
+// runtime prefetching, the bundle needs to be flushed as a separate static
+// prefetch instead.
+export default function RuntimeBailoutLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <p id="layout-runtime-bailout">Static layout content</p>
+      <Suspense fallback={<p>Loading...</p>}>{children}</Suspense>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-bailout/page.tsx
@@ -1,0 +1,12 @@
+import { cookies } from 'next/headers'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
+}
+
+export default async function RuntimeBailoutPage() {
+  const cookieStore = await cookies()
+  const theme = cookieStore.get('theme')?.value ?? 'default'
+  return <p id="page-runtime-bailout">Runtime page (theme: {theme})</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/@sidebar/default.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/@sidebar/default.tsx
@@ -1,0 +1,3 @@
+export default function SidebarDefault() {
+  return <p>Sidebar default</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/@sidebar/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/@sidebar/page.tsx
@@ -1,0 +1,3 @@
+export default function Sidebar() {
+  return <p id="sidebar-runtime-parallel">Sidebar content</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/default.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/default.tsx
@@ -1,0 +1,3 @@
+export default function Default() {
+  return <p>Default</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/inner/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/inner/layout.tsx
@@ -1,0 +1,5 @@
+import { ReactNode } from 'react'
+
+export default function InnerLayout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/inner/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/inner/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page-runtime-parallel">Main content</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/layout.tsx
@@ -1,0 +1,35 @@
+// Runtime layout with parallel routes. The parent's data should pass through
+// this layout into one child slot only — not into both. This tests that the
+// pass-through behavior respects the "parent inlines into one child" rule
+// even when the pass-through segment has multiple child slots.
+import { ReactNode, Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
+}
+
+async function DynamicContent() {
+  const cookieStore = await cookies()
+  const theme = cookieStore.get('theme')?.value ?? 'default'
+  return <p id="layout-runtime-parallel">Runtime layout (theme: {theme})</p>
+}
+
+export default function RuntimeParallelLayout({
+  children,
+  sidebar,
+}: {
+  children: ReactNode
+  sidebar: ReactNode
+}) {
+  return (
+    <div>
+      <Suspense fallback={<p>Loading layout...</p>}>
+        <DynamicContent />
+      </Suspense>
+      <main>{children}</main>
+      <aside>{sidebar}</aside>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/inner/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/inner/layout.tsx
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react'
+
+// Small static layout below the runtime pass-through. The root should be able
+// to inline through the runtime layout above and into this layout's child.
+export default function InnerLayout({ children }: { children: ReactNode }) {
+  return <div>{children}</div>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/inner/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/inner/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p id="page-runtime-passthrough">Static page below runtime layout</p>
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-passthrough/layout.tsx
@@ -1,0 +1,32 @@
+// This layout has runtime prefetching enabled. Static parents above it should
+// be able to inline through it and into the static child below, because this
+// layout acts as a transparent pass-through — its slot in the bundle is null
+// but the chain isn't broken.
+import { ReactNode, Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ cookies: [{ name: 'theme', value: 'default' }] }],
+}
+
+async function DynamicContent() {
+  const cookieStore = await cookies()
+  const theme = cookieStore.get('theme')?.value ?? 'default'
+  return <p id="layout-runtime-passthrough">Runtime layout (theme: {theme})</p>
+}
+
+export default function RuntimePassthroughLayout({
+  children,
+}: {
+  children: ReactNode
+}) {
+  return (
+    <div>
+      <Suspense fallback={<p>Loading layout...</p>}>
+        <DynamicContent />
+      </Suspense>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -3,8 +3,12 @@ import { nextTestSetup } from 'e2e-utils'
 import { createRouterAct } from 'router-act'
 
 // Bit values from PrefetchHint enum (const enum, so we duplicate values here)
+const HasRuntimePrefetch = 0b00001 // 1
 const ParentInlinedIntoSelf = 0b100000 // 32
 const InlinedIntoChild = 0b1000000 // 64
+const HeadInlinedIntoSelf = 0b10000000 // 128
+const HeadOutlined = 0b100000000 // 256
+const PrefetchDisabled = 0b10000000000 // 1024
 
 // Matches the shape of RootTreePrefetch / TreePrefetch from collect-segment-
 // data.tsx. We only declare the fields we need.
@@ -25,14 +29,21 @@ type RootTreePrefetch = {
  * hints are consistent (every InlinedIntoChild parent must have a child with
  * ParentInlinedIntoSelf, and vice versa).
  */
-// "outlined ■" is the fixed-width tag (10 chars). Inlined segments show just
-// the arrow, right-aligned to match.
+// "outlined ■" is the fixed-width tag (10 chars). Other tags are right-aligned
+// to match.
 const OUTLINED_TAG = 'outlined \u25A0'
 const INLINED_TAG = '\u21E3'.padStart(OUTLINED_TAG.length)
+const RUNTIME_TAG = 'runtime \u25FB'.padStart(OUTLINED_TAG.length)
+const DYNAMIC_TAG = 'dynamic \u25FB'.padStart(OUTLINED_TAG.length)
 
 function renderInliningTree(tree: TreePrefetch): string {
   const lines: string[] = []
-  collectNodes(tree, '', true, false, lines)
+  const isHeadOutlined = (tree.prefetchHints & HeadOutlined) !== 0
+  collectNodes(tree, '', !isHeadOutlined, false, lines)
+  if (isHeadOutlined) {
+    // Metadata is not inlined into any page — render as a standalone sibling.
+    lines.push(`${OUTLINED_TAG}  \u2514\u2500\u2500 metadata`)
+  }
   return '\n' + lines.join('\n') + '\n'
 }
 
@@ -44,13 +55,26 @@ function collectNodes(
   lines: string[],
   slotKey?: string
 ): void {
+  const hasRuntimePrefetch = (node.prefetchHints & HasRuntimePrefetch) !== 0
+  const prefetchDisabled = (node.prefetchHints & PrefetchDisabled) !== 0
   const inlinedIntoChild = (node.prefetchHints & InlinedIntoChild) !== 0
   const _parentInlined = (node.prefetchHints & ParentInlinedIntoSelf) !== 0
+  const headInlined = (node.prefetchHints & HeadInlinedIntoSelf) !== 0
 
   const slotPrefix =
     slotKey !== undefined && slotKey !== 'children' ? `@${slotKey}/` : ''
-  const name = hasParent ? `${slotPrefix}"${node.name}"` : 'root'
-  const tag = inlinedIntoChild ? INLINED_TAG : OUTLINED_TAG
+  const headSuffix = headInlined ? ' (+metadata)' : ''
+  const name = hasParent ? `${slotPrefix}"${node.name}"${headSuffix}` : 'root'
+  // Static prefetch is skipped for runtime and dynamic segments. Distinguish
+  // them in the snapshot: runtime segments will be fetched via a runtime
+  // prefetch request, while dynamic segments are not prefetched at all.
+  const tag = hasRuntimePrefetch
+    ? RUNTIME_TAG
+    : prefetchDisabled
+      ? DYNAMIC_TAG
+      : inlinedIntoChild
+        ? INLINED_TAG
+        : OUTLINED_TAG
   const connector = hasParent
     ? isLast
       ? '\u2514\u2500\u2500 '
@@ -137,7 +161,7 @@ describe('prefetch inlining', () => {
      "
               ⇣  root
               ⇣  └── "test-small-chain"
-     outlined ■      └── "__PAGE__"
+     outlined ■      └── "__PAGE__" (+metadata)
      "
     `)
   })
@@ -153,7 +177,7 @@ describe('prefetch inlining', () => {
      "
               ⇣  root
      outlined ■  └── "test-outlined"
-     outlined ■      └── "__PAGE__"
+     outlined ■      └── "__PAGE__" (+metadata)
      "
     `)
   })
@@ -172,7 +196,7 @@ describe('prefetch inlining', () => {
        "
                 ⇣  root
                 ⇣  └── "test-parallel"
-       outlined ■      ├── "__PAGE__"
+       outlined ■      ├── "__PAGE__" (+metadata)
                 ⇣      └── @sidebar/"(__SLOT__)"
        outlined ■          └── "__PAGE__"
        "
@@ -185,7 +209,7 @@ describe('prefetch inlining', () => {
                 ⇣  root
                 ⇣  └── "test-parallel"
                 ⇣      ├── @sidebar/"(__SLOT__)"
-       outlined ■      │   └── "__PAGE__"
+       outlined ■      │   └── "__PAGE__" (+metadata)
        outlined ■      └── "__PAGE__"
        "
       `)
@@ -199,7 +223,7 @@ describe('prefetch inlining', () => {
     expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
      "
               ⇣  root
-     outlined ■  └── "__PAGE__"
+     outlined ■  └── "__PAGE__" (+metadata)
      "
     `)
   })
@@ -220,7 +244,7 @@ describe('prefetch inlining', () => {
               ⇣  └── "test-restart"
      outlined ■      └── "large-middle"
               ⇣          └── "after"
-     outlined ■              └── "__PAGE__"
+     outlined ■              └── "__PAGE__" (+metadata)
      "
     `)
   })
@@ -236,7 +260,7 @@ describe('prefetch inlining', () => {
               ⇣      └── "a"
               ⇣          └── "b"
               ⇣              └── "c"
-     outlined ■                  └── "__PAGE__"
+     outlined ■                  └── "__PAGE__" (+metadata)
      "
     `)
   })
@@ -256,7 +280,7 @@ describe('prefetch inlining', () => {
               ⇣  root
               ⇣  └── "test-dynamic"
      outlined ■      └── "slug"
-     outlined ■          └── "__PAGE__"
+     outlined ■          └── "__PAGE__" (+metadata)
      "
     `)
 
@@ -311,5 +335,81 @@ describe('prefetch inlining', () => {
       // fetched during navigation instead.
       { includes: 'Static page below instant:false root' }
     )
+  })
+
+  it('runtime prefetch: layout cannot inline into a runtime leaf', async () => {
+    // Root → small static layout → page with runtime prefetch. Root inlines
+    // into the layout (the layout accepts root's data). But the layout
+    // cannot inline into the runtime page — the page is a leaf with no
+    // static descendants, so there's no response to carry the layout's data.
+    // The layout remains outlined while root is inlined into it.
+    const data = await fetchRouteTreePrefetch(next, '/test-runtime-bailout')
+    expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
+     "
+              ⇣  root
+     outlined ■  └── "test-runtime-bailout"
+      runtime ◻      └── "__PAGE__" (+metadata)
+     "
+    `)
+  })
+
+  it('runtime passthrough: static parents inline through runtime layout to static child', async () => {
+    // Root → runtime layout → inner static layout → static page. The
+    // runtime layout acts as a transparent pass-through — it has a static
+    // child that can accept the parent data, so the chain passes through
+    // it. The runtime layout's slot in the bundle is null (no static data)
+    // but it still carries InlinedIntoChild.
+    const data = await fetchRouteTreePrefetch(
+      next,
+      '/test-runtime-passthrough/inner'
+    )
+    expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
+     "
+              ⇣  root
+      runtime ◻  └── "test-runtime-passthrough" (+metadata)
+              ⇣      └── "inner"
+     outlined ■          └── "__PAGE__"
+     "
+    `)
+  })
+
+  it('instant false passthrough: static parents inline through dynamic layout to static child', async () => {
+    // Root → dynamic layout (instant: false, uses connection()) → inner
+    // static layout → static page. Same pass-through behavior as runtime
+    // prefetch: the dynamic layout passes parent data through to its static
+    // descendants. Its slot in the bundle is null but the chain isn't broken.
+    const data = await fetchRouteTreePrefetch(
+      next,
+      '/test-instant-false-passthrough/inner'
+    )
+    expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
+     "
+              ⇣  root
+      dynamic ◻  └── "test-instant-false-passthrough"
+              ⇣      └── "inner"
+     outlined ■          └── "__PAGE__" (+metadata)
+     "
+    `)
+  })
+
+  it('runtime parallel: pass-through only flows into one child slot', async () => {
+    // Root → runtime layout with two slots (children + @sidebar) → inner
+    // layout → page. The runtime layout acts as a pass-through, but
+    // the parent's data should only flow into one child slot (the first
+    // that accepts), not both. This extends the existing parallel route
+    // inlining rule to the pass-through case.
+    const data = await fetchRouteTreePrefetch(
+      next,
+      '/test-runtime-parallel/inner'
+    )
+    expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
+     "
+              ⇣  root
+      runtime ◻  └── "test-runtime-parallel" (+metadata)
+              ⇣      ├── "inner"
+     outlined ■      │   └── "__PAGE__"
+     outlined ■      └── @sidebar/"__DEFAULT__"
+     "
+    `)
   })
 })


### PR DESCRIPTION
**Previous (merged):**

1. https://github.com/vercel/next.js/pull/91320

**Current:**

2. https://github.com/vercel/next.js/pull/91438

**Up next:**

3. https://github.com/vercel/next.js/pull/91439

---

Some segments in a route don't benefit from static prefetching. A segment with runtime prefetching enabled will be fetched and computed at runtime instead, and a segment with `instant = false` is not prefetchable at all. There's no reason to pay the prefetch cost for these segments — neither the server (measuring sizes, generating responses) nor the client (fetching, caching) gains anything from including them.

### Pass-through segments

This commit teaches the hint computation pass to identify these segments and mark them accordingly. During the size measurement traversal, disabled segments are skipped (zero size contribution) and act as transparent pass-throughs: parent data flows through them to the nearest static descendant rather than being blocked. This means a small static layout can still be bundled into a grandchild's response even when the intermediate segment is dynamic.

### No behavioral changes yet

The actual server output and client fetching behavior don't change yet — disabled segments still produce standalone responses for now. A follow-up commit will use these hints to actually omit the segments from the output and teach the client to handle the gaps.

### Head (metadata) inlining

The head (metadata/viewport) inlining logic is also updated: the head is only inlined into page segments (not layouts, since pages may access additional params like `searchParams`), and routes with runtime prefetch skip static head inlining entirely since the runtime response already includes the head.