### PR TITLE
Skip loadBindings() Lightning CSS check during next start

### DIFF
--- a/packages/next/src/server/config.ts
+++ b/packages/next/src/server/config.ts
@@ -9,7 +9,7 @@ import {
   PHASE_DEVELOPMENT_SERVER,
   PHASE_EXPORT,
   PHASE_PRODUCTION_BUILD,
-  type PHASE_PRODUCTION_SERVER,
+  PHASE_PRODUCTION_SERVER,
   type PHASE_TYPE,
 } from '../shared/lib/constants'
 import { defaultConfig, normalizeConfig } from './config-shared'
@@ -1796,7 +1796,10 @@ export default async function loadConfig(
       )
     }
 
-    if (userConfig.experimental?.useLightningcss) {
+    if (
+      phase !== PHASE_PRODUCTION_SERVER &&
+      userConfig.experimental?.useLightningcss
+    ) {
       const { loadBindings } =
         require('../build/swc') as typeof import('../build/swc')
       const isLightningSupported = (


### PR DESCRIPTION
## Summary
Avoid calling `loadBindings()` to check whether the loaded binary supports Lightning CSS during `next start`, as this is unnecessary for production server operation. The check should only occur during the build phase.

- Skips the native binary load during `next start` (production server phase)
- No impact on build, development, or export phases
- Reduces production server startup overhead

## Test plan
- [x] Build and start tests passing
- [x] CI green (except pre-existing flaky cache components test in rerun)