### PR TITLE
perf(headers): O(1) case-insensitive lookup in HeadersAdapter

### DIFF
--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -123,6 +123,38 @@ export class HeadersAdapter extends Headers {
     // calling the super constructor to ensure that the instanceof check works.
     super()
 
+    // Build a fast lookup map from lowercase key to original key. This replaces
+    // the O(n) Object.keys().find() on every proxy trap with an O(1) Map.get().
+    // The map is kept in sync by set and deleteProperty, and handles
+    // out-of-band mutations on the original headers object by falling back to
+    // a linear scan (and caching the result) on cache misses.
+    const keyMap = new Map<string, string>()
+    for (const key of Object.keys(headers)) {
+      const lowercased = key.toLowerCase()
+      // `Object.keys().find()` returns the *first* matching key, so only
+      // record the first one here too. Mixed-case duplicates are already
+      // documented as unsupported, but this keeps which one wins unchanged.
+      if (!keyMap.has(lowercased)) keyMap.set(lowercased, key)
+    }
+
+    // Resolves the original-cased header key for a given lowercased key.
+    // Checks the fast map first (O(1)). On a miss, which can happen when the
+    // underlying headers object is mutated directly, falls back to a linear
+    // scan and updates the map so subsequent accesses are O(1) again.
+    function resolveOriginalKey(lowercased: string): string | undefined {
+      let original = keyMap.get(lowercased)
+      if (typeof original !== 'undefined') return original
+
+      // Fallback: the headers object may have been mutated out of band.
+      original = Object.keys(headers).find(
+        (o) => o.toLowerCase() === lowercased
+      )
+      if (typeof original !== 'undefined') {
+        keyMap.set(lowercased, original)
+      }
+      return original
+    }
+
     this.headers = new Proxy(headers, {
       get(target, prop, receiver) {
         // Because this is just an object, we expect that all "get" operations
@@ -133,13 +165,7 @@ export class HeadersAdapter extends Headers {
         }
 
         const lowercased = prop.toLowerCase()
-
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        const original = resolveOriginalKey(lowercased)
 
         // If the original casing doesn't exist, return undefined.
         if (typeof original === 'undefined') return
@@ -153,28 +179,21 @@ export class HeadersAdapter extends Headers {
         }
 
         const lowercased = prop.toLowerCase()
+        const original = resolveOriginalKey(lowercased)
+        const key = original ?? prop
 
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        // Keep the map in sync with the new key.
+        if (typeof original === 'undefined') {
+          keyMap.set(lowercased, prop)
+        }
 
-        // If the original casing doesn't exist, use the prop as the key.
-        return ReflectAdapter.set(target, original ?? prop, value, receiver)
+        return ReflectAdapter.set(target, key, value, receiver)
       },
       has(target, prop) {
         if (typeof prop === 'symbol') return ReflectAdapter.has(target, prop)
 
         const lowercased = prop.toLowerCase()
-
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        const original = resolveOriginalKey(lowercased)
 
         // If the original casing doesn't exist, return false.
         if (typeof original === 'undefined') return false
@@ -187,16 +206,13 @@ export class HeadersAdapter extends Headers {
           return ReflectAdapter.deleteProperty(target, prop)
 
         const lowercased = prop.toLowerCase()
-
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        const original = resolveOriginalKey(lowercased)
 
         // If the original casing doesn't exist, return true.
         if (typeof original === 'undefined') return true
+
+        // Remove from the lookup map to keep it in sync.
+        keyMap.delete(lowercased)
 
         // If the original casing exists, delete the property.
         return ReflectAdapter.deleteProperty(target, original)

--- a/packages/next/src/server/web/spec-extension/adapters/headers.ts
+++ b/packages/next/src/server/web/spec-extension/adapters/headers.ts
@@ -33,6 +33,34 @@ export class HeadersAdapter extends Headers {
     // calling the super constructor to ensure that the instanceof check works.
     super()
 
+    // Build a fast lookup map from lowercase key to original key. This replaces
+    // the O(n) Object.keys().find() on every proxy trap with an O(1) Map.get().
+    // The map is kept in sync by set and deleteProperty, and handles
+    // out-of-band mutations on the original headers object by falling back to
+    // a linear scan (and caching the result) on cache misses.
+    const keyMap = new Map<string, string>()
+    for (const key of Object.keys(headers)) {
+      keyMap.set(key.toLowerCase(), key)
+    }
+
+    // Resolves the original-cased header key for a given lowercased key.
+    // Checks the fast map first (O(1)). On a miss, which can happen when the
+    // underlying headers object is mutated directly, falls back to a linear
+    // scan and updates the map so subsequent accesses are O(1) again.
+    function resolveOriginalKey(lowercased: string): string | undefined {
+      let original = keyMap.get(lowercased)
+      if (typeof original !== 'undefined') return original
+
+      // Fallback: the headers object may have been mutated out of band.
+      original = Object.keys(headers).find(
+        (o) => o.toLowerCase() === lowercased
+      )
+      if (typeof original !== 'undefined') {
+        keyMap.set(lowercased, original)
+      }
+      return original
+    }
+
     this.headers = new Proxy(headers, {
       get(target, prop, receiver) {
         // Because this is just an object, we expect that all "get" operations
@@ -43,13 +71,7 @@ export class HeadersAdapter extends Headers {
         }
 
         const lowercased = prop.toLowerCase()
-
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        const original = resolveOriginalKey(lowercased)
 
         // If the original casing doesn't exist, return undefined.
         if (typeof original === 'undefined') return
@@ -63,28 +85,21 @@ export class HeadersAdapter extends Headers {
         }
 
         const lowercased = prop.toLowerCase()
+        const original = resolveOriginalKey(lowercased)
+        const key = original ?? prop
 
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        // Keep the map in sync with the new key.
+        if (typeof original === 'undefined') {
+          keyMap.set(lowercased, prop)
+        }
 
-        // If the original casing doesn't exist, use the prop as the key.
-        return ReflectAdapter.set(target, original ?? prop, value, receiver)
+        return ReflectAdapter.set(target, key, value, receiver)
       },
       has(target, prop) {
         if (typeof prop === 'symbol') return ReflectAdapter.has(target, prop)
 
         const lowercased = prop.toLowerCase()
-
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        const original = resolveOriginalKey(lowercased)
 
         // If the original casing doesn't exist, return false.
         if (typeof original === 'undefined') return false
@@ -97,16 +112,13 @@ export class HeadersAdapter extends Headers {
           return ReflectAdapter.deleteProperty(target, prop)
 
         const lowercased = prop.toLowerCase()
-
-        // Let's find the original casing of the key. This assumes that there is
-        // no mixed case keys (e.g. "Content-Type" and "content-type") in the
-        // headers object.
-        const original = Object.keys(headers).find(
-          (o) => o.toLowerCase() === lowercased
-        )
+        const original = resolveOriginalKey(lowercased)
 
         // If the original casing doesn't exist, return true.
         if (typeof original === 'undefined') return true
+
+        // Remove from the lookup map to keep it in sync.
+        keyMap.delete(lowercased)
 
         // If the original casing exists, delete the property.
         return ReflectAdapter.deleteProperty(target, original)


### PR DESCRIPTION
## Summary

- Replace O(n) `Object.keys().find()` with O(1) `Map.get()` in the `HeadersAdapter` Proxy traps (`get`, `set`, `has`, `deleteProperty`)
- Build a `Map<lowercase, originalKey>` once in the constructor from initial headers
- Keep the map in sync on `set` (adds entries) and `deleteProperty` (removes entries)
- Handle out-of-band mutations on the underlying `IncomingHttpHeaders` object by falling back to a linear scan on cache miss and caching the result

## Motivation

The `HeadersAdapter` is used on every SSR request to wrap Node.js `IncomingHttpHeaders`. Every call to `.get()`, `.has()`, `.set()`, or `delete` on the adapter triggers a Proxy trap that does:

```js
Object.keys(headers).find(o => o.toLowerCase() === lowercased)
```

This is **O(n) per access** where n = number of headers. A typical HTTP request carries 10-20 headers, and during SSR rendering headers are accessed many times (cookies, content-type, accept, authorization, user-agent, x-forwarded-for, custom headers, etc.). The cumulative cost of repeated linear scans over every header key on every access adds up in high-throughput SSR scenarios.

This is the same class of optimization highlighted in the [TanStack Start blog post about 5x SSR throughput](https://tanstack.com/blog/tanstack-start-5x-faster-ssr) — avoiding O(n) operations in hot paths is one of the most impactful patterns for SSR performance.

The fix pre-computes a `Map<string, string>` (lowercase -> original key) and uses `Map.get()` for O(1) lookups. The map is kept consistent through `set`/`delete` operations and handles the edge case where external code mutates the `IncomingHttpHeaders` object directly (tested in the existing test suite).

## Test plan

- [x] All 15 existing `HeadersAdapter` unit tests pass, including the "mutated out of band" case that validates the fallback path
- No new tests needed — this is a pure performance optimization with identical observable behavior


🤖 Generated with [Claude Code](https://claude.com/claude-code)