### PR TITLE
fix(middleware): correctly match root path when basePath is set

### DIFF
--- a/packages/next/src/server/lib/router-utils/resolve-routes.ts
+++ b/packages/next/src/server/lib/router-utils/resolve-routes.ts
@@ -533,15 +533,29 @@ export function getResolveRoutes(
             /* non-fatal we can't decode so can't match it */
           }
 
+          // Remove basePath before matching, as middleware matchers are defined
+          // relative to the application root, not including the basePath.
+          let normalizedPathname = maybeDecodedPathname
+          if (normalizers.basePath?.match(maybeDecodedPathname)) {
+            normalizedPathname = normalizers.basePath.normalize(
+              maybeDecodedPathname,
+              true
+            )
+          }
+
+          // Also normalize the non-decoded pathname for the first check
+          let normalizedNonDecodedPathname = parsedUrl.pathname || '/'
+          if (normalizers.basePath?.match(parsedUrl.pathname || '')) {
+            normalizedNonDecodedPathname = normalizers.basePath.normalize(
+              parsedUrl.pathname || '/',
+              true
+            )
+          }
+
           if (
             // @ts-expect-error BaseNextRequest stuff
-            match?.(parsedUrl.pathname, req, parsedUrl.query) ||
-            match?.(
-              maybeDecodedPathname,
-              // @ts-expect-error BaseNextRequest stuff
-              req,
-              parsedUrl.query
-            )
+            match?.(normalizedNonDecodedPathname, req, parsedUrl.query) ||
+            match?.(normalizedPathname, req, parsedUrl.query)
           ) {
             if (ensureMiddleware) {
               await ensureMiddleware(req.url)


### PR DESCRIPTION
## Summary

Fixes a bug where middleware matchers did not correctly match the root path when a basePath was configured.

## Problem

When setting a \asePath\ in next.config.js, the middleware matcher does not correctly match the root path \/\.

For example, with \asePath: "/my-app"\, a middleware with \matcher: ["/"]\ should match \/my-app/\ but it didn't.

## Fix

Adjusted the matcher logic to properly account for basePath when matching the root path by normalizing the pathname before passing it to the matcher function.

## Testing

- [x] Existing middleware+basePath tests should now pass
- [x] Verified middleware matches /my-app/ with basePath: "/my-app" and matcher: ["/"]

Fixes vercel/next.js#73786