### PR TITLE
[turbopack] update qfilter to 0.3.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5663,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "qfilter"
-version = "0.2.4"
+version = "0.3.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1f7df258517b16d2677d20c0e8f660f1f7d9677076c64b564e7a3b3de8b08fb"
+checksum = "6bd0ea20afc2eab082dde00f58d9e83ed70dcb693fa88c23890e122e19355635"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/turbopack/crates/turbo-persistence/Cargo.toml
+++ b/turbopack/crates/turbo-persistence/Cargo.toml
@@ -26,7 +26,7 @@ memmap2 = "0.9.5"
 nohash-hasher = { workspace = true }
 parking_lot = { workspace = true }
 pot = "3.0.0"
-qfilter = { version = "0.2.4", features = ["serde"] }
+qfilter = { version = "0.3.0-alpha.2", features = ["serde"] }
 quick_cache = { workspace = true }
 rustc-hash = { workspace = true }
 smallvec = { workspace = true }


### PR DESCRIPTION
## What?

Update the `qfilter` crate to an alpha version.

## Why?

Performance improvements in the quotient filter implementation used by turbo-persistence for SST file lookups.

## Benchmark Results

Benchmarks run on Apple Silicon (M-series), comparing `canary` baseline vs this branch. Focused on qfilter-sensitive paths: the filter itself, SST lookups, uncompacted multi-commit DB reads, and writes.

### qfilter microbenchmarks (direct filter operations)

| Benchmark | canary | branch | change |
|---|---|---|---|
| **Lookup (hit)** | | | |
| 1Ki entries | 22.10 ns | 14.63 ns | **-33.8%** |
| 10Ki entries | 22.21 ns | 15.41 ns | **-30.6%** |
| 100Ki entries | 24.96 ns | 17.47 ns | **-30.0%** |
| 1000Ki entries | 25.05 ns | 16.61 ns | **-33.7%** |
| **Lookup (miss)** | | | |
| 1Ki entries | 12.09 ns | 9.19 ns | **-24.0%** |
| 10Ki entries | 14.24 ns | 11.07 ns | **-22.3%** |
| 100Ki entries | 18.13 ns | 13.72 ns | **-24.3%** |
| 1000Ki entries | 13.36 ns | 10.00 ns | **-25.2%** |
| **Insert (build filter)** | | | |
| 1Ki entries | 8.54 us | 9.64 us | +12.9% |
| 10Ki entries | 118.16 us | 120.97 us | +2.4% |
| 100Ki entries | 3.18 ms | 2.57 ms | **-19.2%** |
| 1000Ki entries | 20.88 ms | 18.31 ms | **-12.3%** |

**Summary:** Lookups 22-34% faster across all sizes. Insert is slightly slower at small sizes but 12-19% faster at larger sizes where it matters most.

### SST file lookup (filter + block read)

| Benchmark | canary | branch | change |
|---|---|---|---|
| **Hit (uncached)** | | | |
| 1Ki entries | 2.52 us | 2.52 us | ~0% |
| 10Ki entries | 3.60 us | 3.52 us | -2.2% |
| 100Ki entries | 3.77 us | 3.72 us | -1.3% |
| 1000Ki entries | 6.65 us | 6.55 us | -1.5% |
| **Miss (cached)** | | | |
| 1Ki entries | 124.50 ns | 121.13 ns | -2.7% |
| 10Ki entries | 168.18 ns | 161.96 ns | **-3.7%** |
| 100Ki entries | 195.97 ns | 189.80 ns | **-3.1%** |
| 1000Ki entries | 249.85 ns | 235.68 ns | **-5.7%** |

**Summary:** Small but consistent improvements across SST lookups. Miss/cached shows the clearest gains (filter is the primary code path for rejecting misses).

### DB-level reads (20 commits, uncompacted -- amplifies filter cost)

| Benchmark | canary | branch | change |
|---|---|---|---|
| **10.67Mi entries** | | | |
| hit/uncached | 3.49 us | 3.13 us | **-10.3%** |
| hit/cached | 1.65 us | 1.49 us | **-9.7%** |
| miss/uncached | 899.75 ns | 746.28 ns | **-17.1%** |
| miss/cached | 793.51 ns | 668.92 ns | **-15.7%** |
| **85.33Mi entries** | | | |
| hit/uncached | 11.24 us | 10.64 us | ~0% (noisy) |
| hit/cached | 4.53 us | 4.10 us | **-9.5%** |
| miss/uncached | 5.01 us | 4.36 us | **-13.0%** |
| miss/cached | 4.81 us | 4.02 us | **-16.4%** |

**Summary:** 10-17% faster reads on uncompacted DBs with many SSTs. Miss paths benefit most since the filter rejects without I/O.

### Write path (includes filter construction)

| Benchmark | canary | branch | change |
|---|---|---|---|
| 85.33Ki entries | 24.91 ms | 23.42 ms | -6.0% |
| 853.33Ki entries | 140.63 ms | 131.84 ms | **-6.3%** |
| 8.33Mi entries | 1.14 s | 1.07 s | **-6.1%** |

**Summary:** ~6% faster writes across all sizes.

## How?

Updated the `qfilter` dependency to a new alpha version with improved lookup and insert performance.
