### PR TITLE
Fix DataUriSource description to include "data:" prefix

### DIFF
--- a/turbopack/crates/turbopack-core/src/data_uri_source.rs
+++ b/turbopack/crates/turbopack-core/src/data_uri_source.rs
@@ -42,11 +42,15 @@ impl DataUriSource {
 impl Source for DataUriSource {
     #[turbo_tasks::function]
     async fn description(&self) -> Result<Vc<RcStr>> {
+        let media_type = &self.media_type;
+        let encoding = &self.encoding;
         let data = self.data.await?;
-        // Include a short prefix of the raw data for identification; data URIs
-        // can be very long so we cap it at 50 characters.
-        let prefix: String = data.chars().take(50).collect();
-        let ellipsis = if data.len() > 50 { "..." } else { "" };
+        // Build the data URI prefix for identification; data URIs can be very
+        // long so we cap the total display at 50 characters.
+        let sep = if encoding.is_empty() { "" } else { ";" };
+        let full_with_data = format!("data:{media_type}{sep}{encoding},{data}");
+        let prefix: String = full_with_data.chars().take(50).collect();
+        let ellipsis = if full_with_data.len() > 50 { "..." } else { "" };
         Ok(Vc::cell(
             format!("data URI content ({prefix}{ellipsis})").into(),
         ))


### PR DESCRIPTION
### What?

Fix the `description()` method of `DataUriSource` in Turbopack to include the full `data:` URI prefix in the display string.

**Before:** `data URI content (svg+xml;charset=utf8,...)`
**After:** `data URI content (data:svg+xml;charset=utf8,...)`

### Why?

The previous implementation only included the raw data content starting from the media type, omitting the `data:` scheme prefix. This made the description string look malformed and not recognizable as a data URI — especially in error messages where this description is shown to developers.

The fix reconstructs the proper data URI format (`data:<media_type>[;<encoding>],<data>`) before truncating it to 50 characters, so the displayed prefix is a valid (partial) data URI that developers can recognize and understand.

### How?

In `turbopack/crates/turbopack-core/src/data_uri_source.rs`, the `description()` function now builds the full data URI string first (`data:{media_type}{sep}{encoding},{data}`), then takes the first 50 characters of that. This ensures the `data:` scheme prefix is always present in the truncated display.

Closes NEXT-