### PR TITLE
[Segment Bundling] Bundle static prefetches based on size

### DIFF
--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -2,8 +2,6 @@ import type {
   TreePrefetch,
   RootTreePrefetch,
   SegmentPrefetchResponse,
-  InlinedPrefetchResponse,
-  InlinedSegmentPrefetch,
 } from '../../../server/app-render/collect-segment-data'
 import type {
   CacheNodeSeedData,
@@ -287,11 +285,27 @@ export type NonEmptySegmentCacheEntry = Exclude<
   EmptySegmentCacheEntry
 >
 
+/**
+ * A linked list of segment cache entries to fulfill from a single prefetch
+ * response. The head is the requested segment; subsequent nodes are parent
+ * segments whose data is bundled into the same response by the server.
+ *
+ * When segments are not bundled, the list has a single node. The list
+ * maps 1:1 to the data array in the SegmentPrefetchResponse the server returns.
+ */
+export type SegmentBundle = {
+  // Null when the segment has prefetching disabled (instant = false).
+  // The bundle chain passes through it but no cache entry is created.
+  tree: RouteTree | null
+  entry: SegmentCacheEntry | null
+  parent: SegmentBundle | null
+}
+
 const isOutputExportMode =
   process.env.NODE_ENV === 'production' &&
   process.env.__NEXT_CONFIG_OUTPUT === 'export'
 
-const MetadataOnlyRequestTree: FlightRouterState = [
+export const MetadataOnlyRequestTree: FlightRouterState = [
   '',
   {},
   null,
@@ -1854,12 +1868,26 @@ export async function fetchRouteOnCacheMiss(
   }
 }
 
-export async function fetchSegmentOnCacheMiss(
+function rejectRemainingSegmentsInBundle(
+  entries: SegmentBundle,
+  staleAt: number
+): void {
+  let node: SegmentBundle | null = entries
+  while (node !== null) {
+    if (node.entry !== null && node.entry.status === EntryStatus.Pending) {
+      rejectSegmentCacheEntry(node.entry as PendingSegmentCacheEntry, staleAt)
+    }
+    node = node.parent
+  }
+}
+
+export async function fetchSegmentsOnCacheMiss(
   route: FulfilledRouteCacheEntry,
-  segmentCacheEntry: PendingSegmentCacheEntry,
   routeKey: RouteCacheKey,
-  tree: RouteTree
-): Promise<PrefetchSubtaskResult<FulfilledSegmentCacheEntry> | null> {
+  tree: RouteTree,
+  segments: SegmentBundle,
+  segmentCount: number
+): Promise<PrefetchSubtaskResult<null> | null> {
   // This function is allowed to use async/await because it contains the actual
   // fetch that gets issued on a cache miss. Notice it writes the result to the
   // cache entry directly, rather than return data that is then written by
@@ -1923,7 +1951,7 @@ export async function fetchSegmentOnCacheMiss(
     ) {
       // Server responded with an error, or with a miss. We should still cache
       // the response, but we can try again after 10 seconds.
-      rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+      rejectRemainingSegmentsInBundle(segments, Date.now() + 10 * 1000)
       return null
     }
 
@@ -1934,69 +1962,110 @@ export async function fetchSegmentOnCacheMiss(
     const { stream: prefetchStream, size: responseSize } =
       await createNonTaskyPrefetchResponseStream(response.body)
     closed.resolve()
-    setSizeInCacheMap(segmentCacheEntry, responseSize)
+    // Distribute the response size evenly across all segments in the bundle.
+    const averageSize = responseSize / segmentCount
+    let sizeNode: SegmentBundle | null = segments
+    while (sizeNode !== null) {
+      if (sizeNode.entry !== null) {
+        setSizeInCacheMap(sizeNode.entry, averageSize)
+      }
+      sizeNode = sizeNode.parent
+    }
+
+    // Parse the response. Always a SegmentPrefetchResponse with a build ID
+    // and a data array.
     const serverResponse =
       await createFromNextReadableStream<SegmentPrefetchResponse>(
         prefetchStream,
         headers,
         { allowPartialStream: true }
       )
+
+    const now = Date.now()
+    const serverDataArray = serverResponse.data
+
+    if (serverDataArray.length === 0) {
+      rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
+      return null
+    }
     if (
       (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
         serverResponse.buildId) !== getNavigationBuildId()
     ) {
       // The server build does not match the client. Treat as a 404. During
       // an actual navigation, the router will trigger an MPA navigation.
-      rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+      rejectRemainingSegmentsInBundle(segments, now + 10 * 1000)
       return null
     }
-    // Iterate over the segment data in the response array. Currently each
-    // per-segment response contains a single entry, but the format supports
-    // bundled responses with multiple entries (used when segment inlining
-    // is enabled).
-    let fulfilledEntry: FulfilledSegmentCacheEntry | null = null
-    for (const serverData of serverResponse.data) {
-      if (serverData === null) {
-        // Null entries represent segments with static prefetch disabled
-        // (runtime prefetch or unstable_instant = false). Skip them.
+
+    // Walk the segments list and the response array in parallel, fulfilling
+    // each cache entry from the corresponding response element.
+    let node: SegmentBundle | null = segments
+    let dataIndex = 0
+    while (node !== null && dataIndex < serverDataArray.length) {
+      const data = serverDataArray[dataIndex]
+
+      // Null data means this segment has prefetching disabled. Skip it
+      // without creating a cache entry.
+      if (data === null || node.tree === null) {
+        node = node.parent
+        dataIndex++
         continue
       }
-      const now = Date.now()
-      const staleAt = now + getStaleTimeMs(serverData.staleTime)
-      fulfilledEntry = fulfillSegmentCacheEntry(
-        segmentCacheEntry,
-        serverData.rsc,
-        staleAt,
-        serverData.isPartial
-      )
 
-      // If the server tells us which params the segment varies by, we can
-      // re-key the entry to a more generic vary path. This allows the entry
-      // to be reused across different param values for params that the
-      // segment doesn't actually depend on.
-      const varyParams = serverData.varyParams
-      const fulfilledVaryPath =
-        process.env.__NEXT_VARY_PARAMS && varyParams !== null
-          ? getFulfilledSegmentVaryPath(tree.varyPath, varyParams)
-          : getSegmentVaryPathForRequest(segmentCacheEntry.fetchStrategy, tree)
-      upsertSegmentEntry(now, fulfilledVaryPath, fulfilledEntry)
+      const entryStaleAt = now + getStaleTimeMs(data.staleTime)
+
+      // Determine the canonical vary path for this segment. If the server
+      // tells us which params the segment varies by, re-key to a more
+      // generic path. Otherwise use the request vary path.
+      const canonicalVaryPath =
+        process.env.__NEXT_VARY_PARAMS && data.varyParams !== null
+          ? getFulfilledSegmentVaryPath(node.tree.varyPath, data.varyParams)
+          : getSegmentVaryPathForRequest(FetchStrategy.PPR, node.tree)
+
+      let fulfilled: FulfilledSegmentCacheEntry | null = null
+      const nodeEntry = node.entry
+      if (nodeEntry !== null && nodeEntry.status === EntryStatus.Pending) {
+        // We own this entry — fulfill it directly.
+        fulfilled = fulfillSegmentCacheEntry(
+          nodeEntry as PendingSegmentCacheEntry,
+          data.rsc,
+          entryStaleAt,
+          data.isPartial
+        )
+      } else {
+        // We don't own this entry. Create a detached entry and attempt
+        // to upsert it into the canonical slot.
+        const detachedEntry = createDetachedSegmentCacheEntry(now)
+        fulfilled = fulfillSegmentCacheEntry(
+          upgradeToPendingSegment(detachedEntry, FetchStrategy.PPR),
+          data.rsc,
+          entryStaleAt,
+          data.isPartial
+        )
+      }
+
+      // Set the fulfilled entry into the canonical cache slot.
+      upsertSegmentEntry(now, canonicalVaryPath, fulfilled)
+
+      node = node.parent
+      dataIndex++
     }
 
-    if (fulfilledEntry === null) {
-      rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
-      return null
+    // If the server returned fewer segments than expected, reject any
+    // remaining pending entries so they don't stay Pending forever.
+    if (node !== null) {
+      rejectRemainingSegmentsInBundle(node, now + 10 * 1000)
     }
 
     return {
-      value: fulfilledEntry,
-      // Return a promise that resolves when the network connection closes, so
-      // the scheduler can track the number of concurrent network connections.
+      value: null,
       closed: closed.promise,
     }
   } catch (error) {
     // Either the connection itself failed, or something bad happened while
     // decoding the response.
-    rejectSegmentCacheEntry(segmentCacheEntry, Date.now() + 10 * 1000)
+    rejectRemainingSegmentsInBundle(segments, Date.now() + 10 * 1000)
     return null
   }
 }
@@ -2006,168 +2075,6 @@ export async function fetchSegmentOnCacheMiss(
 // boolean flag. At that point, the per-segment and inlined fetch paths will
 // merge, and these separate functions will be removed.
 //
-// The call site in the scheduler is guarded by
-// process.env.__NEXT_PREFETCH_INLINING, so these functions are
-// dead-code-eliminated from the client bundle when the feature is disabled.
-
-export async function fetchInlinedSegmentsOnCacheMiss(
-  route: FulfilledRouteCacheEntry,
-  routeKey: RouteCacheKey,
-  tree: RouteTree,
-  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
-): Promise<PrefetchSubtaskResult<null> | null> {
-  // When prefetch inlining is enabled, all segment data for a route is bundled
-  // into a single /_inlined response instead of individual per-segment
-  // requests. This function fetches that response and walks the tree to fill
-  // all segment cache entries at once.
-  const url = new URL(route.canonicalUrl, location.origin)
-  const nextUrl = routeKey.nextUrl
-
-  const headers: RequestHeaders = {
-    [RSC_HEADER]: '1',
-    [NEXT_ROUTER_PREFETCH_HEADER]: '1',
-    [NEXT_ROUTER_SEGMENT_PREFETCH_HEADER]: '/' + PAGE_SEGMENT_KEY,
-  }
-  if (nextUrl !== null) {
-    headers[NEXT_URL] = nextUrl
-  }
-  addInstantPrefetchHeaderIfLocked(headers)
-
-  try {
-    const response = await fetchPrefetchResponse(url, headers)
-    if (
-      !response ||
-      !response.ok ||
-      response.status === 204 ||
-      (response.headers.get(NEXT_DID_POSTPONE_HEADER) !== '2' &&
-        !isOutputExportMode) ||
-      !response.body
-    ) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-      return null
-    }
-
-    // See TODO in fetchRouteOnCacheMiss about removing `closed` for
-    // buffered prefetch paths.
-    const closed = createPromiseWithResolvers<void>()
-
-    const { stream: prefetchStream } =
-      await createNonTaskyPrefetchResponseStream(response.body)
-    closed.resolve()
-    const serverData =
-      await createFromNextReadableStream<InlinedPrefetchResponse>(
-        prefetchStream,
-        headers,
-        { allowPartialStream: true }
-      )
-
-    if (
-      (response.headers.get(NEXT_NAV_DEPLOYMENT_ID_HEADER) ??
-        serverData.buildId) !== getNavigationBuildId()
-    ) {
-      rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-      return null
-    }
-
-    const now = Date.now()
-
-    // Walk the inlined tree in parallel with the RouteTree and fill
-    // segment cache entries.
-    fillInlinedSegmentEntries(now, route, tree, serverData.tree, spawnedEntries)
-
-    // Fill the head entry.
-    const headStaleAt = now + getStaleTimeMs(serverData.head.staleTime)
-    const headKey = route.metadata.requestKey
-    const ownedHeadEntry = spawnedEntries.get(headKey)
-    if (ownedHeadEntry !== undefined) {
-      fulfillSegmentCacheEntry(
-        ownedHeadEntry,
-        serverData.head.rsc,
-        headStaleAt,
-        serverData.head.isPartial
-      )
-    } else {
-      // The head was already cached. Try to upsert if the entry is empty.
-      const existingEntry = readOrCreateSegmentCacheEntry(
-        now,
-        FetchStrategy.PPR,
-        route.metadata
-      )
-      if (existingEntry.status === EntryStatus.Empty) {
-        fulfillSegmentCacheEntry(
-          upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
-          serverData.head.rsc,
-          headStaleAt,
-          serverData.head.isPartial
-        )
-      }
-    }
-
-    // Reject any remaining entries that were not fulfilled by the response.
-    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-
-    return { value: null, closed: closed.promise }
-  } catch (error) {
-    rejectSegmentEntriesIfStillPending(spawnedEntries, Date.now() + 10 * 1000)
-    return null
-  }
-}
-
-function fillInlinedSegmentEntries(
-  now: number,
-  route: FulfilledRouteCacheEntry,
-  tree: RouteTree,
-  inlinedNode: InlinedSegmentPrefetch,
-  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
-): void {
-  // Check if the spawned entries map has an entry for this segment's key.
-  const segment = inlinedNode.segment
-  const staleAt = now + getStaleTimeMs(segment.staleTime)
-  const ownedEntry = spawnedEntries.get(tree.requestKey)
-  if (ownedEntry !== undefined) {
-    // We own this entry. Fulfill it directly.
-    fulfillSegmentCacheEntry(
-      ownedEntry,
-      segment.rsc,
-      staleAt,
-      segment.isPartial
-    )
-  } else {
-    // Not owned by us — this is extra data from the inlined response for a
-    // segment that was already cached. Try to upsert if the entry is empty.
-    const existingEntry = readOrCreateSegmentCacheEntry(
-      now,
-      FetchStrategy.PPR,
-      tree
-    )
-    if (existingEntry.status === EntryStatus.Empty) {
-      fulfillSegmentCacheEntry(
-        upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
-        segment.rsc,
-        staleAt,
-        segment.isPartial
-      )
-    }
-  }
-
-  // Recurse into children.
-  if (tree.slots !== null && inlinedNode.slots !== null) {
-    for (const parallelRouteKey in tree.slots) {
-      const childTree = tree.slots[parallelRouteKey]
-      const childInlinedNode = inlinedNode.slots[parallelRouteKey]
-      if (childInlinedNode !== undefined) {
-        fillInlinedSegmentEntries(
-          now,
-          route,
-          childTree,
-          childInlinedNode,
-          spawnedEntries
-        )
-      }
-    }
-  }
-}
-
 export async function fetchSegmentPrefetchesUsingDynamicRequest(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
@@ -2188,6 +2095,9 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
   ) {
     // The only thing pending is the head. Instruct the server to
     // skip over everything else.
+    // TODO: Lift this logic into the caller. Or perhaps unify the
+    // "request tree" and the spawnedEntries into the same type so they are
+    // guaranteed to always been in sync.
     dynamicRequestTree = MetadataOnlyRequestTree
   }
 

--- a/packages/next/src/client/components/segment-cache/scheduler.ts
+++ b/packages/next/src/client/components/segment-cache/scheduler.ts
@@ -3,21 +3,23 @@ import type {
   Segment as FlightRouterStateSegment,
   Segment,
 } from '../../../shared/lib/app-router-types'
-import { PrefetchHint } from '../../../shared/lib/app-router-types'
+import {
+  PrefetchHint,
+  StaticPrefetchDisabled,
+} from '../../../shared/lib/app-router-types'
 import { matchSegment } from '../match-segments'
 import {
   readOrCreateRouteCacheEntry,
   readOrCreateSegmentCacheEntry,
   fetchRouteOnCacheMiss,
-  fetchSegmentOnCacheMiss,
-  fetchInlinedSegmentsOnCacheMiss,
+  fetchSegmentsOnCacheMiss,
   EntryStatus,
   type FulfilledRouteCacheEntry,
   type RouteCacheEntry,
-  type SegmentCacheEntry,
   type RouteTree,
   fetchSegmentPrefetchesUsingDynamicRequest,
   type PendingSegmentCacheEntry,
+  type SegmentBundle,
   convertRouteTreeToFlightRouterState,
   readOrCreateRevalidatingSegmentEntry,
   upgradeToPendingSegment,
@@ -25,6 +27,7 @@ import {
   canNewFetchStrategyProvideMoreContent,
   attemptToFulfillDynamicSegmentFromBFCache,
   attemptToUpgradeSegmentFromBFCache,
+  MetadataOnlyRequestTree,
 } from './cache'
 import type { RouteCacheKey } from './cache-key'
 import { createCacheKey } from './cache-key'
@@ -746,16 +749,20 @@ function pingRootRouteTree(
             task,
             route,
             task.treeAtTimeOfPrefetch,
-            tree
+            tree,
+            null
           )
           if (exitStatus === PrefetchTaskExitStatus.InProgress) {
             // Child yielded without finishing.
             return PrefetchTaskExitStatus.InProgress
           }
-          const spawnedRuntimePrefetches = task.spawnedRuntimePrefetches
-          if (spawnedRuntimePrefetches !== null) {
-            // During the first pass, we discovered segments that require a
-            // runtime prefetch. Do a second pass to construct a request tree.
+          if (tree.prefetchHints & PrefetchHint.SubtreeHasRuntimePrefetch) {
+            // The route has segments that require a runtime prefetch.
+
+            // Always ping the runtime head — it may need to be fetched
+            // independently even if all runtime segments are already
+            // cached (e.g. navigating between siblings under a shared
+            // runtime layout).
             const spawnedEntries = new Map<
               SegmentRequestKey,
               PendingSegmentCacheEntry
@@ -767,27 +774,47 @@ function pingRootRouteTree(
               spawnedEntries,
               FetchStrategy.PPRRuntime
             )
-            const requestTree = pingRuntimePrefetches(
-              now,
-              task,
-              route,
-              tree,
-              spawnedRuntimePrefetches,
-              spawnedEntries
-            )
-            let needsDynamicRequest = spawnedEntries.size > 0
-            if (needsDynamicRequest) {
-              // Perform a dynamic prefetch request and populate the cache with
-              // the result.
-              spawnPrefetchSubtask(
-                fetchSegmentPrefetchesUsingDynamicRequest(
-                  task,
-                  route,
-                  FetchStrategy.PPRRuntime,
-                  requestTree,
-                  spawnedEntries
-                )
+
+            const spawnedRuntimePrefetches = task.spawnedRuntimePrefetches
+            if (spawnedRuntimePrefetches !== null) {
+              const requestTree = pingRuntimePrefetches(
+                now,
+                task,
+                route,
+                tree,
+                spawnedRuntimePrefetches,
+                spawnedEntries
               )
+              if (spawnedEntries.size > 0) {
+                spawnPrefetchSubtask(
+                  fetchSegmentPrefetchesUsingDynamicRequest(
+                    task,
+                    route,
+                    FetchStrategy.PPRRuntime,
+                    requestTree,
+                    spawnedEntries
+                  )
+                )
+              }
+            } else {
+              // No segments spawned a runtime prefetch; however, the head might
+              // have. If there are any spawned entries, it must have come from
+              // the head. Request the metadata only.
+              // TODO: Refactor the "request tree" format so that the metadata
+              // is less of a special case. Right now the logic for this is
+              // spread across both here
+              // and fetchSegmentPrefetchesUsingDynamicRequest.
+              if (spawnedEntries.size > 0) {
+                spawnPrefetchSubtask(
+                  fetchSegmentPrefetchesUsingDynamicRequest(
+                    task,
+                    route,
+                    FetchStrategy.PPRRuntime,
+                    MetadataOnlyRequestTree,
+                    spawnedEntries
+                  )
+                )
+              }
             }
           }
 
@@ -851,14 +878,27 @@ function pingStaticHead(
   // The Head data for a page (metadata, viewport) is not really a route
   // segment, in the sense that it doesn't appear in the route tree. But we
   // store it in the cache as if it were, using a special key.
-  pingStaticSegmentData(
-    now,
-    task,
-    route,
-    readOrCreateSegmentCacheEntry(now, FetchStrategy.PPR, route.metadata),
-    task.key,
-    route.metadata
-  )
+  //
+  // If the head was inlined into a page's bundle (HeadOutlined is NOT set
+  // on the root), skip the standalone fetch — the head data will arrive
+  // as part of that page's response.
+  if (
+    process.env.__NEXT_PREFETCH_INLINING &&
+    !(route.tree.prefetchHints & PrefetchHint.HeadOutlined)
+  ) {
+    return
+  }
+
+  const segments: SegmentBundle = {
+    tree: route.metadata,
+    entry: readOrCreateSegmentCacheEntry(
+      now,
+      FetchStrategy.PPR,
+      route.metadata
+    ),
+    parent: null,
+  }
+  pingSegmentBundle(now, task, route, task.key, route.metadata, segments)
 }
 
 function pingRuntimeHead(
@@ -893,7 +933,8 @@ function pingSharedPartOfCacheComponentsTree(
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
   oldTree: FlightRouterState,
-  newTree: RouteTree
+  newTree: RouteTree,
+  parentBundle: SegmentBundle | null
 ): PrefetchTaskExitStatus {
   // When Cache Components is enabled (or PPR, or a fully static route when PPR
   // is disabled; those cases are treated equivalently to Cache Components), we
@@ -906,13 +947,13 @@ function pingSharedPartOfCacheComponentsTree(
   // "new" part of the tree, we switch to a different traversal,
   // pingNewPartOfCacheComponentsTree.
 
-  // Prefetch this segment's static data.
-  const segment = readOrCreateSegmentCacheEntry(
+  const bundleInProgress = accumulateSegmentBundle(
     now,
-    task.fetchStrategy,
-    newTree
+    task,
+    route,
+    newTree,
+    parentBundle
   )
-  pingStaticSegmentData(now, task, route, segment, task.key, newTree)
 
   // Recursively ping the children.
   const oldTreeChildren = oldTree[1]
@@ -929,6 +970,14 @@ function pingSharedPartOfCacheComponentsTree(
         oldTreeChildren[parallelRouteKey]
       const oldTreeChildSegment: FlightRouterStateSegment | void =
         oldTreeChild?.[0]
+      // Only pass the bundle to the child that accepts it. A parent is
+      // only ever bundled into one child.
+      const bundleForChild =
+        process.env.__NEXT_PREFETCH_INLINING &&
+        bundleInProgress !== null &&
+        newTreeChild.prefetchHints & PrefetchHint.ParentInlinedIntoSelf
+          ? bundleInProgress
+          : null
       let childExitStatus
       if (
         oldTreeChildSegment !== undefined &&
@@ -944,7 +993,8 @@ function pingSharedPartOfCacheComponentsTree(
           task,
           route,
           oldTreeChild,
-          newTreeChild
+          newTreeChild,
+          bundleForChild
         )
       } else {
         // We've entered the "new" part of the tree. Switch
@@ -953,7 +1003,8 @@ function pingSharedPartOfCacheComponentsTree(
           now,
           task,
           route,
-          newTreeChild
+          newTreeChild,
+          bundleForChild
         )
       }
       if (childExitStatus === PrefetchTaskExitStatus.InProgress) {
@@ -970,7 +1021,8 @@ function pingNewPartOfCacheComponentsTree(
   now: number,
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
-  tree: RouteTree
+  tree: RouteTree,
+  parentBundle: SegmentBundle | null
 ): PrefetchTaskExitStatus.InProgress | PrefetchTaskExitStatus.Done {
   // We're now prefetching in the "new" part of the tree, the part that doesn't
   // exist on the current page. (In other words, we're deeper than the
@@ -978,37 +1030,27 @@ function pingNewPartOfCacheComponentsTree(
   // However, if the server instructs us to, we may switch to a runtime
   // prefetch instead. Traverse the tree and check at each segment.
   if (tree.prefetchHints & PrefetchHint.HasRuntimePrefetch) {
-    // This route has a runtime prefetch response. Since we're below the shared
-    // layout, everything from this point should be prefetched using a single,
-    // combined runtime request, rather than using per-segment static requests.
-    // This is true even if some of the child segments are known to be fully
-    // static — once we've decided to perform a runtime prefetch, we might as
-    // well respond with the static segments in the same roundtrip. (That's how
-    // regular navigations work, too.) We'll still skip over segments that are
-    // already cached, though.
-    //
-    // It's the server's responsibility to set a reasonable value of
-    // `hasRuntimePrefetch`. Currently it's user-defined, but eventually, the
-    // server may send a value of `false` even if the user opts in, if it
-    // determines during build that the route is always fully static. There are
-    // more optimizations we can do once we implement fallback param
-    // tracking, too.
-    //
-    // Use the task object to collect the segments that need a runtime prefetch.
-    // This will signal to the outer task queue that a second traversal is
-    // required to construct a request tree.
     if (task.spawnedRuntimePrefetches === null) {
       task.spawnedRuntimePrefetches = new Set([tree.requestKey])
     } else {
       task.spawnedRuntimePrefetches.add(tree.requestKey)
     }
-    // Then exit the traversal without prefetching anything further.
+    // If there's a pending static bundle from a parent, we need to finish
+    // prefetching it before bailing out to runtime prefetching.
+    if (parentBundle !== null) {
+      finishStaticBundleOnRuntimeBailout(now, task, route, tree, parentBundle)
+    }
     return PrefetchTaskExitStatus.Done
   }
 
-  // This segment should not be runtime prefetched. Prefetch its static data.
-  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
-  pingStaticSegmentData(now, task, route, segment, task.key, tree)
+  const bundleInProgress = accumulateSegmentBundle(
+    now,
+    task,
+    route,
+    tree,
+    parentBundle
+  )
+
   if (tree.slots !== null) {
     if (!hasNetworkBandwidth(task)) {
       // Stop prefetching segments until there's more bandwidth.
@@ -1017,11 +1059,20 @@ function pingNewPartOfCacheComponentsTree(
     // Recursively ping the children.
     for (const parallelRouteKey in tree.slots) {
       const childTree = tree.slots[parallelRouteKey]
+      // Only pass the bundle to the child that accepts it. A parent is
+      // only ever bundled into one child.
+      const bundleForChild =
+        process.env.__NEXT_PREFETCH_INLINING &&
+        bundleInProgress !== null &&
+        childTree.prefetchHints & PrefetchHint.ParentInlinedIntoSelf
+          ? bundleInProgress
+          : null
       const childExitStatus = pingNewPartOfCacheComponentsTree(
         now,
         task,
         route,
-        childTree
+        childTree,
+        bundleForChild
       )
       if (childExitStatus === PrefetchTaskExitStatus.InProgress) {
         // Child yielded without finishing.
@@ -1470,190 +1521,193 @@ function pingRuntimePrefetches(
   return requestTree
 }
 
-function pingStaticSegmentData(
+/**
+ * Walk a SegmentBundle, apply status-based logic to each entry, and if any
+ * entries need data, spawn a single fetch request for the whole bundle.
+ */
+function pingSegmentBundle(
   now: number,
   task: PrefetchTask,
   route: FulfilledRouteCacheEntry,
-  segment: SegmentCacheEntry,
   routeKey: RouteCacheKey,
-  tree: RouteTree
+  tree: RouteTree,
+  segments: SegmentBundle
 ): void {
-  switch (segment.status) {
-    case EntryStatus.Empty:
-      if (process.env.__NEXT_PREFETCH_INLINING) {
-        // All segment data for this route is bundled into a single
-        // /_inlined response. Walk the full route tree to collect all
-        // Empty segments, upgrade them to Pending, and spawn one
-        // bundled request. Subsequent calls for other segments in the
-        // same tree will see them as Pending and skip.
-        const inlinedEntries = collectInlinedEntries(now, route)
-        if (inlinedEntries.size > 0) {
-          spawnPrefetchSubtask(
-            fetchInlinedSegmentsOnCacheMiss(
-              route,
-              routeKey,
-              route.tree,
-              inlinedEntries
-            )
-          )
+  let segmentCount = 0
+  let needsFetch = false
+  let node: SegmentBundle | null = segments
+  while (node !== null) {
+    segmentCount++
+    const nodeEntry = node.entry
+    const nodeTree = node.tree
+    if (nodeEntry === null || nodeTree === null) {
+      node = node.parent
+      continue
+    }
+    switch (nodeEntry.status) {
+      case EntryStatus.Empty:
+        upgradeToPendingSegment(nodeEntry, FetchStrategy.PPR)
+        needsFetch = true
+        break
+      case EntryStatus.Pending:
+        switch (nodeEntry.fetchStrategy) {
+          case FetchStrategy.PPR:
+          case FetchStrategy.PPRRuntime:
+          case FetchStrategy.Full:
+            node.entry = null
+            break
+          case FetchStrategy.LoadingBoundary:
+            if (background(task)) {
+              const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
+                now,
+                FetchStrategy.PPR,
+                nodeTree
+              )
+              if (revalidatingEntry.status === EntryStatus.Empty) {
+                upgradeToPendingSegment(revalidatingEntry, FetchStrategy.PPR)
+                node.entry = revalidatingEntry
+                needsFetch = true
+              } else {
+                node.entry = null
+              }
+            } else {
+              node.entry = null
+            }
+            break
+          default:
+            nodeEntry.fetchStrategy satisfies never
         }
         break
-      }
-      // Upgrade to Pending so we know there's already a request in progress
-      spawnPrefetchSubtask(
-        fetchSegmentOnCacheMiss(
-          route,
-          upgradeToPendingSegment(segment, FetchStrategy.PPR),
-          routeKey,
-          tree
-        )
-      )
-      break
-    case EntryStatus.Pending: {
-      // There's already a request in progress. Depending on what kind of
-      // request it is, we may want to revalidate it.
-      switch (segment.fetchStrategy) {
-        case FetchStrategy.PPR:
-        case FetchStrategy.PPRRuntime:
-        case FetchStrategy.Full:
-          // There's already a request in progress. Don't do anything.
-          break
-        case FetchStrategy.LoadingBoundary:
-          // There's a pending request, but because it's using the old
-          // prefetching strategy, we can't be sure if it will be fulfilled by
-          // the response — it might be inside the loading boundary. Perform
-          // a revalidation, but because it's speculative, wait to do it at
-          // background priority.
-          if (background(task)) {
-            // TODO: Instead of speculatively revalidating, consider including
-            // `hasLoading` in the route tree prefetch response.
-            pingPPRSegmentRevalidation(now, route, routeKey, tree)
+      case EntryStatus.Rejected:
+        switch (nodeEntry.fetchStrategy) {
+          case FetchStrategy.PPR:
+          case FetchStrategy.PPRRuntime:
+          case FetchStrategy.Full:
+            node.entry = null
+            break
+          case FetchStrategy.LoadingBoundary: {
+            const revalidatingEntry = readOrCreateRevalidatingSegmentEntry(
+              now,
+              FetchStrategy.PPR,
+              nodeTree
+            )
+            if (revalidatingEntry.status === EntryStatus.Empty) {
+              upgradeToPendingSegment(revalidatingEntry, FetchStrategy.PPR)
+              node.entry = revalidatingEntry
+              needsFetch = true
+            } else {
+              node.entry = null
+            }
+            break
           }
-          break
-        default:
-          segment.fetchStrategy satisfies never
-      }
-      break
+          default:
+            nodeEntry.fetchStrategy satisfies never
+        }
+        break
+      case EntryStatus.Fulfilled:
+        node.entry = null
+        break
+      default:
+        nodeEntry satisfies never
     }
-    case EntryStatus.Rejected: {
-      // The existing entry in the cache was rejected. Depending on how it
-      // was originally fetched, we may or may not want to revalidate it.
-      switch (segment.fetchStrategy) {
-        case FetchStrategy.PPR:
-        case FetchStrategy.PPRRuntime:
-        case FetchStrategy.Full:
-          // The previous attempt to fetch this entry failed. Don't attempt to
-          // fetch it again until the entry expires.
-          break
-        case FetchStrategy.LoadingBoundary:
-          // There's a rejected entry, but it was fetched using the loading
-          // boundary strategy. So the reason it wasn't returned by the server
-          // might just be because it was inside a loading boundary. Or because
-          // there was a dynamic rewrite. Revalidate it using the per-
-          // segment strategy.
-          //
-          // Because a rejected segment will definitely prevent the segment (and
-          // all of its children) from rendering, we perform this revalidation
-          // immediately instead of deferring it to a background task.
-          pingPPRSegmentRevalidation(now, route, routeKey, tree)
-          break
-        default:
-          segment.fetchStrategy satisfies never
-      }
-      break
-    }
-    case EntryStatus.Fulfilled:
-      // Segment is already cached. There's nothing left to prefetch.
-      break
-    default:
-      segment satisfies never
+    node = node.parent
   }
-
-  // Segments do not have dependent tasks, so once the prefetch is initiated,
-  // there's nothing else for us to do (except write the server data into the
-  // entry, which is handled by `fetchSegmentOnCacheMiss`).
+  if (!needsFetch) {
+    return
+  }
+  spawnPrefetchSubtask(
+    fetchSegmentsOnCacheMiss(route, routeKey, tree, segments, segmentCount)
+  )
 }
 
 /**
- * Walks the RouteTree (including the head metadata) and collects any segments
- * that are still Empty into a Map, upgrading them to Pending. These entries
- * will be fulfilled by the inlined prefetch response.
+ * During the tree walk, decide whether this segment should be added to the
+ * in-progress bundle (if it has InlinedIntoChild) or finalize the bundle
+ * and trigger a fetch (if it doesn't). Returns the updated bundle to pass
+ * to children, or null if a fetch was triggered.
  */
-function collectInlinedEntries(
+function accumulateSegmentBundle(
   now: number,
-  route: FulfilledRouteCacheEntry
-): Map<SegmentRequestKey, PendingSegmentCacheEntry> {
-  const entries = new Map<SegmentRequestKey, PendingSegmentCacheEntry>()
-  collectInlinedEntriesImpl(now, route.tree, entries)
-  // Also collect the head/metadata entry.
-  const headEntry = readOrCreateSegmentCacheEntry(
-    now,
-    FetchStrategy.PPR,
-    route.metadata
-  )
-  if (headEntry.status === EntryStatus.Empty) {
-    entries.set(
-      route.metadata.requestKey,
-      upgradeToPendingSegment(headEntry, FetchStrategy.PPR)
-    )
+  task: PrefetchTask,
+  route: FulfilledRouteCacheEntry,
+  tree: RouteTree,
+  parentBundle: SegmentBundle | null
+): SegmentBundle | null {
+  // Static prefetching is disabled for this segment (runtime prefetch or
+  // instant = false). It participates in the bundle chain with null
+  // tree/entry — no cache entry is created, and the server emits null for
+  // this slot. This check is intentionally NOT gated by the prefetch
+  // inlining feature flag: we never statically prefetch segments that are
+  // runtime-prefetched or unprefetchable, regardless of bundling.
+  if (tree.prefetchHints & StaticPrefetchDisabled) {
+    return {
+      tree: null,
+      entry: null,
+      parent: parentBundle,
+    }
   }
-  return entries
+
+  const segment = readOrCreateSegmentCacheEntry(now, task.fetchStrategy, tree)
+
+  if (
+    process.env.__NEXT_PREFETCH_INLINING &&
+    tree.prefetchHints & PrefetchHint.InlinedIntoChild
+  ) {
+    return {
+      tree,
+      entry: segment,
+      parent: parentBundle,
+    }
+  }
+
+  // Not bundled. Build a single-node bundle and ping it. If this page
+  // accepts the head (HeadInlinedIntoSelf), prepend the head's cache entry
+  // to the bundle.
+  let effectiveParent: SegmentBundle | null = parentBundle
+  if (
+    process.env.__NEXT_PREFETCH_INLINING &&
+    tree.prefetchHints & PrefetchHint.HeadInlinedIntoSelf
+  ) {
+    effectiveParent = {
+      tree: route.metadata,
+      entry: readOrCreateSegmentCacheEntry(
+        now,
+        FetchStrategy.PPR,
+        route.metadata
+      ),
+      parent: parentBundle,
+    }
+  }
+
+  const segments: SegmentBundle = {
+    tree,
+    entry: segment,
+    parent: effectiveParent,
+  }
+
+  pingSegmentBundle(now, task, route, task.key, tree, segments)
+  return null
 }
 
-function collectInlinedEntriesImpl(
+function finishStaticBundleOnRuntimeBailout(
   now: number,
+  task: PrefetchTask,
+  route: FulfilledRouteCacheEntry,
   tree: RouteTree,
-  entries: Map<SegmentRequestKey, PendingSegmentCacheEntry>
+  parentBundle: SegmentBundle
 ): void {
-  const entry = readOrCreateSegmentCacheEntry(now, FetchStrategy.PPR, tree)
-  if (entry.status === EntryStatus.Empty) {
-    entries.set(
-      tree.requestKey,
-      upgradeToPendingSegment(entry, FetchStrategy.PPR)
-    )
+  const bundle = accumulateSegmentBundle(now, task, route, tree, parentBundle)
+  if (bundle === null) {
+    return
   }
   if (tree.slots !== null) {
     for (const parallelRouteKey in tree.slots) {
-      collectInlinedEntriesImpl(now, tree.slots[parallelRouteKey], entries)
+      const childTree = tree.slots[parallelRouteKey]
+      if (childTree.prefetchHints & PrefetchHint.ParentInlinedIntoSelf) {
+        finishStaticBundleOnRuntimeBailout(now, task, route, childTree, bundle)
+        return
+      }
     }
-  }
-}
-
-function pingPPRSegmentRevalidation(
-  now: number,
-  route: FulfilledRouteCacheEntry,
-  routeKey: RouteCacheKey,
-  tree: RouteTree
-): void {
-  const revalidatingSegment = readOrCreateRevalidatingSegmentEntry(
-    now,
-    FetchStrategy.PPR,
-    tree
-  )
-  switch (revalidatingSegment.status) {
-    case EntryStatus.Empty:
-      // Spawn a prefetch request. The fetch function handles upserting
-      // the entry at the correct fulfilled vary path upon completion.
-      spawnPrefetchSubtask(
-        fetchSegmentOnCacheMiss(
-          route,
-          upgradeToPendingSegment(revalidatingSegment, FetchStrategy.PPR),
-          routeKey,
-          tree
-        )
-      )
-      break
-    case EntryStatus.Pending:
-      // There's already a revalidation in progress.
-      break
-    case EntryStatus.Fulfilled:
-    case EntryStatus.Rejected:
-      // A previous revalidation attempt finished, but we chose not to replace
-      // the existing entry in the cache. Don't try again until or unless the
-      // revalidation entry expires.
-      break
-    default:
-      revalidatingSegment satisfies never
   }
 }
 

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -12,7 +12,6 @@ import {
   StaticPrefetchDisabled,
 } from '../../shared/lib/app-router-types'
 import { readVaryParams } from '../../shared/lib/segment-cache/vary-params-decoding'
-import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -24,6 +23,7 @@ import {
   streamFromBuffer,
   streamToBuffer,
 } from '../stream-utils/node-web-streams-helper'
+import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import { waitAtLeastOneReactRenderTask } from '../../lib/scheduler'
 import {
   type SegmentRequestKey,
@@ -79,6 +79,14 @@ export type TreePrefetch = {
 /**
  * Top-level response for a segment prefetch request. Contains the build ID
  * and an array of segment data (one per segment in the bundle).
+ *
+ * Ordering contract: data[0] is the requested (terminal) segment. Subsequent
+ * elements are ancestors that were inlined into this response, built by
+ * walking the SegmentBundleNode linked list. The client's SegmentBundle
+ * linked list is constructed in the same order during scheduling, so the
+ * two are walked in parallel when the response arrives. A null element
+ * indicates a disabled segment (runtime prefetch or instant=false) that
+ * occupies a slot but carries no data.
  */
 export type SegmentPrefetchResponse = {
   buildId: string
@@ -102,28 +110,15 @@ export type SegmentPrefetch = {
 }
 
 /**
- * A node in the inlined prefetch tree. Wraps a SegmentPrefetch with child
- * slots so all segments for a route can be bundled into a single response.
- *
- * This is a separate type from SegmentPrefetch because the inlined flow is
- * still gated behind a feature flag. Eventually inlining will always be
- * enabled, and the per-segment and inlined paths will merge.
+ * Server-side equivalent of the client's SegmentBundle linked list. Each
+ * node holds the RSC data and vary params for a segment whose data will
+ * be bundled into a descendant's response. Flattened to an array only at
+ * serialization time in renderSegmentPrefetch.
  */
-export type InlinedSegmentPrefetch = {
-  segment: SegmentPrefetch
-  slots: null | {
-    [parallelRouteKey: string]: InlinedSegmentPrefetch
-  }
-}
-
-/**
- * The response shape for the /_inlined prefetch endpoint. Contains all segment
- * data for a route bundled into a single tree structure, plus the head segment.
- */
-export type InlinedPrefetchResponse = {
-  buildId: string
-  tree: InlinedSegmentPrefetch
-  head: SegmentPrefetch
+type SegmentBundleNode = {
+  rsc: React.ReactNode
+  varyParams: Set<string> | null
+  next: SegmentBundleNode | null
 }
 
 const filterStackFrame =
@@ -258,8 +253,28 @@ export async function collectSegmentData(
   // Now that we've finished rendering the route tree, all the segment tasks
   // should have been spawned. Await them in parallel and write the segment
   // prefetches to the result map.
+  let hasPageSegment = false
   for (const [segmentPath, buffer] of await Promise.all(segmentTasks)) {
     resultMap.set(segmentPath, buffer)
+    if (segmentPath.endsWith('__PAGE__')) {
+      hasPageSegment = true
+    }
+  }
+
+  if (!hasPageSegment) {
+    // The build requires at least one segment path ending with __PAGE__ to
+    // register the catch-all segment data route. When all page segments are
+    // disabled (e.g. every leaf has runtime prefetching), no __PAGE__ entry
+    // is emitted. Write a dummy entry with a path that doesn't match any
+    // real route segment so the client will never request it.
+    //
+    // TODO: Remove the __PAGE__ requirement from the build instead of
+    // working around it here. The invariant is outdated now that segments
+    // can be disabled.
+    resultMap.set(
+      '/todo-remove-fake-segment/__PAGE__' as SegmentRequestKey,
+      Buffer.alloc(0)
+    )
   }
 
   return resultMap
@@ -320,7 +335,8 @@ export async function collectPrefetchHints(
     head,
     HEAD_REQUEST_KEY,
     headVaryParams,
-    clientModules
+    clientModules,
+    null
   )
   const headGzipSize = await getGzipSize(headBuffer)
 
@@ -432,7 +448,8 @@ async function collectPrefetchHintsImpl(
       seedData[0],
       requestKey,
       varyParams,
-      clientModules
+      clientModules,
+      null
     )
     currentGzipSize = await getGzipSize(buffer)
   }
@@ -685,10 +702,20 @@ async function PrefetchTreeData({
       ? readVaryParams(headVaryParamsThenable)
       : null
 
+  // Only applies when prefetch inlining is enabled — the client doesn't
+  // know to look for the head inside a page's response otherwise.
+  const headIsInlined =
+    prefetchInlining &&
+    hints !== null &&
+    !(hints.hints & PrefetchHint.HeadOutlined)
+
   // Compute the route metadata tree by traversing the FlightRouterState. As we
   // walk the tree, we will also spawn a task to produce a prefetch response for
-  // each segment (unless prefetch inlining is enabled, in which case all
-  // segments are bundled into a single /_inlined response).
+  // each segment. When prefetch inlining is enabled, small segments are bundled
+  // into their children's responses based on the hint bits.
+  const headBundle: SegmentBundleNode | null = headIsInlined
+    ? { rsc: head, varyParams: headVaryParams, next: null }
+    : null
   const tree = collectSegmentDataImpl(
     isClientParamParsingEnabled,
     flightRouterState,
@@ -699,31 +726,14 @@ async function PrefetchTreeData({
     ROOT_SEGMENT_REQUEST_KEY,
     segmentTasks,
     prefetchInlining,
-    hints
+    hints,
+    null,
+    headBundle
   )
 
-  if (prefetchInlining) {
-    // When prefetch inlining is enabled, bundle all segment data into a single
-    // /_inlined response instead of individual per-segment responses. The head
-    // is also included in the inlined response.
-    segmentTasks.push(
-      waitAtLeastOneReactRenderTask().then(() =>
-        renderInlinedPrefetchResponse(
-          flightRouterState,
-          buildId,
-          staleTime,
-          seedData,
-          head,
-          headVaryParams,
-          clientModules
-        )
-      )
-    )
-  } else {
-    // Also spawn a task to produce a prefetch response for the "head" segment.
-    // The head contains metadata, like the title; it's not really a route
-    // segment, but it contains RSC data, so it's treated like a segment by
-    // the client cache.
+  // Spawn a task to produce a prefetch response for the "head" segment,
+  // unless it was inlined into a page's bundle.
+  if (!headIsInlined) {
     segmentTasks.push(
       waitAtLeastOneReactRenderTask().then(() =>
         renderSegmentPrefetch(
@@ -732,7 +742,8 @@ async function PrefetchTreeData({
           head,
           HEAD_REQUEST_KEY,
           headVaryParams,
-          clientModules
+          clientModules,
+          null
         )
       )
     )
@@ -764,8 +775,91 @@ function collectSegmentDataImpl(
   requestKey: SegmentRequestKey,
   segmentTasks: Array<Promise<[string, Buffer]>>,
   prefetchInlining: boolean,
-  hintTree: PrefetchHints | null
+  hintTree: PrefetchHints | null,
+  parentBundle: SegmentBundleNode | null,
+  headBundle: SegmentBundleNode | null
 ): TreePrefetch {
+  // Union the hints already embedded in the FlightRouterState with the
+  // separately-computed build-time hints. During the initial build, the
+  // FlightRouterState was produced before collectPrefetchHints ran, so
+  // inlining hints (ParentInlinedIntoSelf, InlinedIntoChild) won't be in
+  // route[4] yet. On subsequent renders the hints are already in the
+  // FlightRouterState, so the union is idempotent.
+  //
+  // Always strip InliningHintsStale from the result. That bit is only
+  // relevant for the initial RSC payload baked into HTML — the /_tree
+  // response produced here always has correct hints, so the client should
+  // never see InliningHintsStale in a /_tree response.
+  const prefetchHints =
+    ((route[4] ?? 0) | (hintTree !== null ? hintTree.hints : 0)) &
+    ~PrefetchHint.InliningHintsStale
+
+  // Determine which params this segment varies on.
+  const varyParamsThenable = seedData !== null ? seedData[4] : null
+  const varyParams =
+    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+
+  // If static prefetching is disabled for this segment (runtime prefetch or
+  // instant = false), it still participates in the bundle chain but with
+  // null data. The client will skip creating a cache entry for it.
+  const staticPrefetchDisabled = (prefetchHints & StaticPrefetchDisabled) !== 0
+  const rsc = seedData !== null && !staticPrefetchDisabled ? seedData[0] : null
+
+  // Determine whether this segment's data should be accumulated into a
+  // child's response (inlining) or spawned as its own task. When inlining
+  // is disabled, the hint bits may still be set (they're computed at build
+  // time regardless) but we ignore them — every segment is rendered
+  // standalone because the client doesn't know how to parse bundled
+  // responses.
+  let childBundle: SegmentBundleNode | null = null
+  if (prefetchInlining && prefetchHints & PrefetchHint.InlinedIntoChild) {
+    // This segment is small enough that its data will be included in one
+    // of its children's responses. Don't spawn a separate task — prepend
+    // this segment's data onto the linked list so the accepting child can
+    // bundle it into its response.
+    if (seedData !== null) {
+      childBundle = {
+        rsc,
+        varyParams,
+        next: parentBundle,
+      }
+    }
+  } else {
+    // This segment is not inlined into a child. Spawn a task to render it.
+    // If it has ParentInlinedIntoSelf, the accumulated parents are included
+    // in its response. Otherwise parentBundle is null and it renders as a
+    // standalone single-segment response.
+    //
+    // Skip spawning a task if rsc is null (disabled segment) — there's no
+    // data to serve and the client won't request it.
+    if (seedData !== null && rsc !== null) {
+      let bundle =
+        prefetchHints & PrefetchHint.ParentInlinedIntoSelf ? parentBundle : null
+      // If this page accepts the head, append it at the tail of the chain.
+      if (
+        headBundle !== null &&
+        prefetchHints & PrefetchHint.HeadInlinedIntoSelf
+      ) {
+        headBundle.next = bundle
+        bundle = headBundle
+      }
+      segmentTasks.push(
+        waitAtLeastOneReactRenderTask().then(() =>
+          renderSegmentPrefetch(
+            buildId,
+            staleTime,
+            rsc,
+            requestKey,
+            varyParams,
+            clientModules,
+            bundle
+          )
+        )
+      )
+    }
+    // childBundle stays null — reset the accumulator for children.
+  }
+
   // Metadata about the segment. Sent as part of the tree prefetch. Null if
   // there are no children.
   let slotMetadata: { [parallelRouteKey: string]: TreePrefetch } | null = null
@@ -797,65 +891,14 @@ function collectSegmentDataImpl(
       childRequestKey,
       segmentTasks,
       prefetchInlining,
-      childHintTree
+      childHintTree,
+      childBundle,
+      headBundle
     )
     if (slotMetadata === null) {
       slotMetadata = {}
     }
     slotMetadata[parallelRouteKey] = childTree
-  }
-
-  // Union the hints already embedded in the FlightRouterState with the
-  // separately-computed build-time hints. During the initial build, the
-  // FlightRouterState was produced before collectPrefetchHints ran, so
-  // inlining hints (ParentInlinedIntoSelf, InlinedIntoChild) won't be in
-  // route[4] yet. On subsequent renders the hints are already in the
-  // FlightRouterState, so the union is idempotent.
-  //
-  // Strip InliningHintsStale — it's a transient flag set on the initial
-  // build-time FlightRouterState and must never appear in /_tree responses.
-  // If it leaked through, the client would re-fetch the tree in an infinite
-  // loop.
-  const prefetchHints =
-    ((route[4] ?? 0) & ~PrefetchHint.InliningHintsStale) |
-    (hintTree !== null ? hintTree.hints : 0)
-
-  // Determine which params this segment varies on.
-  // Read the vary params thenable directly from the seed data. By the time
-  // collectSegmentData runs, the thenable should be fulfilled. If it's not
-  // fulfilled or null, treat as unknown (null means we can't share cache
-  // entries across param values).
-  const varyParamsThenable = seedData !== null ? seedData[4] : null
-  const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
-
-  if (!prefetchInlining) {
-    // When prefetch inlining is disabled, spawn individual segment tasks.
-    // When enabled, segment data is bundled into the /_inlined response
-    // instead, so we skip per-segment tasks here.
-    if (seedData !== null) {
-      // Spawn a task to write the segment data to a new Flight stream.
-      segmentTasks.push(
-        // Since we're already in the middle of a render, wait until after the
-        // current task to escape the current rendering context.
-        waitAtLeastOneReactRenderTask().then(() =>
-          renderSegmentPrefetch(
-            buildId,
-            staleTime,
-            seedData[0],
-            requestKey,
-            varyParams,
-            clientModules
-          )
-        )
-      )
-    } else {
-      // This segment does not have any seed data. Skip generating a prefetch
-      // response for it. We'll still include it in the route tree, though.
-      // TODO: We should encode in the route tree whether a segment is missing
-      // so we don't attempt to fetch it for no reason. As of now this shouldn't
-      // ever happen in practice, though.
-    }
   }
 
   const segment = route[0]
@@ -891,27 +934,54 @@ async function renderSegmentPrefetch(
   rsc: React.ReactNode,
   requestKey: SegmentRequestKey,
   varyParams: Set<string> | null,
-  clientModules: ManifestNode
+  clientModules: ManifestNode,
+  bundle: SegmentBundleNode | null
 ): Promise<[SegmentRequestKey, Buffer]> {
-  // Render the segment data to a stream.
-  const segmentPrefetch: SegmentPrefetch = {
+  // Build the SegmentPrefetch for the terminal (requested) segment.
+  // The terminal always has non-null rsc data — disabled segments are
+  // skipped by the caller and don't reach this function.
+  const selfPrefetch: SegmentPrefetch = {
     rsc,
     isPartial: await isPartialRSCData(rsc, clientModules),
     staleTime,
     varyParams,
   }
-  // Wrap in a SegmentPrefetchResponse with a top-level buildId.
-  // For non-bundled responses, the data array has a single element.
-  const response: SegmentPrefetchResponse = {
+
+  // Build the data array. Always an array, even for a single segment.
+  const data: Array<SegmentPrefetch | null> = [selfPrefetch]
+  if (bundle !== null) {
+    // Walk the bundle linked list and append each entry to the array.
+    let node: SegmentBundleNode | null = bundle
+    while (node !== null) {
+      if (node.rsc !== null) {
+        data.push({
+          rsc: node.rsc,
+          isPartial: await isPartialRSCData(node.rsc, clientModules),
+          staleTime,
+          varyParams: node.varyParams,
+        })
+      } else {
+        // This segment has static prefetching disabled (runtime prefetch
+        // or instant = false). Emit null as a placeholder so the array
+        // indices stay aligned with the client's SegmentBundle linked
+        // list. The client will skip creating a cache entry for this slot.
+        data.push(null)
+      }
+      node = node.next
+    }
+  }
+
+  // Wrap in the response envelope with the build ID at the top level.
+  const payload: SegmentPrefetchResponse = {
     buildId: buildId ?? '',
-    data: [segmentPrefetch],
+    data,
   }
   // Since all we're doing is decoding and re-encoding a cached prerender, if
   // it takes longer than a microtask, it must because of hanging promises
   // caused by dynamic data. Abort the stream at the end of the current task.
   const abortController = new AbortController()
   waitAtLeastOneReactRenderTask().then(() => abortController.abort())
-  const { prelude: segmentStream } = await prerender(response, clientModules, {
+  const { prelude: segmentStream } = await prerender(payload, clientModules, {
     filterStackFrame,
     signal: abortController.signal,
     onError: onSegmentPrerenderError,
@@ -922,94 +992,6 @@ async function renderSegmentPrefetch(
   } else {
     return [requestKey, segmentBuffer]
   }
-}
-
-async function renderInlinedPrefetchResponse(
-  route: FlightRouterState,
-  buildId: string | undefined,
-  staleTime: number,
-  seedData: CacheNodeSeedData | null,
-  head: HeadData,
-  headVaryParams: Set<string> | null,
-  clientModules: ManifestNode
-): Promise<[SegmentRequestKey, Buffer]> {
-  // Build the inlined tree by walking the route and collecting all segments.
-  const inlinedTree = await buildInlinedSegmentPrefetch(
-    route,
-    buildId,
-    staleTime,
-    seedData,
-    clientModules
-  )
-
-  // Build the head segment.
-  const headPrefetch: SegmentPrefetch = {
-    rsc: head,
-    isPartial: await isPartialRSCData(head, clientModules),
-    staleTime,
-    varyParams: headVaryParams,
-  }
-
-  const response: InlinedPrefetchResponse = {
-    buildId: buildId ?? '',
-    tree: inlinedTree,
-    head: headPrefetch,
-  }
-
-  // Render as a single Flight response.
-  const abortController = new AbortController()
-  waitAtLeastOneReactRenderTask().then(() => abortController.abort())
-  const { prelude } = await prerender(response, clientModules, {
-    filterStackFrame,
-    signal: abortController.signal,
-    onError: onSegmentPrerenderError,
-  })
-  const buffer = await streamToBuffer(prelude)
-  return [('/' + PAGE_SEGMENT_KEY) as SegmentRequestKey, buffer]
-}
-
-async function buildInlinedSegmentPrefetch(
-  route: FlightRouterState,
-  buildId: string | undefined,
-  staleTime: number,
-  seedData: CacheNodeSeedData | null,
-  clientModules: ManifestNode
-): Promise<InlinedSegmentPrefetch> {
-  let slots: {
-    [parallelRouteKey: string]: InlinedSegmentPrefetch
-  } | null = null
-
-  const children = route[1]
-  const seedDataChildren = seedData !== null ? seedData[1] : null
-  for (const parallelRouteKey in children) {
-    const childRoute = children[parallelRouteKey]
-    const childSeedData =
-      seedDataChildren !== null ? seedDataChildren[parallelRouteKey] : null
-    const childPrefetch = await buildInlinedSegmentPrefetch(
-      childRoute,
-      buildId,
-      staleTime,
-      childSeedData,
-      clientModules
-    )
-    if (slots === null) {
-      slots = {}
-    }
-    slots[parallelRouteKey] = childPrefetch
-  }
-
-  const rsc = seedData !== null ? seedData[0] : null
-  const varyParamsThenable = seedData !== null ? seedData[4] : null
-  const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
-
-  const segment: SegmentPrefetch = {
-    rsc,
-    isPartial: rsc !== null ? await isPartialRSCData(rsc, clientModules) : true,
-    staleTime,
-    varyParams,
-  }
-  return { segment, slots }
 }
 
 async function isPartialRSCData(

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/page.tsx
@@ -55,6 +55,16 @@ export default function Page() {
             Runtime parallel
           </LinkAccordion>
         </li>
+        <li>
+          <LinkAccordion href="/test-independent-head/a">
+            Independent head A
+          </LinkAccordion>
+        </li>
+        <li>
+          <LinkAccordion href="/test-independent-head/b">
+            Independent head B
+          </LinkAccordion>
+        </li>
       </ul>
     </div>
   )

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-deep/a/b/c/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-deep/a/b/c/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>Deep page</p>
+  return <p id="page-deep">Deep page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-dynamic/[slug]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-dynamic/[slug]/page.tsx
@@ -4,7 +4,7 @@ export default async function Page({
   params: Promise<{ slug: string }>
 }) {
   const { slug } = await params
-  return <p>Dynamic page: {slug}</p>
+  return <p id="page-dynamic">{`Dynamic page: ${slug}`}</p>
 }
 
 export function generateStaticParams() {

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/[item]/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/[item]/layout.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react'
+
+// This layout does NOT access the [item] param. Its rendered output is
+// identical for /test-independent-head/a and /test-independent-head/b,
+// so the segment cache can reuse it across both routes.
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <div>
+      <p id="item-layout">Item layout</p>
+      {children}
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/[item]/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/[item]/page.tsx
@@ -1,0 +1,38 @@
+import { LinkAccordion } from '../../../components/link-accordion'
+
+// The page segment itself is fully static — it doesn't access searchParams
+// or cookies. Only the metadata accesses searchParams (making the head
+// depend on runtime data) and the [item] param (so it differs per route).
+// The page segment content is the same for all param values.
+export async function generateStaticParams() {
+  return [{ item: 'a' }, { item: 'b' }]
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ item: string }>
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { item } = await params
+  const { q } = await searchParams
+  return { title: `Independent Head Title: ${item}${q ? ` (q=${q})` : ''}` }
+}
+
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ item: string }>
+}) {
+  const { item } = await params
+  const sibling = item === 'a' ? 'b' : 'a'
+  return (
+    <div>
+      <p id="page-independent-head">Independent head page</p>
+      <LinkAccordion href={`/test-independent-head/${sibling}`}>
+        Go to {sibling}
+      </LinkAccordion>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-independent-head/layout.tsx
@@ -1,0 +1,36 @@
+import { ReactNode, Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+// This layout uses runtime prefetching and sits ABOVE the [item] param.
+// It's shared between /test-independent-head/a and /test-independent-head/b.
+// Once cached from the first prefetch, a subsequent prefetch to a sibling
+// page won't need a runtime request for this layout — it's already cached.
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [
+    {
+      cookies: [{ name: 'theme', value: 'default' }],
+      searchParams: { q: null },
+      params: { item: 'a' },
+    },
+  ],
+}
+
+async function LayoutContent({ children }: { children: ReactNode }) {
+  const cookieStore = await cookies()
+  const theme = cookieStore.get('theme')?.value ?? 'default'
+  return (
+    <div>
+      <p id="layout-independent-head">Shared layout (theme: {theme})</p>
+      {children}
+    </div>
+  )
+}
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <Suspense fallback={<p>Loading layout...</p>}>
+      <LayoutContent>{children}</LayoutContent>
+    </Suspense>
+  )
+}

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-outlined/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-outlined/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>Outlined test page</p>
+  return <p id="page-outlined">Outlined test page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-parallel/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-parallel/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>Main content</p>
+  return <p id="page-parallel">Main content</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-restart/large-middle/after/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-restart/large-middle/after/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p>After page</p>
+  return <p id="page-restart">After page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/inner/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-runtime-parallel/inner/page.tsx
@@ -1,3 +1,3 @@
 export default function Page() {
-  return <p id="page-runtime-parallel">Main content</p>
+  return <p id="page-runtime-parallel">Runtime parallel main content</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-small-chain/page.tsx
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/app/test-small-chain/page.tsx
@@ -1,3 +1,3 @@
 export default function SmallChainPage() {
-  return <p>Small chain page</p>
+  return <p id="page-small-chain">Small chain page</p>
 }

--- a/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
+++ b/test/e2e/app-dir/segment-cache/prefetch-inlining/prefetch-inlining.test.ts
@@ -164,6 +164,32 @@ describe('prefetch inlining', () => {
      outlined ■      └── "__PAGE__" (+metadata)
      "
     `)
+
+    // Verify client navigation works with the inlined data.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-small-chain"]')
+          .click()
+      },
+      { includes: 'Small chain page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-small-chain"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-small-chain').text()).toBe(
+      'Small chain page'
+    )
   })
 
   it('outlined: large segment breaks the inlining chain', async () => {
@@ -180,6 +206,31 @@ describe('prefetch inlining', () => {
      outlined ■      └── "__PAGE__" (+metadata)
      "
     `)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-outlined"]')
+          .click()
+      },
+      { includes: 'Outlined test page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-outlined"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-outlined').text()).toBe(
+      'Outlined test page'
+    )
   })
 
   it('parallel routes: parent inlines into one slot only', async () => {
@@ -214,6 +265,31 @@ describe('prefetch inlining', () => {
        "
       `)
     }
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-parallel"]')
+          .click()
+      },
+      { includes: 'Main content' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-parallel"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-parallel').text()).toBe(
+      'Main content'
+    )
   })
 
   it('home: root inlines directly into page', async () => {
@@ -247,6 +323,35 @@ describe('prefetch inlining', () => {
      outlined ■              └── "__PAGE__" (+metadata)
      "
     `)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss(
+            'input[data-link-accordion="/test-restart/large-middle/after"]'
+          )
+          .click()
+      },
+      { includes: 'After page' }
+    )
+
+    await act(async () => {
+      await browser
+        .elementByCss('a[href="/test-restart/large-middle/after"]')
+        .click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-restart').text()).toBe(
+      'After page'
+    )
   })
 
   it('deep chain: all small segments inline to the leaf', async () => {
@@ -263,6 +368,29 @@ describe('prefetch inlining', () => {
      outlined ■                  └── "__PAGE__" (+metadata)
      "
     `)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-deep/a/b/c"]')
+          .click()
+      },
+      { includes: 'Deep page' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-deep/a/b/c"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-deep').text()).toBe('Deep page')
   })
 
   it('dynamic route: hints are based on concrete params, not fallback shell', async () => {
@@ -288,6 +416,31 @@ describe('prefetch inlining', () => {
     // pattern, not concrete path)
     const data2 = await fetchRouteTreePrefetch(next, '/test-dynamic/world')
     expect(renderInliningTree(data2.tree)).toBe(helloTree)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-dynamic/hello"]')
+          .click()
+      },
+      { includes: 'Dynamic page: hello' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-dynamic/hello"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-dynamic').text()).toBe(
+      'Dynamic page: hello'
+    )
   })
 
   // TODO: Add a test for stale hints (InliningHintsStale). The stale hints
@@ -351,6 +504,34 @@ describe('prefetch inlining', () => {
       runtime ◻      └── "__PAGE__" (+metadata)
      "
     `)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-runtime-bailout"]')
+          .click()
+      },
+      { includes: 'Static layout content' }
+    )
+
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-runtime-bailout"]').click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#layout-runtime-bailout').text()).toBe(
+      'Static layout content'
+    )
+    expect(await browser.elementByCss('#page-runtime-bailout').text()).toMatch(
+      /Runtime page/
+    )
   })
 
   it('runtime passthrough: static parents inline through runtime layout to static child', async () => {
@@ -371,6 +552,40 @@ describe('prefetch inlining', () => {
      outlined ■          └── "__PAGE__"
      "
     `)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-link-accordion="/test-runtime-passthrough/inner"]'
+        )
+        .click()
+    }, [
+      { includes: 'Static page below runtime layout' },
+      // Appears twice: once in the static bundle and once in the
+      // runtime prefetch. Static segments below a runtime layout are
+      // not skipped — they participate in inlining normally because
+      // sub-navigations within the runtime layout may need them. The
+      // inlining thresholds ensure the duplication is worth the cost.
+      { includes: 'Static page below runtime layout' },
+    ])
+
+    await act(async () => {
+      await browser
+        .elementByCss('a[href="/test-runtime-passthrough/inner"]')
+        .click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-runtime-passthrough').text()).toBe(
+      'Static page below runtime layout'
+    )
   })
 
   it('instant false passthrough: static parents inline through dynamic layout to static child', async () => {
@@ -390,6 +605,31 @@ describe('prefetch inlining', () => {
      outlined ■          └── "__PAGE__" (+metadata)
      "
     `)
+
+    // Verify the dynamic layout's content is NOT included in any prefetch
+    // response. The layout has instant = false, so its data should be
+    // skipped entirely — fetched only during navigation.
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-link-accordion="/test-instant-false-passthrough/inner"]'
+        )
+        .click()
+    }, [
+      // The static page below the dynamic layout IS prefetched.
+      { includes: 'page-instant-false-passthrough' },
+      // The dynamic layout content must NOT appear in any prefetch
+      // response — it has instant = false, so it's skipped entirely.
+      { includes: 'Dynamic layout', block: 'reject' },
+    ])
   })
 
   it('runtime parallel: pass-through only flows into one child slot', async () => {
@@ -411,5 +651,111 @@ describe('prefetch inlining', () => {
      outlined ■      └── @sidebar/"__DEFAULT__"
      "
     `)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    await act(async () => {
+      await browser
+        .elementByCss(
+          'input[data-link-accordion="/test-runtime-parallel/inner"]'
+        )
+        .click()
+    }, [
+      { includes: 'Runtime parallel main content' },
+      // Appears twice: static bundle + runtime prefetch. Same as
+      // runtime passthrough — static segments below a runtime layout
+      // participate in inlining normally.
+      { includes: 'Runtime parallel main content' },
+    ])
+
+    await act(async () => {
+      await browser
+        .elementByCss('a[href="/test-runtime-parallel/inner"]')
+        .click()
+    }, 'no-requests')
+
+    expect(await browser.elementByCss('#page-runtime-parallel').text()).toBe(
+      'Runtime parallel main content'
+    )
+  })
+
+  it('independent head: metadata is prefetched even when no runtime segment request is needed', async () => {
+    // The layout at /test-independent-head/[item] uses runtime prefetching
+    // (reads cookies). The pages underneath it are static. The metadata
+    // (head) accesses both the [item] param and searchParams, making it
+    // depend on runtime data.
+    //
+    // When we prefetch route A, the runtime layout and head are fetched
+    // together. When we then prefetch sibling route B, the layout is
+    // already cached — no runtime segment request is needed. But the
+    // head is different (it includes the [item] param in the title) and
+    // must still be fetched via a runtime prefetch. This test verifies
+    // that the head is fetched independently even when no runtime segment
+    // request is spawned for the sibling.
+    const data = await fetchRouteTreePrefetch(next, '/test-independent-head/a')
+    expect(renderInliningTree(data.tree)).toMatchInlineSnapshot(`
+     "
+              ⇣  root
+      runtime ◻  └── "test-independent-head" (+metadata)
+              ⇣      └── "item"
+     outlined ■          └── "__PAGE__"
+     "
+    `)
+
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page!)
+
+    // Prefetch and navigate to route A. This caches the runtime layout,
+    // head, and static page, and makes A the current page.
+    await act(async () => {
+      await browser
+        .elementByCss('input[data-link-accordion="/test-independent-head/a"]')
+        .click()
+    })
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-independent-head/a"]').click()
+    }, 'no-requests')
+
+    // Now we're on route A. Reveal the sibling link to route B. The
+    // runtime layout is shared between A and B, so it's already cached
+    // and won't be re-fetched. The only new segment is the [item] page,
+    // which is static. But the head differs (title includes "Item: b")
+    // and depends on runtime data, so it must still be fetched via a
+    // runtime prefetch even though no other runtime request is needed.
+    await act(
+      async () => {
+        await browser
+          .elementByCss('input[data-link-accordion="/test-independent-head/b"]')
+          .click()
+      },
+      { includes: 'Independent Head Title: b' }
+    )
+
+    // Navigate to route B. The page segment is unnecessarily marked as
+    // partial because the metadata outlet in the page's RSC data
+    // contains an unresolved reference to the dynamic metadata. This
+    // causes navigation to re-fetch the page even though the actual
+    // page content is fully static.
+    // TODO: The page segment should not be considered partial just
+    // because the metadata is dynamic. Once this is fixed, this
+    // navigation should not require any network requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/test-independent-head/b"]').click()
+    })
+
+    expect(await browser.elementByCss('#page-independent-head').text()).toBe(
+      'Independent head page'
+    )
   })
 })


### PR DESCRIPTION
**Previous (merged):**

1. https://github.com/vercel/next.js/pull/91320
2. https://github.com/vercel/next.js/pull/91438

**Current:**

3. https://github.com/vercel/next.js/pull/91439

---

This is the final step in the segment bundling system. The first commit ensured correctness when inlining hints are stale or unavailable. The second taught the build-time hint computation to identify which segments can be omitted and how parent data flows through disabled segments to static descendants. This commit makes the server and client act on those decisions: small static segments are combined into a single prefetch response rather than fetched individually.

This step is inherently larger than the previous ones. We moved as much complexity as possible into the earlier commits — the hint bits, the pass-through logic, the metadata assignment, the safety invariants — but the server output changes and the client scheduling changes need to land together to keep behavior coherent.

### Unified response model

The brute-force inlining path that previously existed is removed. Both the old per-segment behavior and the brute-force "inline everything" mode are now modeled in terms of the size-based system:

- **Per-segment (flag off):** each segment's response contains only its own data. This is the behavior when `prefetchInlining` is not enabled, or when a segment exceeds the size threshold.
- **Size-based (flag on):** setting `prefetchInlining: true` uses default thresholds (2KB per-segment, 10KB total budget). Segments below the threshold are bundled into their children's responses. Segments above it get standalone responses.
- **Brute-force (infinite thresholds):** setting the thresholds to infinity means every segment is bundled into a single response for the entire route. The size-based heuristics should make this unnecessary.

There is no separate code path for any of these modes. The same server and client logic handles all three — the only difference is the hint bits computed at build time.

### Metadata bundling

The metadata (head/viewport) is bundled into the response of whichever segment is responsible for it, avoiding a separate metadata fetch in most cases.

On routes with runtime prefetch, the first runtime segment is responsible — its response already includes the metadata. On purely static routes, the first page terminal with budget room gets the metadata. If no terminal has room, the metadata is fetched separately.

### Independent metadata prefetching

When navigating between sibling routes under a shared runtime layout, the layout is already cached and no runtime segment request is needed. But the metadata (head) may differ between siblings. This commit ensures the metadata is always prefetched independently via a runtime request when `SubtreeHasRuntimePrefetch` is set on the route tree, even when no runtime segments need fetching.

### Skipping unnecessary static output

Segments with `instant = false` or runtime prefetch enabled don't benefit from static prefetch responses. Now the server skips generating static output for these segments entirely, reducing build output size. The client also skips creating cache entries for them. They still participate in the bundle chain as null placeholders — parent data flows through them to static descendants — but no actual data is produced or fetched.

This skipping is NOT gated by the `prefetchInlining` feature flag. The hints that drive it (`HasRuntimePrefetch`, `PrefetchDisabled`) are computed at build time and embedded in the route tree regardless of bundling.

### Test plan

The prefetch-inlining test suite covers: basic inlining chains, large segments that break chains, deep chains, parallel routes, dynamic routes with concrete params, runtime prefetch boundaries (both leaf and pass-through), `instant = false` segments, stale hint recovery, metadata assignment, the `instant = false` at root fallback, independent metadata prefetching for routes with runtime data in the head, and runtime parallel slot pass-through. Each test verifies both the hint computation (via snapshot assertions) and the actual navigation behavior (prefetch via link accordion, then navigate to confirm data was prefetched).