### PR TITLE
turbo-tasks-backend: batch schedule dirty tasks in aggregation_update

### DIFF
--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -24,7 +24,8 @@ use tracing::span::Span;
 ))]
 use tracing::trace_span;
 use turbo_tasks::{
-    FxIndexMap, TaskExecutionReason, TaskId, backend::CachedTaskType, event::EventDescription,
+    FxIndexMap, TaskExecutionReason, TaskId, TaskPriority, backend::CachedTaskType,
+    event::EventDescription,
 };
 
 #[cfg(feature = "trace_task_dirty")]
@@ -857,6 +858,8 @@ pub struct AggregationUpdateQueue {
     balance_queue: FxRingSet<BalanceJob>,
     #[bincode(with = "turbo_bincode::ringset")]
     optimize_queue: FxRingSet<OptimizeJob>,
+    #[bincode(skip, default = "Vec::new")]
+    scheduled_tasks: Vec<(TaskId, TaskPriority)>,
 }
 
 impl AggregationUpdateQueue {
@@ -869,6 +872,7 @@ impl AggregationUpdateQueue {
             find_and_schedule: FxRingSet::default(),
             balance_queue: FxRingSet::default(),
             optimize_queue: FxRingSet::default(),
+            scheduled_tasks: Vec::new(),
         }
     }
 
@@ -881,12 +885,14 @@ impl AggregationUpdateQueue {
             balance_queue,
             optimize_queue,
             done_aggregation_number_updates: _,
+            scheduled_tasks,
         } = self;
         jobs.is_empty()
             && aggregation_number_updates.is_empty()
             && find_and_schedule.is_empty()
             && balance_queue.is_empty()
             && optimize_queue.is_empty()
+            && scheduled_tasks.is_empty()
     }
 
     /// Pushes a job to the queue.
@@ -978,6 +984,23 @@ impl AggregationUpdateQueue {
         let mut queue = Self::new();
         queue.push(job);
         queue.execute(ctx);
+    }
+
+    /// Drains `scheduled_tasks` and schedules them all at once using a batched task fetch.
+    fn batch_schedule(&mut self, ctx: &mut impl ExecuteContext<'_>) {
+        if self.scheduled_tasks.is_empty() {
+            return;
+        }
+        let scheduled_tasks = take(&mut self.scheduled_tasks);
+        let priority_map: FxHashMap<TaskId, TaskPriority> =
+            scheduled_tasks.iter().copied().collect();
+        ctx.for_each_task_all(
+            scheduled_tasks.into_iter().map(|(id, _)| id),
+            |task, ctx| {
+                let parent_priority = priority_map[&task.id()];
+                ctx.schedule_task(task, parent_priority);
+            },
+        );
     }
 
     /// Executes a single step of the queue. Returns true, when the queue is empty.
@@ -1255,6 +1278,7 @@ impl AggregationUpdateQueue {
             }
             false
         } else {
+            self.batch_schedule(ctx);
             true
         }
     }
@@ -1478,7 +1502,7 @@ impl AggregationUpdateQueue {
             let description = EventDescription::new(|| task.get_task_desc_fn());
             if task.add_scheduled(reason, description) {
                 drop(task);
-                ctx.schedule(task_id, parent_priority);
+                self.scheduled_tasks.push((task_id, parent_priority));
             }
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -1260,14 +1260,14 @@ impl AggregationUpdateQueue {
                 }
             }
             false
+        } else if !self.scheduled_tasks.is_empty() {
+            ctx.for_each_task_all(self.scheduled_tasks.keys().copied(), |task, ctx| {
+                let parent_priority = self.scheduled_tasks[&task.id()];
+                ctx.schedule_task(task, parent_priority);
+            });
+            self.scheduled_tasks.clear();
+            false
         } else {
-            if !self.scheduled_tasks.is_empty() {
-                ctx.for_each_task_all(self.scheduled_tasks.keys().copied(), |task, ctx| {
-                    let parent_priority = self.scheduled_tasks[&task.id()];
-                    ctx.schedule_task(task, parent_priority);
-                });
-                self.scheduled_tasks.clear();
-            }
             true
         }
     }

--- a/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
+++ b/turbopack/crates/turbo-tasks-backend/src/backend/operation/aggregation_update.rs
@@ -858,8 +858,8 @@ pub struct AggregationUpdateQueue {
     balance_queue: FxRingSet<BalanceJob>,
     #[bincode(with = "turbo_bincode::ringset")]
     optimize_queue: FxRingSet<OptimizeJob>,
-    #[bincode(skip, default = "Vec::new")]
-    scheduled_tasks: Vec<(TaskId, TaskPriority)>,
+    #[bincode(skip, default = "FxHashMap::default")]
+    scheduled_tasks: FxHashMap<TaskId, TaskPriority>,
 }
 
 impl AggregationUpdateQueue {
@@ -872,7 +872,7 @@ impl AggregationUpdateQueue {
             find_and_schedule: FxRingSet::default(),
             balance_queue: FxRingSet::default(),
             optimize_queue: FxRingSet::default(),
-            scheduled_tasks: Vec::new(),
+            scheduled_tasks: FxHashMap::default(),
         }
     }
 
@@ -984,23 +984,6 @@ impl AggregationUpdateQueue {
         let mut queue = Self::new();
         queue.push(job);
         queue.execute(ctx);
-    }
-
-    /// Drains `scheduled_tasks` and schedules them all at once using a batched task fetch.
-    fn batch_schedule(&mut self, ctx: &mut impl ExecuteContext<'_>) {
-        if self.scheduled_tasks.is_empty() {
-            return;
-        }
-        let scheduled_tasks = take(&mut self.scheduled_tasks);
-        let priority_map: FxHashMap<TaskId, TaskPriority> =
-            scheduled_tasks.iter().copied().collect();
-        ctx.for_each_task_all(
-            scheduled_tasks.into_iter().map(|(id, _)| id),
-            |task, ctx| {
-                let parent_priority = priority_map[&task.id()];
-                ctx.schedule_task(task, parent_priority);
-            },
-        );
     }
 
     /// Executes a single step of the queue. Returns true, when the queue is empty.
@@ -1278,7 +1261,13 @@ impl AggregationUpdateQueue {
             }
             false
         } else {
-            self.batch_schedule(ctx);
+            if !self.scheduled_tasks.is_empty() {
+                ctx.for_each_task_all(self.scheduled_tasks.keys().copied(), |task, ctx| {
+                    let parent_priority = self.scheduled_tasks[&task.id()];
+                    ctx.schedule_task(task, parent_priority);
+                });
+                self.scheduled_tasks.clear();
+            }
             true
         }
     }
@@ -1502,7 +1491,7 @@ impl AggregationUpdateQueue {
             let description = EventDescription::new(|| task.get_task_desc_fn());
             if task.add_scheduled(reason, description) {
                 drop(task);
-                self.scheduled_tasks.push((task_id, parent_priority));
+                self.scheduled_tasks.insert(task_id, parent_priority);
             }
         }
     }


### PR DESCRIPTION
### What?

Batch the scheduling of dirty tasks during aggregation update processing instead of scheduling them one at a time.

In `aggregation_update.rs`, `find_and_schedule_dirty_internal` previously called `ctx.schedule()` immediately for each task it decided to schedule. This involved a separate `ctx.task(id, TaskDataCategory::All)` call per task to read `leaf_distance` and `has_output` before calling `turbo_tasks.schedule(id, priority)`.

### Why?

Each individual `ctx.task(...)` call may require restoring task data from persistent storage (disk I/O). When many tasks need scheduling — e.g. during a large invalidation wave, or initially when all session-dependent tasks are scheduled — doing this one-at-a-time is inefficient.

`for_each_task_all` (via `prepare_tasks_with_callback`) can batch the restoration of persistent task data, amortizing I/O overhead across all tasks in the batch.

### How?

- Added a `scheduled_tasks: FxHashMap<TaskId, TaskPriority>` field to `AggregationUpdateQueue` (skipped in bincode serialization — transient state that doesn't survive suspend/resume).
- `find_and_schedule_dirty_internal` now inserts `(task_id, parent_priority)` into `scheduled_tasks` instead of calling `ctx.schedule()` directly.
- At the end of `process()` (in the final `else` branch, when all sub-queues are exhausted), if `scheduled_tasks` is non-empty, `ctx.for_each_task_all` is called to batch-fetch the tasks and schedule them, then `scheduled_tasks` is cleared. This maximizes batch size by deferring all scheduling to the end of the operation.
- `scheduled_tasks` is included in `is_empty()` (with exhaustive struct destructuring) so the compiler enforces the check stays up to date.