### PR TITLE
Remove unnecessary ALS re-exports from `entry-base.ts`

### DIFF
--- a/packages/next/src/build/static-paths/app.test.ts
+++ b/packages/next/src/build/static-paths/app.test.ts
@@ -9,9 +9,7 @@ import {
 } from './app'
 import type { PrerenderedRoute } from './types'
 import type { WorkStore } from '../../server/app-render/work-async-storage.external'
-import type { WorkUnitAsyncStorage } from '../../server/app-render/work-unit-async-storage.external'
 import type { AppSegment } from '../segment-config/app/app-segments'
-import { AsyncLocalStorage } from 'async_hooks'
 
 function pathnameSegments(
   ...segments: Array<string | [string, boolean]>
@@ -983,8 +981,6 @@ const createMockWorkStore = (fetchCache?: WorkStore['fetchCache']) => ({
   page: '/test-page',
 })
 
-const mockWorkUnitAsyncStorage = new AsyncLocalStorage() as WorkUnitAsyncStorage
-
 // Helper to create mock segments
 const createMockSegment = (
   generateStaticParams?: (options: { params?: Params }) => Promise<Params[]>,
@@ -1001,7 +997,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         [],
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1017,7 +1013,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1032,7 +1028,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1054,7 +1050,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1079,7 +1075,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1101,7 +1097,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1116,7 +1112,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1132,7 +1128,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1150,7 +1146,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1172,7 +1168,7 @@ describe('generateRouteStaticParams', () => {
       await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1187,7 +1183,7 @@ describe('generateRouteStaticParams', () => {
       await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1207,7 +1203,7 @@ describe('generateRouteStaticParams', () => {
       await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1228,7 +1224,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1246,7 +1242,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1266,7 +1262,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1283,7 +1279,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1312,7 +1308,7 @@ describe('generateRouteStaticParams', () => {
         generateRouteStaticParams(
           segments,
           store,
-          mockWorkUnitAsyncStorage,
+
           false,
           []
         )
@@ -1330,7 +1326,7 @@ describe('generateRouteStaticParams', () => {
         generateRouteStaticParams(
           segments,
           store,
-          mockWorkUnitAsyncStorage,
+
           false,
           []
         )
@@ -1352,7 +1348,7 @@ describe('generateRouteStaticParams', () => {
         generateRouteStaticParams(
           segments,
           store,
-          mockWorkUnitAsyncStorage,
+
           false,
           []
         )
@@ -1369,7 +1365,7 @@ describe('generateRouteStaticParams', () => {
         generateRouteStaticParams(
           segments,
           store,
-          mockWorkUnitAsyncStorage,
+
           true,
           []
         )
@@ -1387,7 +1383,7 @@ describe('generateRouteStaticParams', () => {
         generateRouteStaticParams(
           segments,
           store,
-          mockWorkUnitAsyncStorage,
+
           true,
           []
         )
@@ -1405,7 +1401,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1420,7 +1416,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1449,7 +1445,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1487,7 +1483,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1528,7 +1524,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )
@@ -1554,7 +1550,7 @@ describe('generateRouteStaticParams', () => {
       const result = await generateRouteStaticParams(
         segments,
         store,
-        mockWorkUnitAsyncStorage,
+
         false,
         []
       )

--- a/packages/next/src/build/static-paths/app.ts
+++ b/packages/next/src/build/static-paths/app.ts
@@ -21,16 +21,19 @@ import {
 import escapePathDelimiters from '../../shared/lib/router/utils/escape-path-delimiters'
 import { createIncrementalCache } from '../../export/helpers/create-incremental-cache'
 import type { NextConfigComplete } from '../../server/config-shared'
-import type { WorkStore } from '../../server/app-render/work-async-storage.external'
+import {
+  type WorkStore,
+  workAsyncStorage,
+} from '../../server/app-render/work-async-storage.external'
 import type { DynamicParamTypes } from '../../shared/lib/app-router-types'
 import { getParamProperties } from '../../shared/lib/router/utils/get-segment-param'
 import { throwEmptyGenerateStaticParamsError } from '../../shared/lib/errors/empty-generate-static-params-error'
 import type { AppRouteModule } from '../../server/route-modules/app-route/module.compiled'
 import type { NormalizedAppRoute } from '../../shared/lib/router/routes/app'
 import { interceptionPrefixFromParamType } from '../../shared/lib/router/utils/interception-prefix-from-param-type'
-import type {
-  GenerateStaticParamsStore,
-  WorkUnitAsyncStorage,
+import {
+  type GenerateStaticParamsStore,
+  workUnitAsyncStorage,
 } from '../../server/app-render/work-unit-async-storage.external'
 import type { ImplicitTags } from '../../server/lib/implicit-tags'
 import { getImplicitTags } from '../../server/lib/implicit-tags'
@@ -606,7 +609,6 @@ export function assignStaticShellMetadata(
  */
 async function callGenerateStaticParams(
   generateStaticParams: NonNullable<AppSegment['generateStaticParams']>,
-  workUnitAsyncStorage: WorkUnitAsyncStorage,
   parentParams: Params,
   rootParamKeys: readonly string[],
   implicitTags: ImplicitTags
@@ -638,7 +640,6 @@ async function callGenerateStaticParams(
  *
  * @param segments - Array of app directory segments to process
  * @param store - Work store for tracking fetch cache configuration
- * @param workUnitAsyncStorage - AsyncLocalStorage for work unit stores
  * @param isRoutePPREnabled - Whether PPR is enabled for this route
  * @param rootParamKeys - The keys identifying which params are root params
  * @returns Promise that resolves to an array of all parameter combinations
@@ -648,7 +649,6 @@ export async function generateRouteStaticParams(
     Readonly<Pick<AppSegment, 'config' | 'generateStaticParams'>>
   >,
   store: Pick<WorkStore, 'fetchCache' | 'page'>,
-  workUnitAsyncStorage: WorkUnitAsyncStorage,
   isRoutePPREnabled: boolean,
   rootParamKeys: readonly string[]
 ): Promise<Params[]> {
@@ -696,7 +696,6 @@ export async function generateRouteStaticParams(
       for (const parentParams of params) {
         const result = await callGenerateStaticParams(
           current.generateStaticParams,
-          workUnitAsyncStorage,
           parentParams,
           rootParamKeys,
           implicitTags
@@ -718,7 +717,6 @@ export async function generateRouteStaticParams(
       // No parent params, call generateStaticParams with empty object
       const result = await callGenerateStaticParams(
         current.generateStaticParams,
-        workUnitAsyncStorage,
         {},
         rootParamKeys,
         implicitTags
@@ -874,12 +872,11 @@ export async function buildAppStaticPaths({
     previouslyRevalidatedTags: [],
   })
 
-  const routeParams = await ComponentMod.workAsyncStorage.run(
+  const routeParams = await workAsyncStorage.run(
     store,
     generateRouteStaticParams,
     segments,
     store,
-    ComponentMod.workUnitAsyncStorage,
     isRoutePPREnabled,
     rootParamKeys
   )

--- a/packages/next/src/server/app-render/action-handler.ts
+++ b/packages/next/src/server/app-render/action-handler.ts
@@ -32,6 +32,7 @@ import RenderResult, {
   type AppPageRenderResultMetadata,
 } from '../render-result'
 import type { WorkStore } from '../app-render/work-async-storage.external'
+import { actionAsyncStorage } from '../app-render/action-async-storage.external'
 import { FlightRenderResult } from './flight-render-result'
 import {
   filterReqHeaders,
@@ -705,8 +706,6 @@ export async function handleAction({
     'Cache-Control',
     'no-cache, no-store, max-age=0, must-revalidate'
   )
-
-  const { actionAsyncStorage } = ComponentMod
 
   const actionWasForwarded = Boolean(req.headers['x-action-forwarded'])
 

--- a/packages/next/src/server/app-render/entry-base.ts
+++ b/packages/next/src/server/app-render/entry-base.ts
@@ -18,10 +18,6 @@ export {
   LoadingBoundaryProvider,
 } from '../../client/components/layout-router'
 export { default as RenderFromTemplateContext } from '../../client/components/render-from-template-context'
-export { workAsyncStorage } from '../app-render/work-async-storage.external'
-export { workUnitAsyncStorage } from './work-unit-async-storage.external'
-export { actionAsyncStorage } from '../app-render/action-async-storage.external'
-
 export { ClientPageRoot } from '../../client/components/client-page'
 export { ClientSegmentRoot } from '../../client/components/client-segment'
 export {


### PR DESCRIPTION
The `workAsyncStorage`, `workUnitAsyncStorage`, and `actionAsyncStorage` instances were re-exported from `entry-base.ts` so that they could be accessed as properties of the bundled page module (`ComponentMod`). This indirection is no longer necessary because the `.external.ts` naming convention forces webpack to externalize these modules to `commonjs next/dist/...` (via `resolveNextExternal` in `handle-externals.ts`), and the `turbopack-transition: 'next-shared'` import attributes achieve the same for Turbopack. Both mechanisms guarantee that the bundled page module and direct imports resolve to the same singleton instance.

This removes the three re-exports from `entry-base.ts` and replaces all `ComponentMod`-based access with direct imports from the `.external` modules in `static-paths/app.ts` and `action-handler.ts`.