### PR TITLE
[turbopack] Optimize compaction cpu usage

### DIFF
--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -9,8 +9,10 @@ use std::{
 
 use memmap2::Mmap;
 
-use crate::shared_bytes::SharedBytes;
-
+use crate::{
+    compression::decompress_into_arc,
+    shared_bytes::{SharedBytes, is_subslice_of},
+};
 /// The backing storage for an `ArcBytes`.
 ///
 /// The inner values are never read directly — they exist solely to keep the
@@ -91,11 +93,17 @@ impl Read for ArcBytes {
     }
 }
 
-use crate::shared_bytes::is_subslice_of;
-
 impl ArcBytes {
-    /// Returns a new `ArcBytes` that points to a sub-range of the current slice.
-    pub fn slice(self, range: Range<usize>) -> ArcBytes {
+    /// Returns `true` if this `ArcBytes` is backed by a memory-mapped file.
+    pub fn is_mmap_backed(&self) -> bool {
+        matches!(self.backing, Backing::Mmap { .. })
+    }
+}
+
+impl SharedBytes for ArcBytes {
+    type MmapHandle = Arc<Mmap>;
+
+    fn slice(self, range: Range<usize>) -> Self {
         let data = &*self;
         let data = &data[range] as *const [u8];
         Self {
@@ -104,14 +112,7 @@ impl ArcBytes {
         }
     }
 
-    /// Creates a sub-slice from a slice reference that points into this ArcBytes' backing data.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `subslice` points to memory within this ArcBytes'
-    /// backing storage (not just within the current slice view, but anywhere in the original
-    /// backing data).
-    pub unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> ArcBytes {
+    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self {
         debug_assert!(
             is_subslice_of(
                 subslice,
@@ -128,45 +129,21 @@ impl ArcBytes {
         }
     }
 
-    /// Creates an `ArcBytes` backed by a memory-mapped file.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `subslice` points to memory within the given `mmap`.
-    pub unsafe fn from_mmap(mmap: Arc<Mmap>, subslice: &[u8]) -> ArcBytes {
+    unsafe fn from_mmap(mmap: &Arc<Mmap>, subslice: &[u8]) -> Self {
         debug_assert!(
-            is_subslice_of(subslice, &mmap),
+            is_subslice_of(subslice, mmap),
             "from_mmap: subslice is not within the mmap"
         );
         ArcBytes {
             data: subslice as *const [u8],
-            backing: Backing::Mmap { _backing: mmap },
+            backing: Backing::Mmap {
+                _backing: mmap.clone(),
+            },
         }
     }
 
-    /// Returns `true` if this `ArcBytes` is backed by a memory-mapped file.
-    pub fn is_mmap_backed(&self) -> bool {
-        matches!(self.backing, Backing::Mmap { .. })
-    }
-}
-
-impl SharedBytes for ArcBytes {
-    type MmapHandle = Arc<Mmap>;
-
-    fn slice(self, range: Range<usize>) -> Self {
-        self.slice(range)
-    }
-
-    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self {
-        unsafe { self.slice_from_subslice(subslice) }
-    }
-
-    unsafe fn from_mmap(mmap: &Arc<Mmap>, subslice: &[u8]) -> Self {
-        unsafe { ArcBytes::from_mmap(mmap.clone(), subslice) }
-    }
-
     fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self> {
-        Ok(ArcBytes::from(crate::compression::decompress_into_arc(
+        Ok(ArcBytes::from(decompress_into_arc(
             uncompressed_length,
             block,
         )?))

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -2,7 +2,6 @@ use std::{
     borrow::Borrow,
     fmt::{self, Debug, Formatter},
     hash::{Hash, Hasher},
-    io::{self, Read},
     ops::{Deref, Range},
     sync::Arc,
 };
@@ -82,16 +81,16 @@ impl Debug for ArcBytes {
 
 impl Eq for ArcBytes {}
 
-impl Read for ArcBytes {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let available = &**self;
-        let len = std::cmp::min(buf.len(), available.len());
-        buf[..len].copy_from_slice(&available[..len]);
-        // Advance the slice view
-        self.data = &available[len..] as *const [u8];
-        Ok(len)
-    }
-}
+// impl Read for ArcBytes {
+//     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+//         let available = &**self;
+//         let len = std::cmp::min(buf.len(), available.len());
+//         buf[..len].copy_from_slice(&available[..len]);
+//         // Advance the slice view
+//         self.data = &available[len..] as *const [u8];
+//         Ok(len)
+//     }
+// }
 
 impl ArcBytes {
     /// Returns `true` if this `ArcBytes` is backed by a memory-mapped file.

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -91,12 +91,7 @@ impl Read for ArcBytes {
     }
 }
 
-/// Returns `true` if `subslice` lies entirely within `backing`.
-fn is_subslice_of(subslice: &[u8], backing: &[u8]) -> bool {
-    let backing = backing.as_ptr_range();
-    let sub = subslice.as_ptr_range();
-    sub.start >= backing.start && sub.end <= backing.end
-}
+use crate::shared_bytes::is_subslice_of;
 
 impl ArcBytes {
     /// Returns a new `ArcBytes` that points to a sub-range of the current slice.

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -9,6 +9,8 @@ use std::{
 
 use memmap2::Mmap;
 
+use crate::shared_bytes::SharedBytes;
+
 /// The backing storage for an `ArcBytes`.
 ///
 /// The inner values are never read directly — they exist solely to keep the
@@ -150,5 +152,28 @@ impl ArcBytes {
     /// Returns `true` if this `ArcBytes` is backed by a memory-mapped file.
     pub fn is_mmap_backed(&self) -> bool {
         matches!(self.backing, Backing::Mmap { .. })
+    }
+}
+
+impl SharedBytes for ArcBytes {
+    type MmapHandle = Arc<Mmap>;
+
+    fn slice(self, range: Range<usize>) -> Self {
+        self.slice(range)
+    }
+
+    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self {
+        unsafe { self.slice_from_subslice(subslice) }
+    }
+
+    unsafe fn from_mmap(mmap: &Arc<Mmap>, subslice: &[u8]) -> Self {
+        unsafe { ArcBytes::from_mmap(mmap.clone(), subslice) }
+    }
+
+    fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self> {
+        Ok(ArcBytes::from(crate::compression::decompress_into_arc(
+            uncompressed_length,
+            block,
+        )?))
     }
 }

--- a/turbopack/crates/turbo-persistence/src/arc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/arc_bytes.rs
@@ -81,17 +81,6 @@ impl Debug for ArcBytes {
 
 impl Eq for ArcBytes {}
 
-// impl Read for ArcBytes {
-//     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-//         let available = &**self;
-//         let len = std::cmp::min(buf.len(), available.len());
-//         buf[..len].copy_from_slice(&available[..len]);
-//         // Advance the slice view
-//         self.data = &available[len..] as *const [u8];
-//         Ok(len)
-//     }
-// }
-
 impl ArcBytes {
     /// Returns `true` if this `ArcBytes` is backed by a memory-mapped file.
     pub fn is_mmap_backed(&self) -> bool {

--- a/turbopack/crates/turbo-persistence/src/be.rs
+++ b/turbopack/crates/turbo-persistence/src/be.rs
@@ -16,9 +16,7 @@ pub fn read_u16(s: &[u8]) -> u16 {
 
 #[inline(always)]
 pub fn read_u24(s: &[u8]) -> u32 {
-    let &[a, b, c, ..] = s else {
-        panic!("slice too short for u24")
-    };
+    let &[a, b, c] = s.first_chunk().unwrap();
     u32::from_be_bytes([0, a, b, c])
 }
 

--- a/turbopack/crates/turbo-persistence/src/be.rs
+++ b/turbopack/crates/turbo-persistence/src/be.rs
@@ -1,0 +1,33 @@
+//! Big-endian integer parsing helpers.
+//!
+//! Each function reads a fixed-width big-endian integer from the prefix of
+//! a byte slice. Panics if the slice is too short (single bounds check via
+//! `first_chunk`).
+
+#[inline(always)]
+pub fn read_u8(s: &[u8]) -> u8 {
+    s[0]
+}
+
+#[inline(always)]
+pub fn read_u16(s: &[u8]) -> u16 {
+    u16::from_be_bytes(*s.first_chunk().unwrap())
+}
+
+#[inline(always)]
+pub fn read_u24(s: &[u8]) -> u32 {
+    let &[a, b, c, ..] = s else {
+        panic!("slice too short for u24")
+    };
+    u32::from_be_bytes([0, a, b, c])
+}
+
+#[inline(always)]
+pub fn read_u32(s: &[u8]) -> u32 {
+    u32::from_be_bytes(*s.first_chunk().unwrap())
+}
+
+#[inline(always)]
+pub fn read_u64(s: &[u8]) -> u64 {
+    u64::from_be_bytes(*s.first_chunk().unwrap())
+}

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -1,7 +1,23 @@
-use std::{mem::MaybeUninit, sync::Arc};
+use std::{mem::MaybeUninit, rc::Rc, sync::Arc};
 
 use anyhow::{Context, Result};
 use lzzzz::lz4::{self, decompress};
+
+/// Decompresses `block` into `dest`, verifying the output length matches `expected_len`.
+fn decompress_block(block: &[u8], dest: &mut [u8], expected_len: u32) -> Result<()> {
+    let bytes_written = decompress(block, dest).with_context(|| {
+        format!(
+            "Failed to decompress block ({} bytes compressed, {} bytes uncompressed)",
+            block.len(),
+            expected_len
+        )
+    })?;
+    assert_eq!(
+        bytes_written, expected_len as usize,
+        "Decompressed length does not match expected length"
+    );
+    Ok(())
+}
 
 /// Decompresses a block into an Arc allocation.
 ///
@@ -15,23 +31,31 @@ pub fn decompress_into_arc(uncompressed_length: u32, block: &[u8]) -> Result<Arc
     );
 
     // Allocate directly into an Arc to avoid a copy. The buffer is uninitialized;
-    // decompression will overwrite it completely (verified by the assert below).
+    // decompression will overwrite it completely (verified by decompress_block).
     let buffer: Arc<[MaybeUninit<u8>]> = Arc::new_uninit_slice(uncompressed_length as usize);
-    // Safety: decompression will fully initialize the buffer we verify with an assert
+    // Safety: decompression will fully initialize the buffer (verified by the assert in
+    // decompress_block).
     let mut buffer = unsafe { buffer.assume_init() };
     // We just created this Arc so refcount is 1; get_mut always succeeds.
-    let decompressed = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
-    let bytes_written = decompress(block, decompressed).with_context(|| {
-        format!(
-            "Failed to decompress block ({} bytes compressed, {} bytes uncompressed)",
-            block.len(),
-            uncompressed_length
-        )
-    })?;
-    assert_eq!(
-        bytes_written, uncompressed_length as usize,
-        "Decompressed length does not match expected length"
+    let dest = Arc::get_mut(&mut buffer).expect("Arc refcount should be 1");
+    decompress_block(block, dest, uncompressed_length)?;
+    Ok(buffer)
+}
+
+/// Like [`decompress_into_arc`] but returns an `Rc<[u8]>` for thread-local use.
+pub fn decompress_into_rc(uncompressed_length: u32, block: &[u8]) -> Result<Rc<[u8]>> {
+    debug_assert!(
+        uncompressed_length > 0,
+        "decompress_into_rc called with uncompressed_length=0; uncompressed blocks should use \
+         zero-copy mmap path"
     );
+
+    let buffer: Rc<[MaybeUninit<u8>]> = Rc::new_uninit_slice(uncompressed_length as usize);
+    // Safety: decompression will fully initialize the buffer (verified by the assert in
+    // decompress_block).
+    let mut buffer = unsafe { buffer.assume_init() };
+    let dest = Rc::get_mut(&mut buffer).expect("Rc refcount should be 1");
+    decompress_block(block, dest, uncompressed_length)?;
     Ok(buffer)
 }
 

--- a/turbopack/crates/turbo-persistence/src/compression.rs
+++ b/turbopack/crates/turbo-persistence/src/compression.rs
@@ -5,6 +5,11 @@ use lzzzz::lz4::{self, decompress};
 
 /// Decompresses `block` into `dest`, verifying the output length matches `expected_len`.
 fn decompress_block(block: &[u8], dest: &mut [u8], expected_len: u32) -> Result<()> {
+    debug_assert!(
+        expected_len > 0,
+        "decompress_block called with uncompressed_length=0; uncompressed blocks should use \
+         zero-copy mmap path"
+    );
     let bytes_written = decompress(block, dest).with_context(|| {
         format!(
             "Failed to decompress block ({} bytes compressed, {} bytes uncompressed)",
@@ -24,12 +29,6 @@ fn decompress_block(block: &[u8], dest: &mut [u8], expected_len: u32) -> Result<
 /// The caller must ensure `uncompressed_length > 0` (i.e., the block is actually compressed).
 /// Uncompressed blocks should be handled via zero-copy mmap slices before calling this.
 pub fn decompress_into_arc(uncompressed_length: u32, block: &[u8]) -> Result<Arc<[u8]>> {
-    debug_assert!(
-        uncompressed_length > 0,
-        "decompress_into_arc called with uncompressed_length=0; uncompressed blocks should use \
-         zero-copy mmap path"
-    );
-
     // Allocate directly into an Arc to avoid a copy. The buffer is uninitialized;
     // decompression will overwrite it completely (verified by decompress_block).
     let buffer: Arc<[MaybeUninit<u8>]> = Arc::new_uninit_slice(uncompressed_length as usize);
@@ -44,12 +43,6 @@ pub fn decompress_into_arc(uncompressed_length: u32, block: &[u8]) -> Result<Arc
 
 /// Like [`decompress_into_arc`] but returns an `Rc<[u8]>` for thread-local use.
 pub fn decompress_into_rc(uncompressed_length: u32, block: &[u8]) -> Result<Rc<[u8]>> {
-    debug_assert!(
-        uncompressed_length > 0,
-        "decompress_into_rc called with uncompressed_length=0; uncompressed blocks should use \
-         zero-copy mmap path"
-    );
-
     let buffer: Rc<[MaybeUninit<u8>]> = Rc::new_uninit_slice(uncompressed_length as usize);
     // Safety: decompression will fully initialize the buffer (verified by the assert in
     // decompress_block).

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -37,7 +37,7 @@ use crate::{
     mmap_helper::advise_mmap_for_persistence,
     parallel_scheduler::ParallelScheduler,
     sst_filter::SstFilter,
-    static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFile},
+    static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFileIter},
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, StreamingSstWriter},
     write_batch::{FinishResult, WriteBatch},
 };
@@ -1075,11 +1075,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     let meta_index = ssts_with_ranges[index].meta_index;
                                     let index_in_meta = ssts_with_ranges[index].index_in_meta;
                                     let entry = meta_files[meta_index].entry(index_in_meta);
-                                    StaticSortedFile::open_for_compaction(
-                                        path,
-                                        entry.sst_metadata(),
-                                    )?
-                                    .try_into_iter()
+                                    StaticSortedFileIter::open(path, entry.sst_metadata())
                                 })
                                 .collect::<Result<Vec<_>>>()?;
 

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -30,7 +30,7 @@ use crate::{
         MAX_ENTRIES_PER_COMPACTED_FILE, VALUE_BLOCK_AVG_SIZE, VALUE_BLOCK_CACHE_SIZE,
     },
     key::{StoreKey, hash_key},
-    lookup_entry::{LazyLookupValue, LookupEntry, LookupValue},
+    lookup_entry::{IterValue, LookupEntry, LookupValue},
     merge_iter::MergeIter,
     meta_file::{MetaEntryFlags, MetaFile, MetaLookupResult, StaticSortedFileRange},
     meta_file_builder::MetaFileBuilder,
@@ -1188,7 +1188,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             }
                             let mut used_collector = Collector::new(MetaEntryFlags::WARM);
                             let mut unused_collector = Collector::new(MetaEntryFlags::COLD);
-                            let mut current_key: Option<ArcBytes> = None;
+                            let mut current_key: Option<crate::rc_bytes::RcBytes> = None;
                             let mut keys_written = 0;
 
                             // MergeIter yields entries from newer SSTs first (by SST sequence
@@ -1220,10 +1220,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                         FamilyKind::MultiValue => {
                                             // For MultiValue families we only skip remaining if we
                                             // see a tombstone
-                                            if matches!(
-                                                entry.value,
-                                                LazyLookupValue::Eager(LookupValue::Deleted)
-                                            ) {
+                                            if matches!(entry.value, IterValue::Deleted) {
                                                 skip_remaining_for_this_key = true;
                                             }
                                         }
@@ -1243,10 +1240,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                                     // Entry is being dropped (superseded by newer entry or
                                     // pruned by tombstone). If it references a blob file,
                                     // mark that blob for deletion.
-                                    if let LazyLookupValue::Eager(LookupValue::Blob {
-                                        sequence_number,
-                                    }) = &entry.value
-                                    {
+                                    if let IterValue::Blob { sequence_number } = &entry.value {
                                         blob_seq_numbers_to_delete.push(*sequence_number);
                                     }
                                 }

--- a/turbopack/crates/turbo-persistence/src/db.rs
+++ b/turbopack/crates/turbo-persistence/src/db.rs
@@ -36,6 +36,7 @@ use crate::{
     meta_file_builder::MetaFileBuilder,
     mmap_helper::advise_mmap_for_persistence,
     parallel_scheduler::ParallelScheduler,
+    rc_bytes::RcBytes,
     sst_filter::SstFilter,
     static_sorted_file::{BlockCache, SstLookupResult, StaticSortedFileIter},
     static_sorted_file_builder::{StaticSortedFileBuilderMeta, StreamingSstWriter},
@@ -1184,7 +1185,7 @@ impl<S: ParallelScheduler, const FAMILIES: usize> TurboPersistence<S, FAMILIES> 
                             }
                             let mut used_collector = Collector::new(MetaEntryFlags::WARM);
                             let mut unused_collector = Collector::new(MetaEntryFlags::COLD);
-                            let mut current_key: Option<crate::rc_bytes::RcBytes> = None;
+                            let mut current_key: Option<RcBytes> = None;
                             let mut keys_written = 0;
 
                             // MergeIter yields entries from newer SSTs first (by SST sequence

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -16,6 +16,7 @@ pub mod meta_file;
 mod meta_file_builder;
 pub mod mmap_helper;
 mod parallel_scheduler;
+mod rc_bytes;
 mod sst_filter;
 pub mod static_sorted_file;
 mod static_sorted_file_builder;

--- a/turbopack/crates/turbo-persistence/src/lib.rs
+++ b/turbopack/crates/turbo-persistence/src/lib.rs
@@ -3,6 +3,7 @@
 #![feature(iter_collect_into)]
 
 mod arc_bytes;
+pub(crate) mod be;
 mod collector;
 mod collector_entry;
 mod compaction;
@@ -17,6 +18,7 @@ mod meta_file_builder;
 pub mod mmap_helper;
 mod parallel_scheduler;
 mod rc_bytes;
+mod shared_bytes;
 mod sst_filter;
 pub mod static_sorted_file;
 mod static_sorted_file_builder;

--- a/turbopack/crates/turbo-persistence/src/lookup_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/lookup_entry.rs
@@ -5,15 +5,17 @@ use crate::{
     static_sorted_file_builder::{Entry, EntryValue},
 };
 
-/// A value from a SST file lookup (lookup path, uses ArcBytes).
+/// A value from a SST file. Generic over the byte representation, defaulting to
+/// `ArcBytes` for the lookup path. The compaction/iteration path uses
+/// `LookupValue<RcBytes>` which is convertible to `IterValue`.
 #[derive(PartialEq)]
-pub enum LookupValue {
+pub enum LookupValue<B = ArcBytes> {
     /// The value was deleted.
     Deleted,
     /// The value is stored in the SST file.
     ///
-    /// The ArcBytes will be pointing either at a keyblock or a value block in the SST
-    Slice { value: ArcBytes },
+    /// The bytes will be pointing either at a keyblock or a value block in the SST
+    Slice { value: B },
     /// The value is stored in a blob file.
     Blob { sequence_number: u32 },
 }
@@ -34,7 +36,15 @@ pub enum IterValue {
         block: RcBytes,
     },
 }
-
+impl From<LookupValue<RcBytes>> for IterValue {
+    fn from(v: LookupValue<RcBytes>) -> Self {
+        match v {
+            LookupValue::Deleted => IterValue::Deleted,
+            LookupValue::Slice { value } => IterValue::Slice { value },
+            LookupValue::Blob { sequence_number } => IterValue::Blob { sequence_number },
+        }
+    }
+}
 /// An entry from SST file iteration (compaction path, uses RcBytes).
 pub struct LookupEntry {
     /// The hash of the key.

--- a/turbopack/crates/turbo-persistence/src/lookup_entry.rs
+++ b/turbopack/crates/turbo-persistence/src/lookup_entry.rs
@@ -1,10 +1,11 @@
 use crate::{
     ArcBytes,
     constants::{MAX_INLINE_VALUE_SIZE, MAX_SMALL_VALUE_SIZE},
+    rc_bytes::RcBytes,
     static_sorted_file_builder::{Entry, EntryValue},
 };
 
-/// A value from a SST file lookup.
+/// A value from a SST file lookup (lookup path, uses ArcBytes).
 #[derive(PartialEq)]
 pub enum LookupValue {
     /// The value was deleted.
@@ -17,73 +18,31 @@ pub enum LookupValue {
     Blob { sequence_number: u32 },
 }
 
-/// A value from a SST file lookup.
-pub enum LazyLookupValue {
-    /// A LookupValue
-    Eager(LookupValue),
+/// A value from SST file iteration (compaction path, uses RcBytes for
+/// non-atomic refcounting).
+pub enum IterValue {
+    /// The value was deleted.
+    Deleted,
+    /// The value is stored in the SST file.
+    Slice { value: RcBytes },
+    /// The value is stored in a blob file.
+    Blob { sequence_number: u32 },
     /// A medium sized value that is still compressed.
     Medium {
         uncompressed_size: u32,
         checksum: u32,
-        block: ArcBytes,
+        block: RcBytes,
     },
 }
 
-impl LazyLookupValue {
-    /// Returns the size of the value in the SST file.
-    pub fn uncompressed_size_in_sst(&self) -> usize {
-        match self {
-            LazyLookupValue::Eager(LookupValue::Slice { value }) => value.len(),
-            LazyLookupValue::Eager(LookupValue::Deleted) => 0,
-            LazyLookupValue::Eager(LookupValue::Blob { .. }) => 0,
-            LazyLookupValue::Medium {
-                uncompressed_size,
-                block,
-                ..
-            } => {
-                if *uncompressed_size == 0 {
-                    block.len()
-                } else {
-                    *uncompressed_size as usize
-                }
-            }
-        }
-    }
-
-    /// Returns true if this value gets its own dedicated value block.
-    pub fn is_medium_value(&self) -> bool {
-        match self {
-            LazyLookupValue::Eager(LookupValue::Slice { value })
-                if value.len() > MAX_SMALL_VALUE_SIZE =>
-            {
-                true
-            }
-            LazyLookupValue::Medium { .. } => true,
-            _ => false,
-        }
-    }
-
-    /// Returns the value size if it will be packed into a small value block, or 0 otherwise.
-    pub fn small_value_size(&self) -> usize {
-        match self {
-            LazyLookupValue::Eager(LookupValue::Slice { value })
-                if value.len() > MAX_INLINE_VALUE_SIZE && value.len() <= MAX_SMALL_VALUE_SIZE =>
-            {
-                value.len()
-            }
-            _ => 0,
-        }
-    }
-}
-
-/// An entry from a SST file lookup.
+/// An entry from SST file iteration (compaction path, uses RcBytes).
 pub struct LookupEntry {
     /// The hash of the key.
     pub hash: u64,
     /// The key.
-    pub key: ArcBytes,
+    pub key: RcBytes,
     /// The value.
-    pub value: LazyLookupValue,
+    pub value: IterValue,
 }
 
 impl Entry for LookupEntry {
@@ -101,8 +60,8 @@ impl Entry for LookupEntry {
 
     fn value(&self) -> EntryValue<'_> {
         match &self.value {
-            LazyLookupValue::Eager(LookupValue::Deleted) => EntryValue::Deleted,
-            LazyLookupValue::Eager(LookupValue::Slice { value }) => {
+            IterValue::Deleted => EntryValue::Deleted,
+            IterValue::Slice { value } => {
                 if value.len() <= MAX_INLINE_VALUE_SIZE {
                     EntryValue::Inline { value }
                 } else if value.len() > MAX_SMALL_VALUE_SIZE {
@@ -111,10 +70,10 @@ impl Entry for LookupEntry {
                     EntryValue::Small { value }
                 }
             }
-            LazyLookupValue::Eager(LookupValue::Blob { sequence_number }) => EntryValue::Large {
+            IterValue::Blob { sequence_number } => EntryValue::Large {
                 blob: *sequence_number,
             },
-            LazyLookupValue::Medium {
+            IterValue::Medium {
                 uncompressed_size,
                 checksum,
                 block,

--- a/turbopack/crates/turbo-persistence/src/merge_iter.rs
+++ b/turbopack/crates/turbo-persistence/src/merge_iter.rs
@@ -15,10 +15,11 @@ struct ActiveIterator<T: Iterator<Item = Result<LookupEntry>>> {
     entry: LookupEntry,
 }
 
-/// A heap node that keeps the hash inline alongside a boxed `ActiveIterator`. During sift-down
-/// the heap compares nodes ~14 times (log2(128) levels × 2 children); by hoisting the hash out
-/// of the Box we avoid a pointer chase on every comparison. Only when hashes collide (extremely
-/// rare with u64) do we dereference the Box to compare keys.
+/// A heap node that keeps the hash inline alongside a boxed `ActiveIterator`. By hoisting the hash
+/// out of the Box we avoid a pointer chase on every comparison when the heap is re-ordered Only
+/// when hashes collide (extremely rare with u64) do we dereference the Box to compare keys.
+/// Note: we cannot use [Prehashed] because we need an non-trivial `Ord` implementation for the heap
+/// (see below)
 struct HeapNode<T: Iterator<Item = Result<LookupEntry>>> {
     /// Cached copy of the current entry's hash, kept in sync with `inner.entry.hash`.
     hash: u64,

--- a/turbopack/crates/turbo-persistence/src/merge_iter.rs
+++ b/turbopack/crates/turbo-persistence/src/merge_iter.rs
@@ -1,4 +1,7 @@
-use std::{cmp::Ordering, collections::BinaryHeap};
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, binary_heap::PeekMut},
+};
 
 use anyhow::Result;
 
@@ -6,45 +9,51 @@ use crate::lookup_entry::LookupEntry;
 
 /// An active iterator that is being merged. It has peeked the next element and can be compared
 /// according to that element. The `order` is used when multiple iterators have the same key.
-///
-/// Boxed so that BinaryHeap sift operations only move a pointer (8 bytes) instead of the full
-/// struct (~312 bytes for StaticSortedFileIter), which is significant with 128 iterators.
 struct ActiveIterator<T: Iterator<Item = Result<LookupEntry>>> {
     iter: T,
     order: usize,
     entry: LookupEntry,
 }
 
-impl<T: Iterator<Item = Result<LookupEntry>>> PartialEq for Box<ActiveIterator<T>> {
+/// A heap node that keeps the hash inline alongside a boxed `ActiveIterator`. During sift-down
+/// the heap compares nodes ~14 times (log2(128) levels × 2 children); by hoisting the hash out
+/// of the Box we avoid a pointer chase on every comparison. Only when hashes collide (extremely
+/// rare with u64) do we dereference the Box to compare keys.
+struct HeapNode<T: Iterator<Item = Result<LookupEntry>>> {
+    /// Cached copy of the current entry's hash, kept in sync with `inner.entry.hash`.
+    hash: u64,
+    inner: Box<ActiveIterator<T>>,
+}
+
+impl<T: Iterator<Item = Result<LookupEntry>>> PartialEq for HeapNode<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.entry.hash == other.entry.hash && *self.entry.key == *other.entry.key
+        self.hash == other.hash && *self.inner.entry.key == *other.inner.entry.key
     }
 }
 
-impl<T: Iterator<Item = Result<LookupEntry>>> Eq for Box<ActiveIterator<T>> {}
+impl<T: Iterator<Item = Result<LookupEntry>>> Eq for HeapNode<T> {}
 
-impl<T: Iterator<Item = Result<LookupEntry>>> PartialOrd for Box<ActiveIterator<T>> {
+impl<T: Iterator<Item = Result<LookupEntry>>> PartialOrd for HeapNode<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<T: Iterator<Item = Result<LookupEntry>>> Ord for Box<ActiveIterator<T>> {
+impl<T: Iterator<Item = Result<LookupEntry>>> Ord for HeapNode<T> {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.entry
-            .hash
-            .cmp(&other.entry.hash)
-            .then_with(|| (*self.entry.key).cmp(&other.entry.key))
+        self.hash
+            .cmp(&other.hash)
+            .then_with(|| (*self.inner.entry.key).cmp(&other.inner.entry.key))
             // Reverse order comparison to yield newest-first
-            .then_with(|| other.order.cmp(&self.order))
+            .then_with(|| other.inner.order.cmp(&self.inner.order))
             .reverse()
     }
 }
 
 /// An iterator that merges multiple sorted iterators into a single sorted iterator. Internally it
-/// uses an heap of iterators to iterate them in order.
+/// uses a heap of iterators to iterate them in order.
 pub struct MergeIter<T: Iterator<Item = Result<LookupEntry>>> {
-    heap: BinaryHeap<Box<ActiveIterator<T>>>,
+    heap: BinaryHeap<HeapNode<T>>,
 }
 
 impl<T: Iterator<Item = Result<LookupEntry>>> MergeIter<T> {
@@ -53,7 +62,11 @@ impl<T: Iterator<Item = Result<LookupEntry>>> MergeIter<T> {
         for (order, mut iter) in iters.enumerate() {
             if let Some(entry) = iter.next() {
                 let entry = entry?;
-                heap.push(Box::new(ActiveIterator { iter, order, entry }));
+                let hash = entry.hash;
+                heap.push(HeapNode {
+                    hash,
+                    inner: Box::new(ActiveIterator { iter, order, entry }),
+                });
             }
         }
         Ok(Self { heap })
@@ -64,13 +77,25 @@ impl<T: Iterator<Item = Result<LookupEntry>>> Iterator for MergeIter<T> {
     type Item = Result<LookupEntry>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let mut active = self.heap.pop()?;
-        let entry = match active.iter.next() {
-            None => return Some(Ok(active.entry)),
-            Some(Err(e)) => return Some(Err(e)),
-            Some(Ok(next)) => std::mem::replace(&mut active.entry, next),
-        };
-        self.heap.push(active);
-        Some(Ok(entry))
+        let mut peek = self.heap.peek_mut()?;
+        let node = &mut *peek;
+        match node.inner.iter.next() {
+            None => {
+                // This iterator is exhausted, drop it and return the last entry
+                let node = PeekMut::pop(peek);
+                Some(Ok(node.inner.entry))
+            }
+            Some(Err(e)) => {
+                PeekMut::pop(peek);
+                Some(Err(e))
+            }
+            Some(Ok(next)) => {
+                let entry = std::mem::replace(&mut node.inner.entry, next);
+                // Update the cached hash before dropping the PeekMut (which triggers sift-down)
+                node.hash = node.inner.entry.hash;
+                drop(peek);
+                Some(Ok(entry))
+            }
+        }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/mmap_helper.rs
+++ b/turbopack/crates/turbo-persistence/src/mmap_helper.rs
@@ -1,5 +1,3 @@
-use anyhow::Context;
-
 /// Apply Linux-specific mmap advice flags that should be set on all persistent mmaps.
 ///
 /// - `DontFork`: prevents mmap regions from being copied into child processes on `fork()`, avoiding
@@ -8,6 +6,7 @@ use anyhow::Context;
 ///   compressed content that won't benefit from deduplication scanning.
 #[cfg(target_os = "linux")]
 pub fn advise_mmap_for_persistence(mmap: &memmap2::Mmap) -> anyhow::Result<()> {
+    use anyhow::Context;
     mmap.advise(memmap2::Advice::DontFork)
         .context("Failed to advise mmap DontFork")?;
     mmap.advise(memmap2::Advice::Unmergeable)

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -7,6 +7,8 @@ use std::{
 
 use memmap2::Mmap;
 
+use crate::shared_bytes::SharedBytes;
+
 /// The backing storage for an `RcBytes`.
 ///
 /// Uses `Rc` for all refcounting, eliminating atomic operations.
@@ -127,5 +129,28 @@ impl RcBytes {
                 _backing: mmap.clone(),
             },
         }
+    }
+}
+
+impl SharedBytes for RcBytes {
+    type MmapHandle = Rc<Mmap>;
+
+    fn slice(self, range: Range<usize>) -> Self {
+        self.slice(range)
+    }
+
+    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self {
+        unsafe { self.slice_from_subslice(subslice) }
+    }
+
+    unsafe fn from_mmap(mmap: &Rc<Mmap>, subslice: &[u8]) -> Self {
+        unsafe { RcBytes::from_mmap(mmap, subslice) }
+    }
+
+    fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self> {
+        Ok(RcBytes::from(crate::compression::decompress_into_rc(
+            uncompressed_length,
+            block,
+        )?))
     }
 }

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -72,12 +72,7 @@ impl Debug for RcBytes {
 
 impl Eq for RcBytes {}
 
-/// Returns `true` if `subslice` lies entirely within `backing`.
-fn is_subslice_of(subslice: &[u8], backing: &[u8]) -> bool {
-    let backing = backing.as_ptr_range();
-    let sub = subslice.as_ptr_range();
-    sub.start >= backing.start && sub.end <= backing.end
-}
+use crate::shared_bytes::is_subslice_of;
 
 impl RcBytes {
     /// Returns a new `RcBytes` that points to a sub-range of the current slice.

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -3,27 +3,17 @@ use std::{
     fmt::{self, Debug, Formatter},
     ops::{Deref, Range},
     rc::Rc,
-    sync::Arc,
 };
 
 use memmap2::Mmap;
 
 /// The backing storage for an `RcBytes`.
 ///
-/// Uses `Rc` for all refcounting, eliminating atomic operations. The mmap
-/// variant wraps `Arc<Mmap>` in an `Rc` so that cloning the backing only
-/// bumps the `Rc` counter (one plain integer increment), not the `Arc`
-/// counter.
+/// Uses `Rc` for all refcounting, eliminating atomic operations.
 #[derive(Clone)]
 enum Backing {
-    Rc {
-        _backing: Rc<[u8]>,
-    },
-    /// The `Arc<Mmap>` is cloned once when the `Rc` is first created; all
-    /// subsequent `Backing::clone()` calls only increment the outer `Rc`.
-    Mmap {
-        _backing: Rc<Arc<Mmap>>,
-    },
+    Rc { _backing: Rc<[u8]> },
+    Mmap { _backing: Rc<Mmap> },
 }
 
 /// An owned byte slice backed by either an `Rc<[u8]>` or a memory-mapped file.
@@ -123,13 +113,10 @@ impl RcBytes {
 
     /// Creates an `RcBytes` backed by a memory-mapped file.
     ///
-    /// The `Arc<Mmap>` is wrapped in an `Rc` so that subsequent clone/drop
-    /// operations are non-atomic.
-    ///
     /// # Safety
     ///
     /// The caller must ensure that `subslice` points to memory within the given `mmap`.
-    pub unsafe fn from_mmap(mmap: &Rc<Arc<Mmap>>, subslice: &[u8]) -> RcBytes {
+    pub unsafe fn from_mmap(mmap: &Rc<Mmap>, subslice: &[u8]) -> RcBytes {
         debug_assert!(
             is_subslice_of(subslice, mmap),
             "from_mmap: subslice is not within the mmap"

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -7,7 +7,10 @@ use std::{
 
 use memmap2::Mmap;
 
-use crate::shared_bytes::SharedBytes;
+use crate::{
+    compression::decompress_into_rc,
+    shared_bytes::{SharedBytes, is_subslice_of},
+};
 
 /// The backing storage for an `RcBytes`.
 ///
@@ -72,11 +75,10 @@ impl Debug for RcBytes {
 
 impl Eq for RcBytes {}
 
-use crate::shared_bytes::is_subslice_of;
+impl SharedBytes for RcBytes {
+    type MmapHandle = Rc<Mmap>;
 
-impl RcBytes {
-    /// Returns a new `RcBytes` that points to a sub-range of the current slice.
-    pub fn slice(self, range: Range<usize>) -> RcBytes {
+    fn slice(self, range: Range<usize>) -> Self {
         let data = &*self;
         let data = &data[range] as *const [u8];
         Self {
@@ -85,13 +87,7 @@ impl RcBytes {
         }
     }
 
-    /// Creates a sub-slice from a slice reference that points into this RcBytes' backing data.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `subslice` points to memory within this RcBytes'
-    /// backing storage.
-    pub unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> RcBytes {
+    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self {
         debug_assert!(
             is_subslice_of(
                 subslice,
@@ -108,12 +104,7 @@ impl RcBytes {
         }
     }
 
-    /// Creates an `RcBytes` backed by a memory-mapped file.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `subslice` points to memory within the given `mmap`.
-    pub unsafe fn from_mmap(mmap: &Rc<Mmap>, subslice: &[u8]) -> RcBytes {
+    unsafe fn from_mmap(mmap: &Rc<Mmap>, subslice: &[u8]) -> Self {
         debug_assert!(
             is_subslice_of(subslice, mmap),
             "from_mmap: subslice is not within the mmap"
@@ -125,25 +116,9 @@ impl RcBytes {
             },
         }
     }
-}
-
-impl SharedBytes for RcBytes {
-    type MmapHandle = Rc<Mmap>;
-
-    fn slice(self, range: Range<usize>) -> Self {
-        self.slice(range)
-    }
-
-    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self {
-        unsafe { self.slice_from_subslice(subslice) }
-    }
-
-    unsafe fn from_mmap(mmap: &Rc<Mmap>, subslice: &[u8]) -> Self {
-        unsafe { RcBytes::from_mmap(mmap, subslice) }
-    }
 
     fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self> {
-        Ok(RcBytes::from(crate::compression::decompress_into_rc(
+        Ok(RcBytes::from(decompress_into_rc(
             uncompressed_length,
             block,
         )?))

--- a/turbopack/crates/turbo-persistence/src/rc_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/rc_bytes.rs
@@ -1,0 +1,144 @@
+use std::{
+    borrow::Borrow,
+    fmt::{self, Debug, Formatter},
+    ops::{Deref, Range},
+    rc::Rc,
+    sync::Arc,
+};
+
+use memmap2::Mmap;
+
+/// The backing storage for an `RcBytes`.
+///
+/// Uses `Rc` for all refcounting, eliminating atomic operations. The mmap
+/// variant wraps `Arc<Mmap>` in an `Rc` so that cloning the backing only
+/// bumps the `Rc` counter (one plain integer increment), not the `Arc`
+/// counter.
+#[derive(Clone)]
+enum Backing {
+    Rc {
+        _backing: Rc<[u8]>,
+    },
+    /// The `Arc<Mmap>` is cloned once when the `Rc` is first created; all
+    /// subsequent `Backing::clone()` calls only increment the outer `Rc`.
+    Mmap {
+        _backing: Rc<Arc<Mmap>>,
+    },
+}
+
+/// An owned byte slice backed by either an `Rc<[u8]>` or a memory-mapped file.
+///
+/// Identical to `ArcBytes` but uses `Rc` instead of `Arc`, eliminating atomic
+/// refcount overhead. Use this in single-threaded contexts like SST iteration
+/// during compaction.
+#[derive(Clone)]
+pub struct RcBytes {
+    data: *const [u8],
+    backing: Backing,
+}
+
+impl From<Rc<[u8]>> for RcBytes {
+    fn from(rc: Rc<[u8]>) -> Self {
+        Self {
+            data: &*rc as *const [u8],
+            backing: Backing::Rc { _backing: rc },
+        }
+    }
+}
+
+impl From<Box<[u8]>> for RcBytes {
+    fn from(b: Box<[u8]>) -> Self {
+        Self::from(Rc::from(b))
+    }
+}
+
+impl Deref for RcBytes {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.data }
+    }
+}
+
+impl Borrow<[u8]> for RcBytes {
+    fn borrow(&self) -> &[u8] {
+        self
+    }
+}
+
+impl PartialEq for RcBytes {
+    fn eq(&self, other: &Self) -> bool {
+        self.deref().eq(other.deref())
+    }
+}
+
+impl Debug for RcBytes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&**self, f)
+    }
+}
+
+impl Eq for RcBytes {}
+
+/// Returns `true` if `subslice` lies entirely within `backing`.
+fn is_subslice_of(subslice: &[u8], backing: &[u8]) -> bool {
+    let backing = backing.as_ptr_range();
+    let sub = subslice.as_ptr_range();
+    sub.start >= backing.start && sub.end <= backing.end
+}
+
+impl RcBytes {
+    /// Returns a new `RcBytes` that points to a sub-range of the current slice.
+    pub fn slice(self, range: Range<usize>) -> RcBytes {
+        let data = &*self;
+        let data = &data[range] as *const [u8];
+        Self {
+            data,
+            backing: self.backing,
+        }
+    }
+
+    /// Creates a sub-slice from a slice reference that points into this RcBytes' backing data.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `subslice` points to memory within this RcBytes'
+    /// backing storage.
+    pub unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> RcBytes {
+        debug_assert!(
+            is_subslice_of(
+                subslice,
+                match &self.backing {
+                    Backing::Rc { _backing } => _backing,
+                    Backing::Mmap { _backing } => _backing,
+                }
+            ),
+            "slice_from_subslice: subslice is not within the backing storage"
+        );
+        Self {
+            data: subslice as *const [u8],
+            backing: self.backing.clone(),
+        }
+    }
+
+    /// Creates an `RcBytes` backed by a memory-mapped file.
+    ///
+    /// The `Arc<Mmap>` is wrapped in an `Rc` so that subsequent clone/drop
+    /// operations are non-atomic.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `subslice` points to memory within the given `mmap`.
+    pub unsafe fn from_mmap(mmap: &Rc<Arc<Mmap>>, subslice: &[u8]) -> RcBytes {
+        debug_assert!(
+            is_subslice_of(subslice, mmap),
+            "from_mmap: subslice is not within the mmap"
+        );
+        RcBytes {
+            data: subslice as *const [u8],
+            backing: Backing::Mmap {
+                _backing: mmap.clone(),
+            },
+        }
+    }
+}

--- a/turbopack/crates/turbo-persistence/src/shared_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/shared_bytes.rs
@@ -1,0 +1,40 @@
+use std::ops::{Deref, Range};
+
+use memmap2::Mmap;
+
+/// Trait abstracting over `ArcBytes` and `RcBytes`.
+///
+/// Both types are owned byte slices backed by either a ref-counted heap
+/// allocation or a memory-mapped file. The only difference is the refcount
+/// flavor: `Arc` (atomic, thread-safe) vs `Rc` (non-atomic, single-threaded).
+///
+/// This trait captures the shared interface so that code in
+/// `static_sorted_file.rs` (block reading, key matching, etc.) can be written
+/// once and used for both lookup (ArcBytes) and iteration (RcBytes) paths.
+pub trait SharedBytes: Clone + Deref<Target = [u8]> + Sized {
+    /// The ref-counted handle to the memory-mapped file.
+    type MmapHandle: Deref<Target = Mmap>;
+
+    /// Returns a new instance that points to a sub-range of the current slice.
+    fn slice(self, range: Range<usize>) -> Self;
+
+    /// Creates a sub-slice from a reference that points into this instance's
+    /// backing data.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `subslice` points to memory within this
+    /// instance's backing storage.
+    unsafe fn slice_from_subslice(&self, subslice: &[u8]) -> Self;
+
+    /// Creates an instance backed by a memory-mapped file.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `subslice` points to memory within the
+    /// given `mmap`.
+    unsafe fn from_mmap(mmap: &Self::MmapHandle, subslice: &[u8]) -> Self;
+
+    /// Creates an instance from a decompressed block.
+    fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self>;
+}

--- a/turbopack/crates/turbo-persistence/src/shared_bytes.rs
+++ b/turbopack/crates/turbo-persistence/src/shared_bytes.rs
@@ -38,3 +38,10 @@ pub trait SharedBytes: Clone + Deref<Target = [u8]> + Sized {
     /// Creates an instance from a decompressed block.
     fn from_decompressed(uncompressed_length: u32, block: &[u8]) -> anyhow::Result<Self>;
 }
+
+/// Returns `true` if `subslice` lies entirely within `backing`.
+pub(crate) fn is_subslice_of(subslice: &[u8], backing: &[u8]) -> bool {
+    let backing = backing.as_ptr_range();
+    let sub = subslice.as_ptr_range();
+    sub.start >= backing.start && sub.end <= backing.end
+}

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -1,11 +1,4 @@
-use std::{
-    cmp::Ordering,
-    fs::File,
-    hash::BuildHasherDefault,
-    path::{Path, PathBuf},
-    rc::Rc,
-    sync::Arc,
-};
+use std::{cmp::Ordering, fs::File, hash::BuildHasherDefault, path::Path, rc::Rc, sync::Arc};
 
 use anyhow::{Context, Result, bail};
 use byteorder::{BE, ReadBytesExt};
@@ -165,25 +158,6 @@ impl StaticSortedFile {
     pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
         let filename = format!("{:08}.sst", meta.sequence_number);
         let path = db_path.join(&filename);
-        Self::open_internal(path, meta, false)
-            .with_context(|| format!("Unable to open static sorted file {filename}"))
-    }
-
-    /// Opens an SST file for compaction. Uses MADV_SEQUENTIAL instead of MADV_RANDOM,
-    /// since compaction reads blocks sequentially and benefits from OS read-ahead
-    /// and page reclamation.
-    pub fn open_for_compaction(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
-        let filename = format!("{:08}.sst", meta.sequence_number);
-        let path = db_path.join(&filename);
-        Self::open_internal(path, meta, true)
-            .with_context(|| format!("Unable to open static sorted file {filename}"))
-    }
-
-    fn open_internal(
-        path: PathBuf,
-        meta: StaticSortedFileMetaData,
-        sequential: bool,
-    ) -> Result<Self> {
         let file = File::open(&path)
             .with_context(|| format!("Failed to open SST file {}", path.display()))?;
         let mmap = unsafe { Mmap::map(&file) }.with_context(|| {
@@ -194,56 +168,15 @@ impl StaticSortedFile {
             )
         })?;
         #[cfg(unix)]
-        if sequential {
-            mmap.advise(memmap2::Advice::Sequential)?;
-        } else {
+        {
             mmap.advise(memmap2::Advice::Random)?;
             let offset = meta.block_offsets_start(mmap.len());
             let _ = mmap.advise_range(memmap2::Advice::Sequential, offset, mmap.len() - offset);
         }
         advise_mmap_for_persistence(&mmap)?;
-        let file = Self {
+        Ok(Self {
             meta,
             mmap: Arc::new(mmap),
-        };
-        Ok(file)
-    }
-
-    /// Consume this file and return an iterator over all entries in sorted order.
-    /// The iterator takes ownership of the SST file, so the mmap and its pages
-    /// are freed when the iterator is dropped.
-    pub fn try_into_iter(self) -> Result<StaticSortedFileIter> {
-        // Create a thread-local Rc handle to the mmap. All RcBytes produced
-        // during iteration share this single Rc, so per-entry refcounting is
-        // a plain integer inc/dec with no atomics.
-        // Wrap the Arc<Mmap> in an Rc. This clones the Arc once (one atomic
-        // increment). All subsequent RcBytes clone/drop operations only touch
-        // the Rc counter (plain integer, no atomics).
-        let rc_mmap = Rc::new(self.mmap.clone());
-
-        let root_block_index = self.meta.block_count - 1;
-        let block_rc = StaticSortedFileIter::read_block_rc(&self, &rc_mmap, root_block_index)?;
-        let block_type = block_rc[0];
-
-        // The builder always writes an index block as the root block.
-        if block_type != BLOCK_TYPE_INDEX {
-            bail!("Root block must be an index block");
-        }
-        let block_len = block_rc.len();
-        let block_indices_count = (block_len - 1 + 8) / 10;
-        let first_child = u16::from_be_bytes(block_rc[1..3].try_into().unwrap());
-        let index_entries = block_rc.slice(1..block_len);
-
-        let current_key_block =
-            StaticSortedFileIter::parse_key_block(&self, &rc_mmap, first_child)?;
-        Ok(StaticSortedFileIter {
-            this: self,
-            rc_mmap,
-            index_entries,
-            index_block_count: block_indices_count,
-            index_pos: 1,
-            current_key_block,
-            value_block_cache: None,
         })
     }
 
@@ -528,22 +461,6 @@ impl StaticSortedFile {
         self.read_block(block_index)
     }
 
-    /// Verifies the CRC32 checksum of on-disk block data. Returns an error on mismatch.
-    fn verify_checksum(&self, data: &[u8], expected: u32, block_index: u16) -> Result<()> {
-        let actual = checksum_block(data);
-        if actual != expected {
-            bail!(
-                "Cache corruption detected: checksum mismatch in block {} of {:08}.sst (expected \
-                 {:08x}, got {:08x})",
-                block_index,
-                self.meta.sequence_number,
-                expected,
-                actual
-            );
-        }
-        Ok(())
-    }
-
     /// Reads a block from the file, decompressing if needed, and verifies its checksum.
     ///
     /// The checksum is verified on the raw on-disk data **before** decompression, so
@@ -551,7 +468,7 @@ impl StaticSortedFile {
     #[tracing::instrument(level = "info", name = "reading database block", skip_all)]
     fn read_block(&self, block_index: u16) -> Result<ArcBytes> {
         let (uncompressed_length, expected_checksum, block) =
-            self.get_raw_block_slice(block_index).with_context(|| {
+            get_raw_block_slice(&self.mmap, &self.meta, block_index).with_context(|| {
                 format!(
                     "Failed to read raw block {} from {:08}.sst",
                     block_index, self.meta.sequence_number
@@ -559,11 +476,12 @@ impl StaticSortedFile {
             })?;
 
         // Verify checksum on the raw on-disk data before decompression.
-        self.verify_checksum(block, expected_checksum, block_index)?;
+        verify_checksum(&self.meta, block, expected_checksum, block_index)?;
 
         // 0 means the block was not compressed, return the mmap-backed ArcBytes directly
         if uncompressed_length == 0 {
-            return Ok(self.mmap_slice_to_arc_bytes(block));
+            // SAFETY: callers guarantee block points into self.mmap.
+            return Ok(unsafe { ArcBytes::from_mmap(self.mmap.clone(), block) });
         }
 
         let buffer = decompress_into_arc(uncompressed_length, block).with_context(|| {
@@ -574,104 +492,122 @@ impl StaticSortedFile {
         })?;
         Ok(ArcBytes::from(buffer))
     }
+}
 
-    /// Promotes a mmap subslice to an owned `ArcBytes`. This clones the `Arc<Mmap>`.
-    fn mmap_slice_to_arc_bytes(&self, subslice: &[u8]) -> ArcBytes {
-        // SAFETY: callers guarantee subslice points into self.mmap.
-        unsafe { ArcBytes::from_mmap(self.mmap.clone(), subslice) }
+/// Gets the raw block slice directly from a memory-mapped file.
+/// Returns `(uncompressed_length, checksum, block_data)`.
+fn get_raw_block_slice<'a>(
+    mmap: &'a Mmap,
+    meta: &StaticSortedFileMetaData,
+    block_index: u16,
+) -> Result<(u32, u32, &'a [u8])> {
+    #[cfg(feature = "strict_checks")]
+    if block_index >= meta.block_count {
+        bail!(
+            "Corrupted file seq:{} block:{} > number of blocks {} (block_offsets: {:x})",
+            meta.sequence_number,
+            block_index,
+            meta.block_count,
+            meta.block_offsets_start(mmap.len()),
+        );
     }
-
-    /// Gets the raw block slice directly from the memory mapped file, without
-    /// cloning the `Arc<Mmap>`. The returned slice borrows from the mmap.
-    fn get_raw_block_slice(&self, block_index: u16) -> Result<(u32, u32, &[u8])> {
-        #[cfg(feature = "strict_checks")]
-        if block_index >= self.meta.block_count {
-            bail!(
-                "Corrupted file seq:{} block:{} > number of blocks {} (block_offsets: {:x})",
-                self.meta.sequence_number,
-                block_index,
-                self.meta.block_count,
-                self.meta.block_offsets_start(self.mmap.len()),
-            );
-        }
-        let offset = self.meta.block_offsets_start(self.mmap.len()) + block_index as usize * 4;
-        #[cfg(feature = "strict_checks")]
-        if offset + 4 > self.mmap.len() {
-            bail!(
-                "Corrupted file seq:{} block:{} block offset locations {} + 4 bytes > file end {} \
-                 (block_offsets: {:x})",
-                self.meta.sequence_number,
-                block_index,
-                offset,
-                self.mmap.len(),
-                self.meta.block_offsets_start(self.mmap.len()),
-            );
-        }
-        let block_start = if block_index == 0 {
-            0
-        } else {
-            (&self.mmap[offset - 4..offset])
-                .read_u32::<BE>()
-                .with_context(|| {
-                    format!(
-                        "Failed to read block_start offset for block {} in {:08}.sst",
-                        block_index, self.meta.sequence_number
-                    )
-                })? as usize
-        };
-        let block_end = (&self.mmap[offset..offset + 4])
+    let offset = meta.block_offsets_start(mmap.len()) + block_index as usize * 4;
+    #[cfg(feature = "strict_checks")]
+    if offset + 4 > mmap.len() {
+        bail!(
+            "Corrupted file seq:{} block:{} block offset locations {} + 4 bytes > file end {} \
+             (block_offsets: {:x})",
+            meta.sequence_number,
+            block_index,
+            offset,
+            mmap.len(),
+            meta.block_offsets_start(mmap.len()),
+        );
+    }
+    let block_start = if block_index == 0 {
+        0
+    } else {
+        (&mmap[offset - 4..offset])
             .read_u32::<BE>()
             .with_context(|| {
                 format!(
-                    "Failed to read block_end offset for block {} in {:08}.sst",
-                    block_index, self.meta.sequence_number
+                    "Failed to read block_start offset for block {} in {:08}.sst",
+                    block_index, meta.sequence_number
                 )
-            })? as usize;
-        #[cfg(feature = "strict_checks")]
-        if block_end > self.mmap.len() || block_start > self.mmap.len() {
-            bail!(
-                "Corrupted file seq:{} block:{} block {} - {} > file end {} (block_offsets: {:x})",
-                self.meta.sequence_number,
-                block_index,
-                block_start,
-                block_end,
-                self.mmap.len(),
-                self.meta.block_offsets_start(self.mmap.len()),
-            );
-        }
-        let uncompressed_length = u32::from_be_bytes(
-            self.mmap[block_start..block_start + 4]
-                .try_into()
-                .with_context(|| {
-                    format!(
-                        "Failed to read uncompressed_length from block {} header in {:08}.sst",
-                        block_index, self.meta.sequence_number
-                    )
-                })?,
+            })? as usize
+    };
+    let block_end = (&mmap[offset..offset + 4])
+        .read_u32::<BE>()
+        .with_context(|| {
+            format!(
+                "Failed to read block_end offset for block {} in {:08}.sst",
+                block_index, meta.sequence_number
+            )
+        })? as usize;
+    #[cfg(feature = "strict_checks")]
+    if block_end > mmap.len() || block_start > mmap.len() {
+        bail!(
+            "Corrupted file seq:{} block:{} block {} - {} > file end {} (block_offsets: {:x})",
+            meta.sequence_number,
+            block_index,
+            block_start,
+            block_end,
+            mmap.len(),
+            meta.block_offsets_start(mmap.len()),
         );
-        let checksum = u32::from_be_bytes(
-            self.mmap[block_start + 4..block_start + 8]
-                .try_into()
-                .with_context(|| {
-                    format!(
-                        "Failed to read checksum from block {} header in {:08}.sst",
-                        block_index, self.meta.sequence_number
-                    )
-                })?,
-        );
-        let block = &self.mmap[block_start + BLOCK_HEADER_SIZE..block_end];
-        Ok((uncompressed_length, checksum, block))
     }
+    let uncompressed_length = u32::from_be_bytes(
+        mmap[block_start..block_start + 4]
+            .try_into()
+            .with_context(|| {
+                format!(
+                    "Failed to read uncompressed_length from block {} header in {:08}.sst",
+                    block_index, meta.sequence_number
+                )
+            })?,
+    );
+    let checksum = u32::from_be_bytes(
+        mmap[block_start + 4..block_start + 8]
+            .try_into()
+            .with_context(|| {
+                format!(
+                    "Failed to read checksum from block {} header in {:08}.sst",
+                    block_index, meta.sequence_number
+                )
+            })?,
+    );
+    let block = &mmap[block_start + BLOCK_HEADER_SIZE..block_end];
+    Ok((uncompressed_length, checksum, block))
+}
+
+/// Verifies the CRC32 checksum of on-disk block data. Returns an error on mismatch.
+fn verify_checksum(
+    meta: &StaticSortedFileMetaData,
+    data: &[u8],
+    expected: u32,
+    block_index: u16,
+) -> Result<()> {
+    let actual = checksum_block(data);
+    if actual != expected {
+        bail!(
+            "Cache corruption detected: checksum mismatch in block {} of {:08}.sst (expected \
+             {:08x}, got {:08x})",
+            block_index,
+            meta.sequence_number,
+            expected,
+            actual
+        );
+    }
+    Ok(())
 }
 
 /// An iterator over all entries in a SST file in sorted order.
 pub struct StaticSortedFileIter {
-    this: StaticSortedFile,
-    /// Thread-local refcount handle to the mmap. The `Arc<Mmap>` is cloned once
-    /// at iterator construction into this `Rc`; all `RcBytes` slices produced
-    /// during iteration share this single `Rc`, so per-entry refcounting is a
-    /// plain integer inc/dec (no atomics).
-    rc_mmap: Rc<Arc<Mmap>>,
+    /// The memory-mapped file, wrapped in `Rc` for non-atomic refcounting.
+    /// All `RcBytes` slices produced during iteration share this `Rc`.
+    mmap: Rc<Mmap>,
+    /// Metadata (sequence number, block count) needed for block access.
+    meta: StaticSortedFileMetaData,
 
     /// The root index block entries (body bytes starting after the type byte).
     /// SST files have exactly one index level.
@@ -717,32 +653,80 @@ impl Iterator for StaticSortedFileIter {
 }
 
 impl StaticSortedFileIter {
+    /// Opens an SST file for sequential iteration. Uses `MADV_SEQUENTIAL` for
+    /// read-ahead and wraps the mmap in `Rc<Mmap>` directly (no `Arc`),
+    /// eliminating all atomic refcounting during iteration.
+    pub fn open(db_path: &Path, meta: StaticSortedFileMetaData) -> Result<Self> {
+        let filename = format!("{:08}.sst", meta.sequence_number);
+        let path = db_path.join(&filename);
+        let file = File::open(&path)
+            .with_context(|| format!("Failed to open SST file {}", path.display()))?;
+        let mmap = unsafe { Mmap::map(&file) }.with_context(|| {
+            format!(
+                "Failed to mmap SST file {} ({} bytes)",
+                path.display(),
+                file.metadata().map(|m| m.len()).unwrap_or(0)
+            )
+        })?;
+        #[cfg(unix)]
+        mmap.advise(memmap2::Advice::Sequential)?;
+        advise_mmap_for_persistence(&mmap)?;
+        Self::new(Rc::new(mmap), meta)
+            .with_context(|| format!("Unable to open static sorted file {filename}"))
+    }
+
+    fn new(mmap: Rc<Mmap>, meta: StaticSortedFileMetaData) -> Result<Self> {
+        let root_block_index = meta.block_count - 1;
+        let block_rc = Self::read_block_rc(&mmap, &meta, root_block_index)?;
+        let block_type = block_rc[0];
+
+        // The builder always writes an index block as the root block.
+        if block_type != BLOCK_TYPE_INDEX {
+            bail!("Root block must be an index block");
+        }
+        let block_len = block_rc.len();
+        let block_indices_count = (block_len - 1 + 8) / 10;
+        let first_child = u16::from_be_bytes(block_rc[1..3].try_into().unwrap());
+        let index_entries = block_rc.slice(1..block_len);
+
+        let current_key_block = Self::parse_key_block(&mmap, &meta, first_child)?;
+        Ok(StaticSortedFileIter {
+            mmap,
+            meta,
+            index_entries,
+            index_block_count: block_indices_count,
+            index_pos: 1,
+            current_key_block,
+            value_block_cache: None,
+        })
+    }
+
     /// Reads a block, decompresses if needed, verifies checksum. Returns `RcBytes`.
     fn read_block_rc(
-        sst: &StaticSortedFile,
-        rc_mmap: &Rc<Arc<Mmap>>,
+        mmap: &Rc<Mmap>,
+        meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<RcBytes> {
         let (uncompressed_length, expected_checksum, block) =
-            sst.get_raw_block_slice(block_index).with_context(|| {
+            get_raw_block_slice(mmap, meta, block_index).with_context(|| {
                 format!(
                     "Failed to read raw block {} from {:08}.sst",
-                    block_index, sst.meta.sequence_number
+                    block_index, meta.sequence_number
                 )
             })?;
 
-        sst.verify_checksum(block, expected_checksum, block_index)?;
+        verify_checksum(meta, block, expected_checksum, block_index)?;
 
         if uncompressed_length == 0 {
             // Uncompressed: wrap the mmap slice in RcBytes (Rc clone, no atomic)
-            return Ok(unsafe { RcBytes::from_mmap(rc_mmap, block) });
+            return Ok(unsafe { RcBytes::from_mmap(mmap, block) });
         }
 
         let buffer = crate::compression::decompress_into_rc(uncompressed_length, block)
             .with_context(|| {
                 format!(
                     "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-                    block_index, sst.meta.sequence_number, uncompressed_length
+                    block_index, meta.sequence_number, uncompressed_length
                 )
             })?;
         Ok(RcBytes::from(buffer))
@@ -750,20 +734,20 @@ impl StaticSortedFileIter {
 
     /// Returns `(uncompressed_length, checksum, block)` as `RcBytes`.
     fn get_raw_block_rc(
-        sst: &StaticSortedFile,
-        rc_mmap: &Rc<Arc<Mmap>>,
+        mmap: &Rc<Mmap>,
+        meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<(u32, u32, RcBytes)> {
-        let (uncompressed_length, checksum, block) = sst.get_raw_block_slice(block_index)?;
+        let (uncompressed_length, checksum, block) = get_raw_block_slice(mmap, meta, block_index)?;
         Ok((uncompressed_length, checksum, unsafe {
-            RcBytes::from_mmap(rc_mmap, block)
+            RcBytes::from_mmap(mmap, block)
         }))
     }
 
     /// Reads a small value block, using a single-entry cache. Returns `RcBytes`.
     fn read_small_value_block_rc(
-        sst: &StaticSortedFile,
-        rc_mmap: &Rc<Arc<Mmap>>,
+        mmap: &Rc<Mmap>,
+        meta: &StaticSortedFileMetaData,
         cache: &mut Option<(u16, RcBytes)>,
         block_index: u16,
     ) -> Result<RcBytes> {
@@ -772,15 +756,15 @@ impl StaticSortedFileIter {
         {
             return Ok(block.clone());
         }
-        let block = Self::read_block_rc(sst, rc_mmap, block_index)?;
+        let block = Self::read_block_rc(mmap, meta, block_index)?;
         *cache = Some((block_index, block.clone()));
         Ok(block)
     }
 
     /// Handles a key match, producing `IterValue` (uses `RcBytes`).
     fn handle_key_match_rc(
-        sst: &StaticSortedFile,
-        rc_mmap: &Rc<Arc<Mmap>>,
+        mmap: &Rc<Mmap>,
+        meta: &StaticSortedFileMetaData,
         ty: u8,
         val: &[u8],
         key_block_entries: &RcBytes,
@@ -791,14 +775,13 @@ impl StaticSortedFileIter {
                 let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
                 let size = u16::from_be_bytes(val[2..4].try_into().unwrap()) as usize;
                 let position = u32::from_be_bytes(val[4..8].try_into().unwrap()) as usize;
-                let value =
-                    Self::read_small_value_block_rc(sst, rc_mmap, value_block_cache, block)?
-                        .slice(position..position + size);
+                let value = Self::read_small_value_block_rc(mmap, meta, value_block_cache, block)?
+                    .slice(position..position + size);
                 IterValue::Slice { value }
             }
             KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
                 let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
-                let value = Self::read_block_rc(sst, rc_mmap, block)?;
+                let value = Self::read_block_rc(mmap, meta, block)?;
                 IterValue::Slice { value }
             }
             KEY_BLOCK_ENTRY_TYPE_BLOB => {
@@ -817,11 +800,11 @@ impl StaticSortedFileIter {
 
     /// Parses a key block at the given index, returning `RcBytes`-backed data.
     fn parse_key_block(
-        sst: &StaticSortedFile,
-        rc_mmap: &Rc<Arc<Mmap>>,
+        mmap: &Rc<Mmap>,
+        meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<CurrentKeyBlock> {
-        let block_rc = Self::read_block_rc(sst, rc_mmap, block_index)?;
+        let block_rc = Self::read_block_rc(mmap, meta, block_index)?;
         let block = &*block_rc;
         let block_type = block[0];
         let entry_count = u32::from_be_bytes([0, block[1], block[2], block[3]]);
@@ -907,7 +890,7 @@ impl StaticSortedFileIter {
                 let value = if ty == KEY_BLOCK_ENTRY_TYPE_MEDIUM {
                     let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
                     let (uncompressed_size, checksum, block) =
-                        Self::get_raw_block_rc(&self.this, &self.rc_mmap, block)?;
+                        Self::get_raw_block_rc(&self.mmap, &self.meta, block)?;
                     IterValue::Medium {
                         uncompressed_size,
                         checksum,
@@ -915,8 +898,8 @@ impl StaticSortedFileIter {
                     }
                 } else {
                     Self::handle_key_match_rc(
-                        &self.this,
-                        &self.rc_mmap,
+                        &self.mmap,
+                        &self.meta,
                         ty,
                         val,
                         &kb.entries,
@@ -937,7 +920,7 @@ impl StaticSortedFileIter {
                     u16::from_be_bytes(self.index_entries[base..base + 2].try_into().unwrap());
                 self.index_pos += 1;
                 self.current_key_block =
-                    Self::parse_key_block(&self.this, &self.rc_mmap, block_index)?;
+                    Self::parse_key_block(&self.mmap, &self.meta, block_index)?;
             } else {
                 return Ok(None);
             }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -16,7 +16,7 @@ use crate::{
     mmap_helper::advise_mmap_for_persistence,
     rc_bytes::RcBytes,
     shared_bytes::SharedBytes,
-    static_sorted_file_builder::BLOCK_HEADER_SIZE,
+    static_sorted_file_builder::{BLOCK_HEADER_SIZE, INDEX_BLOCK_ENTRY_SIZE},
 };
 
 /// The block header for an index block.
@@ -254,8 +254,7 @@ impl StaticSortedFile {
     fn lookup_index_block(&self, block: &[u8], hash: u64) -> Result<u16> {
         ensure!(block.len() >= 3, "index block too short");
         let first_block = be::read_u16(&block[1..]);
-        // Each entry is 10 bytes: 8 bytes for the hash, 2 bytes for the block index
-        let (entries, remainder) = block[3..].as_chunks::<10>();
+        let (entries, remainder) = block[3..].as_chunks::<INDEX_BLOCK_ENTRY_SIZE>();
         if entries.is_empty() {
             return Ok(first_block);
         }
@@ -285,6 +284,10 @@ impl StaticSortedFile {
         ensure!(block.len() >= 4, "key block too short");
         let entry_count = be::read_u24(&block[1..]) as usize;
         let data = &block[4..];
+        ensure!(
+            data.len() >= entry_count * 4,
+            "key block too short for {entry_count} entries"
+        );
         let offsets = &data[..entry_count * 4];
         let entries = &data[entry_count * 4..];
 
@@ -318,6 +321,10 @@ impl StaticSortedFile {
         let val_size = entry_val_size(value_type)?;
         let stride = hash_len as usize + key_size + val_size;
         let entries = &block[6..];
+        ensure!(
+            entries.len() == entry_count * stride,
+            "fixed key block for {entry_count} entries must is the wrong size"
+        );
 
         self.lookup_block_inner::<K, FIND_ALL>(
             &block,
@@ -673,8 +680,8 @@ pub struct StaticSortedFileIter {
     /// The root index block entries (body bytes starting after the type byte).
     /// SST files have exactly one index level.
     index_entries: RcBytes,
-    /// Total number of key block references in the index block.
-    index_block_count: usize,
+    /// Total key block references in the index block (first_child + boundary entries).
+    num_index_entries: usize,
     /// Next index entry to read from the index block.
     index_pos: usize,
     current_key_block: CurrentKeyBlock,
@@ -747,16 +754,22 @@ impl StaticSortedFileIter {
         }
         let block_len = block.len();
         ensure!(block_len >= 3, "index block too short");
-        let block_indices_count = (block_len - 1 + 8) / 10;
-        let first_child = be::read_u16(&block[1..]);
         let index_entries = block.slice(1..block_len);
+        let first_child = be::read_u16(&index_entries);
+        // Index block body layout: [first_child: u16] [hash: u64, block: u16]*
+        // Compute total key block references (first_child + N boundary entries)
+        // using ceil division: (body_len - sizeof(first_child) + ENTRY_SIZE - 1) / ENTRY_SIZE + 1
+        // simplified to (body_len + ENTRY_SIZE - 2) / ENTRY_SIZE
+        let num_index_entries: usize = (index_entries.len() + INDEX_BLOCK_ENTRY_SIZE
+            - size_of::<u16>())
+            / INDEX_BLOCK_ENTRY_SIZE;
 
         let current_key_block = Self::parse_key_block(&mmap, &meta, first_child)?;
         Ok(StaticSortedFileIter {
             mmap,
             meta,
             index_entries,
-            index_block_count: block_indices_count,
+            num_index_entries,
             index_pos: 1,
             current_key_block,
             value_block_cache: None,
@@ -803,6 +816,7 @@ impl StaticSortedFileIter {
                 let value_type = data[5];
                 let val_size = entry_val_size(value_type)?;
                 let stride = hash_len as usize + key_size + val_size;
+                // Header is 6 bytes for fixed-size blocks
                 let entries_range = 6..block.len();
                 let entries = block.slice(entries_range);
                 Ok(CurrentKeyBlock {
@@ -881,8 +895,8 @@ impl StaticSortedFileIter {
                 kb.index += 1;
                 return Ok(Some(entry));
             }
-            if self.index_pos < self.index_block_count {
-                let base = self.index_pos * 10;
+            if self.index_pos < self.num_index_entries {
+                let base = self.index_pos * INDEX_BLOCK_ENTRY_SIZE;
                 let block_index = be::read_u16(&self.index_entries[base..]);
                 self.index_pos += 1;
                 self.current_key_block =

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -3,6 +3,7 @@ use std::{
     fs::File,
     hash::BuildHasherDefault,
     path::{Path, PathBuf},
+    rc::Rc,
     sync::Arc,
 };
 
@@ -18,8 +19,9 @@ use crate::{
     arc_bytes::ArcBytes,
     compression::{checksum_block, decompress_into_arc},
     constants::MAX_INLINE_VALUE_SIZE,
-    lookup_entry::{LazyLookupValue, LookupEntry, LookupValue},
+    lookup_entry::{IterValue, LookupEntry, LookupValue},
     mmap_helper::advise_mmap_for_persistence,
+    rc_bytes::RcBytes,
     static_sorted_file_builder::BLOCK_HEADER_SIZE,
 };
 
@@ -211,15 +213,38 @@ impl StaticSortedFile {
     /// The iterator takes ownership of the SST file, so the mmap and its pages
     /// are freed when the iterator is dropped.
     pub fn try_into_iter(self) -> Result<StaticSortedFileIter> {
-        let block_count = self.meta.block_count;
-        let mut iter = StaticSortedFileIter {
+        // Create a thread-local Rc handle to the mmap. All RcBytes produced
+        // during iteration share this single Rc, so per-entry refcounting is
+        // a plain integer inc/dec with no atomics.
+        // Wrap the Arc<Mmap> in an Rc. This clones the Arc once (one atomic
+        // increment). All subsequent RcBytes clone/drop operations only touch
+        // the Rc counter (plain integer, no atomics).
+        let rc_mmap = Rc::new(self.mmap.clone());
+
+        let root_block_index = self.meta.block_count - 1;
+        let block_rc = StaticSortedFileIter::read_block_rc(&self, &rc_mmap, root_block_index)?;
+        let block_type = block_rc[0];
+
+        // The builder always writes an index block as the root block.
+        if block_type != BLOCK_TYPE_INDEX {
+            bail!("Root block must be an index block");
+        }
+        let block_len = block_rc.len();
+        let block_indices_count = (block_len - 1 + 8) / 10;
+        let first_child = u16::from_be_bytes(block_rc[1..3].try_into().unwrap());
+        let index_entries = block_rc.slice(1..block_len);
+
+        let current_key_block =
+            StaticSortedFileIter::parse_key_block(&self, &rc_mmap, first_child)?;
+        Ok(StaticSortedFileIter {
             this: self,
-            stack: Vec::new(),
-            current_key_block: None,
+            rc_mmap,
+            index_entries,
+            index_block_count: block_indices_count,
+            index_pos: 1,
+            current_key_block,
             value_block_cache: None,
-        };
-        iter.enter_block(block_count - 1)?;
-        Ok(iter)
+        })
     }
 
     /// Looks up a key in this file.
@@ -436,27 +461,27 @@ impl StaticSortedFile {
     fn handle_key_match(
         &self,
         ty: u8,
-        mut val: &[u8],
+        val: &[u8],
         key_block_arc: &ArcBytes,
         value_block_cache: impl ValueBlockCache,
     ) -> Result<LookupValue> {
         Ok(match ty {
             KEY_BLOCK_ENTRY_TYPE_SMALL => {
-                let block = val.read_u16::<BE>()?;
-                let size = val.read_u16::<BE>()? as usize;
-                let position = val.read_u32::<BE>()? as usize;
+                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
+                let size = u16::from_be_bytes(val[2..4].try_into().unwrap()) as usize;
+                let position = u32::from_be_bytes(val[4..8].try_into().unwrap()) as usize;
                 let value = value_block_cache
                     .get_or_read(self, block)?
                     .slice(position..position + size);
                 LookupValue::Slice { value }
             }
             KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
-                let block = val.read_u16::<BE>()?;
+                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
                 let value = self.read_value_block(block)?;
                 LookupValue::Slice { value }
             }
             KEY_BLOCK_ENTRY_TYPE_BLOB => {
-                let sequence_number = val.read_u32::<BE>()?;
+                let sequence_number = u32::from_be_bytes(val[0..4].try_into().unwrap());
                 LookupValue::Blob { sequence_number }
             }
             KEY_BLOCK_ENTRY_TYPE_DELETED => LookupValue::Deleted,
@@ -548,18 +573,6 @@ impl StaticSortedFile {
             )
         })?;
         Ok(ArcBytes::from(buffer))
-    }
-
-    /// Returns `(uncompressed_length, block_data)` as an owned `ArcBytes` backed by
-    /// the mmap. Only use this when the block data needs to outlive the current borrow
-    /// (e.g. medium values stored in `LookupEntry`).
-    fn get_raw_block(&self, block_index: u16) -> Result<(u32, u32, ArcBytes)> {
-        let (uncompressed_length, checksum, block) = self.get_raw_block_slice(block_index)?;
-        Ok((
-            uncompressed_length,
-            checksum,
-            self.mmap_slice_to_arc_bytes(block),
-        ))
     }
 
     /// Promotes a mmap subslice to an owned `ArcBytes`. This clones the `Arc<Mmap>`.
@@ -654,18 +667,29 @@ impl StaticSortedFile {
 /// An iterator over all entries in a SST file in sorted order.
 pub struct StaticSortedFileIter {
     this: StaticSortedFile,
+    /// Thread-local refcount handle to the mmap. The `Arc<Mmap>` is cloned once
+    /// at iterator construction into this `Rc`; all `RcBytes` slices produced
+    /// during iteration share this single `Rc`, so per-entry refcounting is a
+    /// plain integer inc/dec (no atomics).
+    rc_mmap: Rc<Arc<Mmap>>,
 
-    stack: Vec<CurrentIndexBlock>,
-    current_key_block: Option<CurrentKeyBlock>,
+    /// The root index block entries (body bytes starting after the type byte).
+    /// SST files have exactly one index level.
+    index_entries: RcBytes,
+    /// Total number of key block references in the index block.
+    index_block_count: usize,
+    /// Next index entry to read from the index block.
+    index_pos: usize,
+    current_key_block: CurrentKeyBlock,
     /// Single-entry value block cache. Within a key block, entries reference
     /// value blocks sequentially and don't revisit earlier blocks, so caching
     /// just the current one avoids redundant decompression.
-    value_block_cache: Option<(u16, ArcBytes)>,
+    value_block_cache: Option<(u16, RcBytes)>,
 }
 
 enum CurrentKeyBlockKind {
     /// Variable-size entries with an offset table for random access.
-    Variable { offsets: ArcBytes, hash_len: u8 },
+    Variable { offsets: RcBytes, hash_len: u8 },
     /// Fixed-size entries with uniform key size and value type (no offset table).
     Fixed {
         hash_len: u8,
@@ -677,15 +701,11 @@ enum CurrentKeyBlockKind {
 
 struct CurrentKeyBlock {
     kind: CurrentKeyBlockKind,
-    entries: ArcBytes,
-    entry_count: usize,
-    index: usize,
-}
-
-struct CurrentIndexBlock {
-    entries: ArcBytes,
-    block_indices_count: usize,
-    index: usize,
+    entries: RcBytes,
+    /// Number of entries in this key block (max ~819 per 16 KiB block).
+    entry_count: u32,
+    /// Current position within the key block.
+    index: u32,
 }
 
 impl Iterator for StaticSortedFileIter {
@@ -697,48 +717,146 @@ impl Iterator for StaticSortedFileIter {
 }
 
 impl StaticSortedFileIter {
-    /// Enters a block at the given index.
-    fn enter_block(&mut self, block_index: u16) -> Result<()> {
-        let block_arc = self.this.read_key_block(block_index)?;
-        let mut block = &*block_arc;
-        let block_type = block.read_u8()?;
-        match block_type {
-            BLOCK_TYPE_INDEX => {
-                let block_indices_count = (block.len() + 8) / 10;
-                let range = 1..block_arc.len();
-                self.stack.push(CurrentIndexBlock {
-                    entries: block_arc.slice(range),
-                    block_indices_count,
-                    index: 0,
-                });
+    /// Reads a block, decompresses if needed, verifies checksum. Returns `RcBytes`.
+    fn read_block_rc(
+        sst: &StaticSortedFile,
+        rc_mmap: &Rc<Arc<Mmap>>,
+        block_index: u16,
+    ) -> Result<RcBytes> {
+        let (uncompressed_length, expected_checksum, block) =
+            sst.get_raw_block_slice(block_index).with_context(|| {
+                format!(
+                    "Failed to read raw block {} from {:08}.sst",
+                    block_index, sst.meta.sequence_number
+                )
+            })?;
+
+        sst.verify_checksum(block, expected_checksum, block_index)?;
+
+        if uncompressed_length == 0 {
+            // Uncompressed: wrap the mmap slice in RcBytes (Rc clone, no atomic)
+            return Ok(unsafe { RcBytes::from_mmap(rc_mmap, block) });
+        }
+
+        let buffer = crate::compression::decompress_into_rc(uncompressed_length, block)
+            .with_context(|| {
+                format!(
+                    "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+                    block_index, sst.meta.sequence_number, uncompressed_length
+                )
+            })?;
+        Ok(RcBytes::from(buffer))
+    }
+
+    /// Returns `(uncompressed_length, checksum, block)` as `RcBytes`.
+    fn get_raw_block_rc(
+        sst: &StaticSortedFile,
+        rc_mmap: &Rc<Arc<Mmap>>,
+        block_index: u16,
+    ) -> Result<(u32, u32, RcBytes)> {
+        let (uncompressed_length, checksum, block) = sst.get_raw_block_slice(block_index)?;
+        Ok((uncompressed_length, checksum, unsafe {
+            RcBytes::from_mmap(rc_mmap, block)
+        }))
+    }
+
+    /// Reads a small value block, using a single-entry cache. Returns `RcBytes`.
+    fn read_small_value_block_rc(
+        sst: &StaticSortedFile,
+        rc_mmap: &Rc<Arc<Mmap>>,
+        cache: &mut Option<(u16, RcBytes)>,
+        block_index: u16,
+    ) -> Result<RcBytes> {
+        if let Some((idx, block)) = cache.as_ref()
+            && *idx == block_index
+        {
+            return Ok(block.clone());
+        }
+        let block = Self::read_block_rc(sst, rc_mmap, block_index)?;
+        *cache = Some((block_index, block.clone()));
+        Ok(block)
+    }
+
+    /// Handles a key match, producing `IterValue` (uses `RcBytes`).
+    fn handle_key_match_rc(
+        sst: &StaticSortedFile,
+        rc_mmap: &Rc<Arc<Mmap>>,
+        ty: u8,
+        val: &[u8],
+        key_block_entries: &RcBytes,
+        value_block_cache: &mut Option<(u16, RcBytes)>,
+    ) -> Result<IterValue> {
+        Ok(match ty {
+            KEY_BLOCK_ENTRY_TYPE_SMALL => {
+                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
+                let size = u16::from_be_bytes(val[2..4].try_into().unwrap()) as usize;
+                let position = u32::from_be_bytes(val[4..8].try_into().unwrap()) as usize;
+                let value =
+                    Self::read_small_value_block_rc(sst, rc_mmap, value_block_cache, block)?
+                        .slice(position..position + size);
+                IterValue::Slice { value }
             }
+            KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
+                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
+                let value = Self::read_block_rc(sst, rc_mmap, block)?;
+                IterValue::Slice { value }
+            }
+            KEY_BLOCK_ENTRY_TYPE_BLOB => {
+                let sequence_number = u32::from_be_bytes(val[0..4].try_into().unwrap());
+                IterValue::Blob { sequence_number }
+            }
+            KEY_BLOCK_ENTRY_TYPE_DELETED => IterValue::Deleted,
+            _ => {
+                // Inline value — val is already the correct slice
+                // SAFETY: val points into key_block_entries' data
+                let value = unsafe { key_block_entries.slice_from_subslice(val) };
+                IterValue::Slice { value }
+            }
+        })
+    }
+
+    /// Parses a key block at the given index, returning `RcBytes`-backed data.
+    fn parse_key_block(
+        sst: &StaticSortedFile,
+        rc_mmap: &Rc<Arc<Mmap>>,
+        block_index: u16,
+    ) -> Result<CurrentKeyBlock> {
+        let block_rc = Self::read_block_rc(sst, rc_mmap, block_index)?;
+        let block = &*block_rc;
+        let block_type = block[0];
+        let entry_count = u32::from_be_bytes([0, block[1], block[2], block[3]]);
+        match block_type {
             BLOCK_TYPE_KEY_WITH_HASH | BLOCK_TYPE_KEY_NO_HASH => {
-                let has_hash = block_type == BLOCK_TYPE_KEY_WITH_HASH;
-                let hash_len = if has_hash { 8 } else { 0 };
-                let entry_count = block.read_u24::<BE>()? as usize;
-                let offsets_range = 4..4 + entry_count * 4;
-                let entries_range = 4 + entry_count * 4..block_arc.len();
-                let offsets = block_arc.clone().slice(offsets_range);
-                let entries = block_arc.slice(entries_range);
-                self.current_key_block = Some(CurrentKeyBlock {
+                let hash_len = if block_type == BLOCK_TYPE_KEY_WITH_HASH {
+                    8
+                } else {
+                    0
+                };
+                let n = entry_count as usize;
+                let offsets_range = 4..4 + n * 4;
+                let entries_range = 4 + n * 4..block_rc.len();
+                let offsets = block_rc.clone().slice(offsets_range);
+                let entries = block_rc.slice(entries_range);
+                Ok(CurrentKeyBlock {
                     kind: CurrentKeyBlockKind::Variable { offsets, hash_len },
                     entries,
                     entry_count,
                     index: 0,
-                });
+                })
             }
             BLOCK_TYPE_FIXED_KEY_WITH_HASH | BLOCK_TYPE_FIXED_KEY_NO_HASH => {
-                let has_hash = block_type == BLOCK_TYPE_FIXED_KEY_WITH_HASH;
-                let hash_len = if has_hash { 8 } else { 0 };
-                let entry_count = block.read_u24::<BE>()? as usize;
-                let key_size = block.read_u8()? as usize;
-                let value_type = block.read_u8()?;
+                let hash_len = if block_type == BLOCK_TYPE_FIXED_KEY_WITH_HASH {
+                    8
+                } else {
+                    0
+                };
+                let key_size = block[4] as usize;
+                let value_type = block[5];
                 let val_size = entry_val_size(value_type)?;
                 let stride = hash_len as usize + key_size + val_size;
-                // Header is 6 bytes for fixed-size blocks
-                let entries_range = 6..block_arc.len();
-                let entries = block_arc.slice(entries_range);
-                self.current_key_block = Some(CurrentKeyBlock {
+                let entries_range = 6..block_rc.len();
+                let entries = block_rc.slice(entries_range);
+                Ok(CurrentKeyBlock {
                     kind: CurrentKeyBlockKind::Fixed {
                         hash_len,
                         key_size,
@@ -748,28 +866,24 @@ impl StaticSortedFileIter {
                     entries,
                     entry_count,
                     index: 0,
-                });
+                })
             }
             _ => {
-                bail!("Invalid block type");
+                bail!("Invalid key block type: {block_type}");
             }
         }
-        Ok(())
     }
 
     /// Gets the next entry in the file and moves the cursor.
     fn next_internal(&mut self) -> Result<Option<LookupEntry>> {
         loop {
-            if let Some(CurrentKeyBlock {
-                kind,
-                entries,
-                entry_count,
-                index,
-            }) = self.current_key_block.take()
-            {
-                let GetKeyEntryResult { hash, key, ty, val } = match &kind {
+            let kb = &mut self.current_key_block;
+            if kb.index < kb.entry_count {
+                let index = kb.index as usize;
+                let entry_count = kb.entry_count as usize;
+                let GetKeyEntryResult { hash, key, ty, val } = match &kb.kind {
                     CurrentKeyBlockKind::Variable { offsets, hash_len } => {
-                        get_key_entry(offsets, &entries, entry_count, index, *hash_len)?
+                        get_key_entry(offsets, &kb.entries, entry_count, index, *hash_len)?
                     }
                     CurrentKeyBlockKind::Fixed {
                         hash_len,
@@ -777,7 +891,7 @@ impl StaticSortedFileIter {
                         value_type,
                         stride,
                     } => get_fixed_key_entry(
-                        &entries,
+                        &kb.entries,
                         index,
                         *hash_len,
                         *key_size,
@@ -785,61 +899,45 @@ impl StaticSortedFileIter {
                         *stride,
                     ),
                 };
-                // Convert hash slice to u64, computing from key if no hash stored
                 let full_hash = if hash.is_empty() {
                     crate::key::hash_key(&key)
                 } else {
                     u64::from_be_bytes(hash.try_into().unwrap())
                 };
                 let value = if ty == KEY_BLOCK_ENTRY_TYPE_MEDIUM {
-                    let mut val = val;
-                    let block = val.read_u16::<BE>()?;
-                    let (uncompressed_size, checksum, block) = self.this.get_raw_block(block)?;
-                    LazyLookupValue::Medium {
+                    let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
+                    let (uncompressed_size, checksum, block) =
+                        Self::get_raw_block_rc(&self.this, &self.rc_mmap, block)?;
+                    IterValue::Medium {
                         uncompressed_size,
                         checksum,
                         block,
                     }
                 } else {
-                    let value = self.this.handle_key_match(
+                    Self::handle_key_match_rc(
+                        &self.this,
+                        &self.rc_mmap,
                         ty,
                         val,
-                        &entries,
+                        &kb.entries,
                         &mut self.value_block_cache,
-                    )?;
-                    LazyLookupValue::Eager(value)
+                    )?
                 };
                 let entry = LookupEntry {
                     hash: full_hash,
-                    // SAFETY: key points into entries which is backed by the same Arc
-                    key: unsafe { entries.slice_from_subslice(key) },
+                    key: unsafe { kb.entries.slice_from_subslice(key) },
                     value,
                 };
-                if index + 1 < entry_count {
-                    self.current_key_block = Some(CurrentKeyBlock {
-                        kind,
-                        entries,
-                        entry_count,
-                        index: index + 1,
-                    });
-                }
+                kb.index += 1;
                 return Ok(Some(entry));
             }
-            if let Some(CurrentIndexBlock {
-                entries,
-                block_indices_count,
-                index,
-            }) = self.stack.pop()
-            {
-                let block_index = (&entries[index * 10..]).read_u16::<BE>()?;
-                if index + 1 < block_indices_count {
-                    self.stack.push(CurrentIndexBlock {
-                        entries,
-                        block_indices_count,
-                        index: index + 1,
-                    });
-                }
-                self.enter_block(block_index)?;
+            if self.index_pos < self.index_block_count {
+                let base = self.index_pos * 10;
+                let block_index =
+                    u16::from_be_bytes(self.index_entries[base..base + 2].try_into().unwrap());
+                self.index_pos += 1;
+                self.current_key_block =
+                    Self::parse_key_block(&self.this, &self.rc_mmap, block_index)?;
             } else {
                 return Ok(None);
             }
@@ -912,6 +1010,17 @@ fn entry_val_size(ty: u8) -> Result<usize> {
     }
 }
 
+/// Reads the type and start offset from an offset table entry.
+/// Each entry is 4 bytes: 1 byte type + 3 bytes BE offset.
+#[inline(always)]
+fn read_offset_entry(offsets: &[u8], index: usize) -> (u8, usize) {
+    let base = index * 4;
+    let word = u32::from_be_bytes(offsets[base..base + 4].try_into().unwrap());
+    let ty = (word >> 24) as u8;
+    let offset = (word & 0x00FF_FFFF) as usize;
+    (ty, offset)
+}
+
 /// Reads a key entry from a key block.
 fn get_key_entry<'l>(
     offsets: &[u8],
@@ -921,13 +1030,12 @@ fn get_key_entry<'l>(
     hash_len: u8,
 ) -> Result<GetKeyEntryResult<'l>> {
     let hash_len_usize = hash_len as usize;
-    let mut offset = &offsets[index * 4..];
-    let ty = offset.read_u8()?;
-    let start = offset.read_u24::<BE>()? as usize;
+    let (ty, start) = read_offset_entry(offsets, index);
     let end = if index == entry_count - 1 {
         entries.len()
     } else {
-        (&offsets[(index + 1) * 4 + 1..]).read_u24::<BE>()? as usize
+        let (_, next_start) = read_offset_entry(offsets, index + 1);
+        next_start
     };
     // Return the raw hash bytes slice (0-8 bytes depending on hash_len)
     let hash = &entries[start..start + hash_len_usize];

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -340,7 +340,6 @@ impl StaticSortedFile {
         entry_count: usize,
         key_hash: u64,
         key: &K,
-
         value_block_cache: &BlockCache,
         get_entry: impl Fn(usize) -> Result<GetKeyEntryResult<'a>>,
     ) -> Result<SstLookupResult> {

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -1,7 +1,6 @@
 use std::{cmp::Ordering, fs::File, hash::BuildHasherDefault, path::Path, rc::Rc, sync::Arc};
 
-use anyhow::{Context, Result, bail};
-use byteorder::{BE, ReadBytesExt};
+use anyhow::{Context, Result, bail, ensure};
 use memmap2::Mmap;
 use quick_cache::sync::GuardResult;
 use rustc_hash::FxHasher;
@@ -10,11 +9,13 @@ use smallvec::SmallVec;
 use crate::{
     QueryKey,
     arc_bytes::ArcBytes,
-    compression::{checksum_block, decompress_into_arc},
+    be,
+    compression::checksum_block,
     constants::MAX_INLINE_VALUE_SIZE,
     lookup_entry::{IterValue, LookupEntry, LookupValue},
     mmap_helper::advise_mmap_for_persistence,
     rc_bytes::RcBytes,
+    shared_bytes::SharedBytes,
     static_sorted_file_builder::BLOCK_HEADER_SIZE,
 };
 
@@ -89,39 +90,57 @@ impl quick_cache::Weighter<(u32, u16), ArcBytes> for BlockWeighter {
 pub type BlockCache =
     quick_cache::sync::Cache<(u32, u16), ArcBytes, BlockWeighter, BuildHasherDefault<FxHasher>>;
 
-/// Trait abstracting value block caching for `handle_key_match`.
+/// Trait abstracting value block reading for `handle_key_match_generic`.
 ///
-/// Implemented by `&BlockCache` (global shared cache for lookups) and
-/// `&mut Option<(u16, ArcBytes)>` (lightweight single-entry cache for
-/// sequential iteration).
-trait ValueBlockCache {
-    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes>;
+/// Provides cached reads (small value blocks) and uncached reads (medium value
+/// blocks). Generic over the byte type so it works for both the lookup path
+/// (`ArcBytes` with `BlockCache`) and the iteration path (`RcBytes` with a
+/// single-entry `Option` cache).
+trait ValueBlockCache<B: SharedBytes> {
+    fn get_or_read(
+        self,
+        mmap: &B::MmapHandle,
+        meta: &StaticSortedFileMetaData,
+        block_index: u16,
+    ) -> Result<B>;
 }
 
-impl ValueBlockCache for &BlockCache {
-    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes> {
-        let this = &sst;
-        let block = match self.get_value_or_guard(&(this.meta.sequence_number, block_index), None) {
-            GuardResult::Value(block) => block,
-            GuardResult::Guard(guard) => {
-                let block = this.read_small_value_block(block_index)?;
-                let _ = guard.insert(block.clone());
-                block
-            }
-            GuardResult::Timeout => unreachable!(),
-        };
-        Ok(block)
+/// Lookup-path: concurrent `BlockCache`.
+impl ValueBlockCache<ArcBytes> for &BlockCache {
+    fn get_or_read(
+        self,
+        mmap: &Arc<Mmap>,
+        meta: &StaticSortedFileMetaData,
+        block_index: u16,
+    ) -> Result<ArcBytes> {
+        Ok(
+            match self.get_value_or_guard(&(meta.sequence_number, block_index), None) {
+                GuardResult::Value(block) => block,
+                GuardResult::Guard(guard) => {
+                    let block: ArcBytes = read_block_generic(mmap, meta, block_index)?;
+                    let _ = guard.insert(block.clone());
+                    block
+                }
+                GuardResult::Timeout => unreachable!(),
+            },
+        )
     }
 }
 
-impl ValueBlockCache for &mut Option<(u16, ArcBytes)> {
-    fn get_or_read(self, sst: &StaticSortedFile, block_index: u16) -> Result<ArcBytes> {
+/// Iteration-path: lightweight single-entry cache for sequential reads.
+impl ValueBlockCache<RcBytes> for &mut Option<(u16, RcBytes)> {
+    fn get_or_read(
+        self,
+        mmap: &Rc<Mmap>,
+        meta: &StaticSortedFileMetaData,
+        block_index: u16,
+    ) -> Result<RcBytes> {
         if let Some((idx, block)) = self.as_ref()
             && *idx == block_index
         {
             return Ok(block.clone());
         }
-        let block = sst.read_small_value_block(block_index)?;
+        let block: RcBytes = read_block_generic(mmap, meta, block_index)?;
         *self = Some((block_index, block.clone()));
         Ok(block)
     }
@@ -194,8 +213,9 @@ impl StaticSortedFile {
     ) -> Result<SstLookupResult> {
         let mut current_block = self.meta.block_count - 1;
         loop {
-            let mut key_block_arc = self.get_key_block(current_block, key_block_cache)?;
-            let block_type = key_block_arc.read_u8()?;
+            let key_block_arc = self.get_key_block(current_block, key_block_cache)?;
+            ensure!(!key_block_arc.is_empty(), "empty key block");
+            let block_type = be::read_u8(&key_block_arc);
             match block_type {
                 BLOCK_TYPE_INDEX => {
                     current_block = self.lookup_index_block(&key_block_arc, key_hash)?;
@@ -228,20 +248,21 @@ impl StaticSortedFile {
     }
 
     /// Looks up a hash in a index block.
-    fn lookup_index_block(&self, mut block: &[u8], hash: u64) -> Result<u16> {
-        let first_block = block.read_u16::<BE>()?;
+    fn lookup_index_block(&self, block: &[u8], hash: u64) -> Result<u16> {
+        ensure!(block.len() >= 3, "index block too short");
+        let first_block = be::read_u16(&block[1..]);
         // Each entry is 10 bytes: 8 bytes for the hash, 2 bytes for the block index
-        let (entries, remainder) = block.as_chunks::<10>();
+        let (entries, remainder) = block[3..].as_chunks::<10>();
         if entries.is_empty() {
             return Ok(first_block);
         }
         if !remainder.is_empty() {
             bail!("invalid index block, {} extra bytes", remainder.len())
         }
-        match entries.binary_search_by(|entry| (&entry[..]).read_u64::<BE>().unwrap().cmp(&hash)) {
-            Ok(i) => Ok((&entries[i][8..]).read_u16::<BE>()?),
+        match entries.binary_search_by(|entry| be::read_u64(entry).cmp(&hash)) {
+            Ok(i) => Ok(be::read_u16(&entries[i][8..])),
             Err(0) => Ok(first_block),
-            Err(i) => Ok((&entries[i - 1][8..]).read_u16::<BE>()?),
+            Err(i) => Ok(be::read_u16(&entries[i - 1][8..])),
         }
     }
 
@@ -251,16 +272,18 @@ impl StaticSortedFile {
     /// If `FIND_ALL` is true, collects all entries with the same key.
     fn lookup_key_block<K: QueryKey, const FIND_ALL: bool>(
         &self,
-        mut block: ArcBytes,
+        block: ArcBytes,
         key_hash: u64,
         key: &K,
         has_hash: bool,
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
         let hash_len: u8 = if has_hash { 8 } else { 0 };
-        let entry_count = block.read_u24::<BE>()? as usize;
-        let offsets = &block[..entry_count * 4];
-        let entries = &block[entry_count * 4..];
+        ensure!(block.len() >= 4, "key block too short");
+        let entry_count = be::read_u24(&block[1..]) as usize;
+        let data = &block[4..];
+        let offsets = &data[..entry_count * 4];
+        let entries = &data[entry_count * 4..];
 
         self.lookup_block_inner::<K, FIND_ALL>(
             &block,
@@ -278,19 +301,20 @@ impl StaticSortedFile {
     /// enabling direct indexing during binary search.
     fn lookup_fixed_key_block<K: QueryKey, const FIND_ALL: bool>(
         &self,
-        mut block: ArcBytes,
+        block: ArcBytes,
         key_hash: u64,
         key: &K,
         has_hash: bool,
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
         let hash_len: u8 = if has_hash { 8 } else { 0 };
-        let entry_count = block.read_u24::<BE>()? as usize;
-        let key_size = block.read_u8()? as usize;
-        let value_type = block.read_u8()?;
+        ensure!(block.len() >= 6, "fixed key block too short");
+        let entry_count = be::read_u24(&block[1..]) as usize;
+        let key_size = be::read_u8(&block[4..]) as usize;
+        let value_type = be::read_u8(&block[5..]);
         let val_size = entry_val_size(value_type)?;
         let stride = hash_len as usize + key_size + val_size;
-        let entries = &block[..];
+        let entries = &block[6..];
 
         self.lookup_block_inner::<K, FIND_ALL>(
             &block,
@@ -316,6 +340,7 @@ impl StaticSortedFile {
         entry_count: usize,
         key_hash: u64,
         key: &K,
+
         value_block_cache: &BlockCache,
         get_entry: impl Fn(usize) -> Result<GetKeyEntryResult<'a>>,
     ) -> Result<SstLookupResult> {
@@ -396,35 +421,17 @@ impl StaticSortedFile {
         ty: u8,
         val: &[u8],
         key_block_arc: &ArcBytes,
-        value_block_cache: impl ValueBlockCache,
+        value_block_cache: &BlockCache,
     ) -> Result<LookupValue> {
-        Ok(match ty {
-            KEY_BLOCK_ENTRY_TYPE_SMALL => {
-                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
-                let size = u16::from_be_bytes(val[2..4].try_into().unwrap()) as usize;
-                let position = u32::from_be_bytes(val[4..8].try_into().unwrap()) as usize;
-                let value = value_block_cache
-                    .get_or_read(self, block)?
-                    .slice(position..position + size);
-                LookupValue::Slice { value }
-            }
-            KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
-                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
-                let value = self.read_value_block(block)?;
-                LookupValue::Slice { value }
-            }
-            KEY_BLOCK_ENTRY_TYPE_BLOB => {
-                let sequence_number = u32::from_be_bytes(val[0..4].try_into().unwrap());
-                LookupValue::Blob { sequence_number }
-            }
-            KEY_BLOCK_ENTRY_TYPE_DELETED => LookupValue::Deleted,
-            _ => {
-                // Inline value — val is already the correct slice
-                // SAFETY: val points into key_block_arc's data
-                let value = unsafe { key_block_arc.slice_from_subslice(val) };
-                LookupValue::Slice { value }
-            }
-        })
+        Ok(handle_key_match_generic(
+            &self.mmap,
+            &self.meta,
+            ty,
+            val,
+            key_block_arc,
+            value_block_cache,
+        )?
+        .into())
     }
 
     /// Gets a key block from the cache or reads it from the file.
@@ -451,46 +458,12 @@ impl StaticSortedFile {
         self.read_block(block_index)
     }
 
-    /// Reads a small value block from the file.
-    fn read_small_value_block(&self, block_index: u16) -> Result<ArcBytes> {
-        self.read_block(block_index)
-    }
-
-    /// Reads a value block from the file.
-    fn read_value_block(&self, block_index: u16) -> Result<ArcBytes> {
-        self.read_block(block_index)
-    }
-
     /// Reads a block from the file, decompressing if needed, and verifies its checksum.
     ///
     /// The checksum is verified on the raw on-disk data **before** decompression, so
     /// corruption is caught before passing data to LZ4.
-    #[tracing::instrument(level = "info", name = "reading database block", skip_all)]
     fn read_block(&self, block_index: u16) -> Result<ArcBytes> {
-        let (uncompressed_length, expected_checksum, block) =
-            get_raw_block_slice(&self.mmap, &self.meta, block_index).with_context(|| {
-                format!(
-                    "Failed to read raw block {} from {:08}.sst",
-                    block_index, self.meta.sequence_number
-                )
-            })?;
-
-        // Verify checksum on the raw on-disk data before decompression.
-        verify_checksum(&self.meta, block, expected_checksum, block_index)?;
-
-        // 0 means the block was not compressed, return the mmap-backed ArcBytes directly
-        if uncompressed_length == 0 {
-            // SAFETY: callers guarantee block points into self.mmap.
-            return Ok(unsafe { ArcBytes::from_mmap(self.mmap.clone(), block) });
-        }
-
-        let buffer = decompress_into_arc(uncompressed_length, block).with_context(|| {
-            format!(
-                "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-                block_index, self.meta.sequence_number, uncompressed_length
-            )
-        })?;
-        Ok(ArcBytes::from(buffer))
+        read_block_generic(&self.mmap, &self.meta, block_index)
     }
 }
 
@@ -527,23 +500,9 @@ fn get_raw_block_slice<'a>(
     let block_start = if block_index == 0 {
         0
     } else {
-        (&mmap[offset - 4..offset])
-            .read_u32::<BE>()
-            .with_context(|| {
-                format!(
-                    "Failed to read block_start offset for block {} in {:08}.sst",
-                    block_index, meta.sequence_number
-                )
-            })? as usize
+        be::read_u32(&mmap[offset - 4..]) as usize
     };
-    let block_end = (&mmap[offset..offset + 4])
-        .read_u32::<BE>()
-        .with_context(|| {
-            format!(
-                "Failed to read block_end offset for block {} in {:08}.sst",
-                block_index, meta.sequence_number
-            )
-        })? as usize;
+    let block_end = be::read_u32(&mmap[offset..]) as usize;
     #[cfg(feature = "strict_checks")]
     if block_end > mmap.len() || block_start > mmap.len() {
         bail!(
@@ -556,26 +515,14 @@ fn get_raw_block_slice<'a>(
             meta.block_offsets_start(mmap.len()),
         );
     }
-    let uncompressed_length = u32::from_be_bytes(
-        mmap[block_start..block_start + 4]
-            .try_into()
-            .with_context(|| {
-                format!(
-                    "Failed to read uncompressed_length from block {} header in {:08}.sst",
-                    block_index, meta.sequence_number
-                )
-            })?,
+    ensure!(
+        block_start + BLOCK_HEADER_SIZE <= block_end,
+        "block {} header truncated in {:08}.sst",
+        block_index,
+        meta.sequence_number
     );
-    let checksum = u32::from_be_bytes(
-        mmap[block_start + 4..block_start + 8]
-            .try_into()
-            .with_context(|| {
-                format!(
-                    "Failed to read checksum from block {} header in {:08}.sst",
-                    block_index, meta.sequence_number
-                )
-            })?,
-    );
+    let uncompressed_length = be::read_u32(&mmap[block_start..]);
+    let checksum = be::read_u32(&mmap[block_start + 4..]);
     let block = &mmap[block_start + BLOCK_HEADER_SIZE..block_end];
     Ok((uncompressed_length, checksum, block))
 }
@@ -599,6 +546,118 @@ fn verify_checksum(
         );
     }
     Ok(())
+}
+
+/// Returns `(uncompressed_length, checksum, block)` wrapping the raw on-disk
+/// data as the given byte type. Generic over `ArcBytes`/`RcBytes`.
+fn get_raw_block_generic<B: SharedBytes>(
+    mmap: &B::MmapHandle,
+    meta: &StaticSortedFileMetaData,
+    block_index: u16,
+) -> Result<(u32, u32, B)> {
+    let (uncompressed_length, checksum, block) = get_raw_block_slice(mmap, meta, block_index)?;
+    // SAFETY: block points into mmap which backs the MmapHandle.
+    Ok((uncompressed_length, checksum, unsafe {
+        B::from_mmap(mmap, block)
+    }))
+}
+
+/// Reads a block, decompresses if needed, and verifies its checksum.
+/// Generic over the byte type (`ArcBytes` or `RcBytes`).
+#[tracing::instrument(level = "info", name = "reading database block", skip_all)]
+fn read_block_generic<B: SharedBytes>(
+    mmap: &B::MmapHandle,
+    meta: &StaticSortedFileMetaData,
+    block_index: u16,
+) -> Result<B> {
+    let (uncompressed_length, expected_checksum, block) =
+        get_raw_block_slice(mmap, meta, block_index).with_context(|| {
+            format!(
+                "Failed to read raw block {} from {:08}.sst",
+                block_index, meta.sequence_number
+            )
+        })?;
+
+    verify_checksum(meta, block, expected_checksum, block_index)?;
+
+    if uncompressed_length == 0 {
+        // SAFETY: callers guarantee block points into the mmap.
+        return Ok(unsafe { B::from_mmap(mmap, block) });
+    }
+
+    let buffer = B::from_decompressed(uncompressed_length, block).with_context(|| {
+        format!(
+            "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
+            block_index, meta.sequence_number, uncompressed_length
+        )
+    })?;
+    Ok(buffer)
+}
+
+/// Handles a key match by resolving the value reference. Generic over byte type.
+fn handle_key_match_generic<B: SharedBytes>(
+    mmap: &B::MmapHandle,
+    meta: &StaticSortedFileMetaData,
+    ty: u8,
+    val: &[u8],
+    key_block: &B,
+    reader: impl ValueBlockCache<B>,
+) -> Result<GenericValue<B>> {
+    Ok(match ty {
+        KEY_BLOCK_ENTRY_TYPE_SMALL => {
+            let block = be::read_u16(val);
+            let size = be::read_u16(&val[2..]) as usize;
+            let position = be::read_u32(&val[4..]) as usize;
+            let value = reader
+                .get_or_read(mmap, meta, block)?
+                .slice(position..position + size);
+            GenericValue::Slice { value }
+        }
+        KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
+            let block = be::read_u16(val);
+            let value = read_block_generic(mmap, meta, block)?;
+            GenericValue::Slice { value }
+        }
+        KEY_BLOCK_ENTRY_TYPE_BLOB => {
+            let sequence_number = be::read_u32(val);
+            GenericValue::Blob { sequence_number }
+        }
+        KEY_BLOCK_ENTRY_TYPE_DELETED => GenericValue::Deleted,
+        _ => {
+            // Inline value — val is already the correct slice
+            // SAFETY: val points into key_block's data
+            let value = unsafe { key_block.slice_from_subslice(val) };
+            GenericValue::Slice { value }
+        }
+    })
+}
+
+/// Value type generic over the byte representation.
+/// Convertible to both `LookupValue` and `IterValue`.
+enum GenericValue<B> {
+    Deleted,
+    Slice { value: B },
+    Blob { sequence_number: u32 },
+}
+
+impl From<GenericValue<ArcBytes>> for LookupValue {
+    fn from(v: GenericValue<ArcBytes>) -> Self {
+        match v {
+            GenericValue::Deleted => LookupValue::Deleted,
+            GenericValue::Slice { value } => LookupValue::Slice { value },
+            GenericValue::Blob { sequence_number } => LookupValue::Blob { sequence_number },
+        }
+    }
+}
+
+impl From<GenericValue<RcBytes>> for IterValue {
+    fn from(v: GenericValue<RcBytes>) -> Self {
+        match v {
+            GenericValue::Deleted => IterValue::Deleted,
+            GenericValue::Slice { value } => IterValue::Slice { value },
+            GenericValue::Blob { sequence_number } => IterValue::Blob { sequence_number },
+        }
+    }
 }
 
 /// An iterator over all entries in a SST file in sorted order.
@@ -677,17 +736,18 @@ impl StaticSortedFileIter {
 
     fn new(mmap: Rc<Mmap>, meta: StaticSortedFileMetaData) -> Result<Self> {
         let root_block_index = meta.block_count - 1;
-        let block_rc = Self::read_block_rc(&mmap, &meta, root_block_index)?;
-        let block_type = block_rc[0];
+        let block: RcBytes = read_block_generic(&mmap, &meta, root_block_index)?;
+        let block_type = block[0];
 
         // The builder always writes an index block as the root block.
         if block_type != BLOCK_TYPE_INDEX {
             bail!("Root block must be an index block");
         }
-        let block_len = block_rc.len();
+        let block_len = block.len();
+        ensure!(block_len >= 3, "index block too short");
         let block_indices_count = (block_len - 1 + 8) / 10;
-        let first_child = u16::from_be_bytes(block_rc[1..3].try_into().unwrap());
-        let index_entries = block_rc.slice(1..block_len);
+        let first_child = be::read_u16(&block[1..]);
+        let index_entries = block.slice(1..block_len);
 
         let current_key_block = Self::parse_key_block(&mmap, &meta, first_child)?;
         Ok(StaticSortedFileIter {
@@ -701,113 +761,17 @@ impl StaticSortedFileIter {
         })
     }
 
-    /// Reads a block, decompresses if needed, verifies checksum. Returns `RcBytes`.
-    fn read_block_rc(
-        mmap: &Rc<Mmap>,
-        meta: &StaticSortedFileMetaData,
-        block_index: u16,
-    ) -> Result<RcBytes> {
-        let (uncompressed_length, expected_checksum, block) =
-            get_raw_block_slice(mmap, meta, block_index).with_context(|| {
-                format!(
-                    "Failed to read raw block {} from {:08}.sst",
-                    block_index, meta.sequence_number
-                )
-            })?;
-
-        verify_checksum(meta, block, expected_checksum, block_index)?;
-
-        if uncompressed_length == 0 {
-            // Uncompressed: wrap the mmap slice in RcBytes (Rc clone, no atomic)
-            return Ok(unsafe { RcBytes::from_mmap(mmap, block) });
-        }
-
-        let buffer = crate::compression::decompress_into_rc(uncompressed_length, block)
-            .with_context(|| {
-                format!(
-                    "Failed to decompress block {} from {:08}.sst ({} bytes uncompressed)",
-                    block_index, meta.sequence_number, uncompressed_length
-                )
-            })?;
-        Ok(RcBytes::from(buffer))
-    }
-
-    /// Returns `(uncompressed_length, checksum, block)` as `RcBytes`.
-    fn get_raw_block_rc(
-        mmap: &Rc<Mmap>,
-        meta: &StaticSortedFileMetaData,
-        block_index: u16,
-    ) -> Result<(u32, u32, RcBytes)> {
-        let (uncompressed_length, checksum, block) = get_raw_block_slice(mmap, meta, block_index)?;
-        Ok((uncompressed_length, checksum, unsafe {
-            RcBytes::from_mmap(mmap, block)
-        }))
-    }
-
-    /// Reads a small value block, using a single-entry cache. Returns `RcBytes`.
-    fn read_small_value_block_rc(
-        mmap: &Rc<Mmap>,
-        meta: &StaticSortedFileMetaData,
-        cache: &mut Option<(u16, RcBytes)>,
-        block_index: u16,
-    ) -> Result<RcBytes> {
-        if let Some((idx, block)) = cache.as_ref()
-            && *idx == block_index
-        {
-            return Ok(block.clone());
-        }
-        let block = Self::read_block_rc(mmap, meta, block_index)?;
-        *cache = Some((block_index, block.clone()));
-        Ok(block)
-    }
-
-    /// Handles a key match, producing `IterValue` (uses `RcBytes`).
-    fn handle_key_match_rc(
-        mmap: &Rc<Mmap>,
-        meta: &StaticSortedFileMetaData,
-        ty: u8,
-        val: &[u8],
-        key_block_entries: &RcBytes,
-        value_block_cache: &mut Option<(u16, RcBytes)>,
-    ) -> Result<IterValue> {
-        Ok(match ty {
-            KEY_BLOCK_ENTRY_TYPE_SMALL => {
-                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
-                let size = u16::from_be_bytes(val[2..4].try_into().unwrap()) as usize;
-                let position = u32::from_be_bytes(val[4..8].try_into().unwrap()) as usize;
-                let value = Self::read_small_value_block_rc(mmap, meta, value_block_cache, block)?
-                    .slice(position..position + size);
-                IterValue::Slice { value }
-            }
-            KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
-                let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
-                let value = Self::read_block_rc(mmap, meta, block)?;
-                IterValue::Slice { value }
-            }
-            KEY_BLOCK_ENTRY_TYPE_BLOB => {
-                let sequence_number = u32::from_be_bytes(val[0..4].try_into().unwrap());
-                IterValue::Blob { sequence_number }
-            }
-            KEY_BLOCK_ENTRY_TYPE_DELETED => IterValue::Deleted,
-            _ => {
-                // Inline value — val is already the correct slice
-                // SAFETY: val points into key_block_entries' data
-                let value = unsafe { key_block_entries.slice_from_subslice(val) };
-                IterValue::Slice { value }
-            }
-        })
-    }
-
     /// Parses a key block at the given index, returning `RcBytes`-backed data.
     fn parse_key_block(
         mmap: &Rc<Mmap>,
         meta: &StaticSortedFileMetaData,
         block_index: u16,
     ) -> Result<CurrentKeyBlock> {
-        let block_rc = Self::read_block_rc(mmap, meta, block_index)?;
-        let block = &*block_rc;
-        let block_type = block[0];
-        let entry_count = u32::from_be_bytes([0, block[1], block[2], block[3]]);
+        let block: RcBytes = read_block_generic(mmap, meta, block_index)?;
+        let data = &*block;
+        ensure!(data.len() >= 4, "key block too short");
+        let block_type = data[0];
+        let entry_count = be::read_u24(&data[1..]);
         match block_type {
             BLOCK_TYPE_KEY_WITH_HASH | BLOCK_TYPE_KEY_NO_HASH => {
                 let hash_len = if block_type == BLOCK_TYPE_KEY_WITH_HASH {
@@ -817,9 +781,9 @@ impl StaticSortedFileIter {
                 };
                 let n = entry_count as usize;
                 let offsets_range = 4..4 + n * 4;
-                let entries_range = 4 + n * 4..block_rc.len();
-                let offsets = block_rc.clone().slice(offsets_range);
-                let entries = block_rc.slice(entries_range);
+                let entries_range = 4 + n * 4..block.len();
+                let offsets = block.clone().slice(offsets_range);
+                let entries = block.slice(entries_range);
                 Ok(CurrentKeyBlock {
                     kind: CurrentKeyBlockKind::Variable { offsets, hash_len },
                     entries,
@@ -833,12 +797,12 @@ impl StaticSortedFileIter {
                 } else {
                     0
                 };
-                let key_size = block[4] as usize;
-                let value_type = block[5];
+                let key_size = data[4] as usize;
+                let value_type = data[5];
                 let val_size = entry_val_size(value_type)?;
                 let stride = hash_len as usize + key_size + val_size;
-                let entries_range = 6..block_rc.len();
-                let entries = block_rc.slice(entries_range);
+                let entries_range = 6..block.len();
+                let entries = block.slice(entries_range);
                 Ok(CurrentKeyBlock {
                     kind: CurrentKeyBlockKind::Fixed {
                         hash_len,
@@ -885,19 +849,19 @@ impl StaticSortedFileIter {
                 let full_hash = if hash.is_empty() {
                     crate::key::hash_key(&key)
                 } else {
-                    u64::from_be_bytes(hash.try_into().unwrap())
+                    be::read_u64(hash)
                 };
                 let value = if ty == KEY_BLOCK_ENTRY_TYPE_MEDIUM {
-                    let block = u16::from_be_bytes(val[0..2].try_into().unwrap());
+                    let block = be::read_u16(val);
                     let (uncompressed_size, checksum, block) =
-                        Self::get_raw_block_rc(&self.mmap, &self.meta, block)?;
+                        get_raw_block_generic(&self.mmap, &self.meta, block)?;
                     IterValue::Medium {
                         uncompressed_size,
                         checksum,
                         block,
                     }
                 } else {
-                    Self::handle_key_match_rc(
+                    handle_key_match_generic(
                         &self.mmap,
                         &self.meta,
                         ty,
@@ -905,6 +869,7 @@ impl StaticSortedFileIter {
                         &kb.entries,
                         &mut self.value_block_cache,
                     )?
+                    .into()
                 };
                 let entry = LookupEntry {
                     hash: full_hash,
@@ -916,8 +881,7 @@ impl StaticSortedFileIter {
             }
             if self.index_pos < self.index_block_count {
                 let base = self.index_pos * 10;
-                let block_index =
-                    u16::from_be_bytes(self.index_entries[base..base + 2].try_into().unwrap());
+                let block_index = be::read_u16(&self.index_entries[base..]);
                 self.index_pos += 1;
                 self.current_key_block =
                     Self::parse_key_block(&self.mmap, &self.meta, block_index)?;
@@ -998,7 +962,7 @@ fn entry_val_size(ty: u8) -> Result<usize> {
 #[inline(always)]
 fn read_offset_entry(offsets: &[u8], index: usize) -> (u8, usize) {
     let base = index * 4;
-    let word = u32::from_be_bytes(offsets[base..base + 4].try_into().unwrap());
+    let word = be::read_u32(&offsets[base..]);
     let ty = (word >> 24) as u8;
     let offset = (word & 0x00FF_FFFF) as usize;
     (ty, offset)

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -212,6 +212,9 @@ impl StaticSortedFile {
         value_block_cache: &BlockCache,
     ) -> Result<SstLookupResult> {
         let mut current_block = self.meta.block_count - 1;
+        // TODO: there is only one index block per file, so we can simplify control flow directly
+        // parsing the index block and then proceeding to key blocks.  Basically there is no need to
+        // loop.
         loop {
             let key_block_arc = self.get_key_block(current_block, key_block_cache)?;
             ensure!(!key_block_arc.is_empty(), "empty key block");

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -640,16 +640,6 @@ fn handle_key_match_generic<B: SharedBytes>(
     })
 }
 
-impl From<LookupValue<RcBytes>> for IterValue {
-    fn from(v: LookupValue<RcBytes>) -> Self {
-        match v {
-            LookupValue::Deleted => IterValue::Deleted,
-            LookupValue::Slice { value } => IterValue::Slice { value },
-            LookupValue::Blob { sequence_number } => IterValue::Blob { sequence_number },
-        }
-    }
-}
-
 /// An iterator over all entries in a SST file in sorted order.
 pub struct StaticSortedFileIter {
     /// The memory-mapped file, wrapped in `Rc` for non-atomic refcounting.

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file.rs
@@ -432,15 +432,14 @@ impl StaticSortedFile {
         key_block_arc: &ArcBytes,
         value_block_cache: &BlockCache,
     ) -> Result<LookupValue> {
-        Ok(handle_key_match_generic(
+        handle_key_match_generic(
             &self.mmap,
             &self.meta,
             ty,
             val,
             key_block_arc,
             value_block_cache,
-        )?
-        .into())
+        )
     }
 
     /// Gets a key block from the cache or reads it from the file.
@@ -611,7 +610,7 @@ fn handle_key_match_generic<B: SharedBytes>(
     val: &[u8],
     key_block: &B,
     reader: impl ValueBlockCache<B>,
-) -> Result<GenericValue<B>> {
+) -> Result<LookupValue<B>> {
     Ok(match ty {
         KEY_BLOCK_ENTRY_TYPE_SMALL => {
             let block = be::read_u16(val);
@@ -620,51 +619,33 @@ fn handle_key_match_generic<B: SharedBytes>(
             let value = reader
                 .get_or_read(mmap, meta, block)?
                 .slice(position..position + size);
-            GenericValue::Slice { value }
+            LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_MEDIUM => {
             let block = be::read_u16(val);
             let value = read_block_generic(mmap, meta, block)?;
-            GenericValue::Slice { value }
+            LookupValue::Slice { value }
         }
         KEY_BLOCK_ENTRY_TYPE_BLOB => {
             let sequence_number = be::read_u32(val);
-            GenericValue::Blob { sequence_number }
+            LookupValue::Blob { sequence_number }
         }
-        KEY_BLOCK_ENTRY_TYPE_DELETED => GenericValue::Deleted,
+        KEY_BLOCK_ENTRY_TYPE_DELETED => LookupValue::Deleted,
         _ => {
             // Inline value — val is already the correct slice
             // SAFETY: val points into key_block's data
             let value = unsafe { key_block.slice_from_subslice(val) };
-            GenericValue::Slice { value }
+            LookupValue::Slice { value }
         }
     })
 }
 
-/// Value type generic over the byte representation.
-/// Convertible to both `LookupValue` and `IterValue`.
-enum GenericValue<B> {
-    Deleted,
-    Slice { value: B },
-    Blob { sequence_number: u32 },
-}
-
-impl From<GenericValue<ArcBytes>> for LookupValue {
-    fn from(v: GenericValue<ArcBytes>) -> Self {
+impl From<LookupValue<RcBytes>> for IterValue {
+    fn from(v: LookupValue<RcBytes>) -> Self {
         match v {
-            GenericValue::Deleted => LookupValue::Deleted,
-            GenericValue::Slice { value } => LookupValue::Slice { value },
-            GenericValue::Blob { sequence_number } => LookupValue::Blob { sequence_number },
-        }
-    }
-}
-
-impl From<GenericValue<RcBytes>> for IterValue {
-    fn from(v: GenericValue<RcBytes>) -> Self {
-        match v {
-            GenericValue::Deleted => IterValue::Deleted,
-            GenericValue::Slice { value } => IterValue::Slice { value },
-            GenericValue::Blob { sequence_number } => IterValue::Blob { sequence_number },
+            LookupValue::Deleted => IterValue::Deleted,
+            LookupValue::Slice { value } => IterValue::Slice { value },
+            LookupValue::Blob { sequence_number } => IterValue::Blob { sequence_number },
         }
     }
 }

--- a/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
+++ b/turbopack/crates/turbo-persistence/src/static_sorted_file_builder.rs
@@ -1196,10 +1196,10 @@ struct IndexBlockBuilder<W: Write> {
 }
 
 /// Size of a single index block entry (u64 hash + u16 block index).
-const INDEX_BLOCK_ENTRY_SIZE: usize = size_of::<u64>() + size_of::<u16>();
+pub(crate) const INDEX_BLOCK_ENTRY_SIZE: usize = size_of::<u64>() + size_of::<u16>();
 
 /// Size of the index block header (u8 type + u16 first_block).
-const INDEX_BLOCK_HEADER_SIZE: usize = size_of::<u8>() + size_of::<u16>();
+pub(crate) const INDEX_BLOCK_HEADER_SIZE: usize = size_of::<u8>() + size_of::<u16>();
 
 impl<W: Write> IndexBlockBuilder<W> {
     /// Creates a new builder for an index block with the specified number of entries and a pointer


### PR DESCRIPTION
## Summary

Optimizes the turbo-persistence compaction and iteration paths with several targeted improvements:

### Iterator optimizations

- **Flatten index block iteration** — The iterator previously used a `Vec<CurrentIndexBlock>` stack, but SST files have exactly one index level. Inline the index block fields (`index_entries`, `index_block_count`, `index_pos`) directly into `StaticSortedFileIter`, eliminating the stack allocation and `Option` overhead.

- **Non-optional `CurrentKeyBlock`** — Parse the first key block during `try_into_iter()` construction so `current_key_block` is always populated, removing the `Option<CurrentKeyBlock>` wrapper and its `take()`/`Some()` ceremony in the hot loop.

- **Replace `ReadBytesExt` with direct byte indexing** — In `handle_key_match`, `parse_key_block`, and `next_internal`, replace `val.read_u16::<BE>()` etc. with `u16::from_be_bytes(val[0..2].try_into().unwrap())`. This eliminates th mutable slice pointer advancement.

- **Extract `read_offset_entry` helper** — Read type + offset from the key block offset table in a single `u32` load + shift, replacing two separate `ReadBytesExt` calls.


### Refcounting optimization

- **Introduce `RcBytes`** — Thread-local byte slice type using `Rc` instead of `Arc`, eliminating atomic refcount overhead during single-threaded SST iteration. The iteration path (`StaticSortedFileIter`) now produces `RcBytes` slices backed by an `Rc<Mmap>`, so per-entry clone/drop operations are plain integer increments rather than atomic operations.


### Merge iterator simplification

- **Optimize `MergeIter::next`** — Replaced the straightforwards `pop/push` pattern with `PeekMut`-based replace-top pattern, which means we only need to adjust the heap once per iteration instead of twice.

## Benchmark results

### Compaction (`key_8/value_4/entries_16.00Mi/commits_128`)

| Benchmark | Canary | Optimized | Change |
|-----------|--------|-----------|--------|
| partial compaction | 1.949 s | 1.515 s | **-22%** |
| full compaction | 2.051 s | 1.542 s | **-25%** |

### Read path (`static_sorted_file_lookup/entries_1000.00Ki`)

No read regression — the branch is neutral to slightly faster:

| Benchmark | Canary | Optimized | Change |
|-----------|--------|-----------|--------|
| hit/uncached | 6.73 µs | 6.59 µs | **-2%** |
| hit/cached | 140.8 ns | 130.7 ns | **-7%** |
| miss/uncached | 5.10 µs | 5.02 µs | **-2%** |
| miss/cached | 230.1 ns | 233.1 ns | ~+1% (noise) |

## Test plan

- [x] `cargo test -p turbo-persistence` — 60/60 tests passing
- [x] Compaction benchmarks run and compared against canary baseline
- [x] Read path (lookup) benchmarks verified no regression