### PR TITLE
Turbopack: Merge release-with-assertions-no-lto profile into release-with-assertions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -271,16 +271,17 @@ opt-level = "s"
 [profile.release.package.miette]
 opt-level = "s"
 
-
-# Use a custom profile for CI where many tests are performance sensitive but we still want the additional validation of debug-assertions
+# Use a custom profile for CI or local testing where we are somewhat performance
+# sensitive but we still want the additional validation of debug-assertions.
+#
+# This is not suitable for benchmarking, as debug assertions worsen performance
+# and we disable LTO.
 [profile.release-with-assertions]
 inherits = "release"
 debug-assertions = true
 overflow-checks = true
-
-# Like release-with-assertions but without LTO for faster test binary linking
-[profile.release-with-assertions-no-lto]
-inherits = "release-with-assertions"
+# Thin-LTO can make the binary ~5-10% faster, but it can make our build take a
+# couple more minutes, so it's not worth it for most test scenarios.
 lto = false
 
 [profile.release-with-debug]

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -19,7 +19,7 @@
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-clippy": "cargo clippy --workspace --all-targets -- -D warnings -A deprecated",
     "rust-check-napi": "cargo check -p next-napi-bindings",
-    "test-cargo-unit": "cargo nextest run --workspace --exclude next-napi-bindings --exclude turbo-tasks-macros --cargo-profile release-with-assertions-no-lto --no-fail-fast"
+    "test-cargo-unit": "cargo nextest run --workspace --exclude next-napi-bindings --exclude turbo-tasks-macros --cargo-profile release-with-assertions --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",


### PR DESCRIPTION
- More profiles means more bloat to the `target` directory and more cold builds.
- There's no practical use case where we'd be okay with the performance hit of `debug-assertions` and not okay with the performance hit of `lto = false`. Neither profile was suitable for benchmarking.
- `release-with-assertions-no-lto` is too long to type and was giving me carpal tunnel.