### PR TITLE
Handle `target` option in React Compiler for Pages + React 18

### DIFF
--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -959,6 +959,15 @@ pub enum ReactCompilerPanicThreshold {
     AllErrors,
 }
 
+#[turbo_tasks::value(shared, operation)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ReactCompilerTarget {
+    #[serde(rename = "17")]
+    React17,
+    #[serde(rename = "18")]
+    React18,
+}
+
 /// Subset of react compiler options, we pass these options through to the webpack loader, so it
 /// must be serializable
 #[turbo_tasks::value(shared, operation)]
@@ -969,6 +978,8 @@ pub struct ReactCompilerOptions {
     pub compilation_mode: ReactCompilerCompilationMode,
     #[serde(default)]
     pub panic_threshold: ReactCompilerPanicThreshold,
+    #[serde(default, skip_deserializing, skip_serializing_if = "Option::is_none")]
+    pub target: Option<ReactCompilerTarget>,
 }
 
 #[derive(

--- a/crates/next-core/src/next_config.rs
+++ b/crates/next-core/src/next_config.rs
@@ -962,8 +962,6 @@ pub enum ReactCompilerPanicThreshold {
 #[turbo_tasks::value(shared, operation)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ReactCompilerTarget {
-    #[serde(rename = "17")]
-    React17,
     #[serde(rename = "18")]
     React18,
 }

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -2,11 +2,11 @@ use std::{collections::BTreeSet, sync::LazyLock};
 
 use anyhow::{Context, Result};
 use regex::Regex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use turbo_esregex::EsRegex;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{self, FileJsonContent, FileSystemEntryType, FileSystemPath, to_sys_path};
+use turbo_tasks_fs::{self, FileContent, FileSystemEntryType, FileSystemPath, to_sys_path};
 use turbopack::module_options::{ConditionItem, LoaderRuleItem};
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
@@ -246,6 +246,11 @@ pub async fn get_babel_loader_rules(
 async fn detect_react_compiler_target(
     project_path: &FileSystemPath,
 ) -> Result<Option<ReactCompilerTarget>> {
+    #[derive(Deserialize)]
+    struct ReactPackageVersion {
+        version: Option<String>,
+    }
+
     let react_pkg_result = resolve(
         project_path.clone(),
         ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
@@ -258,18 +263,30 @@ async fn detect_react_compiler_target(
     };
 
     let path = source.ident().path().await?;
-    let FileJsonContent::Content(value) = &*path.read_json().await? else {
+    let FileContent::Content(file) = &*path.read().await? else {
         return Ok(None);
     };
 
-    let major = value
-        .get("version")
-        .and_then(|v| v.as_str())
+    let pkg: ReactPackageVersion = match serde_json::from_reader(file.read()) {
+        Ok(pkg) => pkg,
+        Err(e) => {
+            ReactPackageJsonParseIssue {
+                file_path: (*path).clone(),
+                error: e.to_string().into(),
+            }
+            .resolved_cell()
+            .emit();
+            return Ok(None);
+        }
+    };
+
+    let major = pkg
+        .version
+        .as_deref()
         .and_then(|v| v.split('.').next())
         .and_then(|s| s.parse::<u32>().ok());
 
     match major {
-        Some(17) => Ok(Some(ReactCompilerTarget::React17)),
         Some(18) => Ok(Some(ReactCompilerTarget::React18)),
         _ => Ok(None),
     }
@@ -386,6 +403,51 @@ impl Issue for BabelPluginReactCompilerResolutionIssue {
                 StyledString::Text(rcstr!(" installed in your ")),
                 StyledString::Code(rcstr!("node_modules")),
                 StyledString::Text(rcstr!(" directory?")),
+            ])
+            .resolved_cell(),
+        ))
+    }
+}
+
+#[turbo_tasks::value]
+struct ReactPackageJsonParseIssue {
+    file_path: FileSystemPath,
+    error: RcStr,
+}
+
+#[turbo_tasks::value_impl]
+impl Issue for ReactPackageJsonParseIssue {
+    #[turbo_tasks::function]
+    fn stage(&self) -> Vc<IssueStage> {
+        IssueStage::Transform.cell()
+    }
+
+    fn severity(&self) -> IssueSeverity {
+        IssueSeverity::Warning
+    }
+
+    #[turbo_tasks::function]
+    fn file_path(&self) -> Vc<FileSystemPath> {
+        self.file_path.clone().cell()
+    }
+
+    #[turbo_tasks::function]
+    fn title(&self) -> Vc<StyledString> {
+        StyledString::Line(vec![
+            StyledString::Text(rcstr!("Failed to parse ")),
+            StyledString::Code(rcstr!("react/package.json")),
+        ])
+        .cell()
+    }
+
+    #[turbo_tasks::function]
+    fn description(&self) -> Vc<OptionStyledString> {
+        Vc::cell(Some(
+            StyledString::Line(vec![
+                StyledString::Text(rcstr!(
+                    "Could not determine the React version for React Compiler target detection: "
+                )),
+                StyledString::Text(self.error.clone()),
             ])
             .resolved_cell(),
         ))

--- a/crates/next-core/src/next_shared/webpack_rules/babel.rs
+++ b/crates/next-core/src/next_shared/webpack_rules/babel.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use turbo_esregex::EsRegex;
 use turbo_rcstr::{RcStr, rcstr};
 use turbo_tasks::{ResolvedVc, Vc};
-use turbo_tasks_fs::{self, FileSystemEntryType, FileSystemPath, to_sys_path};
+use turbo_tasks_fs::{self, FileJsonContent, FileSystemEntryType, FileSystemPath, to_sys_path};
 use turbopack::module_options::{ConditionItem, LoaderRuleItem};
 use turbopack_core::{
     issue::{Issue, IssueExt, IssueSeverity, IssueStage, OptionStyledString, StyledString},
@@ -17,7 +17,9 @@ use turbopack_core::{
 use turbopack_node::transforms::webpack::WebpackLoaderItem;
 
 use crate::{
-    next_config::{NextConfig, ReactCompilerCompilationMode, ReactCompilerOptions},
+    next_config::{
+        NextConfig, ReactCompilerCompilationMode, ReactCompilerOptions, ReactCompilerTarget,
+    },
     next_import_map::try_get_next_package,
     next_shared::webpack_rules::{
         ManuallyConfiguredBuiltinLoaderIssue, WebpackLoaderBuiltinCondition,
@@ -152,6 +154,12 @@ pub async fn get_babel_loader_rules(
     {
         let react_compiler_options = react_compiler_options.await?;
 
+        let mut react_compiler_options_with_target: ReactCompilerOptions =
+            (*react_compiler_options).clone();
+        if let Some(target) = detect_react_compiler_target(project_path).await? {
+            react_compiler_options_with_target.target = Some(target);
+        }
+
         // we don't want to accept user-supplied `environment` options, but we do want to pass
         // `enableNameAnonymousFunctions` down to the babel plugin based on dev/prod.
         #[derive(Serialize)]
@@ -168,7 +176,7 @@ pub async fn get_babel_loader_rules(
         }
 
         let resolved_options = ResolvedOptions {
-            base: &react_compiler_options,
+            base: &react_compiler_options_with_target,
             environment: EnvironmentOptions {
                 enable_name_anonymous_functions: builtin_conditions
                     .contains(&WebpackLoaderBuiltinCondition::Development),
@@ -233,6 +241,38 @@ pub async fn get_babel_loader_rules(
             module_type: None,
         },
     )])
+}
+
+async fn detect_react_compiler_target(
+    project_path: &FileSystemPath,
+) -> Result<Option<ReactCompilerTarget>> {
+    let react_pkg_result = resolve(
+        project_path.clone(),
+        ReferenceType::CommonJs(CommonJsReferenceSubType::Undefined),
+        Request::parse(Pattern::Constant(rcstr!("react/package.json"))),
+        node_cjs_resolve_options(project_path.root().owned().await?),
+    );
+
+    let Some(source) = &*react_pkg_result.first_source().await? else {
+        return Ok(None);
+    };
+
+    let path = source.ident().path().await?;
+    let FileJsonContent::Content(value) = &*path.read_json().await? else {
+        return Ok(None);
+    };
+
+    let major = value
+        .get("version")
+        .and_then(|v| v.as_str())
+        .and_then(|v| v.split('.').next())
+        .and_then(|s| s.parse::<u32>().ok());
+
+    match major {
+        Some(17) => Ok(Some(ReactCompilerTarget::React17)),
+        Some(18) => Ok(Some(ReactCompilerTarget::React18)),
+        _ => Ok(None),
+    }
 }
 
 /// A system path that can be passed to the webpack loader

--- a/packages/next/src/build/get-babel-loader-config.ts
+++ b/packages/next/src/build/get-babel-loader-config.ts
@@ -26,13 +26,13 @@ const getReactCompilerPlugins = (
   // Detect user's React version for React Compiler target. For React 17/18,
   // the compiler emits imports from 'react-compiler-runtime' instead of
   // 'react/compiler-runtime' (which is only available in React 19+).
-  let target: '17' | '18' | undefined
+  let target: '18' | undefined
   try {
     const reactPkgPath = require.resolve('react/package.json', {
       paths: [cwd],
     })
     const majorVersion: string = require(reactPkgPath).version.split('.')[0]
-    if (majorVersion === '17' || majorVersion === '18') {
+    if (majorVersion === '18') {
       target = majorVersion
     }
   } catch {

--- a/packages/next/src/build/get-babel-loader-config.ts
+++ b/packages/next/src/build/get-babel-loader-config.ts
@@ -23,9 +23,9 @@ const getReactCompilerPlugins = (
     return undefined
   }
 
-  // Detect user's React version for React Compiler target. For React 17/18,
-  // the compiler emits imports from 'react-compiler-runtime' instead of
-  // 'react/compiler-runtime' (which is only available in React 19+).
+  // Set the React Compiler target based on the installed React version.
+  // Handle only the supported versions.
+  // https://react.dev/reference/react-compiler/target
   let target: '18' | undefined
   try {
     const reactPkgPath = require.resolve('react/package.json', {

--- a/packages/next/src/build/get-babel-loader-config.ts
+++ b/packages/next/src/build/get-babel-loader-config.ts
@@ -16,10 +16,27 @@ function getReactCompiler() {
 const getReactCompilerPlugins = (
   maybeOptions: boolean | ReactCompilerOptions | undefined,
   isServer: boolean,
-  isDev: boolean
+  isDev: boolean,
+  cwd: string
 ): undefined | JSONValue[] => {
   if (!maybeOptions || isServer) {
     return undefined
+  }
+
+  // Detect user's React version for React Compiler target. For React 17/18,
+  // the compiler emits imports from 'react-compiler-runtime' instead of
+  // 'react/compiler-runtime' (which is only available in React 19+).
+  let target: '17' | '18' | undefined
+  try {
+    const reactPkgPath = require.resolve('react/package.json', {
+      paths: [cwd],
+    })
+    const majorVersion: string = require(reactPkgPath).version.split('.')[0]
+    if (majorVersion === '17' || majorVersion === '18') {
+      target = majorVersion
+    }
+  } catch {
+    // react/package.json not resolvable — skip target detection
   }
 
   const environment: Pick<EnvironmentConfig, 'enableNameAnonymousFunctions'> = {
@@ -29,6 +46,7 @@ const getReactCompilerPlugins = (
     typeof maybeOptions === 'boolean' ? {} : maybeOptions
   const compilerOptions: JSONValue = {
     ...options,
+    ...(target ? { target } : {}),
     environment,
   }
   return [[getReactCompiler(), compilerOptions]]
@@ -64,7 +82,8 @@ const getBabelLoader = (
       reactCompilerPlugins: getReactCompilerPlugins(
         reactCompilerOptions,
         isServer,
-        dev
+        dev,
+        cwd
       ),
       reactCompilerExclude,
     }
@@ -93,7 +112,8 @@ const getReactCompilerLoader = (
   const reactCompilerPlugins = getReactCompilerPlugins(
     reactCompilerOptions,
     isServer,
-    isDev
+    isDev,
+    cwd
   )
   if (!reactCompilerPlugins) {
     return undefined

--- a/test/e2e/react-compiler/app/function-naming/page.tsx
+++ b/test/e2e/react-compiler/app/function-naming/page.tsx
@@ -8,11 +8,11 @@ export default function Page() {
     const error = new Error('test-top-frame')
     console.error(error)
 
-    const callStack = new Error('test-top-frame').stack?.split(
+    const callStack = new Error('test-top-frame').stack!.split(
       'test-top-frame\n'
     )[1]
     // indices might change due to different compiler optimizations
-    const callFrame = callStack?.split('\n')[0] ?? null
+    const callFrame = callStack.split('\n')[0]
     setCallFrame(callFrame)
   }, [])
   return (

--- a/test/e2e/react-compiler/app/function-naming/page.tsx
+++ b/test/e2e/react-compiler/app/function-naming/page.tsx
@@ -3,16 +3,16 @@
 import { useEffect, useState } from 'react'
 
 export default function Page() {
-  const [callFrame, setCallFrame] = useState(null)
+  const [callFrame, setCallFrame] = useState<string | null>(null)
   useEffect(() => {
     const error = new Error('test-top-frame')
     console.error(error)
 
-    const callStack = new Error('test-top-frame').stack.split(
+    const callStack = new Error('test-top-frame').stack?.split(
       'test-top-frame\n'
     )[1]
     // indices might change due to different compiler optimizations
-    const callFrame = callStack.split('\n')[0]
+    const callFrame = callStack?.split('\n')[0] ?? null
     setCallFrame(callFrame)
   }, [])
   return (

--- a/test/e2e/react-compiler/pages/pages-router.tsx
+++ b/test/e2e/react-compiler/pages/pages-router.tsx
@@ -1,0 +1,29 @@
+import { Profiler, useReducer } from 'react'
+
+if (typeof window !== 'undefined') {
+  ;(window as any).staticChildRenders = 0
+}
+
+function StaticChild() {
+  return (
+    <Profiler
+      onRender={(id, phase) => {
+        ;(window as any).staticChildRenders += 1
+      }}
+      id="test"
+    >
+      <div>static child</div>
+    </Profiler>
+  )
+}
+
+export default function Page() {
+  const [count, increment] = useReducer((n) => n + 1, 1)
+  return (
+    <>
+      <div data-testid="parent-commits">Parent commits: {count}</div>
+      <button onClick={increment}>Increment</button>
+      <StaticChild />
+    </>
+  )
+}

--- a/test/e2e/react-compiler/react-compiler.test.ts
+++ b/test/e2e/react-compiler/react-compiler.test.ts
@@ -3,6 +3,8 @@ import { waitForRedbox } from 'next-test-utils'
 import { join } from 'path'
 import stripAnsi from 'strip-ansi'
 
+const isReact18 = parseInt(process.env.NEXT_TEST_REACT_VERSION) === 18
+
 function normalizeCodeLocInfo(str) {
   return (
     str &&
@@ -33,6 +35,7 @@ describe.each(['default', 'babelrc'] as const)(
           ? __dirname
           : {
               app: new FileRef(join(__dirname, 'app')),
+              pages: new FileRef(join(__dirname, 'pages')),
               'next.config.js': new FileRef(join(__dirname, 'next.config.js')),
               'reference-library': new FileRef(
                 join(__dirname, 'reference-library')
@@ -42,12 +45,33 @@ describe.each(['default', 'babelrc'] as const)(
       buildArgs: ['--profile'],
       dependencies: {
         'babel-plugin-react-compiler': '0.0.0-experimental-3fde738-20250918',
+        // For React versions below 19, need to install react-compiler-runtime.
+        // https://react.dev/reference/react-compiler/target#targeting-react-17-or-18
+        ...(isReact18 ? { 'react-compiler-runtime': 'latest' } : {}),
         ...dependencies,
       },
     })
 
     it('should memoize Components', async () => {
       const browser = await next.browser('/')
+
+      expect(await browser.eval('window.staticChildRenders')).toEqual(1)
+      expect(
+        await browser.elementByCss('[data-testid="parent-commits"]').text()
+      ).toEqual('Parent commits: 1')
+
+      await browser.elementByCss('button').click()
+      await browser.elementByCss('button').click()
+      await browser.elementByCss('button').click()
+
+      expect(await browser.eval('window.staticChildRenders')).toEqual(1)
+      expect(
+        await browser.elementByCss('[data-testid="parent-commits"]').text()
+      ).toEqual('Parent commits: 4')
+    })
+
+    it('should memoize Pages Router Components', async () => {
+      const browser = await next.browser('/pages-router')
 
       expect(await browser.eval('window.staticChildRenders')).toEqual(1)
       expect(


### PR DESCRIPTION
### Why?

`test/e2e/app-dir/catch-error/catch-error-react-compiler.test.ts` is skipped in CI due to incompatibility with React 18  tests.

```
Module not found: Can't resolve 'react/compiler-runtime'
> 1 | import { c as _c } from "react/compiler-runtime";
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Failed CI: https://github.com/vercel/next.js/actions/runs/23170738194/job/67327462789#step:36:317
x-ref: https://react.dev/reference/react-compiler/target#targeting-react-17-or-18