### PR TITLE
Move adapterPath from experimental to stable top-level config

### DIFF
--- a/docs/01-app/02-guides/upgrading/version-16.mdx
+++ b/docs/01-app/02-guides/upgrading/version-16.mdx
@@ -1040,7 +1040,7 @@ const nextConfig = {
 module.exports = nextConfig
 ```
 
-Share your feedback in the [RFC discussion](https://github.com/vercel/next.js/discussions/77740).
+`adapterPath` was promoted to a stable, top-level option in 16.2.0. See [`adapterPath`](/docs/app/api-reference/config/next-config-js/adapterPath) for the current API reference.
 
 ## Modern Sass API
 

--- a/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
+++ b/docs/01-app/03-api-reference/05-config/01-next-config-js/adapterPath.mdx
@@ -1,7 +1,6 @@
 ---
 title: adapterPath
 description: Configure a custom adapter for Next.js to hook into the build process.
-version: experimental
 ---
 
 Next.js provides a built-in adapters API. It allows deployment platforms or build systems to integrate with the Next.js build process.
@@ -10,14 +9,12 @@ For a full reference implementation, see the [`nextjs/adapter-vercel`](https://g
 
 ## Configuration
 
-To use an adapter, specify the path to your adapter module in `experimental.adapterPath`:
+To use an adapter, specify the path to your adapter module in `adapterPath`:
 
 ```js filename="next.config.js"
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    adapterPath: require.resolve('./my-adapter.js'),
-  },
+  adapterPath: require.resolve('./my-adapter.js'),
 }
 
 module.exports = nextConfig

--- a/docs/02-pages/04-api-reference/04-config/01-next-config-js/adapterPath.mdx
+++ b/docs/02-pages/04-api-reference/04-config/01-next-config-js/adapterPath.mdx
@@ -1,5 +1,5 @@
 ---
-title: experimental.adapterPath
+title: adapterPath
 description: Configure a custom adapter for Next.js to hook into the build process with modifyConfig and buildComplete callbacks.
 source: app/api-reference/config/next-config-js/adapterPath
 ---

--- a/packages/next/src/build/index.ts
+++ b/packages/next/src/build/index.ts
@@ -4122,7 +4122,7 @@ export default async function build(
       // This should come after output: export handling but before
       // output: standalone, in the future output: standalone might
       // not be allowed if an adapter with onBuildComplete is configured
-      const adapterPath = config.experimental.adapterPath
+      const adapterPath = config.adapterPath
       if (adapterPath) {
         await nextBuildSpan
           .traceChild('adapter-handle-build-complete')

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -1059,7 +1059,7 @@ export async function handler(
           // When fallback isn't present, abort this render so we 404
           fallbackMode === FallbackMode.NOT_FOUND
         ) {
-          if (nextConfig.experimental.adapterPath) {
+          if (nextConfig.adapterPath) {
             return await render404()
           }
           throw new NoFallbackError()

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -160,7 +160,7 @@ export async function handler(
 
     if (prerenderInfo) {
       if (prerenderInfo.fallback === false && !isPrerendered) {
-        if (nextConfig.experimental.adapterPath) {
+        if (nextConfig.adapterPath) {
           return await render404()
         }
         throw new NoFallbackError()

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -188,6 +188,7 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
 })
 
 export const experimentalSchema = {
+  /** @deprecated use top-level `adapterPath` instead */
   adapterPath: z.string().optional(),
   useSkewCookie: z.boolean().optional(),
   after: z.boolean().optional(),
@@ -411,6 +412,7 @@ export const experimentalSchema = {
 
 export const configSchema: zod.ZodType<NextConfig> = z.lazy(() =>
   z.strictObject({
+    adapterPath: z.string().optional(),
     allowedDevOrigins: z.array(z.string()).optional(),
     assetPrefix: z.string().optional(),
     basePath: z.string().optional(),

--- a/packages/next/src/server/config-schema.ts
+++ b/packages/next/src/server/config-schema.ts
@@ -188,8 +188,6 @@ const zTurbopackConfig: zod.ZodType<TurbopackOptions> = z.strictObject({
 })
 
 export const experimentalSchema = {
-  /** @deprecated use top-level `adapterPath` instead */
-  adapterPath: z.string().optional(),
   useSkewCookie: z.boolean().optional(),
   after: z.boolean().optional(),
   appNavFailHandling: z.boolean().optional(),

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -393,6 +393,7 @@ export interface LightningCssFeatures {
 }
 
 export interface ExperimentalConfig {
+  /** @deprecated use top-level `adapterPath` instead */
   adapterPath?: string
   appNewScrollHandler?: boolean
   useSkewCookie?: boolean
@@ -1258,6 +1259,12 @@ export interface NextConfig {
    */
   cacheHandler?: string | undefined
 
+  /**
+   * Path to a custom adapter module for deployment platform integration.
+   * Can also be set via the `NEXT_ADAPTER_PATH` environment variable.
+   */
+  adapterPath?: string
+
   cacheHandlers?: {
     default?: string
     remote?: string
@@ -1707,8 +1714,8 @@ export const defaultConfig = Object.freeze({
     remote: process.env.NEXT_REMOTE_CACHE_HANDLER_PATH,
     static: process.env.NEXT_STATIC_CACHE_HANDLER_PATH,
   },
+  adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
   experimental: {
-    adapterPath: process.env.NEXT_ADAPTER_PATH || undefined,
     appNewScrollHandler: false,
     useSkewCookie: false,
     cssChunking: true,
@@ -1858,6 +1865,7 @@ export interface NextConfigRuntime {
   pageExtensions: NextConfigComplete['pageExtensions']
   useFileSystemPublicRoutes: NextConfigComplete['useFileSystemPublicRoutes']
   logging?: NextConfigComplete['logging']
+  adapterPath?: NextConfigComplete['adapterPath']
 
   experimental: Pick<
     NextConfigComplete['experimental'],
@@ -1872,7 +1880,6 @@ export interface NextConfigRuntime {
     | 'authInterrupts'
     | 'clientTraceMetadata'
     | 'clientParamParsingOrigins'
-    | 'adapterPath'
     | 'allowedRevalidateHeaderKeys'
     | 'fetchCacheKeyPrefix'
     | 'isrFlushToDisk'
@@ -1938,10 +1945,6 @@ export function getNextConfigRuntime(
         authInterrupts: ex.authInterrupts,
         clientTraceMetadata: ex.clientTraceMetadata,
         clientParamParsingOrigins: ex.clientParamParsingOrigins,
-        // The full adapterPath might be non-deterministic across builds and doesn't actually matter
-        // at runtime, as it's only used to determine whether the adapter was used or not, not to
-        // execute it again. So replace it with a placeholder if it's set.
-        adapterPath: ex.adapterPath ? '<ommited but set>' : undefined,
         allowedRevalidateHeaderKeys: ex.allowedRevalidateHeaderKeys,
         fetchCacheKeyPrefix: ex.fetchCacheKeyPrefix,
         isrFlushToDisk: ex.isrFlushToDisk,
@@ -2002,6 +2005,9 @@ export function getNextConfigRuntime(
     poweredByHeader: config.poweredByHeader,
     cacheHandler: config.cacheHandler,
     cacheHandlers: config.cacheHandlers,
+    // The full adapterPath might be non-deterministic across builds and doesn't
+    // actually matter at runtime, so replace it with a placeholder if it's set.
+    adapterPath: config.adapterPath ? '<omitted but set>' : undefined,
     cacheMaxMemorySize: config.cacheMaxMemorySize,
     compress: config.compress,
     i18n: config.i18n,

--- a/packages/next/src/server/config-shared.ts
+++ b/packages/next/src/server/config-shared.ts
@@ -393,8 +393,6 @@ export interface LightningCssFeatures {
 }
 
 export interface ExperimentalConfig {
-  /** @deprecated use top-level `adapterPath` instead */
-  adapterPath?: string
   appNewScrollHandler?: boolean
   useSkewCookie?: boolean
   /** @deprecated use top-level `cacheHandlers` instead */

--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -798,6 +798,13 @@ function assignDefaultsAndValidate(
     configFileName,
     silent
   )
+  warnOptionHasBeenMovedOutOfExperimental(
+    result,
+    'adapterPath',
+    'adapterPath',
+    configFileName,
+    silent
+  )
 
   if ((result.experimental as any).outputStandalone) {
     if (!silent) {
@@ -1452,11 +1459,9 @@ async function applyModifyConfig(
 ): Promise<NextConfigComplete> {
   // we always call modify config  and phase can be used to only
   // modify for specific times
-  if (config.experimental?.adapterPath) {
+  if (config.adapterPath) {
     const adapterMod = interopDefault(
-      await import(
-        pathToFileURL(require.resolve(config.experimental.adapterPath)).href
-      )
+      await import(pathToFileURL(require.resolve(config.adapterPath)).href)
     ) as NextAdapter
 
     if (typeof adapterMod.modifyConfig === 'function') {

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -196,7 +196,7 @@ export const getHandler = ({
 
       if (prerenderInfo) {
         if (prerenderInfo.fallback === false && !isPrerendered) {
-          if (nextConfig.experimental.adapterPath) {
+          if (nextConfig.adapterPath) {
             return await render404()
           }
           throw new NoFallbackError()

--- a/test/e2e/app-dir/cache-components/next.config.js
+++ b/test/e2e/app-dir/cache-components/next.config.js
@@ -3,10 +3,8 @@
  */
 const nextConfig = {
   cacheComponents: true,
-  experimental: {
-    adapterPath:
-      process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.mjs'),
-  },
+  adapterPath:
+    process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.mjs'),
 }
 
 module.exports = nextConfig

--- a/test/e2e/edge-pages-support/app/next.config.js
+++ b/test/e2e/edge-pages-support/app/next.config.js
@@ -11,8 +11,6 @@ module.exports = {
       },
     ]
   },
-  experimental: {
-    adapterPath:
-      process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.js'),
-  },
+  adapterPath:
+    process.env.NEXT_ADAPTER_PATH ?? require.resolve('./my-adapter.js'),
 }

--- a/test/production/adapter-config/next.config.mjs
+++ b/test/production/adapter-config/next.config.mjs
@@ -3,9 +3,7 @@ const require = Module.createRequire(import.meta.url)
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  experimental: {
-    adapterPath: require.resolve('./my-adapter.mjs'),
-  },
+  adapterPath: require.resolve('./my-adapter.mjs'),
   cacheComponents: process.env.TEST_CACHE_COMPONENTS === '1',
   rewrites() {
     return [

--- a/test/production/app-dir/adapter-partial-fallback/next.config.js
+++ b/test/production/app-dir/adapter-partial-fallback/next.config.js
@@ -3,8 +3,8 @@
  */
 const nextConfig = {
   cacheComponents: true,
+  adapterPath: require.resolve('./my-adapter.mjs'),
   experimental: {
-    adapterPath: require.resolve('./my-adapter.mjs'),
     partialFallbacks: true,
   },
 }


### PR DESCRIPTION
## Move `adapterPath` from experimental to stable

Graduates `adapterPath` from `experimental.adapterPath` to a top-level `NextConfig` option, following the same pattern used for `cacheHandlers`, `cacheComponents`, `typedRoutes`, and other options that moved out of experimental.

### Changes

- **Type definition** (`config-shared.ts`): Added `adapterPath` to `NextConfig` interface, moved default value to top-level in `defaultConfig`, updated `NextConfigRuntime` and `getNextConfigRuntime`
- **Zod schema** (`config-schema.ts`): Added `adapterPath` to top-level `configSchema`
- **Backward compat** (`config.ts`): Added `warnOptionHasBeenMovedOutOfExperimental` call so existing `experimental.adapterPath` configs still work with a deprecation warning, updated `applyModifyConfig` to read from `config.adapterPath`
- **Runtime references**: Updated `build/index.ts`, `app-page.ts`, `app-route.ts`, `pages-handler.ts` to use `config.adapterPath` / `nextConfig.adapterPath`
- **Tests**: Updated 4 test fixture `next.config` files
- **Docs**: Updated app router doc (removed `version: experimental` frontmatter, top-level config example), pages router doc title, and v16 upgrade guide