### PR TITLE
Turbopack: single module graph for Pages Router pages

### DIFF
--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -1253,6 +1253,7 @@ impl AppEndpoint {
 
         let is_app_page = matches!(this.ty, AppEndpointType::Page { .. });
 
+        // TODO replace with self.module_graphs()
         let module_graphs = this
             .app_project
             .app_module_graphs(

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -699,15 +699,7 @@ impl PageEndpoint {
     }
 
     #[turbo_tasks::function]
-    async fn client_module_graph(self: Vc<Self>) -> Result<Vc<ModuleGraph>> {
-        let this = self.await?;
-        let project = this.pages_project.project();
-        let evaluatable_assets = self.client_evaluatable_assets();
-        Ok(project.module_graph_for_modules(evaluatable_assets))
-    }
-
-    #[turbo_tasks::function]
-    async fn ssr_module_graph(self: Vc<Self>) -> Result<Vc<ModuleGraph>> {
+    async fn module_graph(self: Vc<Self>) -> Result<Vc<ModuleGraph>> {
         let this = self.await?;
         let project = this.pages_project.project();
 
@@ -740,7 +732,21 @@ impl PageEndpoint {
             }
 
             let graph = SingleModuleGraph::new_with_entries_visited_intern(
-                vec![ChunkGroupEntry::Entry(vec![ssr_chunk_module.ssr_module])],
+                [ChunkGroupEntry::Entry(vec![ssr_chunk_module.ssr_module])]
+                    .into_iter()
+                    .chain(if this.ty == PageEndpointType::Html {
+                        Some(ChunkGroupEntry::Entry(
+                            self.client_evaluatable_assets()
+                                .await?
+                                .iter()
+                                .map(|m| ResolvedVc::upcast(*m))
+                                .collect(),
+                        ))
+                        .into_iter()
+                    } else {
+                        None.into_iter()
+                    })
+                    .collect::<Vec<_>>(),
                 visited_modules,
                 should_trace,
                 should_read_binding_usage,
@@ -774,7 +780,7 @@ impl PageEndpoint {
             let project = this.pages_project.project();
             let client_chunking_context = project.client_chunking_context();
 
-            let module_graph = self.client_module_graph();
+            let module_graph = self.module_graph();
 
             let evaluatable_assets = self
                 .client_evaluatable_assets()
@@ -922,15 +928,11 @@ impl PageEndpoint {
             } = *self.internal_ssr_chunk_module().await?;
 
             let project = this.pages_project.project();
-            // The SSR and Client Graphs are not connected in Pages Router.
-            // We are only interested in get_next_dynamic_imports_for_endpoint at the
-            // moment, which only needs the client graph anyway.
-            let ssr_module_graph = self.ssr_module_graph();
+            let module_graph = self.module_graph();
 
             let next_dynamic_imports = if let PageEndpointType::Html = this.ty {
                 let client_availability_info = self.client_chunk_group().await?.availability_info;
 
-                let client_module_graph = self.client_module_graph();
                 let per_page_module_graph = *project.per_page_module_graph().await?;
 
                 // We only validate the global css imports when there is not a `app` folder at the
@@ -938,7 +940,7 @@ impl PageEndpoint {
                 if project.app_project().await?.is_none() {
                     // We recreate the app_module here because the one provided from the
                     // `internal_ssr_chunk_module` is not the same as the one
-                    // provided from the `client_module_graph`. There can be cases where
+                    // provided from the `module_graph`. There can be cases where
                     // the `app_module` is None, and we are processing the `pages/_app.js` file
                     // as a page rather than the app module.
                     let app_module = project
@@ -955,7 +957,7 @@ impl PageEndpoint {
                         .module();
 
                     validate_pages_css_imports(
-                        client_module_graph,
+                        module_graph,
                         per_page_module_graph,
                         self.client_module(),
                         app_module,
@@ -964,7 +966,7 @@ impl PageEndpoint {
                 }
 
                 let next_dynamic_imports =
-                    NextDynamicGraphs::new(client_module_graph, per_page_module_graph)
+                    NextDynamicGraphs::new(module_graph, per_page_module_graph)
                         .get_next_dynamic_imports_for_endpoint(self.client_module())
                         .await?;
                 Some((next_dynamic_imports, client_availability_info))
@@ -978,7 +980,7 @@ impl PageEndpoint {
             )) = next_dynamic_imports
             {
                 collect_next_dynamic_chunks(
-                    self.client_module_graph(),
+                    self.module_graph(),
                     project.client_chunking_context(),
                     next_dynamic_imports,
                     NextDynamicChunkAvailability::AvailabilityInfo(client_availability_info),
@@ -1003,7 +1005,7 @@ impl PageEndpoint {
                     let chunk_group = chunking_context.chunk_group(
                         layout.ident(),
                         ChunkGroup::Shared(layout),
-                        ssr_module_graph,
+                        module_graph,
                         current_chunk_group.await?.availability_info,
                     );
 
@@ -1023,7 +1025,7 @@ impl PageEndpoint {
                 let chunk_assets = edge_chunking_context.evaluated_chunk_group_assets(
                     ssr_module.ident(),
                     ChunkGroup::Entry(vec![ssr_module]),
-                    ssr_module_graph,
+                    module_graph,
                     current_chunk_group.await?.availability_info,
                 );
 
@@ -1051,7 +1053,7 @@ impl PageEndpoint {
                     .entry_chunk_group_asset(
                         ssr_entry_chunk_path,
                         ChunkGroup::Entry(vec![ssr_module]),
-                        ssr_module_graph,
+                        module_graph,
                         current_chunk_group.primary_assets(),
                         current_chunk_group.referenced_assets(),
                         current_chunk_group.await?.availability_info,
@@ -1712,13 +1714,7 @@ impl Endpoint for PageEndpoint {
 
     #[turbo_tasks::function]
     async fn module_graphs(self: Vc<Self>) -> Result<Vc<ModuleGraphs>> {
-        let client_module_graph = self.client_module_graph().to_resolved().await?;
-        let ssr_module_graph = self.ssr_module_graph().to_resolved().await?;
-        Ok(Vc::cell(if client_module_graph != ssr_module_graph {
-            vec![client_module_graph, ssr_module_graph]
-        } else {
-            vec![ssr_module_graph]
-        }))
+        Ok(Vc::cell(vec![self.module_graph().to_resolved().await?]))
     }
 
     #[turbo_tasks::function]

--- a/test/integration/next-image-new/invalid-image-import/test/index.test.ts
+++ b/test/integration/next-image-new/invalid-image-import/test/index.test.ts
@@ -45,11 +45,7 @@ function runTests({ isDev }) {
          Caused by:
          - Source code does not contain a <svg> root element
 
-         Import traces:
-           Browser:
-             ./test/integration/next-image-new/invalid-image-import/public/invalid.svg
-             ./test/integration/next-image-new/invalid-image-import/pages/index.js
-
+         Import trace:
            SSR:
              ./test/integration/next-image-new/invalid-image-import/public/invalid.svg
              ./test/integration/next-image-new/invalid-image-import/pages/index.js"


### PR DESCRIPTION
This mirrors what we effectively do for App Router as well. (Though in that case, it's a `ChunkGroup::Entry(rsc_module)` which then has references to the SSR and the Client chunks)