### PR TITLE
`navigation()`: omit content from prefetches

### DIFF
--- a/packages/next/cache.d.ts
+++ b/packages/next/cache.d.ts
@@ -152,3 +152,5 @@ export function cacheLife(profile: {
 
 export const unstable_cacheLife: typeof cacheLife
 export const unstable_cacheTag: typeof cacheTag
+
+export { unstable_navigation } from 'next/dist/server/use-cache/navigation'

--- a/packages/next/cache.js
+++ b/packages/next/cache.js
@@ -24,6 +24,7 @@ if (process.env.NEXT_RUNTIME === '') {
     refresh: notAvailableInClient('refresh'),
     cacheLife: notAvailableInClient('cacheLife'),
     cacheTag: notAvailableInClient('cacheTag'),
+    unstable_navigation: notAvailableInClient('unstable_navigation'),
   }
 } else {
   // Keep server requires in this branch so browser builds can DCE them.
@@ -47,6 +48,8 @@ if (process.env.NEXT_RUNTIME === '') {
         .unstable_noStore,
     cacheLife: require('next/dist/server/use-cache/cache-life').cacheLife,
     cacheTag: require('next/dist/server/use-cache/cache-tag').cacheTag,
+    unstable_navigation: require('next/dist/server/use-cache/navigation')
+      .unstable_navigation,
   }
 }
 
@@ -92,3 +95,4 @@ exports.unstable_cacheLife = cacheExports.unstable_cacheLife
 exports.cacheTag = cacheExports.cacheTag
 exports.unstable_cacheTag = cacheExports.unstable_cacheTag
 exports.refresh = cacheExports.refresh
+exports.unstable_navigation = cacheExports.unstable_navigation

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1144,5 +1144,11 @@
   "1143": "Prefetch inlining is enabled but no hint tree was provided during incremental static revalidation. The prefetch-hints.json manifest should contain an entry for this route.",
   "1144": "Prefetch inlining is enabled but no hints were found for route \"%s\". This is a bug in the Next.js build pipeline — prefetch-hints.json should contain an entry for every route that produces segment data.",
   "1145": "Internal Next.js Error: Prefetch inlining is enabled but no hints were found for route \"%s\". prefetch-hints.json should contain an entry for every route that produces segment data. This is a bug in Next.js.",
-  "1146": "Internal Next.js Error: Prefetch inlining is enabled but no hint tree was provided during incremental static revalidation. The prefetch-hints.json manifest should contain an entry for this route. This is a bug in Next.js."
+  "1146": "Internal Next.js Error: Prefetch inlining is enabled but no hint tree was provided during incremental static revalidation. The prefetch-hints.json manifest should contain an entry for this route. This is a bug in Next.js.",
+  "1147": "`unstable_navigation` must not be used within a Client Component. Next.js should be preventing `unstable_navigation` from being included in Client Components statically, but did not in this case.",
+  "1148": "Unexpected work unit store type.",
+  "1149": "`unstable_navigation()` cannot be called inside `generateStaticParams()`.",
+  "1150": "`unstable_navigation()` is only available with the `cacheComponents` config.",
+  "1151": "`unstable_navigation()` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context",
+  "1152": "`unstable_navigation()` cannot be called inside `unstable_cache()`."
 }

--- a/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
+++ b/packages/next/src/client/components/router-reducer/create-initial-router-state.ts
@@ -205,7 +205,8 @@ export function createInitialRouterState({
               processed.headVaryParams,
               processed.staleAt,
               processed.navigationSeed,
-              null
+              null,
+              processed.stage
             )
           }
         })

--- a/packages/next/src/client/components/router-reducer/ppr-navigations.ts
+++ b/packages/next/src/client/components/router-reducer/ppr-navigations.ts
@@ -1680,7 +1680,8 @@ async function fetchMissingDynamicData(
               processed.headVaryParams,
               processed.staleAt,
               processed.navigationSeed,
-              null
+              null,
+              processed.stage
             )
           }
         })

--- a/packages/next/src/client/components/segment-cache/cache.ts
+++ b/packages/next/src/client/components/segment-cache/cache.ts
@@ -12,10 +12,10 @@ import type {
 } from '../../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../../shared/lib/app-router-types'
 import {
-  readVaryParams,
-  type VaryParams,
-  type VaryParamsThenable,
-} from '../../../shared/lib/segment-cache/vary-params-decoding'
+  readCacheInfo,
+  type CacheInfo,
+} from '../../../shared/lib/segment-cache/cache-info-decoding'
+import type { VaryParams } from '../../../shared/lib/app-router-types'
 import {
   NEXT_DID_POSTPONE_HEADER,
   NEXT_INSTANT_PREFETCH_HEADER,
@@ -104,6 +104,7 @@ import { STATIC_STALETIME_MS } from '../router-reducer/reducers/navigate-reducer
 import { pingVisibleLinks } from '../links'
 import { PAGE_SEGMENT_KEY } from '../../../shared/lib/segment'
 import { FetchStrategy } from './types'
+import { CacheStage } from '../../../shared/lib/segment-cache/cache-stage'
 import { createPromiseWithResolvers } from '../../../shared/lib/promise-with-resolvers'
 import { readFromBFCache, UnknownDynamicStaleTime } from './bfcache'
 import { discoverKnownRoute, matchKnownRoute } from './optimistic-routes'
@@ -240,6 +241,16 @@ export type RouteCacheEntry =
 
 type SegmentCacheEntryShared = {
   fetchStrategy: FetchStrategy
+
+  /**
+   * How much content past navigation boundaries is included.
+   * Used to compare completeness of two cache entries with the same fetch
+   * strategy. A higher stage means more content is available.
+   *
+   * TODO: This could be combined with fetchStrategy and isPartial into a
+   * single comparable value. See the TODO in upsertSegmentEntry.
+   */
+  stage: CacheStage
 
   // Map-related fields.
   ref: UnknownMapEntry | null
@@ -854,6 +865,14 @@ export function upsertSegmentEntry(
     // Don't replace a more specific segment with a less-specific one. A case where this
     // might happen is if the existing segment was fetched via
     // `<Link prefetch={true}>`.
+    //
+    // TODO: The fields compared here (fetchStrategy, isPartial, stage) all
+    // serve the same purpose: determining which entry has more content. They
+    // could be combined into a single comparable value (e.g. a bit field) so
+    // that this is a single comparison instead of multiple. Benefits:
+    // - Less juggling to pass these various values around
+    // - Harder to forget to check one but not the other
+    // - Conceptually aligns them as a single "completeness" dimension
     if (
       // We fetched the new segment using a different, less specific fetch strategy
       // than the segment we already have in the cache, so it can't have more content.
@@ -864,7 +883,11 @@ export function upsertSegmentEntry(
         )) ||
       // The existing entry isn't partial, but the new one is.
       // (TODO: can this be true if `candidateEntry.fetchStrategy >= existingEntry.fetchStrategy`?)
-      (!existingEntry.isPartial && candidateEntry.isPartial)
+      (!existingEntry.isPartial && candidateEntry.isPartial) ||
+      // The existing entry has a higher cache stage (more content past
+      // navigation boundaries) than the candidate.
+      (candidateEntry.fetchStrategy === existingEntry.fetchStrategy &&
+        candidateEntry.stage < existingEntry.stage)
     ) {
       // We're going to leave revalidating entry in the cache so that it doesn't
       // get revalidated again unnecessarily. Downgrade the Fulfilled entry to
@@ -897,6 +920,8 @@ export function createDetachedSegmentCacheEntry(
     // Default to assuming the fetch strategy will be PPR. This will be updated
     // when a fetch is actually initiated.
     fetchStrategy: FetchStrategy.PPR,
+    // Default to max stage (all content). Will be updated when fulfilled.
+    stage: CacheStage.Max,
     rsc: null,
     isPartial: true,
     promise: null,
@@ -970,7 +995,9 @@ export function attemptToFulfillDynamicSegmentFromBFCache(
       pendingSegment,
       bfcacheEntry.rsc,
       dynamicPrefetchStaleAt,
-      isPartial
+      isPartial,
+      // Full navigations include all content.
+      CacheStage.Max
     )
   }
   return null
@@ -1003,7 +1030,9 @@ export function attemptToUpgradeSegmentFromBFCache(
       pendingSegment,
       bfcacheEntry.rsc,
       dynamicPrefetchStaleAt,
-      isPartial
+      isPartial,
+      // Full navigations include all content.
+      CacheStage.Max
     )
     const segmentVaryPath = getSegmentVaryPathForRequest(
       FetchStrategy.Full,
@@ -1145,13 +1174,15 @@ function fulfillSegmentCacheEntry(
   segmentCacheEntry: PendingSegmentCacheEntry,
   rsc: React.ReactNode,
   staleAt: number,
-  isPartial: boolean
+  isPartial: boolean,
+  stage: CacheStage
 ): FulfilledSegmentCacheEntry {
   const fulfilledEntry: FulfilledSegmentCacheEntry = segmentCacheEntry as any
   fulfilledEntry.status = EntryStatus.Fulfilled
   fulfilledEntry.rsc = rsc
   fulfilledEntry.staleAt = staleAt
   fulfilledEntry.isPartial = isPartial
+  fulfilledEntry.stage = stage
   // Resolve any listeners that were waiting for this data.
   if (segmentCacheEntry.promise !== null) {
     segmentCacheEntry.promise.resolve(fulfilledEntry)
@@ -1803,7 +1834,7 @@ export async function fetchRouteOnCacheMiss(
       const headVaryParamsThenable = serverData.h
       const headVaryParams =
         headVaryParamsThenable !== null
-          ? readVaryParams(headVaryParamsThenable)
+          ? readCacheInfo(headVaryParamsThenable)
           : null
       writeDynamicTreeResponseIntoCache(
         Date.now(),
@@ -1967,7 +1998,9 @@ export async function fetchSegmentOnCacheMiss(
         segmentCacheEntry,
         serverData.rsc,
         staleAt,
-        serverData.isPartial
+        serverData.isPartial,
+        // Not relevant to static prefetches, only runtime ones.
+        CacheStage.Max
       )
 
       // If the server tells us which params the segment varies by, we can
@@ -2084,7 +2117,9 @@ export async function fetchInlinedSegmentsOnCacheMiss(
         ownedHeadEntry,
         serverData.head.rsc,
         headStaleAt,
-        serverData.head.isPartial
+        serverData.head.isPartial,
+        // Not relevant to static prefetches, only runtime ones.
+        CacheStage.Max
       )
     } else {
       // The head was already cached. Try to upsert if the entry is empty.
@@ -2098,7 +2133,9 @@ export async function fetchInlinedSegmentsOnCacheMiss(
           upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
           serverData.head.rsc,
           headStaleAt,
-          serverData.head.isPartial
+          serverData.head.isPartial,
+          // Not relevant to static prefetches, only runtime ones.
+          CacheStage.Max
         )
       }
     }
@@ -2130,7 +2167,10 @@ function fillInlinedSegmentEntries(
       ownedEntry,
       segment.rsc,
       staleAt,
-      segment.isPartial
+      segment.isPartial,
+      // Cache stage is only relevant for runtime prefetch responses. Static
+      // prefetches are not affected. This may change in the future.
+      CacheStage.Max
     )
   } else {
     // Not owned by us — this is extra data from the inlined response for a
@@ -2145,7 +2185,9 @@ function fillInlinedSegmentEntries(
         upgradeToPendingSegment(existingEntry, FetchStrategy.PPR),
         segment.rsc,
         staleAt,
-        segment.isPartial
+        segment.isPartial,
+        // Not relevant to static prefetches, only runtime ones.
+        CacheStage.Max
       )
     }
   }
@@ -2295,7 +2337,7 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
     const headVaryParamsThenable = serverData.h
     const headVaryParams =
       headVaryParamsThenable !== null
-        ? readVaryParams(headVaryParamsThenable)
+        ? readCacheInfo(headVaryParamsThenable)
         : null
 
     const now = Date.now()
@@ -2324,6 +2366,12 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       // Not needed for prefetch responses; pass unknown to use the default.
       UnknownDynamicStaleTime
     )
+    // Read the cache stage from the response. If absent, default to max.
+    const stage: CacheStage =
+      serverData.g !== undefined
+        ? (readCacheInfo(serverData.g) ?? CacheStage.Max)
+        : CacheStage.Max
+
     fulfilledEntries = writeDynamicRenderResponseIntoCache(
       now,
       fetchStrategy,
@@ -2333,7 +2381,8 @@ export async function fetchSegmentPrefetchesUsingDynamicRequest(
       headVaryParams,
       staleAt,
       navigationSeed,
-      spawnedEntries
+      spawnedEntries,
+      stage
     )
 
     // For buffered responses, update LRU sizes now that we know which
@@ -2453,7 +2502,10 @@ function writeDynamicTreeResponseIntoCache(
     headVaryParams,
     getStaleAtFromHeader(now, response),
     navigationSeed,
-    null
+    null,
+    // Cache stage is only relevant for runtime prefetch responses. Static
+    // prefetches are not affected. This may change in the future.
+    CacheStage.Max
   )
 }
 
@@ -2485,7 +2537,8 @@ export function writeDynamicRenderResponseIntoCache(
   headVaryParams: VaryParams | null,
   staleAt: number,
   navigationSeed: NavigationSeed,
-  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null
+  spawnedEntries: Map<SegmentRequestKey, PendingSegmentCacheEntry> | null,
+  stage: CacheStage
 ): Array<FulfilledSegmentCacheEntry> | null {
   if (buildId && buildId !== getNavigationBuildId()) {
     // The server build does not match the client. Treat as a 404. During
@@ -2533,7 +2586,8 @@ export function writeDynamicRenderResponseIntoCache(
         staleAt,
         seedData,
         isResponsePartial,
-        spawnedEntries
+        spawnedEntries,
+        stage
       )
     }
 
@@ -2562,6 +2616,7 @@ export function writeDynamicRenderResponseIntoCache(
         // parameter.
         headVaryParams,
         metadataTree,
+        stage,
         spawnedEntries
       )
     }
@@ -2598,7 +2653,8 @@ function writeSeedDataIntoCache(
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
-  > | null
+  > | null,
+  stage: CacheStage
 ) {
   // This function is used to write the result of a runtime server request
   // (CacheNodeSeedData) into the prefetch cache.
@@ -2609,7 +2665,7 @@ function writeSeedDataIntoCache(
   // thenable resolves to the set of params the segment accessed during render.
   // A null thenable means tracking was not enabled (not a prerender).
   const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+    varyParamsThenable !== null ? readCacheInfo(varyParamsThenable) : null
   fulfillEntrySpawnedByRuntimePrefetch(
     now,
     fetchStrategy,
@@ -2618,6 +2674,7 @@ function writeSeedDataIntoCache(
     staleAt,
     varyParams,
     tree,
+    stage,
     entriesOwnedByCurrentTask
   )
 
@@ -2637,7 +2694,8 @@ function writeSeedDataIntoCache(
           staleAt,
           childSeedData,
           isResponsePartial,
-          entriesOwnedByCurrentTask
+          entriesOwnedByCurrentTask,
+          stage
         )
       }
     }
@@ -2656,6 +2714,7 @@ function fulfillEntrySpawnedByRuntimePrefetch(
   staleAt: number,
   segmentVaryParams: Set<string> | null,
   tree: RouteTree,
+  stage: CacheStage,
   entriesOwnedByCurrentTask: Map<
     SegmentRequestKey,
     PendingSegmentCacheEntry
@@ -2673,7 +2732,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
       ownedEntry,
       rsc,
       staleAt,
-      isPartial
+      isPartial,
+      stage
     )
     // Re-key the entry based on which params the segment actually depends on.
     if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
@@ -2703,7 +2763,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
         upgradeToPendingSegment(newEntry, fetchStrategy),
         rsc,
         staleAt,
-        isPartial
+        isPartial,
+        stage
       )
       // Re-key the entry based on which params the segment actually depends on.
       if (process.env.__NEXT_VARY_PARAMS && segmentVaryParams !== null) {
@@ -2729,7 +2790,8 @@ function fulfillEntrySpawnedByRuntimePrefetch(
         ),
         rsc,
         staleAt,
-        isPartial
+        isPartial,
+        stage
       )
       // Use the fulfilled vary path if available, otherwise fall back to
       // the request vary path.
@@ -2956,7 +3018,7 @@ function getStaleAtFromHeader(
  * returns a staleAt timestamp.
  *
  * TODO: Buffer the response and then read the iterable values
- * synchronously, similar to readVaryParams. This would avoid the need to
+ * synchronously, similar to readCacheInfo. This would avoid the need to
  * make this async, and we could also use it in
  * writeDynamicTreeResponseIntoCache. This will also be needed when React
  * starts leaving async iterables hanging when the outer RSC stream is
@@ -3003,7 +3065,7 @@ export function writeStaticStageResponseIntoCache(
   now: number,
   flightData: FlightData,
   buildId: string | undefined,
-  headVaryParamsThenable: VaryParamsThenable | null,
+  headVaryParamsThenable: CacheInfo<VaryParams> | null,
   staleAt: number,
   baseTree: FlightRouterState,
   renderedSearch: string,
@@ -3015,7 +3077,7 @@ export function writeStaticStageResponseIntoCache(
 
   const headVaryParams =
     headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
+      ? readCacheInfo(headVaryParamsThenable)
       : null
 
   const flightDatas = normalizeFlightData(flightData)
@@ -3038,7 +3100,10 @@ export function writeStaticStageResponseIntoCache(
     headVaryParams,
     staleAt,
     navigationSeed,
-    null // spawnedEntries — no pre-created entries; will create or upsert
+    null, // spawnedEntries — no pre-created entries; will create or upsert
+    // Cache stage is only relevant for runtime prefetch responses. Static
+    // prefetches are not affected. This may change in the future.
+    CacheStage.Max
   )
 }
 
@@ -3060,6 +3125,7 @@ export async function processRuntimePrefetchStream(
   isResponsePartial: boolean
   headVaryParams: VaryParams | null
   staleAt: number
+  stage: CacheStage
 } | null> {
   const { stream, isPartial } = await stripIsPartialByte(runtimePrefetchStream)
 
@@ -3073,7 +3139,7 @@ export async function processRuntimePrefetchStream(
   const headVaryParamsThenable = serverData.h
   const headVaryParams =
     headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
+      ? readCacheInfo(headVaryParamsThenable)
       : null
 
   const staleAt = await getStaleAt(now, serverData.s)
@@ -3097,6 +3163,10 @@ export async function processRuntimePrefetchStream(
     isResponsePartial: isPartial,
     headVaryParams,
     staleAt,
+    stage:
+      serverData.g !== undefined
+        ? (readCacheInfo(serverData.g) ?? CacheStage.Max)
+        : CacheStage.Max,
   }
 }
 

--- a/packages/next/src/client/components/segment-cache/navigation.ts
+++ b/packages/next/src/client/components/segment-cache/navigation.ts
@@ -494,7 +494,8 @@ async function navigateToUnknownRoute(
               processed.headVaryParams,
               processed.staleAt,
               processed.navigationSeed,
-              null
+              null,
+              processed.stage
             )
           }
         })

--- a/packages/next/src/server/app-render/app-render.tsx
+++ b/packages/next/src/server/app-render/app-render.tsx
@@ -203,6 +203,12 @@ import {
   finishAccumulatingVaryParams,
   getMetadataVaryParamsThenable,
 } from './vary-params'
+import {
+  createCacheInfo,
+  finishCacheStageTracking,
+  getCacheStageThenable,
+} from './cache-info'
+import { CacheStage } from '../../shared/lib/segment-cache/cache-stage'
 import { getTracedMetadata } from '../lib/trace/utils'
 import { InvariantError } from '../../shared/lib/invariant-error'
 import {
@@ -728,6 +734,13 @@ async function generateDynamicRSCPayload(
     }
   }
 
+  // Read the cache stage thenable from the current work unit store, if
+  // present. This follows the same pattern as getMetadataVaryParamsThenable.
+  const cacheStageThenable = getCacheStageThenable()
+  if (cacheStageThenable !== null) {
+    baseResponse.g = cacheStageThenable
+  }
+
   return baseResponse
 }
 
@@ -999,7 +1012,9 @@ async function spawnRuntimePrefetchWithFilledCaches(
 
     const { result } = await finalRuntimeServerPrerender(
       ctx,
-      generateDynamicRSCPayload.bind(null, ctx, { staleTimeIterable }),
+      generateDynamicRSCPayload.bind(null, ctx, {
+        staleTimeIterable,
+      }),
       prerenderResumeDataCache,
       null, // renderResumeDataCache
       rootParams,
@@ -1398,6 +1413,7 @@ async function prospectiveRuntimeServerPrerender(
     hmrRefreshHash: undefined,
     // We don't track vary params during initial prerender, only the final one
     varyParamsAccumulator: null,
+    cacheStageAccumulator: createCacheInfo(CacheStage.Max),
     // No stage sequencing needed for prospective renders.
     stagedRendering: null,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
@@ -1539,6 +1555,7 @@ async function finalRuntimeServerPrerender(
   )
 
   const varyParamsAccumulator = createResponseVaryParamsAccumulator()
+  const cacheStageAccumulator = createCacheInfo(CacheStage.Max)
 
   const finalServerPrerenderStore: PrerenderStoreModernRuntime = {
     type: 'prerender-runtime',
@@ -1560,6 +1577,7 @@ async function finalRuntimeServerPrerender(
     renderResumeDataCache,
     hmrRefreshHash: undefined,
     varyParamsAccumulator,
+    cacheStageAccumulator,
     // Used to separate the stages in the 5-task pipeline.
     stagedRendering: finalStageController,
     // These are not present in regular prerenders, but allowed in a runtime prerender.
@@ -1614,13 +1632,24 @@ async function finalRuntimeServerPrerender(
       finalStageController.advanceStage(RenderStage.Runtime)
     },
     () => {
+      // Resolve all cache info thenables, then abort the prerender. These
+      // are resolved in parallel because they are conceptually the same
+      // operation — finalizing info that Flight needs to serialize into the
+      // stream before we close it. See cache-info.ts for more context.
+      //
+      // TODO: These all follow the same pattern (resolve thenable, flush
+      // microtasks). They should be consolidated into shared machinery in
+      // cache-info.ts.
       Promise.all([
         finishStaleTimeTracking(staleTimeIterable),
         finishAccumulatingVaryParams(varyParamsAccumulator),
+        finishCacheStageTracking(
+          finalServerPrerenderStore.cacheStageAccumulator
+        ),
       ]).then(() => {
         // Abort. This runs as a microtask after Flight has flushed the
-        // staleTime and varyParams closing chunks, but before the next
-        // macrotask resolves the overall result.
+        // closing chunks, but before the next macrotask resolves the
+        // overall result.
         if (finalServerController.signal.aborted) {
           // If the server controller is already aborted we must have called
           // something that required aborting the prerender synchronously such
@@ -4359,6 +4388,7 @@ async function warmupClientModulesForStagedValidation(
       hmrRefreshHash: undefined,
       // Client prerenders don't track server param access
       varyParamsAccumulator: null,
+      cacheStageAccumulator: null,
     }
     initialClientPrerenderStore = store
   } else {
@@ -4383,6 +4413,7 @@ async function warmupClientModulesForStagedValidation(
       hmrRefreshHash: undefined,
       // Client prerenders don't track server param access
       varyParamsAccumulator: null,
+      cacheStageAccumulator: null,
       // We're not rendering any validation boundaries yet.
       boundaryState: null,
       validationSamples,
@@ -4534,6 +4565,7 @@ async function validateStagedShell(
     hmrRefreshHash,
     // Client prerenders don't track server param access
     varyParamsAccumulator: null,
+    cacheStageAccumulator: null,
   }
 
   const dynamicValidation = createDynamicValidationState()
@@ -4804,6 +4836,7 @@ async function validateInstantConfigs(
       renderResumeDataCache: null,
       hmrRefreshHash,
       varyParamsAccumulator: null,
+      cacheStageAccumulator: null,
       boundaryState,
       fallbackRouteParams,
       validationSamples,
@@ -5898,6 +5931,7 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
         // We don't track vary params during initial prerender, only the final one
         varyParamsAccumulator: null,
+        cacheStageAccumulator: null,
       }
 
       // We're not going to use the result of this render because the only time it could be used
@@ -5933,6 +5967,7 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
         // We don't track vary params during initial prerender, only the final one
         varyParamsAccumulator: null,
+        cacheStageAccumulator: null,
       })
 
       const initialPrerenderOptions = {
@@ -6056,6 +6091,7 @@ async function prerenderToStream(
           hmrRefreshHash: undefined,
           // Client prerenders don't track server param access
           varyParamsAccumulator: null,
+          cacheStageAccumulator: null,
         }
 
         const pendingInitialClientResult = workUnitAsyncStorage.run(
@@ -6180,6 +6216,7 @@ async function prerenderToStream(
         renderResumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator,
+        cacheStageAccumulator: null,
       }
 
       const finalAttemptRSCPayload = await workUnitAsyncStorage.run(
@@ -6221,6 +6258,7 @@ async function prerenderToStream(
         renderResumeDataCache,
         hmrRefreshHash: undefined,
         varyParamsAccumulator,
+        cacheStageAccumulator: null,
       })
 
       if (staleTimeIterable !== undefined) {
@@ -6334,6 +6372,7 @@ async function prerenderToStream(
         hmrRefreshHash: undefined,
         // Client prerenders don't track server param access
         varyParamsAccumulator: null,
+        cacheStageAccumulator: null,
       }
 
       let dynamicValidation = createDynamicValidationState()

--- a/packages/next/src/server/app-render/cache-info.ts
+++ b/packages/next/src/server/app-render/cache-info.ts
@@ -1,0 +1,126 @@
+/**
+ * Cache Info
+ *
+ * Machinery for tracking streaming metadata about Flight prerender responses.
+ *
+ * During a prerender, certain information (like the cache stage level) is not
+ * known until rendering completes. This module provides thenables that follow
+ * the React Flight thenable protocol: they are embedded in the Flight payload
+ * before rendering begins, then resolved right before the prerender is aborted.
+ * Flight serializes the resolved values lazily into the response stream.
+ *
+ * This pattern is only used for prerender responses (not dynamic requests or
+ * navigations), because only prerenders have the two-phase lifecycle where the
+ * payload is constructed before the final values are known.
+ *
+ * TODO: Vary params (see vary-params.ts) use the same pattern — a thenable
+ * embedded in the response, resolved after rendering, serialized by Flight.
+ * The shared parts of that implementation should be unified into this module
+ * so each new piece of cache info doesn't need its own thenable type, create
+ * function, and resolve function.
+ */
+
+import type { CacheInfo } from '../../shared/lib/segment-cache/cache-info-decoding'
+import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+
+/**
+ * Server-side CacheInfo with additional fields for accumulation
+ * during rendering. Extends the shared CacheInfo with:
+ * - `current`: mutable accumulator updated during rendering (inspired by
+ *   React refs). Used to derive the final `value` when resolved.
+ * - `resolvers`: callbacks waiting for resolution.
+ */
+export type ServerCacheInfo<T> = CacheInfo<T> & {
+  status: 'pending' | 'fulfilled'
+  value: T
+  current: T
+  resolvers: Array<(value: T) => void>
+}
+
+/**
+ * Creates a pending ServerCacheInfo with the given default value.
+ * Flight serializes it lazily into the response stream.
+ */
+export function createCacheInfo<T>(defaultValue: T): ServerCacheInfo<T> {
+  const thenable = {
+    status: 'pending' as const,
+    value: defaultValue,
+    current: defaultValue,
+    then(onfulfilled: ((value: T) => unknown) | null | undefined) {
+      if (onfulfilled) {
+        if (thenable.status === 'pending') {
+          thenable.resolvers.push(onfulfilled)
+        } else {
+          onfulfilled(thenable.value)
+        }
+      }
+    },
+    resolvers: [] as Array<(value: T) => void>,
+  } as ServerCacheInfo<T>
+  return thenable
+}
+
+/**
+ * Resolves a ServerCacheInfo with its final value.
+ */
+function resolveCacheInfo<T>(thenable: ServerCacheInfo<T>, value: T): void {
+  if (thenable.status !== 'pending') {
+    return
+  }
+  thenable.value = value
+  thenable.status = 'fulfilled'
+  for (const resolver of thenable.resolvers) {
+    resolver(value)
+  }
+  thenable.resolvers = []
+}
+
+/**
+ * Resolves the cache stage thenable with its accumulated `current` value,
+ * then waits for Flight to flush it into the response stream.
+ *
+ * Follows the same pattern as `finishStaleTimeTracking` and
+ * `finishAccumulatingVaryParams`.
+ */
+export async function finishCacheStageTracking(
+  thenable: ServerCacheInfo<number>
+): Promise<void> {
+  resolveCacheInfo(thenable, thenable.current)
+
+  // Wait for Flight to flush the resolved value into the response stream.
+  // See finishAccumulatingVaryParams for a detailed explanation of why
+  // these microtask awaits are necessary.
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+/**
+ * Returns the cache stage accumulator from the current work unit store,
+ * cast to the shared CacheInfo type for embedding in the Flight response.
+ *
+ * Follows the same pattern as `getMetadataVaryParamsThenable`.
+ */
+export function getCacheStageThenable(): CacheInfo<number> | null {
+  const workUnitStore = workUnitAsyncStorage.getStore()
+  if (workUnitStore) {
+    switch (workUnitStore.type) {
+      case 'prerender-runtime':
+        return workUnitStore.cacheStageAccumulator as unknown as CacheInfo<number>
+      case 'prerender':
+      case 'prerender-ppr':
+      case 'prerender-legacy':
+      case 'prerender-client':
+      case 'validation-client':
+      case 'request':
+      case 'cache':
+      case 'private-cache':
+      case 'unstable-cache':
+      case 'generate-static-params':
+        return null
+      default:
+        workUnitStore satisfies never
+    }
+  }
+  return null
+}

--- a/packages/next/src/server/app-render/collect-segment-data.tsx
+++ b/packages/next/src/server/app-render/collect-segment-data.tsx
@@ -8,7 +8,7 @@ import type {
   PrefetchHints,
 } from '../../shared/lib/app-router-types'
 import { PrefetchHint } from '../../shared/lib/app-router-types'
-import { readVaryParams } from '../../shared/lib/segment-cache/vary-params-decoding'
+import { readCacheInfo } from '../../shared/lib/segment-cache/cache-info-decoding'
 import { PAGE_SEGMENT_KEY } from '../../shared/lib/segment'
 import type { ManifestNode } from '../../build/webpack/plugins/flight-manifest-plugin'
 
@@ -308,7 +308,7 @@ export async function collectPrefetchHints(
   const headVaryParamsThenable = initialRSCPayload.h
   const headVaryParams =
     headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
+      ? readCacheInfo(headVaryParamsThenable)
       : null
 
   const [, headBuffer] = await renderSegmentPrefetch(
@@ -401,7 +401,7 @@ async function collectPrefetchHintsImpl(
   if (seedData !== null) {
     const varyParamsThenable = seedData[4]
     const varyParams =
-      varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+      varyParamsThenable !== null ? readCacheInfo(varyParamsThenable) : null
 
     const [, buffer] = await renderSegmentPrefetch(
       buildId,
@@ -620,7 +620,7 @@ async function PrefetchTreeData({
   const headVaryParamsThenable = initialRSCPayload.h
   const headVaryParams =
     headVaryParamsThenable !== null
-      ? readVaryParams(headVaryParamsThenable)
+      ? readCacheInfo(headVaryParamsThenable)
       : null
 
   // Compute the route metadata tree by traversing the FlightRouterState. As we
@@ -765,7 +765,7 @@ function collectSegmentDataImpl(
   // entries across param values).
   const varyParamsThenable = seedData !== null ? seedData[4] : null
   const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+    varyParamsThenable !== null ? readCacheInfo(varyParamsThenable) : null
 
   if (!prefetchInlining) {
     // When prefetch inlining is disabled, spawn individual segment tasks.
@@ -939,7 +939,7 @@ async function buildInlinedSegmentPrefetch(
   const rsc = seedData !== null ? seedData[0] : null
   const varyParamsThenable = seedData !== null ? seedData[4] : null
   const varyParams =
-    varyParamsThenable !== null ? readVaryParams(varyParamsThenable) : null
+    varyParamsThenable !== null ? readCacheInfo(varyParamsThenable) : null
 
   const segment: SegmentPrefetch = {
     rsc,

--- a/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
+++ b/packages/next/src/server/app-render/instant-validation/instant-validation.tsx
@@ -5,7 +5,8 @@ import type {
   InitialRSCPayload,
   Segment,
 } from '../../../shared/lib/app-router-types'
-import type { VaryParamsThenable } from '../../../shared/lib/segment-cache/vary-params-decoding'
+import type { CacheInfo } from '../../../shared/lib/segment-cache/cache-info-decoding'
+import type { VaryParams } from '../../../shared/lib/app-router-types'
 import { InvariantError } from '../../../shared/lib/invariant-error'
 import { RenderStage } from '../staged-rendering'
 import { getServerModuleMap } from '../manifests-singleton'
@@ -708,7 +709,7 @@ function deserializeFromChunks<T>(
 type SegmentData = {
   node: React.ReactNode | null
   isPartial: boolean
-  varyParams: VaryParamsThenable | null
+  varyParams: CacheInfo<VaryParams> | null
 }
 
 function createSegmentData(seedData: CacheNodeSeedData): SegmentData {

--- a/packages/next/src/server/app-render/vary-params.ts
+++ b/packages/next/src/server/app-render/vary-params.ts
@@ -1,10 +1,8 @@
 import type { Params } from '../request/params'
 import type { SearchParams } from '../request/search-params'
 import { workUnitAsyncStorage } from './work-unit-async-storage.external'
-import type {
-  VaryParamsThenable,
-  VaryParams,
-} from '../../shared/lib/segment-cache/vary-params-decoding'
+import type { CacheInfo } from '../../shared/lib/segment-cache/cache-info-decoding'
+import type { VaryParams } from '../../shared/lib/app-router-types'
 
 /**
  * Accumulates vary params for a single segment (or for metadata/rootParams).
@@ -174,11 +172,11 @@ export function getMetadataVaryParamsAccumulator(): VaryParamsAccumulator | null
 
 export function getVaryParamsThenable(
   accumulator: VaryParamsAccumulator
-): VaryParamsThenable | null {
-  return accumulator as unknown as VaryParamsThenable | null
+): CacheInfo<VaryParams> | null {
+  return accumulator as unknown as CacheInfo<VaryParams> | null
 }
 
-export function getMetadataVaryParamsThenable(): VaryParamsThenable | null {
+export function getMetadataVaryParamsThenable(): CacheInfo<VaryParams> | null {
   const accumulator = getMetadataVaryParamsAccumulator()
   if (accumulator !== null) {
     return getVaryParamsThenable(accumulator)

--- a/packages/next/src/server/app-render/work-unit-async-storage.external.ts
+++ b/packages/next/src/server/app-render/work-unit-async-storage.external.ts
@@ -25,6 +25,8 @@ import { RenderStage } from './staged-rendering'
 import type { ValidationBoundaryTracking } from './instant-validation/boundary-tracking'
 import type { InstantValidationSampleTracking } from './instant-validation/instant-samples'
 
+import type { ServerCacheInfo } from './cache-info'
+
 export type WorkUnitPhase = 'action' | 'render' | 'after'
 
 export interface CommonWorkUnitStore {
@@ -185,6 +187,9 @@ export interface PrerenderStoreModernRuntime
    */
   readonly stagedRendering: StagedRenderingController | null
 
+  // Always created for runtime prerenders.
+  readonly cacheStageAccumulator: ServerCacheInfo<number>
+
   readonly headers: RequestStore['headers']
   readonly cookies: RequestStore['cookies']
   readonly draftMode: RequestStore['draftMode']
@@ -264,6 +269,13 @@ interface PrerenderStoreModernCommon
    * cache to re-key entries for better sharing across different param values.
    */
   readonly varyParamsAccumulator: ResponseVaryParamsAccumulator | null
+
+  /**
+   * A thenable that resolves to the cache stage level after rendering. Flight
+   * serializes this lazily into the response stream. The `current` field is
+   * updated during rendering as navigation boundaries are encountered.
+   */
+  readonly cacheStageAccumulator: ServerCacheInfo<number> | null
 }
 
 interface StaticPrerenderStoreCommon {
@@ -337,6 +349,17 @@ export interface CommonUseCacheStore extends CommonCacheStore, RevalidateStore {
   explicitRevalidate: undefined | number // explicit revalidate time from cacheLife() calls
   explicitExpire: undefined | number // server expiration time
   explicitStale: undefined | number // client expiration time
+  /**
+   * Whether this cache entry includes the maximum prefetchable content.
+   * Set to `false` by `unstable_navigation()` to indicate that content
+   * after the navigation boundary should be excluded from default runtime
+   * prefetches.
+   *
+   * Currently a boolean, but this will likely evolve into an integer
+   * representing the cache stage level, once multiple stage boundaries
+   * are supported.
+   */
+  hasMaxPrefetch?: boolean
   readonly hmrRefreshHash: string | undefined
   readonly isHmrRefresh: boolean
   readonly serverComponentsHmrCache: ServerComponentsHmrCache | undefined

--- a/packages/next/src/server/resume-data-cache/cache-store.ts
+++ b/packages/next/src/server/resume-data-cache/cache-store.ts
@@ -45,6 +45,7 @@ export interface UseCacheCacheStoreSerialized {
   hasExplicitRevalidate: boolean | undefined
   hasExplicitExpire: boolean | undefined
   readRootParamNames: string[] | undefined
+  hasMaxPrefetch?: boolean
 }
 
 /**
@@ -65,7 +66,13 @@ export function parseUseCacheCacheStore(
 
   for (const [
     key,
-    { entry, hasExplicitRevalidate, hasExplicitExpire, readRootParamNames },
+    {
+      entry,
+      hasExplicitRevalidate,
+      hasExplicitExpire,
+      readRootParamNames,
+      hasMaxPrefetch,
+    },
   ] of entries) {
     store.set(
       key,
@@ -92,6 +99,7 @@ export function parseUseCacheCacheStore(
         readRootParamNames: readRootParamNames
           ? new Set(readRootParamNames)
           : undefined,
+        hasMaxPrefetch,
       })
     )
   }
@@ -117,6 +125,7 @@ export async function serializeUseCacheCacheStore(
             hasExplicitRevalidate,
             hasExplicitExpire,
             readRootParamNames,
+            hasMaxPrefetch,
           }) => {
             if (
               isCacheComponentsEnabled &&
@@ -156,6 +165,7 @@ export async function serializeUseCacheCacheStore(
                 readRootParamNames: readRootParamNames
                   ? [...readRootParamNames]
                   : undefined,
+                hasMaxPrefetch,
               },
             ] satisfies [string, UseCacheCacheStoreSerialized]
           }

--- a/packages/next/src/server/route-modules/app-route/module.ts
+++ b/packages/next/src/server/route-modules/app-route/module.ts
@@ -446,6 +446,7 @@ export class AppRouteRouteModule extends RouteModule<
               renderResumeDataCache: null,
               hmrRefreshHash: undefined,
               varyParamsAccumulator: null,
+              cacheStageAccumulator: null,
             })
 
           let prospectiveResult
@@ -543,6 +544,7 @@ export class AppRouteRouteModule extends RouteModule<
             renderResumeDataCache: null,
             hmrRefreshHash: undefined,
             varyParamsAccumulator: null,
+            cacheStageAccumulator: null,
           })
 
           let responseHandled = false

--- a/packages/next/src/server/use-cache/navigation.ts
+++ b/packages/next/src/server/use-cache/navigation.ts
@@ -1,0 +1,85 @@
+import { workAsyncStorage } from '../app-render/work-async-storage.external'
+import { workUnitAsyncStorage } from '../app-render/work-unit-async-storage.external'
+import { makeHangingPromise } from '../dynamic-rendering-utils'
+import { InvariantError } from '../../shared/lib/invariant-error'
+
+/**
+ * Marks a cache stage boundary. Content after `await unstable_navigation()` is
+ * still cacheable but excluded from default runtime prefetches, reducing server
+ * cost per prefetch.
+ *
+ * Inside `"use cache"`: sets a flag on the cache entry so that the
+ * `use-cache-wrapper` returns a hanging promise for runtime prefetches.
+ *
+ * Outside `"use cache"` (bare server component): directly returns a hanging
+ * promise during runtime prefetch.
+ */
+export function unstable_navigation(): Promise<void> {
+  if (!process.env.__NEXT_USE_CACHE) {
+    throw new Error(
+      '`unstable_navigation()` is only available with the `cacheComponents` config.'
+    )
+  }
+
+  const workStore = workAsyncStorage.getStore()
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
+  if (!workUnitStore) {
+    throw new Error(
+      '`unstable_navigation()` was called outside a request scope. Read more: https://nextjs.org/docs/messages/next-dynamic-api-wrong-context'
+    )
+  }
+
+  switch (workUnitStore.type) {
+    case 'cache':
+    case 'private-cache':
+      // Inside "use cache": flag the cache entry so the wrapper can omit it
+      // from runtime prefetches.
+      workUnitStore.hasMaxPrefetch = false
+      return Promise.resolve()
+
+    case 'request':
+      // Real navigation or cached navigation — resolve immediately.
+      return Promise.resolve()
+
+    case 'prerender-runtime':
+      // Runtime prefetch — suspend forever (until the render signal aborts).
+      return makeHangingPromise(
+        workUnitStore.renderSignal,
+        workStore?.route ?? '',
+        '`unstable_navigation()`'
+      )
+
+    case 'prerender':
+    case 'prerender-ppr':
+    case 'prerender-client':
+    case 'prerender-legacy':
+      // Static builds are unaffected.
+      return Promise.resolve()
+
+    case 'unstable-cache':
+      throw new Error(
+        '`unstable_navigation()` cannot be called inside `unstable_cache()`.'
+      )
+
+    case 'generate-static-params':
+      throw new Error(
+        '`unstable_navigation()` cannot be called inside `generateStaticParams()`.'
+      )
+
+    case 'validation-client': {
+      const exportName = '`unstable_navigation`'
+      throw new InvariantError(
+        `${exportName} must not be used within a Client Component. Next.js should be preventing ${exportName} from being included in Client Components statically, but did not in this case.`
+      )
+    }
+
+    default: {
+      workUnitStore satisfies never
+      throw new InvariantError('Unexpected work unit store type.')
+    }
+  }
+}
+
+// Also export as `navigation` for internal use / future stable API.
+export { unstable_navigation as navigation }

--- a/packages/next/src/server/use-cache/use-cache-wrapper.ts
+++ b/packages/next/src/server/use-cache/use-cache-wrapper.ts
@@ -57,6 +57,7 @@ import { createReactServerErrorHandler } from '../app-render/create-error-handle
 import { DYNAMIC_EXPIRE, RUNTIME_PREFETCH_DYNAMIC_STALE } from './constants'
 import { NEXT_CACHE_ROOT_PARAM_TAG_ID } from '../../lib/constants'
 import type { CacheHandler } from '../lib/cache-handlers/types'
+import { CacheStage } from '../../shared/lib/segment-cache/cache-stage'
 import { getCacheHandler } from './handlers'
 import { UseCacheTimeoutError } from './use-cache-errors'
 import {
@@ -634,6 +635,13 @@ export interface CollectedCacheResult {
    * don't have this information.
    */
   readRootParamNames: ReadonlySet<string> | undefined
+  /**
+   * Whether this cache entry includes the maximum prefetchable content.
+   * Set to `false` by `unstable_navigation()` to indicate the entry should
+   * be omitted from default runtime prefetches. In the future this will
+   * likely become an integer representing the cache stage level.
+   */
+  hasMaxPrefetch?: boolean
 }
 
 async function collectResult(
@@ -719,6 +727,18 @@ async function collectResult(
         : undefined
     )
 
+    // Propagate hasMaxPrefetch to outer cache stores so that if
+    // navigation() is called in a deeply nested cache, the outermost cache
+    // entry is also omitted from prefetches.
+    if (innerCacheStore.hasMaxPrefetch === false) {
+      if (
+        cacheContext.outerWorkUnitStore.type === 'cache' ||
+        cacheContext.outerWorkUnitStore.type === 'private-cache'
+      ) {
+        cacheContext.outerWorkUnitStore.hasMaxPrefetch = false
+      }
+    }
+
     const cacheSignal = getCacheSignal(cacheContext.outerWorkUnitStore)
     if (cacheSignal) {
       cacheSignal.endRead()
@@ -733,6 +753,8 @@ async function collectResult(
       innerCacheStore.type === 'cache'
         ? innerCacheStore.readRootParamNames
         : undefined,
+    hasMaxPrefetch:
+      innerCacheStore.hasMaxPrefetch === false ? false : undefined,
   }
 }
 
@@ -1005,12 +1027,14 @@ function cloneCacheResult(
       hasExplicitRevalidate: result.hasExplicitRevalidate,
       hasExplicitExpire: result.hasExplicitExpire,
       readRootParamNames: result.readRootParamNames,
+      hasMaxPrefetch: result.hasMaxPrefetch,
     },
     {
       entry: entryB,
       hasExplicitRevalidate: result.hasExplicitRevalidate,
       hasExplicitExpire: result.hasExplicitExpire,
       readRootParamNames: result.readRootParamNames,
+      hasMaxPrefetch: result.hasMaxPrefetch,
     },
   ]
 }
@@ -1686,6 +1710,43 @@ export async function cache(
               workUnitStore satisfies never
           }
         }
+
+        if (rdcResult.hasMaxPrefetch === false) {
+          switch (workUnitStore.type) {
+            case 'prerender-runtime':
+              // The cache entry does not have the maximum prefetchable content
+              // (unstable_navigation() was called inside it). During runtime
+              // prefetches, we omit this entry so the client fetches fresh
+              // content on actual navigation.
+              if (workUnitStore.cacheStageAccumulator) {
+                workUnitStore.cacheStageAccumulator.current = CacheStage.Default
+              }
+              debug?.(
+                'omitting entry',
+                serializedCacheKey,
+                'from runtime shell due to navigation boundary'
+              )
+              if (cacheSignal) {
+                cacheSignal.endRead()
+              }
+              return makeHangingPromise(
+                workUnitStore.renderSignal,
+                workStore.route,
+                'navigation boundary "use cache"'
+              )
+            case 'request':
+            case 'prerender':
+            case 'prerender-ppr':
+            case 'prerender-legacy':
+            case 'cache':
+            case 'private-cache':
+            case 'unstable-cache':
+            case 'generate-static-params':
+              break
+            default:
+              workUnitStore satisfies never
+          }
+        }
       }
 
       if (rdcResult !== undefined) {
@@ -1710,6 +1771,17 @@ export async function cache(
           rdcResult.entry,
           rdcResult.readRootParamNames
         )
+
+        // Propagate hasMaxPrefetch to outer cache stores.
+        if (rdcResult.hasMaxPrefetch === false) {
+          const outerWorkUnitStore = cacheContext.outerWorkUnitStore
+          if (
+            outerWorkUnitStore.type === 'cache' ||
+            outerWorkUnitStore.type === 'private-cache'
+          ) {
+            outerWorkUnitStore.hasMaxPrefetch = false
+          }
+        }
 
         const [streamA, streamB] = rdcResult.entry.value.tee()
         rdcResult.entry.value = streamB

--- a/packages/next/src/shared/lib/app-router-types.ts
+++ b/packages/next/src/shared/lib/app-router-types.ts
@@ -6,12 +6,13 @@
  */
 
 import type React from 'react'
+import type { CacheInfo } from './segment-cache/cache-info-decoding'
+
+export type VaryParams = Set<string>
 
 export type LoadingModuleData =
   | [React.JSX.Element, React.ReactNode, React.ReactNode]
   | null
-
-import type { VaryParamsThenable } from './segment-cache/vary-params-decoding'
 
 /** viewport metadata node */
 export type HeadData = React.ReactNode
@@ -265,7 +266,7 @@ export type CacheNodeSeedData = [
    * - Thenable resolves to non-empty Set: segment depends on those params.
    *   Can only reuse when those specific params match.
    */
-  varyParams: VaryParamsThenable | null,
+  varyParams: CacheInfo<VaryParams> | null,
 ]
 
 export type FlightDataSegment = [
@@ -330,7 +331,7 @@ export type InitialRSCPayload = {
   /**
    * headVaryParams - vary params for the head (metadata) of the response.
    */
-  h: VaryParamsThenable | null
+  h: CacheInfo<VaryParams> | null
   /** staleTime in seconds - Only present when Cache Components is enabled. */
   s?: AsyncIterable<number>
   /** staticStageByteLength - Resolves when the static stage ends. */
@@ -364,7 +365,7 @@ export type NavigationFlightResponse = {
   /** staticStageByteLength - Resolves when the static stage ends. */
   l?: Promise<number>
   /** headVaryParams */
-  h: VaryParamsThenable | null
+  h: CacheInfo<VaryParams> | null
   /** runtimePrefetchStream — Embedded runtime prefetch Flight stream. */
   p?: ReadableStream<Uint8Array>
   /**
@@ -375,6 +376,13 @@ export type NavigationFlightResponse = {
    * staleness.
    */
   d?: number
+  /**
+   * cacheStage — The prefetch stage level of this response. A Flight
+   * thenable that resolves to a number: 0 = default (content was
+   * intentionally omitted due to navigation boundaries), 1 = max (nothing
+   * was intentionally omitted). Absent means max.
+   */
+  g?: CacheInfo<number>
 }
 
 // Response from `createFromFetch` for server actions. Action's flight data can be null

--- a/packages/next/src/shared/lib/segment-cache/cache-info-decoding.ts
+++ b/packages/next/src/shared/lib/segment-cache/cache-info-decoding.ts
@@ -1,30 +1,33 @@
 /**
- * Vary Params Decoding
+ * Cache Info Decoding
+ *
+ * Types and utilities for cache info thenables — the mechanism used to
+ * embed lazily-resolved metadata (vary params, cache stage, etc.) into
+ * Flight prerender responses.
  *
  * This module is shared between server and client.
  */
 
 export type VaryParams = Set<string>
 
-type FulfilledVaryParamsThenable = {
-  status: 'fulfilled'
-  value: VaryParams
-} & PromiseLike<VaryParams>
-
-type PendingVaryParamsThenable = {
-  // 'resolved_model' is an internal React Flight state: the underlying model
-  // data has arrived but the thenable hasn't been "unwrapped" yet. Calling
-  // .then() triggers Flight to synchronously transition to 'fulfilled'.
-  status: 'pending' | 'resolved_model'
+/**
+ * A thenable that follows the React Flight thenable protocol for lazily
+ * serializing values into a Flight response stream.
+ *
+ * On the server, a CacheInfo is created in a 'pending' state,
+ * accumulates data during rendering (via the `current` field), and is
+ * resolved right before the prerender is aborted.
+ *
+ * On the client, the thenable arrives from the Flight stream and can be
+ * read synchronously via `readCacheInfo()` once the stream is received.
+ */
+export type CacheInfo<T> = {
+  status: string
   value: unknown
-} & PromiseLike<VaryParams>
-
-export type VaryParamsThenable =
-  | FulfilledVaryParamsThenable
-  | PendingVaryParamsThenable
+} & PromiseLike<T>
 
 /**
- * Synchronously reads vary params from a thenable.
+ * Synchronously reads a value from a CacheInfo.
  *
  * By the time this is called (client-side or in collectSegmentData), the
  * thenable should already be fulfilled because the Flight stream has been
@@ -32,11 +35,9 @@ export type VaryParamsThenable =
  * microtasks.
  *
  * Returns null if the thenable is still pending (which shouldn't happen in
- * normal operation - it indicates the server failed to track vary params).
+ * normal operation - it indicates the server failed to resolve the thenable).
  */
-export function readVaryParams(
-  thenable: VaryParamsThenable
-): VaryParams | null {
+export function readCacheInfo<T>(thenable: CacheInfo<T>): T | null {
   // Attach a no-op listener to force Flight to synchronously resolve the
   // thenable. When a thenable arrives from the Flight stream, it may be in an
   // intermediate 'resolved_model' state (data received but not unwrapped).
@@ -49,7 +50,7 @@ export function readVaryParams(
   if (thenable.status !== 'fulfilled') {
     return null
   }
-  return thenable.value
+  return thenable.value as T
 }
 
 const noop = () => {}

--- a/packages/next/src/shared/lib/segment-cache/cache-stage.ts
+++ b/packages/next/src/shared/lib/segment-cache/cache-stage.ts
@@ -1,0 +1,22 @@
+/**
+ * Cache Stage
+ *
+ * Represents the prefetch stage level of a cache entry or response. Shared
+ * between client and server.
+ *
+ * Note that this does not guarantee all content up to a given stage is
+ * present in the response. It only indicates that the server did not
+ * intentionally omit anything before this level. For example, static
+ * prefetches omit request-specific info like cookies because they're not
+ * accessible during static prerendering — that's different from
+ * intentionally omitting content to control prefetching costs at runtime.
+ *
+ * Currently binary (Default vs Max), but may expand to more levels as
+ * additional stage boundaries are supported.
+ */
+export const enum CacheStage {
+  /** The default prefetching strategy. */
+  Default = 0,
+  /** Everything that is possibly prefetchable. */
+  Max = 1,
+}

--- a/test/e2e/app-dir/cache-stages/app/dynamic-page/page.tsx
+++ b/test/e2e/app-dir/cache-stages/app/dynamic-page/page.tsx
@@ -1,0 +1,25 @@
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { unstable_navigation } from 'next/cache'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ searchParams: { q: 'test' } }],
+}
+
+export default function Page() {
+  return (
+    <div>
+      <p id="static-content">Static content</p>
+      <Suspense fallback={<p id="dynamic-fallback">Loading dynamic...</p>}>
+        <DynamicWithNavigation />
+      </Suspense>
+    </div>
+  )
+}
+
+async function DynamicWithNavigation() {
+  await connection()
+  await unstable_navigation()
+  return <p id="dynamic-content">Dynamic content after navigation()</p>
+}

--- a/test/e2e/app-dir/cache-stages/app/layout.tsx
+++ b/test/e2e/app-dir/cache-stages/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/cache-stages/app/other/page.tsx
+++ b/test/e2e/app-dir/cache-stages/app/other/page.tsx
@@ -1,0 +1,15 @@
+import { LinkAccordion } from '../../components/link-accordion'
+
+export default function OtherPage() {
+  return (
+    <main>
+      <h1>Other Page</h1>
+      <p>Navigate back to the target page using the link accordion below.</p>
+      <div>
+        <LinkAccordion href="/target-page?q=test">
+          Back to target page
+        </LinkAccordion>
+      </div>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-stages/app/page.tsx
+++ b/test/e2e/app-dir/cache-stages/app/page.tsx
@@ -1,0 +1,37 @@
+import { LinkAccordion } from '../components/link-accordion'
+
+export default function Page() {
+  return (
+    <main>
+      <h1>Cache Stages Test</h1>
+      <p>
+        This fixture tests <code>unstable_navigation()</code> from{' '}
+        <code>next/cache</code>. The target page at{' '}
+        <code>/target-page?q=test</code> has a cached component that calls{' '}
+        <code>await unstable_navigation()</code>. Content after that call should
+        be excluded from runtime prefetch responses but included when the user
+        actually navigates.
+      </p>
+      <p>
+        To test manually: check the link accordion below to reveal the link.
+        This triggers a runtime prefetch. Inspect the network response — it
+        should contain "Included in prefetch" but not "Not included in
+        prefetch". Then click the link to navigate. The full page should render,
+        including "Not included in prefetch".
+      </p>
+      <div>
+        <LinkAccordion href="/target-page?q=test">Target page</LinkAccordion>
+      </div>
+      <div>
+        <LinkAccordion href="/dynamic-page?q=test">
+          Dynamic page (no use cache)
+        </LinkAccordion>
+      </div>
+      <div>
+        <LinkAccordion href="/static-page">
+          Static page (no runtime prefetch)
+        </LinkAccordion>
+      </div>
+    </main>
+  )
+}

--- a/test/e2e/app-dir/cache-stages/app/static-page/page.tsx
+++ b/test/e2e/app-dir/cache-stages/app/static-page/page.tsx
@@ -1,0 +1,18 @@
+import { unstable_navigation } from 'next/cache'
+
+// No unstable_instant config — this page is fully static.
+
+async function ContentAfterNavigationCall() {
+  'use cache'
+  await unstable_navigation()
+  return <p id="static-after-nav">Static content after navigation()</p>
+}
+
+export default function Page() {
+  return (
+    <div>
+      <p id="static-before-nav">Static content before navigation()</p>
+      <ContentAfterNavigationCall />
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-stages/app/target-page/cached-with-navigation.tsx
+++ b/test/e2e/app-dir/cache-stages/app/target-page/cached-with-navigation.tsx
@@ -1,0 +1,8 @@
+'use cache'
+
+import { unstable_navigation } from 'next/cache'
+
+export async function CachedWithNavigation() {
+  await unstable_navigation()
+  return <p id="not-included-in-prefetch">Not included in prefetch</p>
+}

--- a/test/e2e/app-dir/cache-stages/app/target-page/page.tsx
+++ b/test/e2e/app-dir/cache-stages/app/target-page/page.tsx
@@ -1,0 +1,28 @@
+import { Suspense } from 'react'
+import { CachedWithNavigation } from './cached-with-navigation'
+import { SearchParamDisplay } from './search-param-display'
+import { LinkAccordion } from '../../components/link-accordion'
+
+export const unstable_instant = {
+  prefetch: 'runtime',
+  samples: [{ searchParams: { q: 'test' } }],
+}
+
+export default function Page({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  return (
+    <div>
+      <p id="included-in-prefetch">Included in prefetch</p>
+      <Suspense fallback={<p>loading search...</p>}>
+        <SearchParamDisplay searchParams={searchParams} />
+      </Suspense>
+      <Suspense fallback={<p id="nav-fallback">loading nav...</p>}>
+        <CachedWithNavigation />
+      </Suspense>
+      <LinkAccordion href="/other">Go to other page</LinkAccordion>
+    </div>
+  )
+}

--- a/test/e2e/app-dir/cache-stages/app/target-page/search-param-display.tsx
+++ b/test/e2e/app-dir/cache-stages/app/target-page/search-param-display.tsx
@@ -1,0 +1,8 @@
+export async function SearchParamDisplay({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  return <p id="search-param">search: {q ?? 'none'}</p>
+}

--- a/test/e2e/app-dir/cache-stages/cache-stages.test.ts
+++ b/test/e2e/app-dir/cache-stages/cache-stages.test.ts
@@ -1,0 +1,195 @@
+import { nextTestSetup } from 'e2e-utils'
+import type * as Playwright from 'playwright'
+import { createRouterAct } from 'router-act'
+
+describe('cache-stages', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (isNextDev) {
+    it('is skipped', () => {})
+    return
+  }
+
+  it('unstable_navigation() in "use cache" is omitted from runtime prefetch but included in navigation', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal the link to trigger a runtime prefetch for /target-page.
+    // The prefetch should include static content but NOT the content
+    // after unstable_navigation().
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/target-page?q=test"]'
+      )
+      await linkToggle.click()
+    }, [
+      {
+        includes: 'Included in prefetch',
+      },
+      {
+        includes: 'Not included in prefetch',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to /target-page. The navigation response should include
+    // the content after unstable_navigation().
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/target-page?q=test"]').click()
+      },
+      {
+        includes: 'Not included in prefetch',
+      }
+    )
+
+    // Verify the page rendered correctly after navigation.
+    expect(await browser.elementByCss('#included-in-prefetch').text()).toBe(
+      'Included in prefetch'
+    )
+    expect(
+      await browser.elementByCss('#not-included-in-prefetch').text()
+    ).toContain('Not included in prefetch')
+  })
+
+  it('cached navigation includes content past unstable_navigation() without a new prefetch', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Step 1: Reveal the link and navigate to /target-page (first visit).
+    // The full navigation response includes all content.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/target-page?q=test"]'
+      )
+      await linkToggle.click()
+    })
+    await browser.elementByCss('a[href="/target-page?q=test"]').click()
+    // Wait for navigation to settle by checking for content on the
+    // target page.
+    await browser.elementByCss('#not-included-in-prefetch')
+
+    // Step 2: Reveal link to /other and navigate away.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/other"]'
+      )
+      await linkToggle.click()
+    })
+    await browser.elementByCss('a[href="/other"]').click()
+    // Wait for navigation to settle.
+    await browser.elementByCss('h1')
+
+    // Step 3: Reveal the link back to /target-page. The first visit
+    // cached the response, so no new prefetch should be initiated.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/target-page?q=test"]'
+      )
+      await linkToggle.click()
+    }, 'no-requests')
+
+    // Step 4: Navigate back. The cached response includes all content
+    // (including past navigation()), so it should render immediately
+    // from cache without any network requests.
+    await act(async () => {
+      await browser.elementByCss('a[href="/target-page?q=test"]').click()
+      // Assert inside the act scope: content is visible before any
+      // network response could arrive, proving it came from cache.
+      expect(await browser.elementByCss('#included-in-prefetch').text()).toBe(
+        'Included in prefetch'
+      )
+      expect(
+        await browser.elementByCss('#not-included-in-prefetch').text()
+      ).toContain('Not included in prefetch')
+    }, 'no-requests')
+  })
+
+  it('unstable_navigation() outside "use cache" suspends during prefetch but renders on navigation', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal the link to trigger a runtime prefetch for /dynamic-page.
+    // The dynamic component calls connection() then unstable_navigation(),
+    // so its content should be excluded from the prefetch.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/dynamic-page?q=test"]'
+      )
+      await linkToggle.click()
+    }, [
+      {
+        includes: 'Static content',
+      },
+      {
+        includes: 'Dynamic content after navigation()',
+        block: 'reject',
+      },
+    ])
+
+    // Navigate to /dynamic-page. The navigation response should include
+    // the dynamic content after unstable_navigation().
+    await act(
+      async () => {
+        await browser.elementByCss('a[href="/dynamic-page?q=test"]').click()
+      },
+      {
+        includes: 'Dynamic content after navigation()',
+      }
+    )
+
+    // Verify the page rendered correctly.
+    expect(await browser.elementByCss('#static-content').text()).toBe(
+      'Static content'
+    )
+    expect(await browser.elementByCss('#dynamic-content').text()).toBe(
+      'Dynamic content after navigation()'
+    )
+  })
+
+  it('unstable_navigation() has no effect during static prerender — prefetch includes all content', async () => {
+    let page: Playwright.Page
+    const browser = await next.browser('/', {
+      beforePageLoad(p: Playwright.Page) {
+        page = p
+      },
+    })
+    const act = createRouterAct(page)
+
+    // Reveal the link to trigger a prefetch for /static-page.
+    // This page has no unstable_instant config, so it's fully static.
+    // The prefetch should include ALL content, even content after
+    // unstable_navigation(), because static prerenders are not affected
+    // by cache stage boundaries.
+    await act(async () => {
+      const linkToggle = await browser.elementByCss(
+        'input[data-link-accordion="/static-page"]'
+      )
+      await linkToggle.click()
+    }, [
+      {
+        includes: 'Static content before navigation()',
+      },
+      {
+        includes: 'Static content after navigation()',
+      },
+    ])
+  })
+})

--- a/test/e2e/app-dir/cache-stages/components/link-accordion.tsx
+++ b/test/e2e/app-dir/cache-stages/components/link-accordion.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link, { type LinkProps } from 'next/link'
+import { useState } from 'react'
+
+export function LinkAccordion({
+  href,
+  children,
+  prefetch,
+}: {
+  href: string
+  children: React.ReactNode
+  prefetch?: LinkProps['prefetch']
+}) {
+  const [isVisible, setIsVisible] = useState(false)
+  return (
+    <>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => setIsVisible(!isVisible)}
+        data-link-accordion={href}
+      />
+      {isVisible ? (
+        <Link href={href} prefetch={prefetch}>
+          {children}
+        </Link>
+      ) : (
+        <>{children} (link is hidden)</>
+      )}
+    </>
+  )
+}

--- a/test/e2e/app-dir/cache-stages/next.config.js
+++ b/test/e2e/app-dir/cache-stages/next.config.js
@@ -1,0 +1,11 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  cacheComponents: true,
+  experimental: {
+    cachedNavigations: true,
+  },
+}
+
+module.exports = nextConfig


### PR DESCRIPTION
`navigation()` from `next/cache` lets a Cache Component mark content as cacheable but not worth prefetching:

```tsx
async function ExpensiveSection() {
  'use cache'
  await navigation()
  // Everything below is cached but not included in prefetch responses.
  // It renders when the user actually navigates to this page.
  return <Dashboard />
}
```

A common approach to controlling prefetching costs is to delay when prefetches happen — only on hover, only when the cursor is close, only when a link enters the viewport. The problem is that if you delay prefetches until right before a prospective navigation, it makes it very likely that the cache will be cold by the time the user actually navigates. This is systemic: no matter how long the browser sits idle, the cache remains cold until right before navigation happens.

A better strategy is to prefetch as early as possible — or at least much earlier than when an actual navigation would happen. That's why Next.js prefetches on viewport entry by default: it's a good balance between eagerness and cost. But prefetching early means prefetching more, so controlling how much work each prefetch does becomes important.

By default, Next.js only prefetches up to what the server can produce cheaply and store in a static cache. If you opt in to runtime prefetching (via `unstable_instant`), it will additionally prefetch anything that is cacheable — even content that depends on cookies, headers, or search params. The only things excluded are content that is fully dynamic (like `connection()`) or has an extremely low cache life.

Sometimes even that is too much. A route might have sections that are technically cacheable but expensive to render, and you'd rather not pay that cost on every speculative prefetch. `navigation()` lets you stop the prefetch earlier without having to remove the content from cache entirely. The content is still cacheable by the client — when the user actually navigates, it renders and is cached for reuse on repeat visits.

This is why the API is called `navigation()`: it doesn't affect the cacheability of the content. It only affects *when* the content is allowed to be loaded into the cache — not during a speculative prefetch, but when someone actually navigates to the page.

Unlike `connection()`, which says "this content is inherently dynamic and should never be cached at any layer," `navigation()` says "this content is cacheable, but it's too expensive to render speculatively — only produce it when the user actually navigates."

Static prerenders are unaffected — `navigation()` resolves immediately since static prefetches don't go through the runtime prefetch path.

## Relationship to `instant`

Routes that use `navigation()` should also configure `unstable_instant` with `prefetch: 'runtime'`. This tells Next.js that the route has content that varies per-request and should be prefetched at runtime rather than served from a static shell. Without this config, the page is fully static and `navigation()` has no effect. In a future PR, a `prefetch: 'max'` option on `<Link>` will allow opting specific links into prefetching past `navigation()` boundaries.

The API is currently exported with an `unstable_` prefix until it becomes stable.