### PR TITLE
Error when accessing undefined root params in `generateStaticParams`

### DIFF
--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1139,5 +1139,6 @@
   "1138": "`unstable_retry()` can only be used in the App Router. Use `reset()` in the Pages Router.",
   "1139": "`unstable_catchError` can only be used in Client Components.",
   "1140": "Route %s used \\`import('next/root-params').%s()\\` inside \\`\"use cache\"\\` nested within \\`unstable_cache\\`. Root params are not available in this context.",
-  "1141": "Route %s used \\`import('next/root-params').%s()\\` inside \\`unstable_cache\\`. This is not supported. Use \\`\"use cache\"\\` instead."
+  "1141": "Route %s used \\`import('next/root-params').%s()\\` inside \\`unstable_cache\\`. This is not supported. Use \\`\"use cache\"\\` instead.",
+  "1142": "Route %s used \\`import('next/root-params').%s()\\` inside \\`generateStaticParams\\`, but the \\`%s\\` parameter was not provided by a parent \\`generateStaticParams\\`. In \\`generateStaticParams\\`, root params are only available for segments nested below the segment that provides them."
 }

--- a/packages/next/src/server/request/root-params.ts
+++ b/packages/next/src/server/request/root-params.ts
@@ -109,8 +109,15 @@ export function getRootParam(paramName: string): Promise<ParamValue> {
       break
     }
     case 'private-cache':
-    case 'prerender-runtime':
+    case 'prerender-runtime': {
+      break
+    }
     case 'generate-static-params': {
+      if (!(paramName in workUnitStore.rootParams)) {
+        throw new Error(
+          `Route ${workStore.route} used ${apiName} inside \`generateStaticParams\`, but the \`${paramName}\` parameter was not provided by a parent \`generateStaticParams\`. In \`generateStaticParams\`, root params are only available for segments nested below the segment that provides them.`
+        )
+      }
       break
     }
     default: {

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/app/[lang]/[locale]/layout.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/app/[lang]/[locale]/layout.tsx
@@ -1,0 +1,18 @@
+import { lang } from 'next/root-params'
+import { ReactNode } from 'react'
+
+export default async function Root({ children }: { children: ReactNode }) {
+  return (
+    <html lang={await lang()}>
+      <body>{children}</body>
+    </html>
+  )
+}
+
+export async function generateStaticParams() {
+  // This should error: we're reading `lang` inside the generateStaticParams
+  // that is supposed to define it. The `lang` param is not yet available
+  // because no parent segment has provided it.
+  const l = await lang()
+  return [{ lang: l, locale: 'us' }]
+}

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/app/[lang]/[locale]/page.tsx
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/app/[lang]/[locale]/page.tsx
@@ -1,0 +1,3 @@
+export default function Page() {
+  return <p>hello world</p>
+}

--- a/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/next.config.ts
+++ b/test/e2e/app-dir/app-root-params-getters/fixtures/generate-static-params-error/next.config.ts
@@ -1,0 +1,9 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  experimental: {
+    rootParams: true,
+  },
+}
+
+export default nextConfig

--- a/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
+++ b/test/e2e/app-dir/app-root-params-getters/generate-static-params-error.test.ts
@@ -1,0 +1,44 @@
+import { nextTestSetup } from 'e2e-utils'
+import path from 'path'
+
+describe('app-root-param-getters - generateStaticParams error', () => {
+  const { next, isNextDev } = nextTestSetup({
+    files: path.join(__dirname, 'fixtures', 'generate-static-params-error'),
+    skipStart: true,
+    skipDeployment: true,
+  })
+
+  beforeAll(async () => {
+    try {
+      await next.start()
+    } catch {}
+  })
+
+  if (isNextDev) {
+    it('should error when reading a root param inside the generateStaticParams that defines it - dev', async () => {
+      const browser = await next.browser('/en/us')
+
+      // TODO: This is not the correct error code.
+      await expect(browser).toDisplayRedbox(`
+       {
+         "code": "E394",
+         "description": "Route /[lang]/[locale] used \`import('next/root-params').lang()\` inside \`generateStaticParams\`, but the \`lang\` parameter was not provided by a parent \`generateStaticParams\`. In \`generateStaticParams\`, root params are only available for segments nested below the segment that provides them.",
+         "environmentLabel": null,
+         "label": "Runtime Error",
+         "source": "app/[lang]/[locale]/layout.tsx (16:23) @ generateStaticParams
+       > 16 |   const l = await lang()
+            |                       ^",
+         "stack": [
+           "generateStaticParams app/[lang]/[locale]/layout.tsx (16:23)",
+         ],
+       }
+      `)
+    })
+  } else {
+    it('should error when reading a root param inside the generateStaticParams that defines it - build', async () => {
+      expect(next.cliOutput).toContain(
+        "Route /[lang]/[locale] used `import('next/root-params').lang()` inside `generateStaticParams`, but the `lang` parameter was not provided by a parent `generateStaticParams`. In `generateStaticParams`, root params are only available for segments nested below the segment that provides them."
+      )
+    })
+  }
+})


### PR DESCRIPTION
Follow-up to #91189 which added support for accessing root params inside `generateStaticParams`. Previously, if a `generateStaticParams` function tried to read a root param that hasn't been defined yet — either because the current segment is supposed to define it, or because a child segment defines it — `getRootParam` would silently return `undefined`. This is especially problematic because #91019 will type root param getters as `Promise<string>` without `undefined`, making this a silent type safety violation.

This change makes `getRootParam` throw an explicit error with the `generate-static-params` work unit store when the requested param is not present in `rootParams`.