### PR TITLE
Fix startup warmup for empty-shell app route cache

### DIFF
--- a/packages/next/src/server/lib/incremental-cache/memory-cache.external.ts
+++ b/packages/next/src/server/lib/incremental-cache/memory-cache.external.ts
@@ -4,6 +4,24 @@ import { LRUCache } from '../lru-cache'
 
 let memoryCache: LRUCache<CacheHandlerValue> | undefined
 
+function getBufferSize(buffer: Buffer | undefined) {
+  return buffer?.length || 0
+}
+
+function getSegmentDataSize(segmentData: Map<string, Buffer> | undefined) {
+  if (!segmentData) {
+    return 0
+  }
+
+  let size = 0
+
+  for (const [segmentPath, buffer] of segmentData) {
+    size += segmentPath.length + getBufferSize(buffer)
+  }
+
+  return size
+}
+
 export function getMemoryCache(maxMemoryCacheSize: number) {
   if (!memoryCache) {
     memoryCache = new LRUCache(maxMemoryCacheSize, function length({ value }) {
@@ -19,14 +37,17 @@ export function getMemoryCache(maxMemoryCacheSize: number) {
         return value.body.length
       }
       // rough estimate of size of cache value
-      return (
-        value.html.length +
-        (JSON.stringify(
-          value.kind === CachedRouteKind.APP_PAGE
-            ? value.rscData
-            : value.pageData
-        )?.length || 0)
-      )
+      if (value.kind === CachedRouteKind.APP_PAGE) {
+        return Math.max(
+          1,
+          value.html.length +
+            getBufferSize(value.rscData) +
+            (value.postponed?.length || 0) +
+            getSegmentDataSize(value.segmentData)
+        )
+      }
+
+      return value.html.length + (JSON.stringify(value.pageData)?.length || 0)
     })
   }
 

--- a/test/production/app-dir/empty-shell-route-cache/app/layout.tsx
+++ b/test/production/app-dir/empty-shell-route-cache/app/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/production/app-dir/empty-shell-route-cache/app/page.tsx
+++ b/test/production/app-dir/empty-shell-route-cache/app/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Empty Shell Route Cache</h1>
+      <ul>
+        <li>
+          <Link href="/with-suspense">With Suspense</Link>
+        </li>
+        <li>
+          <Link href="/without-suspense">Without Suspense</Link>
+        </li>
+      </ul>
+    </main>
+  )
+}

--- a/test/production/app-dir/empty-shell-route-cache/app/with-suspense/page.tsx
+++ b/test/production/app-dir/empty-shell-route-cache/app/with-suspense/page.tsx
@@ -1,0 +1,18 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+
+async function DynamicContent() {
+  await connection()
+  return <p>Dynamic content rendered at request time</p>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <h1>With Suspense</h1>
+      <Suspense fallback={<p>Loading...</p>}>
+        <DynamicContent />
+      </Suspense>
+    </div>
+  )
+}

--- a/test/production/app-dir/empty-shell-route-cache/app/without-suspense/page.tsx
+++ b/test/production/app-dir/empty-shell-route-cache/app/without-suspense/page.tsx
@@ -1,0 +1,13 @@
+import { connection } from 'next/server'
+
+export const unstable_instant = false
+
+export default async function Page() {
+  await connection()
+  return (
+    <div>
+      <h1>Without Suspense</h1>
+      <p>Dynamic content rendered at request time</p>
+    </div>
+  )
+}

--- a/test/production/app-dir/empty-shell-route-cache/empty-shell-route-cache.test.ts
+++ b/test/production/app-dir/empty-shell-route-cache/empty-shell-route-cache.test.ts
@@ -1,0 +1,92 @@
+import fs from 'fs/promises'
+import { nextTestSetup } from 'e2e-utils'
+import path from 'path'
+
+describe('empty-shell-route-cache', () => {
+  const { next } = nextTestSetup({
+    files: __dirname,
+    skipStart: true,
+    // This regression inspects on-disk .next artifacts, so it only applies to
+    // self-hosted build + start and is not portable to deployment mode.
+    skipDeployment: true,
+  })
+
+  beforeAll(async () => {
+    await next.build()
+  })
+
+  async function getRouteArtifactMtimes(route: string) {
+    const routeMeta = JSON.parse(
+      await next.readFile(`.next/server/app/${route}.meta`)
+    )
+    const files = [
+      `${route}.html`,
+      `${route}.meta`,
+      ...routeMeta.segmentPaths.map(
+        (segmentPath: string) => `${route}.segments${segmentPath}.segment.rsc`
+      ),
+    ]
+
+    return Object.fromEntries(
+      await Promise.all(
+        files.map(async (file) => {
+          const stat = await fs.stat(
+            path.join(next.testDir, '.next/server/app', file)
+          )
+
+          return [file, stat.mtimeMs]
+        })
+      )
+    )
+  }
+
+  it('should emit both routes as partially static build artifacts', async () => {
+    const prerenderManifest = JSON.parse(
+      await next.readFile('.next/prerender-manifest.json')
+    )
+
+    expect(prerenderManifest.routes['/with-suspense'].renderingMode).toBe(
+      'PARTIALLY_STATIC'
+    )
+    expect(prerenderManifest.routes['/without-suspense'].renderingMode).toBe(
+      'PARTIALLY_STATIC'
+    )
+
+    expect(await next.readFile('.next/server/app/with-suspense.html')).not.toBe(
+      ''
+    )
+    expect(await next.readFile('.next/server/app/without-suspense.html')).toBe(
+      ''
+    )
+
+    const withoutSuspenseMeta = JSON.parse(
+      await next.readFile('.next/server/app/without-suspense.meta')
+    )
+    expect(withoutSuspenseMeta.postponed).toBeTruthy()
+  })
+
+  describe('after next start', () => {
+    beforeAll(async () => {
+      await next.start({ skipBuild: true })
+    })
+
+    afterAll(async () => {
+      await next.stop()
+    })
+
+    it.each([
+      ['/with-suspense', 'with-suspense'],
+      ['/without-suspense', 'without-suspense'],
+    ])(
+      'should not rewrite %s build artifacts on the first request',
+      async (pathname, route) => {
+        const before = await getRouteArtifactMtimes(route)
+        const response = await next.fetch(pathname)
+        const after = await getRouteArtifactMtimes(route)
+
+        expect(response.status).toBe(200)
+        expect(after).toEqual(before)
+      }
+    )
+  })
+})

--- a/test/production/app-dir/empty-shell-route-cache/next.config.js
+++ b/test/production/app-dir/empty-shell-route-cache/next.config.js
@@ -1,0 +1,8 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
Startup loading of APP_PAGE PPR entries seeded the in-memory cache from disk using a size estimate that only counted html and the route-level RSC payload. Empty-shell prerenders have 0-byte html and do not persist a monolithic .rsc file, with the reusable data instead stored in postponed metadata and per-segment .segment.rsc files. That made the computed size 0, caused LRUCache to reject the seeded entry, and forced the first request after next start to rerun prerender and rewrite the build artifacts.

Account for postponed state and segment buffers when sizing APP_PAGE cache entries so empty-shell prerenders can warm the startup cache the same way contentful shells do. Add a production regression that asserts both routes are emitted as build artifacts and that next start does not rewrite them on the first request.

The regression skips deployment mode because it verifies self-hosted behavior by inspecting local .next artifact mtimes, which is not a portable signal in deployment mode. When deployed through an adapter it is not expected that the local Next.js process is handling entries through the Response cache reading from the `.next` folder anyway