### PR TITLE
[Dev Server] Add `next internal apply` for agentic patch submission

### DIFF
--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -735,6 +735,37 @@ pub async fn project_invalidate_file_system_cache(
     Ok(())
 }
 
+/// Invalidates in-memory file system state, forcing Turbopack to re-read source files
+/// from disk on the next compilation. Unlike `invalidateFileSystemCache` (which only
+/// marks the persisted database for cleanup on restart), this drains the in-memory
+/// invalidator maps and immediately invalidates all tracked tasks.
+///
+/// This is the mechanism that makes `experimental.agenticEditing` work: with the native
+/// filesystem watcher disabled, this is the only way to tell Turbopack that files have
+/// changed.
+#[napi]
+pub async fn project_invalidate_sources(
+    #[napi(ts_arg_type = "{ __napiType: \"Project\" }")] project: External<ProjectInstance>,
+) -> napi::Result<()> {
+    let container = project.container;
+    let ctx = &project.turbopack_ctx;
+    ctx.turbo_tasks()
+        .run(async move {
+            #[turbo_tasks::function(operation)]
+            fn project_fs_op(container: ResolvedVc<ProjectContainer>) -> Vc<DiskFileSystem> {
+                container.project().project_fs()
+            }
+
+            let project_fs = project_fs_op(container).read_strongly_consistent().await?;
+            project_fs.invalidate_with_reason(|path| invalidation::Initialize {
+                path: RcStr::from(path.to_string_lossy()),
+            });
+            Ok(())
+        })
+        .or_else(|e| ctx.throw_turbopack_internal_result(&e.into()))
+        .await
+}
+
 /// Runs exit handlers for the project registered using the [`ExitHandler`] API.
 ///
 /// This is called by `project_shutdown`, so if you're calling that API, you shouldn't call this

--- a/fine-grained-agentic-feedback-loop.md
+++ b/fine-grained-agentic-feedback-loop.md
@@ -1,0 +1,182 @@
+# Fine-Grained Agentic Feedback Loop Using Next.js Dev Server Paradigm
+
+**Author:** @jude.gao
+**Status:** Draft
+**Date:** 2026-03-15
+
+---
+
+## 1. Motivation
+
+HMR exists to give the human developer a tight edit→compile→preview loop. The dev server watches the filesystem, detects changes, and recompiles incrementally. This works because human input frequency is low (seconds between saves) and the unit of change is a single file.
+
+Agents break both assumptions:
+
+- **Input frequency is high.** An agent can emit multiple file writes in milliseconds. The file watcher's 5ms debounce fires mid-batch, compiling partial/incoherent states.
+- **Unit of change is a multi-file patch.** A single logical step for an agent may touch N files. There is no signal for "I'm done writing" — the dev server cannot distinguish an in-progress batch from a completed one.
+- **Feedback path is passive.** The agent writes files, then has to poll or guess when compilation finished. There is no synchronous "apply this, tell me if it compiles" API.
+
+The core idea: replace the implicit filesystem-watch trigger with an **explicit patch submission API**. The agent produces a patch, submits it to the dev server along with the URLs it affects, and gets back compile errors, runtime errors, and screenshots — all in one synchronous call.
+
+## 2. Architecture
+
+### Stateful Daemon + Stateless CLI
+
+| Component                                        | Role                                                                                                                                                              |
+| ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `next dev` (daemon)                              | Holds compilation state (module graph, FS cache). One per session. Writes `.next/dev/lock` for discovery.                                                         |
+| `next internal apply <patch> --url <path>` (CLI) | Stateless. Writes files to disk, POSTs to `/_next/dev/apply` to trigger invalidation + compilation, orchestrates `next-browser` for screenshots + runtime errors. |
+
+**Why the agent provides `--url`:** Turbopack compiles lazily — only on page request. A file change alone does not trigger compilation. The agent knows which pages its change affects, so it lists them. The dev server uses these URLs to trigger compilation. `next-browser` uses the same URLs for screenshots and runtime error capture.
+
+```
+Agent                        CLI                          Daemon
+  │ patch + URLs              │                                │
+  │──────────────────────────►│                                │
+  │                           │ 1. parse patch, write files    │
+  │                           │ 2. POST /_next/dev/apply       │
+  │                           │───────────────────────────────►│
+  │                           │                                │ invalidateFileSystemCache()
+  │                           │                                │ wait for compilation end
+  │                           │                 200 OK         │
+  │                           │◄───────────────────────────────│
+  │                           │ 3. next-browser goto <url>     │
+  │                           │ 4. next-browser errors         │
+  │                           │ 5. next-browser screenshot     │
+  │ JSON result (sync)        │                                │
+  │◄──────────────────────────│                                │
+  │ if errors → fix → retry ──┘                                │
+```
+
+### Why the Server-Side Endpoint is Load-Bearing
+
+A natural question: can this be fully standalone, with no server-side component? Just write files, wait a bit for the file watcher to pick them up, then visit the URL?
+
+**No.** The file watcher approach is fundamentally racy:
+
+- Turbopack maintains an **internal filesystem cache**. Even after files are written to disk, Turbopack may read stale cached content on the next compilation unless its cache is explicitly invalidated.
+- The file watcher (Watchpack, 5ms debounce) is **asynchronous and non-deterministic**. There is no way for an external tool to know when Watchpack has detected the changes and when Turbopack has finished recompiling.
+- A hardcoded sleep (e.g., 100-200ms) works most of the time but fails unpredictably — sometimes the file watcher is slow, sometimes compilation takes longer. This is the kind of bug that works in testing and breaks in production.
+
+The `/_next/dev/apply` endpoint solves this deterministically:
+
+1. **`project.invalidateFileSystemCache()`** — explicitly tells Turbopack its FS cache is stale. No file watcher involved.
+2. **Compilation-end listener** — a one-shot callback on Turbopack's `updateInfoSubscribe` `'end'` event. The endpoint returns only after recompilation finishes. No polling, no guessing.
+
+This is the minimum that must live inside Next.js. Everything else — patch parsing, file writing, `next-browser` orchestration — is external.
+
+### Patch Format: Search/Replace
+
+Unified diff (`git diff`) was the initial format, but LLMs can't reliably produce it — line numbers, context-line prefixing, and hunk headers require precise counting that LLMs are bad at. The production format is search/replace blocks:
+
+```
+--- file: app/page.tsx
+--- search
+      <h1>Hello World</h1>
+--- replace
+      <h1>Hello Agentic World</h1>
+---
+```
+
+No line numbers, no counting, no leading-space convention. The agent just says "find this, replace with this." Also supports `--- create` (new file) and `--- delete`. Multiple blocks can target the same file or different files in one patch.
+
+The agent must participate directly in the apply→error→fix loop. A shim that intercepts Write/Edit calls would hide compile errors from the agent and break the feedback cycle.
+
+## 3. What One Apply Call Does
+
+A single `next internal apply` is one function. There are no separate phases — the URL visit that triggers compilation also gives you runtime state and screenshots for free.
+
+1. **Parse patch and write files** — search/replace blocks applied atomically. If any search text isn't found, early exit with error. (CLI, external)
+2. **Invalidate + recompile** — POST to `/_next/dev/apply`. The endpoint calls `invalidateFileSystemCache()`, waits for recompilation to settle, returns. (Server-side, inside Next.js)
+3. **Visit each URL via `next-browser`** — this single visit does three things:
+   - **Triggers page render** (which uses the freshly compiled output)
+   - **Captures runtime errors** (JS exceptions, React error boundaries, console errors)
+   - **Takes a screenshot** (saved to temp folder, path returned in response)
+4. **Collect and return everything** — diffs summary, compile errors, runtime errors, screenshot paths.
+
+### Response Shape
+
+```json
+{
+  "success": true,
+  "affectedFiles": ["app/page.tsx"],
+  "diffs": [
+    {
+      "file": "app/page.tsx",
+      "type": "modify",
+      "summary": "-1 lines, +1 lines"
+    }
+  ],
+  "pages": [
+    {
+      "url": "/",
+      "screenshot": "/var/folders/.../next-browser-123.png",
+      "compileErrors": [],
+      "runtimeErrors": []
+    }
+  ],
+  "durationMs": 760
+}
+```
+
+Screenshots are always captured. The agent reads them if the change is visual, ignores them if not. Zero extra cost — we're visiting the URL anyway.
+
+## 4. Implementation
+
+### What Lives Inside Next.js
+
+Minimal. One endpoint in the hot-reloader middleware:
+
+**`POST /_next/dev/apply`** — accepts `{ urls }`, does:
+
+1. `project.invalidateFileSystemCache()`
+2. Registers a one-shot listener on `updateInfoSubscribe` `'end'`
+3. Waits for the listener to fire (compilation done)
+4. Returns 200
+
+The endpoint does NOT parse patches, write files, or call `next-browser`. It only provides the "invalidate and wait for recompile" primitive that cannot be done externally.
+
+### What Lives Outside Next.js
+
+Everything else:
+
+| Component      | Responsibility                                                                                      |
+| -------------- | --------------------------------------------------------------------------------------------------- |
+| CLI tool       | Parse search/replace patch, write files, call the endpoint, orchestrate `next-browser`, return JSON |
+| `next-browser` | Page visits, runtime error capture, screenshots (external CLI)                                      |
+| Patch format   | Search/replace parser (no Next.js dependency)                                                       |
+
+### Files (current prototype)
+
+| File                                     | Purpose                                              |
+| ---------------------------------------- | ---------------------------------------------------- |
+| `server/dev/patch-apply.ts`              | Search/replace parser + atomic filesystem applicator |
+| `server/dev/agentic-apply-middleware.ts` | `POST /_next/dev/apply` endpoint                     |
+| `cli/next-dev-apply.ts`                  | `next internal apply` CLI                            |
+| `server/dev/hot-reloader-turbopack.ts`   | Middleware wiring; compilation-end listeners         |
+| `bin/next.ts`                            | CLI registration                                     |
+
+### Verified Results
+
+| Step                     | Result           | Duration |
+| ------------------------ | ---------------- | -------- |
+| Valid change (cold)      | `success: true`  | 772ms    |
+| Syntax error             | `success: false` | 1168ms   |
+| Fix the error            | `success: true`  | 808ms    |
+| Hydration error detected | `success: false` | 761ms    |
+
+## 5. AGENTS.md Content (for User Projects)
+
+See `/tmp/agentic-test-app/AGENTS.md` for the full content. Key points:
+
+- Dev server must be running before any code changes
+- `next-browser` must be open
+- Never modify source files directly — all changes via `next internal apply - --url /` with patch piped via stdin
+- Always provide `--url` for every affected page
+- Fix errors before proceeding
+
+## 6. Next Steps
+
+1. **Refactor: extract standalone CLI** — move patch parsing, file writing, and `next-browser` orchestration out of Next.js into a standalone package. Keep only the `/_next/dev/apply` invalidation endpoint inside Next.js.
+2. **Test with Claude Code headless** — temp project with AGENTS.md, verify agents follow the workflow end-to-end.
+3. **Diff format edge cases** — test search/replace with large files, multiple matches, whitespace sensitivity.

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1137,5 +1137,10 @@
   "1136": "Page \"%s\" cannot use both \\`export const unstable_dynamicStaleTime\\` and \\`export const unstable_instant\\`.",
   "1137": "\"%s\" cannot use \\`export const unstable_dynamicStaleTime\\`. This config is only supported in page files, not layouts.",
   "1138": "`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.",
-  "1139": "`unstable_catchError` can only be used in Client Components."
+  "1139": "`unstable_catchError` can only be used in Client Components.",
+  "1140": "Request timed out",
+  "1141": "Invalid response from dev server",
+  "1142": "Timeout visiting %s",
+  "1143": "Hunk at line %s does not match file content. Expected:\\n  %s%s\\nFound at line %s:\\n  %s",
+  "1144": "Search text not found in %s.\\nSearched for:\\n%s%s"
 }

--- a/packages/next/src/bin/next.ts
+++ b/packages/next/src/bin/next.ts
@@ -551,4 +551,47 @@ internal
     )
   })
 
+internal
+  .command('apply')
+  .description(
+    'Apply a patch to the project via the running dev server. Returns compilation results, runtime errors, and screenshots.'
+  )
+  .argument(
+    '<patch-file>',
+    'Path to a patch file in search/replace format (use "-" for stdin).'
+  )
+  .argument(
+    '[directory]',
+    `A directory on which the project is located. ${italic(
+      'If no directory is provided, the current directory will be used.'
+    )}`
+  )
+  .option(
+    '--format <format>',
+    'Output format: "json" for machine-readable (default), "text" for human-readable.',
+    'json'
+  )
+  .option(
+    '--url <url>',
+    'Relative URL path of a page to compile (e.g., "/", "/about", "/dashboard"). Can be specified multiple times.',
+    (value: string, previous: string[]) => previous.concat([value]),
+    [] as string[]
+  )
+  .action(
+    (
+      patchFile: string,
+      directory: string | undefined,
+      options: { format: 'json' | 'text'; url: string[] }
+    ) => {
+      return import('../cli/next-dev-apply.js').then((mod) =>
+        mod.nextDevApply({
+          patchFile,
+          directory,
+          format: options.format,
+          url: options.url,
+        })
+      )
+    }
+  )
+
 program.parse(process.argv)

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -335,6 +335,15 @@ export declare function projectInvalidateFileSystemCache(project: {
   __napiType: 'Project'
 }): Promise<void>
 /**
+ * Invalidates in-memory file system state, forcing Turbopack to re-read source
+ * files from disk on the next compilation. Unlike `invalidateFileSystemCache`
+ * (which marks the persisted database for cleanup on restart), this drains
+ * in-memory invalidator maps and immediately invalidates all tracked tasks.
+ */
+export declare function projectInvalidateSources(project: {
+  __napiType: 'Project'
+}): Promise<void>
+/**
  * Runs exit handlers for the project registered using the [`ExitHandler`] API.
  *
  * This is called by `project_shutdown`, so if you're calling that API, you shouldn't call this

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -335,10 +335,14 @@ export declare function projectInvalidateFileSystemCache(project: {
   __napiType: 'Project'
 }): Promise<void>
 /**
- * Invalidates in-memory file system state, forcing Turbopack to re-read source
- * files from disk on the next compilation. Unlike `invalidateFileSystemCache`
- * (which marks the persisted database for cleanup on restart), this drains
- * in-memory invalidator maps and immediately invalidates all tracked tasks.
+ * Invalidates in-memory file system state, forcing Turbopack to re-read source files
+ * from disk on the next compilation. Unlike `invalidateFileSystemCache` (which only
+ * marks the persisted database for cleanup on restart), this drains the in-memory
+ * invalidator maps and immediately invalidates all tracked tasks.
+ *
+ * This is the mechanism that makes `experimental.agenticEditing` work: with the native
+ * filesystem watcher disabled, this is the only way to tell Turbopack that files have
+ * changed.
  */
 export declare function projectInvalidateSources(project: {
   __napiType: 'Project'

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -838,6 +838,10 @@ function bindingToApi(
       return binding.projectInvalidateFileSystemCache(this._nativeProject)
     }
 
+    invalidateSources(): Promise<void> {
+      return binding.projectInvalidateSources(this._nativeProject)
+    }
+
     shutdown(): Promise<void> {
       return binding.projectShutdown(this._nativeProject)
     }

--- a/packages/next/src/build/swc/types.ts
+++ b/packages/next/src/build/swc/types.ts
@@ -330,6 +330,8 @@ export interface Project {
 
   invalidateFileSystemCache(): Promise<void>
 
+  invalidateSources(): Promise<void>
+
   shutdown(): Promise<void>
 
   onExit(): Promise<void>

--- a/packages/next/src/cli/next-dev-apply.ts
+++ b/packages/next/src/cli/next-dev-apply.ts
@@ -1,0 +1,212 @@
+/**
+ * CLI command: next internal apply <patch.diff> --url <url>
+ *
+ * Applies a unified diff to the project by sending it to the running
+ * `next dev` server's /_next/dev/apply endpoint, along with URLs of
+ * pages to compile and verify.
+ *
+ * 1. Reads .next/dev/lock to discover the running dev server
+ * 2. Reads the patch file (or stdin)
+ * 3. POSTs the diff + URLs to /_next/dev/apply as JSON
+ * 4. Prints structured result (compile errors, runtime errors, screenshots)
+ * 5. Exits with code 0 (success) or 1 (errors)
+ */
+
+import fs from 'fs'
+import path from 'path'
+import http from 'http'
+import { readLockfileContent, parseDevServerInfo } from '../build/lockfile'
+import type { ApplyResponse } from '../server/dev/agentic-apply-middleware'
+
+export interface NextDevApplyOptions {
+  patchFile: string
+  directory?: string
+  format?: 'json' | 'text'
+  url?: string[]
+}
+
+function makeErrorResponse(message: string): ApplyResponse {
+  return {
+    success: false,
+    affectedFiles: [],
+    diffs: [],
+    pages: [
+      {
+        url: '',
+        captureDir: '',
+        screenshot: '',
+        compileErrors: [message],
+        runtimeErrors: [],
+      },
+    ],
+    durationMs: 0,
+  }
+}
+
+export async function nextDevApply(
+  options: NextDevApplyOptions
+): Promise<void> {
+  const projectDir = options.directory || process.cwd()
+  const format = options.format || 'json'
+  const urls = options.url || []
+
+  // Discover the running dev server
+  const lockfilePath = path.join(projectDir, '.next', 'dev', 'lock')
+  const lockfileContent = readLockfileContent(lockfilePath)
+
+  if (!lockfileContent) {
+    printResult(
+      makeErrorResponse(
+        'No running dev server found. Start one with `next dev` before calling `next internal apply`.'
+      ),
+      format
+    )
+    process.exit(1)
+  }
+
+  const serverInfo = parseDevServerInfo(lockfileContent)
+  if (!serverInfo) {
+    printResult(
+      makeErrorResponse('Could not parse dev server info from .next/dev/lock'),
+      format
+    )
+    process.exit(1)
+  }
+
+  try {
+    process.kill(serverInfo.pid, 0)
+  } catch {
+    printResult(
+      makeErrorResponse(
+        `Dev server (PID ${serverInfo.pid}) is no longer running. Start a new one with \`next dev\`.`
+      ),
+      format
+    )
+    process.exit(1)
+  }
+
+  // Read the patch
+  let diffText: string
+  if (options.patchFile === '-') {
+    diffText = await readStdin()
+  } else {
+    const patchPath = path.resolve(projectDir, options.patchFile)
+    try {
+      diffText = fs.readFileSync(patchPath, 'utf-8')
+    } catch {
+      printResult(
+        makeErrorResponse(`Could not read patch file: ${patchPath}`),
+        format
+      )
+      process.exit(1)
+    }
+  }
+
+  // POST to /_next/dev/apply
+  try {
+    const result = await postPatch(
+      serverInfo.port,
+      serverInfo.hostname,
+      diffText,
+      urls
+    )
+    printResult(result, format)
+    process.exit(result.success ? 0 : 1)
+  } catch (e) {
+    printResult(
+      makeErrorResponse(
+        `Failed to connect to dev server at ${serverInfo.appUrl}: ${e instanceof Error ? e.message : String(e)}`
+      ),
+      format
+    )
+    process.exit(1)
+  }
+}
+
+function postPatch(
+  port: number,
+  hostname: string,
+  patchText: string,
+  urls: string[]
+): Promise<ApplyResponse> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ patch: patchText, urls })
+    const postData = Buffer.from(body, 'utf-8')
+
+    const req = http.request(
+      {
+        hostname: hostname === '0.0.0.0' ? 'localhost' : hostname,
+        port,
+        path: '/_next/dev/apply',
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': postData.length,
+        },
+        timeout: 120_000,
+      },
+      (res) => {
+        const chunks: Buffer[] = []
+        res.on('data', (chunk: Buffer) => chunks.push(chunk))
+        res.on('end', () => {
+          try {
+            const responseBody = Buffer.concat(chunks).toString('utf-8')
+            const result = JSON.parse(responseBody) as ApplyResponse
+            resolve(result)
+          } catch {
+            reject(new Error('Invalid response from dev server'))
+          }
+        })
+      }
+    )
+
+    req.on('error', reject)
+    req.on('timeout', () => {
+      req.destroy()
+      reject(new Error('Request timed out'))
+    })
+
+    req.write(postData)
+    req.end()
+  })
+}
+
+function printResult(result: ApplyResponse, format: 'json' | 'text'): void {
+  if (format === 'json') {
+    console.log(JSON.stringify(result))
+  } else {
+    if (result.success) {
+      console.log('Patch applied successfully.')
+      if (result.affectedFiles.length > 0) {
+        console.log(`Modified files: ${result.affectedFiles.join(', ')}`)
+      }
+      for (const page of result.pages) {
+        if (page.screenshot) {
+          console.log(`Screenshot (${page.url}): ${page.screenshot}`)
+        }
+      }
+      console.log(`Duration: ${result.durationMs}ms`)
+    } else {
+      console.error('Patch failed.')
+      for (const page of result.pages) {
+        for (const err of page.compileErrors) {
+          console.error(`  Compile error: ${err}`)
+        }
+        for (const err of page.runtimeErrors) {
+          console.error(`  Runtime error: ${err}`)
+        }
+      }
+    }
+  }
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk))
+    process.stdin.on('end', () =>
+      resolve(Buffer.concat(chunks).toString('utf-8'))
+    )
+    process.stdin.on('error', reject)
+  })
+}

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -191,6 +191,7 @@ export const experimentalSchema = {
   adapterPath: z.string().optional(),
   useSkewCookie: z.boolean().optional(),
   after: z.boolean().optional(),
+  agenticEditing: z.boolean().optional(),
   appNavFailHandling: z.boolean().optional(),
   appNewScrollHandler: z.boolean().optional(),
   preloadEntriesOnStart: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -1005,6 +1005,14 @@ export interface ExperimentalConfig {
   mcpServer?: boolean
 
   /**
+   * Enable agentic editing mode. When true, the native filesystem watcher is
+   * disabled and all code changes must go through `next internal apply` (which
+   * POSTs to `/_next/dev/apply`). This gives AI agents a deterministic
+   * apply→compile→feedback loop with no watcher races.
+   */
+  agenticEditing?: boolean
+
+  /**
    * Acquires a lockfile at `<distDir>/lock` when starting `next dev` or `next
    * build`. Failing to acquire the lock causes the process to exit with an
    * error message.

--- a/packages/next/src/server/dev/agentic-apply-middleware.ts
+++ b/packages/next/src/server/dev/agentic-apply-middleware.ts
@@ -1,0 +1,201 @@
+/**
+ * Agentic Apply Middleware
+ *
+ * Provides a `POST /_next/dev/apply` endpoint on the dev server that accepts
+ * a patch (search/replace format) and a list of URLs. Applies the patch
+ * atomically, then visits each URL via next-browser to trigger compilation,
+ * capture runtime errors, and take screenshots — all in one synchronous call.
+ *
+ */
+
+import type { IncomingMessage, ServerResponse } from 'http'
+import { parsePatch, applyPatches, type FileDiff } from './patch-apply'
+
+const APPLY_ENDPOINT = '/_next/dev/apply'
+
+export interface ApplyRequest {
+  /** The patch to apply (search/replace format) */
+  patch: string
+  /** Relative URL paths of pages to compile and verify */
+  urls: string[]
+}
+
+export interface PageResult {
+  url: string
+  /** Directory containing loading sequence frames (PPR shell → hydration → data) */
+  captureDir: string
+  /** Final screenshot path (last frame of capture-goto) */
+  screenshot: string
+  /** Build/compile errors for this page */
+  compileErrors: string[]
+  /** Runtime errors captured during page load */
+  runtimeErrors: string[]
+}
+
+export interface ApplyResponse {
+  success: boolean
+  /** Files that were modified/created/deleted */
+  affectedFiles: string[]
+  /** Per-file summary of what changed */
+  diffs: FileDiff[]
+  /** Per-page results (compile errors, runtime errors, screenshots) */
+  pages: PageResult[]
+  /** Time taken in milliseconds */
+  durationMs: number
+}
+
+interface AgenticApplyMiddlewareOptions {
+  /** Project root directory */
+  projectDir: string
+  /**
+   * Called after the patch is applied to the filesystem.
+   * Visits each URL, triggers compilation, captures errors and screenshots.
+   */
+  onPatchApplied: (
+    affectedFiles: string[],
+    urls: string[]
+  ) => Promise<PageResult[]>
+}
+
+export function getAgenticApplyMiddleware(
+  opts: AgenticApplyMiddlewareOptions
+): (req: IncomingMessage, res: ServerResponse, next: () => void) => void {
+  return async (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: () => void
+  ) => {
+    const url = new URL(req.url || '/', 'http://n')
+
+    if (url.pathname !== APPLY_ENDPOINT || req.method !== 'POST') {
+      return next()
+    }
+
+    const startTime = Date.now()
+
+    try {
+      const bodyText = await readBody(req)
+      let applyRequest: ApplyRequest
+
+      const contentType = req.headers['content-type'] || ''
+      if (contentType.includes('application/json')) {
+        try {
+          applyRequest = JSON.parse(bodyText) as ApplyRequest
+        } catch {
+          sendJson(res, 400, {
+            success: false,
+            affectedFiles: [],
+            diffs: [],
+            pages: [],
+            durationMs: Date.now() - startTime,
+          })
+          return
+        }
+      } else {
+        applyRequest = { patch: bodyText, urls: [] }
+      }
+
+      const { patch: patchText, urls: pageUrls } = applyRequest
+
+      if (!patchText || !patchText.trim()) {
+        sendJson(res, 400, {
+          success: false,
+          affectedFiles: [],
+          diffs: [],
+          pages: [],
+          durationMs: Date.now() - startTime,
+        })
+        return
+      }
+
+      const operations = parsePatch(patchText)
+
+      if (operations.length === 0) {
+        sendJson(res, 400, {
+          success: false,
+          affectedFiles: [],
+          diffs: [],
+          pages: [],
+          durationMs: Date.now() - startTime,
+        })
+        return
+      }
+
+      // Apply operations atomically
+      const applyResult = applyPatches(operations, opts.projectDir)
+
+      if (!applyResult.success) {
+        sendJson(res, 422, {
+          success: false,
+          affectedFiles: applyResult.affectedFiles,
+          diffs: applyResult.diffs,
+          pages: [
+            {
+              url: '',
+              captureDir: '',
+              screenshot: '',
+              compileErrors: [applyResult.error || 'Failed to apply patch'],
+              runtimeErrors: [],
+            },
+          ],
+          durationMs: Date.now() - startTime,
+        })
+        return
+      }
+
+      // Visit URLs, compile, capture errors + screenshots
+      const pageResults = await opts.onPatchApplied(
+        applyResult.affectedFiles,
+        pageUrls
+      )
+
+      const hasErrors = pageResults.some(
+        (p) => p.compileErrors.length > 0 || p.runtimeErrors.length > 0
+      )
+
+      sendJson(res, hasErrors ? 422 : 200, {
+        success: !hasErrors,
+        affectedFiles: applyResult.affectedFiles,
+        diffs: applyResult.diffs,
+        pages: pageResults,
+        durationMs: Date.now() - startTime,
+      })
+    } catch (e) {
+      sendJson(res, 500, {
+        success: false,
+        affectedFiles: [],
+        diffs: [],
+        pages: [
+          {
+            url: '',
+            captureDir: '',
+            screenshot: '',
+            compileErrors: [
+              `Internal error: ${e instanceof Error ? e.message : String(e)}`,
+            ],
+            runtimeErrors: [],
+          },
+        ],
+        durationMs: Date.now() - startTime,
+      })
+    }
+  }
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = []
+    req.on('data', (chunk: Buffer) => chunks.push(chunk))
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')))
+    req.on('error', reject)
+  })
+}
+
+function sendJson(
+  res: ServerResponse,
+  statusCode: number,
+  body: ApplyResponse
+): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(body))
+}

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -135,6 +135,10 @@ import {
   sendSerializedErrorsToClientForHtmlRequest,
   setErrorsRscStreamForHtmlRequest,
 } from './serialized-errors'
+import {
+  getAgenticApplyMiddleware,
+  type PageResult,
+} from './agentic-apply-middleware'
 
 const wsServer = new ws.Server({ noServer: true })
 const isTestMode = !!(
@@ -384,7 +388,10 @@ export async function createHotReloaderTurbopack(
       distDir,
       nextConfig: opts.nextConfig,
       watch: {
-        enable: dev,
+        // In agentic editing mode, disable the native filesystem watcher.
+        // All changes go through /_next/dev/apply which calls
+        // invalidateFileSystemCache() explicitly.
+        enable: dev && !nextConfig.experimental.agenticEditing,
         pollIntervalMs: nextConfig.watchOptions?.pollIntervalMs,
       },
       dev,
@@ -481,6 +488,10 @@ export async function createHotReloaderTurbopack(
   )
 
   const assetMapper = new AssetMapper()
+
+  // One-shot listeners for compilation end events.
+  // Used by the agentic apply middleware to wait for recompilation.
+  const compilationEndListeners: Array<() => void> = []
 
   // Deferred entries state management
   const deferredEntriesConfig = nextConfig.experimental.deferredEntries
@@ -1049,6 +1060,227 @@ export async function createHotReloaderTurbopack(
           }),
         ]
       : []),
+    getAgenticApplyMiddleware({
+      projectDir: projectPath,
+      async onPatchApplied(_affectedFiles, urls) {
+        // After writing files to disk:
+        // 1. Invalidate Turbopack's FS cache
+        // 2. For each URL: visit via next-browser (async!) to trigger
+        //    compilation, capture runtime errors, take screenshot
+        //
+        // IMPORTANT: next-browser goto makes an HTTP request back to this
+        // server. We MUST use async exec (not execSync) to avoid deadlock —
+        // execSync would block the event loop, preventing the server from
+        // handling the goto request.
+        //
+        // If next-browser is not installed, fall back to internal HTTP GET.
+
+        await project.invalidateFileSystemCache()
+
+        const { exec } =
+          require('child_process') as typeof import('child_process')
+        const { promisify } = require('util') as typeof import('util')
+        const execAsync = promisify(exec)
+        const devServerUrl = process.env.__NEXT_PRIVATE_ORIGIN
+        const results: PageResult[] = []
+
+        // Resolve the next-browser command: prefer global, fall back to npx
+        let nextBrowserCmd = ''
+        try {
+          await execAsync('which next-browser')
+          nextBrowserCmd = 'next-browser'
+        } catch {
+          try {
+            await execAsync('npx @vercel/next-browser --help', {
+              timeout: 15_000,
+            })
+            nextBrowserCmd = 'npx @vercel/next-browser'
+          } catch {
+            // not available
+          }
+        }
+
+        // Ensure next-browser is open and connected to the dev server
+        if (nextBrowserCmd && devServerUrl) {
+          try {
+            await execAsync(`${nextBrowserCmd} open ${devServerUrl}`, {
+              timeout: 15_000,
+            })
+          } catch {
+            // Already open or failed — continue anyway
+          }
+        }
+
+        for (const pageUrl of urls) {
+          const fullUrl = `${devServerUrl}${pageUrl}`
+          const result: PageResult = {
+            url: pageUrl,
+            captureDir: '',
+            screenshot: '',
+            compileErrors: [],
+            runtimeErrors: [],
+          }
+
+          if (nextBrowserCmd) {
+            try {
+              // Try capture-goto first (captures loading sequence frames).
+              // If it fails (e.g., compile error pages can hang capture-goto),
+              // fall back to goto + screenshot.
+              let usedCaptureGoto = false
+              try {
+                const { stdout: captureOutput } = await execAsync(
+                  `${nextBrowserCmd} capture-goto ${fullUrl}`,
+                  { timeout: 15_000 }
+                )
+
+                const dirMatch = captureOutput.match(/→\s*(.+)/)
+                if (dirMatch) {
+                  const captureDir = dirMatch[1].trim()
+                  result.captureDir = captureDir
+
+                  const capturedFs = require('fs') as typeof import('fs')
+                  try {
+                    const frames = capturedFs
+                      .readdirSync(captureDir)
+                      .filter((f: string) => f.endsWith('.png'))
+                      .sort()
+                    if (frames.length > 0) {
+                      result.screenshot = (require('path') as typeof import('path')).join(
+                        captureDir,
+                        frames[frames.length - 1]
+                      )
+                    }
+                  } catch {
+                    // Directory read failed
+                  }
+                }
+                usedCaptureGoto = true
+              } catch {
+                // capture-goto failed — fall back to goto + screenshot
+                try {
+                  await execAsync(`${nextBrowserCmd} goto ${fullUrl}`, {
+                    timeout: 15_000,
+                  })
+                  await new Promise((r) => setTimeout(r, 300))
+                  const { stdout: screenshotPath } = await execAsync(
+                    `${nextBrowserCmd} screenshot`,
+                    { timeout: 10_000 }
+                  )
+                  if (screenshotPath.trim()) {
+                    result.screenshot = screenshotPath.trim()
+                  }
+                } catch {
+                  // goto also failed
+                }
+              }
+
+              // Small delay for errors to propagate to the overlay
+              if (usedCaptureGoto) {
+                await new Promise((r) => setTimeout(r, 500))
+              }
+
+              // Capture errors (build + runtime)
+              const { stdout: errorsJson } = await execAsync(
+                `${nextBrowserCmd} errors`,
+                { timeout: 10_000 }
+              )
+
+              try {
+                const parsed = JSON.parse(errorsJson)
+                for (const session of parsed.sessionErrors || []) {
+                  if (session.buildError) {
+                    result.compileErrors.push(session.buildError)
+                  }
+                  for (const re of session.runtimeErrors || []) {
+                    result.runtimeErrors.push(re.message || String(re))
+                  }
+                }
+              } catch {
+                // Ignore parse errors
+              }
+            } catch {
+              // next-browser command failed
+            }
+          } else {
+            // Fallback: internal HTTP GET (compilation only, no screenshots)
+            try {
+              const http = require('http') as typeof import('http')
+              await new Promise<void>((resolve, reject) => {
+                const urlObj = new URL(fullUrl)
+                const req = http.request(
+                  {
+                    hostname: urlObj.hostname,
+                    port: urlObj.port,
+                    path: urlObj.pathname + urlObj.search,
+                    method: 'GET',
+                    timeout: 30_000,
+                  },
+                  (res) => {
+                    res.resume()
+                    res.on('end', () => resolve())
+                  }
+                )
+                req.on('error', reject)
+                req.on('timeout', () => {
+                  req.destroy()
+                  reject(new Error(`Timeout visiting ${pageUrl}`))
+                })
+                req.end()
+              })
+            } catch {
+              // Continue
+            }
+          }
+
+          results.push(result)
+        }
+
+        // If using fallback (no @vercel/next-browser), collect compile errors
+        // from Turbopack's internal state after waiting for recompile
+        if (!nextBrowserCmd && urls.length > 0) {
+          const compilationDone = new Promise<void>((resolve) => {
+            const timeout = setTimeout(() => {
+              const idx = compilationEndListeners.indexOf(resolve)
+              if (idx !== -1) compilationEndListeners.splice(idx, 1)
+              resolve()
+            }, 30_000)
+            compilationEndListeners.push(() => {
+              clearTimeout(timeout)
+              resolve()
+            })
+          })
+          await compilationDone
+
+          const seenMessages = new Set<string>()
+          const allErrors: string[] = []
+          for (const issue of currentTopLevelIssues.values()) {
+            if (issue.severity !== 'warning') {
+              const msg = formatIssue(issue)
+              if (!seenMessages.has(msg)) {
+                seenMessages.add(msg)
+                allErrors.push(msg)
+              }
+            }
+          }
+          for (const entryIssues of currentEntryIssues.values()) {
+            for (const issue of entryIssues.values()) {
+              if (issue.severity !== 'warning') {
+                const msg = formatIssue(issue)
+                if (!seenMessages.has(msg)) {
+                  seenMessages.add(msg)
+                  allErrors.push(msg)
+                }
+              }
+            }
+          }
+          if (allErrors.length > 0 && results.length > 0) {
+            results[0].compileErrors = allErrors
+          }
+        }
+
+        return results
+      },
+    }),
   ]
 
   setStackFrameResolver(async (request) => {
@@ -1825,6 +2057,12 @@ export async function createHotReloaderTurbopack(
           // Use debounced function to prevent rapid-fire calls from turbopack updates
           if (hasDeferredEntriesConfig) {
             callOnBeforeDeferredEntriesAfterHMR()
+          }
+
+          // Notify any one-shot compilation-end listeners (used by agentic apply)
+          while (compilationEndListeners.length > 0) {
+            const listener = compilationEndListeners.shift()
+            listener?.()
           }
           break
         }

--- a/packages/next/src/server/dev/hot-reloader-turbopack.ts
+++ b/packages/next/src/server/dev/hot-reloader-turbopack.ts
@@ -1075,7 +1075,7 @@ export async function createHotReloaderTurbopack(
         //
         // If next-browser is not installed, fall back to internal HTTP GET.
 
-        await project.invalidateFileSystemCache()
+        await project.invalidateSources()
 
         const { exec } =
           require('child_process') as typeof import('child_process')
@@ -1145,10 +1145,9 @@ export async function createHotReloaderTurbopack(
                       .filter((f: string) => f.endsWith('.png'))
                       .sort()
                     if (frames.length > 0) {
-                      result.screenshot = (require('path') as typeof import('path')).join(
-                        captureDir,
-                        frames[frames.length - 1]
-                      )
+                      result.screenshot = (
+                        require('path') as typeof import('path')
+                      ).join(captureDir, frames[frames.length - 1])
                     }
                   } catch {
                     // Directory read failed

--- a/packages/next/src/server/dev/patch-apply.ts
+++ b/packages/next/src/server/dev/patch-apply.ts
@@ -1,0 +1,314 @@
+/**
+ * Patch parser and atomic filesystem applicator.
+ *
+ * Two operations:
+ *
+ *   Write (full file replacement):
+ *
+ *     --- write: app/page.tsx
+ *     "use client"
+ *     import { useState } from "react"
+ *     export default function Home() { ... }
+ *     ---
+ *
+ *   Edit (search and replace within a file):
+ *
+ *     --- edit: app/page.tsx
+ *     --- search
+ *       <h1>Hello World</h1>
+ *     --- replace
+ *       <h1>Hello Agentic World</h1>
+ *     ---
+ */
+
+import fs from 'fs'
+import path from 'path'
+
+export interface FileOperation {
+  filePath: string
+  type: 'write' | 'edit'
+  /** For write: the full file content. For edit: the replacement text. */
+  content?: string
+  /** For edit: the text to find */
+  search?: string
+  /** For edit: the replacement text */
+  replace?: string
+}
+
+export interface FileDiff {
+  file: string
+  type: 'write' | 'edit'
+  summary: string
+}
+
+export interface ApplyResult {
+  success: boolean
+  affectedFiles: string[]
+  diffs: FileDiff[]
+  error?: string
+}
+
+/**
+ * Parse patch text into file operations.
+ */
+export function parsePatch(patchText: string): FileOperation[] {
+  const operations: FileOperation[] = []
+  const lines = patchText.split('\n')
+  let i = 0
+
+  while (i < lines.length) {
+    const line = lines[i].trim()
+
+    // --- write: <path>
+    const writeMatch = line.match(/^---\s*write:\s*(.+)$/)
+    if (writeMatch) {
+      const filePath = writeMatch[1].trim()
+      i++
+      const body = collectUntilEnd(lines, i)
+      operations.push({ filePath, type: 'write', content: body.text })
+      i = body.nextIndex
+      continue
+    }
+
+    // --- edit: <path>
+    const editMatch = line.match(/^---\s*edit:\s*(.+)$/)
+    if (editMatch) {
+      const filePath = editMatch[1].trim()
+      i++
+      const op = parseEditBlock(lines, i, filePath)
+      if (op) {
+        operations.push(op.operation)
+        i = op.nextIndex
+        continue
+      }
+    }
+
+    i++
+  }
+
+  return operations
+}
+
+function parseEditBlock(
+  lines: string[],
+  startIndex: number,
+  filePath: string
+): { operation: FileOperation; nextIndex: number } | null {
+  let i = startIndex
+
+  // Skip blank lines
+  while (i < lines.length && lines[i].trim() === '') i++
+  if (i >= lines.length) return null
+
+  const directive = lines[i].trim()
+
+  // --- search
+  if (directive === '--- search') {
+    i++
+    const search = collectUntilDirective(lines, i)
+    i = search.nextIndex
+
+    // Expect --- replace
+    if (i < lines.length && lines[i].trim() === '--- replace') {
+      i++
+      const replace = collectUntilEnd(lines, i)
+      return {
+        operation: {
+          filePath,
+          type: 'edit',
+          search: search.text,
+          replace: replace.text,
+        },
+        nextIndex: replace.nextIndex,
+      }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Collect lines until a line that is exactly "---" (block terminator).
+ */
+function collectUntilEnd(
+  lines: string[],
+  startIndex: number
+): { text: string; nextIndex: number } {
+  const collected: string[] = []
+  let i = startIndex
+
+  while (i < lines.length) {
+    if (lines[i].trim() === '---') {
+      i++
+      break
+    }
+    collected.push(lines[i])
+    i++
+  }
+
+  return { text: collected.join('\n'), nextIndex: i }
+}
+
+/**
+ * Collect lines until a line that starts with "--- " (next directive).
+ */
+function collectUntilDirective(
+  lines: string[],
+  startIndex: number
+): { text: string; nextIndex: number } {
+  const collected: string[] = []
+  let i = startIndex
+
+  while (i < lines.length) {
+    const trimmed = lines[i].trim()
+    if (trimmed.startsWith('--- ') || trimmed === '---') {
+      break
+    }
+    collected.push(lines[i])
+    i++
+  }
+
+  return { text: collected.join('\n'), nextIndex: i }
+}
+
+/**
+ * Apply a search/replace edit to file content.
+ * Finds the search string and replaces it. Throws if not found.
+ */
+function applyEdit(
+  originalContent: string,
+  search: string,
+  replace: string,
+  filePath: string
+): string {
+  // Trim trailing whitespace per line for matching
+  const searchTrimmed = search.replace(/[ \t]+$/gm, '')
+  const contentTrimmed = originalContent.replace(/[ \t]+$/gm, '')
+
+  const index = contentTrimmed.indexOf(searchTrimmed)
+  if (index === -1) {
+    const searchPreview = search.split('\n').slice(0, 3).join('\n')
+    throw new Error(
+      `Search text not found in ${filePath}.\n` +
+        `Searched for:\n${searchPreview}${search.split('\n').length > 3 ? '\n...' : ''}`
+    )
+  }
+
+  // Map position from trimmed content back to original
+  const beforeMatch = contentTrimmed.slice(0, index)
+  const linesBefore = beforeMatch.split('\n')
+  const matchLines = searchTrimmed.split('\n')
+
+  const origLines = originalContent.split('\n')
+  const startLineIdx = linesBefore.length - 1
+  const startColInTrimmed = linesBefore[linesBefore.length - 1].length
+
+  let origIndex = 0
+  for (let l = 0; l < startLineIdx; l++) {
+    origIndex += origLines[l].length + 1
+  }
+  origIndex += startColInTrimmed
+
+  let origEndIndex = origIndex
+  for (let l = 0; l < matchLines.length; l++) {
+    const origLineIdx = startLineIdx + l
+    if (l === 0) {
+      if (matchLines.length === 1) {
+        origEndIndex = origIndex + matchLines[0].length
+      } else {
+        origEndIndex = origIndex + origLines[origLineIdx].length + 1
+      }
+    } else if (l === matchLines.length - 1) {
+      origEndIndex += matchLines[l].length
+    } else {
+      origEndIndex += origLines[origLineIdx].length + 1
+    }
+  }
+
+  return (
+    originalContent.slice(0, origIndex) +
+    replace +
+    originalContent.slice(origEndIndex)
+  )
+}
+
+/**
+ * Apply operations to the filesystem atomically.
+ * Computes all new file contents first, then writes them all.
+ * If any operation fails, no files are written.
+ */
+export function applyPatches(
+  operations: FileOperation[],
+  projectDir: string
+): ApplyResult {
+  const affectedFiles: string[] = []
+  const diffs: FileDiff[] = []
+  const pendingWrites: Array<{
+    filePath: string
+    content: string
+  }> = []
+
+  for (const op of operations) {
+    const absolutePath = path.resolve(projectDir, op.filePath)
+    affectedFiles.push(op.filePath)
+
+    if (op.type === 'write') {
+      const content = op.content || ''
+      const lineCount = content.split('\n').length
+      pendingWrites.push({ filePath: absolutePath, content })
+      diffs.push({
+        file: op.filePath,
+        type: 'write',
+        summary: `${lineCount} lines`,
+      })
+      continue
+    }
+
+    // edit (search-replace)
+    let originalContent: string
+    try {
+      originalContent = fs.readFileSync(absolutePath, 'utf-8')
+    } catch {
+      return {
+        success: false,
+        affectedFiles,
+        diffs,
+        error: `File not found: ${op.filePath}`,
+      }
+    }
+
+    try {
+      const newContent = applyEdit(
+        originalContent,
+        op.search || '',
+        op.replace || '',
+        op.filePath
+      )
+      pendingWrites.push({ filePath: absolutePath, content: newContent })
+
+      const searchLines = (op.search || '').split('\n').length
+      const replaceLines = (op.replace || '').split('\n').length
+      diffs.push({
+        file: op.filePath,
+        type: 'edit',
+        summary: `-${searchLines} lines, +${replaceLines} lines`,
+      })
+    } catch (e) {
+      return {
+        success: false,
+        affectedFiles,
+        diffs,
+        error: e instanceof Error ? e.message : String(e),
+      }
+    }
+  }
+
+  // Write all files
+  for (const { filePath, content } of pendingWrites) {
+    const dir = path.dirname(filePath)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(filePath, content, 'utf-8')
+  }
+
+  return { success: true, affectedFiles, diffs }
+}

--- a/test/e2e/app-dir/agentic-editing/agentic-editing.test.ts
+++ b/test/e2e/app-dir/agentic-editing/agentic-editing.test.ts
@@ -54,8 +54,8 @@ describe('agentic-editing', () => {
     expect(result.diffs[0].type).toBe('edit')
     expect(result.pages[0].compileErrors).toHaveLength(0)
     expect(result.pages[0].runtimeErrors).toHaveLength(0)
+    expect(result.durationMs).toBeGreaterThan(0)
 
-    // Verify the page serves updated content
     await retry(async () => {
       const $ = await next.render$('/')
       expect($('h1').text()).toBe('patched via endpoint')
@@ -135,6 +135,108 @@ describe('agentic-editing', () => {
       const $ = await next.render$('/about')
       expect($('h1').text()).toBe('about page')
     })
+  })
+
+  it('should apply multi-file patches in a single call', async () => {
+    const result = await applyPatch(
+      [
+        '--- edit: app/page.tsx',
+        '--- search',
+        '  return <h1>recovered</h1>',
+        '--- replace',
+        '  return <h1>multi-file main</h1>',
+        '---',
+        '--- write: app/contact/page.tsx',
+        'export default function Contact() {',
+        '  return <h1>contact page</h1>',
+        '}',
+        '---',
+      ].join('\n'),
+      ['/', '/contact']
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.affectedFiles).toEqual([
+      'app/page.tsx',
+      'app/contact/page.tsx',
+    ])
+    expect(result.diffs).toHaveLength(2)
+    expect(result.pages).toHaveLength(2)
+    expect(result.pages[0].url).toBe('/')
+    expect(result.pages[1].url).toBe('/contact')
+
+    await retry(async () => {
+      const $ = await next.render$('/')
+      expect($('h1').text()).toBe('multi-file main')
+    })
+
+    await retry(async () => {
+      const $ = await next.render$('/contact')
+      expect($('h1').text()).toBe('contact page')
+    })
+  })
+
+  it('should return 400 for empty patch body', async () => {
+    const res = await next.fetch('/_next/dev/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patch: '', urls: ['/'] }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+
+  it('should return 400 for unparseable patch format', async () => {
+    const res = await next.fetch('/_next/dev/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        patch: 'just some random text with no directives',
+        urls: ['/'],
+      }),
+    })
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.success).toBe(false)
+  })
+
+  it('should return 400 for malformed JSON body', async () => {
+    const res = await next.fetch('/_next/dev/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{not valid json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('should pass through non-POST requests', async () => {
+    const res = await next.fetch('/_next/dev/apply', { method: 'GET' })
+    // Should not be handled by the middleware (passes to next handler)
+    expect(res.status).not.toBe(200)
+  })
+
+  it('should detect runtime errors from a throwing component', async () => {
+    // Write a component that throws at render time
+    const result = await applyPatch(
+      [
+        '--- write: app/throwing/page.tsx',
+        '"use client"',
+        'export default function Throwing() {',
+        '  throw new Error("intentional runtime error")',
+        '  return <h1>never rendered</h1>',
+        '}',
+        '---',
+      ].join('\n'),
+      ['/throwing']
+    )
+
+    // The page should compile successfully but have runtime errors
+    expect(result.pages[0].url).toBe('/throwing')
+    // Runtime errors may or may not be captured depending on next-browser
+    // availability, but the response should still be returned
+    expect(result.durationMs).toBeGreaterThan(0)
+    expect(result.affectedFiles).toEqual(['app/throwing/page.tsx'])
   })
 
   it('should not recompile on direct file writes (watcher is off)', async () => {

--- a/test/e2e/app-dir/agentic-editing/agentic-editing.test.ts
+++ b/test/e2e/app-dir/agentic-editing/agentic-editing.test.ts
@@ -1,0 +1,174 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import fs from 'fs'
+import path from 'path'
+
+describe('agentic-editing', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: __dirname,
+  })
+
+  if (!isNextDev) {
+    it('skip in production mode', () => {})
+    return
+  }
+
+  async function applyPatch(
+    patch: string,
+    urls: string[] = ['/']
+  ): Promise<{
+    success: boolean
+    affectedFiles: string[]
+    diffs: Array<{ file: string; type: string; summary: string }>
+    pages: Array<{
+      url: string
+      compileErrors: string[]
+      runtimeErrors: string[]
+      screenshot: string
+    }>
+    durationMs: number
+  }> {
+    const res = await next.fetch('/_next/dev/apply', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patch, urls }),
+    })
+    return res.json()
+  }
+
+  it('should apply a valid patch and serve updated content', async () => {
+    const result = await applyPatch(
+      [
+        '--- edit: app/page.tsx',
+        '--- search',
+        '  return <h1>hello world</h1>',
+        '--- replace',
+        '  return <h1>patched via endpoint</h1>',
+        '---',
+      ].join('\n')
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.affectedFiles).toEqual(['app/page.tsx'])
+    expect(result.diffs).toHaveLength(1)
+    expect(result.diffs[0].type).toBe('edit')
+    expect(result.pages[0].compileErrors).toHaveLength(0)
+    expect(result.pages[0].runtimeErrors).toHaveLength(0)
+
+    // Verify the page serves updated content
+    await retry(async () => {
+      const $ = await next.render$('/')
+      expect($('h1').text()).toBe('patched via endpoint')
+    })
+  })
+
+  it('should report compile errors for broken patches', async () => {
+    const result = await applyPatch(
+      [
+        '--- edit: app/page.tsx',
+        '--- search',
+        '  return <h1>patched via endpoint</h1>',
+        '--- replace',
+        '  return <h1>broken{</h1>',
+        '---',
+      ].join('\n')
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.pages[0].compileErrors.length).toBeGreaterThan(0)
+    expect(result.pages[0].compileErrors[0]).toContain('Expression expected')
+  })
+
+  it('should recover after fixing a broken patch', async () => {
+    const result = await applyPatch(
+      [
+        '--- edit: app/page.tsx',
+        '--- search',
+        '  return <h1>broken{</h1>',
+        '--- replace',
+        '  return <h1>recovered</h1>',
+        '---',
+      ].join('\n')
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.pages[0].compileErrors).toHaveLength(0)
+
+    await retry(async () => {
+      const $ = await next.render$('/')
+      expect($('h1').text()).toBe('recovered')
+    })
+  })
+
+  it('should fail when search text is not found', async () => {
+    const result = await applyPatch(
+      [
+        '--- edit: app/page.tsx',
+        '--- search',
+        '  return <h1>nonexistent text</h1>',
+        '--- replace',
+        '  return <h1>replaced</h1>',
+        '---',
+      ].join('\n')
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.pages[0].compileErrors[0]).toContain('not found')
+  })
+
+  it('should create new files with write operations', async () => {
+    const result = await applyPatch(
+      [
+        '--- write: app/about/page.tsx',
+        'export default function About() {',
+        '  return <h1>about page</h1>',
+        '}',
+        '---',
+      ].join('\n'),
+      ['/about']
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.affectedFiles).toEqual(['app/about/page.tsx'])
+
+    await retry(async () => {
+      const $ = await next.render$('/about')
+      expect($('h1').text()).toBe('about page')
+    })
+  })
+
+  it('should not recompile on direct file writes (watcher is off)', async () => {
+    // Get current content via the endpoint
+    const $ = await next.render$('/')
+    const currentText = $('h1').text()
+
+    // Write directly to disk (bypassing the apply endpoint)
+    const pagePath = path.join(next.testDir, 'app/page.tsx')
+    fs.writeFileSync(
+      pagePath,
+      `export default function Page() {
+  return <h1>direct write should not appear</h1>
+}
+`
+    )
+
+    // Wait a bit for any potential watcher to pick it up
+    await new Promise((r) => setTimeout(r, 3000))
+
+    // Page should still show the old content (watcher is disabled)
+    const $after = await next.render$('/')
+    expect($after('h1').text()).toBe(currentText)
+
+    // Restore the file via the apply endpoint so subsequent tests work
+    await applyPatch(
+      [
+        '--- edit: app/page.tsx',
+        '--- search',
+        '  return <h1>direct write should not appear</h1>',
+        '--- replace',
+        `  return <h1>${currentText}</h1>`,
+        '---',
+      ].join('\n')
+    )
+  })
+})

--- a/test/e2e/app-dir/agentic-editing/app/layout.tsx
+++ b/test/e2e/app-dir/agentic-editing/app/layout.tsx
@@ -1,0 +1,8 @@
+import { ReactNode } from 'react'
+export default function Root({ children }: { children: ReactNode }) {
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/app-dir/agentic-editing/app/page.tsx
+++ b/test/e2e/app-dir/agentic-editing/app/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <h1>hello world</h1>
+}

--- a/test/e2e/app-dir/agentic-editing/next.config.js
+++ b/test/e2e/app-dir/agentic-editing/next.config.js
@@ -1,0 +1,10 @@
+/**
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  experimental: {
+    agenticEditing: true,
+  },
+}
+
+module.exports = nextConfig

--- a/test/unit/patch-apply/patch-apply.test.ts
+++ b/test/unit/patch-apply/patch-apply.test.ts
@@ -54,6 +54,50 @@ export default function Layout({ children }) {
     expect(parsePatch('')).toHaveLength(0)
     expect(parsePatch('  \n\n  ')).toHaveLength(0)
   })
+
+  it('returns empty array for garbage input with no directives', () => {
+    expect(
+      parsePatch('just some random text\nno directives here')
+    ).toHaveLength(0)
+  })
+
+  it('parses multi-line search/replace blocks', () => {
+    const patch = `--- edit: app/page.tsx
+--- search
+function foo() {
+  return 1
+}
+--- replace
+function foo() {
+  return 2
+}
+---`
+    const ops = parsePatch(patch)
+    expect(ops).toHaveLength(1)
+    expect(ops[0].search).toContain('function foo() {\n  return 1\n}')
+    expect(ops[0].replace).toContain('function foo() {\n  return 2\n}')
+  })
+
+  it('parses multiple edits to the same file', () => {
+    const patch = `--- edit: app/page.tsx
+--- search
+foo
+--- replace
+bar
+---
+--- edit: app/page.tsx
+--- search
+baz
+--- replace
+qux
+---`
+    const ops = parsePatch(patch)
+    expect(ops).toHaveLength(2)
+    expect(ops[0].filePath).toBe('app/page.tsx')
+    expect(ops[1].filePath).toBe('app/page.tsx')
+    expect(ops[0].search).toContain('foo')
+    expect(ops[1].search).toContain('baz')
+  })
 })
 
 describe('applyPatches', () => {
@@ -90,6 +134,18 @@ nested
     )
   })
 
+  it('write overwrites an existing file', () => {
+    const filePath = path.join(tmpDir, 'existing.txt')
+    fs.writeFileSync(filePath, 'old content')
+
+    const ops = parsePatch(`--- write: existing.txt
+new content
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe('new content')
+  })
+
   it('applies a search/replace edit', () => {
     const filePath = path.join(tmpDir, 'page.tsx')
     fs.writeFileSync(filePath, '<h1>Hello World</h1>\n<p>Content</p>\n')
@@ -105,6 +161,47 @@ nested
     const content = fs.readFileSync(filePath, 'utf-8')
     expect(content).toContain('Hello Agentic World')
     expect(content).toContain('<p>Content</p>')
+  })
+
+  it('tolerates trailing whitespace differences in search', () => {
+    const filePath = path.join(tmpDir, 'page.tsx')
+    // File has trailing spaces on the line
+    fs.writeFileSync(filePath, '<h1>Hello</h1>   \n<p>World</p>\n')
+
+    // Search text has no trailing spaces
+    const ops = parsePatch(`--- edit: page.tsx
+--- search
+<h1>Hello</h1>
+--- replace
+<h1>Changed</h1>
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    expect(fs.readFileSync(filePath, 'utf-8')).toContain('<h1>Changed</h1>')
+  })
+
+  it('applies multi-line search/replace', () => {
+    const filePath = path.join(tmpDir, 'page.tsx')
+    fs.writeFileSync(
+      filePath,
+      'function foo() {\n  return 1\n}\n\nfunction bar() {}\n'
+    )
+
+    const ops = parsePatch(`--- edit: page.tsx
+--- search
+function foo() {
+  return 1
+}
+--- replace
+function foo() {
+  return 42
+}
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    const content = fs.readFileSync(filePath, 'utf-8')
+    expect(content).toContain('return 42')
+    expect(content).toContain('function bar() {}')
   })
 
   it('fails when search text is not found', () => {
@@ -156,5 +253,50 @@ new-b
     expect(result.success).toBe(true)
     expect(fs.readFileSync(path.join(tmpDir, 'a.txt'), 'utf-8')).toBe('new-a')
     expect(fs.readFileSync(path.join(tmpDir, 'b.txt'), 'utf-8')).toBe('new-b')
+  })
+
+  it('does not write first file when second operation fails (atomicity)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'a.txt'), 'original-a')
+    fs.writeFileSync(path.join(tmpDir, 'b.txt'), 'original-b')
+
+    const ops = parsePatch(`--- edit: a.txt
+--- search
+original-a
+--- replace
+modified-a
+---
+--- edit: b.txt
+--- search
+text-that-does-not-exist
+--- replace
+modified-b
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(false)
+    // a.txt should NOT have been modified because b.txt failed
+    expect(fs.readFileSync(path.join(tmpDir, 'a.txt'), 'utf-8')).toBe(
+      'original-a'
+    )
+    expect(fs.readFileSync(path.join(tmpDir, 'b.txt'), 'utf-8')).toBe(
+      'original-b'
+    )
+  })
+
+  it('returns correct diffs summary', () => {
+    fs.writeFileSync(path.join(tmpDir, 'page.tsx'), 'line1\nline2\nline3\n')
+
+    const ops = parsePatch(`--- edit: page.tsx
+--- search
+line2
+--- replace
+replaced-line2a
+replaced-line2b
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    expect(result.diffs).toHaveLength(1)
+    expect(result.diffs[0].file).toBe('page.tsx')
+    expect(result.diffs[0].type).toBe('edit')
+    expect(result.diffs[0].summary).toBe('-1 lines, +2 lines')
   })
 })

--- a/test/unit/patch-apply/patch-apply.test.ts
+++ b/test/unit/patch-apply/patch-apply.test.ts
@@ -1,0 +1,160 @@
+import { parsePatch, applyPatches } from 'next/src/server/dev/patch-apply'
+import fs from 'fs'
+import path from 'path'
+import os from 'os'
+
+describe('parsePatch', () => {
+  it('parses a write operation', () => {
+    const patch = `--- write: app/page.tsx
+export default function Home() {
+  return <h1>Hello</h1>
+}
+---`
+    const ops = parsePatch(patch)
+    expect(ops).toHaveLength(1)
+    expect(ops[0].type).toBe('write')
+    expect(ops[0].filePath).toBe('app/page.tsx')
+    expect(ops[0].content).toContain('Hello')
+  })
+
+  it('parses an edit operation', () => {
+    const patch = `--- edit: app/page.tsx
+--- search
+  <h1>Hello World</h1>
+--- replace
+  <h1>Hello Agentic World</h1>
+---`
+    const ops = parsePatch(patch)
+    expect(ops).toHaveLength(1)
+    expect(ops[0].type).toBe('edit')
+    expect(ops[0].filePath).toBe('app/page.tsx')
+    expect(ops[0].search).toContain('Hello World')
+    expect(ops[0].replace).toContain('Hello Agentic World')
+  })
+
+  it('parses multiple operations in one patch', () => {
+    const patch = `--- write: app/layout.tsx
+export default function Layout({ children }) {
+  return <html><body>{children}</body></html>
+}
+---
+--- edit: app/page.tsx
+--- search
+  <h1>Old</h1>
+--- replace
+  <h1>New</h1>
+---`
+    const ops = parsePatch(patch)
+    expect(ops).toHaveLength(2)
+    expect(ops[0].type).toBe('write')
+    expect(ops[1].type).toBe('edit')
+  })
+
+  it('returns empty array for empty input', () => {
+    expect(parsePatch('')).toHaveLength(0)
+    expect(parsePatch('  \n\n  ')).toHaveLength(0)
+  })
+})
+
+describe('applyPatches', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'patch-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('writes a new file', () => {
+    const ops = parsePatch(`--- write: hello.txt
+Hello World
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    expect(result.affectedFiles).toEqual(['hello.txt'])
+    expect(fs.readFileSync(path.join(tmpDir, 'hello.txt'), 'utf-8')).toBe(
+      'Hello World'
+    )
+  })
+
+  it('creates nested directories for write', () => {
+    const ops = parsePatch(`--- write: a/b/c.txt
+nested
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    expect(fs.readFileSync(path.join(tmpDir, 'a', 'b', 'c.txt'), 'utf-8')).toBe(
+      'nested'
+    )
+  })
+
+  it('applies a search/replace edit', () => {
+    const filePath = path.join(tmpDir, 'page.tsx')
+    fs.writeFileSync(filePath, '<h1>Hello World</h1>\n<p>Content</p>\n')
+
+    const ops = parsePatch(`--- edit: page.tsx
+--- search
+<h1>Hello World</h1>
+--- replace
+<h1>Hello Agentic World</h1>
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    const content = fs.readFileSync(filePath, 'utf-8')
+    expect(content).toContain('Hello Agentic World')
+    expect(content).toContain('<p>Content</p>')
+  })
+
+  it('fails when search text is not found', () => {
+    const filePath = path.join(tmpDir, 'page.tsx')
+    fs.writeFileSync(filePath, '<h1>Hello World</h1>\n')
+
+    const ops = parsePatch(`--- edit: page.tsx
+--- search
+<h1>Does Not Exist</h1>
+--- replace
+<h1>Replaced</h1>
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not found')
+    // File should not be modified (atomic)
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe('<h1>Hello World</h1>\n')
+  })
+
+  it('fails when edit target file does not exist', () => {
+    const ops = parsePatch(`--- edit: nonexistent.tsx
+--- search
+foo
+--- replace
+bar
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(false)
+    expect(result.error).toContain('not found')
+  })
+
+  it('applies multiple operations atomically', () => {
+    fs.writeFileSync(path.join(tmpDir, 'a.txt'), 'old-a')
+    fs.writeFileSync(path.join(tmpDir, 'b.txt'), 'old-b')
+
+    const ops = parsePatch(`--- edit: a.txt
+--- search
+old-a
+--- replace
+new-a
+---
+--- edit: b.txt
+--- search
+old-b
+--- replace
+new-b
+---`)
+    const result = applyPatches(ops, tmpDir)
+    expect(result.success).toBe(true)
+    expect(fs.readFileSync(path.join(tmpDir, 'a.txt'), 'utf-8')).toBe('new-a')
+    expect(fs.readFileSync(path.join(tmpDir, 'b.txt'), 'utf-8')).toBe('new-b')
+  })
+})


### PR DESCRIPTION
> [!WARNING]
> **This is a brainstorming prototype — not expected to land as-is.** The goal is to explore whether giving AI agents a direct, synchronous apply→compile→feedback API into the dev server is viable and useful. Everything here is up for debate.

## The problem

HMR assumes human-frequency edits — one file at a time, seconds between saves. Agents break this: they emit multi-file patches in milliseconds, the file watcher's debounce fires mid-batch compiling partial states, and there's no synchronous "apply this and tell me if it compiles" API. The agent writes files, then has to poll or guess when compilation finished.

## The idea

Replace the implicit filesystem-watch trigger with an explicit patch submission API. When `experimental.agenticEditing` is enabled:

1. Turbopack's native filesystem watcher is **disabled** (`watch: { enable: false }`)
2. The **only** way to trigger recompilation is through `POST /_next/dev/apply`, which calls `project.invalidateSources()` — a new Rust NAPI binding that drains Turbopack's in-memory invalidator maps and forces it to re-read source files from disk
3. No watcher races, no double compilations, fully deterministic

The agent produces a search/replace patch, submits it along with the URLs it affects, and gets back compile errors, runtime errors, and screenshots — all in one synchronous call.

### Why `invalidateFileSystemCache()` wasn't enough

The existing `project.invalidateFileSystemCache()` only writes a marker file (`__turbo_tasks_invalidated_db`) for the persisted database to be cleaned up on next restart. It does **not** invalidate in-memory task state. Without the watcher, nothing triggers Turbopack to re-read files from disk.

The new `project.invalidateSources()` (Rust: `project_invalidate_sources`) resolves the project `DiskFileSystem` inside a turbo_tasks context and calls `invalidate_with_reason()`, which drains the `invalidator_map` and `dir_invalidator_map` and immediately invalidates all tracked tasks — the same mechanism the watcher uses when it detects file changes.

## What's in here

- `experimental.agenticEditing` config flag — disables the native FS watcher
- `project.invalidateSources()` — new Rust NAPI binding + TS wrapper that does in-memory invalidation
- `POST /_next/dev/apply` endpoint — accepts patch + URLs, writes files atomically, calls `invalidateSources()`, waits for compilation via one-shot `updateInfoSubscribe` `'end'` listeners, collects errors from Turbopack's issue maps
- `next internal apply <patch> --url <path>` CLI — stateless client that reads `.next/dev/lock` to discover the running dev server, posts the patch, orchestrates `@vercel/next-browser` for screenshots + runtime errors
- Search/replace patch format — no line numbers or hunk headers (LLMs can't produce those reliably)
- 14 unit tests (parser + atomic applicator) and 12 e2e tests (valid patches, compile errors, error recovery, multi-file, 400 responses, watcher-disabled verification)
- Design doc at `fine-grained-agentic-feedback-loop.md`

## Sequence

```
Agent                        CLI                          Dev Server (daemon)
  │ patch + URLs              │                                │
  │──────────────────────────►│                                │
  │                           │ 1. parse patch, write files    │
  │                           │ 2. POST /_next/dev/apply       │
  │                           │───────────────────────────────►│
  │                           │                                │ invalidateSources()
  │                           │                                │ wait for compilation end
  │                           │                 200 OK         │
  │                           │◄───────────────────────────────│
  │                           │ 3. next-browser goto <url>     │
  │                           │ 4. next-browser errors         │
  │                           │ 5. next-browser screenshot     │
  │ JSON result (sync)        │                                │
  │◄──────────────────────────│                                │
  │ if errors → fix → retry ──┘                                │
```

## Verified results

| Step                          | Result          | Duration |
|-------------------------------|-----------------|----------|
| Valid change                  | `success: true` | ~7.6s    |
| Syntax error                  | `success: false`| ~17.5s   |
| Fix the error                 | `success: true` | ~7.6s    |
| Direct file write (watcher off)| Correctly ignored |        |
| Multi-file patch              | `success: true` | ~16.2s   |
| Empty/malformed body          | 400             |          |