### PR TITLE
perf: pre-compile regex in stripParameterSeparators

### DIFF
--- a/packages/next/src/lib/route-pattern-normalizer.ts
+++ b/packages/next/src/lib/route-pattern-normalizer.ts
@@ -17,6 +17,14 @@ import type { Token } from 'next/dist/compiled/path-to-regexp'
 export const PARAM_SEPARATOR = '_NEXTSEP_'
 
 /**
+ * Pre-compiled regexes for stripping PARAM_SEPARATOR.
+ * These are derived from the constant above and reused across calls
+ * to avoid repeated RegExp construction inside hot loops.
+ */
+const PARAM_SEPARATOR_LEADING_RE = new RegExp(`^${PARAM_SEPARATOR}`)
+const PARAM_SEPARATOR_AFTER_PAREN_RE = new RegExp(`\\)${PARAM_SEPARATOR}`, 'g')
+
+/**
  * Detects if a route pattern needs normalization for path-to-regexp compatibility.
  */
 export function hasAdjacentParameterIssues(route: string): boolean {
@@ -112,7 +120,7 @@ export function stripNormalizedSeparators(pathname: string): string {
   // Remove separator after interception route markers
   // Pattern: (.)_NEXTSEP_ -> (.), (..)_NEXTSEP_ -> (..), etc.
   // The separator appears after the closing paren of interception markers
-  return pathname.replace(new RegExp(`\\)${PARAM_SEPARATOR}`, 'g'), ')')
+  return pathname.replace(PARAM_SEPARATOR_AFTER_PAREN_RE, ')')
 }
 
 /**
@@ -127,12 +135,12 @@ export function stripParameterSeparators(
   for (const [key, value] of Object.entries(params)) {
     if (typeof value === 'string') {
       // Remove the separator if it appears at the start of parameter values
-      cleaned[key] = value.replace(new RegExp(`^${PARAM_SEPARATOR}`), '')
+      cleaned[key] = value.replace(PARAM_SEPARATOR_LEADING_RE, '')
     } else if (Array.isArray(value)) {
       // Handle array parameters (from repeated route segments)
       cleaned[key] = value.map((item) =>
         typeof item === 'string'
-          ? item.replace(new RegExp(`^${PARAM_SEPARATOR}`), '')
+          ? item.replace(PARAM_SEPARATOR_LEADING_RE, '')
           : item
       )
     } else {


### PR DESCRIPTION
## Summary

- Pre-compile `PARAM_SEPARATOR` regexes at module level instead of constructing them via `new RegExp()` on every invocation
- `stripParameterSeparators` was creating a fresh `RegExp` per parameter inside a loop; `stripNormalizedSeparators` did the same on each call
- Both regexes are derived from the constant `PARAM_SEPARATOR = '_NEXTSEP_'` and never change, so they can safely be hoisted

## Why

`stripParameterSeparators` showed up as **~22 ms** in CPU profiles during sustained load. The cost comes from repeated `new RegExp(`^${PARAM_SEPARATOR}`)` inside the `for...of` loop over `Object.entries(params)` — one allocation per string param, plus one per array item.

Moving the two patterns (`^_NEXTSEP_` and `\)_NEXTSEP_` with `g` flag) to module-scope constants eliminates the repeated regex compilation entirely.

## Test plan

- [ ] Existing `route-match-utils.test.ts` tests pass (behavioral, no change to inputs/outputs)
- [ ] No new tests needed — this is a pure refactor with identical semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)