### PR TITLE
[test] Ensure target page is compiled before navigation in `instant-navs-devtools`

### DIFF
--- a/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
+++ b/test/development/app-dir/instant-navs-devtools/instant-navs-devtools.test.ts
@@ -93,11 +93,13 @@ describe('instant-nav-panel', () => {
 
   it('should show client nav state after clicking Start and navigating', async () => {
     const targetPage = '/target-page/my-post?search=foo'
-    if (isNextDev && !isTurbopack) {
-      // warmup target page compilation before clicking Start, to avoid extra flakiness.
-      void next.render(targetPage).catch(() => {})
-    }
-    const browser = await next.browser('/')
+    const [browser] = await Promise.all([
+      next.browser('/'),
+      isNextDev && !isTurbopack
+        ? // warmup target page compilation before clicking Start, to avoid extra flakiness.
+          next.render(targetPage).catch(() => {})
+        : null,
+    ])
     await clearInstantModeCookie(browser)
     await browser.waitForElementByCss('[data-testid="home-title"]')
 
@@ -135,11 +137,13 @@ describe('instant-nav-panel', () => {
 
   it('should show loading skeleton during SPA navigation after clicking Start', async () => {
     const targetPage = '/target-page/my-post?search=foo'
-    if (isNextDev && !isTurbopack) {
-      // warmup target page compilation before clicking Start, to avoid extra flakiness.
-      void next.render(targetPage).catch(() => {})
-    }
-    const browser = await next.browser('/')
+    const [browser] = await Promise.all([
+      next.browser('/'),
+      isNextDev && !isTurbopack
+        ? // warmup target page compilation before clicking Start, to avoid extra flakiness.
+          next.render(targetPage).catch(() => {})
+        : null,
+    ])
     await clearInstantModeCookie(browser)
     await browser.waitForElementByCss('[data-testid="home-title"]')
 


### PR DESCRIPTION


Can actually take more than 3s on Webpack to compile which would exceed default `retry` timeout.

Now we await the initial render which ensures the page is compiled.