### PR TITLE
Fix: Server Actions do not await onRequestError from instrumentation

### DIFF
--- a/packages/next/src/server/app-render/create-error-handler.tsx
+++ b/packages/next/src/server/app-render/create-error-handler.tsx
@@ -56,7 +56,10 @@ export function createReactServerErrorHandler(
   shouldFormatError: boolean,
   isBuildTimePrerendering: boolean,
   reactServerErrors: Map<string, DigestedError>,
-  onReactServerRenderError: (err: DigestedError, silenceLog: boolean) => void,
+  onReactServerRenderError: (
+    err: DigestedError,
+    silenceLog: boolean
+  ) => void | Promise<void>,
   spanToRecordOn?: any
 ): RSCErrorHandler {
   return (thrownValue: unknown) => {
@@ -141,7 +144,22 @@ export function createReactServerErrorHandler(
         })
       }
 
-      onReactServerRenderError(err, silenceLog)
+      const instrumentationPromise = onReactServerRenderError(err, silenceLog)
+      // onReactServerRenderError may return a Promise (e.g. from async
+      // instrumentation hooks like onRequestError). React's onError
+      // callback must be synchronous, so we cannot await it here.
+      // Register it with after() so serverless runtimes keep the
+      // invocation alive until the promise settles.
+      if (instrumentationPromise) {
+        try {
+          const { after } =
+            require('../after/after') as typeof import('../after/after')
+          after(instrumentationPromise)
+        } catch {
+          // after() is unavailable (e.g. during build-time prerendering
+          // or outside a request scope). Fall back to fire-and-forget.
+        }
+      }
     }
 
     return err.digest

--- a/test/e2e/on-request-error/server-action-error-async/app/form-error/page.js
+++ b/test/e2e/on-request-error/server-action-error-async/app/form-error/page.js
@@ -1,0 +1,17 @@
+import { connection } from 'next/server'
+
+export default async function Page() {
+  await connection()
+  async function action(formData) {
+    'use server'
+
+    throw new Error('[server-action-async]:form')
+  }
+
+  return (
+    <form action={action}>
+      <input type="hidden" name="payload" value={'payload-value'} />
+      <button type="submit">submit</button>
+    </form>
+  )
+}

--- a/test/e2e/on-request-error/server-action-error-async/app/layout.js
+++ b/test/e2e/on-request-error/server-action-error-async/app/layout.js
@@ -1,0 +1,10 @@
+import { connection } from 'next/server'
+
+export default async function Layout({ children }) {
+  await connection()
+  return (
+    <html>
+      <body>{children}</body>
+    </html>
+  )
+}

--- a/test/e2e/on-request-error/server-action-error-async/app/write-log/route.js
+++ b/test/e2e/on-request-error/server-action-error-async/app/write-log/route.js
@@ -1,0 +1,40 @@
+import fs from 'fs'
+import fsp from 'fs/promises'
+import path from 'path'
+
+const dir = path.join(path.dirname(new URL(import.meta.url).pathname), '../..')
+const logPath = path.join(dir, 'output-log.json')
+
+export async function POST(req) {
+  let payloadString = ''
+  const decoder = new TextDecoder()
+  const reader = req.clone().body.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) {
+      break
+    }
+
+    payloadString += decoder.decode(value)
+  }
+
+  const payload = JSON.parse(payloadString)
+
+  const json = fs.existsSync(logPath)
+    ? JSON.parse(await fsp.readFile(logPath, 'utf8'))
+    : {}
+
+  if (!json[payload.message]) {
+    json[payload.message] = {
+      payload,
+      count: 1,
+    }
+  } else {
+    json[payload.message].count++
+  }
+
+  await fsp.writeFile(logPath, JSON.stringify(json, null, 2), 'utf8')
+
+  console.log(`[instrumentation] write-log:${payload.message}`)
+  return new Response(null, { status: 204 })
+}

--- a/test/e2e/on-request-error/server-action-error-async/instrumentation.js
+++ b/test/e2e/on-request-error/server-action-error-async/instrumentation.js
@@ -1,0 +1,40 @@
+// Inject a mock waitUntil via @next/request-context so we can verify
+// that after() is called with the onRequestError promise.
+// Pattern borrowed from test/e2e/app-dir/next-after-app (see
+// utils/provided-request-context.js and the "uses waitUntil from
+// request context if available" describe block in index.test.ts).
+function injectRequestContext() {
+  globalThis[Symbol.for('@next/request-context')] = {
+    get() {
+      return {
+        waitUntil(promise) {
+          console.log('[test] waitUntil called')
+          promise.catch((err) => {
+            console.error(err)
+          })
+        },
+      }
+    },
+  }
+}
+
+export function register() {
+  injectRequestContext()
+}
+
+// Return the fetch promise so the framework can register it with
+// after()/waitUntil. Without the fix in create-error-handler.tsx,
+// this promise is silently discarded.
+export function onRequestError(err, request, context) {
+  return fetch(`http://localhost:${process.env.PORT}/write-log`, {
+    method: 'POST',
+    body: JSON.stringify({
+      message: err.message,
+      request,
+      context,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  })
+}

--- a/test/e2e/on-request-error/server-action-error-async/next.config.js
+++ b/test/e2e/on-request-error/server-action-error-async/next.config.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/test/e2e/on-request-error/server-action-error-async/server-action-error-async.test.ts
+++ b/test/e2e/on-request-error/server-action-error-async/server-action-error-async.test.ts
@@ -1,0 +1,76 @@
+import { nextTestSetup } from 'e2e-utils'
+import { retry } from 'next-test-utils'
+import { getOutputLogJson } from '../_testing/utils'
+
+// Verifies that when onRequestError returns a Promise, the framework
+// registers it with after()/waitUntil so async error reporting completes
+// reliably in serverless environments.
+//
+// The instrumentation injects a mock waitUntil via @next/request-context
+// (same pattern as test/e2e/app-dir/next-after-app) and returns the
+// fetch promise from onRequestError. If the fix in
+// create-error-handler.tsx is working, after() will call waitUntil with
+// that promise, producing a "[test] waitUntil called" log line.
+//
+// Without the fix, the promise is silently discarded and waitUntil is
+// never called.
+describe('on-request-error - async instrumentation with waitUntil', () => {
+  const { next, skipped } = nextTestSetup({
+    files: __dirname,
+    skipDeployment: true,
+  })
+
+  if (skipped) {
+    return
+  }
+
+  const outputLogPath = 'output-log.json'
+
+  beforeAll(async () => {
+    await next.patchFile(outputLogPath, '{}')
+  })
+
+  it('should register onRequestError promise with waitUntil via after()', async () => {
+    const browser = await next.browser('/form-error')
+    await browser.elementByCss('button').click()
+
+    // Verify that waitUntil was called — this proves after() was invoked
+    // with the promise returned by onRequestError
+    await retry(async () => {
+      const logs = next.cliOutput
+      expect(logs).toContain('[test] waitUntil called')
+    }, 5000)
+
+    // Also verify the error was actually reported (the fetch completed)
+    await retry(async () => {
+      const recordLogLines = next.cliOutput
+        .split('\n')
+        .filter((log) => log.includes('[instrumentation] write-log'))
+
+      expect(recordLogLines).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('[server-action-async]:form'),
+        ])
+      )
+    }, 5000)
+
+    const json = await getOutputLogJson(next, outputLogPath)
+    const record = json['[server-action-async]:form']
+
+    expect(record).toMatchObject({
+      payload: {
+        message: '[server-action-async]:form',
+        request: {
+          path: '/form-error',
+          method: 'POST',
+        },
+        context: {
+          routerKind: 'App Router',
+          routeType: 'action',
+          renderSource: 'react-server-components-payload',
+        },
+      },
+      count: 1,
+    })
+  })
+})


### PR DESCRIPTION
## Bug Fix: Await `onRequestError` promise for server action errors

> **Disclaimer:** This is my first time in the Next.js codebase. I used AI tooling (Claude) to help trace the error flow and generate the fix + test. I've done my best to verify the analysis, but I may have misread the code or missed context that's obvious to maintainers. Please take the specifics with a grain of salt — I'd rather flag that upfront than waste your time reviewing something built on a wrong assumption. Happy to adjust or close if the approach is off.

### What?

Register the Promise returned by `onRequestError` (from `instrumentation.ts`) with `after()` when the error originates from a server action, so async error reporting completes before serverless runtimes tear down.

### Why?

As far as I can tell, `createReactServerErrorHandler` in `create-error-handler.tsx` calls `onReactServerRenderError(err, silenceLog)` without awaiting the returned Promise. The Promise appears to be silently discarded, which would turn async error reporting into a race condition.

If this reading is correct, it would affect error tracking integrations that do async work inside `onRequestError` — Sentry, PostHog, Datadog, custom solutions, etc. The hook fires, but the async work (HTTP requests to ingest APIs) may not complete before the response lifecycle ends.

- **Affected (I think)**: Server action errors (App Router)
- **Not affected**: Route handler errors (these appear to be properly awaited in `app-route.ts`)
- **Severity**: In serverless environments (Vercel Functions, AWS Lambda), the runtime may freeze or terminate after the response is sent. On long-running servers it would be a race condition but would usually complete in practice.

**Error flow as I understand it**: Server action throws → error wrapped in `Promise.reject()` → embedded in RSC payload → React's `renderToReadableStream` calls synchronous `onError` callback → `onReactServerRenderError` returns a Promise → Promise discarded (line 144).

Route handlers use a separate code path (`app-route.ts:528`) that properly `await`s the same instrumentation chain.

### How?

React's `onError` callback must be synchronous (returns a digest string), so we can't `await` inline. The fix uses Next.js's existing `after()` API to register the instrumentation promise with the platform's `waitUntil` mechanism. The `after()` call itself is synchronous — it just registers the promise — so the error handler still returns `err.digest` immediately.

```ts
const instrumentationPromise = onReactServerRenderError(err, silenceLog)
if (instrumentationPromise) {
  try {
    const { after } = require('../after/after')
    after(instrumentationPromise)
  } catch {
    // after() unavailable (e.g. build-time prerendering) — fall back to fire-and-forget
  }
}
```

The `try/catch` handles cases where `AfterContext` is unavailable (build-time prerendering, outside request scope).

**Note:** `createHTMLErrorHandler` in the same file has what looks like the same pattern — `onHTMLRenderSSRError` also returns a Promise that is discarded. I didn't touch it since I couldn't confirm with a concrete reproduction.

### Test plan

- [x] e2e test added at `test/e2e/on-request-error/server-action-error-async/`
- [x] Test injects a mock `waitUntil` via `@next/request-context` (same pattern as `test/e2e/app-dir/next-after-app`)
- [x] Test verifies `waitUntil` is called (proving `after()` registered the promise)
- [x] Test verifies the error was actually reported (fetch to `/write-log` completed)
- [x] Test verifies correct error metadata (route path, method, routerKind, routeType, renderSource)

### Checklist

- [x] Related issues linked
- [x] Tests added
- [x] No new errors requiring helpful links

Possibly related issues: #83404, #85261
Related: [Sentry discussion #11709](https://github.com/getsentry/sentry-javascript/discussions/11709)
