### PR TITLE
Add NAPI-based WASM runtime for SWC plugins

### DIFF
--- a/.github/workflows/test-turbopack-rust-bench-test.yml
+++ b/.github/workflows/test-turbopack-rust-bench-test.yml
@@ -49,12 +49,12 @@ jobs:
       - name: Build benchmarks for tests
         timeout-minutes: 120
         run: |
-          cargo test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude next-napi-bindings --no-run
+          cargo test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude next-napi-bindings --exclude turbopack-ecmascript-plugins --exclude next-core --no-run
 
       - name: Run cargo test on benchmarks
         timeout-minutes: 120
         run: |
-          cargo test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude next-napi-bindings
+          cargo test --benches --workspace --release --no-fail-fast --exclude turbopack-bench --exclude next-napi-bindings --exclude turbopack-ecmascript-plugins --exclude next-core
 
       - name: Build benchmarks for tests for other bundlers
         if: inputs.all

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,16 +379,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-wait"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
-dependencies = [
- "libc",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8440,10 +8430,8 @@ name = "swc_plugin_backend_napi"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "atomic-wait",
  "napi",
  "napi-derive",
- "once_cell",
  "swc_plugin_runner 25.0.0",
 ]
 
@@ -11708,21 +11696,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4936,7 +4936,7 @@ dependencies = [
  "serde_json",
  "supports-hyperlinks",
  "swc_core",
- "swc_plugin_backend_wasmtime",
+ "swc_plugin_backend_napi",
  "terminal_hyperlink",
  "terminal_size",
  "tokio",
@@ -8738,6 +8738,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_plugin_backend_napi"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "napi",
+ "napi-derive",
+ "once_cell",
+ "swc_plugin_runner 25.0.0",
+]
+
+[[package]]
 name = "swc_plugin_backend_wasmer"
 version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10477,7 +10488,7 @@ dependencies = [
  "styled_jsx",
  "swc_core",
  "swc_emotion",
- "swc_plugin_backend_wasmtime",
+ "swc_plugin_backend_napi",
  "swc_relay",
  "tracing",
  "turbo-rcstr",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,15 +22,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli 0.32.3",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,12 +138,6 @@ dependencies = [
  "unicode-general-category",
  "unicode-joining-type",
 ]
-
-[[package]]
-name = "ambient-authority"
-version = "0.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
 
 [[package]]
 name = "android-tzdata"
@@ -394,6 +379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-wait"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55b94919229f2c42292fd71ffa4b75e83193bffdd77b1e858cd55fd2d0b0ea8"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,7 +523,7 @@ version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
- "addr2line 0.20.0",
+ "addr2line",
  "cc",
  "cfg-if",
  "libc",
@@ -666,8 +661,8 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "swc",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms",
  "swc_ecma_visit",
  "wasm-bindgen",
@@ -939,72 +934,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cap-fs-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
-dependencies = [
- "cap-primitives",
- "cap-std",
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "cap-primitives"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
-dependencies = [
- "ambient-authority",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "ipnet",
- "maybe-owned",
- "rustix 1.0.7",
- "rustix-linux-procfs",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
-name = "cap-rand"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
-dependencies = [
- "ambient-authority",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "cap-std"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
-dependencies = [
- "cap-primitives",
- "io-extras",
- "io-lifetimes",
- "rustix 1.0.7",
-]
-
-[[package]]
-name = "cap-time-ext"
-version = "3.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
-dependencies = [
- "ambient-authority",
- "cap-primitives",
- "iana-time-zone",
- "once_cell",
- "rustix 1.0.7",
- "winx",
-]
-
-[[package]]
 name = "cargo-lock"
 version = "8.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,7 +1036,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1605,39 +1534,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-assembler-x64"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c088d3406f0c0252efa7445adfd2d05736bfb5218838f64eaf79d567077aed14"
-dependencies = [
- "cranelift-assembler-x64-meta",
-]
-
-[[package]]
-name = "cranelift-assembler-x64-meta"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c03f887a763abb9c1dc08f722aa82b69067fda623b6f0273050f45f8b1a6776"
-dependencies = [
- "cranelift-srcgen",
-]
-
-[[package]]
 name = "cranelift-bforest"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "305d51c180ebdc46ef61bc60c54ae6512db3bc9a05842a1f1e762e45977019ab"
 dependencies = [
- "cranelift-entity 0.110.2",
-]
-
-[[package]]
-name = "cranelift-bforest"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206887a11a43f507fee320a218dc365980bfc42ec2696792079a9f8c9369e90"
-dependencies = [
- "cranelift-entity 0.125.4",
+ "cranelift-entity",
 ]
 
 [[package]]
@@ -1647,63 +1549,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "690d8ae6c73748e5ce3d8fe59034dceadb8823e6c8994ba324141c5eae909b0e"
 
 [[package]]
-name = "cranelift-bitset"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac0790c83cfdab95709c5d0105fd888221e3af9049a7d7ec376ec901ab4e4dba"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "cranelift-codegen"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7ca95e831c18d1356da783765c344207cbdffea91e13e47fa9327dbb2e0719"
 dependencies = [
  "bumpalo",
- "cranelift-bforest 0.110.2",
- "cranelift-bitset 0.110.3",
- "cranelift-codegen-meta 0.110.3",
- "cranelift-codegen-shared 0.110.3",
- "cranelift-control 0.110.3",
- "cranelift-entity 0.110.2",
- "cranelift-isle 0.110.2",
+ "cranelift-bforest",
+ "cranelift-bitset",
+ "cranelift-codegen-meta",
+ "cranelift-codegen-shared",
+ "cranelift-control",
+ "cranelift-entity",
+ "cranelift-isle",
  "gimli 0.28.1",
  "hashbrown 0.14.5",
  "log",
- "regalloc2 0.9.3",
+ "regalloc2",
  "rustc-hash 1.1.0",
  "smallvec",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-codegen"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a98aed2d262eda69310e84bae8e053ee4f17dbdd3347b8d9156aa618ba2de0a"
-dependencies = [
- "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest 0.125.4",
- "cranelift-bitset 0.125.4",
- "cranelift-codegen-meta 0.125.4",
- "cranelift-codegen-shared 0.125.4",
- "cranelift-control 0.125.4",
- "cranelift-entity 0.125.4",
- "cranelift-isle 0.125.4",
- "gimli 0.32.3",
- "hashbrown 0.15.4",
- "log",
- "pulley-interpreter",
- "regalloc2 0.13.5",
- "rustc-hash 2.1.1",
- "serde",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasmtime-internal-math",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1712,20 +1577,7 @@ version = "0.110.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0a2d2ab65e6cbf91f81781d8da65ec2005510f18300eff21a99526ed6785863"
 dependencies = [
- "cranelift-codegen-shared 0.110.3",
-]
-
-[[package]]
-name = "cranelift-codegen-meta"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6906852826988563e9b0a9232ad951f53a47aa41ffd02f8ac852d3f41aae836a"
-dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared 0.125.4",
- "cranelift-srcgen",
- "heck 0.5.0",
- "pulley-interpreter",
+ "cranelift-codegen-shared",
 ]
 
 [[package]]
@@ -1733,12 +1585,6 @@ name = "cranelift-codegen-shared"
 version = "0.110.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efcff860573cf3db9ae98fbd949240d78b319df686cc306872e7fab60e9c84d7"
-
-[[package]]
-name = "cranelift-codegen-shared"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a50105aab667b5cc845f2be37c78475d7cc127cd8ec0a31f7b2b71d526099a7"
 
 [[package]]
 name = "cranelift-control"
@@ -1750,32 +1596,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "cranelift-control"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6adcc7aa7c0bc1727176a6f2d99c28a9e79a541ccd5ca911a0cb352da8befa36"
-dependencies = [
- "arbitrary",
-]
-
-[[package]]
 name = "cranelift-entity"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a48cb0a194c9ba82fec35a1e492055388d89b2e3c03dee9dcf2488892be8004d"
 dependencies = [
- "cranelift-bitset 0.110.3",
-]
-
-[[package]]
-name = "cranelift-entity"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981b56af777f9a34ea6dcce93255125776d391410c2a68b75bed5941b714fa15"
-dependencies = [
- "cranelift-bitset 0.125.4",
- "serde",
- "serde_derive",
+ "cranelift-bitset",
 ]
 
 [[package]]
@@ -1784,22 +1610,10 @@ version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8327afc6c1c05f4be62fefce5b439fa83521c65363a322e86ea32c85e7ceaf64"
 dependencies = [
- "cranelift-codegen 0.110.2",
+ "cranelift-codegen",
  "log",
  "smallvec",
- "target-lexicon 0.12.16",
-]
-
-[[package]]
-name = "cranelift-frontend"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea982589684dfb71afecb9fc09555c3a266300a1162a60d7fa39d41a5705b1c"
-dependencies = [
- "cranelift-codegen 0.125.4",
- "log",
- "smallvec",
- "target-lexicon 0.13.5",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1807,29 +1621,6 @@ name = "cranelift-isle"
 version = "0.110.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b08621c00321efcfa3eee6a3179adc009e21ea8d24ca7adc3c326184bc3f48"
-
-[[package]]
-name = "cranelift-isle"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0422686b22ed6a1f33cc40e3c43eb84b67155788568d1a5cac8439d3dca1783"
-
-[[package]]
-name = "cranelift-native"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f697bbbe135c655ea1deb7af0bae4a5c4fae2c88fdfc0fa57b34ae58c91040"
-dependencies = [
- "cranelift-codegen 0.125.4",
- "libc",
- "target-lexicon 0.13.5",
-]
-
-[[package]]
-name = "cranelift-srcgen"
-version = "0.125.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718efe674f3df645462677e22a3128e890d88ba55821bb091083d257707be76c"
 
 [[package]]
 name = "crc32fast"
@@ -2526,17 +2317,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
-name = "fd-lock"
-version = "4.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
-dependencies = [
- "cfg-if",
- "rustix 1.0.7",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2623,17 +2403,6 @@ checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
  "swc_macros_common",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "fs-set-times"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
-dependencies = [
- "io-lifetimes",
- "rustix 1.0.7",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2835,17 +2604,6 @@ name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-dependencies = [
- "fallible-iterator",
- "indexmap 2.13.0",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
  "indexmap 2.13.0",
@@ -3724,22 +3482,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-extras"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
-dependencies = [
- "io-lifetimes",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
-
-[[package]]
 name = "io-uring"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,15 +3563,6 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -4083,12 +3816,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -4362,12 +4089,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "maybe-owned"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
-
-[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4392,15 +4113,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memfd"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
-dependencies = [
- "rustix 1.0.7",
-]
 
 [[package]]
 name = "memmap2"
@@ -4573,8 +4285,8 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_visit",
 ]
 
@@ -5214,18 +4926,6 @@ dependencies = [
  "indexmap 2.13.0",
  "memchr",
  "ruzstd",
-]
-
-[[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "crc32fast",
- "hashbrown 0.15.4",
- "indexmap 2.13.0",
- "memchr",
 ]
 
 [[package]]
@@ -5965,29 +5665,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pulley-interpreter"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beafc309a2d35e16cc390644d88d14dfa45e45e15075ec6a9e37f6dfb43e926f"
-dependencies = [
- "cranelift-bitset 0.125.4",
- "log",
- "pulley-macros",
- "wasmtime-internal-math",
-]
-
-[[package]]
-name = "pulley-macros"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885fbb6c07454cfc8725a18a1da3cfc328ee8c53fb8d0671ea313edc8567947"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "pxfm"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6281,8 +5958,8 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_visit",
 ]
 
@@ -6325,20 +6002,6 @@ dependencies = [
  "log",
  "rustc-hash 1.1.0",
  "slice-group-by",
- "smallvec",
-]
-
-[[package]]
-name = "regalloc2"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08effbc1fa53aaebff69521a5c05640523fab037b34a4a2c109506bc938246fa"
-dependencies = [
- "allocator-api2",
- "bumpalo",
- "hashbrown 0.15.4",
- "log",
- "rustc-hash 2.1.1",
  "smallvec",
 ]
 
@@ -6408,8 +6071,8 @@ dependencies = [
  "serde",
  "swc_atoms",
  "swc_cached",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_visit",
 ]
 
@@ -6668,16 +6331,6 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix-linux-procfs"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
-dependencies = [
- "once_cell",
- "rustix 1.0.7",
 ]
 
 [[package]]
@@ -7506,8 +7159,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "tracing",
@@ -7527,7 +7180,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_css_ast",
  "swc_css_codegen",
  "swc_css_compat",
@@ -7535,7 +7188,7 @@ dependencies = [
  "swc_css_parser",
  "swc_css_prefixer",
  "swc_css_visit",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -7579,10 +7232,10 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_compiler_base",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen",
  "swc_ecma_ext_transforms",
  "swc_ecma_loader",
@@ -7599,11 +7252,11 @@ dependencies = [
  "swc_error_reporters",
  "swc_node_comments",
  "swc_plugin_backend_wasmer",
- "swc_plugin_proxy",
- "swc_plugin_runner",
+ "swc_plugin_proxy 23.0.0",
+ "swc_plugin_runner 27.0.0",
  "swc_sourcemap",
  "swc_timer",
- "swc_transform_common",
+ "swc_transform_common 15.0.0",
  "swc_visit",
  "tokio",
  "tracing",
@@ -7665,6 +7318,32 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
+version = "19.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "623a4ee8bb19d87de6fc781e44e1696af20136d1c1eabf9f3712ff1fb50b6189"
+dependencies = [
+ "anyhow",
+ "ast_node",
+ "better_scoped_tls",
+ "bytes-str",
+ "either",
+ "from_variant",
+ "num-bigint",
+ "once_cell",
+ "parking_lot",
+ "rustc-hash 2.1.1",
+ "serde",
+ "siphasher",
+ "swc_atoms",
+ "swc_eq_ignore_macros",
+ "swc_visit",
+ "tracing",
+ "unicode-width 0.2.1",
+ "url",
+]
+
+[[package]]
+name = "swc_common"
 version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a771e6a245d82746eee4a06849e1ed481ddf0e6fa1d5794a833b516513bb414"
@@ -7711,9 +7390,9 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen",
  "swc_ecma_minifier",
  "swc_ecma_parser",
@@ -7766,8 +7445,8 @@ dependencies = [
  "swc",
  "swc_allocator",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen",
  "swc_ecma_lints",
  "swc_ecma_loader",
@@ -7783,8 +7462,8 @@ dependencies = [
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_plugin_proxy",
- "swc_plugin_runner",
+ "swc_plugin_proxy 23.0.0",
+ "swc_plugin_runner 27.0.0",
  "testing",
  "vergen",
 ]
@@ -7798,7 +7477,7 @@ dependencies = [
  "is-macro",
  "string_enum",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
 ]
 
 [[package]]
@@ -7812,7 +7491,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_css_ast",
  "swc_css_codegen_macros",
  "swc_css_utils",
@@ -7837,7 +7516,7 @@ dependencies = [
  "bitflags 2.9.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7852,7 +7531,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7867,7 +7546,7 @@ dependencies = [
  "lexical",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_css_ast",
 ]
 
@@ -7883,7 +7562,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_css_ast",
  "swc_css_utils",
  "swc_css_visit",
@@ -7912,9 +7591,28 @@ checksum = "e16cd73f86ec2fe7df85499a63abb4b4f956b24bf1e3540dacb598406e2e14c6"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_css_ast",
  "swc_visit",
+]
+
+[[package]]
+name = "swc_ecma_ast"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27111582629a1cc116f9cffa6bfa501e6c849e0e66fafdf78cd404dce919117d"
+dependencies = [
+ "bitflags 2.9.1",
+ "is-macro",
+ "num-bigint",
+ "once_cell",
+ "phf",
+ "rustc-hash 2.1.1",
+ "string_enum",
+ "swc_atoms",
+ "swc_common 19.0.0",
+ "swc_visit",
+ "unicode-id-start",
 ]
 
 [[package]]
@@ -7934,7 +7632,7 @@ dependencies = [
  "shrink-to-fit",
  "string_enum",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_visit",
  "unicode-id-start",
 ]
@@ -7956,8 +7654,8 @@ dependencies = [
  "serde",
  "swc_allocator",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen_macros",
  "tracing",
 ]
@@ -7981,8 +7679,8 @@ checksum = "22d4da77f7014b5efd416bb5208ab6e3d005ad5d532df8ced2904e50ca233d44"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_compat_es2015",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -7997,8 +7695,8 @@ version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d72d7d499e4bd4059ccfe432c1a52111a28fdd2b49b3882f18108fddfa3f6b4f"
 dependencies = [
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_utils",
 ]
@@ -8017,9 +7715,9 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_compat_common",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
@@ -8037,7 +7735,7 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1358f912b0b5bdb6509f64dada8dc9ac8dc9233175b1d033c571cd34ad0bbec"
 dependencies = [
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -8051,8 +7749,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65a437c6a98cbfed7b355e2da721a52b1731537b6debf81cadccc9f196bbdbba"
 dependencies = [
  "serde",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -8066,7 +7764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ffcf499581d598250e4d93d45ef64fe81b16f83c3bcb8c21d27af2004e6f54"
 dependencies = [
  "serde",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -8079,8 +7777,8 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5125766d7ca9c4789eefdb68fd9d1bc9eba1119df21ad3d1fd7b0ac2808893d0"
 dependencies = [
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -8094,8 +7792,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eba7cf139b36cdf75daf9f1fc9096f566c8034d774ce040f09f0fccd4ffe02e"
 dependencies = [
  "serde",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_compat_es2022",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
@@ -8110,7 +7808,7 @@ version = "42.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64ee2ff23cdc2bb9749f3fb730bd4a95cc26cdea84b384b85574a1ab43f78af"
 dependencies = [
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -8125,8 +7823,8 @@ checksum = "d9e0499dc93f8eb04c88d5cf6aefc4ce34fdcca9dd69155d6882eb011339c9dd"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
@@ -8155,8 +7853,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b81ca56fdd7170e23194ab05e6be528de490432eeadfa4b9a287be231017d46b"
 dependencies = [
  "phf",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_utils",
  "swc_ecma_visit",
 ]
@@ -8168,8 +7866,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee7662517362f6726b0e107a3caec2b4cc7d629f9bf702958948e9350722e52f"
 dependencies = [
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_visit",
 ]
 
@@ -8187,9 +7885,9 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_utils",
  "swc_ecma_visit",
 ]
@@ -8212,7 +7910,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "tracing",
 ]
 
@@ -8238,9 +7936,9 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen",
  "swc_ecma_hooks",
  "swc_ecma_parser",
@@ -8268,8 +7966,8 @@ dependencies = [
  "smartstring",
  "stacker",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "tracing",
 ]
 
@@ -8290,8 +7988,8 @@ dependencies = [
  "serde_json",
  "string_enum",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transformer",
  "swc_ecma_transforms",
  "swc_ecma_utils",
@@ -8309,8 +8007,8 @@ dependencies = [
  "quote",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_parser",
  "swc_macros_common",
  "syn 2.0.104",
@@ -8325,7 +8023,7 @@ dependencies = [
  "phf",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_ecma_regexp_ast",
  "swc_ecma_regexp_common",
  "swc_ecma_regexp_visit",
@@ -8341,7 +8039,7 @@ dependencies = [
  "bitflags 2.9.1",
  "is-macro",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_ecma_regexp_common",
 ]
 
@@ -8359,7 +8057,7 @@ checksum = "73317054bba9a6fed553ce2c830702b8602fc5f5c08d9328bd3ab9d8489ce827"
 dependencies = [
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_ecma_regexp_ast",
  "swc_visit",
 ]
@@ -8385,8 +8083,8 @@ checksum = "65c334a42d7d8252e5a80dbae85a1230144d29f7ed4aa7feada2a47167f9282e"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_compat_regexp",
  "swc_ecma_hooks",
  "swc_ecma_regexp",
@@ -8403,8 +8101,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94503bbcd555d82cb33ff0e591e935bb925b79b254e94e706521f15d762b473"
 dependencies = [
  "par-core",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_module",
@@ -8429,8 +8127,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_parser",
  "swc_ecma_utils",
  "swc_ecma_visit",
@@ -8443,8 +8141,8 @@ version = "41.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55e0dcc5887dcf8aef9309495198d25b9c03da5f023848f8a916fcb4ed543586"
 dependencies = [
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_ecma_visit",
@@ -8460,8 +8158,8 @@ dependencies = [
  "par-core",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_compat_bugfixes",
  "swc_ecma_compat_common",
  "swc_ecma_compat_es2015",
@@ -8507,9 +8205,9 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_loader",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -8533,8 +8231,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde_json",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -8552,8 +8250,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_utils",
@@ -8575,9 +8273,9 @@ dependencies = [
  "sha1",
  "string_enum",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_config",
- "swc_ecma_ast",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_hooks",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -8598,8 +8296,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen",
  "swc_ecma_parser",
  "swc_ecma_testing",
@@ -8621,8 +8319,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
  "swc_ecma_utils",
@@ -8642,8 +8340,8 @@ dependencies = [
  "par-core",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_visit",
  "tracing",
 ]
@@ -8658,8 +8356,8 @@ dependencies = [
  "num-bigint",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_visit",
  "tracing",
 ]
@@ -8679,8 +8377,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_codegen",
  "swc_ecma_transforms",
  "swc_ecma_utils",
@@ -8711,7 +8409,7 @@ dependencies = [
  "miette",
  "once_cell",
  "serde",
- "swc_common",
+ "swc_common 21.0.0",
 ]
 
 [[package]]
@@ -8734,7 +8432,7 @@ dependencies = [
  "dashmap 5.5.3",
  "rustc-hash 2.1.1",
  "swc_atoms",
- "swc_common",
+ "swc_common 21.0.0",
 ]
 
 [[package]]
@@ -8742,6 +8440,7 @@ name = "swc_plugin_backend_napi"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "atomic-wait",
  "napi",
  "napi-derive",
  "once_cell",
@@ -8757,24 +8456,11 @@ dependencies = [
  "anyhow",
  "enumset",
  "parking_lot",
- "swc_common",
- "swc_plugin_runner",
+ "swc_common 21.0.0",
+ "swc_plugin_runner 27.0.0",
  "wasmer",
  "wasmer-compiler-cranelift",
  "wasmer-wasix",
-]
-
-[[package]]
-name = "swc_plugin_backend_wasmtime"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80db3340ec910c54bb4c418cd838e51bd3574982d81debc8ffb1c28640931d10"
-dependencies = [
- "anyhow",
- "swc_common",
- "swc_plugin_runner",
- "wasi-common",
- "wasmtime",
 ]
 
 [[package]]
@@ -8790,6 +8476,20 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa426e25a63f653fd7efb19f5c684057e66572773ebbd176e8be38f3b7378e75"
+dependencies = [
+ "better_scoped_tls",
+ "rustc-hash 2.1.1",
+ "swc_common 19.0.0",
+ "swc_ecma_ast 21.0.0",
+ "swc_trace_macro",
+ "tracing",
+]
+
+[[package]]
+name = "swc_plugin_proxy"
 version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbfc8183fc43f5617a6bf5e6af0869dd634f3df469070f61b6f98d7cbd300d5a"
@@ -8797,10 +8497,29 @@ dependencies = [
  "better_scoped_tls",
  "cbor4ii",
  "rustc-hash 2.1.1",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_trace_macro",
  "tracing",
+]
+
+[[package]]
+name = "swc_plugin_runner"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6a0d20fa98d2a94ddb82d924ac98175a7e10d607d3bfd007bf72981b1dcc218"
+dependencies = [
+ "anyhow",
+ "parking_lot",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_atoms",
+ "swc_common 19.0.0",
+ "swc_plugin_proxy 21.0.0",
+ "swc_transform_common 13.0.0",
+ "tracing",
+ "vergen",
 ]
 
 [[package]]
@@ -8816,10 +8535,10 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_plugin_proxy",
- "swc_transform_common",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
+ "swc_plugin_proxy 23.0.0",
+ "swc_transform_common 15.0.0",
  "tracing",
  "vergen",
 ]
@@ -8835,8 +8554,8 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
+ "swc_common 21.0.0",
+ "swc_ecma_ast 23.0.0",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "tracing",
@@ -8882,6 +8601,18 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
+version = "13.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1874cae422d398137e9b7cb39ceb2d91068342ca152ab3137709dbc175cc965f"
+dependencies = [
+ "better_scoped_tls",
+ "rustc-hash 2.1.1",
+ "serde",
+ "swc_common 19.0.0",
+]
+
+[[package]]
+name = "swc_transform_common"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6619f4691d3934610de7d0acf4807634161f395bf44d695810ebae9e405d2"
@@ -8889,7 +8620,7 @@ dependencies = [
  "better_scoped_tls",
  "rustc-hash 2.1.1",
  "serde",
- "swc_common",
+ "swc_common 21.0.0",
 ]
 
 [[package]]
@@ -8968,22 +8699,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-interface"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4592f674ce18521c2a81483873a49596655b179f71c5e05d10c1fe66c78745"
-dependencies = [
- "bitflags 2.9.1",
- "cap-fs-ext",
- "cap-std",
- "fd-lock",
- "io-lifetimes",
- "rustix 0.38.41",
- "windows-sys 0.59.0",
- "winx",
-]
-
-[[package]]
 name = "tabled"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9030,12 +8745,6 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-triple"
@@ -9104,7 +8813,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_common",
+ "swc_common 21.0.0",
  "swc_error_reporters",
  "testing_macros",
  "tracing",
@@ -11308,31 +11017,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi-common"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7178030744403adba447b07cd5c1d683e4b01c5521dd96e14d082f3ed2c1f29c"
-dependencies = [
- "anyhow",
- "bitflags 2.9.1",
- "cap-fs-ext",
- "cap-rand",
- "cap-std",
- "cap-time-ext",
- "fs-set-times",
- "io-extras",
- "io-lifetimes",
- "log",
- "rustix 1.0.7",
- "system-interface",
- "thiserror 2.0.12",
- "tracing",
- "wasmtime",
- "wiggle",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11442,16 +11126,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be00faa2b4950c76fe618c409d2c3ea5a3c9422013e079482d78544bb2d184c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
@@ -11492,7 +11166,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "shared-buffer",
  "tar",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "thiserror 1.0.69",
  "tracing",
  "wasm-bindgen",
@@ -11526,7 +11200,7 @@ dependencies = [
  "self_cell",
  "shared-buffer",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "thiserror 1.0.69",
  "wasmer-types",
  "wasmer-vm",
@@ -11541,14 +11215,14 @@ version = "6.1.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69f548bcccd4791b2647e0d748eb8ddd4d0856233778867c8b0db3781a82ca1"
 dependencies = [
- "cranelift-codegen 0.110.2",
- "cranelift-entity 0.110.2",
- "cranelift-frontend 0.110.2",
+ "cranelift-codegen",
+ "cranelift-entity",
+ "cranelift-frontend",
  "gimli 0.28.1",
  "itertools 0.12.1",
  "more-asserts",
  "smallvec",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "tracing",
  "wasmer-compiler",
  "wasmer-types",
@@ -11661,7 +11335,7 @@ dependencies = [
  "rkyv 0.8.10",
  "serde",
  "sha2",
- "target-lexicon 0.12.16",
+ "target-lexicon",
  "thiserror 1.0.69",
  "wasmparser 0.224.1",
  "xxhash-rust",
@@ -11817,19 +11491,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9d90bb93e764f6beabf1d02028c70a2156a6583e63ac4218dd07ef733368b0"
-dependencies = [
- "bitflags 2.9.1",
- "hashbrown 0.15.4",
- "indexmap 2.13.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -11838,213 +11499,6 @@ dependencies = [
  "hashbrown 0.15.4",
  "indexmap 2.13.0",
  "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.239.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3981f3d51f39f24f5fc90f93049a90f08dbbca8deba602cd46bb8ca67a94718"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.239.0",
-]
-
-[[package]]
-name = "wasmtime"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81eafc07c867be94c47e0dc66355d9785e09107a18901f76a20701ba0663ad7"
-dependencies = [
- "addr2line 0.25.1",
- "anyhow",
- "async-trait",
- "bitflags 2.9.1",
- "bumpalo",
- "cc",
- "cfg-if",
- "hashbrown 0.15.4",
- "indexmap 2.13.0",
- "libc",
- "log",
- "mach2",
- "memfd",
- "object 0.37.3",
- "once_cell",
- "postcard",
- "pulley-interpreter",
- "rustix 1.0.7",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime-environ"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78587abe085a44a13c90fa16fea6db014e9883e627a7044d7f0cb397ad08d1da"
-dependencies = [
- "anyhow",
- "cranelift-bitset 0.125.4",
- "cranelift-entity 0.125.4",
- "gimli 0.32.3",
- "indexmap 2.13.0",
- "log",
- "object 0.37.3",
- "postcard",
- "serde",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.13.5",
- "wasm-encoder 0.239.0",
- "wasmparser 0.239.0",
- "wasmprinter",
-]
-
-[[package]]
-name = "wasmtime-internal-cranelift"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb50f1c50365c32e557266ca85acdf77696c44a3f98797ba6af58cebc6d6d1e"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen 0.125.4",
- "cranelift-control 0.125.4",
- "cranelift-entity 0.125.4",
- "cranelift-frontend 0.125.4",
- "cranelift-native",
- "gimli 0.32.3",
- "itertools 0.14.0",
- "log",
- "object 0.37.3",
- "pulley-interpreter",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 2.0.12",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-math",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-fiber"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9308cdb17f8d51e3164185616d809e28c29a6515c03b9dd95c89436b71f6d154"
-dependencies = [
- "anyhow",
- "cc",
- "cfg-if",
- "libc",
- "rustix 1.0.7",
- "wasmtime-internal-versioned-export-macros",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-debug"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c9b63a22bf2a8b6a149a41c6768bc17a8b2e3288a249cb8216987fbd7128e81"
-dependencies = [
- "cc",
- "wasmtime-internal-versioned-export-macros",
-]
-
-[[package]]
-name = "wasmtime-internal-jit-icache-coherence"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e042b6e3de2f3d708279f89f50b4b9aa1b9bab177300cdffb0ffcd2816df5"
-dependencies = [
- "anyhow",
- "cfg-if",
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "wasmtime-internal-math"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1f0674f38cd7d014eb1a49ea1d1766cca1a64459e8856ee118a10005302e16"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb24b7535306713e7a250f8b71e35f05b6a5031bf9c3ed7330c308e899cbe7d3"
-
-[[package]]
-name = "wasmtime-internal-unwinder"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d5a80e2623a49cb8e8c419542337b8fe0260b162c40dcc201080a84cbe9b7c"
-dependencies = [
- "anyhow",
- "cfg-if",
- "cranelift-codegen 0.125.4",
- "log",
- "object 0.37.3",
-]
-
-[[package]]
-name = "wasmtime-internal-versioned-export-macros"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e277f734b9256359b21517c3b0c26a2a9de6c53a51b670ae55cdcde548bf4e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
-name = "wasmtime-internal-winch"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4dc9333737142f6ece4369c8bcdda03a11edbd43d8fbd3e15004c194b9b743"
-dependencies = [
- "anyhow",
- "cranelift-codegen 0.125.4",
- "gimli 0.32.3",
- "log",
- "object 0.37.3",
- "target-lexicon 0.13.5",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
-name = "wast"
-version = "35.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef140f1b49946586078353a453a1d28ba90adfc54dde75710bc1931de204d68"
-dependencies = [
- "leb128",
 ]
 
 [[package]]
@@ -12066,7 +11520,7 @@ version = "1.235.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e777e0327115793cb96ab220b98f85327ec3d11f34ec9e8d723264522ef206aa"
 dependencies = [
- "wast 235.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -12161,47 +11615,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wiggle"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ee0c6dd73bdf0aff4404059bdc24ca61ad92056d20f4e59b8b0780789cafb4"
-dependencies = [
- "anyhow",
- "async-trait",
- "bitflags 2.9.1",
- "thiserror 2.0.12",
- "tracing",
- "wasmtime",
- "wiggle-macro",
-]
-
-[[package]]
-name = "wiggle-generate"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e415549583fd492ccab881076fa5c41590362d3b5e99df793f619d67333c97b"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "witx",
-]
-
-[[package]]
-name = "wiggle-macro"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a533b4fdc593bf9c4bf52ae0b3a126f15babfb25fce03bfe0bcc84e1172222"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
- "wiggle-generate",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12231,26 +11644,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "38.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c0bb17ae9bf89ebc74512150e6ee0a27b1eac5ff3b54d8cec264f4b4255022d"
-dependencies = [
- "anyhow",
- "cranelift-assembler-x64",
- "cranelift-codegen 0.125.4",
- "gimli 0.32.3",
- "regalloc2 0.13.5",
- "smallvec",
- "target-lexicon 0.13.5",
- "thiserror 2.0.12",
- "wasmparser 0.239.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
-]
 
 [[package]]
 name = "windows-core"
@@ -12315,6 +11708,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -12643,16 +12051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winx"
-version = "0.36.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
-dependencies = [
- "bitflags 2.9.1",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12747,18 +12145,6 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
-]
-
-[[package]]
-name = "witx"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e366f27a5cabcddb2706a78296a40b8fcc451e1a6aba2fc1d94b4a01bdaaef4b"
-dependencies = [
- "anyhow",
- "log",
- "thiserror 1.0.69",
- "wast 35.0.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/next-core",
   "crates/next-custom-transforms",
   "crates/next-taskless",
+  "crates/swc-plugin-backend-napi",
   "turbopack/crates/*",
   "turbopack/crates/*/fuzz",
   "turbopack/xtask",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ swc_core = { version = "63.1.0", default-features = false, features = [
 
 swc_plugin_backend_wasmtime = "9.0.0"
 testing = "22.0.0"
+swc_plugin_backend_napi = { path = "crates/swc-plugin-backend-napi" }
 
 # Keep consistent with preset_env_base through swc_core
 browserslist-rs = "0.19.0"

--- a/crates/next-api/src/app.rs
+++ b/crates/next-api/src/app.rs
@@ -188,6 +188,7 @@ impl AppProject {
             self.project().next_mode(),
             self.project().next_config(),
             self.project().encryption_key(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -220,6 +221,7 @@ impl AppProject {
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -235,6 +237,7 @@ impl AppProject {
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -250,6 +253,7 @@ impl AppProject {
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -265,6 +269,7 @@ impl AppProject {
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -592,6 +597,7 @@ impl AppProject {
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -607,6 +613,7 @@ impl AppProject {
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 

--- a/crates/next-api/src/pages.rs
+++ b/crates/next-api/src/pages.rs
@@ -357,6 +357,7 @@ impl PagesProject {
             self.project().next_mode(),
             self.project().next_config(),
             self.project().encryption_key(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -444,6 +445,7 @@ impl PagesProject {
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -461,6 +463,7 @@ impl PagesProject {
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -478,6 +481,7 @@ impl PagesProject {
             self.project().encryption_key(),
             self.project().server_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 
@@ -495,6 +499,7 @@ impl PagesProject {
             self.project().encryption_key(),
             self.project().edge_compile_time_info().environment(),
             self.project().client_compile_time_info().environment(),
+            *self.project().wasm_plugin_runtime_id().await?,
         ))
     }
 

--- a/crates/next-api/src/project.rs
+++ b/crates/next-api/src/project.rs
@@ -375,6 +375,9 @@ pub struct ProjectOptions {
     /// force new filenames without changing file content. Empty string means
     /// no salt.
     pub hash_salt: RcStr,
+    /// The runtime_id from register_wasm_plugin_runtime, used to look up the
+    /// NAPI-based WASM plugin runtime. 0 means no runtime registered.
+    pub wasm_plugin_runtime_id: u64,
 }
 
 #[derive(Default)]
@@ -824,6 +827,7 @@ impl ProjectContainer {
         let is_persistent_caching_enabled;
         let server_hmr;
         let hash_salt;
+        let wasm_plugin_runtime_id;
         {
             let options = self.options_state.get();
             let options = options
@@ -853,6 +857,7 @@ impl ProjectContainer {
             is_persistent_caching_enabled = options.is_persistent_caching_enabled;
             server_hmr = options.server_hmr;
             hash_salt = options.hash_salt.clone();
+            wasm_plugin_runtime_id = options.wasm_plugin_runtime_id;
         }
 
         let dist_dir = next_config.dist_dir().owned().await?;
@@ -884,6 +889,7 @@ impl ProjectContainer {
             is_persistent_caching_enabled,
             server_hmr,
             hash_salt,
+            wasm_plugin_runtime_id,
         }
         .cell())
     }
@@ -991,6 +997,9 @@ pub struct Project {
     /// A salt to mix into chunk and asset content hashes. Empty string means
     /// no salt.
     hash_salt: RcStr,
+    /// The runtime_id from register_wasm_plugin_runtime, used to look up the
+    /// NAPI-based WASM plugin runtime. 0 means no runtime registered.
+    wasm_plugin_runtime_id: u64,
 }
 
 #[turbo_tasks::value]
@@ -1243,6 +1252,11 @@ impl Project {
     #[turbo_tasks::function]
     pub(super) fn encryption_key(&self) -> Vc<RcStr> {
         Vc::cell(self.encryption_key.clone())
+    }
+
+    #[turbo_tasks::function]
+    pub(super) fn wasm_plugin_runtime_id(&self) -> Vc<u64> {
+        Vc::cell(self.wasm_plugin_runtime_id)
     }
 
     #[turbo_tasks::function]
@@ -1942,6 +1956,7 @@ impl Project {
                 self.encryption_key(),
                 self.edge_compile_time_info().environment(),
                 self.client_compile_time_info().environment(),
+                *self.wasm_plugin_runtime_id().await?,
             ),
             get_edge_resolve_options_context(
                 self.project_path().owned().await?,
@@ -2005,6 +2020,7 @@ impl Project {
                 self.encryption_key(),
                 self.server_compile_time_info().environment(),
                 self.client_compile_time_info().environment(),
+                *self.wasm_plugin_runtime_id().await?,
             ),
             get_server_resolve_options_context(
                 self.project_path().owned().await?,
@@ -2120,6 +2136,7 @@ impl Project {
                 self.encryption_key(),
                 self.server_compile_time_info().environment(),
                 self.client_compile_time_info().environment(),
+                *self.wasm_plugin_runtime_id().await?,
             ),
             get_server_resolve_options_context(
                 self.project_path().owned().await?,
@@ -2183,6 +2200,7 @@ impl Project {
                 self.encryption_key(),
                 self.edge_compile_time_info().environment(),
                 self.client_compile_time_info().environment(),
+                *self.wasm_plugin_runtime_id().await?,
             ),
             get_edge_resolve_options_context(
                 self.project_path().owned().await?,

--- a/crates/next-core/src/next_client/context.rs
+++ b/crates/next-core/src/next_client/context.rs
@@ -233,6 +233,7 @@ pub async fn get_client_module_options_context(
     mode: Vc<NextMode>,
     next_config: Vc<NextConfig>,
     encryption_key: ResolvedVc<RcStr>,
+    wasm_plugin_runtime_id: u64,
 ) -> Result<Vc<ModuleOptionsContext>> {
     let next_mode = mode.await?;
     let resolve_options_context = get_client_resolve_options_context(
@@ -298,7 +299,12 @@ pub async fn get_client_module_options_context(
         get_next_client_transforms_rules(next_config, ty.clone(), mode, true, encryption_key)
             .await?;
     let additional_rules: Vec<ModuleRule> = vec![
-        get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?,
+        get_swc_ecma_transform_plugin_rule(
+            next_config,
+            project_path.clone(),
+            wasm_plugin_runtime_id,
+        )
+        .await?,
         get_relay_transform_rule(next_config, project_path.clone()).await?,
         get_emotion_transform_rule(next_config).await?,
         get_styled_components_transform_rule(next_config).await?,

--- a/crates/next-core/src/next_server/context.rs
+++ b/crates/next-core/src/next_server/context.rs
@@ -418,6 +418,7 @@ pub async fn get_server_module_options_context(
     encryption_key: ResolvedVc<RcStr>,
     environment: ResolvedVc<Environment>,
     client_environment: ResolvedVc<Environment>,
+    wasm_plugin_runtime_id: u64,
 ) -> Result<Vc<ModuleOptionsContext>> {
     let next_mode = mode.await?;
     let mut next_server_rules = get_next_server_transforms_rules(
@@ -537,7 +538,12 @@ pub async fn get_server_module_options_context(
         get_react_remove_properties_transform_rule(next_config).await?,
         get_emotion_transform_rule(next_config).await?,
         get_relay_transform_rule(next_config, project_path.clone()).await?,
-        get_swc_ecma_transform_plugin_rule(next_config, project_path.clone()).await?,
+        get_swc_ecma_transform_plugin_rule(
+            next_config,
+            project_path.clone(),
+            wasm_plugin_runtime_id,
+        )
+        .await?,
     ]
     .into_iter()
     .flatten()

--- a/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
+++ b/crates/next-core/src/next_shared/transforms/swc_ecma_transform_plugins.rs
@@ -12,18 +12,25 @@ use crate::next_config::NextConfig;
 pub async fn get_swc_ecma_transform_plugin_rule(
     next_config: Vc<NextConfig>,
     project_path: FileSystemPath,
+    wasm_plugin_runtime_id: u64,
 ) -> Result<Option<ModuleRule>> {
     let plugin_configs = next_config.experimental_swc_plugins().await?;
     if !plugin_configs.is_empty() {
         #[cfg(feature = "plugin")]
         {
             let enable_mdx_rs = next_config.mdx_rs().await?.is_some();
-            get_swc_ecma_transform_rule_impl(project_path, &plugin_configs, enable_mdx_rs).await
+            get_swc_ecma_transform_rule_impl(
+                project_path,
+                &plugin_configs,
+                enable_mdx_rs,
+                wasm_plugin_runtime_id,
+            )
+            .await
         }
 
         #[cfg(not(feature = "plugin"))]
         {
-            let _ = project_path; // To satisfy lint
+            let _ = (project_path, wasm_plugin_runtime_id);
             Ok(None)
         }
     } else {
@@ -66,6 +73,7 @@ pub async fn get_swc_ecma_transform_rule_impl(
     project_path: FileSystemPath,
     plugin_configs: &[(RcStr, serde_json::Value)],
     enable_mdx_rs: bool,
+    wasm_plugin_runtime_id: u64,
 ) -> Result<Option<ModuleRule>> {
     use anyhow::bail;
     use turbo_tasks::TryFlatJoinIterExt;
@@ -147,8 +155,12 @@ pub async fn get_swc_ecma_transform_rule_impl(
                 };
 
                 Ok(Some((
-                    SwcPluginModule::new(name.clone(), file.content().to_bytes().to_vec())
-                        .resolved_cell(),
+                    SwcPluginModule::new(
+                        name.clone(),
+                        file.content().to_bytes().to_vec(),
+                        wasm_plugin_runtime_id,
+                    )
+                    .resolved_cell(),
                     config.clone(),
                 )))
             }
@@ -157,7 +169,10 @@ pub async fn get_swc_ecma_transform_rule_impl(
         .await?;
 
     Ok(Some(get_ecma_transform_rule(
-        Box::new(SwcEcmaTransformPluginsTransformer::new(plugins)),
+        Box::new(SwcEcmaTransformPluginsTransformer::new(
+            plugins,
+            wasm_plugin_runtime_id,
+        )),
         enable_mdx_rs,
         EcmascriptTransformStage::Main,
     )))

--- a/crates/next-napi-bindings/Cargo.toml
+++ b/crates/next-napi-bindings/Cargo.toml
@@ -18,7 +18,7 @@ plugin = [
     "swc_core/__plugin_transform_host",
     "swc_core/__plugin_transform_host_schema_v1",
     "swc_core/plugin_transform_host_native_filesystem_cache",
-    "dep:swc_plugin_backend_wasmtime",
+    "dep:swc_plugin_backend_napi",
     "next-custom-transforms/plugin",
     "next-core/plugin",
     "turbopack-ecmascript-plugins",
@@ -54,7 +54,7 @@ ignored = [
     # directly import it
     "turbopack-ecmascript-plugins",
     # used conditionally behind the `plugin` feature flag
-    "swc_plugin_backend_wasmtime",
+    "swc_plugin_backend_napi",
 ]
 
 [dependencies]
@@ -110,7 +110,7 @@ swc_core = { workspace = true, features = [
 # Dependencies for the native, non-wasm32 build.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 lightningcss-napi = { workspace = true }
-swc_plugin_backend_wasmtime = { workspace = true, optional = true }
+swc_plugin_backend_napi = { workspace = true, optional = true }
 lightningcss = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 turbo-rcstr = { workspace = true, features = ["napi"] }

--- a/crates/next-napi-bindings/src/next_api/project.rs
+++ b/crates/next-napi-bindings/src/next_api/project.rs
@@ -221,6 +221,9 @@ pub struct NapiProjectOptions {
     /// force new filenames without changing file content. Empty string means
     /// no salt.
     pub hash_salt: RcStr,
+    /// The runtime_id from registerWasmPluginRuntime, used to look up the
+    /// NAPI-based WASM plugin runtime. Omit or pass 0 if no plugins are used.
+    pub wasm_plugin_runtime_id: Option<f64>,
 }
 
 /// [NapiProjectOptions] with all fields optional.
@@ -335,6 +338,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
             next_version,
             server_hmr,
             hash_salt,
+            wasm_plugin_runtime_id: _wasm_plugin_runtime_id,
         } = val;
         ProjectOptions {
             root_path,
@@ -360,6 +364,7 @@ impl From<NapiProjectOptions> for ProjectOptions {
             next_version,
             server_hmr: server_hmr.unwrap_or(false),
             hash_salt,
+            wasm_plugin_runtime_id: _wasm_plugin_runtime_id.map(|v| v as u64).unwrap_or(0),
         }
     }
 }

--- a/crates/next-napi-bindings/src/transform.rs
+++ b/crates/next-napi-bindings/src/transform.rs
@@ -50,6 +50,11 @@ use swc_core::{
 
 use crate::{complete_output, get_compiler, util::MapErr};
 
+/// The runtime_id from the most recent register_wasm_plugin_runtime call.
+/// Used by the webpack transform path which doesn't go through Project.
+#[cfg(feature = "plugin")]
+static CURRENT_WASM_RUNTIME_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Input to transform
 #[derive(Debug)]
 pub enum Input {
@@ -63,6 +68,8 @@ pub struct TransformTask {
     pub c: Compiler,
     pub input: Input,
     pub options: Buffer,
+    #[cfg(feature = "plugin")]
+    pub wasm_plugin_runtime_id: u64,
 }
 
 fn skip_filename() -> bool {
@@ -133,11 +140,16 @@ impl Task for TransformTask {
 
                             #[cfg(feature = "plugin")]
                             {
-                                options.swc.runtime_options =
-                                    swc_core::base::config::RuntimeOptions::default()
-                                        .plugin_runtime(std::sync::Arc::new(
-                                            swc_plugin_backend_napi::NapiRuntime,
-                                        ));
+                                if self.wasm_plugin_runtime_id != 0 {
+                                    let runtime =
+                                        swc_plugin_backend_napi::NapiRuntime::from_runtime_id(
+                                            self.wasm_plugin_runtime_id,
+                                        )
+                                        .map_err(|e| anyhow!(e))?;
+                                    options.swc.runtime_options =
+                                        swc_core::base::config::RuntimeOptions::default()
+                                            .plugin_runtime(std::sync::Arc::new(runtime));
+                                }
                             }
 
                             let cm = self.c.cm.clone();
@@ -227,7 +239,13 @@ pub fn transform(
         Either3::C(_) => Input::FromFilename,
     };
 
-    let task = TransformTask { c, input, options };
+    let task = TransformTask {
+        c,
+        input,
+        options,
+        #[cfg(feature = "plugin")]
+        wasm_plugin_runtime_id: CURRENT_WASM_RUNTIME_ID.load(std::sync::atomic::Ordering::Relaxed),
+    };
     Ok(AsyncTask::with_optional_signal(task, signal))
 }
 
@@ -248,7 +266,13 @@ pub fn transform_sync(
         Either3::C(_) => Input::FromFilename,
     };
 
-    let mut task = TransformTask { c, input, options };
+    let mut task = TransformTask {
+        c,
+        input,
+        options,
+        #[cfg(feature = "plugin")]
+        wasm_plugin_runtime_id: CURRENT_WASM_RUNTIME_ID.load(std::sync::atomic::Ordering::Relaxed),
+    };
     let output = task.compute()?;
     task.resolve(env, output)
 }
@@ -263,10 +287,13 @@ fn test_deser() {
 
 /// Register the NAPI-based WASM plugin runtime.
 /// Must be called from JS before any SWC transforms that use plugins.
+/// Returns the runtime_id that identifies this registration.
 #[cfg(feature = "plugin")]
 #[napi]
-pub fn register_wasm_plugin_runtime(env: Env, js_manager: JsObject) -> napi::Result<()> {
-    swc_plugin_backend_napi::register_wasm_runtime(&env, &js_manager)
+pub fn register_wasm_plugin_runtime(env: Env, js_manager: JsObject) -> napi::Result<f64> {
+    let runtime_id = swc_plugin_backend_napi::register_wasm_runtime(&env, &js_manager)?;
+    CURRENT_WASM_RUNTIME_ID.store(runtime_id, std::sync::atomic::Ordering::Relaxed);
+    Ok(runtime_id as f64)
 }
 
 #[test]

--- a/crates/next-napi-bindings/src/transform.rs
+++ b/crates/next-napi-bindings/src/transform.rs
@@ -34,6 +34,8 @@ use std::{
 };
 
 use anyhow::{Context as _, anyhow, bail};
+#[cfg(feature = "plugin")]
+use napi::JsObject;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use next_custom_transforms::chain_transforms::{TransformOptions, custom_before_pass};
@@ -134,7 +136,7 @@ impl Task for TransformTask {
                                 options.swc.runtime_options =
                                     swc_core::base::config::RuntimeOptions::default()
                                         .plugin_runtime(std::sync::Arc::new(
-                                            swc_plugin_backend_wasmtime::WasmtimeRuntime,
+                                            swc_plugin_backend_napi::NapiRuntime,
                                         ));
                             }
 
@@ -257,6 +259,14 @@ fn test_deser() {
     let tr: TransformOptions = serde_json::from_str(JSON_STR).unwrap();
 
     println!("{tr:#?}");
+}
+
+/// Register the NAPI-based WASM plugin runtime.
+/// Must be called from JS before any SWC transforms that use plugins.
+#[cfg(feature = "plugin")]
+#[napi]
+pub fn register_wasm_plugin_runtime(env: Env, js_manager: JsObject) -> napi::Result<()> {
+    swc_plugin_backend_napi::register_wasm_runtime(&env, &js_manager)
 }
 
 #[test]

--- a/crates/swc-plugin-backend-napi/Cargo.toml
+++ b/crates/swc-plugin-backend-napi/Cargo.toml
@@ -9,8 +9,6 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-atomic-wait = "1.1.0"
-once_cell = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 swc_plugin_runner = { version = "25.0.0", default-features = false }

--- a/crates/swc-plugin-backend-napi/Cargo.toml
+++ b/crates/swc-plugin-backend-napi/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "swc_plugin_backend_napi"
+edition = "2024"
+version = "0.0.0"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+once_cell = { workspace = true }
+napi = { workspace = true }
+napi-derive = { workspace = true }
+swc_plugin_runner = { version = "25.0.0", default-features = false }

--- a/crates/swc-plugin-backend-napi/Cargo.toml
+++ b/crates/swc-plugin-backend-napi/Cargo.toml
@@ -9,6 +9,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+atomic-wait = "1.1.0"
 once_cell = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }

--- a/crates/swc-plugin-backend-napi/src/lib.rs
+++ b/crates/swc-plugin-backend-napi/src/lib.rs
@@ -1,8 +1,13 @@
 use std::{
     path::Path,
-    sync::{Arc, mpsc},
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+        mpsc,
+    },
 };
 
+use atomic_wait::{wait, wake_one};
 use napi::{
     Env, JsBuffer, JsFunction, JsNumber, JsObject, JsUnknown, NapiRaw, NapiValue, Status,
     threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode},
@@ -13,11 +18,124 @@ use swc_plugin_runner::runtime;
 /// Identifier for cache stored in local filesystem.
 const NAPI_RUNTIME_ID: &str = "napi-v8-v1";
 
-/// Global TSFN for dispatching WASM operations to the JS main thread.
+/// Global TSFN for dispatching setup operations to the JS main thread.
+/// Transforms bypass this entirely and go directly to workers via Atomics.
 static WASM_TSFN: OnceCell<ThreadsafeFunction<WasmRequest>> = OnceCell::new();
 
+/// Worker shared memory regions, indexed by worker_index.
+static WORKERS: OnceCell<Vec<WorkerSharedMem>> = OnceCell::new();
+
 // ---------------------------------------------------------------------------
-// Request types dispatched through the TSFN
+// Shared memory layout constants (must match wasm-worker.ts)
+// ---------------------------------------------------------------------------
+
+const FLAG: usize = 0;
+
+// Transform request/response (ctrl indices 1-6):
+const INSTANCE_ID: usize = 1;
+const PROGRAM_PTR: usize = 2;
+const PROGRAM_LEN: usize = 3;
+const UNRESOLVED_MARK: usize = 4;
+const COMMENTS_PROXY: usize = 5;
+const TRANSFORM_RESULT: usize = 6;
+
+// Host function callback (ctrl indices 7-9, args at 10+):
+const HOST_FN_INDEX: usize = 7;
+const HOST_FN_PARAM_COUNT: usize = 8;
+const HOST_FN_RESULT_COUNT: usize = 9;
+const HOST_FN_ARGS_START: usize = 10;
+
+// Memory operation (ctrl indices 7-10, reuses host fn space since they're exclusive):
+const MEM_OP_TYPE: usize = 7;
+const MEM_OP_PTR: usize = 8;
+const MEM_OP_LEN: usize = 9;
+const MEM_OP_RESULT: usize = 10;
+
+// Flag values (stored as u32 in Rust, i32 in JS — same bit pattern):
+const IDLE: u32 = 0;
+const TRANSFORM_REQ: u32 = 1;
+const TRANSFORM_RESP: u32 = 2;
+const HOST_FN_REQ: u32 = 3;
+const HOST_FN_RESP: u32 = 4;
+const MEM_OP_REQ: u32 = 5;
+const MEM_OP_RESP: u32 = 6;
+
+// Memory op types:
+const MEM_READ: u32 = 1;
+const MEM_WRITE: u32 = 2;
+const MEM_ALLOC: u32 = 3;
+const MEM_FREE: u32 = 4;
+
+// ---------------------------------------------------------------------------
+// Worker shared memory
+// ---------------------------------------------------------------------------
+
+struct WorkerSharedMem {
+    /// Pointer to the control SharedArrayBuffer (treated as u32 slots).
+    /// JS uses Int32Array (i32) but the bit patterns are identical for our
+    /// small non-negative flag values and we only use atomic ops.
+    ctrl: *mut u32,
+    ctrl_len: usize, // number of u32 slots
+    data: *mut u8,
+    data_len: usize,
+}
+
+// SAFETY: SharedArrayBuffer memory is shared between Rust and JS worker threads.
+// Access is synchronized via atomic operations (futex-based wait/wake).
+unsafe impl Send for WorkerSharedMem {}
+unsafe impl Sync for WorkerSharedMem {}
+
+impl WorkerSharedMem {
+    fn flag(&self) -> &AtomicU32 {
+        self.atomic(FLAG)
+    }
+
+    fn atomic(&self, index: usize) -> &AtomicU32 {
+        assert!(index < self.ctrl_len);
+        unsafe { &*(self.ctrl.add(index) as *const AtomicU32) }
+    }
+
+    fn store(&self, index: usize, value: u32) {
+        self.atomic(index).store(value, Ordering::Release);
+    }
+
+    fn load(&self, index: usize) -> u32 {
+        self.atomic(index).load(Ordering::Acquire)
+    }
+
+    /// Block until flag != expected. Uses futex (same as Atomics.wait in V8).
+    fn wait_flag_change(&self, expected: u32) {
+        loop {
+            let current = self.flag().load(Ordering::Acquire);
+            if current != expected {
+                return;
+            }
+            wait(self.flag(), expected);
+        }
+    }
+
+    /// Wake one waiter on the flag. Uses futex (same as Atomics.notify in V8).
+    fn notify_flag(&self) {
+        wake_one(self.flag());
+    }
+
+    fn read_data(&self, buf: &mut [u8]) {
+        assert!(buf.len() <= self.data_len);
+        unsafe {
+            std::ptr::copy_nonoverlapping(self.data, buf.as_mut_ptr(), buf.len());
+        }
+    }
+
+    fn write_data(&self, buf: &[u8]) {
+        assert!(buf.len() <= self.data_len);
+        unsafe {
+            std::ptr::copy_nonoverlapping(buf.as_ptr(), self.data, buf.len());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TSFN request types (setup operations only — transforms bypass TSFN)
 // ---------------------------------------------------------------------------
 
 enum WasmRequest {
@@ -25,46 +143,23 @@ enum WasmRequest {
         wasm_bytes: Vec<u8>,
         reply: mpsc::SyncSender<anyhow::Result<u64>>,
     },
+    CloneModule {
+        module_id: u64,
+        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+    },
+    /// Instantiate a module on a worker. Returns (instance_id, worker_index).
+    /// The TSFN callback sends the request to the worker via postMessage and
+    /// stores the reply sender. The worker's response (via the manager's
+    /// message handler) completes the reply.
     Instantiate {
         module_id: u64,
         host_fn_descriptors: Vec<HostFnDescriptor>,
-        host_functions: Arc<Vec<(String, runtime::Func)>>,
-        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+        reply: mpsc::SyncSender<anyhow::Result<(u64, usize)>>,
     },
-    Transform {
+    /// Async operations on worker instances (go through postMessage).
+    WorkerOp {
         instance_id: u64,
-        program_ptr: u32,
-        program_len: u32,
-        unresolved_mark: u32,
-        should_enable_comments_proxy: u32,
-        reply: mpsc::SyncSender<anyhow::Result<u32>>,
-    },
-    ReadMemory {
-        instance_id: u64,
-        ptr: u32,
-        len: u32,
-        reply: mpsc::SyncSender<anyhow::Result<Vec<u8>>>,
-    },
-    WriteMemory {
-        instance_id: u64,
-        ptr: u32,
-        data: Vec<u8>,
-        reply: mpsc::SyncSender<anyhow::Result<()>>,
-    },
-    Alloc {
-        instance_id: u64,
-        size: u32,
-        reply: mpsc::SyncSender<anyhow::Result<u32>>,
-    },
-    Free {
-        instance_id: u64,
-        ptr: u32,
-        size: u32,
-        reply: mpsc::SyncSender<anyhow::Result<u32>>,
-    },
-    GetDiagnostics {
-        instance_id: u64,
-        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+        op: WorkerOp,
     },
     DropModule {
         module_id: u64,
@@ -74,12 +169,34 @@ enum WasmRequest {
     },
 }
 
-// WasmRequest is Send because all fields are Send:
-// - Vec<u8>, u32, u64 are Send
-// - mpsc::SyncSender is Send
-// - Arc<Vec<(String, runtime::Func)>> is Send because Func.func is Box<dyn Fn + Send + Sync>
-// - HostFnDescriptor is Send (all primitive/String fields)
+enum WorkerOp {
+    ReadMemory {
+        ptr: u32,
+        len: u32,
+        reply: mpsc::SyncSender<anyhow::Result<Vec<u8>>>,
+    },
+    WriteMemory {
+        ptr: u32,
+        data: Vec<u8>,
+        reply: mpsc::SyncSender<anyhow::Result<()>>,
+    },
+    Alloc {
+        size: u32,
+        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+    },
+    Free {
+        ptr: u32,
+        size: u32,
+        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+    },
+    GetDiag {
+        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+    },
+}
+
+// SAFETY: All fields are Send.
 unsafe impl Send for WasmRequest {}
+unsafe impl Send for WorkerOp {}
 
 struct HostFnDescriptor {
     name: String,
@@ -89,23 +206,44 @@ struct HostFnDescriptor {
 }
 
 // ---------------------------------------------------------------------------
-// TSFN registration (called from JS main thread)
+// TSFN registration
 // ---------------------------------------------------------------------------
 
-/// Register the WASM plugin runtime. Must be called from the JS main thread
-/// before any SWC transforms that use plugins.
-///
-/// `js_manager` is a JS object with methods: compileModule, instantiateModule,
-/// callTransform, readMemory, writeMemory, callAlloc, callFree, callGetDiag,
-/// dropModule, dropInstance.
 pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<()> {
-    // Store the manager on globalThis so the TSFN callback can access it.
-    // We can't capture napi::Ref in the TSFN closure because Ref is !Send.
     let mut global = env.get_global()?;
     global.set_named_property("__nextSwcWasmManager", js_manager)?;
 
-    // Create a dummy JS function for the TSFN.
-    // The actual work happens in the mapper closure which has access to Env.
+    // Initialize worker pool.
+    let init_fn: JsFunction = js_manager.get_named_property("initWorkerPool")?;
+    let worker_count = num_cpus().max(1);
+    let worker_configs = init_fn.call(
+        None,
+        &[env.create_uint32(worker_count as u32)?.into_unknown()],
+    )?;
+    let worker_configs: JsObject = worker_configs.try_into()?;
+
+    let mut worker_mems = Vec::with_capacity(worker_count);
+    for i in 0..worker_count {
+        let config: JsObject = worker_configs.get_element(i as u32)?;
+        let ctrl_sab: JsObject = config.get_named_property("ctrlBuffer")?;
+        let data_sab: JsObject = config.get_named_property("dataBuffer")?;
+
+        let (ctrl_ptr, ctrl_byte_len) = get_sab_info(env, &ctrl_sab)?;
+        let (data_ptr, data_byte_len) = get_sab_info(env, &data_sab)?;
+
+        worker_mems.push(WorkerSharedMem {
+            ctrl: ctrl_ptr as *mut u32,
+            ctrl_len: ctrl_byte_len / 4,
+            data: data_ptr as *mut u8,
+            data_len: data_byte_len,
+        });
+    }
+
+    WORKERS
+        .set(worker_mems)
+        .map_err(|_| napi::Error::from_reason("Workers already registered"))?;
+
+    // Create TSFN for setup operations.
     let dummy_fn = env.create_function_from_closure("__wasm_tsfn_noop", |ctx| {
         ctx.env.get_undefined().map(|v| v.into_unknown())
     })?;
@@ -115,7 +253,6 @@ pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<(
             let global = ctx.env.get_global()?;
             let manager: JsObject = global.get_named_property("__nextSwcWasmManager")?;
             handle_wasm_request(&ctx.env, &manager, ctx.value)?;
-            // Return empty vec - we don't use the TSFN's JS callback
             Ok(Vec::<JsUnknown>::new())
         })?;
 
@@ -126,117 +263,99 @@ pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<(
     Ok(())
 }
 
+fn num_cpus() -> usize {
+    std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+}
+
+fn get_sab_info(env: &Env, sab: &JsObject) -> napi::Result<(*mut u8, usize)> {
+    let mut data = std::ptr::null_mut();
+    let mut len = 0;
+    let status =
+        unsafe { napi::sys::napi_get_arraybuffer_info(env.raw(), sab.raw(), &mut data, &mut len) };
+    if status != napi::sys::Status::napi_ok {
+        return Err(napi::Error::from_reason(format!(
+            "Failed to get SharedArrayBuffer info: {:?}",
+            status
+        )));
+    }
+    Ok((data as *mut u8, len))
+}
+
 // ---------------------------------------------------------------------------
-// TSFN callback: handle WASM requests on the JS main thread
+// TSFN callback
 // ---------------------------------------------------------------------------
 
 fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> napi::Result<()> {
     match request {
         WasmRequest::CompileModule { wasm_bytes, reply } => {
-            let result = compile_module_on_js_thread(env, manager, wasm_bytes);
+            let result = compile_module_js(env, manager, wasm_bytes);
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::CloneModule { module_id, reply } => {
+            let result = clone_module_js(env, manager, module_id);
             let _ = reply.send(result);
         }
 
         WasmRequest::Instantiate {
             module_id,
             host_fn_descriptors,
-            host_functions,
             reply,
         } => {
-            let result = instantiate_on_js_thread(
-                env,
-                manager,
-                module_id,
-                host_fn_descriptors,
-                host_functions,
-            );
-            let _ = reply.send(result);
+            // This calls instantiateOnWorker which returns sync metadata +
+            // an async promise for the actual instantiation. We register
+            // a promise callback to complete the reply.
+            let result = instantiate_js(env, manager, module_id, host_fn_descriptors, reply);
+            if let Err(e) = result {
+                // If setup failed, the reply was already consumed or needs to be sent.
+                // Just log — reply sender was moved into instantiate_js.
+                eprintln!("Instantiate setup failed: {}", e);
+            }
         }
 
-        WasmRequest::Transform {
-            instance_id,
-            program_ptr,
-            program_len,
-            unresolved_mark,
-            should_enable_comments_proxy,
-            reply,
-        } => {
-            let result = call_transform_on_js_thread(
-                env,
-                manager,
-                instance_id,
-                program_ptr,
-                program_len,
-                unresolved_mark,
-                should_enable_comments_proxy,
-            );
-            let _ = reply.send(result);
-        }
-
-        WasmRequest::ReadMemory {
-            instance_id,
-            ptr,
-            len,
-            reply,
-        } => {
-            let result = read_memory_on_js_thread(env, manager, instance_id, ptr, len);
-            let _ = reply.send(result);
-        }
-
-        WasmRequest::WriteMemory {
-            instance_id,
-            ptr,
-            data,
-            reply,
-        } => {
-            let result = write_memory_on_js_thread(env, manager, instance_id, ptr, &data);
-            let _ = reply.send(result);
-        }
-
-        WasmRequest::Alloc {
-            instance_id,
-            size,
-            reply,
-        } => {
-            let result = call_alloc_on_js_thread(env, manager, instance_id, size);
-            let _ = reply.send(result);
-        }
-
-        WasmRequest::Free {
-            instance_id,
-            ptr,
-            size,
-            reply,
-        } => {
-            let result = call_free_on_js_thread(env, manager, instance_id, ptr, size);
-            let _ = reply.send(result);
-        }
-
-        WasmRequest::GetDiagnostics { instance_id, reply } => {
-            let result = call_get_diag_on_js_thread(env, manager, instance_id);
-            let _ = reply.send(result);
+        WasmRequest::WorkerOp { instance_id, op } => {
+            handle_worker_op(env, manager, instance_id, op);
         }
 
         WasmRequest::DropModule { module_id } => {
-            let _ = call_drop_module_on_js_thread(env, manager, module_id);
+            let drop_fn: JsFunction = manager.get_named_property("dropModule")?;
+            drop_fn.call(None, &[env.create_double(module_id as f64)?.into_unknown()])?;
         }
 
         WasmRequest::DropInstance { instance_id } => {
-            let _ = call_drop_instance_on_js_thread(env, manager, instance_id);
+            let drop_fn: JsFunction = manager.get_named_property("dropInstance")?;
+            drop_fn.call(
+                None,
+                &[env.create_double(instance_id as f64)?.into_unknown()],
+            )?;
         }
     }
     Ok(())
 }
 
+fn tsfn_call_blocking<T: Send + 'static>(
+    request_fn: impl FnOnce(mpsc::SyncSender<T>) -> WasmRequest,
+) -> anyhow::Result<T> {
+    let tsfn = WASM_TSFN
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("WASM TSFN not registered"))?;
+    let (tx, rx) = mpsc::sync_channel(1);
+    let request = request_fn(tx);
+    let status = tsfn.call(Ok(request), ThreadsafeFunctionCallMode::Blocking);
+    if !matches!(status, Status::Ok) {
+        anyhow::bail!("TSFN call failed with status: {:?}", status);
+    }
+    rx.recv()
+        .map_err(|e| anyhow::anyhow!("TSFN recv failed: {}", e))
+}
+
 // ---------------------------------------------------------------------------
-// JS manager method calls (all run on JS main thread)
+// JS manager method implementations (all on main thread)
 // ---------------------------------------------------------------------------
 
-fn compile_module_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    wasm_bytes: Vec<u8>,
-) -> anyhow::Result<u64> {
+fn compile_module_js(env: &Env, manager: &JsObject, wasm_bytes: Vec<u8>) -> anyhow::Result<u64> {
     let compile_fn: JsFunction = manager.get_named_property("compileModule")?;
     let buffer = env.create_buffer_with_data(wasm_bytes)?.into_raw();
     let result = compile_fn.call(None, &[buffer])?;
@@ -244,17 +363,20 @@ fn compile_module_on_js_thread(
     Ok(result.get_double()? as u64)
 }
 
-fn instantiate_on_js_thread(
+fn clone_module_js(env: &Env, manager: &JsObject, module_id: u64) -> anyhow::Result<u64> {
+    let clone_fn: JsFunction = manager.get_named_property("cloneModule")?;
+    let result = clone_fn.call(None, &[env.create_double(module_id as f64)?.into_unknown()])?;
+    let result: JsNumber = result.try_into()?;
+    Ok(result.get_double()? as u64)
+}
+
+fn instantiate_js(
     env: &Env,
     manager: &JsObject,
     module_id: u64,
     host_fn_descriptors: Vec<HostFnDescriptor>,
-    host_functions: Arc<Vec<(String, runtime::Func)>>,
-) -> anyhow::Result<u64> {
-    // Create the Rust dispatch function callable from JS
-    let dispatch_fn = create_dispatch_fn(env, host_functions)?;
-
-    // Build the descriptors array for JS
+    reply: mpsc::SyncSender<anyhow::Result<(u64, usize)>>,
+) -> napi::Result<()> {
     let mut descriptors_arr = env.create_array_with_length(host_fn_descriptors.len())?;
     for (i, desc) in host_fn_descriptors.iter().enumerate() {
         let mut obj = env.create_object()?;
@@ -265,374 +387,175 @@ fn instantiate_on_js_thread(
         descriptors_arr.set_element(i as u32, obj)?;
     }
 
-    let instantiate_fn: JsFunction = manager.get_named_property("instantiateModule")?;
-    let module_id_js = env.create_double(module_id as f64)?;
+    let instantiate_fn: JsFunction = manager.get_named_property("instantiateOnWorker")?;
     let result = instantiate_fn.call(
         None,
         &[
-            unsafe { JsUnknown::from_raw_unchecked(env.raw(), module_id_js.raw()) },
+            env.create_double(module_id as f64)?.into_unknown(),
             unsafe { JsUnknown::from_raw_unchecked(env.raw(), descriptors_arr.raw()) },
-            unsafe { JsUnknown::from_raw_unchecked(env.raw(), dispatch_fn.raw()) },
         ],
     )?;
-    let result: JsNumber = result.try_into()?;
-    Ok(result.get_double()? as u64)
-}
 
-fn call_transform_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    instance_id: u64,
-    program_ptr: u32,
-    program_len: u32,
-    unresolved_mark: u32,
-    should_enable_comments_proxy: u32,
-) -> anyhow::Result<u32> {
-    let transform_fn: JsFunction = manager.get_named_property("callTransform")?;
-    let result = transform_fn.call(
-        None,
-        &[
-            env.create_double(instance_id as f64)?.into_unknown(),
-            env.create_uint32(program_ptr)?.into_unknown(),
-            env.create_uint32(program_len)?.into_unknown(),
-            env.create_uint32(unresolved_mark)?.into_unknown(),
-            env.create_uint32(should_enable_comments_proxy)?
-                .into_unknown(),
-        ],
-    )?;
-    let result: JsNumber = result.try_into()?;
-    Ok(result.get_uint32()?)
-}
+    let result: JsObject = result.try_into()?;
+    let instance_id: JsNumber = result.get_named_property("instanceId")?;
+    let worker_index: JsNumber = result.get_named_property("workerIndex")?;
+    let instance_id_val = instance_id.get_double()? as u64;
+    let worker_index_val = worker_index.get_uint32()? as usize;
 
-fn read_memory_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    instance_id: u64,
-    ptr: u32,
-    len: u32,
-) -> anyhow::Result<Vec<u8>> {
-    let read_fn: JsFunction = manager.get_named_property("readMemory")?;
-    let result = read_fn.call(
-        None,
-        &[
-            env.create_double(instance_id as f64)?.into_unknown(),
-            env.create_uint32(ptr)?.into_unknown(),
-            env.create_uint32(len)?.into_unknown(),
-        ],
-    )?;
-    let buffer: JsBuffer = result.try_into()?;
-    let buffer_value = buffer.into_value()?;
-    Ok(buffer_value.to_vec())
-}
+    // The promise resolves when the worker finishes instantiation.
+    // Attach .then() to send the reply when ready.
+    let promise: JsObject = result.get_named_property("promise")?;
+    let then_fn: JsFunction = promise.get_named_property("then")?;
 
-fn write_memory_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    instance_id: u64,
-    ptr: u32,
-    data: &[u8],
-) -> anyhow::Result<()> {
-    let write_fn: JsFunction = manager.get_named_property("writeMemory")?;
-    let data_buffer = env.create_buffer_with_data(data.to_vec())?.into_raw();
-    write_fn.call(
-        None,
-        &[
-            env.create_double(instance_id as f64)?.into_unknown(),
-            env.create_uint32(ptr)?.into_unknown(),
-            data_buffer.into_unknown(),
-        ],
+    let reply_ok = reply.clone();
+    let resolve_cb = env.create_function_from_closure("resolve", move |ctx| {
+        let _ = reply_ok.send(Ok((instance_id_val, worker_index_val)));
+        ctx.env.get_undefined()
+    })?;
+
+    let reject_cb = env.create_function_from_closure("reject", move |ctx| {
+        let err: JsUnknown = ctx.get(0)?;
+        let msg = err
+            .coerce_to_string()
+            .and_then(|s| s.into_utf8()?.as_str().map(|s| s.to_owned()))
+            .unwrap_or_else(|_| "unknown error".to_string());
+        let _ = reply.send(Err(anyhow::anyhow!("Instantiate failed: {}", msg)));
+        ctx.env.get_undefined()
+    })?;
+
+    then_fn.call(
+        Some(&promise),
+        &[resolve_cb.into_unknown(), reject_cb.into_unknown()],
     )?;
+
     Ok(())
 }
 
-fn call_alloc_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    instance_id: u64,
-    size: u32,
-) -> anyhow::Result<u32> {
-    let alloc_fn: JsFunction = manager.get_named_property("callAlloc")?;
-    let result = alloc_fn.call(
-        None,
-        &[
-            env.create_double(instance_id as f64)?.into_unknown(),
-            env.create_uint32(size)?.into_unknown(),
-        ],
-    )?;
-    let result: JsNumber = result.try_into()?;
-    Ok(result.get_uint32()?)
+/// Handle async worker operations. These go through the manager's postMessage
+/// methods which return promises. We attach .then() to complete the reply.
+fn handle_worker_op(env: &Env, manager: &JsObject, instance_id: u64, op: WorkerOp) {
+    let result = match op {
+        WorkerOp::ReadMemory { ptr, len, reply } => handle_promise_op(
+            env,
+            manager,
+            "readMemoryAsync",
+            instance_id,
+            reply,
+            |env, args| {
+                args.push(env.create_uint32(ptr)?.into_unknown());
+                args.push(env.create_uint32(len)?.into_unknown());
+                Ok(())
+            },
+            |_env, val| {
+                let buf: JsBuffer = val.try_into()?;
+                Ok(buf.into_value()?.to_vec())
+            },
+        ),
+        WorkerOp::WriteMemory { ptr, data, reply } => handle_promise_op(
+            env,
+            manager,
+            "writeMemoryAsync",
+            instance_id,
+            reply,
+            |env, args| {
+                args.push(env.create_uint32(ptr)?.into_unknown());
+                let buffer = env.create_buffer_with_data(data)?.into_raw();
+                args.push(buffer.into_unknown());
+                Ok(())
+            },
+            |_env, _val| Ok(()),
+        ),
+        WorkerOp::Alloc { size, reply } => handle_promise_op(
+            env,
+            manager,
+            "allocAsync",
+            instance_id,
+            reply,
+            |env, args| {
+                args.push(env.create_uint32(size)?.into_unknown());
+                Ok(())
+            },
+            |_env, val| {
+                let n: JsNumber = val.try_into()?;
+                Ok(n.get_uint32()?)
+            },
+        ),
+        WorkerOp::Free { ptr, size, reply } => handle_promise_op(
+            env,
+            manager,
+            "freeAsync",
+            instance_id,
+            reply,
+            |env, args| {
+                args.push(env.create_uint32(ptr)?.into_unknown());
+                args.push(env.create_uint32(size)?.into_unknown());
+                Ok(())
+            },
+            |_env, val| {
+                let n: JsNumber = val.try_into()?;
+                Ok(n.get_uint32()?)
+            },
+        ),
+        WorkerOp::GetDiag { reply } => handle_promise_op(
+            env,
+            manager,
+            "getDiagAsync",
+            instance_id,
+            reply,
+            |_env, _args| Ok(()),
+            |_env, val| {
+                let n: JsNumber = val.try_into()?;
+                Ok(n.get_uint32()?)
+            },
+        ),
+    };
+
+    if let Err(e) = result {
+        eprintln!("Worker op setup failed: {}", e);
+    }
 }
 
-fn call_free_on_js_thread(
+fn handle_promise_op<T: Send + 'static>(
     env: &Env,
     manager: &JsObject,
+    method: &str,
     instance_id: u64,
-    ptr: u32,
-    size: u32,
-) -> anyhow::Result<u32> {
-    let free_fn: JsFunction = manager.get_named_property("callFree")?;
-    let result = free_fn.call(
-        None,
-        &[
-            env.create_double(instance_id as f64)?.into_unknown(),
-            env.create_uint32(ptr)?.into_unknown(),
-            env.create_uint32(size)?.into_unknown(),
-        ],
-    )?;
-    let result: JsNumber = result.try_into()?;
-    Ok(result.get_uint32()?)
-}
-
-fn call_get_diag_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    instance_id: u64,
-) -> anyhow::Result<u32> {
-    let diag_fn: JsFunction = manager.get_named_property("callGetDiag")?;
-    let result = diag_fn.call(
-        None,
-        &[env.create_double(instance_id as f64)?.into_unknown()],
-    )?;
-    let result: JsNumber = result.try_into()?;
-    Ok(result.get_uint32()?)
-}
-
-fn call_drop_module_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    module_id: u64,
+    reply: mpsc::SyncSender<anyhow::Result<T>>,
+    setup_args: impl FnOnce(&Env, &mut Vec<JsUnknown>) -> napi::Result<()>,
+    extract: impl Fn(&Env, JsUnknown) -> napi::Result<T> + Send + 'static,
 ) -> napi::Result<()> {
-    let drop_fn: JsFunction = manager.get_named_property("dropModule")?;
-    drop_fn.call(None, &[env.create_double(module_id as f64)?.into_unknown()])?;
-    Ok(())
-}
+    let func: JsFunction = manager.get_named_property(method)?;
+    let mut args: Vec<JsUnknown> = vec![env.create_double(instance_id as f64)?.into_unknown()];
+    setup_args(env, &mut args)?;
 
-fn call_drop_instance_on_js_thread(
-    env: &Env,
-    manager: &JsObject,
-    instance_id: u64,
-) -> napi::Result<()> {
-    let drop_fn: JsFunction = manager.get_named_property("dropInstance")?;
-    drop_fn.call(
-        None,
-        &[env.create_double(instance_id as f64)?.into_unknown()],
+    let promise = func.call(None, &args)?;
+    let promise: JsObject = promise.try_into()?;
+    let then_fn: JsFunction = promise.get_named_property("then")?;
+
+    let reply_ok = reply.clone();
+    let resolve_cb = env.create_function_from_closure("resolve", move |ctx| {
+        let val: JsUnknown = ctx.get(0)?;
+        let result = extract(ctx.env, val).map_err(|e| anyhow::anyhow!("{}", e));
+        let _ = reply_ok.send(result);
+        ctx.env.get_undefined()
+    })?;
+
+    let reject_cb = env.create_function_from_closure("reject", move |ctx| {
+        let err: JsUnknown = ctx.get(0)?;
+        let msg = err
+            .coerce_to_string()
+            .and_then(|s| s.into_utf8()?.as_str().map(|s| s.to_owned()))
+            .unwrap_or_else(|_| "unknown error".to_string());
+        let _ = reply.send(Err(anyhow::anyhow!("{}", msg)));
+        ctx.env.get_undefined()
+    })?;
+
+    then_fn.call(
+        Some(&promise),
+        &[resolve_cb.into_unknown(), reject_cb.into_unknown()],
     )?;
+
     Ok(())
-}
-
-// ---------------------------------------------------------------------------
-// Host function dispatch (called synchronously from JS during WASM execution)
-// ---------------------------------------------------------------------------
-
-/// Create a Rust function callable from JS that dispatches host function calls.
-///
-/// During WASM execution, JS import wrappers call this function with:
-///   (fn_index: number, args: number[], memory: WebAssembly.Memory,
-///    allocFn: Function, freeFn: Function) => number[] | undefined
-fn create_dispatch_fn(
-    env: &Env,
-    host_functions: Arc<Vec<(String, runtime::Func)>>,
-) -> napi::Result<JsFunction> {
-    env.create_function_from_closure("__swc_plugin_dispatch", move |ctx| {
-        let fn_index: u32 = ctx.get::<JsNumber>(0)?.get_uint32()?;
-        let js_args: JsObject = ctx.get(1)?;
-        let memory: JsObject = ctx.get(2)?;
-        let alloc_fn: JsFunction = ctx.get(3)?;
-        let free_fn: JsFunction = ctx.get(4)?;
-
-        let (ref _name, ref func) = host_functions[fn_index as usize];
-        let param_count = func.sign.0 as usize;
-        let result_count = func.sign.1 as usize;
-
-        // Read input args from JS array
-        let mut input = vec![0i32; param_count];
-        for i in 0..param_count {
-            let val: JsNumber = js_args.get_element(i as u32)?;
-            input[i] = val.get_int32()?;
-        }
-
-        // Create DirectCaller for synchronous memory access on JS thread
-        let mut direct_caller = DirectCaller {
-            env: ctx.env,
-            memory: &memory,
-            alloc_fn: &alloc_fn,
-            free_fn: &free_fn,
-        };
-
-        let mut output = vec![0i32; result_count];
-        (func.func)(&mut direct_caller, &input, &mut output);
-
-        // Return results as JS array (or undefined if no results)
-        if result_count == 0 {
-            ctx.env.get_undefined().map(|v| v.into_unknown())
-        } else {
-            let mut result_array = ctx.env.create_array_with_length(result_count)?;
-            for (i, &v) in output.iter().enumerate() {
-                result_array.set_element(i as u32, ctx.env.create_int32(v)?)?;
-            }
-            Ok(result_array.into_unknown())
-        }
-    })
-}
-
-// ---------------------------------------------------------------------------
-// DirectCaller: JS-thread Caller with direct memory access
-// ---------------------------------------------------------------------------
-
-/// Caller implementation for host function callbacks during WASM execution.
-/// Runs on the JS main thread with direct access to the WASM instance's memory.
-struct DirectCaller<'a> {
-    env: &'a Env,
-    memory: &'a JsObject,     // WebAssembly.Memory object
-    alloc_fn: &'a JsFunction, // instance.exports.__alloc
-    free_fn: &'a JsFunction,  // instance.exports.__free
-}
-
-impl<'a> runtime::Caller<'a> for DirectCaller<'a> {
-    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
-        // Re-read memory.buffer each time (may change after memory growth)
-        let buffer: JsObject = self.memory.get_named_property("buffer")?;
-        // Get the raw buffer data
-        let array_buffer = unsafe {
-            let mut data = std::ptr::null_mut();
-            let mut len = 0;
-            let status = napi::sys::napi_get_arraybuffer_info(
-                self.env.raw(),
-                buffer.raw(),
-                &mut data,
-                &mut len,
-            );
-            if status != napi::sys::Status::napi_ok {
-                anyhow::bail!("Failed to get ArrayBuffer info: {:?}", status);
-            }
-            std::slice::from_raw_parts(data as *const u8, len)
-        };
-
-        let start = ptr as usize;
-        let end = start + buf.len();
-        if end > array_buffer.len() {
-            anyhow::bail!(
-                "read out of bounds: {}..{} > {}",
-                start,
-                end,
-                array_buffer.len()
-            );
-        }
-        buf.copy_from_slice(&array_buffer[start..end]);
-        Ok(())
-    }
-
-    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
-        // Re-read memory.buffer each time (may change after memory growth)
-        let buffer: JsObject = self.memory.get_named_property("buffer")?;
-        let array_buffer = unsafe {
-            let mut data = std::ptr::null_mut();
-            let mut len = 0;
-            let status = napi::sys::napi_get_arraybuffer_info(
-                self.env.raw(),
-                buffer.raw(),
-                &mut data,
-                &mut len,
-            );
-            if status != napi::sys::Status::napi_ok {
-                anyhow::bail!("Failed to get ArrayBuffer info: {:?}", status);
-            }
-            std::slice::from_raw_parts_mut(data as *mut u8, len)
-        };
-
-        let start = ptr as usize;
-        let end = start + buf.len();
-        if end > array_buffer.len() {
-            anyhow::bail!(
-                "write out of bounds: {}..{} > {}",
-                start,
-                end,
-                array_buffer.len()
-            );
-        }
-        array_buffer[start..end].copy_from_slice(buf);
-        Ok(())
-    }
-
-    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
-        let size_js = self.env.create_uint32(size)?;
-        let result = self.alloc_fn.call(None, &[size_js])?;
-        let result: JsNumber = result.try_into()?;
-        Ok(result.get_uint32()?)
-    }
-
-    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
-        let ptr_js = self.env.create_uint32(ptr)?;
-        let size_js = self.env.create_uint32(size)?;
-        let result = self.free_fn.call(None, &[ptr_js, size_js])?;
-        let result: JsNumber = result.try_into()?;
-        Ok(result.get_uint32()?)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// TsfnCaller: background-thread Caller via TSFN dispatch
-// ---------------------------------------------------------------------------
-
-/// Caller implementation for the background thread.
-/// Dispatches all memory operations to the JS main thread via the global TSFN.
-struct TsfnCaller {
-    instance_id: u64,
-}
-
-fn tsfn_call_blocking<T: Send + 'static>(
-    request_fn: impl FnOnce(mpsc::SyncSender<T>) -> WasmRequest,
-) -> anyhow::Result<T> {
-    let tsfn = WASM_TSFN
-        .get()
-        .ok_or_else(|| anyhow::anyhow!("WASM TSFN not registered"))?;
-    let (tx, rx) = mpsc::sync_channel(0);
-    let request = request_fn(tx);
-    let status = tsfn.call(Ok(request), ThreadsafeFunctionCallMode::Blocking);
-    if !matches!(status, Status::Ok) {
-        anyhow::bail!("TSFN call failed with status: {:?}", status);
-    }
-    rx.recv()
-        .map_err(|e| anyhow::anyhow!("TSFN recv failed: {}", e))
-}
-
-impl<'a> runtime::Caller<'a> for TsfnCaller {
-    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
-        let data = tsfn_call_blocking(|reply| WasmRequest::ReadMemory {
-            instance_id: self.instance_id,
-            ptr,
-            len: buf.len() as u32,
-            reply,
-        })??;
-        buf.copy_from_slice(&data);
-        Ok(())
-    }
-
-    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
-        tsfn_call_blocking(|reply| WasmRequest::WriteMemory {
-            instance_id: self.instance_id,
-            ptr,
-            data: buf.to_vec(),
-            reply,
-        })?
-    }
-
-    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
-        tsfn_call_blocking(|reply| WasmRequest::Alloc {
-            instance_id: self.instance_id,
-            size,
-            reply,
-        })?
-    }
-
-    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
-        tsfn_call_blocking(|reply| WasmRequest::Free {
-            instance_id: self.instance_id,
-            ptr,
-            size,
-            reply,
-        })?
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -640,13 +563,9 @@ impl<'a> runtime::Caller<'a> for TsfnCaller {
 // ---------------------------------------------------------------------------
 
 struct NapiModuleCache {
-    wasm_bytes: Vec<u8>,
+    module_id: u64,
 }
 
-/// The NAPI-based SWC plugin runtime.
-///
-/// Delegates WASM compilation and execution to Node.js's V8 engine via NAPI.
-/// This eliminates the wasmtime/Cranelift compiler from the binary.
 #[derive(Clone, Copy, Debug)]
 pub struct NapiRuntime;
 
@@ -656,9 +575,11 @@ impl runtime::Runtime for NapiRuntime {
     }
 
     fn prepare_module(&self, bytes: &[u8]) -> anyhow::Result<runtime::ModuleCache> {
-        // Store raw WASM bytes. V8 compilation happens lazily during init().
+        let wasm_bytes = bytes.to_vec();
+        let module_id =
+            tsfn_call_blocking(|reply| WasmRequest::CompileModule { wasm_bytes, reply })??;
         Ok(runtime::ModuleCache(Box::new(NapiModuleCache {
-            wasm_bytes: bytes.to_vec(),
+            module_id,
         })))
     }
 
@@ -669,18 +590,16 @@ impl runtime::Runtime for NapiRuntime {
         _envs: Vec<(String, String)>,
         module: runtime::Module,
     ) -> anyhow::Result<Box<dyn runtime::Instance>> {
-        let wasm_bytes = match module {
+        let module_id = match module {
             runtime::Module::Cache(cache) => {
-                cache.0.downcast::<NapiModuleCache>().unwrap().wasm_bytes
+                cache.0.downcast::<NapiModuleCache>().unwrap().module_id
             }
-            runtime::Module::Bytes(buf) => buf.to_vec(),
+            runtime::Module::Bytes(buf) => {
+                let wasm_bytes = buf.to_vec();
+                tsfn_call_blocking(|reply| WasmRequest::CompileModule { wasm_bytes, reply })??
+            }
         };
 
-        // Step 1: Compile WASM module on JS thread
-        let module_id =
-            tsfn_call_blocking(|reply| WasmRequest::CompileModule { wasm_bytes, reply })??;
-
-        // Step 2: Build host function descriptors
         let host_fn_descriptors: Vec<HostFnDescriptor> = imports
             .iter()
             .enumerate()
@@ -694,59 +613,68 @@ impl runtime::Runtime for NapiRuntime {
 
         let host_functions = Arc::new(imports);
 
-        // Step 3: Instantiate on JS thread (creates dispatch_fn + JS import wrappers)
-        let instance_id = tsfn_call_blocking(|reply| WasmRequest::Instantiate {
+        // Instantiate on a worker thread. The reply comes back asynchronously
+        // when the worker's promise resolves.
+        let (instance_id, worker_index) = tsfn_call_blocking(|reply| WasmRequest::Instantiate {
             module_id,
             host_fn_descriptors,
-            host_functions: host_functions.clone(),
             reply,
         })??;
 
-        // Step 4: Diagnostics handshake
-        let _diag =
-            tsfn_call_blocking(|reply| WasmRequest::GetDiagnostics { instance_id, reply })??;
+        // getDiag handshake to verify the instance is ready.
+        let _diag = tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
+            instance_id,
+            op: WorkerOp::GetDiag { reply },
+        })??;
 
         Ok(Box::new(NapiInstance {
             instance_id,
             module_id,
-            _host_functions: host_functions,
+            worker_index,
+            host_functions,
         }))
     }
 
     fn clone_cache(&self, cache: &runtime::ModuleCache) -> Option<runtime::ModuleCache> {
         let cache = cache.0.downcast_ref::<NapiModuleCache>()?;
+        let module_id = tsfn_call_blocking(|reply| WasmRequest::CloneModule {
+            module_id: cache.module_id,
+            reply,
+        })
+        .ok()?
+        .ok()?;
         Some(runtime::ModuleCache(Box::new(NapiModuleCache {
-            wasm_bytes: cache.wasm_bytes.clone(),
+            module_id,
         })))
     }
 
     unsafe fn load_cache(&self, _path: &Path) -> Option<runtime::ModuleCache> {
-        // V8 does not expose WebAssembly.Module serialization via NAPI
         None
     }
 
     fn store_cache(&self, _path: &Path, _cache: &runtime::ModuleCache) -> anyhow::Result<()> {
-        // No-op: V8 does not expose WebAssembly.Module serialization
         Ok(())
     }
 }
 
 // ---------------------------------------------------------------------------
-// NapiInstance: implements swc_plugin_runner::runtime::Instance
+// NapiInstance
 // ---------------------------------------------------------------------------
 
 struct NapiInstance {
     instance_id: u64,
     module_id: u64,
-    /// Keep host functions alive for the lifetime of the instance.
-    /// The dispatch_fn closure (on JS thread) holds an Arc clone.
-    _host_functions: Arc<Vec<(String, runtime::Func)>>,
+    worker_index: usize,
+    host_functions: Arc<Vec<(String, runtime::Func)>>,
 }
 
-// SAFETY: NapiInstance is Sync because all access to the JS-side instance
-// goes through the TSFN (which handles thread safety). The _host_functions
-// Arc is Send+Sync because Func.func is Box<dyn Fn + Send + Sync>.
 unsafe impl Sync for NapiInstance {}
+
+impl NapiInstance {
+    fn worker(&self) -> &WorkerSharedMem {
+        &WORKERS.get().expect("Workers not initialized")[self.worker_index]
+    }
+}
 
 impl runtime::Instance for NapiInstance {
     fn transform(
@@ -756,32 +684,100 @@ impl runtime::Instance for NapiInstance {
         unresolved_mark: u32,
         should_enable_comments_proxy: u32,
     ) -> anyhow::Result<u32> {
-        tsfn_call_blocking(|reply| WasmRequest::Transform {
-            instance_id: self.instance_id,
-            program_ptr,
-            program_len,
-            unresolved_mark,
-            should_enable_comments_proxy,
-            reply,
-        })?
+        let w = self.worker();
+
+        // Write transform args to shared memory.
+        w.store(INSTANCE_ID, self.instance_id as u32);
+        w.store(PROGRAM_PTR, program_ptr);
+        w.store(PROGRAM_LEN, program_len);
+        w.store(UNRESOLVED_MARK, unresolved_mark);
+        w.store(COMMENTS_PROXY, should_enable_comments_proxy);
+
+        // Signal worker.
+        w.store(FLAG, TRANSFORM_REQ);
+        w.notify_flag();
+
+        // Process host function callbacks until transform completes.
+        loop {
+            w.wait_flag_change(TRANSFORM_REQ);
+            let flag = w.load(FLAG);
+
+            if flag == TRANSFORM_RESP {
+                let result = w.load(TRANSFORM_RESULT);
+                // Reset to IDLE for next operation.
+                w.store(FLAG, IDLE);
+                w.notify_flag();
+
+                // Worker stores u32::MAX (0xFFFFFFFF, which is -1 as i32) on error
+                if result == u32::MAX {
+                    anyhow::bail!("Transform failed in worker");
+                }
+                return Ok(result);
+            }
+
+            if flag == HOST_FN_REQ {
+                self.handle_host_fn_call(w)?;
+                // After HOST_FN_RESP, the worker continues. Wait for next event.
+                continue;
+            }
+
+            // Unexpected flag — bail
+            anyhow::bail!("Unexpected flag during transform: {}", flag);
+        }
     }
 
     fn caller(&mut self) -> anyhow::Result<Box<dyn runtime::Caller<'_> + '_>> {
+        // Outside of transform, use TSFN-based caller (postMessage path).
         Ok(Box::new(TsfnCaller {
             instance_id: self.instance_id,
         }))
     }
 
     fn cache(&self) -> Option<runtime::ModuleCache> {
-        // No serialization support for V8 modules
         None
+    }
+}
+
+impl NapiInstance {
+    fn handle_host_fn_call(&self, w: &WorkerSharedMem) -> anyhow::Result<()> {
+        let fn_index = w.load(HOST_FN_INDEX) as usize;
+        let param_count = w.load(HOST_FN_PARAM_COUNT) as usize;
+        let result_count = w.load(HOST_FN_RESULT_COUNT) as usize;
+
+        let mut input = vec![0i32; param_count];
+        for i in 0..param_count {
+            input[i] = w.load(HOST_FN_ARGS_START + i) as i32;
+        }
+
+        let (ref _name, ref func) = self.host_functions[fn_index];
+
+        // The Caller for host function callbacks uses Atomics to proxy
+        // memory operations to the worker.
+        let mut caller = TransformCaller { worker: w };
+
+        let mut output = vec![0i32; result_count];
+        (func.func)(&mut caller, &input, &mut output);
+
+        // Write results to shared memory.
+        for (i, &v) in output.iter().enumerate() {
+            w.store(HOST_FN_ARGS_START + i, v as u32);
+        }
+
+        // Signal worker that host function is complete.
+        w.store(FLAG, HOST_FN_RESP);
+        w.notify_flag();
+
+        // Wait for worker to continue — it will set HOST_FN_REQ (another
+        // callback) or TRANSFORM_RESP (done). The outer loop handles both.
+        w.wait_flag_change(HOST_FN_RESP);
+
+        Ok(())
     }
 }
 
 impl Drop for NapiInstance {
     fn drop(&mut self) {
         if let Some(tsfn) = WASM_TSFN.get() {
-            // Fire-and-forget cleanup on the JS thread
             tsfn.call(
                 Ok(WasmRequest::DropInstance {
                     instance_id: self.instance_id,
@@ -795,5 +791,138 @@ impl Drop for NapiInstance {
                 ThreadsafeFunctionCallMode::NonBlocking,
             );
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TransformCaller: memory ops via SharedArrayBuffer (during transform)
+// ---------------------------------------------------------------------------
+
+struct TransformCaller<'a> {
+    worker: &'a WorkerSharedMem,
+}
+
+impl<'a> runtime::Caller<'a> for TransformCaller<'a> {
+    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
+        let w = self.worker;
+
+        w.store(MEM_OP_TYPE, MEM_READ);
+        w.store(MEM_OP_PTR, ptr);
+        w.store(MEM_OP_LEN, buf.len() as u32);
+
+        w.store(FLAG, MEM_OP_REQ);
+        w.notify_flag();
+        w.wait_flag_change(MEM_OP_REQ);
+
+        let flag = w.load(FLAG);
+        if flag != MEM_OP_RESP {
+            anyhow::bail!("Expected MEM_OP_RESP after read, got {}", flag);
+        }
+
+        w.read_data(buf);
+        Ok(())
+    }
+
+    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
+        let w = self.worker;
+
+        w.write_data(buf);
+
+        w.store(MEM_OP_TYPE, MEM_WRITE);
+        w.store(MEM_OP_PTR, ptr);
+        w.store(MEM_OP_LEN, buf.len() as u32);
+
+        w.store(FLAG, MEM_OP_REQ);
+        w.notify_flag();
+        w.wait_flag_change(MEM_OP_REQ);
+
+        let flag = w.load(FLAG);
+        if flag != MEM_OP_RESP {
+            anyhow::bail!("Expected MEM_OP_RESP after write, got {}", flag);
+        }
+
+        Ok(())
+    }
+
+    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
+        let w = self.worker;
+
+        w.store(MEM_OP_TYPE, MEM_ALLOC);
+        w.store(MEM_OP_LEN, size);
+
+        w.store(FLAG, MEM_OP_REQ);
+        w.notify_flag();
+        w.wait_flag_change(MEM_OP_REQ);
+
+        let flag = w.load(FLAG);
+        if flag != MEM_OP_RESP {
+            anyhow::bail!("Expected MEM_OP_RESP after alloc, got {}", flag);
+        }
+
+        Ok(w.load(MEM_OP_RESULT) as u32)
+    }
+
+    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
+        let w = self.worker;
+
+        w.store(MEM_OP_TYPE, MEM_FREE);
+        w.store(MEM_OP_PTR, ptr);
+        w.store(MEM_OP_LEN, size);
+
+        w.store(FLAG, MEM_OP_REQ);
+        w.notify_flag();
+        w.wait_flag_change(MEM_OP_REQ);
+
+        let flag = w.load(FLAG);
+        if flag != MEM_OP_RESP {
+            anyhow::bail!("Expected MEM_OP_RESP after free, got {}", flag);
+        }
+
+        Ok(w.load(MEM_OP_RESULT) as u32)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TsfnCaller: memory ops via TSFN+postMessage (outside of transform)
+// ---------------------------------------------------------------------------
+
+struct TsfnCaller {
+    instance_id: u64,
+}
+
+impl<'a> runtime::Caller<'a> for TsfnCaller {
+    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
+        let len = buf.len() as u32;
+        let data = tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
+            instance_id: self.instance_id,
+            op: WorkerOp::ReadMemory { ptr, len, reply },
+        })??;
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+
+    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
+        tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
+            instance_id: self.instance_id,
+            op: WorkerOp::WriteMemory {
+                ptr,
+                data: buf.to_vec(),
+                reply,
+            },
+        })?
+    }
+
+    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
+        tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
+            instance_id: self.instance_id,
+            op: WorkerOp::Alloc { size, reply },
+        })?
+    }
+
+    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
+        tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
+            instance_id: self.instance_id,
+            op: WorkerOp::Free { ptr, size, reply },
+        })?
     }
 }

--- a/crates/swc-plugin-backend-napi/src/lib.rs
+++ b/crates/swc-plugin-backend-napi/src/lib.rs
@@ -2,7 +2,11 @@ use std::{
     cell::UnsafeCell,
     collections::HashMap,
     path::Path,
-    sync::{Arc, LazyLock, Mutex, OnceLock, mpsc},
+    sync::{
+        Arc, LazyLock, Mutex, RwLock,
+        atomic::{AtomicU64, Ordering},
+        mpsc,
+    },
 };
 
 use napi::{
@@ -14,26 +18,60 @@ use swc_plugin_runner::runtime;
 /// Identifier for cache stored in local filesystem.
 const NAPI_RUNTIME_ID: &str = "napi-v8-v1";
 
-/// Global TSFN for dispatching operations to the JS main thread.
-/// Used for module compilation, instantiation, and non-hot-path memory ops.
-static WASM_TSFN: OnceLock<ThreadsafeFunction<WasmRequest>> = OnceLock::new();
+// ---------------------------------------------------------------------------
+// Shared runtime state — one per register_wasm_runtime call
+// ---------------------------------------------------------------------------
 
-/// The raw napi_env pointer that registered the WASM runtime.
-/// Used to assert we're never re-registered from a different environment.
-static WASM_TSFN_ENV: OnceLock<usize> = OnceLock::new();
+/// All per-env state that was previously in global statics.
+pub struct WasmRuntimeState {
+    /// Unique ID for this runtime registration.
+    pub runtime_id: u64,
+    /// TSFN for dispatching operations to the JS main thread.
+    tsfn: ThreadsafeFunction<WasmRequest>,
+    /// Per-instance TSFN registry: maps instance_id → TSFN targeting the worker thread.
+    instance_tsfns: Mutex<HashMap<u64, Arc<ThreadsafeFunction<InstanceWork>>>>,
+    /// Per-instance host function registry: maps instance_id → Vec<Func>.
+    host_fns: Mutex<HashMap<u64, Arc<Vec<runtime::Func>>>>,
+}
 
-/// Global host function registry: maps instance_id → Vec<Func>.
-/// Workers call back into these during WASM execution via NAPI.
-static HOST_FNS: LazyLock<Mutex<HashMap<u64, Arc<Vec<runtime::Func>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+impl std::fmt::Debug for WasmRuntimeState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WasmRuntimeState")
+            .field("runtime_id", &self.runtime_id)
+            .finish_non_exhaustive()
+    }
+}
 
-/// Global per-instance TSFN registry: maps instance_id → TSFN targeting the worker thread.
-/// Used to dispatch transform/getDiag/memory ops to the correct worker.
-static INSTANCE_TSFNS: LazyLock<Mutex<HashMap<u64, Arc<ThreadsafeFunction<InstanceWork>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+/// Monotonically increasing runtime ID counter.
+static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Global registry of live runtime states, keyed by runtime_id.
+/// Multiple runtimes can coexist (e.g. across different napi_envs in tests).
+static RUNTIMES: LazyLock<RwLock<HashMap<u64, Arc<WasmRuntimeState>>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+fn get_runtime_state(runtime_id: u64) -> anyhow::Result<Arc<WasmRuntimeState>> {
+    RUNTIMES
+        .read()
+        .unwrap()
+        .get(&runtime_id)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!("No WASM runtime registered with id {}", runtime_id))
+}
+
+fn get_runtime_state_napi(runtime_id: u64) -> napi::Result<Arc<WasmRuntimeState>> {
+    RUNTIMES
+        .read()
+        .unwrap()
+        .get(&runtime_id)
+        .cloned()
+        .ok_or_else(|| {
+            napi::Error::from_reason(format!("No WASM runtime registered with id {}", runtime_id))
+        })
+}
 
 // ---------------------------------------------------------------------------
-// Per-instance work dispatch via TSFN (no more Condvar work queue)
+// Per-instance work dispatch via TSFN
 // ---------------------------------------------------------------------------
 
 enum InstanceWork {
@@ -110,12 +148,13 @@ impl OptRef {
 
 /// Dispatch work to an instance's worker thread via its TSFN and block for the result.
 fn instance_call_blocking<T: Send + 'static>(
+    state: &WasmRuntimeState,
     instance_id: u64,
     work: InstanceWork,
     rx: mpsc::Receiver<anyhow::Result<T>>,
 ) -> anyhow::Result<T> {
     let tsfn = {
-        let tsfns = INSTANCE_TSFNS.lock().unwrap();
+        let tsfns = state.instance_tsfns.lock().unwrap();
         tsfns
             .get(&instance_id)
             .ok_or_else(|| anyhow::anyhow!("No TSFN for instance {}", instance_id))?
@@ -149,10 +188,13 @@ fn instance_call_blocking<T: Send + 'static>(
 #[napi_derive::napi]
 pub fn wasm_worker_register_callback(
     env: Env,
+    runtime_id: f64,
     instance_id: f64,
     ops: JsObject,
 ) -> napi::Result<()> {
+    let rid = runtime_id as u64;
     let id = instance_id as u64;
+    let state = get_runtime_state_napi(rid)?;
 
     // Extract and ref each function up front so we don't do property lookups on every call.
     let transform_fn: JsFunction = ops.get_named_property("transform")?;
@@ -318,7 +360,11 @@ pub fn wasm_worker_register_callback(
         },
     )?;
 
-    INSTANCE_TSFNS.lock().unwrap().insert(id, Arc::new(tsfn));
+    state
+        .instance_tsfns
+        .lock()
+        .unwrap()
+        .insert(id, Arc::new(tsfn));
     Ok(())
 }
 
@@ -333,13 +379,17 @@ pub fn wasm_worker_register_callback(
 #[napi_derive::napi]
 pub fn wasm_worker_dispatch_host_fn(
     env: Env,
+    runtime_id: f64,
     instance_id: f64,
     fn_index: u32,
     args: Vec<i32>,
     memory_accessor: JsObject,
 ) -> napi::Result<JsUnknown> {
+    let rid = runtime_id as u64;
     let id = instance_id as u64;
-    let fns = HOST_FNS.lock().unwrap();
+    let state = get_runtime_state_napi(rid)?;
+
+    let fns = state.host_fns.lock().unwrap();
     let host_functions = fns
         .get(&id)
         .ok_or_else(|| napi::Error::from_reason(format!("No host fns for instance {}", id)))?
@@ -456,6 +506,8 @@ enum WasmRequest {
     },
     DropInstance {
         instance_id: u64,
+        /// The runtime state, needed to clean up instance_tsfns and host_fns.
+        state: Arc<WasmRuntimeState>,
     },
 }
 
@@ -473,18 +525,10 @@ struct HostFnDescriptor {
 // TSFN registration
 // ---------------------------------------------------------------------------
 
-pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<()> {
-    let env_addr = env.raw() as usize;
-
-    // Idempotent: skip if already registered from the same Env.
-    if WASM_TSFN.get().is_some() {
-        let registered_env = WASM_TSFN_ENV.get().copied().unwrap_or(0);
-        assert_eq!(
-            registered_env, env_addr,
-            "WASM runtime already registered from a different napi_env"
-        );
-        return Ok(());
-    }
+/// Register the NAPI-based WASM plugin runtime.
+/// Returns the runtime_id that can be used to look up this runtime later.
+pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<u64> {
+    let runtime_id = NEXT_RUNTIME_ID.fetch_add(1, Ordering::Relaxed);
 
     let mut global = env.get_global()?;
     global.set_named_property("__nextSwcWasmManager", js_manager)?;
@@ -510,12 +554,16 @@ pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<(
             Ok(Vec::<JsUnknown>::new())
         })?;
 
-    WASM_TSFN
-        .set(tsfn)
-        .map_err(|_| napi::Error::from_reason("WASM TSFN already registered"))?;
-    let _ = WASM_TSFN_ENV.set(env_addr);
+    let state = Arc::new(WasmRuntimeState {
+        runtime_id,
+        tsfn,
+        instance_tsfns: Mutex::new(HashMap::new()),
+        host_fns: Mutex::new(HashMap::new()),
+    });
 
-    Ok(())
+    RUNTIMES.write().unwrap().insert(runtime_id, state);
+
+    Ok(runtime_id)
 }
 
 fn num_cpus() -> usize {
@@ -556,11 +604,16 @@ fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> n
             drop_fn.call(None, &[env.create_double(module_id as f64)?.into_unknown()])?;
         }
 
-        WasmRequest::DropInstance { instance_id } => {
+        WasmRequest::DropInstance { instance_id, state } => {
             // Send Cleanup to the worker's TSFN to unref NAPI Refs before
             // we drop the TSFN (which would drop the closure and trigger
             // debug_assert panics in Ref::drop).
-            let tsfn = INSTANCE_TSFNS.lock().unwrap().get(&instance_id).cloned();
+            let tsfn = state
+                .instance_tsfns
+                .lock()
+                .unwrap()
+                .get(&instance_id)
+                .cloned();
 
             if let Some(tsfn) = &tsfn {
                 let (tx, rx) = mpsc::sync_channel(1);
@@ -574,10 +627,10 @@ fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> n
 
             // Now safe to remove the TSFN — all Refs have been unref'd
             drop(tsfn);
-            INSTANCE_TSFNS.lock().unwrap().remove(&instance_id);
+            state.instance_tsfns.lock().unwrap().remove(&instance_id);
 
             // Clean up host functions
-            HOST_FNS.lock().unwrap().remove(&instance_id);
+            state.host_fns.lock().unwrap().remove(&instance_id);
 
             let drop_fn: JsFunction = manager.get_named_property("dropInstance")?;
             drop_fn.call(
@@ -590,14 +643,14 @@ fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> n
 }
 
 fn tsfn_call_blocking<T: Send + 'static>(
+    state: &WasmRuntimeState,
     request_fn: impl FnOnce(mpsc::SyncSender<T>) -> WasmRequest,
 ) -> anyhow::Result<T> {
-    let tsfn = WASM_TSFN
-        .get()
-        .ok_or_else(|| anyhow::anyhow!("WASM TSFN not registered"))?;
     let (tx, rx) = mpsc::sync_channel(1);
     let request = request_fn(tx);
-    let status = tsfn.call(Ok(request), ThreadsafeFunctionCallMode::Blocking);
+    let status = state
+        .tsfn
+        .call(Ok(request), ThreadsafeFunctionCallMode::Blocking);
     if !matches!(status, Status::Ok) {
         anyhow::bail!("TSFN call failed with status: {:?}", status);
     }
@@ -682,8 +735,18 @@ struct NapiModuleCache {
     module_id: u64,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub struct NapiRuntime;
+#[derive(Clone, Debug)]
+pub struct NapiRuntime {
+    state: Arc<WasmRuntimeState>,
+}
+
+impl NapiRuntime {
+    /// Look up a registered runtime by its ID.
+    pub fn from_runtime_id(runtime_id: u64) -> anyhow::Result<Self> {
+        let state = get_runtime_state(runtime_id)?;
+        Ok(NapiRuntime { state })
+    }
+}
 
 impl runtime::Runtime for NapiRuntime {
     fn identifier(&self) -> &'static str {
@@ -692,8 +755,10 @@ impl runtime::Runtime for NapiRuntime {
 
     fn prepare_module(&self, bytes: &[u8]) -> anyhow::Result<runtime::ModuleCache> {
         let wasm_bytes = bytes.to_vec();
-        let module_id =
-            tsfn_call_blocking(|reply| WasmRequest::CompileModule { wasm_bytes, reply })??;
+        let module_id = tsfn_call_blocking(&self.state, |reply| WasmRequest::CompileModule {
+            wasm_bytes,
+            reply,
+        })??;
         Ok(runtime::ModuleCache(Box::new(NapiModuleCache {
             module_id,
         })))
@@ -712,7 +777,10 @@ impl runtime::Runtime for NapiRuntime {
             }
             runtime::Module::Bytes(buf) => {
                 let wasm_bytes = buf.to_vec();
-                tsfn_call_blocking(|reply| WasmRequest::CompileModule { wasm_bytes, reply })??
+                tsfn_call_blocking(&self.state, |reply| WasmRequest::CompileModule {
+                    wasm_bytes,
+                    reply,
+                })??
             }
         };
 
@@ -731,18 +799,23 @@ impl runtime::Runtime for NapiRuntime {
 
         // Instantiate on a worker thread via TSFN → postMessage.
         // The worker will call wasmWorkerRegisterCallback to set up the per-instance TSFN.
-        let instance_id = tsfn_call_blocking(|reply| WasmRequest::Instantiate {
+        let instance_id = tsfn_call_blocking(&self.state, |reply| WasmRequest::Instantiate {
             module_id,
             host_fn_descriptors,
             reply,
         })??;
 
         // Store host functions so worker can call them via NAPI.
-        HOST_FNS.lock().unwrap().insert(instance_id, host_functions);
+        self.state
+            .host_fns
+            .lock()
+            .unwrap()
+            .insert(instance_id, host_functions);
 
         let mut instance = NapiInstance {
             instance_id,
             module_id,
+            state: self.state.clone(),
         };
 
         // The runtime contract requires calling __get_transform_plugin_core_pkg_diag
@@ -754,7 +827,7 @@ impl runtime::Runtime for NapiRuntime {
 
     fn clone_cache(&self, cache: &runtime::ModuleCache) -> Option<runtime::ModuleCache> {
         let cache = cache.0.downcast_ref::<NapiModuleCache>()?;
-        let module_id = tsfn_call_blocking(|reply| WasmRequest::CloneModule {
+        let module_id = tsfn_call_blocking(&self.state, |reply| WasmRequest::CloneModule {
             module_id: cache.module_id,
             reply,
         })
@@ -781,6 +854,7 @@ impl runtime::Runtime for NapiRuntime {
 struct NapiInstance {
     instance_id: u64,
     module_id: u64,
+    state: Arc<WasmRuntimeState>,
 }
 
 unsafe impl Sync for NapiInstance {}
@@ -795,6 +869,7 @@ impl runtime::Instance for NapiInstance {
     ) -> anyhow::Result<u32> {
         let (tx, rx) = mpsc::sync_channel(1);
         let result = instance_call_blocking(
+            &self.state,
             self.instance_id,
             InstanceWork::Transform {
                 program_ptr,
@@ -815,6 +890,7 @@ impl runtime::Instance for NapiInstance {
     fn caller(&mut self) -> anyhow::Result<Box<dyn runtime::Caller<'_> + '_>> {
         Ok(Box::new(TsfnCaller {
             instance_id: self.instance_id,
+            state: &self.state,
         }))
     }
 
@@ -826,8 +902,12 @@ impl runtime::Instance for NapiInstance {
 impl NapiInstance {
     fn get_diag(&mut self) -> anyhow::Result<u32> {
         let (tx, rx) = mpsc::sync_channel(1);
-        let result =
-            instance_call_blocking(self.instance_id, InstanceWork::GetDiag { reply: tx }, rx)?;
+        let result = instance_call_blocking(
+            &self.state,
+            self.instance_id,
+            InstanceWork::GetDiag { reply: tx },
+            rx,
+        )?;
 
         if result == -1 {
             anyhow::bail!("getDiag failed in worker");
@@ -841,22 +921,25 @@ impl Drop for NapiInstance {
         // Clean up host functions synchronously so that Arc references held by
         // Func closures (e.g. TransformResultHostEnvironment) are released
         // before the caller tries Arc::try_unwrap on transform_result.
-        HOST_FNS.lock().unwrap().remove(&self.instance_id);
+        self.state
+            .host_fns
+            .lock()
+            .unwrap()
+            .remove(&self.instance_id);
 
-        if let Some(tsfn) = WASM_TSFN.get() {
-            tsfn.call(
-                Ok(WasmRequest::DropInstance {
-                    instance_id: self.instance_id,
-                }),
-                ThreadsafeFunctionCallMode::NonBlocking,
-            );
-            tsfn.call(
-                Ok(WasmRequest::DropModule {
-                    module_id: self.module_id,
-                }),
-                ThreadsafeFunctionCallMode::NonBlocking,
-            );
-        }
+        self.state.tsfn.call(
+            Ok(WasmRequest::DropInstance {
+                instance_id: self.instance_id,
+                state: self.state.clone(),
+            }),
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
+        self.state.tsfn.call(
+            Ok(WasmRequest::DropModule {
+                module_id: self.module_id,
+            }),
+            ThreadsafeFunctionCallMode::NonBlocking,
+        );
     }
 }
 
@@ -864,15 +947,17 @@ impl Drop for NapiInstance {
 // TsfnCaller: memory ops via per-instance TSFN
 // ---------------------------------------------------------------------------
 
-struct TsfnCaller {
+struct TsfnCaller<'a> {
     instance_id: u64,
+    state: &'a WasmRuntimeState,
 }
 
-impl<'a> runtime::Caller<'a> for TsfnCaller {
+impl<'a> runtime::Caller<'a> for TsfnCaller<'a> {
     fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
         let len = buf.len() as u32;
         let (tx, rx) = mpsc::sync_channel(1);
         let data = instance_call_blocking(
+            self.state,
             self.instance_id,
             InstanceWork::ReadMemory {
                 ptr,
@@ -888,6 +973,7 @@ impl<'a> runtime::Caller<'a> for TsfnCaller {
     fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
         let (tx, rx) = mpsc::sync_channel(1);
         instance_call_blocking(
+            self.state,
             self.instance_id,
             InstanceWork::WriteMemory {
                 ptr,
@@ -901,6 +987,7 @@ impl<'a> runtime::Caller<'a> for TsfnCaller {
     fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
         let (tx, rx) = mpsc::sync_channel(1);
         instance_call_blocking(
+            self.state,
             self.instance_id,
             InstanceWork::Alloc { size, reply: tx },
             rx,
@@ -910,6 +997,7 @@ impl<'a> runtime::Caller<'a> for TsfnCaller {
     fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
         let (tx, rx) = mpsc::sync_channel(1);
         instance_call_blocking(
+            self.state,
             self.instance_id,
             InstanceWork::Free {
                 ptr,

--- a/crates/swc-plugin-backend-napi/src/lib.rs
+++ b/crates/swc-plugin-backend-napi/src/lib.rs
@@ -1,0 +1,799 @@
+use std::{
+    path::Path,
+    sync::{Arc, mpsc},
+};
+
+use napi::{
+    Env, JsBuffer, JsFunction, JsNumber, JsObject, JsUnknown, NapiRaw, NapiValue, Status,
+    threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode},
+};
+use once_cell::sync::OnceCell;
+use swc_plugin_runner::runtime;
+
+/// Identifier for cache stored in local filesystem.
+const NAPI_RUNTIME_ID: &str = "napi-v8-v1";
+
+/// Global TSFN for dispatching WASM operations to the JS main thread.
+static WASM_TSFN: OnceCell<ThreadsafeFunction<WasmRequest>> = OnceCell::new();
+
+// ---------------------------------------------------------------------------
+// Request types dispatched through the TSFN
+// ---------------------------------------------------------------------------
+
+enum WasmRequest {
+    CompileModule {
+        wasm_bytes: Vec<u8>,
+        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+    },
+    Instantiate {
+        module_id: u64,
+        host_fn_descriptors: Vec<HostFnDescriptor>,
+        host_functions: Arc<Vec<(String, runtime::Func)>>,
+        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+    },
+    Transform {
+        instance_id: u64,
+        program_ptr: u32,
+        program_len: u32,
+        unresolved_mark: u32,
+        should_enable_comments_proxy: u32,
+        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+    },
+    ReadMemory {
+        instance_id: u64,
+        ptr: u32,
+        len: u32,
+        reply: mpsc::SyncSender<anyhow::Result<Vec<u8>>>,
+    },
+    WriteMemory {
+        instance_id: u64,
+        ptr: u32,
+        data: Vec<u8>,
+        reply: mpsc::SyncSender<anyhow::Result<()>>,
+    },
+    Alloc {
+        instance_id: u64,
+        size: u32,
+        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+    },
+    Free {
+        instance_id: u64,
+        ptr: u32,
+        size: u32,
+        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+    },
+    GetDiagnostics {
+        instance_id: u64,
+        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+    },
+    DropModule {
+        module_id: u64,
+    },
+    DropInstance {
+        instance_id: u64,
+    },
+}
+
+// WasmRequest is Send because all fields are Send:
+// - Vec<u8>, u32, u64 are Send
+// - mpsc::SyncSender is Send
+// - Arc<Vec<(String, runtime::Func)>> is Send because Func.func is Box<dyn Fn + Send + Sync>
+// - HostFnDescriptor is Send (all primitive/String fields)
+unsafe impl Send for WasmRequest {}
+
+struct HostFnDescriptor {
+    name: String,
+    param_count: u8,
+    result_count: u8,
+    index: usize,
+}
+
+// ---------------------------------------------------------------------------
+// TSFN registration (called from JS main thread)
+// ---------------------------------------------------------------------------
+
+/// Register the WASM plugin runtime. Must be called from the JS main thread
+/// before any SWC transforms that use plugins.
+///
+/// `js_manager` is a JS object with methods: compileModule, instantiateModule,
+/// callTransform, readMemory, writeMemory, callAlloc, callFree, callGetDiag,
+/// dropModule, dropInstance.
+pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<()> {
+    // Store the manager on globalThis so the TSFN callback can access it.
+    // We can't capture napi::Ref in the TSFN closure because Ref is !Send.
+    let mut global = env.get_global()?;
+    global.set_named_property("__nextSwcWasmManager", js_manager)?;
+
+    // Create a dummy JS function for the TSFN.
+    // The actual work happens in the mapper closure which has access to Env.
+    let dummy_fn = env.create_function_from_closure("__wasm_tsfn_noop", |ctx| {
+        ctx.env.get_undefined().map(|v| v.into_unknown())
+    })?;
+
+    let tsfn: ThreadsafeFunction<WasmRequest> =
+        dummy_fn.create_threadsafe_function(0, |ctx: ThreadSafeCallContext<WasmRequest>| {
+            let global = ctx.env.get_global()?;
+            let manager: JsObject = global.get_named_property("__nextSwcWasmManager")?;
+            handle_wasm_request(&ctx.env, &manager, ctx.value)?;
+            // Return empty vec - we don't use the TSFN's JS callback
+            Ok(Vec::<JsUnknown>::new())
+        })?;
+
+    WASM_TSFN
+        .set(tsfn)
+        .map_err(|_| napi::Error::from_reason("WASM TSFN already registered"))?;
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// TSFN callback: handle WASM requests on the JS main thread
+// ---------------------------------------------------------------------------
+
+fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> napi::Result<()> {
+    match request {
+        WasmRequest::CompileModule { wasm_bytes, reply } => {
+            let result = compile_module_on_js_thread(env, manager, wasm_bytes);
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::Instantiate {
+            module_id,
+            host_fn_descriptors,
+            host_functions,
+            reply,
+        } => {
+            let result = instantiate_on_js_thread(
+                env,
+                manager,
+                module_id,
+                host_fn_descriptors,
+                host_functions,
+            );
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::Transform {
+            instance_id,
+            program_ptr,
+            program_len,
+            unresolved_mark,
+            should_enable_comments_proxy,
+            reply,
+        } => {
+            let result = call_transform_on_js_thread(
+                env,
+                manager,
+                instance_id,
+                program_ptr,
+                program_len,
+                unresolved_mark,
+                should_enable_comments_proxy,
+            );
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::ReadMemory {
+            instance_id,
+            ptr,
+            len,
+            reply,
+        } => {
+            let result = read_memory_on_js_thread(env, manager, instance_id, ptr, len);
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::WriteMemory {
+            instance_id,
+            ptr,
+            data,
+            reply,
+        } => {
+            let result = write_memory_on_js_thread(env, manager, instance_id, ptr, &data);
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::Alloc {
+            instance_id,
+            size,
+            reply,
+        } => {
+            let result = call_alloc_on_js_thread(env, manager, instance_id, size);
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::Free {
+            instance_id,
+            ptr,
+            size,
+            reply,
+        } => {
+            let result = call_free_on_js_thread(env, manager, instance_id, ptr, size);
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::GetDiagnostics { instance_id, reply } => {
+            let result = call_get_diag_on_js_thread(env, manager, instance_id);
+            let _ = reply.send(result);
+        }
+
+        WasmRequest::DropModule { module_id } => {
+            let _ = call_drop_module_on_js_thread(env, manager, module_id);
+        }
+
+        WasmRequest::DropInstance { instance_id } => {
+            let _ = call_drop_instance_on_js_thread(env, manager, instance_id);
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// JS manager method calls (all run on JS main thread)
+// ---------------------------------------------------------------------------
+
+fn compile_module_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    wasm_bytes: Vec<u8>,
+) -> anyhow::Result<u64> {
+    let compile_fn: JsFunction = manager.get_named_property("compileModule")?;
+    let buffer = env.create_buffer_with_data(wasm_bytes)?.into_raw();
+    let result = compile_fn.call(None, &[buffer])?;
+    let result: JsNumber = result.try_into()?;
+    Ok(result.get_double()? as u64)
+}
+
+fn instantiate_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    module_id: u64,
+    host_fn_descriptors: Vec<HostFnDescriptor>,
+    host_functions: Arc<Vec<(String, runtime::Func)>>,
+) -> anyhow::Result<u64> {
+    // Create the Rust dispatch function callable from JS
+    let dispatch_fn = create_dispatch_fn(env, host_functions)?;
+
+    // Build the descriptors array for JS
+    let mut descriptors_arr = env.create_array_with_length(host_fn_descriptors.len())?;
+    for (i, desc) in host_fn_descriptors.iter().enumerate() {
+        let mut obj = env.create_object()?;
+        obj.set_named_property("name", env.create_string(&desc.name)?)?;
+        obj.set_named_property("paramCount", env.create_int32(desc.param_count as i32)?)?;
+        obj.set_named_property("resultCount", env.create_int32(desc.result_count as i32)?)?;
+        obj.set_named_property("index", env.create_int32(desc.index as i32)?)?;
+        descriptors_arr.set_element(i as u32, obj)?;
+    }
+
+    let instantiate_fn: JsFunction = manager.get_named_property("instantiateModule")?;
+    let module_id_js = env.create_double(module_id as f64)?;
+    let result = instantiate_fn.call(
+        None,
+        &[
+            unsafe { JsUnknown::from_raw_unchecked(env.raw(), module_id_js.raw()) },
+            unsafe { JsUnknown::from_raw_unchecked(env.raw(), descriptors_arr.raw()) },
+            unsafe { JsUnknown::from_raw_unchecked(env.raw(), dispatch_fn.raw()) },
+        ],
+    )?;
+    let result: JsNumber = result.try_into()?;
+    Ok(result.get_double()? as u64)
+}
+
+fn call_transform_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    instance_id: u64,
+    program_ptr: u32,
+    program_len: u32,
+    unresolved_mark: u32,
+    should_enable_comments_proxy: u32,
+) -> anyhow::Result<u32> {
+    let transform_fn: JsFunction = manager.get_named_property("callTransform")?;
+    let result = transform_fn.call(
+        None,
+        &[
+            env.create_double(instance_id as f64)?.into_unknown(),
+            env.create_uint32(program_ptr)?.into_unknown(),
+            env.create_uint32(program_len)?.into_unknown(),
+            env.create_uint32(unresolved_mark)?.into_unknown(),
+            env.create_uint32(should_enable_comments_proxy)?
+                .into_unknown(),
+        ],
+    )?;
+    let result: JsNumber = result.try_into()?;
+    Ok(result.get_uint32()?)
+}
+
+fn read_memory_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    instance_id: u64,
+    ptr: u32,
+    len: u32,
+) -> anyhow::Result<Vec<u8>> {
+    let read_fn: JsFunction = manager.get_named_property("readMemory")?;
+    let result = read_fn.call(
+        None,
+        &[
+            env.create_double(instance_id as f64)?.into_unknown(),
+            env.create_uint32(ptr)?.into_unknown(),
+            env.create_uint32(len)?.into_unknown(),
+        ],
+    )?;
+    let buffer: JsBuffer = result.try_into()?;
+    let buffer_value = buffer.into_value()?;
+    Ok(buffer_value.to_vec())
+}
+
+fn write_memory_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    instance_id: u64,
+    ptr: u32,
+    data: &[u8],
+) -> anyhow::Result<()> {
+    let write_fn: JsFunction = manager.get_named_property("writeMemory")?;
+    let data_buffer = env.create_buffer_with_data(data.to_vec())?.into_raw();
+    write_fn.call(
+        None,
+        &[
+            env.create_double(instance_id as f64)?.into_unknown(),
+            env.create_uint32(ptr)?.into_unknown(),
+            data_buffer.into_unknown(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn call_alloc_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    instance_id: u64,
+    size: u32,
+) -> anyhow::Result<u32> {
+    let alloc_fn: JsFunction = manager.get_named_property("callAlloc")?;
+    let result = alloc_fn.call(
+        None,
+        &[
+            env.create_double(instance_id as f64)?.into_unknown(),
+            env.create_uint32(size)?.into_unknown(),
+        ],
+    )?;
+    let result: JsNumber = result.try_into()?;
+    Ok(result.get_uint32()?)
+}
+
+fn call_free_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    instance_id: u64,
+    ptr: u32,
+    size: u32,
+) -> anyhow::Result<u32> {
+    let free_fn: JsFunction = manager.get_named_property("callFree")?;
+    let result = free_fn.call(
+        None,
+        &[
+            env.create_double(instance_id as f64)?.into_unknown(),
+            env.create_uint32(ptr)?.into_unknown(),
+            env.create_uint32(size)?.into_unknown(),
+        ],
+    )?;
+    let result: JsNumber = result.try_into()?;
+    Ok(result.get_uint32()?)
+}
+
+fn call_get_diag_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    instance_id: u64,
+) -> anyhow::Result<u32> {
+    let diag_fn: JsFunction = manager.get_named_property("callGetDiag")?;
+    let result = diag_fn.call(
+        None,
+        &[env.create_double(instance_id as f64)?.into_unknown()],
+    )?;
+    let result: JsNumber = result.try_into()?;
+    Ok(result.get_uint32()?)
+}
+
+fn call_drop_module_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    module_id: u64,
+) -> napi::Result<()> {
+    let drop_fn: JsFunction = manager.get_named_property("dropModule")?;
+    drop_fn.call(None, &[env.create_double(module_id as f64)?.into_unknown()])?;
+    Ok(())
+}
+
+fn call_drop_instance_on_js_thread(
+    env: &Env,
+    manager: &JsObject,
+    instance_id: u64,
+) -> napi::Result<()> {
+    let drop_fn: JsFunction = manager.get_named_property("dropInstance")?;
+    drop_fn.call(
+        None,
+        &[env.create_double(instance_id as f64)?.into_unknown()],
+    )?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Host function dispatch (called synchronously from JS during WASM execution)
+// ---------------------------------------------------------------------------
+
+/// Create a Rust function callable from JS that dispatches host function calls.
+///
+/// During WASM execution, JS import wrappers call this function with:
+///   (fn_index: number, args: number[], memory: WebAssembly.Memory,
+///    allocFn: Function, freeFn: Function) => number[] | undefined
+fn create_dispatch_fn(
+    env: &Env,
+    host_functions: Arc<Vec<(String, runtime::Func)>>,
+) -> napi::Result<JsFunction> {
+    env.create_function_from_closure("__swc_plugin_dispatch", move |ctx| {
+        let fn_index: u32 = ctx.get::<JsNumber>(0)?.get_uint32()?;
+        let js_args: JsObject = ctx.get(1)?;
+        let memory: JsObject = ctx.get(2)?;
+        let alloc_fn: JsFunction = ctx.get(3)?;
+        let free_fn: JsFunction = ctx.get(4)?;
+
+        let (ref _name, ref func) = host_functions[fn_index as usize];
+        let param_count = func.sign.0 as usize;
+        let result_count = func.sign.1 as usize;
+
+        // Read input args from JS array
+        let mut input = vec![0i32; param_count];
+        for i in 0..param_count {
+            let val: JsNumber = js_args.get_element(i as u32)?;
+            input[i] = val.get_int32()?;
+        }
+
+        // Create DirectCaller for synchronous memory access on JS thread
+        let mut direct_caller = DirectCaller {
+            env: ctx.env,
+            memory: &memory,
+            alloc_fn: &alloc_fn,
+            free_fn: &free_fn,
+        };
+
+        let mut output = vec![0i32; result_count];
+        (func.func)(&mut direct_caller, &input, &mut output);
+
+        // Return results as JS array (or undefined if no results)
+        if result_count == 0 {
+            ctx.env.get_undefined().map(|v| v.into_unknown())
+        } else {
+            let mut result_array = ctx.env.create_array_with_length(result_count)?;
+            for (i, &v) in output.iter().enumerate() {
+                result_array.set_element(i as u32, ctx.env.create_int32(v)?)?;
+            }
+            Ok(result_array.into_unknown())
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// DirectCaller: JS-thread Caller with direct memory access
+// ---------------------------------------------------------------------------
+
+/// Caller implementation for host function callbacks during WASM execution.
+/// Runs on the JS main thread with direct access to the WASM instance's memory.
+struct DirectCaller<'a> {
+    env: &'a Env,
+    memory: &'a JsObject,     // WebAssembly.Memory object
+    alloc_fn: &'a JsFunction, // instance.exports.__alloc
+    free_fn: &'a JsFunction,  // instance.exports.__free
+}
+
+impl<'a> runtime::Caller<'a> for DirectCaller<'a> {
+    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
+        // Re-read memory.buffer each time (may change after memory growth)
+        let buffer: JsObject = self.memory.get_named_property("buffer")?;
+        // Get the raw buffer data
+        let array_buffer = unsafe {
+            let mut data = std::ptr::null_mut();
+            let mut len = 0;
+            let status = napi::sys::napi_get_arraybuffer_info(
+                self.env.raw(),
+                buffer.raw(),
+                &mut data,
+                &mut len,
+            );
+            if status != napi::sys::Status::napi_ok {
+                anyhow::bail!("Failed to get ArrayBuffer info: {:?}", status);
+            }
+            std::slice::from_raw_parts(data as *const u8, len)
+        };
+
+        let start = ptr as usize;
+        let end = start + buf.len();
+        if end > array_buffer.len() {
+            anyhow::bail!(
+                "read out of bounds: {}..{} > {}",
+                start,
+                end,
+                array_buffer.len()
+            );
+        }
+        buf.copy_from_slice(&array_buffer[start..end]);
+        Ok(())
+    }
+
+    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
+        // Re-read memory.buffer each time (may change after memory growth)
+        let buffer: JsObject = self.memory.get_named_property("buffer")?;
+        let array_buffer = unsafe {
+            let mut data = std::ptr::null_mut();
+            let mut len = 0;
+            let status = napi::sys::napi_get_arraybuffer_info(
+                self.env.raw(),
+                buffer.raw(),
+                &mut data,
+                &mut len,
+            );
+            if status != napi::sys::Status::napi_ok {
+                anyhow::bail!("Failed to get ArrayBuffer info: {:?}", status);
+            }
+            std::slice::from_raw_parts_mut(data as *mut u8, len)
+        };
+
+        let start = ptr as usize;
+        let end = start + buf.len();
+        if end > array_buffer.len() {
+            anyhow::bail!(
+                "write out of bounds: {}..{} > {}",
+                start,
+                end,
+                array_buffer.len()
+            );
+        }
+        array_buffer[start..end].copy_from_slice(buf);
+        Ok(())
+    }
+
+    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
+        let size_js = self.env.create_uint32(size)?;
+        let result = self.alloc_fn.call(None, &[size_js])?;
+        let result: JsNumber = result.try_into()?;
+        Ok(result.get_uint32()?)
+    }
+
+    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
+        let ptr_js = self.env.create_uint32(ptr)?;
+        let size_js = self.env.create_uint32(size)?;
+        let result = self.free_fn.call(None, &[ptr_js, size_js])?;
+        let result: JsNumber = result.try_into()?;
+        Ok(result.get_uint32()?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TsfnCaller: background-thread Caller via TSFN dispatch
+// ---------------------------------------------------------------------------
+
+/// Caller implementation for the background thread.
+/// Dispatches all memory operations to the JS main thread via the global TSFN.
+struct TsfnCaller {
+    instance_id: u64,
+}
+
+fn tsfn_call_blocking<T: Send + 'static>(
+    request_fn: impl FnOnce(mpsc::SyncSender<T>) -> WasmRequest,
+) -> anyhow::Result<T> {
+    let tsfn = WASM_TSFN
+        .get()
+        .ok_or_else(|| anyhow::anyhow!("WASM TSFN not registered"))?;
+    let (tx, rx) = mpsc::sync_channel(0);
+    let request = request_fn(tx);
+    let status = tsfn.call(Ok(request), ThreadsafeFunctionCallMode::Blocking);
+    if !matches!(status, Status::Ok) {
+        anyhow::bail!("TSFN call failed with status: {:?}", status);
+    }
+    rx.recv()
+        .map_err(|e| anyhow::anyhow!("TSFN recv failed: {}", e))
+}
+
+impl<'a> runtime::Caller<'a> for TsfnCaller {
+    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
+        let data = tsfn_call_blocking(|reply| WasmRequest::ReadMemory {
+            instance_id: self.instance_id,
+            ptr,
+            len: buf.len() as u32,
+            reply,
+        })??;
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+
+    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
+        tsfn_call_blocking(|reply| WasmRequest::WriteMemory {
+            instance_id: self.instance_id,
+            ptr,
+            data: buf.to_vec(),
+            reply,
+        })?
+    }
+
+    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
+        tsfn_call_blocking(|reply| WasmRequest::Alloc {
+            instance_id: self.instance_id,
+            size,
+            reply,
+        })?
+    }
+
+    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
+        tsfn_call_blocking(|reply| WasmRequest::Free {
+            instance_id: self.instance_id,
+            ptr,
+            size,
+            reply,
+        })?
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NapiRuntime: implements swc_plugin_runner::runtime::Runtime
+// ---------------------------------------------------------------------------
+
+struct NapiModuleCache {
+    wasm_bytes: Vec<u8>,
+}
+
+/// The NAPI-based SWC plugin runtime.
+///
+/// Delegates WASM compilation and execution to Node.js's V8 engine via NAPI.
+/// This eliminates the wasmtime/Cranelift compiler from the binary.
+#[derive(Clone, Copy, Debug)]
+pub struct NapiRuntime;
+
+impl runtime::Runtime for NapiRuntime {
+    fn identifier(&self) -> &'static str {
+        NAPI_RUNTIME_ID
+    }
+
+    fn prepare_module(&self, bytes: &[u8]) -> anyhow::Result<runtime::ModuleCache> {
+        // Store raw WASM bytes. V8 compilation happens lazily during init().
+        Ok(runtime::ModuleCache(Box::new(NapiModuleCache {
+            wasm_bytes: bytes.to_vec(),
+        })))
+    }
+
+    fn init(
+        &self,
+        _name: &str,
+        imports: Vec<(String, runtime::Func)>,
+        _envs: Vec<(String, String)>,
+        module: runtime::Module,
+    ) -> anyhow::Result<Box<dyn runtime::Instance>> {
+        let wasm_bytes = match module {
+            runtime::Module::Cache(cache) => {
+                cache.0.downcast::<NapiModuleCache>().unwrap().wasm_bytes
+            }
+            runtime::Module::Bytes(buf) => buf.to_vec(),
+        };
+
+        // Step 1: Compile WASM module on JS thread
+        let module_id =
+            tsfn_call_blocking(|reply| WasmRequest::CompileModule { wasm_bytes, reply })??;
+
+        // Step 2: Build host function descriptors
+        let host_fn_descriptors: Vec<HostFnDescriptor> = imports
+            .iter()
+            .enumerate()
+            .map(|(i, (name, func))| HostFnDescriptor {
+                name: name.clone(),
+                param_count: func.sign.0,
+                result_count: func.sign.1,
+                index: i,
+            })
+            .collect();
+
+        let host_functions = Arc::new(imports);
+
+        // Step 3: Instantiate on JS thread (creates dispatch_fn + JS import wrappers)
+        let instance_id = tsfn_call_blocking(|reply| WasmRequest::Instantiate {
+            module_id,
+            host_fn_descriptors,
+            host_functions: host_functions.clone(),
+            reply,
+        })??;
+
+        // Step 4: Diagnostics handshake
+        let _diag =
+            tsfn_call_blocking(|reply| WasmRequest::GetDiagnostics { instance_id, reply })??;
+
+        Ok(Box::new(NapiInstance {
+            instance_id,
+            module_id,
+            _host_functions: host_functions,
+        }))
+    }
+
+    fn clone_cache(&self, cache: &runtime::ModuleCache) -> Option<runtime::ModuleCache> {
+        let cache = cache.0.downcast_ref::<NapiModuleCache>()?;
+        Some(runtime::ModuleCache(Box::new(NapiModuleCache {
+            wasm_bytes: cache.wasm_bytes.clone(),
+        })))
+    }
+
+    unsafe fn load_cache(&self, _path: &Path) -> Option<runtime::ModuleCache> {
+        // V8 does not expose WebAssembly.Module serialization via NAPI
+        None
+    }
+
+    fn store_cache(&self, _path: &Path, _cache: &runtime::ModuleCache) -> anyhow::Result<()> {
+        // No-op: V8 does not expose WebAssembly.Module serialization
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NapiInstance: implements swc_plugin_runner::runtime::Instance
+// ---------------------------------------------------------------------------
+
+struct NapiInstance {
+    instance_id: u64,
+    module_id: u64,
+    /// Keep host functions alive for the lifetime of the instance.
+    /// The dispatch_fn closure (on JS thread) holds an Arc clone.
+    _host_functions: Arc<Vec<(String, runtime::Func)>>,
+}
+
+// SAFETY: NapiInstance is Sync because all access to the JS-side instance
+// goes through the TSFN (which handles thread safety). The _host_functions
+// Arc is Send+Sync because Func.func is Box<dyn Fn + Send + Sync>.
+unsafe impl Sync for NapiInstance {}
+
+impl runtime::Instance for NapiInstance {
+    fn transform(
+        &mut self,
+        program_ptr: u32,
+        program_len: u32,
+        unresolved_mark: u32,
+        should_enable_comments_proxy: u32,
+    ) -> anyhow::Result<u32> {
+        tsfn_call_blocking(|reply| WasmRequest::Transform {
+            instance_id: self.instance_id,
+            program_ptr,
+            program_len,
+            unresolved_mark,
+            should_enable_comments_proxy,
+            reply,
+        })?
+    }
+
+    fn caller(&mut self) -> anyhow::Result<Box<dyn runtime::Caller<'_> + '_>> {
+        Ok(Box::new(TsfnCaller {
+            instance_id: self.instance_id,
+        }))
+    }
+
+    fn cache(&self) -> Option<runtime::ModuleCache> {
+        // No serialization support for V8 modules
+        None
+    }
+}
+
+impl Drop for NapiInstance {
+    fn drop(&mut self) {
+        if let Some(tsfn) = WASM_TSFN.get() {
+            // Fire-and-forget cleanup on the JS thread
+            tsfn.call(
+                Ok(WasmRequest::DropInstance {
+                    instance_id: self.instance_id,
+                }),
+                ThreadsafeFunctionCallMode::NonBlocking,
+            );
+            tsfn.call(
+                Ok(WasmRequest::DropModule {
+                    module_id: self.module_id,
+                }),
+                ThreadsafeFunctionCallMode::NonBlocking,
+            );
+        }
+    }
+}

--- a/crates/swc-plugin-backend-napi/src/lib.rs
+++ b/crates/swc-plugin-backend-napi/src/lib.rs
@@ -23,7 +23,7 @@ static WASM_TSFN_ENV: OnceLock<usize> = OnceLock::new();
 
 /// Global host function registry: maps instance_id → Vec<Func>.
 /// Workers call back into these during WASM execution via NAPI.
-static HOST_FNS: LazyLock<Mutex<HashMap<u64, Arc<Vec<(String, runtime::Func)>>>>> =
+static HOST_FNS: LazyLock<Mutex<HashMap<u64, Arc<Vec<runtime::Func>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Global per-instance TSFN registry: maps instance_id → TSFN targeting the worker thread.
@@ -294,7 +294,7 @@ pub fn wasm_worker_dispatch_host_fn(
         )));
     }
 
-    let (ref _name, ref func) = host_functions[fn_index];
+    let func = &host_functions[fn_index];
     let result_count = func.sign.1 as usize;
 
     let mut caller = NapiDirectCaller {
@@ -557,52 +557,44 @@ fn instantiate_js(
     host_fn_descriptors: Vec<HostFnDescriptor>,
     reply: mpsc::SyncSender<anyhow::Result<u64>>,
 ) -> napi::Result<()> {
+    // Each descriptor is a [name, paramCount, resultCount, index] tuple —
+    // arrays are faster to construct and serialize than objects.
     let mut descriptors_arr = env.create_array_with_length(host_fn_descriptors.len())?;
     for (i, desc) in host_fn_descriptors.iter().enumerate() {
-        let mut obj = env.create_object()?;
-        obj.set_named_property("name", env.create_string(&desc.name)?)?;
-        obj.set_named_property("paramCount", env.create_int32(desc.param_count as i32)?)?;
-        obj.set_named_property("resultCount", env.create_int32(desc.result_count as i32)?)?;
-        obj.set_named_property("index", env.create_int32(desc.index as i32)?)?;
-        descriptors_arr.set_element(i as u32, obj)?;
+        let mut tuple = env.create_array_with_length(4)?;
+        tuple.set_element(0, env.create_string(&desc.name)?)?;
+        tuple.set_element(1, env.create_int32(desc.param_count as i32)?)?;
+        tuple.set_element(2, env.create_int32(desc.result_count as i32)?)?;
+        tuple.set_element(3, env.create_int32(desc.index as i32)?)?;
+        descriptors_arr.set_element(i as u32, tuple)?;
     }
 
+    // Single callback: JS calls with a number (instanceId) on success,
+    // or a string (error message) on failure.
+    let callback = env.create_function_from_closure("callback", move |ctx| {
+        let result: JsUnknown = ctx.get(0)?;
+        match result.get_type()? {
+            napi::ValueType::Number => {
+                let n: JsNumber = result.try_into()?;
+                let _ = reply.send(Ok(n.get_double()? as u64));
+            }
+            _ => {
+                let s: napi::JsString = result.try_into()?;
+                let msg = s.into_utf8()?.as_str()?.to_owned();
+                let _ = reply.send(Err(anyhow::anyhow!("Instantiate failed: {}", msg)));
+            }
+        }
+        ctx.env.get_undefined()
+    })?;
+
     let instantiate_fn: JsFunction = manager.get_named_property("instantiateOnWorker")?;
-    let result = instantiate_fn.call(
+    instantiate_fn.call(
         None,
         &[
             env.create_double(module_id as f64)?.into_unknown(),
             unsafe { JsUnknown::from_raw_unchecked(env.raw(), descriptors_arr.raw()) },
+            callback.into_unknown(),
         ],
-    )?;
-
-    let result: JsObject = result.try_into()?;
-    let instance_id: JsNumber = result.get_named_property("instanceId")?;
-    let instance_id_val = instance_id.get_double()? as u64;
-
-    // The promise resolves when the worker finishes instantiation.
-    let promise: JsObject = result.get_named_property("promise")?;
-    let then_fn: JsFunction = promise.get_named_property("then")?;
-
-    let reply_ok = reply.clone();
-    let resolve_cb = env.create_function_from_closure("resolve", move |ctx| {
-        let _ = reply_ok.send(Ok(instance_id_val));
-        ctx.env.get_undefined()
-    })?;
-
-    let reject_cb = env.create_function_from_closure("reject", move |ctx| {
-        let err: JsUnknown = ctx.get(0)?;
-        let msg = err
-            .coerce_to_string()
-            .and_then(|s| s.into_utf8()?.as_str().map(|s| s.to_owned()))
-            .unwrap_or_else(|_| "unknown error".to_string());
-        let _ = reply.send(Err(anyhow::anyhow!("Instantiate failed: {}", msg)));
-        ctx.env.get_undefined()
-    })?;
-
-    then_fn.call(
-        Some(&promise),
-        &[resolve_cb.into_unknown(), reject_cb.into_unknown()],
     )?;
 
     Ok(())
@@ -650,18 +642,18 @@ impl runtime::Runtime for NapiRuntime {
             }
         };
 
-        let host_fn_descriptors: Vec<HostFnDescriptor> = imports
-            .iter()
-            .enumerate()
-            .map(|(i, (name, func))| HostFnDescriptor {
-                name: name.clone(),
+        let mut host_fn_descriptors = Vec::with_capacity(imports.len());
+        let mut host_functions = Vec::with_capacity(imports.len());
+        for (i, (name, func)) in imports.into_iter().enumerate() {
+            host_fn_descriptors.push(HostFnDescriptor {
+                name,
                 param_count: func.sign.0,
                 result_count: func.sign.1,
                 index: i,
-            })
-            .collect();
-
-        let host_functions = Arc::new(imports);
+            });
+            host_functions.push(func);
+        }
+        let host_functions = Arc::new(host_functions);
 
         // Instantiate on a worker thread via TSFN → postMessage.
         // The worker will call wasmWorkerRegisterCallback to set up the per-instance TSFN.

--- a/crates/swc-plugin-backend-napi/src/lib.rs
+++ b/crates/swc-plugin-backend-napi/src/lib.rs
@@ -1,175 +1,51 @@
 use std::{
+    collections::HashMap,
     path::Path,
-    sync::{
-        Arc,
-        atomic::{AtomicU32, Ordering},
-        mpsc,
-    },
+    sync::{Arc, LazyLock, Mutex, OnceLock, mpsc},
 };
 
-use atomic_wait::{wait, wake_one};
 use napi::{
     Env, JsBuffer, JsFunction, JsNumber, JsObject, JsUnknown, NapiRaw, NapiValue, Status,
     threadsafe_function::{ThreadSafeCallContext, ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
-use once_cell::sync::OnceCell;
 use swc_plugin_runner::runtime;
 
 /// Identifier for cache stored in local filesystem.
 const NAPI_RUNTIME_ID: &str = "napi-v8-v1";
 
-/// Global TSFN for dispatching setup operations to the JS main thread.
-/// Transforms bypass this entirely and go directly to workers via Atomics.
-static WASM_TSFN: OnceCell<ThreadsafeFunction<WasmRequest>> = OnceCell::new();
+/// Global TSFN for dispatching operations to the JS main thread.
+/// Used for module compilation, instantiation, and non-hot-path memory ops.
+static WASM_TSFN: OnceLock<ThreadsafeFunction<WasmRequest>> = OnceLock::new();
 
-/// Worker shared memory regions, indexed by worker_index.
-static WORKERS: OnceCell<Vec<WorkerSharedMem>> = OnceCell::new();
+/// The raw napi_env pointer that registered the WASM runtime.
+/// Used to assert we're never re-registered from a different environment.
+static WASM_TSFN_ENV: OnceLock<usize> = OnceLock::new();
 
-// ---------------------------------------------------------------------------
-// Shared memory layout constants (must match wasm-worker.ts)
-// ---------------------------------------------------------------------------
+/// Global host function registry: maps instance_id → Vec<Func>.
+/// Workers call back into these during WASM execution via NAPI.
+static HOST_FNS: LazyLock<Mutex<HashMap<u64, Arc<Vec<(String, runtime::Func)>>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
-const FLAG: usize = 0;
-
-// Transform request/response (ctrl indices 1-6):
-const INSTANCE_ID: usize = 1;
-const PROGRAM_PTR: usize = 2;
-const PROGRAM_LEN: usize = 3;
-const UNRESOLVED_MARK: usize = 4;
-const COMMENTS_PROXY: usize = 5;
-const TRANSFORM_RESULT: usize = 6;
-
-// Host function callback (ctrl indices 7-9, args at 10+):
-const HOST_FN_INDEX: usize = 7;
-const HOST_FN_PARAM_COUNT: usize = 8;
-const HOST_FN_RESULT_COUNT: usize = 9;
-const HOST_FN_ARGS_START: usize = 10;
-
-// Memory operation (ctrl indices 7-10, reuses host fn space since they're exclusive):
-const MEM_OP_TYPE: usize = 7;
-const MEM_OP_PTR: usize = 8;
-const MEM_OP_LEN: usize = 9;
-const MEM_OP_RESULT: usize = 10;
-
-// Flag values (stored as u32 in Rust, i32 in JS — same bit pattern):
-const IDLE: u32 = 0;
-const TRANSFORM_REQ: u32 = 1;
-const TRANSFORM_RESP: u32 = 2;
-const HOST_FN_REQ: u32 = 3;
-const HOST_FN_RESP: u32 = 4;
-const MEM_OP_REQ: u32 = 5;
-const MEM_OP_RESP: u32 = 6;
-
-// Memory op types:
-const MEM_READ: u32 = 1;
-const MEM_WRITE: u32 = 2;
-const MEM_ALLOC: u32 = 3;
-const MEM_FREE: u32 = 4;
+/// Global per-instance TSFN registry: maps instance_id → TSFN targeting the worker thread.
+/// Used to dispatch transform/getDiag/memory ops to the correct worker.
+static INSTANCE_TSFNS: LazyLock<Mutex<HashMap<u64, ThreadsafeFunction<InstanceWork>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 // ---------------------------------------------------------------------------
-// Worker shared memory
+// Per-instance work dispatch via TSFN (no more Condvar work queue)
 // ---------------------------------------------------------------------------
 
-struct WorkerSharedMem {
-    /// Pointer to the control SharedArrayBuffer (treated as u32 slots).
-    /// JS uses Int32Array (i32) but the bit patterns are identical for our
-    /// small non-negative flag values and we only use atomic ops.
-    ctrl: *mut u32,
-    ctrl_len: usize, // number of u32 slots
-    data: *mut u8,
-    data_len: usize,
-}
-
-// SAFETY: SharedArrayBuffer memory is shared between Rust and JS worker threads.
-// Access is synchronized via atomic operations (futex-based wait/wake).
-unsafe impl Send for WorkerSharedMem {}
-unsafe impl Sync for WorkerSharedMem {}
-
-impl WorkerSharedMem {
-    fn flag(&self) -> &AtomicU32 {
-        self.atomic(FLAG)
-    }
-
-    fn atomic(&self, index: usize) -> &AtomicU32 {
-        assert!(index < self.ctrl_len);
-        unsafe { &*(self.ctrl.add(index) as *const AtomicU32) }
-    }
-
-    fn store(&self, index: usize, value: u32) {
-        self.atomic(index).store(value, Ordering::Release);
-    }
-
-    fn load(&self, index: usize) -> u32 {
-        self.atomic(index).load(Ordering::Acquire)
-    }
-
-    /// Block until flag != expected. Uses futex (same as Atomics.wait in V8).
-    fn wait_flag_change(&self, expected: u32) {
-        loop {
-            let current = self.flag().load(Ordering::Acquire);
-            if current != expected {
-                return;
-            }
-            wait(self.flag(), expected);
-        }
-    }
-
-    /// Wake one waiter on the flag. Uses futex (same as Atomics.notify in V8).
-    fn notify_flag(&self) {
-        wake_one(self.flag());
-    }
-
-    fn read_data(&self, buf: &mut [u8]) {
-        assert!(buf.len() <= self.data_len);
-        unsafe {
-            std::ptr::copy_nonoverlapping(self.data, buf.as_mut_ptr(), buf.len());
-        }
-    }
-
-    fn write_data(&self, buf: &[u8]) {
-        assert!(buf.len() <= self.data_len);
-        unsafe {
-            std::ptr::copy_nonoverlapping(buf.as_ptr(), self.data, buf.len());
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// TSFN request types (setup operations only — transforms bypass TSFN)
-// ---------------------------------------------------------------------------
-
-enum WasmRequest {
-    CompileModule {
-        wasm_bytes: Vec<u8>,
-        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+enum InstanceWork {
+    Transform {
+        program_ptr: u32,
+        program_len: u32,
+        unresolved_mark: u32,
+        comments_proxy: u32,
+        reply: mpsc::SyncSender<anyhow::Result<i32>>,
     },
-    CloneModule {
-        module_id: u64,
-        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+    GetDiag {
+        reply: mpsc::SyncSender<anyhow::Result<i32>>,
     },
-    /// Instantiate a module on a worker. Returns (instance_id, worker_index).
-    /// The TSFN callback sends the request to the worker via postMessage and
-    /// stores the reply sender. The worker's response (via the manager's
-    /// message handler) completes the reply.
-    Instantiate {
-        module_id: u64,
-        host_fn_descriptors: Vec<HostFnDescriptor>,
-        reply: mpsc::SyncSender<anyhow::Result<(u64, usize)>>,
-    },
-    /// Async operations on worker instances (go through postMessage).
-    WorkerOp {
-        instance_id: u64,
-        op: WorkerOp,
-    },
-    DropModule {
-        module_id: u64,
-    },
-    DropInstance {
-        instance_id: u64,
-    },
-}
-
-enum WorkerOp {
     ReadMemory {
         ptr: u32,
         len: u32,
@@ -189,14 +65,341 @@ enum WorkerOp {
         size: u32,
         reply: mpsc::SyncSender<anyhow::Result<u32>>,
     },
-    GetDiag {
-        reply: mpsc::SyncSender<anyhow::Result<u32>>,
+}
+
+// SAFETY: All fields are Send (mpsc::SyncSender is Send).
+unsafe impl Send for InstanceWork {}
+
+/// Dispatch work to an instance's worker thread via its TSFN and block for the result.
+fn instance_call_blocking<T: Send + 'static>(
+    instance_id: u64,
+    work_fn: impl FnOnce(mpsc::SyncSender<anyhow::Result<T>>) -> InstanceWork,
+) -> anyhow::Result<T> {
+    let tsfns = INSTANCE_TSFNS.lock().unwrap();
+    let tsfn = tsfns
+        .get(&instance_id)
+        .ok_or_else(|| anyhow::anyhow!("No TSFN for instance {}", instance_id))?;
+    let (tx, rx) = mpsc::sync_channel(1);
+    let work = work_fn(tx);
+    let status = tsfn.call(Ok(work), ThreadsafeFunctionCallMode::Blocking);
+    drop(tsfns); // Release lock before blocking
+    if !matches!(status, Status::Ok) {
+        anyhow::bail!("Instance TSFN call failed with status: {:?}", status);
+    }
+    rx.recv()
+        .map_err(|e| anyhow::anyhow!("Instance TSFN recv failed: {}", e))?
+}
+
+// ---------------------------------------------------------------------------
+// NAPI exports for worker threads
+// ---------------------------------------------------------------------------
+
+/// Called by worker after WASM instantiation to register a dispatch callback.
+///
+/// The `ops` object must have these methods:
+///   - transform(programPtr, programLen, unresolvedMark, commentsProxy) → number
+///   - getDiag() → number
+///   - readBuf(ptr, len) → Buffer
+///   - writeBuf(ptr, data: Buffer) → void
+///   - alloc(size) → number
+///   - free(ptr, size) → number
+///
+/// A TSFN is created targeting this worker's event loop. When Rust needs to
+/// call a WASM export, it posts to this TSFN, which runs the appropriate
+/// method on `ops` and sends the result back via a sync channel.
+#[napi_derive::napi]
+pub fn wasm_worker_register_callback(
+    env: Env,
+    instance_id: f64,
+    ops: JsObject,
+) -> napi::Result<()> {
+    let id = instance_id as u64;
+
+    // Extract and ref each function up front so we don't do property lookups on every call.
+    let transform_fn: JsFunction = ops.get_named_property("transform")?;
+    let diag_fn: JsFunction = ops.get_named_property("getDiag")?;
+    let read_fn: JsFunction = ops.get_named_property("readBuf")?;
+    let write_fn: JsFunction = ops.get_named_property("writeBuf")?;
+    let alloc_fn: JsFunction = ops.get_named_property("alloc")?;
+    let free_fn: JsFunction = ops.get_named_property("free")?;
+
+    let transform_ref = env.create_reference(&transform_fn)?;
+    let diag_ref = env.create_reference(&diag_fn)?;
+    let read_ref = env.create_reference(&read_fn)?;
+    let write_ref = env.create_reference(&write_fn)?;
+    let alloc_ref = env.create_reference(&alloc_fn)?;
+    let free_ref = env.create_reference(&free_fn)?;
+
+    // We need a JsFunction to create the TSFN from. Create a no-op.
+    let dummy_fn = env.create_function_from_closure("__instance_tsfn_noop", |ctx| {
+        ctx.env.get_undefined().map(|v| v.into_unknown())
+    })?;
+
+    let tsfn: ThreadsafeFunction<InstanceWork> = dummy_fn.create_threadsafe_function(
+        0,
+        move |ctx: ThreadSafeCallContext<InstanceWork>| {
+            let env = &ctx.env;
+
+            match ctx.value {
+                InstanceWork::Transform {
+                    program_ptr,
+                    program_len,
+                    unresolved_mark,
+                    comments_proxy,
+                    reply,
+                } => {
+                    let f: JsFunction = env.get_reference_value(&transform_ref)?;
+                    let result = f.call(
+                        None,
+                        &[
+                            env.create_uint32(program_ptr)?.into_unknown(),
+                            env.create_uint32(program_len)?.into_unknown(),
+                            env.create_uint32(unresolved_mark)?.into_unknown(),
+                            env.create_uint32(comments_proxy)?.into_unknown(),
+                        ],
+                    );
+                    match result {
+                        Ok(val) => {
+                            let n: JsNumber = val.try_into()?;
+                            let _ = reply.send(Ok(n.get_int32()?));
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(anyhow::anyhow!("{}", e)));
+                        }
+                    }
+                }
+                InstanceWork::GetDiag { reply } => {
+                    let f: JsFunction = env.get_reference_value(&diag_ref)?;
+                    let result = f.call::<JsUnknown>(None, &[]);
+                    match result {
+                        Ok(val) => {
+                            let n: JsNumber = val.try_into()?;
+                            let _ = reply.send(Ok(n.get_int32()?));
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(anyhow::anyhow!("{}", e)));
+                        }
+                    }
+                }
+                InstanceWork::ReadMemory { ptr, len, reply } => {
+                    let f: JsFunction = env.get_reference_value(&read_ref)?;
+                    let result = f.call(
+                        None,
+                        &[
+                            env.create_uint32(ptr)?.into_unknown(),
+                            env.create_uint32(len)?.into_unknown(),
+                        ],
+                    );
+                    match result {
+                        Ok(val) => {
+                            let buffer: JsBuffer = val.try_into()?;
+                            let data = buffer.into_value()?;
+                            let _ = reply.send(Ok(data.to_vec()));
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(anyhow::anyhow!("{}", e)));
+                        }
+                    }
+                }
+                InstanceWork::WriteMemory { ptr, data, reply } => {
+                    let f: JsFunction = env.get_reference_value(&write_ref)?;
+                    let js_buf = env.create_buffer_with_data(data)?.into_raw();
+                    let result = f.call(
+                        None,
+                        &[
+                            env.create_uint32(ptr)?.into_unknown(),
+                            js_buf.into_unknown(),
+                        ],
+                    );
+                    match result {
+                        Ok(_) => {
+                            let _ = reply.send(Ok(()));
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(anyhow::anyhow!("{}", e)));
+                        }
+                    }
+                }
+                InstanceWork::Alloc { size, reply } => {
+                    let f: JsFunction = env.get_reference_value(&alloc_ref)?;
+                    let result = f.call(None, &[env.create_uint32(size)?.into_unknown()]);
+                    match result {
+                        Ok(val) => {
+                            let n: JsNumber = val.try_into()?;
+                            let _ = reply.send(Ok(n.get_uint32()?));
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(anyhow::anyhow!("{}", e)));
+                        }
+                    }
+                }
+                InstanceWork::Free { ptr, size, reply } => {
+                    let f: JsFunction = env.get_reference_value(&free_ref)?;
+                    let result = f.call(
+                        None,
+                        &[
+                            env.create_uint32(ptr)?.into_unknown(),
+                            env.create_uint32(size)?.into_unknown(),
+                        ],
+                    );
+                    match result {
+                        Ok(val) => {
+                            let n: JsNumber = val.try_into()?;
+                            let _ = reply.send(Ok(n.get_uint32()?));
+                        }
+                        Err(e) => {
+                            let _ = reply.send(Err(anyhow::anyhow!("{}", e)));
+                        }
+                    }
+                }
+            }
+            Ok(Vec::<JsUnknown>::new())
+        },
+    )?;
+
+    INSTANCE_TSFNS.lock().unwrap().insert(id, tsfn);
+    Ok(())
+}
+
+/// Called by worker when WASM hits a host function import.
+/// Runs the Func closure synchronously on the worker thread and returns the result.
+///
+/// The worker provides a `memoryAccessor` object with methods to read/write WASM memory:
+///   - readBuf(ptr, len) → Buffer
+///   - writeBuf(ptr, data: Buffer) → void
+///   - alloc(size) → number
+///   - free(ptr, size) → number
+#[napi_derive::napi]
+pub fn wasm_worker_dispatch_host_fn(
+    env: Env,
+    instance_id: f64,
+    fn_index: u32,
+    args: Vec<i32>,
+    memory_accessor: JsObject,
+) -> napi::Result<JsUnknown> {
+    let id = instance_id as u64;
+    let fns = HOST_FNS.lock().unwrap();
+    let host_functions = fns
+        .get(&id)
+        .ok_or_else(|| napi::Error::from_reason(format!("No host fns for instance {}", id)))?
+        .clone();
+    drop(fns); // Release lock before calling the closure
+
+    let fn_index = fn_index as usize;
+    if fn_index >= host_functions.len() {
+        return Err(napi::Error::from_reason(format!(
+            "Host fn index {} out of range (max {})",
+            fn_index,
+            host_functions.len()
+        )));
+    }
+
+    let (ref _name, ref func) = host_functions[fn_index];
+    let result_count = func.sign.1 as usize;
+
+    let mut caller = NapiDirectCaller {
+        env: &env,
+        accessor: &memory_accessor,
+    };
+
+    let mut output = vec![0i32; result_count];
+    (func.func)(&mut caller, &args, &mut output);
+
+    if result_count == 0 {
+        env.get_undefined().map(|v| v.into_unknown())
+    } else {
+        env.create_int32(output[0]).map(|v| v.into_unknown())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// NapiDirectCaller: memory ops via direct NAPI calls on the worker thread
+// ---------------------------------------------------------------------------
+
+struct NapiDirectCaller<'a> {
+    env: &'a Env,
+    accessor: &'a JsObject,
+}
+
+impl<'a> runtime::Caller<'a> for NapiDirectCaller<'a> {
+    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
+        let read_fn: JsFunction = self.accessor.get_named_property("readBuf")?;
+        let result = read_fn.call(
+            None,
+            &[
+                self.env.create_uint32(ptr)?.into_unknown(),
+                self.env.create_uint32(buf.len() as u32)?.into_unknown(),
+            ],
+        )?;
+        let buffer: JsBuffer = result.try_into()?;
+        let data = buffer.into_value()?;
+        buf.copy_from_slice(&data);
+        Ok(())
+    }
+
+    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
+        let write_fn: JsFunction = self.accessor.get_named_property("writeBuf")?;
+        let js_buf = self.env.create_buffer_with_data(buf.to_vec())?.into_raw();
+        write_fn.call(
+            None,
+            &[
+                self.env.create_uint32(ptr)?.into_unknown(),
+                js_buf.into_unknown(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
+        let alloc_fn: JsFunction = self.accessor.get_named_property("alloc")?;
+        let result = alloc_fn.call(None, &[self.env.create_uint32(size)?.into_unknown()])?;
+        let n: JsNumber = result.try_into()?;
+        Ok(n.get_uint32()?)
+    }
+
+    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
+        let free_fn: JsFunction = self.accessor.get_named_property("free")?;
+        let result = free_fn.call(
+            None,
+            &[
+                self.env.create_uint32(ptr)?.into_unknown(),
+                self.env.create_uint32(size)?.into_unknown(),
+            ],
+        )?;
+        let n: JsNumber = result.try_into()?;
+        Ok(n.get_uint32()?)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TSFN request types (main-thread operations only)
+// ---------------------------------------------------------------------------
+
+enum WasmRequest {
+    CompileModule {
+        wasm_bytes: Vec<u8>,
+        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+    },
+    CloneModule {
+        module_id: u64,
+        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+    },
+    /// Instantiate a module on a worker. Returns instance_id.
+    Instantiate {
+        module_id: u64,
+        host_fn_descriptors: Vec<HostFnDescriptor>,
+        reply: mpsc::SyncSender<anyhow::Result<u64>>,
+    },
+    DropModule {
+        module_id: u64,
+    },
+    DropInstance {
+        instance_id: u64,
     },
 }
 
 // SAFETY: All fields are Send.
 unsafe impl Send for WasmRequest {}
-unsafe impl Send for WorkerOp {}
 
 struct HostFnDescriptor {
     name: String,
@@ -210,40 +413,30 @@ struct HostFnDescriptor {
 // ---------------------------------------------------------------------------
 
 pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<()> {
+    let env_addr = env.raw() as usize;
+
+    // Idempotent: skip if already registered from the same Env.
+    if WASM_TSFN.get().is_some() {
+        let registered_env = WASM_TSFN_ENV.get().copied().unwrap_or(0);
+        assert_eq!(
+            registered_env, env_addr,
+            "WASM runtime already registered from a different napi_env"
+        );
+        return Ok(());
+    }
+
     let mut global = env.get_global()?;
     global.set_named_property("__nextSwcWasmManager", js_manager)?;
 
-    // Initialize worker pool.
+    // Initialize worker pool (no SABs — workers load native addon directly).
     let init_fn: JsFunction = js_manager.get_named_property("initWorkerPool")?;
     let worker_count = num_cpus().max(1);
-    let worker_configs = init_fn.call(
+    init_fn.call(
         None,
         &[env.create_uint32(worker_count as u32)?.into_unknown()],
     )?;
-    let worker_configs: JsObject = worker_configs.try_into()?;
 
-    let mut worker_mems = Vec::with_capacity(worker_count);
-    for i in 0..worker_count {
-        let config: JsObject = worker_configs.get_element(i as u32)?;
-        let ctrl_sab: JsObject = config.get_named_property("ctrlBuffer")?;
-        let data_sab: JsObject = config.get_named_property("dataBuffer")?;
-
-        let (ctrl_ptr, ctrl_byte_len) = get_sab_info(env, &ctrl_sab)?;
-        let (data_ptr, data_byte_len) = get_sab_info(env, &data_sab)?;
-
-        worker_mems.push(WorkerSharedMem {
-            ctrl: ctrl_ptr as *mut u32,
-            ctrl_len: ctrl_byte_len / 4,
-            data: data_ptr as *mut u8,
-            data_len: data_byte_len,
-        });
-    }
-
-    WORKERS
-        .set(worker_mems)
-        .map_err(|_| napi::Error::from_reason("Workers already registered"))?;
-
-    // Create TSFN for setup operations.
+    // Create TSFN for main-thread operations.
     let dummy_fn = env.create_function_from_closure("__wasm_tsfn_noop", |ctx| {
         ctx.env.get_undefined().map(|v| v.into_unknown())
     })?;
@@ -259,6 +452,7 @@ pub fn register_wasm_runtime(env: &Env, js_manager: &JsObject) -> napi::Result<(
     WASM_TSFN
         .set(tsfn)
         .map_err(|_| napi::Error::from_reason("WASM TSFN already registered"))?;
+    let _ = WASM_TSFN_ENV.set(env_addr);
 
     Ok(())
 }
@@ -269,22 +463,8 @@ fn num_cpus() -> usize {
         .unwrap_or(4)
 }
 
-fn get_sab_info(env: &Env, sab: &JsObject) -> napi::Result<(*mut u8, usize)> {
-    let mut data = std::ptr::null_mut();
-    let mut len = 0;
-    let status =
-        unsafe { napi::sys::napi_get_arraybuffer_info(env.raw(), sab.raw(), &mut data, &mut len) };
-    if status != napi::sys::Status::napi_ok {
-        return Err(napi::Error::from_reason(format!(
-            "Failed to get SharedArrayBuffer info: {:?}",
-            status
-        )));
-    }
-    Ok((data as *mut u8, len))
-}
-
 // ---------------------------------------------------------------------------
-// TSFN callback
+// TSFN callback (runs on main JS thread)
 // ---------------------------------------------------------------------------
 
 fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> napi::Result<()> {
@@ -304,19 +484,10 @@ fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> n
             host_fn_descriptors,
             reply,
         } => {
-            // This calls instantiateOnWorker which returns sync metadata +
-            // an async promise for the actual instantiation. We register
-            // a promise callback to complete the reply.
             let result = instantiate_js(env, manager, module_id, host_fn_descriptors, reply);
             if let Err(e) = result {
-                // If setup failed, the reply was already consumed or needs to be sent.
-                // Just log — reply sender was moved into instantiate_js.
-                eprintln!("Instantiate setup failed: {}", e);
+                eprintln!("[napi-wasm] Instantiate setup failed: {}", e);
             }
-        }
-
-        WasmRequest::WorkerOp { instance_id, op } => {
-            handle_worker_op(env, manager, instance_id, op);
         }
 
         WasmRequest::DropModule { module_id } => {
@@ -325,6 +496,15 @@ fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> n
         }
 
         WasmRequest::DropInstance { instance_id } => {
+            // Remove the per-instance TSFN (signals worker to stop receiving work)
+            {
+                let mut tsfns = INSTANCE_TSFNS.lock().unwrap();
+                tsfns.remove(&instance_id);
+            }
+
+            // Clean up host functions
+            HOST_FNS.lock().unwrap().remove(&instance_id);
+
             let drop_fn: JsFunction = manager.get_named_property("dropInstance")?;
             drop_fn.call(
                 None,
@@ -375,7 +555,7 @@ fn instantiate_js(
     manager: &JsObject,
     module_id: u64,
     host_fn_descriptors: Vec<HostFnDescriptor>,
-    reply: mpsc::SyncSender<anyhow::Result<(u64, usize)>>,
+    reply: mpsc::SyncSender<anyhow::Result<u64>>,
 ) -> napi::Result<()> {
     let mut descriptors_arr = env.create_array_with_length(host_fn_descriptors.len())?;
     for (i, desc) in host_fn_descriptors.iter().enumerate() {
@@ -398,18 +578,15 @@ fn instantiate_js(
 
     let result: JsObject = result.try_into()?;
     let instance_id: JsNumber = result.get_named_property("instanceId")?;
-    let worker_index: JsNumber = result.get_named_property("workerIndex")?;
     let instance_id_val = instance_id.get_double()? as u64;
-    let worker_index_val = worker_index.get_uint32()? as usize;
 
     // The promise resolves when the worker finishes instantiation.
-    // Attach .then() to send the reply when ready.
     let promise: JsObject = result.get_named_property("promise")?;
     let then_fn: JsFunction = promise.get_named_property("then")?;
 
     let reply_ok = reply.clone();
     let resolve_cb = env.create_function_from_closure("resolve", move |ctx| {
-        let _ = reply_ok.send(Ok((instance_id_val, worker_index_val)));
+        let _ = reply_ok.send(Ok(instance_id_val));
         ctx.env.get_undefined()
     })?;
 
@@ -420,133 +597,6 @@ fn instantiate_js(
             .and_then(|s| s.into_utf8()?.as_str().map(|s| s.to_owned()))
             .unwrap_or_else(|_| "unknown error".to_string());
         let _ = reply.send(Err(anyhow::anyhow!("Instantiate failed: {}", msg)));
-        ctx.env.get_undefined()
-    })?;
-
-    then_fn.call(
-        Some(&promise),
-        &[resolve_cb.into_unknown(), reject_cb.into_unknown()],
-    )?;
-
-    Ok(())
-}
-
-/// Handle async worker operations. These go through the manager's postMessage
-/// methods which return promises. We attach .then() to complete the reply.
-fn handle_worker_op(env: &Env, manager: &JsObject, instance_id: u64, op: WorkerOp) {
-    let result = match op {
-        WorkerOp::ReadMemory { ptr, len, reply } => handle_promise_op(
-            env,
-            manager,
-            "readMemoryAsync",
-            instance_id,
-            reply,
-            |env, args| {
-                args.push(env.create_uint32(ptr)?.into_unknown());
-                args.push(env.create_uint32(len)?.into_unknown());
-                Ok(())
-            },
-            |_env, val| {
-                let buf: JsBuffer = val.try_into()?;
-                Ok(buf.into_value()?.to_vec())
-            },
-        ),
-        WorkerOp::WriteMemory { ptr, data, reply } => handle_promise_op(
-            env,
-            manager,
-            "writeMemoryAsync",
-            instance_id,
-            reply,
-            |env, args| {
-                args.push(env.create_uint32(ptr)?.into_unknown());
-                let buffer = env.create_buffer_with_data(data)?.into_raw();
-                args.push(buffer.into_unknown());
-                Ok(())
-            },
-            |_env, _val| Ok(()),
-        ),
-        WorkerOp::Alloc { size, reply } => handle_promise_op(
-            env,
-            manager,
-            "allocAsync",
-            instance_id,
-            reply,
-            |env, args| {
-                args.push(env.create_uint32(size)?.into_unknown());
-                Ok(())
-            },
-            |_env, val| {
-                let n: JsNumber = val.try_into()?;
-                Ok(n.get_uint32()?)
-            },
-        ),
-        WorkerOp::Free { ptr, size, reply } => handle_promise_op(
-            env,
-            manager,
-            "freeAsync",
-            instance_id,
-            reply,
-            |env, args| {
-                args.push(env.create_uint32(ptr)?.into_unknown());
-                args.push(env.create_uint32(size)?.into_unknown());
-                Ok(())
-            },
-            |_env, val| {
-                let n: JsNumber = val.try_into()?;
-                Ok(n.get_uint32()?)
-            },
-        ),
-        WorkerOp::GetDiag { reply } => handle_promise_op(
-            env,
-            manager,
-            "getDiagAsync",
-            instance_id,
-            reply,
-            |_env, _args| Ok(()),
-            |_env, val| {
-                let n: JsNumber = val.try_into()?;
-                Ok(n.get_uint32()?)
-            },
-        ),
-    };
-
-    if let Err(e) = result {
-        eprintln!("Worker op setup failed: {}", e);
-    }
-}
-
-fn handle_promise_op<T: Send + 'static>(
-    env: &Env,
-    manager: &JsObject,
-    method: &str,
-    instance_id: u64,
-    reply: mpsc::SyncSender<anyhow::Result<T>>,
-    setup_args: impl FnOnce(&Env, &mut Vec<JsUnknown>) -> napi::Result<()>,
-    extract: impl Fn(&Env, JsUnknown) -> napi::Result<T> + Send + 'static,
-) -> napi::Result<()> {
-    let func: JsFunction = manager.get_named_property(method)?;
-    let mut args: Vec<JsUnknown> = vec![env.create_double(instance_id as f64)?.into_unknown()];
-    setup_args(env, &mut args)?;
-
-    let promise = func.call(None, &args)?;
-    let promise: JsObject = promise.try_into()?;
-    let then_fn: JsFunction = promise.get_named_property("then")?;
-
-    let reply_ok = reply.clone();
-    let resolve_cb = env.create_function_from_closure("resolve", move |ctx| {
-        let val: JsUnknown = ctx.get(0)?;
-        let result = extract(ctx.env, val).map_err(|e| anyhow::anyhow!("{}", e));
-        let _ = reply_ok.send(result);
-        ctx.env.get_undefined()
-    })?;
-
-    let reject_cb = env.create_function_from_closure("reject", move |ctx| {
-        let err: JsUnknown = ctx.get(0)?;
-        let msg = err
-            .coerce_to_string()
-            .and_then(|s| s.into_utf8()?.as_str().map(|s| s.to_owned()))
-            .unwrap_or_else(|_| "unknown error".to_string());
-        let _ = reply.send(Err(anyhow::anyhow!("{}", msg)));
         ctx.env.get_undefined()
     })?;
 
@@ -613,26 +663,27 @@ impl runtime::Runtime for NapiRuntime {
 
         let host_functions = Arc::new(imports);
 
-        // Instantiate on a worker thread. The reply comes back asynchronously
-        // when the worker's promise resolves.
-        let (instance_id, worker_index) = tsfn_call_blocking(|reply| WasmRequest::Instantiate {
+        // Instantiate on a worker thread via TSFN → postMessage.
+        // The worker will call wasmWorkerRegisterCallback to set up the per-instance TSFN.
+        let instance_id = tsfn_call_blocking(|reply| WasmRequest::Instantiate {
             module_id,
             host_fn_descriptors,
             reply,
         })??;
 
-        // getDiag handshake to verify the instance is ready.
-        let _diag = tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
-            instance_id,
-            op: WorkerOp::GetDiag { reply },
-        })??;
+        // Store host functions so worker can call them via NAPI.
+        HOST_FNS.lock().unwrap().insert(instance_id, host_functions);
 
-        Ok(Box::new(NapiInstance {
+        let mut instance = NapiInstance {
             instance_id,
             module_id,
-            worker_index,
-            host_functions,
-        }))
+        };
+
+        // The runtime contract requires calling __get_transform_plugin_core_pkg_diag
+        // after instantiation to populate diagnostics.
+        instance.get_diag()?;
+
+        Ok(Box::new(instance))
     }
 
     fn clone_cache(&self, cache: &runtime::ModuleCache) -> Option<runtime::ModuleCache> {
@@ -664,17 +715,9 @@ impl runtime::Runtime for NapiRuntime {
 struct NapiInstance {
     instance_id: u64,
     module_id: u64,
-    worker_index: usize,
-    host_functions: Arc<Vec<(String, runtime::Func)>>,
 }
 
 unsafe impl Sync for NapiInstance {}
-
-impl NapiInstance {
-    fn worker(&self) -> &WorkerSharedMem {
-        &WORKERS.get().expect("Workers not initialized")[self.worker_index]
-    }
-}
 
 impl runtime::Instance for NapiInstance {
     fn transform(
@@ -684,50 +727,21 @@ impl runtime::Instance for NapiInstance {
         unresolved_mark: u32,
         should_enable_comments_proxy: u32,
     ) -> anyhow::Result<u32> {
-        let w = self.worker();
+        let result = instance_call_blocking(self.instance_id, |reply| InstanceWork::Transform {
+            program_ptr,
+            program_len,
+            unresolved_mark,
+            comments_proxy: should_enable_comments_proxy,
+            reply,
+        })?;
 
-        // Write transform args to shared memory.
-        w.store(INSTANCE_ID, self.instance_id as u32);
-        w.store(PROGRAM_PTR, program_ptr);
-        w.store(PROGRAM_LEN, program_len);
-        w.store(UNRESOLVED_MARK, unresolved_mark);
-        w.store(COMMENTS_PROXY, should_enable_comments_proxy);
-
-        // Signal worker.
-        w.store(FLAG, TRANSFORM_REQ);
-        w.notify_flag();
-
-        // Process host function callbacks until transform completes.
-        loop {
-            w.wait_flag_change(TRANSFORM_REQ);
-            let flag = w.load(FLAG);
-
-            if flag == TRANSFORM_RESP {
-                let result = w.load(TRANSFORM_RESULT);
-                // Reset to IDLE for next operation.
-                w.store(FLAG, IDLE);
-                w.notify_flag();
-
-                // Worker stores u32::MAX (0xFFFFFFFF, which is -1 as i32) on error
-                if result == u32::MAX {
-                    anyhow::bail!("Transform failed in worker");
-                }
-                return Ok(result);
-            }
-
-            if flag == HOST_FN_REQ {
-                self.handle_host_fn_call(w)?;
-                // After HOST_FN_RESP, the worker continues. Wait for next event.
-                continue;
-            }
-
-            // Unexpected flag — bail
-            anyhow::bail!("Unexpected flag during transform: {}", flag);
+        if result == -1 {
+            anyhow::bail!("Transform failed in worker");
         }
+        Ok(result as u32)
     }
 
     fn caller(&mut self) -> anyhow::Result<Box<dyn runtime::Caller<'_> + '_>> {
-        // Outside of transform, use TSFN-based caller (postMessage path).
         Ok(Box::new(TsfnCaller {
             instance_id: self.instance_id,
         }))
@@ -739,39 +753,14 @@ impl runtime::Instance for NapiInstance {
 }
 
 impl NapiInstance {
-    fn handle_host_fn_call(&self, w: &WorkerSharedMem) -> anyhow::Result<()> {
-        let fn_index = w.load(HOST_FN_INDEX) as usize;
-        let param_count = w.load(HOST_FN_PARAM_COUNT) as usize;
-        let result_count = w.load(HOST_FN_RESULT_COUNT) as usize;
+    fn get_diag(&mut self) -> anyhow::Result<u32> {
+        let result =
+            instance_call_blocking(self.instance_id, |reply| InstanceWork::GetDiag { reply })?;
 
-        let mut input = vec![0i32; param_count];
-        for i in 0..param_count {
-            input[i] = w.load(HOST_FN_ARGS_START + i) as i32;
+        if result == -1 {
+            anyhow::bail!("getDiag failed in worker");
         }
-
-        let (ref _name, ref func) = self.host_functions[fn_index];
-
-        // The Caller for host function callbacks uses Atomics to proxy
-        // memory operations to the worker.
-        let mut caller = TransformCaller { worker: w };
-
-        let mut output = vec![0i32; result_count];
-        (func.func)(&mut caller, &input, &mut output);
-
-        // Write results to shared memory.
-        for (i, &v) in output.iter().enumerate() {
-            w.store(HOST_FN_ARGS_START + i, v as u32);
-        }
-
-        // Signal worker that host function is complete.
-        w.store(FLAG, HOST_FN_RESP);
-        w.notify_flag();
-
-        // Wait for worker to continue — it will set HOST_FN_REQ (another
-        // callback) or TRANSFORM_RESP (done). The outer loop handles both.
-        w.wait_flag_change(HOST_FN_RESP);
-
-        Ok(())
+        Ok(result as u32)
     }
 }
 
@@ -795,95 +784,7 @@ impl Drop for NapiInstance {
 }
 
 // ---------------------------------------------------------------------------
-// TransformCaller: memory ops via SharedArrayBuffer (during transform)
-// ---------------------------------------------------------------------------
-
-struct TransformCaller<'a> {
-    worker: &'a WorkerSharedMem,
-}
-
-impl<'a> runtime::Caller<'a> for TransformCaller<'a> {
-    fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
-        let w = self.worker;
-
-        w.store(MEM_OP_TYPE, MEM_READ);
-        w.store(MEM_OP_PTR, ptr);
-        w.store(MEM_OP_LEN, buf.len() as u32);
-
-        w.store(FLAG, MEM_OP_REQ);
-        w.notify_flag();
-        w.wait_flag_change(MEM_OP_REQ);
-
-        let flag = w.load(FLAG);
-        if flag != MEM_OP_RESP {
-            anyhow::bail!("Expected MEM_OP_RESP after read, got {}", flag);
-        }
-
-        w.read_data(buf);
-        Ok(())
-    }
-
-    fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
-        let w = self.worker;
-
-        w.write_data(buf);
-
-        w.store(MEM_OP_TYPE, MEM_WRITE);
-        w.store(MEM_OP_PTR, ptr);
-        w.store(MEM_OP_LEN, buf.len() as u32);
-
-        w.store(FLAG, MEM_OP_REQ);
-        w.notify_flag();
-        w.wait_flag_change(MEM_OP_REQ);
-
-        let flag = w.load(FLAG);
-        if flag != MEM_OP_RESP {
-            anyhow::bail!("Expected MEM_OP_RESP after write, got {}", flag);
-        }
-
-        Ok(())
-    }
-
-    fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
-        let w = self.worker;
-
-        w.store(MEM_OP_TYPE, MEM_ALLOC);
-        w.store(MEM_OP_LEN, size);
-
-        w.store(FLAG, MEM_OP_REQ);
-        w.notify_flag();
-        w.wait_flag_change(MEM_OP_REQ);
-
-        let flag = w.load(FLAG);
-        if flag != MEM_OP_RESP {
-            anyhow::bail!("Expected MEM_OP_RESP after alloc, got {}", flag);
-        }
-
-        Ok(w.load(MEM_OP_RESULT) as u32)
-    }
-
-    fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
-        let w = self.worker;
-
-        w.store(MEM_OP_TYPE, MEM_FREE);
-        w.store(MEM_OP_PTR, ptr);
-        w.store(MEM_OP_LEN, size);
-
-        w.store(FLAG, MEM_OP_REQ);
-        w.notify_flag();
-        w.wait_flag_change(MEM_OP_REQ);
-
-        let flag = w.load(FLAG);
-        if flag != MEM_OP_RESP {
-            anyhow::bail!("Expected MEM_OP_RESP after free, got {}", flag);
-        }
-
-        Ok(w.load(MEM_OP_RESULT) as u32)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// TsfnCaller: memory ops via TSFN+postMessage (outside of transform)
+// TsfnCaller: memory ops via per-instance TSFN
 // ---------------------------------------------------------------------------
 
 struct TsfnCaller {
@@ -893,36 +794,35 @@ struct TsfnCaller {
 impl<'a> runtime::Caller<'a> for TsfnCaller {
     fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
         let len = buf.len() as u32;
-        let data = tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
-            instance_id: self.instance_id,
-            op: WorkerOp::ReadMemory { ptr, len, reply },
-        })??;
+        let data = instance_call_blocking(self.instance_id, |reply| InstanceWork::ReadMemory {
+            ptr,
+            len,
+            reply,
+        })?;
         buf.copy_from_slice(&data);
         Ok(())
     }
 
     fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
-        tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
-            instance_id: self.instance_id,
-            op: WorkerOp::WriteMemory {
-                ptr,
-                data: buf.to_vec(),
-                reply,
-            },
-        })?
+        instance_call_blocking(self.instance_id, |reply| InstanceWork::WriteMemory {
+            ptr,
+            data: buf.to_vec(),
+            reply,
+        })
     }
 
     fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
-        tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
-            instance_id: self.instance_id,
-            op: WorkerOp::Alloc { size, reply },
-        })?
+        instance_call_blocking(self.instance_id, |reply| InstanceWork::Alloc {
+            size,
+            reply,
+        })
     }
 
     fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
-        tsfn_call_blocking(|reply| WasmRequest::WorkerOp {
-            instance_id: self.instance_id,
-            op: WorkerOp::Free { ptr, size, reply },
-        })?
+        instance_call_blocking(self.instance_id, |reply| InstanceWork::Free {
+            ptr,
+            size,
+            reply,
+        })
     }
 }

--- a/crates/swc-plugin-backend-napi/src/lib.rs
+++ b/crates/swc-plugin-backend-napi/src/lib.rs
@@ -1,4 +1,5 @@
 use std::{
+    cell::UnsafeCell,
     collections::HashMap,
     path::Path,
     sync::{Arc, LazyLock, Mutex, OnceLock, mpsc},
@@ -28,7 +29,7 @@ static HOST_FNS: LazyLock<Mutex<HashMap<u64, Arc<Vec<runtime::Func>>>>> =
 
 /// Global per-instance TSFN registry: maps instance_id → TSFN targeting the worker thread.
 /// Used to dispatch transform/getDiag/memory ops to the correct worker.
-static INSTANCE_TSFNS: LazyLock<Mutex<HashMap<u64, ThreadsafeFunction<InstanceWork>>>> =
+static INSTANCE_TSFNS: LazyLock<Mutex<HashMap<u64, Arc<ThreadsafeFunction<InstanceWork>>>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 // ---------------------------------------------------------------------------
@@ -65,24 +66,62 @@ enum InstanceWork {
         size: u32,
         reply: mpsc::SyncSender<anyhow::Result<u32>>,
     },
+    /// Unref all NAPI Refs before the TSFN is dropped.
+    Cleanup {
+        reply: mpsc::SyncSender<anyhow::Result<()>>,
+    },
 }
 
 // SAFETY: All fields are Send (mpsc::SyncSender is Send).
 unsafe impl Send for InstanceWork {}
 
+/// Wrapper around `Option<napi::Ref<()>>` that is `Send`.
+///
+/// SAFETY: All access happens on the worker thread's TSFN callback, which is
+/// single-threaded and serialized by the event loop. The `Send` impl is needed
+/// because the TSFN closure must be `Send`, but we never actually access the
+/// inner value from multiple threads.
+struct OptRef(UnsafeCell<Option<napi::Ref<()>>>);
+unsafe impl Send for OptRef {}
+
+impl OptRef {
+    fn new(r: napi::Ref<()>) -> Self {
+        Self(UnsafeCell::new(Some(r)))
+    }
+
+    /// Take the ref out and unref it. Returns `None` if already taken.
+    ///
+    /// SAFETY: Caller must ensure this is called on the same JS thread that
+    /// created the ref, and that no other access is concurrent.
+    unsafe fn take_and_unref(&self, env: Env) -> napi::Result<()> {
+        if let Some(mut r) = unsafe { (*self.0.get()).take() } {
+            r.unref(env)?;
+        }
+        Ok(())
+    }
+
+    /// Get a reference to the inner Ref.
+    ///
+    /// SAFETY: Caller must ensure no concurrent mutable access.
+    unsafe fn as_ref(&self) -> Option<&napi::Ref<()>> {
+        unsafe { (*self.0.get()).as_ref() }
+    }
+}
+
 /// Dispatch work to an instance's worker thread via its TSFN and block for the result.
 fn instance_call_blocking<T: Send + 'static>(
     instance_id: u64,
-    work_fn: impl FnOnce(mpsc::SyncSender<anyhow::Result<T>>) -> InstanceWork,
+    work: InstanceWork,
+    rx: mpsc::Receiver<anyhow::Result<T>>,
 ) -> anyhow::Result<T> {
-    let tsfns = INSTANCE_TSFNS.lock().unwrap();
-    let tsfn = tsfns
-        .get(&instance_id)
-        .ok_or_else(|| anyhow::anyhow!("No TSFN for instance {}", instance_id))?;
-    let (tx, rx) = mpsc::sync_channel(1);
-    let work = work_fn(tx);
+    let tsfn = {
+        let tsfns = INSTANCE_TSFNS.lock().unwrap();
+        tsfns
+            .get(&instance_id)
+            .ok_or_else(|| anyhow::anyhow!("No TSFN for instance {}", instance_id))?
+            .clone()
+    };
     let status = tsfn.call(Ok(work), ThreadsafeFunctionCallMode::Blocking);
-    drop(tsfns); // Release lock before blocking
     if !matches!(status, Status::Ok) {
         anyhow::bail!("Instance TSFN call failed with status: {:?}", status);
     }
@@ -123,12 +162,12 @@ pub fn wasm_worker_register_callback(
     let alloc_fn: JsFunction = ops.get_named_property("alloc")?;
     let free_fn: JsFunction = ops.get_named_property("free")?;
 
-    let transform_ref = env.create_reference(&transform_fn)?;
-    let diag_ref = env.create_reference(&diag_fn)?;
-    let read_ref = env.create_reference(&read_fn)?;
-    let write_ref = env.create_reference(&write_fn)?;
-    let alloc_ref = env.create_reference(&alloc_fn)?;
-    let free_ref = env.create_reference(&free_fn)?;
+    let transform_ref = OptRef::new(env.create_reference(&transform_fn)?);
+    let diag_ref = OptRef::new(env.create_reference(&diag_fn)?);
+    let read_ref = OptRef::new(env.create_reference(&read_fn)?);
+    let write_ref = OptRef::new(env.create_reference(&write_fn)?);
+    let alloc_ref = OptRef::new(env.create_reference(&alloc_fn)?);
+    let free_ref = OptRef::new(env.create_reference(&free_fn)?);
 
     // We need a JsFunction to create the TSFN from. Create a no-op.
     let dummy_fn = env.create_function_from_closure("__instance_tsfn_noop", |ctx| {
@@ -140,6 +179,8 @@ pub fn wasm_worker_register_callback(
         move |ctx: ThreadSafeCallContext<InstanceWork>| {
             let env = &ctx.env;
 
+            // SAFETY: All access to OptRef happens on this worker thread's
+            // TSFN callback, which is serialized by the event loop.
             match ctx.value {
                 InstanceWork::Transform {
                     program_ptr,
@@ -148,7 +189,8 @@ pub fn wasm_worker_register_callback(
                     comments_proxy,
                     reply,
                 } => {
-                    let f: JsFunction = env.get_reference_value(&transform_ref)?;
+                    let r = unsafe { transform_ref.as_ref() }.unwrap();
+                    let f: JsFunction = env.get_reference_value(r)?;
                     let result = f.call(
                         None,
                         &[
@@ -169,7 +211,8 @@ pub fn wasm_worker_register_callback(
                     }
                 }
                 InstanceWork::GetDiag { reply } => {
-                    let f: JsFunction = env.get_reference_value(&diag_ref)?;
+                    let r = unsafe { diag_ref.as_ref() }.unwrap();
+                    let f: JsFunction = env.get_reference_value(r)?;
                     let result = f.call::<JsUnknown>(None, &[]);
                     match result {
                         Ok(val) => {
@@ -182,7 +225,8 @@ pub fn wasm_worker_register_callback(
                     }
                 }
                 InstanceWork::ReadMemory { ptr, len, reply } => {
-                    let f: JsFunction = env.get_reference_value(&read_ref)?;
+                    let r = unsafe { read_ref.as_ref() }.unwrap();
+                    let f: JsFunction = env.get_reference_value(r)?;
                     let result = f.call(
                         None,
                         &[
@@ -202,7 +246,8 @@ pub fn wasm_worker_register_callback(
                     }
                 }
                 InstanceWork::WriteMemory { ptr, data, reply } => {
-                    let f: JsFunction = env.get_reference_value(&write_ref)?;
+                    let r = unsafe { write_ref.as_ref() }.unwrap();
+                    let f: JsFunction = env.get_reference_value(r)?;
                     let js_buf = env.create_buffer_with_data(data)?.into_raw();
                     let result = f.call(
                         None,
@@ -221,7 +266,8 @@ pub fn wasm_worker_register_callback(
                     }
                 }
                 InstanceWork::Alloc { size, reply } => {
-                    let f: JsFunction = env.get_reference_value(&alloc_ref)?;
+                    let r = unsafe { alloc_ref.as_ref() }.unwrap();
+                    let f: JsFunction = env.get_reference_value(r)?;
                     let result = f.call(None, &[env.create_uint32(size)?.into_unknown()]);
                     match result {
                         Ok(val) => {
@@ -234,7 +280,8 @@ pub fn wasm_worker_register_callback(
                     }
                 }
                 InstanceWork::Free { ptr, size, reply } => {
-                    let f: JsFunction = env.get_reference_value(&free_ref)?;
+                    let r = unsafe { free_ref.as_ref() }.unwrap();
+                    let f: JsFunction = env.get_reference_value(r)?;
                     let result = f.call(
                         None,
                         &[
@@ -252,12 +299,26 @@ pub fn wasm_worker_register_callback(
                         }
                     }
                 }
+                InstanceWork::Cleanup { reply } => {
+                    // Unref all NAPI Refs on the worker thread before the
+                    // TSFN is dropped. This prevents the debug_assert panic
+                    // in Ref::drop when count != 0.
+                    unsafe {
+                        transform_ref.take_and_unref(*env)?;
+                        diag_ref.take_and_unref(*env)?;
+                        read_ref.take_and_unref(*env)?;
+                        write_ref.take_and_unref(*env)?;
+                        alloc_ref.take_and_unref(*env)?;
+                        free_ref.take_and_unref(*env)?;
+                    }
+                    let _ = reply.send(Ok(()));
+                }
             }
             Ok(Vec::<JsUnknown>::new())
         },
     )?;
 
-    INSTANCE_TSFNS.lock().unwrap().insert(id, tsfn);
+    INSTANCE_TSFNS.lock().unwrap().insert(id, Arc::new(tsfn));
     Ok(())
 }
 
@@ -496,11 +557,24 @@ fn handle_wasm_request(env: &Env, manager: &JsObject, request: WasmRequest) -> n
         }
 
         WasmRequest::DropInstance { instance_id } => {
-            // Remove the per-instance TSFN (signals worker to stop receiving work)
-            {
-                let mut tsfns = INSTANCE_TSFNS.lock().unwrap();
-                tsfns.remove(&instance_id);
+            // Send Cleanup to the worker's TSFN to unref NAPI Refs before
+            // we drop the TSFN (which would drop the closure and trigger
+            // debug_assert panics in Ref::drop).
+            let tsfn = INSTANCE_TSFNS.lock().unwrap().get(&instance_id).cloned();
+
+            if let Some(tsfn) = &tsfn {
+                let (tx, rx) = mpsc::sync_channel(1);
+                tsfn.call(
+                    Ok(InstanceWork::Cleanup { reply: tx }),
+                    ThreadsafeFunctionCallMode::Blocking,
+                );
+                // Best-effort: ignore errors (worker may already be gone)
+                let _ = rx.recv();
             }
+
+            // Now safe to remove the TSFN — all Refs have been unref'd
+            drop(tsfn);
+            INSTANCE_TSFNS.lock().unwrap().remove(&instance_id);
 
             // Clean up host functions
             HOST_FNS.lock().unwrap().remove(&instance_id);
@@ -719,13 +793,18 @@ impl runtime::Instance for NapiInstance {
         unresolved_mark: u32,
         should_enable_comments_proxy: u32,
     ) -> anyhow::Result<u32> {
-        let result = instance_call_blocking(self.instance_id, |reply| InstanceWork::Transform {
-            program_ptr,
-            program_len,
-            unresolved_mark,
-            comments_proxy: should_enable_comments_proxy,
-            reply,
-        })?;
+        let (tx, rx) = mpsc::sync_channel(1);
+        let result = instance_call_blocking(
+            self.instance_id,
+            InstanceWork::Transform {
+                program_ptr,
+                program_len,
+                unresolved_mark,
+                comments_proxy: should_enable_comments_proxy,
+                reply: tx,
+            },
+            rx,
+        )?;
 
         if result == -1 {
             anyhow::bail!("Transform failed in worker");
@@ -746,8 +825,9 @@ impl runtime::Instance for NapiInstance {
 
 impl NapiInstance {
     fn get_diag(&mut self) -> anyhow::Result<u32> {
+        let (tx, rx) = mpsc::sync_channel(1);
         let result =
-            instance_call_blocking(self.instance_id, |reply| InstanceWork::GetDiag { reply })?;
+            instance_call_blocking(self.instance_id, InstanceWork::GetDiag { reply: tx }, rx)?;
 
         if result == -1 {
             anyhow::bail!("getDiag failed in worker");
@@ -758,6 +838,11 @@ impl NapiInstance {
 
 impl Drop for NapiInstance {
     fn drop(&mut self) {
+        // Clean up host functions synchronously so that Arc references held by
+        // Func closures (e.g. TransformResultHostEnvironment) are released
+        // before the caller tries Arc::try_unwrap on transform_result.
+        HOST_FNS.lock().unwrap().remove(&self.instance_id);
+
         if let Some(tsfn) = WASM_TSFN.get() {
             tsfn.call(
                 Ok(WasmRequest::DropInstance {
@@ -786,35 +871,52 @@ struct TsfnCaller {
 impl<'a> runtime::Caller<'a> for TsfnCaller {
     fn read_buf(&self, ptr: u32, buf: &mut [u8]) -> anyhow::Result<()> {
         let len = buf.len() as u32;
-        let data = instance_call_blocking(self.instance_id, |reply| InstanceWork::ReadMemory {
-            ptr,
-            len,
-            reply,
-        })?;
+        let (tx, rx) = mpsc::sync_channel(1);
+        let data = instance_call_blocking(
+            self.instance_id,
+            InstanceWork::ReadMemory {
+                ptr,
+                len,
+                reply: tx,
+            },
+            rx,
+        )?;
         buf.copy_from_slice(&data);
         Ok(())
     }
 
     fn write_buf(&mut self, ptr: u32, buf: &[u8]) -> anyhow::Result<()> {
-        instance_call_blocking(self.instance_id, |reply| InstanceWork::WriteMemory {
-            ptr,
-            data: buf.to_vec(),
-            reply,
-        })
+        let (tx, rx) = mpsc::sync_channel(1);
+        instance_call_blocking(
+            self.instance_id,
+            InstanceWork::WriteMemory {
+                ptr,
+                data: buf.to_vec(),
+                reply: tx,
+            },
+            rx,
+        )
     }
 
     fn alloc(&mut self, size: u32) -> anyhow::Result<u32> {
-        instance_call_blocking(self.instance_id, |reply| InstanceWork::Alloc {
-            size,
-            reply,
-        })
+        let (tx, rx) = mpsc::sync_channel(1);
+        instance_call_blocking(
+            self.instance_id,
+            InstanceWork::Alloc { size, reply: tx },
+            rx,
+        )
     }
 
     fn free(&mut self, ptr: u32, size: u32) -> anyhow::Result<u32> {
-        instance_call_blocking(self.instance_id, |reply| InstanceWork::Free {
-            ptr,
-            size,
-            reply,
-        })
+        let (tx, rx) = mpsc::sync_channel(1);
+        instance_call_blocking(
+            self.instance_id,
+            InstanceWork::Free {
+                ptr,
+                size,
+                reply: tx,
+            },
+            rx,
+        )
     }
 }

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "@swc/cli": "0.1.55",
     "@swc/core": "1.11.24",
     "@swc/helpers": "0.5.15",
+    "@swc/plugin-react-remove-properties": "11.1.0",
     "@swc/types": "0.1.7",
     "@taskr/esnext": "1.1.0",
     "@testing-library/jest-dom": "6.1.2",

--- a/packages/next-swc/package.json
+++ b/packages/next-swc/package.json
@@ -21,7 +21,7 @@
     "rust-check-doc": "RUSTDOCFLAGS='-Zunstable-options --output-format=json' cargo doc --no-deps --workspace",
     "rust-check-fmt": "cd ../..; cargo fmt -- --check",
     "rust-check-napi": "cargo check -p next-napi-bindings",
-    "test-cargo-unit": "cargo nextest run --workspace --exclude next-napi-bindings --exclude turbo-tasks-macros --cargo-profile release-with-assertions --no-fail-fast"
+    "test-cargo-unit": "cargo nextest run --workspace --exclude next-napi-bindings --exclude turbopack-ecmascript-plugins --exclude next-core --exclude turbo-tasks-macros --cargo-profile release-with-assertions --no-fail-fast"
   },
   "napi": {
     "name": "next-swc",

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1164,5 +1164,7 @@
   "1163": "No active instance for memory operation",
   "1164": "Unknown request type: %s",
   "1165": "Instance %s not found",
-  "1166": "wasm-worker must be run as a worker thread"
+  "1166": "wasm-worker must be run as a worker thread",
+  "1167": "wasm-manager: nativeBindingsPath not set",
+  "1168": "Instance %s not found for host fn"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1158,5 +1158,11 @@
   "1157": "`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.",
   "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable.",
   "1159": "WASM instance %s not found",
-  "1160": "WASM module %s not found"
+  "1160": "WASM module %s not found",
+  "1161": "Unexpected optype: %s",
+  "1162": "Module %s not found",
+  "1163": "No active instance for memory operation",
+  "1164": "Unknown request type: %s",
+  "1165": "Instance %s not found",
+  "1166": "wasm-worker must be run as a worker thread"
 }

--- a/packages/next/errors.json
+++ b/packages/next/errors.json
@@ -1156,5 +1156,7 @@
   "1155": "Not implemented",
   "1156": "Cannot create a replay stream after the ReplayableNodeStream has been disposed.",
   "1157": "`unstable_io()` requires the `experimental.unstableIO` option to be enabled in your Next.js config.",
-  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable."
+  "1158": "The prerender-ppr work unit type has been removed. This code path should be unreachable.",
+  "1159": "WASM instance %s not found",
+  "1160": "WASM module %s not found"
 }

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -68,8 +68,8 @@ export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
  * The `ops` object must have these methods:
  *   - transform(programPtr, programLen, unresolvedMark, commentsProxy) → number
  *   - getDiag() → number
- *   - readMemory(ptr, len) → Buffer
- *   - writeMemory(ptr, data: Buffer) → void
+ *   - readBuf(ptr, len) → Buffer
+ *   - writeBuf(ptr, data: Buffer) → void
  *   - alloc(size) → number
  *   - free(ptr, size) → number
  *

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -62,6 +62,41 @@ export declare function recvTaskMessageInWorker(
   workerId: number
 ): Promise<NapiTaskMessage>
 export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
+/**
+ * Called by worker after WASM instantiation to register a dispatch callback.
+ *
+ * The `ops` object must have these methods:
+ *   - transform(programPtr, programLen, unresolvedMark, commentsProxy) → number
+ *   - getDiag() → number
+ *   - readMemory(ptr, len) → Buffer
+ *   - writeMemory(ptr, data: Buffer) → void
+ *   - alloc(size) → number
+ *   - free(ptr, size) → number
+ *
+ * A TSFN is created targeting this worker's event loop. When Rust needs to
+ * call a WASM export, it posts to this TSFN, which runs the appropriate
+ * method on `ops` and sends the result back via a sync channel.
+ */
+export declare function wasmWorkerRegisterCallback(
+  instanceId: number,
+  ops: object
+): void
+/**
+ * Called by worker when WASM hits a host function import.
+ * Runs the Func closure synchronously on the worker thread and returns the result.
+ *
+ * The worker provides a `memoryAccessor` object with methods to read/write WASM memory:
+ *   - readBuf(ptr, len) → Buffer
+ *   - writeBuf(ptr, data: Buffer) → void
+ *   - alloc(size) → number
+ *   - free(ptr, size) → number
+ */
+export declare function wasmWorkerDispatchHostFn(
+  instanceId: number,
+  fnIndex: number,
+  args: Array<number>,
+  memoryAccessor: object
+): unknown
 export interface NapiLocation {
   line: number
   column?: number

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -618,6 +618,11 @@ export declare function transformSync(
   isModule: boolean,
   options: Buffer
 ): object
+/**
+ * Register the NAPI-based WASM plugin runtime.
+ * Must be called from JS before any SWC transforms that use plugins.
+ */
+export declare function registerWasmPluginRuntime(jsManager: object): void
 export declare function startTurbopackTraceServer(
   path: string,
   port?: number | undefined | null

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -21,7 +21,8 @@ export function lightningCssTransformStyleAttribute(
 export function lightningcssFeatureNamesToMaskNapi(names: Array<string>): number
 
 // Optional: only available when built with the "plugin" feature.
-export function registerWasmPluginRuntime(jsManager: object): void
+// Returns the runtime_id that identifies this registration.
+export function registerWasmPluginRuntime(jsManager: object): number
 
 // GENERATED-TYPES-BELOW
 // DO NOT MANUALLY EDIT THESE TYPES
@@ -38,6 +39,43 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
+/**
+ * Called by worker after WASM instantiation to register a dispatch callback.
+ *
+ * The `ops` object must have these methods:
+ *   - transform(programPtr, programLen, unresolvedMark, commentsProxy) → number
+ *   - getDiag() → number
+ *   - readBuf(ptr, len) → Buffer
+ *   - writeBuf(ptr, data: Buffer) → void
+ *   - alloc(size) → number
+ *   - free(ptr, size) → number
+ *
+ * A TSFN is created targeting this worker's event loop. When Rust needs to
+ * call a WASM export, it posts to this TSFN, which runs the appropriate
+ * method on `ops` and sends the result back via a sync channel.
+ */
+export declare function wasmWorkerRegisterCallback(
+  runtimeId: number,
+  instanceId: number,
+  ops: object
+): void
+/**
+ * Called by worker when WASM hits a host function import.
+ * Runs the Func closure synchronously on the worker thread and returns the result.
+ *
+ * The worker provides a `memoryAccessor` object with methods to read/write WASM memory:
+ *   - readBuf(ptr, len) → Buffer
+ *   - writeBuf(ptr, data: Buffer) → void
+ *   - alloc(size) → number
+ *   - free(ptr, size) → number
+ */
+export declare function wasmWorkerDispatchHostFn(
+  runtimeId: number,
+  instanceId: number,
+  fnIndex: number,
+  args: Array<number>,
+  memoryAccessor: object
+): unknown
 export declare function registerWorkerScheduler(
   creator: (arg: NapiWorkerCreation) => any,
   terminator: (arg: NapiWorkerTermination) => any
@@ -62,41 +100,6 @@ export declare function recvTaskMessageInWorker(
   workerId: number
 ): Promise<NapiTaskMessage>
 export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
-/**
- * Called by worker after WASM instantiation to register a dispatch callback.
- *
- * The `ops` object must have these methods:
- *   - transform(programPtr, programLen, unresolvedMark, commentsProxy) → number
- *   - getDiag() → number
- *   - readBuf(ptr, len) → Buffer
- *   - writeBuf(ptr, data: Buffer) → void
- *   - alloc(size) → number
- *   - free(ptr, size) → number
- *
- * A TSFN is created targeting this worker's event loop. When Rust needs to
- * call a WASM export, it posts to this TSFN, which runs the appropriate
- * method on `ops` and sends the result back via a sync channel.
- */
-export declare function wasmWorkerRegisterCallback(
-  instanceId: number,
-  ops: object
-): void
-/**
- * Called by worker when WASM hits a host function import.
- * Runs the Func closure synchronously on the worker thread and returns the result.
- *
- * The worker provides a `memoryAccessor` object with methods to read/write WASM memory:
- *   - readBuf(ptr, len) → Buffer
- *   - writeBuf(ptr, data: Buffer) → void
- *   - alloc(size) → number
- *   - free(ptr, size) → number
- */
-export declare function wasmWorkerDispatchHostFn(
-  instanceId: number,
-  fnIndex: number,
-  args: Array<number>,
-  memoryAccessor: object
-): unknown
 export interface NapiLocation {
   line: number
   column?: number
@@ -302,6 +305,10 @@ export interface NapiProjectOptions {
    * no salt.
    */
   hashSalt: RcStr
+   * The runtime_id from registerWasmPluginRuntime, used to look up the
+   * NAPI-based WASM plugin runtime. Omit or pass 0 if no plugins are used.
+   */
+  wasmPluginRuntimeId?: number
 }
 /** [NapiProjectOptions] with all fields optional. */
 export interface NapiPartialProjectOptions {
@@ -656,8 +663,9 @@ export declare function transformSync(
 /**
  * Register the NAPI-based WASM plugin runtime.
  * Must be called from JS before any SWC transforms that use plugins.
+ * Returns the runtime_id that identifies this registration.
  */
-export declare function registerWasmPluginRuntime(jsManager: object): void
+export declare function registerWasmPluginRuntime(jsManager: object): number
 export declare function startTurbopackTraceServer(
   path: string,
   port?: number | undefined | null

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -38,6 +38,30 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
+export declare function registerWorkerScheduler(
+  creator: (arg: NapiWorkerCreation) => any,
+  terminator: (arg: NapiWorkerTermination) => any
+): void
+export declare function workerCreated(workerId: number): void
+export interface NapiWorkerCreation {
+  options: NapiWorkerOptions
+}
+export interface NapiWorkerOptions {
+  filename: RcStr
+  cwd: RcStr
+}
+export interface NapiWorkerTermination {
+  options: NapiWorkerOptions
+  workerId: number
+}
+export interface NapiTaskMessage {
+  taskId: number
+  data: Buffer
+}
+export declare function recvTaskMessageInWorker(
+  workerId: number
+): Promise<NapiTaskMessage>
+export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
 /**
  * Called by worker after WASM instantiation to register a dispatch callback.
  *
@@ -73,30 +97,6 @@ export declare function wasmWorkerDispatchHostFn(
   args: Array<number>,
   memoryAccessor: object
 ): unknown
-export declare function registerWorkerScheduler(
-  creator: (arg: NapiWorkerCreation) => any,
-  terminator: (arg: NapiWorkerTermination) => any
-): void
-export declare function workerCreated(workerId: number): void
-export interface NapiWorkerCreation {
-  options: NapiWorkerOptions
-}
-export interface NapiWorkerOptions {
-  filename: RcStr
-  cwd: RcStr
-}
-export interface NapiWorkerTermination {
-  options: NapiWorkerOptions
-  workerId: number
-}
-export interface NapiTaskMessage {
-  taskId: number
-  data: Buffer
-}
-export declare function recvTaskMessageInWorker(
-  workerId: number
-): Promise<NapiTaskMessage>
-export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
 export interface NapiLocation {
   line: number
   column?: number

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -38,30 +38,6 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
-export declare function registerWorkerScheduler(
-  creator: (arg: NapiWorkerCreation) => any,
-  terminator: (arg: NapiWorkerTermination) => any
-): void
-export declare function workerCreated(workerId: number): void
-export interface NapiWorkerCreation {
-  options: NapiWorkerOptions
-}
-export interface NapiWorkerOptions {
-  filename: RcStr
-  cwd: RcStr
-}
-export interface NapiWorkerTermination {
-  options: NapiWorkerOptions
-  workerId: number
-}
-export interface NapiTaskMessage {
-  taskId: number
-  data: Buffer
-}
-export declare function recvTaskMessageInWorker(
-  workerId: number
-): Promise<NapiTaskMessage>
-export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
 /**
  * Called by worker after WASM instantiation to register a dispatch callback.
  *
@@ -97,6 +73,30 @@ export declare function wasmWorkerDispatchHostFn(
   args: Array<number>,
   memoryAccessor: object
 ): unknown
+export declare function registerWorkerScheduler(
+  creator: (arg: NapiWorkerCreation) => any,
+  terminator: (arg: NapiWorkerTermination) => any
+): void
+export declare function workerCreated(workerId: number): void
+export interface NapiWorkerCreation {
+  options: NapiWorkerOptions
+}
+export interface NapiWorkerOptions {
+  filename: RcStr
+  cwd: RcStr
+}
+export interface NapiWorkerTermination {
+  options: NapiWorkerOptions
+  workerId: number
+}
+export interface NapiTaskMessage {
+  taskId: number
+  data: Buffer
+}
+export declare function recvTaskMessageInWorker(
+  workerId: number
+): Promise<NapiTaskMessage>
+export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
 export interface NapiLocation {
   line: number
   column?: number

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -39,6 +39,30 @@ export declare class ExternalObject<T> {
     [K: symbol]: T
   }
 }
+export declare function registerWorkerScheduler(
+  creator: (arg: NapiWorkerCreation) => any,
+  terminator: (arg: NapiWorkerTermination) => any
+): void
+export declare function workerCreated(workerId: number): void
+export interface NapiWorkerCreation {
+  options: NapiWorkerOptions
+}
+export interface NapiWorkerOptions {
+  filename: RcStr
+  cwd: RcStr
+}
+export interface NapiWorkerTermination {
+  options: NapiWorkerOptions
+  workerId: number
+}
+export interface NapiTaskMessage {
+  taskId: number
+  data: Buffer
+}
+export declare function recvTaskMessageInWorker(
+  workerId: number
+): Promise<NapiTaskMessage>
+export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
 /**
  * Called by worker after WASM instantiation to register a dispatch callback.
  *
@@ -76,30 +100,6 @@ export declare function wasmWorkerDispatchHostFn(
   args: Array<number>,
   memoryAccessor: object
 ): unknown
-export declare function registerWorkerScheduler(
-  creator: (arg: NapiWorkerCreation) => any,
-  terminator: (arg: NapiWorkerTermination) => any
-): void
-export declare function workerCreated(workerId: number): void
-export interface NapiWorkerCreation {
-  options: NapiWorkerOptions
-}
-export interface NapiWorkerOptions {
-  filename: RcStr
-  cwd: RcStr
-}
-export interface NapiWorkerTermination {
-  options: NapiWorkerOptions
-  workerId: number
-}
-export interface NapiTaskMessage {
-  taskId: number
-  data: Buffer
-}
-export declare function recvTaskMessageInWorker(
-  workerId: number
-): Promise<NapiTaskMessage>
-export declare function sendTaskMessage(message: NapiTaskMessage): Promise<void>
 export interface NapiLocation {
   line: number
   column?: number

--- a/packages/next/src/build/swc/generated-native.d.ts
+++ b/packages/next/src/build/swc/generated-native.d.ts
@@ -20,6 +20,9 @@ export function lightningCssTransformStyleAttribute(
 ): Promise<unknown>
 export function lightningcssFeatureNamesToMaskNapi(names: Array<string>): number
 
+// Optional: only available when built with the "plugin" feature.
+export function registerWasmPluginRuntime(jsManager: object): void
+
 // GENERATED-TYPES-BELOW
 // DO NOT MANUALLY EDIT THESE TYPES
 // You can regenerate this file by running `pnpm swc-build-native` in the root of the repo.

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -172,6 +172,9 @@ let loadedBindings: Binding | undefined = undefined
 let downloadWasmPromise: any
 let swcTraceFlushGuard: any
 let downloadNativeBindingsPromise: Promise<void> | undefined = undefined
+// The runtime_id returned by registerWasmPluginRuntime, passed to turbopack
+// project creation so it can look up the correct WASM plugin runtime.
+let wasmPluginRuntimeId: number = 0
 
 export const lockfilePatchPromise: { cur?: Promise<void> } = {}
 
@@ -662,6 +665,7 @@ function bindingToApi(
         path.join(options.rootPath, options.projectPath)
       ),
       env: rustifyEnv(options.env),
+      wasmPluginRuntimeId: wasmPluginRuntimeId || undefined,
     }
   }
 
@@ -1743,7 +1747,8 @@ function loadNative(importPath?: string): Binding {
       const { wasmManager } =
         require('./wasm-manager') as typeof import('./wasm-manager')
       wasmManager.setBindingsPath(bindingsPath)
-      bindings.registerWasmPluginRuntime(wasmManager)
+      wasmPluginRuntimeId = bindings.registerWasmPluginRuntime(wasmManager)
+      wasmManager.setRuntimeId(wasmPluginRuntimeId)
     }
 
     return loadedBindings!

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1736,8 +1736,13 @@ function loadNative(importPath?: string): Binding {
 
     // Register the NAPI-based WASM plugin runtime so SWC plugins run via
     // Node's V8 WebAssembly engine instead of wasmtime.
-    if (typeof bindings.registerWasmPluginRuntime === 'function') {
-      const { wasmManager } = (require('./wasm-manager') as typeof import('./wasm-manager'))
+    if (
+      typeof bindings.registerWasmPluginRuntime === 'function' &&
+      bindingsPath
+    ) {
+      const { wasmManager } =
+        require('./wasm-manager') as typeof import('./wasm-manager')
+      wasmManager.setBindingsPath(bindingsPath)
       bindings.registerWasmPluginRuntime(wasmManager)
     }
 

--- a/packages/next/src/build/swc/index.ts
+++ b/packages/next/src/build/swc/index.ts
@@ -1733,6 +1733,14 @@ function loadNative(importPath?: string): Binding {
         return bindings.codeFrameColumns(source, location, options) ?? undefined
       },
     }
+
+    // Register the NAPI-based WASM plugin runtime so SWC plugins run via
+    // Node's V8 WebAssembly engine instead of wasmtime.
+    if (typeof bindings.registerWasmPluginRuntime === 'function') {
+      const { wasmManager } = (require('./wasm-manager') as typeof import('./wasm-manager'))
+      bindings.registerWasmPluginRuntime(wasmManager)
+    }
+
     return loadedBindings!
   }
 

--- a/packages/next/src/build/swc/wasm-manager.ts
+++ b/packages/next/src/build/swc/wasm-manager.ts
@@ -11,7 +11,7 @@
  * workers, and provide the shared memory pointers to Rust for direct access.
  */
 
-import { Worker } from 'worker_threads'
+import { Worker, type TransferListItem } from 'worker_threads'
 import path from 'path'
 
 // ---------------------------------------------------------------------------
@@ -107,7 +107,7 @@ function createWorker(): WorkerEntry {
 function sendToWorker(
   entry: WorkerEntry,
   msg: any,
-  transfer?: ArrayBuffer[]
+  transfer?: TransferListItem[]
 ): Promise<any> {
   return new Promise((resolve, reject) => {
     const id = nextMessageId++
@@ -261,7 +261,7 @@ export const wasmManager = {
     const ab = data.buffer.slice(
       data.byteOffset,
       data.byteOffset + data.byteLength
-    )
+    ) as ArrayBuffer
     return sendToWorker(
       workers[workerIndex],
       { type: 'writeMemory', instanceId, ptr, data: ab },

--- a/packages/next/src/build/swc/wasm-manager.ts
+++ b/packages/next/src/build/swc/wasm-manager.ts
@@ -170,19 +170,16 @@ export const wasmManager = {
    * Instantiate a WASM module on a worker. The module is transferred via
    * structured clone (zero-cost for WebAssembly.Module).
    *
-   * Returns { instanceId, promise } — Rust waits on the promise for completion.
+   * Rust passes a single callback; JS calls it with the instanceId (number)
+   * on success or an error message (string) on failure.
    * After instantiation, the worker registers ops with Rust via NAPI and
    * its event loop remains free to receive TSFN callbacks.
    */
   instantiateOnWorker(
     moduleId: number,
-    hostFnDescriptors: Array<{
-      name: string
-      paramCount: number
-      resultCount: number
-      index: number
-    }>
-  ): { instanceId: number; promise: Promise<number> } {
+    hostFnDescriptors: Array<[string, number, number, number]>,
+    callback: (result: number | string) => void
+  ): void {
     const module = compiledModules.get(moduleId)
     if (!module) throw new Error(`Module ${moduleId} not found`)
 
@@ -193,14 +190,15 @@ export const wasmManager = {
     instanceWorkerMap.set(instanceId, workerIndex)
     workerEntry.instances.add(instanceId)
 
-    const promise = sendToWorker(workerEntry, {
+    sendToWorker(workerEntry, {
       type: 'instantiate',
       instanceId,
       module,
       hostFnDescriptors,
-    })
-
-    return { instanceId, promise }
+    }).then(
+      () => callback(instanceId),
+      (err) => callback(String(err))
+    )
   },
 
   dropModule(moduleId: number): void {

--- a/packages/next/src/build/swc/wasm-manager.ts
+++ b/packages/next/src/build/swc/wasm-manager.ts
@@ -1,0 +1,184 @@
+/**
+ * JS-side WASM module and instance manager for the NAPI-based SWC plugin
+ * runtime.
+ *
+ * This module is called from Rust via a ThreadsafeFunction. The Rust side
+ * dispatches WASM operations (compile, instantiate, transform, memory
+ * read/write, alloc/free) to the JS main thread, where V8's WebAssembly APIs
+ * are available.
+ *
+ * Host function callbacks during WASM execution are handled by a Rust
+ * `dispatch_fn` that runs synchronously on the JS thread with direct memory
+ * access (no cross-thread overhead).
+ */
+
+interface WasmModuleEntry {
+  module: WebAssembly.Module
+}
+
+interface WasmInstanceEntry {
+  instance: WebAssembly.Instance
+  memory: WebAssembly.Memory
+}
+
+interface HostFnDescriptor {
+  name: string
+  paramCount: number
+  resultCount: number
+  index: number
+}
+
+type DispatchFn = (
+  index: number,
+  args: number[],
+  memory: WebAssembly.Memory,
+  allocFn: Function,
+  freeFn: Function
+) => number[] | undefined
+
+let nextId = 1
+const modules = new Map<number, WasmModuleEntry>()
+const instances = new Map<number, WasmInstanceEntry>()
+
+export const wasmManager = {
+  compileModule(wasmBytes: Buffer): number {
+    const id = nextId++
+    // WebAssembly.Module() is synchronous in Node.js (no size limit unlike
+    // browsers).  Use the underlying ArrayBuffer to satisfy TypeScript's
+    // BufferSource constraint (Buffer's .buffer may be SharedArrayBuffer).
+    const module = new WebAssembly.Module(wasmBytes as Uint8Array<ArrayBuffer>)
+    modules.set(id, { module })
+    return id
+  },
+
+  instantiateModule(
+    moduleId: number,
+    descriptors: HostFnDescriptor[],
+    dispatchFn: DispatchFn
+  ): number {
+    const entry = modules.get(moduleId)
+    if (!entry) {
+      throw new Error(`WASM module ${moduleId} not found`)
+    }
+
+    const envImports: Record<string, Function> = {}
+
+    // Mutable context set after instantiation (circular: imports reference
+    // exports). Wrapped in an object so loop closures capture a stable ref.
+    const ctx: {
+      memory: WebAssembly.Memory | null
+      allocFn: Function | null
+      freeFn: Function | null
+    } = { memory: null, allocFn: null, freeFn: null }
+
+    for (const desc of descriptors) {
+      const { index, paramCount, resultCount } = desc
+      envImports[desc.name] = (...args: number[]) => {
+        const results = dispatchFn(
+          index,
+          args.slice(0, paramCount),
+          ctx.memory!,
+          ctx.allocFn!,
+          ctx.freeFn!
+        )
+        if (resultCount === 0) return undefined
+        if (results && resultCount === 1) return results[0]
+        return results?.[0]
+      }
+    }
+
+    const instance = new WebAssembly.Instance(entry.module, { env: envImports })
+    ctx.memory = instance.exports.memory as WebAssembly.Memory
+    ctx.allocFn = instance.exports.__alloc as Function
+    ctx.freeFn = instance.exports.__free as Function
+    const memory = ctx.memory
+
+    const id = nextId++
+    instances.set(id, { instance, memory })
+    return id
+  },
+
+  callTransform(
+    instanceId: number,
+    programPtr: number,
+    programLen: number,
+    unresolvedMark: number,
+    shouldEnableCommentsProxy: number
+  ): number {
+    const entry = instances.get(instanceId)
+    if (!entry) {
+      throw new Error(`WASM instance ${instanceId} not found`)
+    }
+    const fn_ = entry.instance.exports
+      .__transform_plugin_process_impl as Function
+    return fn_(
+      programPtr,
+      programLen,
+      unresolvedMark,
+      shouldEnableCommentsProxy
+    )
+  },
+
+  readMemory(instanceId: number, ptr: number, len: number): Buffer {
+    const entry = instances.get(instanceId)
+    if (!entry) {
+      throw new Error(`WASM instance ${instanceId} not found`)
+    }
+    const view = new Uint8Array(entry.memory.buffer, ptr, len)
+    // Copy the data out (the buffer may be detached on memory growth)
+    return Buffer.from(view)
+  },
+
+  writeMemory(instanceId: number, ptr: number, data: Buffer): void {
+    const entry = instances.get(instanceId)
+    if (!entry) {
+      throw new Error(`WASM instance ${instanceId} not found`)
+    }
+    new Uint8Array(entry.memory.buffer).set(data, ptr)
+  },
+
+  callAlloc(instanceId: number, size: number): number {
+    const entry = instances.get(instanceId)
+    if (!entry) {
+      throw new Error(`WASM instance ${instanceId} not found`)
+    }
+    return (entry.instance.exports.__alloc as Function)(size)
+  },
+
+  callFree(instanceId: number, ptr: number, size: number): number {
+    const entry = instances.get(instanceId)
+    if (!entry) {
+      throw new Error(`WASM instance ${instanceId} not found`)
+    }
+    return (entry.instance.exports.__free as Function)(ptr, size)
+  },
+
+  callGetDiag(instanceId: number): number {
+    const entry = instances.get(instanceId)
+    if (!entry) {
+      throw new Error(`WASM instance ${instanceId} not found`)
+    }
+    return (
+      entry.instance.exports.__get_transform_plugin_core_pkg_diag as Function
+    )()
+  },
+
+  cloneModule(moduleId: number): number {
+    const entry = modules.get(moduleId)
+    if (!entry) {
+      throw new Error(`WASM module ${moduleId} not found`)
+    }
+    // WebAssembly.Module is internally reference-counted; sharing is cheap
+    const id = nextId++
+    modules.set(id, { module: entry.module })
+    return id
+  },
+
+  dropModule(moduleId: number): void {
+    modules.delete(moduleId)
+  },
+
+  dropInstance(instanceId: number): void {
+    instances.delete(instanceId)
+  },
+}

--- a/packages/next/src/build/swc/wasm-manager.ts
+++ b/packages/next/src/build/swc/wasm-manager.ts
@@ -206,6 +206,7 @@ export const wasmManager = {
       instanceId,
       module,
       hostFnDescriptors,
+      runtimeId,
     }).then(
       () => callback(instanceId),
       (err) => callback(String(err))

--- a/packages/next/src/build/swc/wasm-manager.ts
+++ b/packages/next/src/build/swc/wasm-manager.ts
@@ -1,184 +1,327 @@
 /**
- * JS-side WASM module and instance manager for the NAPI-based SWC plugin
- * runtime.
+ * WASM plugin manager: worker pool + module cache.
  *
- * This module is called from Rust via a ThreadsafeFunction. The Rust side
- * dispatches WASM operations (compile, instantiate, transform, memory
- * read/write, alloc/free) to the JS main thread, where V8's WebAssembly APIs
- * are available.
+ * Architecture:
+ *   - Module compilation: cached on main thread (WebAssembly.Module is ref-counted)
+ *   - Instance lifecycle: delegated to worker threads via postMessage
+ *   - Transform hot path: Rust thread talks directly to worker via SharedArrayBuffer
+ *   - Host function callbacks during transform: Rust ↔ worker via Atomics
  *
- * Host function callbacks during WASM execution are handled by a Rust
- * `dispatch_fn` that runs synchronously on the JS thread with direct memory
- * access (no cross-thread overhead).
+ * The main thread's role is minimal: compile modules, route setup requests to
+ * workers, and provide the shared memory pointers to Rust for direct access.
  */
 
-interface WasmModuleEntry {
-  module: WebAssembly.Module
+import { Worker } from 'worker_threads'
+import path from 'path'
+
+// ---------------------------------------------------------------------------
+// Shared memory layout constants (must match wasm-worker.ts and lib.rs)
+// ---------------------------------------------------------------------------
+
+const CTRL_BUFFER_INTS = 32 // Int32 slots in control buffer
+const CTRL_BUFFER_SIZE = CTRL_BUFFER_INTS * 4
+const DATA_BUFFER_SIZE = 8 * 1024 * 1024 // 8MB for memory read/write ops
+
+// ---------------------------------------------------------------------------
+// Worker pool
+// ---------------------------------------------------------------------------
+
+interface WorkerEntry {
+  worker: Worker
+  ctrlBuffer: SharedArrayBuffer
+  dataBuffer: SharedArrayBuffer
+  /** Instance IDs owned by this worker */
+  instances: Set<number>
+  /** Pending postMessage responses */
+  pending: Map<
+    number,
+    { resolve: (v: any) => void; reject: (e: Error) => void }
+  >
+  /** True while a transform is in progress (Atomics-based) */
+  busy: boolean
 }
 
-interface WasmInstanceEntry {
-  instance: WebAssembly.Instance
-  memory: WebAssembly.Memory
-}
+const workers: WorkerEntry[] = []
+let nextMessageId = 1
+let nextInstanceId = 1
 
-interface HostFnDescriptor {
-  name: string
-  paramCount: number
-  resultCount: number
-  index: number
-}
+// Map from instance ID → worker index for routing
+const instanceWorkerMap = new Map<number, number>()
 
-type DispatchFn = (
-  index: number,
-  args: number[],
-  memory: WebAssembly.Memory,
-  allocFn: Function,
-  freeFn: Function
-) => number[] | undefined
+// ---------------------------------------------------------------------------
+// Module cache: compile once, clone to workers for free
+// ---------------------------------------------------------------------------
 
-let nextId = 1
-const modules = new Map<number, WasmModuleEntry>()
-const instances = new Map<number, WasmInstanceEntry>()
+let nextModuleId = 1
+const compiledModules = new Map<number, WebAssembly.Module>()
 
-export const wasmManager = {
-  compileModule(wasmBytes: Buffer): number {
-    const id = nextId++
-    // WebAssembly.Module() is synchronous in Node.js (no size limit unlike
-    // browsers).  Use the underlying ArrayBuffer to satisfy TypeScript's
-    // BufferSource constraint (Buffer's .buffer may be SharedArrayBuffer).
-    const module = new WebAssembly.Module(wasmBytes as Uint8Array<ArrayBuffer>)
-    modules.set(id, { module })
-    return id
-  },
+// ---------------------------------------------------------------------------
+// Worker management
+// ---------------------------------------------------------------------------
 
-  instantiateModule(
-    moduleId: number,
-    descriptors: HostFnDescriptor[],
-    dispatchFn: DispatchFn
-  ): number {
-    const entry = modules.get(moduleId)
-    if (!entry) {
-      throw new Error(`WASM module ${moduleId} not found`)
-    }
+function createWorker(): WorkerEntry {
+  const ctrlBuffer = new SharedArrayBuffer(CTRL_BUFFER_SIZE)
+  const dataBuffer = new SharedArrayBuffer(DATA_BUFFER_SIZE)
 
-    const envImports: Record<string, Function> = {}
+  // Initialize control flag to IDLE (0)
+  new Int32Array(ctrlBuffer)[0] = 0
 
-    // Mutable context set after instantiation (circular: imports reference
-    // exports). Wrapped in an object so loop closures capture a stable ref.
-    const ctx: {
-      memory: WebAssembly.Memory | null
-      allocFn: Function | null
-      freeFn: Function | null
-    } = { memory: null, allocFn: null, freeFn: null }
+  const workerPath = path.join(__dirname, 'wasm-worker.js')
+  const worker = new Worker(workerPath, {
+    workerData: { ctrlBuffer, dataBuffer },
+  })
 
-    for (const desc of descriptors) {
-      const { index, paramCount, resultCount } = desc
-      envImports[desc.name] = (...args: number[]) => {
-        const results = dispatchFn(
-          index,
-          args.slice(0, paramCount),
-          ctx.memory!,
-          ctx.allocFn!,
-          ctx.freeFn!
-        )
-        if (resultCount === 0) return undefined
-        if (results && resultCount === 1) return results[0]
-        return results?.[0]
+  const entry: WorkerEntry = {
+    worker,
+    ctrlBuffer,
+    dataBuffer,
+    instances: new Set(),
+    pending: new Map(),
+    busy: false,
+  }
+
+  worker.on('message', (msg: { id: number; result?: any; error?: string }) => {
+    const p = entry.pending.get(msg.id)
+    if (p) {
+      entry.pending.delete(msg.id)
+      if (msg.error) {
+        p.reject(new Error(msg.error))
+      } else {
+        p.resolve(msg.result)
       }
     }
+  })
 
-    const instance = new WebAssembly.Instance(entry.module, { env: envImports })
-    ctx.memory = instance.exports.memory as WebAssembly.Memory
-    ctx.allocFn = instance.exports.__alloc as Function
-    ctx.freeFn = instance.exports.__free as Function
-    const memory = ctx.memory
+  worker.on('error', (err) => {
+    // Reject all pending operations
+    for (const [, p] of entry.pending) {
+      p.reject(err)
+    }
+    entry.pending.clear()
+  })
 
-    const id = nextId++
-    instances.set(id, { instance, memory })
+  workers.push(entry)
+  return entry
+}
+
+function sendToWorker(
+  entry: WorkerEntry,
+  msg: any,
+  transfer?: ArrayBuffer[]
+): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const id = nextMessageId++
+    msg.id = id
+    entry.pending.set(id, { resolve, reject })
+    if (transfer) {
+      entry.worker.postMessage(msg, transfer)
+    } else {
+      entry.worker.postMessage(msg)
+    }
+  })
+}
+
+/** Pick the least-loaded worker (fewest instances) */
+function pickWorker(): WorkerEntry {
+  if (workers.length === 0) {
+    return createWorker()
+  }
+
+  let best = workers[0]
+  for (let i = 1; i < workers.length; i++) {
+    if (workers[i].instances.size < best.instances.size) {
+      best = workers[i]
+    }
+  }
+  return best
+}
+
+// ---------------------------------------------------------------------------
+// Public API (called from Rust via TSFN)
+// ---------------------------------------------------------------------------
+
+export const wasmManager = {
+  /**
+   * Initialize the worker pool. Called once during registration.
+   * Returns an array of { ctrlBuffer, dataBuffer } for each worker,
+   * which Rust stores for direct Atomics access.
+   */
+  initWorkerPool(workerCount: number): Array<{
+    ctrlBuffer: SharedArrayBuffer
+    dataBuffer: SharedArrayBuffer
+  }> {
+    for (let i = 0; i < workerCount; i++) {
+      createWorker()
+    }
+    return workers.map((w) => ({
+      ctrlBuffer: w.ctrlBuffer,
+      dataBuffer: w.dataBuffer,
+    }))
+  },
+
+  /**
+   * Compile a WASM module and cache it. Returns a module ID.
+   * The WebAssembly.Module is stored on the main thread; workers receive
+   * it via postMessage structured clone (V8 shares the compiled code).
+   */
+  compileModule(wasmBytes: Buffer): number {
+    const id = nextModuleId++
+    const module = new WebAssembly.Module(wasmBytes as Uint8Array<ArrayBuffer>)
+    compiledModules.set(id, module)
     return id
   },
 
-  callTransform(
+  /**
+   * Clone a cached module (just increments ref count, no recompilation).
+   */
+  cloneModule(moduleId: number): number {
+    const module = compiledModules.get(moduleId)
+    if (!module) throw new Error(`Module ${moduleId} not found`)
+    const id = nextModuleId++
+    compiledModules.set(id, module)
+    return id
+  },
+
+  /**
+   * Instantiate a WASM module on a worker. The module is transferred via
+   * structured clone (zero-cost for WebAssembly.Module).
+   *
+   * Returns { instanceId, workerIndex } so Rust knows which worker's
+   * SharedArrayBuffer to use for transforms.
+   */
+  instantiateOnWorker(
+    moduleId: number,
+    hostFnDescriptors: Array<{
+      name: string
+      paramCount: number
+      resultCount: number
+      index: number
+    }>
+  ): { instanceId: number; workerIndex: number; promise: Promise<number> } {
+    const module = compiledModules.get(moduleId)
+    if (!module) throw new Error(`Module ${moduleId} not found`)
+
+    const workerEntry = pickWorker()
+    const workerIndex = workers.indexOf(workerEntry)
+    const instanceId = nextInstanceId++
+
+    instanceWorkerMap.set(instanceId, workerIndex)
+    workerEntry.instances.add(instanceId)
+
+    const promise = sendToWorker(workerEntry, {
+      type: 'instantiate',
+      instanceId,
+      module,
+      hostFnDescriptors,
+    })
+
+    return { instanceId, workerIndex, promise }
+  },
+
+  /**
+   * Get the worker index for a given instance (for routing).
+   */
+  getWorkerIndex(instanceId: number): number {
+    const idx = instanceWorkerMap.get(instanceId)
+    if (idx === undefined) throw new Error(`Instance ${instanceId} not found`)
+    return idx
+  },
+
+  /**
+   * Read memory from a worker's WASM instance via postMessage.
+   * Used for non-hot-path operations (setup, teardown).
+   */
+  readMemoryAsync(
     instanceId: number,
-    programPtr: number,
-    programLen: number,
-    unresolvedMark: number,
-    shouldEnableCommentsProxy: number
-  ): number {
-    const entry = instances.get(instanceId)
-    if (!entry) {
-      throw new Error(`WASM instance ${instanceId} not found`)
-    }
-    const fn_ = entry.instance.exports
-      .__transform_plugin_process_impl as Function
-    return fn_(
-      programPtr,
-      programLen,
-      unresolvedMark,
-      shouldEnableCommentsProxy
+    ptr: number,
+    len: number
+  ): Promise<Buffer> {
+    const workerIndex = instanceWorkerMap.get(instanceId)
+    if (workerIndex === undefined)
+      throw new Error(`Instance ${instanceId} not found`)
+    return sendToWorker(workers[workerIndex], {
+      type: 'readMemory',
+      instanceId,
+      ptr,
+      len,
+    }).then((ab: ArrayBuffer) => Buffer.from(ab))
+  },
+
+  /**
+   * Write memory to a worker's WASM instance via postMessage.
+   */
+  writeMemoryAsync(
+    instanceId: number,
+    ptr: number,
+    data: Buffer
+  ): Promise<void> {
+    const workerIndex = instanceWorkerMap.get(instanceId)
+    if (workerIndex === undefined)
+      throw new Error(`Instance ${instanceId} not found`)
+    const ab = data.buffer.slice(
+      data.byteOffset,
+      data.byteOffset + data.byteLength
+    )
+    return sendToWorker(
+      workers[workerIndex],
+      { type: 'writeMemory', instanceId, ptr, data: ab },
+      [ab]
     )
   },
 
-  readMemory(instanceId: number, ptr: number, len: number): Buffer {
-    const entry = instances.get(instanceId)
-    if (!entry) {
-      throw new Error(`WASM instance ${instanceId} not found`)
-    }
-    const view = new Uint8Array(entry.memory.buffer, ptr, len)
-    // Copy the data out (the buffer may be detached on memory growth)
-    return Buffer.from(view)
+  /**
+   * Allocate memory in a worker's WASM instance via postMessage.
+   */
+  allocAsync(instanceId: number, size: number): Promise<number> {
+    const workerIndex = instanceWorkerMap.get(instanceId)
+    if (workerIndex === undefined)
+      throw new Error(`Instance ${instanceId} not found`)
+    return sendToWorker(workers[workerIndex], {
+      type: 'alloc',
+      instanceId,
+      size,
+    })
   },
 
-  writeMemory(instanceId: number, ptr: number, data: Buffer): void {
-    const entry = instances.get(instanceId)
-    if (!entry) {
-      throw new Error(`WASM instance ${instanceId} not found`)
-    }
-    new Uint8Array(entry.memory.buffer).set(data, ptr)
+  /**
+   * Free memory in a worker's WASM instance via postMessage.
+   */
+  freeAsync(instanceId: number, ptr: number, size: number): Promise<number> {
+    const workerIndex = instanceWorkerMap.get(instanceId)
+    if (workerIndex === undefined)
+      throw new Error(`Instance ${instanceId} not found`)
+    return sendToWorker(workers[workerIndex], {
+      type: 'free',
+      instanceId,
+      ptr,
+      size,
+    })
   },
 
-  callAlloc(instanceId: number, size: number): number {
-    const entry = instances.get(instanceId)
-    if (!entry) {
-      throw new Error(`WASM instance ${instanceId} not found`)
-    }
-    return (entry.instance.exports.__alloc as Function)(size)
-  },
-
-  callFree(instanceId: number, ptr: number, size: number): number {
-    const entry = instances.get(instanceId)
-    if (!entry) {
-      throw new Error(`WASM instance ${instanceId} not found`)
-    }
-    return (entry.instance.exports.__free as Function)(ptr, size)
-  },
-
-  callGetDiag(instanceId: number): number {
-    const entry = instances.get(instanceId)
-    if (!entry) {
-      throw new Error(`WASM instance ${instanceId} not found`)
-    }
-    return (
-      entry.instance.exports.__get_transform_plugin_core_pkg_diag as Function
-    )()
-  },
-
-  cloneModule(moduleId: number): number {
-    const entry = modules.get(moduleId)
-    if (!entry) {
-      throw new Error(`WASM module ${moduleId} not found`)
-    }
-    // WebAssembly.Module is internally reference-counted; sharing is cheap
-    const id = nextId++
-    modules.set(id, { module: entry.module })
-    return id
+  /**
+   * Get diagnostics from a worker's WASM instance via postMessage.
+   */
+  getDiagAsync(instanceId: number): Promise<number> {
+    const workerIndex = instanceWorkerMap.get(instanceId)
+    if (workerIndex === undefined)
+      throw new Error(`Instance ${instanceId} not found`)
+    return sendToWorker(workers[workerIndex], {
+      type: 'getDiag',
+      instanceId,
+    })
   },
 
   dropModule(moduleId: number): void {
-    modules.delete(moduleId)
+    compiledModules.delete(moduleId)
   },
 
   dropInstance(instanceId: number): void {
-    instances.delete(instanceId)
+    const workerIndex = instanceWorkerMap.get(instanceId)
+    if (workerIndex === undefined) return
+    const entry = workers[workerIndex]
+    entry.instances.delete(instanceId)
+    instanceWorkerMap.delete(instanceId)
+    // Fire-and-forget cleanup
+    sendToWorker(entry, { type: 'dropInstance', instanceId }).catch(() => {})
   },
 }

--- a/packages/next/src/build/swc/wasm-manager.ts
+++ b/packages/next/src/build/swc/wasm-manager.ts
@@ -39,6 +39,9 @@ const instanceWorkerMap = new Map<number, number>()
 // Path to the native .node binding, set during init
 let nativeBindingsPath: string | null = null
 
+// The runtime_id from registerWasmPluginRuntime, passed to workers
+let runtimeId: number = 0
+
 // ---------------------------------------------------------------------------
 // Module cache: compile once, clone to workers for free
 // ---------------------------------------------------------------------------
@@ -57,7 +60,7 @@ function createWorker(): WorkerEntry {
 
   const workerPath = path.join(__dirname, 'wasm-worker.js')
   const worker = new Worker(workerPath, {
-    workerData: { nativeBindingsPath },
+    workerData: { nativeBindingsPath, runtimeId },
     // Suppress the WASI warnings, this isn't a great solution
     execArgv: ['--no-warnings'],
   })
@@ -143,6 +146,14 @@ export const wasmManager = {
    */
   setBindingsPath(bindingsPath: string): void {
     nativeBindingsPath = bindingsPath
+  },
+
+  /**
+   * Set the runtime_id returned by registerWasmPluginRuntime.
+   * Workers use this to look up the correct runtime state in NAPI calls.
+   */
+  setRuntimeId(id: number): void {
+    runtimeId = id
   },
 
   /**

--- a/packages/next/src/build/swc/wasm-manager.ts
+++ b/packages/next/src/build/swc/wasm-manager.ts
@@ -4,23 +4,15 @@
  * Architecture:
  *   - Module compilation: cached on main thread (WebAssembly.Module is ref-counted)
  *   - Instance lifecycle: delegated to worker threads via postMessage
- *   - Transform hot path: Rust thread talks directly to worker via SharedArrayBuffer
- *   - Host function callbacks during transform: Rust ↔ worker via Atomics
+ *   - Transform/getDiag/memory ops: Rust dispatches to worker threads via
+ *     per-instance ThreadsafeFunctions (TSFNs) — no blocking loops or Condvars
+ *   - Host function callbacks: synchronous NAPI calls on the worker thread
  *
- * The main thread's role is minimal: compile modules, route setup requests to
- * workers, and provide the shared memory pointers to Rust for direct access.
+ * The main thread's role: compile modules and route setup requests to workers.
  */
 
-import { Worker, type TransferListItem } from 'worker_threads'
+import { Worker } from 'worker_threads'
 import path from 'path'
-
-// ---------------------------------------------------------------------------
-// Shared memory layout constants (must match wasm-worker.ts and lib.rs)
-// ---------------------------------------------------------------------------
-
-const CTRL_BUFFER_INTS = 32 // Int32 slots in control buffer
-const CTRL_BUFFER_SIZE = CTRL_BUFFER_INTS * 4
-const DATA_BUFFER_SIZE = 8 * 1024 * 1024 // 8MB for memory read/write ops
 
 // ---------------------------------------------------------------------------
 // Worker pool
@@ -28,17 +20,13 @@ const DATA_BUFFER_SIZE = 8 * 1024 * 1024 // 8MB for memory read/write ops
 
 interface WorkerEntry {
   worker: Worker
-  ctrlBuffer: SharedArrayBuffer
-  dataBuffer: SharedArrayBuffer
-  /** Instance IDs owned by this worker */
+  /** Instance IDs owned by this worker (one per worker in current design) */
   instances: Set<number>
   /** Pending postMessage responses */
   pending: Map<
     number,
     { resolve: (v: any) => void; reject: (e: Error) => void }
   >
-  /** True while a transform is in progress (Atomics-based) */
-  busy: boolean
 }
 
 const workers: WorkerEntry[] = []
@@ -47,6 +35,9 @@ let nextInstanceId = 1
 
 // Map from instance ID → worker index for routing
 const instanceWorkerMap = new Map<number, number>()
+
+// Path to the native .node binding, set during init
+let nativeBindingsPath: string | null = null
 
 // ---------------------------------------------------------------------------
 // Module cache: compile once, clone to workers for free
@@ -60,24 +51,21 @@ const compiledModules = new Map<number, WebAssembly.Module>()
 // ---------------------------------------------------------------------------
 
 function createWorker(): WorkerEntry {
-  const ctrlBuffer = new SharedArrayBuffer(CTRL_BUFFER_SIZE)
-  const dataBuffer = new SharedArrayBuffer(DATA_BUFFER_SIZE)
-
-  // Initialize control flag to IDLE (0)
-  new Int32Array(ctrlBuffer)[0] = 0
+  if (!nativeBindingsPath) {
+    throw new Error('wasm-manager: nativeBindingsPath not set')
+  }
 
   const workerPath = path.join(__dirname, 'wasm-worker.js')
   const worker = new Worker(workerPath, {
-    workerData: { ctrlBuffer, dataBuffer },
+    workerData: { nativeBindingsPath },
+    // Suppress the WASI warnings, this isn't a great solution
+    execArgv: ['--no-warnings'],
   })
 
   const entry: WorkerEntry = {
     worker,
-    ctrlBuffer,
-    dataBuffer,
     instances: new Set(),
     pending: new Map(),
-    busy: false,
   }
 
   worker.on('message', (msg: { id: number; result?: any; error?: string }) => {
@@ -93,31 +81,29 @@ function createWorker(): WorkerEntry {
   })
 
   worker.on('error', (err) => {
-    // Reject all pending operations
+    console.error(`[wasm-manager] worker error:`, err)
     for (const [, p] of entry.pending) {
       p.reject(err)
     }
     entry.pending.clear()
   })
 
+  worker.on('exit', (code) => {
+    if (code !== 0) {
+      console.error(`[wasm-manager] worker exited with code ${code}`)
+    }
+  })
+
   workers.push(entry)
   return entry
 }
 
-function sendToWorker(
-  entry: WorkerEntry,
-  msg: any,
-  transfer?: TransferListItem[]
-): Promise<any> {
+function sendToWorker(entry: WorkerEntry, msg: any): Promise<any> {
   return new Promise((resolve, reject) => {
     const id = nextMessageId++
     msg.id = id
     entry.pending.set(id, { resolve, reject })
-    if (transfer) {
-      entry.worker.postMessage(msg, transfer)
-    } else {
-      entry.worker.postMessage(msg)
-    }
+    entry.worker.postMessage(msg)
   })
 }
 
@@ -143,26 +129,24 @@ function pickWorker(): WorkerEntry {
 export const wasmManager = {
   /**
    * Initialize the worker pool. Called once during registration.
-   * Returns an array of { ctrlBuffer, dataBuffer } for each worker,
-   * which Rust stores for direct Atomics access.
+   * Workers load the native addon directly for NAPI-based communication.
    */
-  initWorkerPool(workerCount: number): Array<{
-    ctrlBuffer: SharedArrayBuffer
-    dataBuffer: SharedArrayBuffer
-  }> {
+  initWorkerPool(workerCount: number): void {
     for (let i = 0; i < workerCount; i++) {
       createWorker()
     }
-    return workers.map((w) => ({
-      ctrlBuffer: w.ctrlBuffer,
-      dataBuffer: w.dataBuffer,
-    }))
+  },
+
+  /**
+   * Set the path to the native .node binding file.
+   * Must be called before initWorkerPool.
+   */
+  setBindingsPath(bindingsPath: string): void {
+    nativeBindingsPath = bindingsPath
   },
 
   /**
    * Compile a WASM module and cache it. Returns a module ID.
-   * The WebAssembly.Module is stored on the main thread; workers receive
-   * it via postMessage structured clone (V8 shares the compiled code).
    */
   compileModule(wasmBytes: Buffer): number {
     const id = nextModuleId++
@@ -186,8 +170,9 @@ export const wasmManager = {
    * Instantiate a WASM module on a worker. The module is transferred via
    * structured clone (zero-cost for WebAssembly.Module).
    *
-   * Returns { instanceId, workerIndex } so Rust knows which worker's
-   * SharedArrayBuffer to use for transforms.
+   * Returns { instanceId, promise } — Rust waits on the promise for completion.
+   * After instantiation, the worker registers ops with Rust via NAPI and
+   * its event loop remains free to receive TSFN callbacks.
    */
   instantiateOnWorker(
     moduleId: number,
@@ -197,7 +182,7 @@ export const wasmManager = {
       resultCount: number
       index: number
     }>
-  ): { instanceId: number; workerIndex: number; promise: Promise<number> } {
+  ): { instanceId: number; promise: Promise<number> } {
     const module = compiledModules.get(moduleId)
     if (!module) throw new Error(`Module ${moduleId} not found`)
 
@@ -215,100 +200,7 @@ export const wasmManager = {
       hostFnDescriptors,
     })
 
-    return { instanceId, workerIndex, promise }
-  },
-
-  /**
-   * Get the worker index for a given instance (for routing).
-   */
-  getWorkerIndex(instanceId: number): number {
-    const idx = instanceWorkerMap.get(instanceId)
-    if (idx === undefined) throw new Error(`Instance ${instanceId} not found`)
-    return idx
-  },
-
-  /**
-   * Read memory from a worker's WASM instance via postMessage.
-   * Used for non-hot-path operations (setup, teardown).
-   */
-  readMemoryAsync(
-    instanceId: number,
-    ptr: number,
-    len: number
-  ): Promise<Buffer> {
-    const workerIndex = instanceWorkerMap.get(instanceId)
-    if (workerIndex === undefined)
-      throw new Error(`Instance ${instanceId} not found`)
-    return sendToWorker(workers[workerIndex], {
-      type: 'readMemory',
-      instanceId,
-      ptr,
-      len,
-    }).then((ab: ArrayBuffer) => Buffer.from(ab))
-  },
-
-  /**
-   * Write memory to a worker's WASM instance via postMessage.
-   */
-  writeMemoryAsync(
-    instanceId: number,
-    ptr: number,
-    data: Buffer
-  ): Promise<void> {
-    const workerIndex = instanceWorkerMap.get(instanceId)
-    if (workerIndex === undefined)
-      throw new Error(`Instance ${instanceId} not found`)
-    const ab = data.buffer.slice(
-      data.byteOffset,
-      data.byteOffset + data.byteLength
-    ) as ArrayBuffer
-    return sendToWorker(
-      workers[workerIndex],
-      { type: 'writeMemory', instanceId, ptr, data: ab },
-      [ab]
-    )
-  },
-
-  /**
-   * Allocate memory in a worker's WASM instance via postMessage.
-   */
-  allocAsync(instanceId: number, size: number): Promise<number> {
-    const workerIndex = instanceWorkerMap.get(instanceId)
-    if (workerIndex === undefined)
-      throw new Error(`Instance ${instanceId} not found`)
-    return sendToWorker(workers[workerIndex], {
-      type: 'alloc',
-      instanceId,
-      size,
-    })
-  },
-
-  /**
-   * Free memory in a worker's WASM instance via postMessage.
-   */
-  freeAsync(instanceId: number, ptr: number, size: number): Promise<number> {
-    const workerIndex = instanceWorkerMap.get(instanceId)
-    if (workerIndex === undefined)
-      throw new Error(`Instance ${instanceId} not found`)
-    return sendToWorker(workers[workerIndex], {
-      type: 'free',
-      instanceId,
-      ptr,
-      size,
-    })
-  },
-
-  /**
-   * Get diagnostics from a worker's WASM instance via postMessage.
-   */
-  getDiagAsync(instanceId: number): Promise<number> {
-    const workerIndex = instanceWorkerMap.get(instanceId)
-    if (workerIndex === undefined)
-      throw new Error(`Instance ${instanceId} not found`)
-    return sendToWorker(workers[workerIndex], {
-      type: 'getDiag',
-      instanceId,
-    })
+    return { instanceId, promise }
   },
 
   dropModule(moduleId: number): void {

--- a/packages/next/src/build/swc/wasm-worker.ts
+++ b/packages/next/src/build/swc/wasm-worker.ts
@@ -1,0 +1,381 @@
+/**
+ * Worker thread for WASM plugin execution.
+ *
+ * Each worker owns WebAssembly.Instance objects and runs transforms in its own
+ * V8 isolate — true parallelism across workers.
+ *
+ * Two communication channels:
+ *
+ * 1. postMessage (async): setup operations (instantiate, drop) and
+ *    non-hot-path memory operations (caller read/write/alloc/free outside
+ *    of transforms, getDiag).
+ *
+ * 2. SharedArrayBuffer + Atomics (sync): transform hot path.
+ *    Rust thread writes transform args → Atomics.notify → worker runs transform.
+ *    During transform, host function callbacks ping-pong between worker and
+ *    Rust thread via Atomics.wait/notify — no main thread involvement.
+ *
+ * The worker uses Atomics.waitAsync to watch for transform requests without
+ * blocking the event loop, so postMessage handlers remain responsive.
+ * Once a transform starts, it runs synchronously (blocking the event loop
+ * briefly), which is correct since no messages need processing mid-transform.
+ *
+ * Protocol state machine (ctrl[0] = FLAG):
+ *
+ *   IDLE → TRANSFORM_REQ → [worker runs __transform_plugin_process_impl]
+ *     │                       │
+ *     │                       ├─ WASM calls host fn import:
+ *     │                       │    → HOST_FN_REQ (worker waits)
+ *     │                       │    → [Rust runs Func closure]
+ *     │                       │       │
+ *     │                       │       ├─ Rust needs mem op:
+ *     │                       │       │    → MEM_OP_REQ (Rust waits)
+ *     │                       │       │    → [worker does mem op]
+ *     │                       │       │    → MEM_OP_RESP (worker waits)
+ *     │                       │       │    → [Rust continues, may do more ops]
+ *     │                       │       │
+ *     │                       │       → HOST_FN_RESP (Rust waits)
+ *     │                       │       → [worker continues WASM, may hit more host fns]
+ *     │                       │
+ *     │                       → TRANSFORM_RESP
+ *     │
+ *     → IDLE (Rust resets after reading result)
+ */
+
+import { parentPort, workerData } from 'worker_threads'
+
+if (!parentPort) {
+  throw new Error('wasm-worker must be run as a worker thread')
+}
+
+// ---------------------------------------------------------------------------
+// Shared memory layout constants (must match lib.rs)
+// ---------------------------------------------------------------------------
+
+const FLAG = 0
+
+// Transform request/response:
+const INSTANCE_ID = 1
+const PROGRAM_PTR = 2
+const PROGRAM_LEN = 3
+const UNRESOLVED_MARK = 4
+const COMMENTS_PROXY = 5
+const TRANSFORM_RESULT = 6
+
+// Host function callback (worker → Rust):
+const HOST_FN_INDEX = 7
+const HOST_FN_PARAM_COUNT = 8
+const HOST_FN_RESULT_COUNT = 9
+const HOST_FN_ARGS_START = 10 // args and results at [10..10+N]
+
+// Memory operation (Rust → worker, during host fn):
+const MEM_OP_TYPE = 7
+const MEM_OP_PTR = 8
+const MEM_OP_LEN = 9
+const MEM_OP_RESULT = 10
+
+// Flag values:
+const IDLE = 0
+const TRANSFORM_REQ = 1
+const TRANSFORM_RESP = 2
+const HOST_FN_REQ = 3
+const HOST_FN_RESP = 4
+const MEM_OP_REQ = 5
+const MEM_OP_RESP = 6
+
+// Memory op types:
+const MEM_READ = 1
+const MEM_WRITE = 2
+const MEM_ALLOC = 3
+const MEM_FREE = 4
+
+// ---------------------------------------------------------------------------
+// Shared buffers
+// ---------------------------------------------------------------------------
+
+const ctrlBuffer: SharedArrayBuffer = workerData.ctrlBuffer
+const dataBuffer: SharedArrayBuffer = workerData.dataBuffer
+const ctrl = new Int32Array(ctrlBuffer)
+const data = new Uint8Array(dataBuffer)
+
+// ---------------------------------------------------------------------------
+// Instance storage
+// ---------------------------------------------------------------------------
+
+interface InstanceEntry {
+  instance: WebAssembly.Instance
+  memory: WebAssembly.Memory
+}
+
+const instances = new Map<number, InstanceEntry>()
+let activeEntry: InstanceEntry | null = null
+
+// ---------------------------------------------------------------------------
+// Host function dispatch via Atomics (during transform only)
+// ---------------------------------------------------------------------------
+
+function dispatchHostFn(
+  fnIndex: number,
+  args: number[],
+  paramCount: number,
+  resultCount: number
+): number | undefined {
+  // Write host function request (fields 7+ are free since transform args
+  // were already consumed)
+  Atomics.store(ctrl, HOST_FN_INDEX, fnIndex)
+  Atomics.store(ctrl, HOST_FN_PARAM_COUNT, paramCount)
+  Atomics.store(ctrl, HOST_FN_RESULT_COUNT, resultCount)
+  for (let i = 0; i < paramCount; i++) {
+    Atomics.store(ctrl, HOST_FN_ARGS_START + i, args[i])
+  }
+
+  // Signal Rust thread
+  Atomics.store(ctrl, FLAG, HOST_FN_REQ)
+  Atomics.notify(ctrl, FLAG)
+
+  // Wait for Rust to finish the host function.
+  // During execution, Rust may send MEM_OP_REQ for memory operations.
+  while (true) {
+    Atomics.wait(ctrl, FLAG, HOST_FN_REQ)
+    const flag = Atomics.load(ctrl, FLAG)
+
+    if (flag === HOST_FN_RESP) {
+      // Host function completed. Read results.
+      if (resultCount === 0) return undefined
+      return Atomics.load(ctrl, HOST_FN_ARGS_START)
+    }
+
+    if (flag === MEM_OP_REQ) {
+      handleMemoryOp()
+      // After handling, flag is MEM_OP_RESP. Wait for Rust to continue
+      // (it will set either MEM_OP_REQ for another op, or HOST_FN_RESP).
+      Atomics.wait(ctrl, FLAG, MEM_OP_RESP)
+      continue
+    }
+
+    // Unexpected flag — possible spurious wakeup, re-check
+  }
+}
+
+function handleMemoryOp(): void {
+  if (!activeEntry) {
+    throw new Error('No active instance for memory operation')
+  }
+
+  const opType = Atomics.load(ctrl, MEM_OP_TYPE)
+  const ptr = Atomics.load(ctrl, MEM_OP_PTR)
+  const len = Atomics.load(ctrl, MEM_OP_LEN)
+
+  switch (opType) {
+    case MEM_READ: {
+      const src = new Uint8Array(activeEntry.memory.buffer, ptr, len)
+      data.set(src, 0)
+      break
+    }
+    case MEM_WRITE: {
+      new Uint8Array(activeEntry.memory.buffer, ptr, len).set(
+        data.subarray(0, len)
+      )
+      break
+    }
+    case MEM_ALLOC: {
+      const result = (activeEntry.instance.exports.__alloc as Function)(
+        len
+      ) as number
+      Atomics.store(ctrl, MEM_OP_RESULT, result)
+      break
+    }
+    case MEM_FREE: {
+      const result = (activeEntry.instance.exports.__free as Function)(
+        ptr,
+        len
+      ) as number
+      Atomics.store(ctrl, MEM_OP_RESULT, result)
+      break
+    }
+    default:
+      throw new Error(`Unexpected optype: ${opType}`)
+  }
+
+  // Signal completion
+  Atomics.store(ctrl, FLAG, MEM_OP_RESP)
+  Atomics.notify(ctrl, FLAG)
+}
+
+// ---------------------------------------------------------------------------
+// Transform via Atomics.waitAsync
+// ---------------------------------------------------------------------------
+
+function waitForTransformRequest(): void {
+  const result = Atomics.waitAsync(ctrl, FLAG, IDLE)
+  if (result.async) {
+    result.value.then(onTransformWake)
+  } else {
+    // Flag already changed — handle immediately
+    setImmediate(() => onTransformWake('not-equal'))
+  }
+}
+
+function onTransformWake(_result: string): void {
+  const flag = Atomics.load(ctrl, FLAG)
+  if (flag === TRANSFORM_REQ) {
+    runTransform()
+  }
+  // Re-arm for next transform (flag should be IDLE after Rust resets it)
+  waitForTransformRequest()
+}
+
+function runTransform(): void {
+  const instanceId = Atomics.load(ctrl, INSTANCE_ID)
+  const programPtr = Atomics.load(ctrl, PROGRAM_PTR)
+  const programLen = Atomics.load(ctrl, PROGRAM_LEN)
+  const unresolvedMark = Atomics.load(ctrl, UNRESOLVED_MARK)
+  const commentsProxy = Atomics.load(ctrl, COMMENTS_PROXY)
+
+  const entry = instances.get(instanceId)
+  if (!entry) {
+    Atomics.store(ctrl, TRANSFORM_RESULT, -1)
+    Atomics.store(ctrl, FLAG, TRANSFORM_RESP)
+    Atomics.notify(ctrl, FLAG)
+    return
+  }
+
+  activeEntry = entry
+
+  try {
+    const transformFn = entry.instance.exports
+      .__transform_plugin_process_impl as Function
+    const result = transformFn(
+      programPtr,
+      programLen,
+      unresolvedMark,
+      commentsProxy
+    ) as number
+    Atomics.store(ctrl, TRANSFORM_RESULT, result)
+  } catch {
+    Atomics.store(ctrl, TRANSFORM_RESULT, -1)
+  } finally {
+    activeEntry = null
+  }
+
+  Atomics.store(ctrl, FLAG, TRANSFORM_RESP)
+  Atomics.notify(ctrl, FLAG)
+}
+
+// Start watching for transform requests
+waitForTransformRequest()
+
+// ---------------------------------------------------------------------------
+// postMessage handlers for non-hot-path operations
+// ---------------------------------------------------------------------------
+
+interface HostFnDescriptor {
+  name: string
+  paramCount: number
+  resultCount: number
+  index: number
+}
+
+parentPort.on('message', (req: any) => {
+  try {
+    let response: { result: any; transfer?: ArrayBuffer[] }
+
+    switch (req.type) {
+      case 'instantiate': {
+        const envImports: Record<string, Function> = {}
+        for (const desc of req.hostFnDescriptors as HostFnDescriptor[]) {
+          const { index, paramCount, resultCount } = desc
+          envImports[desc.name] = (...args: number[]) => {
+            return dispatchHostFn(
+              index,
+              args.slice(0, paramCount),
+              paramCount,
+              resultCount
+            )
+          }
+        }
+
+        const instance = new WebAssembly.Instance(req.module, {
+          env: envImports,
+        })
+        const memory = instance.exports.memory as WebAssembly.Memory
+        instances.set(req.instanceId, { instance, memory })
+        response = { result: req.instanceId }
+        break
+      }
+
+      case 'readMemory': {
+        const entry = instances.get(req.instanceId)
+        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
+        const copy = new Uint8Array(req.len)
+        copy.set(new Uint8Array(entry.memory.buffer, req.ptr, req.len))
+        response = { result: copy.buffer, transfer: [copy.buffer] }
+        break
+      }
+
+      case 'writeMemory': {
+        const entry = instances.get(req.instanceId)
+        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
+        new Uint8Array(entry.memory.buffer).set(
+          new Uint8Array(req.data),
+          req.ptr
+        )
+        response = { result: null }
+        break
+      }
+
+      case 'alloc': {
+        const entry = instances.get(req.instanceId)
+        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
+        response = {
+          result: (entry.instance.exports.__alloc as Function)(req.size),
+        }
+        break
+      }
+
+      case 'free': {
+        const entry = instances.get(req.instanceId)
+        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
+        response = {
+          result: (entry.instance.exports.__free as Function)(
+            req.ptr,
+            req.size
+          ),
+        }
+        break
+      }
+
+      case 'getDiag': {
+        const entry = instances.get(req.instanceId)
+        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
+        response = {
+          result: (
+            entry.instance.exports
+              .__get_transform_plugin_core_pkg_diag as Function
+          )(),
+        }
+        break
+      }
+
+      case 'dropInstance': {
+        instances.delete(req.instanceId)
+        response = { result: null }
+        break
+      }
+
+      default:
+        throw new Error(`Unknown request type: ${req.type}`)
+    }
+
+    if (response.transfer) {
+      parentPort!.postMessage(
+        { id: req.id, result: response.result },
+        response.transfer
+      )
+    } else {
+      parentPort!.postMessage({ id: req.id, result: response.result })
+    }
+  } catch (err: any) {
+    parentPort!.postMessage({ id: req.id, error: err.message || String(err) })
+  }
+})

--- a/packages/next/src/build/swc/wasm-worker.ts
+++ b/packages/next/src/build/swc/wasm-worker.ts
@@ -23,6 +23,7 @@ if (!parentPort) {
 // Load native addon directly in the worker thread.
 // This gives us direct NAPI access for host function callbacks.
 const bindings = require(workerData.nativeBindingsPath)
+const runtimeId: number = workerData.runtimeId
 
 // ---------------------------------------------------------------------------
 // Instance storage — the ops object closes over the WASM instance/memory,
@@ -105,6 +106,7 @@ parentPort.on('message', (req: any) => {
               throw new Error(`Instance ${instanceId} not found for host fn`)
             }
             return bindings.wasmWorkerDispatchHostFn(
+              runtimeId,
               instanceId,
               index,
               args.slice(0, paramCount),
@@ -128,7 +130,7 @@ parentPort.on('message', (req: any) => {
         // the instance handle and the ops interface for Rust.
         const ops = createInstanceOps(instance, memory)
         instances.set(instanceId, ops)
-        bindings.wasmWorkerRegisterCallback(instanceId, ops)
+        bindings.wasmWorkerRegisterCallback(runtimeId, instanceId, ops)
 
         response = { result: instanceId }
         break

--- a/packages/next/src/build/swc/wasm-worker.ts
+++ b/packages/next/src/build/swc/wasm-worker.ts
@@ -25,25 +25,16 @@ if (!parentPort) {
 const bindings = require(workerData.nativeBindingsPath)
 
 // ---------------------------------------------------------------------------
-// Instance storage
+// Instance storage — the ops object closes over the WASM instance/memory,
+// so it serves as both the instance handle and the ops interface.
 // ---------------------------------------------------------------------------
 
-interface InstanceEntry {
-  instance: WebAssembly.Instance
+const instances = new Map<number, ReturnType<typeof createInstanceOps>>()
+
+function createInstanceOps(
+  instance: WebAssembly.Instance,
   memory: WebAssembly.Memory
-}
-
-const instances = new Map<number, InstanceEntry>()
-const instanceOps = new Map<number, ReturnType<typeof createInstanceOps>>()
-
-// ---------------------------------------------------------------------------
-// Create ops object for a WASM instance.
-// These methods are called by Rust via the per-instance TSFN (transform,
-// getDiag, memory ops) and also passed as the memory accessor during host
-// function dispatch (readBuf, writeBuf, alloc, free).
-// ---------------------------------------------------------------------------
-
-function createInstanceOps(entry: InstanceEntry) {
+) {
   return {
     transform(
       programPtr: number,
@@ -51,7 +42,7 @@ function createInstanceOps(entry: InstanceEntry) {
       unresolvedMark: number,
       commentsProxy: number
     ): number {
-      const transformFn = entry.instance.exports
+      const transformFn = instance.exports
         .__transform_plugin_process_impl as Function
       return transformFn(
         programPtr,
@@ -62,25 +53,25 @@ function createInstanceOps(entry: InstanceEntry) {
     },
 
     getDiag(): number {
-      const diagFn = entry.instance.exports
+      const diagFn = instance.exports
         .__get_transform_plugin_core_pkg_diag as Function
       return diagFn() as number
     },
 
     readBuf(ptr: number, len: number): Buffer {
-      return Buffer.from(new Uint8Array(entry.memory.buffer, ptr, len).slice())
+      return Buffer.from(new Uint8Array(memory.buffer, ptr, len).slice())
     },
 
     writeBuf(ptr: number, data: Buffer): void {
-      new Uint8Array(entry.memory.buffer, ptr, data.byteLength).set(data)
+      new Uint8Array(memory.buffer, ptr, data.byteLength).set(data)
     },
 
     alloc(size: number): number {
-      return (entry.instance.exports.__alloc as Function)(size) as number
+      return (instance.exports.__alloc as Function)(size) as number
     },
 
     free(ptr: number, size: number): number {
-      return (entry.instance.exports.__free as Function)(ptr, size) as number
+      return (instance.exports.__free as Function)(ptr, size) as number
     },
   }
 }
@@ -89,12 +80,8 @@ function createInstanceOps(entry: InstanceEntry) {
 // postMessage handlers
 // ---------------------------------------------------------------------------
 
-interface HostFnDescriptor {
-  name: string
-  paramCount: number
-  resultCount: number
-  index: number
-}
+// Each descriptor is a [name, paramCount, resultCount, index] tuple.
+type HostFnDescriptor = [string, number, number, number]
 
 parentPort.on('message', (req: any) => {
   try {
@@ -106,10 +93,14 @@ parentPort.on('message', (req: any) => {
 
         // Build env imports that call Rust host functions directly via NAPI
         const envImports: Record<string, Function> = {}
-        for (const desc of req.hostFnDescriptors as HostFnDescriptor[]) {
-          const { index, paramCount } = desc
-          envImports[desc.name] = (...args: number[]) => {
-            const ops = instanceOps.get(instanceId)
+        for (const [
+          name,
+          paramCount,
+          ,
+          index,
+        ] of req.hostFnDescriptors as HostFnDescriptor[]) {
+          envImports[name] = (...args: number[]) => {
+            const ops = instances.get(instanceId)
             if (!ops) {
               throw new Error(`Instance ${instanceId} not found for host fn`)
             }
@@ -132,13 +123,11 @@ parentPort.on('message', (req: any) => {
         })
         wasi.initialize(instance)
         const memory = instance.exports.memory as WebAssembly.Memory
-        const entry: InstanceEntry = { instance, memory }
-        instances.set(instanceId, entry)
 
-        // Register ops with Rust — this creates a TSFN targeting this worker's
-        // event loop. Rust will call these ops directly via the TSFN.
-        const ops = createInstanceOps(entry)
-        instanceOps.set(instanceId, ops)
+        // The ops object closes over instance/memory and serves as both
+        // the instance handle and the ops interface for Rust.
+        const ops = createInstanceOps(instance, memory)
+        instances.set(instanceId, ops)
         bindings.wasmWorkerRegisterCallback(instanceId, ops)
 
         response = { result: instanceId }
@@ -147,7 +136,6 @@ parentPort.on('message', (req: any) => {
 
       case 'dropInstance': {
         instances.delete(req.instanceId)
-        instanceOps.delete(req.instanceId)
         response = { result: null }
         break
       }

--- a/packages/next/src/build/swc/wasm-worker.ts
+++ b/packages/next/src/build/swc/wasm-worker.ts
@@ -23,7 +23,8 @@ if (!parentPort) {
 // Load native addon directly in the worker thread.
 // This gives us direct NAPI access for host function callbacks.
 const bindings = require(workerData.nativeBindingsPath)
-const runtimeId: number = workerData.runtimeId
+// runtimeId may be 0 at worker creation time; it gets updated per-instantiate message.
+let runtimeId: number = workerData.runtimeId
 
 // ---------------------------------------------------------------------------
 // Instance storage — the ops object closes over the WASM instance/memory,
@@ -91,6 +92,11 @@ parentPort.on('message', (req: any) => {
     switch (req.type) {
       case 'instantiate': {
         const instanceId = req.instanceId as number
+        // Update runtimeId from the message (may differ from workerData if
+        // workers were created before runtime registration).
+        if (req.runtimeId != null) {
+          runtimeId = req.runtimeId as number
+        }
 
         // Build env imports that call Rust host functions directly via NAPI
         const envImports: Record<string, Function> = {}
@@ -100,13 +106,14 @@ parentPort.on('message', (req: any) => {
           ,
           index,
         ] of req.hostFnDescriptors as HostFnDescriptor[]) {
+          const capturedRuntimeID = runtimeId
           envImports[name] = (...args: number[]) => {
             const ops = instances.get(instanceId)
             if (!ops) {
               throw new Error(`Instance ${instanceId} not found for host fn`)
             }
             return bindings.wasmWorkerDispatchHostFn(
-              runtimeId,
+              capturedRuntimeID,
               instanceId,
               index,
               args.slice(0, paramCount),

--- a/packages/next/src/build/swc/wasm-worker.ts
+++ b/packages/next/src/build/swc/wasm-worker.ts
@@ -1,102 +1,28 @@
 /**
  * Worker thread for WASM plugin execution.
  *
- * Each worker owns WebAssembly.Instance objects and runs transforms in its own
- * V8 isolate — true parallelism across workers.
+ * Each worker loads the native NAPI addon directly and communicates with
+ * Rust via synchronous NAPI calls — no SharedArrayBuffer or Atomics needed.
  *
- * Two communication channels:
- *
- * 1. postMessage (async): setup operations (instantiate, drop) and
- *    non-hot-path memory operations (caller read/write/alloc/free outside
- *    of transforms, getDiag).
- *
- * 2. SharedArrayBuffer + Atomics (sync): transform hot path.
- *    Rust thread writes transform args → Atomics.notify → worker runs transform.
- *    During transform, host function callbacks ping-pong between worker and
- *    Rust thread via Atomics.wait/notify — no main thread involvement.
- *
- * The worker uses Atomics.waitAsync to watch for transform requests without
- * blocking the event loop, so postMessage handlers remain responsive.
- * Once a transform starts, it runs synchronously (blocking the event loop
- * briefly), which is correct since no messages need processing mid-transform.
- *
- * Protocol state machine (ctrl[0] = FLAG):
- *
- *   IDLE → TRANSFORM_REQ → [worker runs __transform_plugin_process_impl]
- *     │                       │
- *     │                       ├─ WASM calls host fn import:
- *     │                       │    → HOST_FN_REQ (worker waits)
- *     │                       │    → [Rust runs Func closure]
- *     │                       │       │
- *     │                       │       ├─ Rust needs mem op:
- *     │                       │       │    → MEM_OP_REQ (Rust waits)
- *     │                       │       │    → [worker does mem op]
- *     │                       │       │    → MEM_OP_RESP (worker waits)
- *     │                       │       │    → [Rust continues, may do more ops]
- *     │                       │       │
- *     │                       │       → HOST_FN_RESP (Rust waits)
- *     │                       │       → [worker continues WASM, may hit more host fns]
- *     │                       │
- *     │                       → TRANSFORM_RESP
- *     │
- *     → IDLE (Rust resets after reading result)
+ * Lifecycle:
+ *   1. Main thread sends 'instantiate' with a WebAssembly.Module
+ *   2. Worker instantiates the module, wiring host function imports to NAPI calls
+ *   3. Worker registers an ops object with Rust via wasmWorkerRegisterCallback
+ *   4. Rust dispatches work via a per-instance ThreadsafeFunction (TSFN)
+ *   5. The TSFN callback runs on this worker's event loop, calling WASM exports directly
+ *   6. Results are returned to Rust via sync channels (handled inside the TSFN)
  */
 
 import { parentPort, workerData } from 'worker_threads'
+import { WASI } from 'wasi'
 
 if (!parentPort) {
   throw new Error('wasm-worker must be run as a worker thread')
 }
 
-// ---------------------------------------------------------------------------
-// Shared memory layout constants (must match lib.rs)
-// ---------------------------------------------------------------------------
-
-const FLAG = 0
-
-// Transform request/response:
-const INSTANCE_ID = 1
-const PROGRAM_PTR = 2
-const PROGRAM_LEN = 3
-const UNRESOLVED_MARK = 4
-const COMMENTS_PROXY = 5
-const TRANSFORM_RESULT = 6
-
-// Host function callback (worker → Rust):
-const HOST_FN_INDEX = 7
-const HOST_FN_PARAM_COUNT = 8
-const HOST_FN_RESULT_COUNT = 9
-const HOST_FN_ARGS_START = 10 // args and results at [10..10+N]
-
-// Memory operation (Rust → worker, during host fn):
-const MEM_OP_TYPE = 7
-const MEM_OP_PTR = 8
-const MEM_OP_LEN = 9
-const MEM_OP_RESULT = 10
-
-// Flag values:
-const IDLE = 0
-const TRANSFORM_REQ = 1
-const TRANSFORM_RESP = 2
-const HOST_FN_REQ = 3
-const HOST_FN_RESP = 4
-const MEM_OP_REQ = 5
-const MEM_OP_RESP = 6
-
-// Memory op types:
-const MEM_READ = 1
-const MEM_WRITE = 2
-const MEM_ALLOC = 3
-const MEM_FREE = 4
-
-// ---------------------------------------------------------------------------
-// Shared buffers
-// ---------------------------------------------------------------------------
-
-const ctrlBuffer: SharedArrayBuffer = workerData.ctrlBuffer
-const dataBuffer: SharedArrayBuffer = workerData.dataBuffer
-const ctrl = new Int32Array(ctrlBuffer)
-const data = new Uint8Array(dataBuffer)
+// Load native addon directly in the worker thread.
+// This gives us direct NAPI access for host function callbacks.
+const bindings = require(workerData.nativeBindingsPath)
 
 // ---------------------------------------------------------------------------
 // Instance storage
@@ -108,165 +34,59 @@ interface InstanceEntry {
 }
 
 const instances = new Map<number, InstanceEntry>()
-let activeEntry: InstanceEntry | null = null
+const instanceOps = new Map<number, ReturnType<typeof createInstanceOps>>()
 
 // ---------------------------------------------------------------------------
-// Host function dispatch via Atomics (during transform only)
+// Create ops object for a WASM instance.
+// These methods are called by Rust via the per-instance TSFN (transform,
+// getDiag, memory ops) and also passed as the memory accessor during host
+// function dispatch (readBuf, writeBuf, alloc, free).
 // ---------------------------------------------------------------------------
 
-function dispatchHostFn(
-  fnIndex: number,
-  args: number[],
-  paramCount: number,
-  resultCount: number
-): number | undefined {
-  // Write host function request (fields 7+ are free since transform args
-  // were already consumed)
-  Atomics.store(ctrl, HOST_FN_INDEX, fnIndex)
-  Atomics.store(ctrl, HOST_FN_PARAM_COUNT, paramCount)
-  Atomics.store(ctrl, HOST_FN_RESULT_COUNT, resultCount)
-  for (let i = 0; i < paramCount; i++) {
-    Atomics.store(ctrl, HOST_FN_ARGS_START + i, args[i])
-  }
-
-  // Signal Rust thread
-  Atomics.store(ctrl, FLAG, HOST_FN_REQ)
-  Atomics.notify(ctrl, FLAG)
-
-  // Wait for Rust to finish the host function.
-  // During execution, Rust may send MEM_OP_REQ for memory operations.
-  while (true) {
-    Atomics.wait(ctrl, FLAG, HOST_FN_REQ)
-    const flag = Atomics.load(ctrl, FLAG)
-
-    if (flag === HOST_FN_RESP) {
-      // Host function completed. Read results.
-      if (resultCount === 0) return undefined
-      return Atomics.load(ctrl, HOST_FN_ARGS_START)
-    }
-
-    if (flag === MEM_OP_REQ) {
-      handleMemoryOp()
-      // After handling, flag is MEM_OP_RESP. Wait for Rust to continue
-      // (it will set either MEM_OP_REQ for another op, or HOST_FN_RESP).
-      Atomics.wait(ctrl, FLAG, MEM_OP_RESP)
-      continue
-    }
-
-    // Unexpected flag — possible spurious wakeup, re-check
-  }
-}
-
-function handleMemoryOp(): void {
-  if (!activeEntry) {
-    throw new Error('No active instance for memory operation')
-  }
-
-  const opType = Atomics.load(ctrl, MEM_OP_TYPE)
-  const ptr = Atomics.load(ctrl, MEM_OP_PTR)
-  const len = Atomics.load(ctrl, MEM_OP_LEN)
-
-  switch (opType) {
-    case MEM_READ: {
-      const src = new Uint8Array(activeEntry.memory.buffer, ptr, len)
-      data.set(src, 0)
-      break
-    }
-    case MEM_WRITE: {
-      new Uint8Array(activeEntry.memory.buffer, ptr, len).set(
-        data.subarray(0, len)
-      )
-      break
-    }
-    case MEM_ALLOC: {
-      const result = (activeEntry.instance.exports.__alloc as Function)(
-        len
+function createInstanceOps(entry: InstanceEntry) {
+  return {
+    transform(
+      programPtr: number,
+      programLen: number,
+      unresolvedMark: number,
+      commentsProxy: number
+    ): number {
+      const transformFn = entry.instance.exports
+        .__transform_plugin_process_impl as Function
+      return transformFn(
+        programPtr,
+        programLen,
+        unresolvedMark,
+        commentsProxy
       ) as number
-      Atomics.store(ctrl, MEM_OP_RESULT, result)
-      break
-    }
-    case MEM_FREE: {
-      const result = (activeEntry.instance.exports.__free as Function)(
-        ptr,
-        len
-      ) as number
-      Atomics.store(ctrl, MEM_OP_RESULT, result)
-      break
-    }
-    default:
-      throw new Error(`Unexpected optype: ${opType}`)
-  }
+    },
 
-  // Signal completion
-  Atomics.store(ctrl, FLAG, MEM_OP_RESP)
-  Atomics.notify(ctrl, FLAG)
+    getDiag(): number {
+      const diagFn = entry.instance.exports
+        .__get_transform_plugin_core_pkg_diag as Function
+      return diagFn() as number
+    },
+
+    readBuf(ptr: number, len: number): Buffer {
+      return Buffer.from(new Uint8Array(entry.memory.buffer, ptr, len).slice())
+    },
+
+    writeBuf(ptr: number, data: Buffer): void {
+      new Uint8Array(entry.memory.buffer, ptr, data.byteLength).set(data)
+    },
+
+    alloc(size: number): number {
+      return (entry.instance.exports.__alloc as Function)(size) as number
+    },
+
+    free(ptr: number, size: number): number {
+      return (entry.instance.exports.__free as Function)(ptr, size) as number
+    },
+  }
 }
 
 // ---------------------------------------------------------------------------
-// Transform via Atomics.waitAsync
-// ---------------------------------------------------------------------------
-
-function waitForTransformRequest(): void {
-  const result = Atomics.waitAsync(ctrl, FLAG, IDLE)
-  if (result.async) {
-    result.value.then(onTransformWake)
-  } else {
-    // Flag already changed — handle immediately
-    setImmediate(() => onTransformWake('not-equal'))
-  }
-}
-
-function onTransformWake(_result: string): void {
-  const flag = Atomics.load(ctrl, FLAG)
-  if (flag === TRANSFORM_REQ) {
-    runTransform()
-  }
-  // Re-arm for next transform (flag should be IDLE after Rust resets it)
-  waitForTransformRequest()
-}
-
-function runTransform(): void {
-  const instanceId = Atomics.load(ctrl, INSTANCE_ID)
-  const programPtr = Atomics.load(ctrl, PROGRAM_PTR)
-  const programLen = Atomics.load(ctrl, PROGRAM_LEN)
-  const unresolvedMark = Atomics.load(ctrl, UNRESOLVED_MARK)
-  const commentsProxy = Atomics.load(ctrl, COMMENTS_PROXY)
-
-  const entry = instances.get(instanceId)
-  if (!entry) {
-    Atomics.store(ctrl, TRANSFORM_RESULT, -1)
-    Atomics.store(ctrl, FLAG, TRANSFORM_RESP)
-    Atomics.notify(ctrl, FLAG)
-    return
-  }
-
-  activeEntry = entry
-
-  try {
-    const transformFn = entry.instance.exports
-      .__transform_plugin_process_impl as Function
-    const result = transformFn(
-      programPtr,
-      programLen,
-      unresolvedMark,
-      commentsProxy
-    ) as number
-    Atomics.store(ctrl, TRANSFORM_RESULT, result)
-  } catch {
-    Atomics.store(ctrl, TRANSFORM_RESULT, -1)
-  } finally {
-    activeEntry = null
-  }
-
-  Atomics.store(ctrl, FLAG, TRANSFORM_RESP)
-  Atomics.notify(ctrl, FLAG)
-}
-
-// Start watching for transform requests
-waitForTransformRequest()
-
-// ---------------------------------------------------------------------------
-// postMessage handlers for non-hot-path operations
+// postMessage handlers
 // ---------------------------------------------------------------------------
 
 interface HostFnDescriptor {
@@ -278,87 +98,56 @@ interface HostFnDescriptor {
 
 parentPort.on('message', (req: any) => {
   try {
-    let response: { result: any; transfer?: ArrayBuffer[] }
+    let response: { result: any }
 
     switch (req.type) {
       case 'instantiate': {
+        const instanceId = req.instanceId as number
+
+        // Build env imports that call Rust host functions directly via NAPI
         const envImports: Record<string, Function> = {}
         for (const desc of req.hostFnDescriptors as HostFnDescriptor[]) {
-          const { index, paramCount, resultCount } = desc
+          const { index, paramCount } = desc
           envImports[desc.name] = (...args: number[]) => {
-            return dispatchHostFn(
+            const ops = instanceOps.get(instanceId)
+            if (!ops) {
+              throw new Error(`Instance ${instanceId} not found for host fn`)
+            }
+            return bindings.wasmWorkerDispatchHostFn(
+              instanceId,
               index,
               args.slice(0, paramCount),
-              paramCount,
-              resultCount
+              ops
             )
           }
         }
 
+        // SWC plugins are compiled as WASI modules
+        const wasi = new WASI({ version: 'preview1' })
+        const wasiImports = wasi.wasiImport
+
         const instance = new WebAssembly.Instance(req.module, {
           env: envImports,
+          wasi_snapshot_preview1: wasiImports,
         })
+        wasi.initialize(instance)
         const memory = instance.exports.memory as WebAssembly.Memory
-        instances.set(req.instanceId, { instance, memory })
-        response = { result: req.instanceId }
-        break
-      }
+        const entry: InstanceEntry = { instance, memory }
+        instances.set(instanceId, entry)
 
-      case 'readMemory': {
-        const entry = instances.get(req.instanceId)
-        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
-        const copy = new Uint8Array(req.len)
-        copy.set(new Uint8Array(entry.memory.buffer, req.ptr, req.len))
-        response = { result: copy.buffer, transfer: [copy.buffer] }
-        break
-      }
+        // Register ops with Rust — this creates a TSFN targeting this worker's
+        // event loop. Rust will call these ops directly via the TSFN.
+        const ops = createInstanceOps(entry)
+        instanceOps.set(instanceId, ops)
+        bindings.wasmWorkerRegisterCallback(instanceId, ops)
 
-      case 'writeMemory': {
-        const entry = instances.get(req.instanceId)
-        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
-        new Uint8Array(entry.memory.buffer).set(
-          new Uint8Array(req.data),
-          req.ptr
-        )
-        response = { result: null }
-        break
-      }
-
-      case 'alloc': {
-        const entry = instances.get(req.instanceId)
-        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
-        response = {
-          result: (entry.instance.exports.__alloc as Function)(req.size),
-        }
-        break
-      }
-
-      case 'free': {
-        const entry = instances.get(req.instanceId)
-        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
-        response = {
-          result: (entry.instance.exports.__free as Function)(
-            req.ptr,
-            req.size
-          ),
-        }
-        break
-      }
-
-      case 'getDiag': {
-        const entry = instances.get(req.instanceId)
-        if (!entry) throw new Error(`Instance ${req.instanceId} not found`)
-        response = {
-          result: (
-            entry.instance.exports
-              .__get_transform_plugin_core_pkg_diag as Function
-          )(),
-        }
+        response = { result: instanceId }
         break
       }
 
       case 'dropInstance': {
         instances.delete(req.instanceId)
+        instanceOps.delete(req.instanceId)
         response = { result: null }
         break
       }
@@ -367,14 +156,7 @@ parentPort.on('message', (req: any) => {
         throw new Error(`Unknown request type: ${req.type}`)
     }
 
-    if (response.transfer) {
-      parentPort!.postMessage(
-        { id: req.id, result: response.result },
-        response.transfer
-      )
-    } else {
-      parentPort!.postMessage({ id: req.id, result: response.result })
-    }
+    parentPort!.postMessage({ id: req.id, result: response.result })
   } catch (err: any) {
     parentPort!.postMessage({ id: req.id, error: err.message || String(err) })
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       '@swc/helpers':
         specifier: 0.5.15
         version: 0.5.15
+      '@swc/plugin-react-remove-properties':
+        specifier: 11.1.0
+        version: 11.1.0
       '@swc/types':
         specifier: 0.1.7
         version: 0.1.7
@@ -6435,6 +6438,9 @@ packages:
     engines: {npm: '>= 7.0.0'}
     peerDependencies:
       '@swc/core': '*'
+
+  '@swc/plugin-react-remove-properties@11.1.0':
+    resolution: {integrity: sha512-+L+wq63DMWi4dbcYUmNNEWYZdJjCFqnOTglsTh3/ZHPbB3DWOd2qQtb/CyxfqC6liih4/RoNff2yogm6JBf4aQ==}
 
   '@swc/types@0.1.21':
     resolution: {integrity: sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==}
@@ -24119,6 +24125,10 @@ snapshots:
       '@swc/core': 1.11.24(@swc/helpers@0.5.15)
       '@swc/counter': 0.1.3
       jsonc-parser: 3.3.1
+
+  '@swc/plugin-react-remove-properties@11.1.0':
+    dependencies:
+      '@swc/counter': 0.1.3
 
   '@swc/types@0.1.21':
     dependencies:

--- a/test/unit/swc-plugin-wasm.test.ts
+++ b/test/unit/swc-plugin-wasm.test.ts
@@ -1,0 +1,200 @@
+/* eslint-env jest */
+/**
+ * Tests for the NAPI-based WASM plugin runtime.
+ *
+ * Level 1: wasm-manager worker pool lifecycle (compile, instantiate, drop)
+ * Level 2: Full transform through the SWC bindings with a real plugin binary
+ */
+import path from 'path'
+
+// ---------------------------------------------------------------------------
+// Level 1: wasm-manager worker pool and module lifecycle
+// ---------------------------------------------------------------------------
+
+describe('wasm-manager', () => {
+  let wasmManager: typeof import('next/dist/build/swc/wasm-manager').wasmManager
+
+  beforeAll(() => {
+    // Import wasm-manager directly to test its API without loading native bindings
+    wasmManager = require('next/dist/build/swc/wasm-manager').wasmManager
+  })
+
+  afterAll(() => {
+    // Workers are daemon threads; they'll be cleaned up on process exit.
+    // No explicit shutdown API yet.
+  })
+
+  it('initWorkerPool creates workers', () => {
+    // Set a dummy bindings path for testing (workers won't actually load it
+    // in these lifecycle tests since we don't instantiate WASM modules)
+    wasmManager.setBindingsPath(
+      path.join(
+        __dirname,
+        '..',
+        '..',
+        'node_modules',
+        '@next',
+        'swc',
+        'native',
+        'next-swc.darwin-arm64.node'
+      )
+    )
+    // initWorkerPool now returns void (no SABs)
+    wasmManager.initWorkerPool(2)
+  })
+
+  it('compileModule returns a module ID', () => {
+    // Minimal valid WASM module: magic + version + empty
+    const minimalWasm = new Uint8Array([
+      0x00,
+      0x61,
+      0x73,
+      0x6d, // magic: \0asm
+      0x01,
+      0x00,
+      0x00,
+      0x00, // version: 1
+    ])
+    const moduleId = wasmManager.compileModule(Buffer.from(minimalWasm))
+    expect(typeof moduleId).toBe('number')
+    expect(moduleId).toBeGreaterThan(0)
+
+    // Clean up
+    wasmManager.dropModule(moduleId)
+  })
+
+  it('cloneModule returns a new ID for the same module', () => {
+    const minimalWasm = new Uint8Array([
+      0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+    ])
+    const moduleId = wasmManager.compileModule(Buffer.from(minimalWasm))
+    const cloneId = wasmManager.cloneModule(moduleId)
+
+    expect(cloneId).not.toBe(moduleId)
+    expect(typeof cloneId).toBe('number')
+
+    // Both should be droppable independently
+    wasmManager.dropModule(moduleId)
+    wasmManager.dropModule(cloneId)
+  })
+
+  it('cloneModule throws for unknown module', () => {
+    expect(() => wasmManager.cloneModule(999999)).toThrow(/not found/)
+  })
+
+  // Note: instantiateOnWorker is not tested here because it requires
+  // the native addon to be loaded in the worker thread (the worker enters
+  // a blocking NAPI work loop after instantiation). Full instantiation
+  // is tested in the Level 2 tests via the SWC transform path.
+})
+
+// ---------------------------------------------------------------------------
+// Level 2: Full SWC transform with a real plugin
+// ---------------------------------------------------------------------------
+
+describe('swc plugin transform via NAPI runtime', () => {
+  let transform: typeof import('next/dist/build/swc').transform
+  let pluginPath: string
+
+  beforeAll(async () => {
+    // installBindings() sets loadedBindings so transform() (which uses
+    // getBindingsSync()) works. The Rust side is idempotent — if the
+    // jest-transformer already registered workers, this is a no-op.
+    const { installBindings } = require('next/dist/build/swc/install-bindings')
+    await installBindings()
+    transform = require('next/dist/build/swc').transform
+    pluginPath = require.resolve('@swc/plugin-react-remove-properties')
+  })
+
+  it('transforms code without plugins (sanity check)', async () => {
+    const result = await transform('const x = 1', {
+      filename: 'test.ts',
+      jsc: { parser: { syntax: 'typescript', tsx: false } },
+    })
+    expect(result.code).toContain('x')
+  }, 10000)
+
+  it('transforms code with swc plugin (removes data-* attributes)', async () => {
+    const source = `
+      export default function Page() {
+        return <div data-testid="hello" data-custom="remove-me">Hello World</div>
+      }
+    `
+
+    let result: any
+    try {
+      result = await transform(source, {
+        filename: 'test.tsx',
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            tsx: true,
+          },
+          experimental: {
+            plugins: [[pluginPath, { properties: ['data-custom'] }]],
+          },
+        },
+      })
+    } catch (e: any) {
+      console.error('Transform error:', e.message)
+      console.error('Full error:', JSON.stringify(e, null, 2))
+      throw e
+    }
+
+    expect(result.code).toContain('Hello World')
+    // data-testid should remain (not in the removal list)
+    expect(result.code).toContain('data-testid')
+    // data-custom should be removed by the plugin
+    expect(result.code).not.toContain('data-custom')
+  })
+
+  it('transforms code with plugin removing all data-testid', async () => {
+    const source = `
+      export default function Page() {
+        return (
+          <div data-testid="a">
+            <span data-testid="b">text</span>
+          </div>
+        )
+      }
+    `
+
+    const result = await transform(source, {
+      filename: 'test.tsx',
+      jsc: {
+        parser: {
+          syntax: 'typescript',
+          tsx: true,
+        },
+        experimental: {
+          plugins: [[pluginPath, { properties: ['^data-testid$'] }]],
+        },
+      },
+    })
+
+    expect(result.code).toContain('text')
+    expect(result.code).not.toContain('data-testid')
+  })
+
+  it('handles multiple sequential transforms', async () => {
+    for (let i = 0; i < 5; i++) {
+      const source = `
+        export function Comp${i}() {
+          return <div data-remove="yes">item ${i}</div>
+        }
+      `
+      const result = await transform(source, {
+        filename: `test${i}.tsx`,
+        jsc: {
+          parser: { syntax: 'typescript', tsx: true },
+          experimental: {
+            plugins: [[pluginPath, { properties: ['data-remove'] }]],
+          },
+        },
+      })
+
+      expect(result.code).toContain(`item ${i}`)
+      expect(result.code).not.toContain('data-remove')
+    }
+  })
+})

--- a/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
+++ b/turbopack/crates/turbopack-ecmascript-plugins/Cargo.toml
@@ -17,10 +17,10 @@ swc_ecma_transform_plugin = [
   # Use granular plugin features to avoid pulling in wasmer via __plugin_transform_env_native.
   # __plugin_transform_host provides the plugin runner types and proxy re-exports.
   # __plugin_transform_host_schema_v1 provides the schema version support.
-  # We provide WasmtimeRuntime explicitly, so we don't need swc's env-native backend wiring.
+  # We provide NapiRuntime explicitly, so we don't need swc's env-native backend wiring.
   "swc_core/__plugin_transform_host",
   "swc_core/__plugin_transform_host_schema_v1",
-  "swc_plugin_backend_wasmtime"
+  "swc_plugin_backend_napi"
 ]
 
 [lints]
@@ -46,7 +46,7 @@ turbopack-ecmascript = { workspace = true }
 styled_components = { workspace = true }
 styled_jsx = { workspace = true }
 swc_core = { workspace = true, features = ["ecma_ast", "ecma_visit", "common"] }
-swc_plugin_backend_wasmtime = { workspace = true, optional = true }
+swc_plugin_backend_napi = { workspace = true, optional = true }
 swc_emotion = { workspace = true }
 swc_relay = { workspace = true }
 

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -22,7 +22,7 @@ pub struct SwcPluginModule {
 }
 
 impl SwcPluginModule {
-    pub fn new(plugin_name: RcStr, plugin_bytes: Vec<u8>) -> Self {
+    pub fn new(plugin_name: RcStr, plugin_bytes: Vec<u8>, wasm_plugin_runtime_id: u64) -> Self {
         #[cfg(feature = "swc_ecma_transform_plugin")]
         {
             use swc_core::plugin_runner::plugin_module_bytes::{
@@ -30,9 +30,12 @@ impl SwcPluginModule {
             };
             use swc_plugin_backend_napi::NapiRuntime;
 
+            let runtime = NapiRuntime::from_runtime_id(wasm_plugin_runtime_id)
+                .expect("WASM plugin runtime not registered");
+
             Self {
                 plugin: CompiledPluginModuleBytes::from_raw_module(
-                    &NapiRuntime,
+                    &runtime,
                     RawPluginModuleBytes::new(plugin_name.to_string(), plugin_bytes),
                 ),
                 name: plugin_name,
@@ -41,7 +44,7 @@ impl SwcPluginModule {
 
         #[cfg(not(feature = "swc_ecma_transform_plugin"))]
         {
-            let _ = plugin_bytes;
+            let _ = (plugin_bytes, wasm_plugin_runtime_id);
             Self { name: plugin_name }
         }
     }
@@ -140,14 +143,20 @@ impl Issue for SwcEcmaTransformFailureIssue {
 pub struct SwcEcmaTransformPluginsTransformer {
     #[cfg(feature = "swc_ecma_transform_plugin")]
     plugins: Vec<(turbo_tasks::ResolvedVc<SwcPluginModule>, serde_json::Value)>,
+    #[cfg(feature = "swc_ecma_transform_plugin")]
+    wasm_plugin_runtime_id: u64,
 }
 
 impl SwcEcmaTransformPluginsTransformer {
     #[cfg(feature = "swc_ecma_transform_plugin")]
     pub fn new(
         plugins: Vec<(turbo_tasks::ResolvedVc<SwcPluginModule>, serde_json::Value)>,
+        wasm_plugin_runtime_id: u64,
     ) -> Self {
-        Self { plugins }
+        Self {
+            plugins,
+            wasm_plugin_runtime_id,
+        }
     }
 
     // [TODO] Due to WEB-1102 putting this module itself behind compile time feature
@@ -184,6 +193,9 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
             use swc_plugin_backend_napi::NapiRuntime;
             use turbo_tasks::TryJoinIterExt;
 
+            let runtime = NapiRuntime::from_runtime_id(self.wasm_plugin_runtime_id)
+                .expect("WASM plugin runtime not registered");
+
             let plugins = self
                 .plugins
                 .iter()
@@ -192,7 +204,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                     Ok((
                         plugin_module.name.clone(),
                         config.clone(),
-                        Box::new(plugin_module.plugin.clone_module(&NapiRuntime)),
+                        Box::new(plugin_module.plugin.clone_module(&runtime)),
                     ))
                 })
                 .try_join()
@@ -232,8 +244,10 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                 ctx: &TransformContext<'_>,
                 plugins: Vec<(RcStr, serde_json::Value, Box<CompiledPluginModuleBytes>)>,
                 should_enable_comments_proxy: bool,
+                runtime_id: u64,
             ) -> Result<Program> {
                 use either::Either;
+                use swc_plugin_backend_napi::NapiRuntime;
 
                 let transform_metadata_context = Arc::new(TransformPluginMetadataContext::new(
                     Some(ctx.file_path_str.to_string()),
@@ -251,6 +265,8 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                 // still have to construct from raw bytes internally to perform actual
                 // transform.
                 for (plugin_name, plugin_config, plugin_module) in plugins {
+                    let runtime = NapiRuntime::from_runtime_id(runtime_id)
+                        .expect("WASM plugin runtime not registered");
                     let mut transform_plugin_executor =
                         swc_core::plugin_runner::create_plugin_transform_executor(
                             ctx.source_map,
@@ -259,7 +275,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                             None,
                             plugin_module,
                             Some(plugin_config),
-                            Arc::new(NapiRuntime),
+                            Arc::new(runtime),
                         );
 
                     serialized_program = Either::Right(
@@ -294,6 +310,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                         ctx,
                         plugins,
                         should_enable_comments_proxy,
+                        self.wasm_plugin_runtime_id,
                     ) {
                         Ok(program) => anyhow::Ok(program),
                         Err(e) => {

--- a/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
+++ b/turbopack/crates/turbopack-ecmascript-plugins/src/transform/swc_ecma_transform_plugins.rs
@@ -28,11 +28,11 @@ impl SwcPluginModule {
             use swc_core::plugin_runner::plugin_module_bytes::{
                 CompiledPluginModuleBytes, RawPluginModuleBytes,
             };
-            use swc_plugin_backend_wasmtime::WasmtimeRuntime;
+            use swc_plugin_backend_napi::NapiRuntime;
 
             Self {
                 plugin: CompiledPluginModuleBytes::from_raw_module(
-                    &WasmtimeRuntime,
+                    &NapiRuntime,
                     RawPluginModuleBytes::new(plugin_name.to_string(), plugin_bytes),
                 ),
                 name: plugin_name,
@@ -181,7 +181,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                 plugin::proxies::{COMMENTS, HostCommentsStorage},
                 plugin_runner::plugin_module_bytes::CompiledPluginModuleBytes,
             };
-            use swc_plugin_backend_wasmtime::WasmtimeRuntime;
+            use swc_plugin_backend_napi::NapiRuntime;
             use turbo_tasks::TryJoinIterExt;
 
             let plugins = self
@@ -192,7 +192,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                     Ok((
                         plugin_module.name.clone(),
                         config.clone(),
-                        Box::new(plugin_module.plugin.clone_module(&WasmtimeRuntime)),
+                        Box::new(plugin_module.plugin.clone_module(&NapiRuntime)),
                     ))
                 })
                 .try_join()
@@ -259,7 +259,7 @@ impl CustomTransformer for SwcEcmaTransformPluginsTransformer {
                             None,
                             plugin_module,
                             Some(plugin_config),
-                            Arc::new(WasmtimeRuntime),
+                            Arc::new(NapiRuntime),
                         );
 
                     serialized_program = Either::Right(


### PR DESCRIPTION
## Replace Wasmer with NAPI+V8 for SWC WASM plugin execution

### Summary

This PR replaces the Wasmer WASM runtime used for SWC plugin execution with a new architecture that leverages Node.js's built-in V8 WASM engine via NAPI. Instead of bundling a full WASM runtime (Wasmer/Wasmtime) in the native binary, plugins are executed in Node.js worker threads using `WebAssembly.compile`/`WebAssembly.instantiate`.

### Design

**Architecture:**
- **Main thread** (`wasm-manager.ts`): Manages a worker pool, caches compiled `WebAssembly.Module` objects, and routes setup requests to workers via `postMessage`.
- **Worker threads** (`wasm-worker.ts`): Each worker owns WASM instances in its own V8 isolate, enabling true parallelism across workers.
- **Rust side** (`swc-plugin-backend-napi/src/lib.rs`): Implements the `swc_plugin_runner` runtime trait. Uses a NAPI ThreadsafeFunction for setup operations (compile, instantiate, drop). Transform hot path bypasses the main thread entirely.

**Transform hot path (SharedArrayBuffer + Atomics):**
- Rust writes transform args to a SharedArrayBuffer control region → `Atomics.notify` → worker runs the WASM transform synchronously.
- During transform, host function callbacks (memory read/write/alloc/free) ping-pong between the worker and Rust thread via `Atomics.wait`/`Atomics.notify` — no main thread involvement.
- This avoids the overhead of `postMessage` serialization on every transform call.

**Key benefits:**
- Removes Wasmer/Wasmtime from the dependency tree — smaller native binary
- Uses the same V8 WASM engine that Node.js already ships — no duplicate runtime
- Module compilation is cached and shared across workers via structured clone

### Binary size impact (darwin-arm64)

| Metric | `update_swc_to_support_plugins` (wasmer) | `use_napi_and_v8_for_wasm` (napi+v8) | Delta |
|---|---|---|---|
| Release build | 132 MB (138,774,128 B) | 118 MB (123,401,936 B) | **-15 MB (-11.1%)** |
| Stripped (\`strip -x\`) | 91 MB (95,592,072 B) | 81 MB (84,932,456 B) | **-10.7 MB (-11.2%)** |
| Gzipped stripped (npm) | 31 MB (32,471,211 B) | 27 MB (28,701,967 B) | **-3.8 MB (-11.6%)** |

The binary size reduction comes from removing the Wasmer runtime and its cranelift compiler backend from the dependency tree, relying instead on V8's built-in WASM support.