### PR TITLE
[react-sync] Allow locking in manual sync

### DIFF
--- a/packages/next/taskfile.js
+++ b/packages/next/taskfile.js
@@ -1457,7 +1457,11 @@ export async function copy_vendor_react(task_) {
     // TODO-APP: remove unused fields from package.json and unused files
     function overridePackageName(source) {
       const json = JSON.parse(source)
-      json.name = json.name + '-' + channel
+      // avoid infinite suffix addition in case the package name already has the suffix
+      // e.g. if we install from src/compiled instead of npm registry.
+      if (!json.name.endsWith(`-${channel}`)) {
+        json.name = json.name + '-' + channel
+      }
       return JSON.stringify(
         {
           name: json.name,


### PR DESCRIPTION
Allows pointing the installed, vendored React at the currently vendored in source e.g. 
```json
"react-server-dom-turbopack": "file:packages/next/src/compiled/react-server-dom-turbopack",
"react-server-dom-turbopack-experimental": "file:packages/next/src/compiled/react-server-dom-turbopack-experimental",
"react-server-dom-webpack": "file:packages/next/src/compiled/react-server-dom-webpack",
"react-server-dom-webpack-experimental": "file:packages/next/src/compiled/react-server-dom-webpack-experimental",
```

This is mostly useful if you quickly want to check a manual edit to React without having `types-and-precompiled` scream at you.