### PR TITLE
Turbopack: Enable server HMR by default for app pages

### DIFF
--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -368,7 +368,7 @@ pub struct ProjectOptions {
     /// The version of Next.js that is running.
     pub next_version: RcStr,
 
-    /// Whether server-side HMR is enabled (--experimental-server-fast-refresh).
+    /// Whether server-side HMR is enabled (disabled with --no-server-fast-refresh).
     pub server_hmr: bool,
 }
 
@@ -960,7 +960,7 @@ pub struct Project {
     /// Whether to enable persistent caching
     is_persistent_caching_enabled: bool,
 
-    /// Whether server-side HMR is enabled (--experimental-server-fast-refresh).
+    /// Whether server-side HMR is enabled (disabled with --no-server-fast-refresh).
     server_hmr: bool,
 }
 

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -212,7 +212,7 @@ pub struct NapiProjectOptions {
     /// The version of Next.js that is running.
     pub next_version: RcStr,
 
-    /// Whether server-side HMR is enabled (--experimental-server-fast-refresh).
+    /// Whether server-side HMR is enabled (disabled with --no-server-fast-refresh).
     pub server_hmr: Option<bool>,
 }
 

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -313,10 +313,7 @@ program
     '--experimental-https-ca, <path>',
     'Path to a HTTPS certificate authority file.'
   )
-  .option(
-    '--experimental-server-fast-refresh',
-    'Enable experimental server-side Fast Refresh.'
-  )
+  .option('--no-server-fast-refresh', 'Disable server-side Fast Refresh')
   .option(
     '--experimental-upload-trace, <traceUrl>',
     'Reports a subset of the debugging trace to a remote HTTP URL. Includes sensitive data.'

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -256,7 +256,7 @@ export interface NapiProjectOptions {
   isPersistentCachingEnabled: boolean
   /** The version of Next.js that is running. */
   nextVersion: RcStr
-  /** Whether server-side HMR is enabled (--experimental-server-fast-refresh). */
+  /** Whether server-side HMR is enabled (disabled with --no-server-fast-refresh). */
   serverHmr?: boolean
 }
 /** [NapiProjectOptions] with all fields optional. */

--- a/packages/next/src/cli/next-dev.ts
+++ b/packages/next/src/cli/next-dev.ts
@@ -55,7 +55,7 @@ export type NextDevOptions = {
   experimentalUploadTrace?: string
   experimentalNextConfigStripTypes?: boolean
   experimentalCpuProf?: boolean
-  experimentalServerFastRefresh?: boolean
+  serverFastRefresh?: boolean
 }
 
 type PortSource = 'cli' | 'default' | 'env'
@@ -249,7 +249,7 @@ const nextDev = async (
 
   const enabledFeatures = Object.fromEntries(
     Object.entries({
-      experimentalServerFastRefresh: options.experimentalServerFastRefresh,
+      serverFastRefreshDisabled: options.serverFastRefresh === false,
       experimentalCpuProf: options.experimentalCpuProf,
     }).filter(([_, value]) => value)
   )
@@ -269,7 +269,7 @@ const nextDev = async (
     allowRetry,
     isDev: true,
     hostname: host,
-    experimentalServerFastRefresh: options.experimentalServerFastRefresh,
+    serverFastRefresh: options.serverFastRefresh,
   }
 
   const startServerPath = require.resolve('../server/lib/start-server')

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -309,7 +309,7 @@ export async function createHotReloaderTurbopack(
   distDir: string,
   resetFetch: () => void,
   lockfile: Lockfile | undefined,
-  experimentalServerFastRefresh?: boolean
+  serverFastRefresh?: boolean
 ): Promise<NextJsHotReloaderInterface> {
   const dev = true
   const buildId = 'development'
@@ -413,7 +413,7 @@ export async function createHotReloaderTurbopack(
         opts.nextConfig
       ),
       nextVersion: process.env.__NEXT_VERSION as string,
-      serverHmr: experimentalServerFastRefresh,
+      serverHmr: serverFastRefresh,
     },
     {
       memoryLimit: opts.nextConfig.experimental?.turbopackMemoryLimit,
@@ -616,9 +616,7 @@ export async function createHotReloaderTurbopack(
     //   - Middleware
     //   - App Router route handlers (route.ts)
     const usesServerHmr =
-      experimentalServerFastRefresh &&
-      isAppPage &&
-      writtenEndpoint.type !== 'edge'
+      serverFastRefresh && isAppPage && writtenEndpoint.type !== 'edge'
 
     const filesToDelete: string[] = []
     for (const file of serverPaths) {
@@ -1840,7 +1838,7 @@ export async function createHotReloaderTurbopack(
     process.exit(1)
   })
 
-  if (experimentalServerFastRefresh) {
+  if (serverFastRefresh) {
     serverHmrSubscriptions = setupServerHmr(project, {
       clear: async () => {
         // Clear Node's require cache of all Turbopack-built modules

--- a/packages/next/src/server/lib/router-server.ts
+++ b/packages/next/src/server/lib/router-server.ts
@@ -90,7 +90,7 @@ export async function initialize(opts: {
   keepAliveTimeout?: number
   customServer?: boolean
   experimentalHttpsServer?: boolean
-  experimentalServerFastRefresh?: boolean
+  serverFastRefresh?: boolean
   startServerSpan?: Span
   quiet?: boolean
 }): Promise<ServerInitResult> {
@@ -179,7 +179,7 @@ export async function initialize(opts: {
         port: opts.port,
         onDevServerCleanup: opts.onDevServerCleanup,
         resetFetch,
-        experimentalServerFastRefresh: opts.experimentalServerFastRefresh,
+        serverFastRefresh: opts.serverFastRefresh,
       })
     )
 

--- a/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
+++ b/packages/next/src/server/lib/router-utils/setup-dev-bundler.ts
@@ -117,7 +117,7 @@ export type SetupOpts = {
   port: number
   onDevServerCleanup: ((listener: () => Promise<void>) => void) | undefined
   resetFetch: () => void
-  experimentalServerFastRefresh?: boolean
+  serverFastRefresh?: boolean
 }
 
 export interface DevRoutesManifest {
@@ -241,7 +241,7 @@ async function startWatcher(
           distDir,
           resetFetch,
           lockfile,
-          opts.experimentalServerFastRefresh
+          opts.serverFastRefresh
         )
       })()
     : await (async () => {

--- a/packages/next/src/server/lib/start-server.ts
+++ b/packages/next/src/server/lib/start-server.ts
@@ -129,7 +129,7 @@ export interface StartServerOptions {
   keepAliveTimeout?: number
   // this is dev-server only
   selfSignedCertificate?: SelfSignedCertificate
-  experimentalServerFastRefresh?: boolean
+  serverFastRefresh?: boolean
 }
 
 export async function getRequestHandlers({
@@ -142,7 +142,7 @@ export async function getRequestHandlers({
   minimalMode,
   keepAliveTimeout,
   experimentalHttpsServer,
-  experimentalServerFastRefresh,
+  serverFastRefresh,
   quiet,
 }: {
   dir: string
@@ -154,7 +154,7 @@ export async function getRequestHandlers({
   minimalMode?: boolean
   keepAliveTimeout?: number
   experimentalHttpsServer?: boolean
-  experimentalServerFastRefresh?: boolean
+  serverFastRefresh?: boolean
   quiet?: boolean
 }): ReturnType<typeof initialize> {
   return initialize({
@@ -167,7 +167,7 @@ export async function getRequestHandlers({
     server,
     keepAliveTimeout,
     experimentalHttpsServer,
-    experimentalServerFastRefresh,
+    serverFastRefresh,
     startServerSpan,
     quiet,
   })
@@ -188,7 +188,7 @@ export async function startServer(
     allowRetry,
     keepAliveTimeout,
     selfSignedCertificate,
-    experimentalServerFastRefresh,
+    serverFastRefresh,
   } = serverOptions
   let { port } = serverOptions
 
@@ -489,7 +489,7 @@ export async function startServer(
           minimalMode,
           keepAliveTimeout,
           experimentalHttpsServer: !!selfSignedCertificate,
-          experimentalServerFastRefresh,
+          serverFastRefresh,
         })
         requestHandler = initResult.requestHandler
         upgradeHandler = initResult.upgradeHandler

--- a/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
+++ b/test/development/app-dir/enabled-features-trace/enabled-features-trace.test.ts
@@ -8,7 +8,7 @@ import { parseTraceFile } from '../../../lib/parse-trace-file'
 describe('enabled features in trace', () => {
   const { next, isNextDev } = nextTestSetup({
     files: __dirname,
-    startArgs: ['--experimental-server-fast-refresh'],
+    startArgs: ['--no-server-fast-refresh'],
   })
 
   if (!isNextDev) {
@@ -37,9 +37,9 @@ describe('enabled features in trace', () => {
 
     const startDevServerEvent = startDevServerEvents![0]
     expect(startDevServerEvent.tags).toBeDefined()
-    expect(
-      startDevServerEvent.tags!['feature.experimentalServerFastRefresh']
-    ).toBe(true)
+    expect(startDevServerEvent.tags!['feature.serverFastRefreshDisabled']).toBe(
+      true
+    )
   })
 
   it('should denormalize inherited enabled features during upload', async () => {
@@ -99,16 +99,14 @@ describe('enabled features in trace', () => {
     const compilePathEvent = traces.find((e: any) => e.name === 'compile-path')
     const renderPathEvent = traces.find((e: any) => e.name === 'render-path')
 
-    // Both should have inherited feature.experimentalServerFastRefresh from their parent
+    // Both should have inherited feature.serverFastRefreshDisabled from their parent
     expect(compilePathEvent).toBeDefined()
-    expect(compilePathEvent.tags['feature.experimentalServerFastRefresh']).toBe(
+    expect(compilePathEvent.tags['feature.serverFastRefreshDisabled']).toBe(
       true
     )
 
     expect(renderPathEvent).toBeDefined()
-    expect(renderPathEvent.tags['feature.experimentalServerFastRefresh']).toBe(
-      true
-    )
+    expect(renderPathEvent.tags['feature.serverFastRefreshDisabled']).toBe(true)
   })
 })
 

--- a/test/development/app-dir/server-hmr/server-hmr.test.ts
+++ b/test/development/app-dir/server-hmr/server-hmr.test.ts
@@ -5,7 +5,6 @@ import { retry } from 'next-test-utils'
 describe('server-hmr', () => {
   const { next, isTurbopack, isNextDev } = nextTestSetup({
     files: __dirname,
-    startArgs: ['--experimental-server-fast-refresh'],
   })
 
   // Server HMR is a Turbopack-only feature, only available in dev mode


### PR DESCRIPTION
This enables server HMR (formally, this is called server fast refresh) by default for app router pages. For now, it's still disabled for routes and middleware even with app router.

- Replaces `--experimental-server-fast-refresh` with `--no-server-fast-refresh` to opt out
- Updates telemetry to record `feature.serverFastRefreshDisabled` when the disable flag is passed

- [x] Verify `next dev` enables server HMR by default (Turbopack, app dir, non-edge routes)
- [x] Verify `next dev --no-server-fast-refresh` disables it
- CI
