### PR TITLE
perf: skip reactive overhead during SSR and avoid V8 hidden class mutations

### DIFF
--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1616,14 +1616,11 @@ export default abstract class Server<
         }
         parsedUrl.pathname = normalizeResult.pathname
 
-        for (const key of Object.keys(parsedUrl.query)) {
-          delete parsedUrl.query[key]
-        }
+        // Replace the query object instead of loop-deleting every key.
+        // Using `delete` on object properties mutates V8 hidden classes,
+        // which de-optimises inline caches on downstream property accesses.
         const invokeQuery = getRequestMeta(req, 'invokeQuery')
-
-        if (invokeQuery) {
-          Object.assign(parsedUrl.query, invokeQuery)
-        }
+        parsedUrl.query = invokeQuery ? { ...invokeQuery } : {}
 
         finished = await this.normalizeAndAttachMetadata(req, res, parsedUrl)
         if (finished) return
@@ -2100,7 +2097,9 @@ export default abstract class Server<
     if (!addedNextUrlToVary) {
       // Remove `Next-URL` from the request headers we determined it wasn't necessary to include in the Vary header.
       // This is to avoid any dependency on the `Next-URL` header being present when preparing the response.
-      delete req.headers[NEXT_URL]
+      // Use undefined assignment instead of delete to preserve V8 hidden class.
+      // Downstream code checks this header by value, not with the `in` operator.
+      req.headers[NEXT_URL] = undefined
     }
   }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2097,9 +2097,7 @@ export default abstract class Server<
     if (!addedNextUrlToVary) {
       // Remove `Next-URL` from the request headers we determined it wasn't necessary to include in the Vary header.
       // This is to avoid any dependency on the `Next-URL` header being present when preparing the response.
-      // Use undefined assignment instead of delete to preserve V8 hidden class.
-      // Downstream code checks this header by value, not with the `in` operator.
-      req.headers[NEXT_URL] = undefined
+      delete req.headers[NEXT_URL]
     }
   }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -1541,14 +1541,11 @@ export default abstract class Server<
         }
         parsedUrl.pathname = normalizeResult.pathname
 
-        for (const key of Object.keys(parsedUrl.query)) {
-          delete parsedUrl.query[key]
-        }
+        // Replace the query object instead of loop-deleting every key.
+        // Using `delete` on object properties mutates V8 hidden classes,
+        // which de-optimises inline caches on downstream property accesses.
         const invokeQuery = getRequestMeta(req, 'invokeQuery')
-
-        if (invokeQuery) {
-          Object.assign(parsedUrl.query, invokeQuery)
-        }
+        parsedUrl.query = invokeQuery ? { ...invokeQuery } : {}
 
         finished = await this.normalizeAndAttachMetadata(req, res, parsedUrl)
         if (finished) return
@@ -2018,7 +2015,9 @@ export default abstract class Server<
     if (!addedNextUrlToVary) {
       // Remove `Next-URL` from the request headers we determined it wasn't necessary to include in the Vary header.
       // This is to avoid any dependency on the `Next-URL` header being present when preparing the response.
-      delete req.headers[NEXT_URL]
+      // Use undefined assignment instead of delete to preserve V8 hidden class.
+      // Downstream code checks this header by value, not with the `in` operator.
+      req.headers[NEXT_URL] = undefined
     }
   }
 

--- a/packages/next/src/server/base-server.ts
+++ b/packages/next/src/server/base-server.ts
@@ -2015,9 +2015,7 @@ export default abstract class Server<
     if (!addedNextUrlToVary) {
       // Remove `Next-URL` from the request headers we determined it wasn't necessary to include in the Vary header.
       // This is to avoid any dependency on the `Next-URL` header being present when preparing the response.
-      // Use undefined assignment instead of delete to preserve V8 hidden class.
-      // Downstream code checks this header by value, not with the `in` operator.
-      req.headers[NEXT_URL] = undefined
+      delete req.headers[NEXT_URL]
     }
   }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -414,10 +414,7 @@ export function removeRequestMeta<K extends keyof RequestMeta>(
   key: K
 ) {
   const meta = getRequestMeta(request)
-  // Set to undefined instead of delete to preserve V8 hidden class.
-  // All consumers use getRequestMeta(req, key) which returns meta[key],
-  // so undefined is semantically equivalent to a missing key.
-  meta[key] = undefined as RequestMeta[K]
+  delete meta[key]
   return setRequestMeta(request, meta)
 }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -414,7 +414,10 @@ export function removeRequestMeta<K extends keyof RequestMeta>(
   key: K
 ) {
   const meta = getRequestMeta(request)
-  delete meta[key]
+  // Set to undefined instead of delete to preserve V8 hidden class.
+  // All consumers use getRequestMeta(req, key) which returns meta[key],
+  // so undefined is semantically equivalent to a missing key.
+  meta[key] = undefined as RequestMeta[K]
   return setRequestMeta(request, meta)
 }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -372,7 +372,10 @@ export function removeRequestMeta<K extends keyof RequestMeta>(
   key: K
 ) {
   const meta = getRequestMeta(request)
-  delete meta[key]
+  // Set to undefined instead of delete to preserve V8 hidden class.
+  // All consumers use getRequestMeta(req, key) which returns meta[key],
+  // so undefined is semantically equivalent to a missing key.
+  meta[key] = undefined as RequestMeta[K]
   return setRequestMeta(request, meta)
 }
 

--- a/packages/next/src/server/request-meta.ts
+++ b/packages/next/src/server/request-meta.ts
@@ -372,10 +372,7 @@ export function removeRequestMeta<K extends keyof RequestMeta>(
   key: K
 ) {
   const meta = getRequestMeta(request)
-  // Set to undefined instead of delete to preserve V8 hidden class.
-  // All consumers use getRequestMeta(req, key) which returns meta[key],
-  // so undefined is semantically equivalent to a missing key.
-  meta[key] = undefined as RequestMeta[K]
+  delete meta[key]
   return setRequestMeta(request, meta)
 }
 

--- a/packages/next/src/shared/lib/loadable.shared-runtime.tsx
+++ b/packages/next/src/shared/lib/loadable.shared-runtime.tsx
@@ -196,7 +196,10 @@ class LoadableSubscription {
       if (typeof opts.delay === 'number') {
         if (opts.delay === 0) {
           this._state.pastDelay = true
-        } else {
+        } else if (typeof window !== 'undefined') {
+          // Skip timers during SSR — the render is synchronous,
+          // there are no subscribers to notify, and the timers
+          // would leak in the Node.js process.
           this._delay = setTimeout(() => {
             this._update({
               pastDelay: true,
@@ -205,7 +208,7 @@ class LoadableSubscription {
         }
       }
 
-      if (typeof opts.timeout === 'number') {
+      if (typeof opts.timeout === 'number' && typeof window !== 'undefined') {
         this._timeout = setTimeout(() => {
           this._update({ timedOut: true })
         }, opts.timeout)


### PR DESCRIPTION
## Summary

Two targeted optimizations for SSR hot paths, inspired by [TanStack Start's 5.5x SSR throughput improvements](https://tanstack.com/blog/tanstack-start-5x-ssr-throughput).

### 1. Replace loop-delete with fresh object for query clearing

In `base-server.ts`, the invoke path handler clears `parsedUrl.query` by loop-deleting every key, then repopulating via `Object.assign`. This performs N `delete` operations, each mutating the V8 hidden class. Replaced with a single object assignment:

\`\`\`ts
// Before: N delete operations + Object.assign
for (const key of Object.keys(parsedUrl.query)) { delete parsedUrl.query[key] }
if (invokeQuery) { Object.assign(parsedUrl.query, invokeQuery) }

// After: single assignment
parsedUrl.query = invokeQuery ? { ...invokeQuery } : {}
\`\`\`

### 2. Skip loadable timer setup during SSR

\`LoadableSubscription.retry()\` creates \`setTimeout\` timers for delay/timeout states. During SSR, \`useSyncExternalStore\` uses the server snapshot directly without subscribing, so these timers fire with no listeners and leak in the Node.js process. Added \`typeof window !== 'undefined'\` guards.

## Test plan

- [ ] Verify invoke path query handling works correctly
- [ ] Verify \`next/dynamic\` with loading/timeout works in SSR and client
- [ ] No regressions in SSR rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)