### PR TITLE
fix : assetPrefix detection when document.currentScript is null

### DIFF
--- a/packages/next/src/client/asset-prefix.ts
+++ b/packages/next/src/client/asset-prefix.ts
@@ -1,7 +1,14 @@
 import { InvariantError } from '../shared/lib/invariant-error'
 
 export function getAssetPrefix() {
-  const currentScript = document.currentScript
+  let currentScript = document.currentScript
+
+  if (!(currentScript instanceof HTMLScriptElement)) {
+    const scripts = document.querySelectorAll<HTMLScriptElement>(
+      'script[src*="/_next/"]'
+    )
+    currentScript = scripts.length > 0 ? scripts[scripts.length - 1] : null
+  }
 
   if (!(currentScript instanceof HTMLScriptElement)) {
     throw new InvariantError(


### PR DESCRIPTION
### What?

- Fix asset prefix detection when document.currentScript is null in the browser.

### Why?

- Turbopack apps failed to hydrate on Pale Moon because getAssetPrefix threw when document.currentScript was null.

### How?

- Fallback to the last <script> whose src contains /_next/ when document.currentScript is not an HTMLScriptElement, keeping existing invariant checks and asset prefix parsing.


fix : #91448
