### PR TITLE
Turbopack: correctly apply effects for issue snapshots

### DIFF
--- a/turbopack/crates/turbopack-tests/tests/snapshot.rs
+++ b/turbopack/crates/turbopack-tests/tests/snapshot.rs
@@ -11,7 +11,7 @@ use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde_json::json;
 use turbo_rcstr::{RcStr, rcstr};
-use turbo_tasks::{Effects, ResolvedVc, TurboTasks, Vc, get_effects, turbofmt};
+use turbo_tasks::{Effects, OperationVc, ResolvedVc, TurboTasks, Vc, get_effects, turbofmt};
 use turbo_tasks_backend::{BackendOptions, TurboTasksBackend, noop_backing_storage};
 use turbo_tasks_env::DotenvProcessEnv;
 use turbo_tasks_fs::{
@@ -222,7 +222,7 @@ async fn run(resource: PathBuf) -> Result<()> {
     ));
     tt.run_once(async move {
         #[turbo_tasks::function(operation)]
-        async fn inner_operation(resource: RcStr) -> Result<Vc<Effects>> {
+        async fn inner_operation(resource: RcStr) -> Result<Vc<()>> {
             let out_op = run_test_operation(resource);
             let out_vc = out_op.resolve_strongly_consistent().await?.owned().await?;
 
@@ -234,10 +234,16 @@ async fn run(resource: PathBuf) -> Result<()> {
             snapshot_issues(plain_issues, out_vc.join("issues")?, &REPO_ROOT)
                 .await
                 .context("Unable to handle issues")?;
-
-            Ok(get_effects(out_op).await?.cell())
+            Ok(Vc::cell(()))
         }
-        inner_operation(resource.to_str().unwrap().into())
+
+        #[turbo_tasks::function(operation)]
+        async fn extract_effects(op: OperationVc<()>) -> Result<Vc<Effects>> {
+            let _ = op.resolve_strongly_consistent().await?;
+            Ok(get_effects(op).await?.cell())
+        }
+
+        extract_effects(inner_operation(resource.to_str().unwrap().into()))
             .read_strongly_consistent()
             .await?
             .apply()


### PR DESCRIPTION
`snapshot_issues` emits effects when `UPDATE=1` 