### PR TITLE
Turbopack: Use `debug = "line-tables-only"` for dev builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ unexpected_cfgs = { level = "warn", check-cfg = [
   'cfg(codspeed)',
 ] }
 
+[profile.dev]
+# https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html
+debug = "line-tables-only"
+
 # This crate is particularly sensitive to compiler optimizations
 [profile.dev.package.turbo-persistence]
 opt-level = 1
@@ -43,6 +47,10 @@ opt-level = 1
 # Set the settings for build scripts and proc-macros.
 [profile.dev.build-override]
 opt-level = 3
+
+[profile.dev-with-debug]
+inherits = "dev"
+debug = true
 
 [profile.release]
 lto = "thin"


### PR DESCRIPTION
This defaults to `true`: https://doc.rust-lang.org/cargo/reference/profiles.html#debug

Nobody on the team uses a debugger often enough for this to be worth the time tradeoff: https://kobzol.github.io/rust/rustc/2025/05/20/disable-debuginfo-to-improve-rust-compile-times.html

I'm gathering some rough numbers, and I'll add them to the PR.

After `cargo clean` and one `cargo build -p next-napi-bindings` with each profile (Linux arm64):

```
du -sh target/*
4.0K    target/CACHEDIR.TAG
7.9G    target/debug
14G     target/dev-with-debug
7.5M    target/generated
```

This is nearly half the size.

Due to cargo quirks, the `dev` profile defaults to the `target/debug` directory. Of course, any disk size wins you get are more than offset if you need to use a debugger and end up with an additional profile.

```
hyperfine -w 1 -r 5 -p 'cargo clean' 'cargo build --profile dev-with-debug -p next-napi-bindings' 'cargo build -p next-napi-bindings'
```

![Screenshot 2026-03-18 at 11.46.19 AM.png](https://app.graphite.com/user-attachments/assets/c7117107-7d8f-465f-b7aa-382c3ed222ac.png)

(this is on https://github.com/bgw/benchmark-scripts/, on my M2 Macbook inside of a Linux VM this takes closer to 2m20s)

That's a cold build, the blog post I linked indicated this may be even more significant for incremental builds.