### PR TITLE
fix(metadata): preserve URL instance pathname in alternates

### DIFF
--- a/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
+++ b/packages/next/src/lib/metadata/resolvers/resolve-basics.ts
@@ -22,14 +22,12 @@ function resolveAlternateUrl(
   pathname: string,
   metadataContext: MetadataContext
 ) {
-  // If alter native url is an URL instance,
-  // we treat it as a URL base and resolve with current pathname
+  // If the url is a URL instance, convert it to its href string so that
+  // its full path is preserved. Previously this used the URL as a base and
+  // resolved with the current page pathname, which incorrectly discarded
+  // the URL's own pathname (e.g. new URL('/nl/blog', base) lost '/nl/blog').
   if (url instanceof URL) {
-    const newUrl = new URL(pathname, url)
-    url.searchParams.forEach((value, key) =>
-      newUrl.searchParams.set(key, value)
-    )
-    url = newUrl
+    url = url.href
   }
   return resolveAbsoluteUrlWithPathname(
     url,

--- a/test/e2e/app-dir/metadata/app/alternates/url-instance/page.tsx
+++ b/test/e2e/app-dir/metadata/app/alternates/url-instance/page.tsx
@@ -1,0 +1,14 @@
+export default function Page() {
+  return <p id="alternates-url-instance">alternate url instance</p>
+}
+
+export const metadata = {
+  metadataBase: new URL('https://example.com'),
+  alternates: {
+    canonical: new URL('https://example.com/alternates/url-instance'),
+    languages: {
+      'en-US': new URL('https://example.com/us/alternates/url-instance'),
+      'de-DE': new URL('/de/alternates/url-instance', 'https://example.com'),
+    },
+  },
+}

--- a/test/e2e/app-dir/metadata/metadata.test.ts
+++ b/test/e2e/app-dir/metadata/metadata.test.ts
@@ -228,6 +228,23 @@ describe('app dir - metadata', () => {
       })
     })
 
+    it('should preserve URL instance pathname in alternates', async () => {
+      const browser = await next.browser('/alternates/url-instance')
+      const matchDom = createDomMatcher(browser)
+
+      await matchDom('link', 'rel="canonical"', {
+        href: 'https://example.com/alternates/url-instance',
+      })
+      await matchDom('link', 'hreflang="en-US"', {
+        rel: 'alternate',
+        href: 'https://example.com/us/alternates/url-instance',
+      })
+      await matchDom('link', 'hreflang="de-DE"', {
+        rel: 'alternate',
+        href: 'https://example.com/de/alternates/url-instance',
+      })
+    })
+
     it('should not contain query in canonical url after client navigation', async () => {
       const browser = await next.browser('/')
       await browser.waitForElementByCss('p#index')


### PR DESCRIPTION
### What?

Fix `resolveAlternateUrl` to preserve the full pathname of `URL` instances passed in `metadata.alternates.languages`, `alternates.canonical`, `alternates.media`, and `alternates.types`.

### Why?

When users pass a `URL` object for alternate language URLs (e.g. `new URL('/nl/blog', 'http://localhost:3000')`), the URL's own pathname was being silently discarded. The old code did `new URL(pathname, url)`, treating the user's URL as a **base** and resolving it against the **current page's** pathname — effectively replacing `/nl/blog` with `/blog`.

This means any locale prefix, subpath, or custom path encoded in the URL was lost. The workaround was to call `.toString()` on the URL, which shouldn't be necessary.

Reported by multiple users in #68351, confirmed still present as of v15.2.3.

### How?

In `resolveAlternateUrl`, when the input is a `URL` instance, convert it to its `href` string before passing it downstream to `resolveAbsoluteUrlWithPathname`. This way the full path the user specified is treated as an absolute URL and preserved as-is.

**Before (broken):**
```ts
if (url instanceof URL) {
  const newUrl = new URL(pathname, url)  // ← overwrites url's own pathname
  // ...
  url = newUrl
}
```

**After (fixed):**
```ts
if (url instanceof URL) {
  url = url.href  // ← preserves url's full path
}
```

### Test plan

- Added `test/e2e/app-dir/metadata/app/alternates/url-instance/page.tsx` fixture that uses `URL` instances for `canonical` and `languages`
- Added test case `'should preserve URL instance pathname in alternates'` to the existing metadata e2e test suite
- Existing alternate tests (relative paths, string URLs) continue to pass as before

Fixes #68351