### PR TITLE
perf: optimize parseRelativeUrl with server-side fast path

### DIFF
--- a/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
+++ b/packages/next/src/shared/lib/router/utils/parse-relative-url.ts
@@ -16,6 +16,10 @@ export interface ParsedRelativeUrl {
   slashes: null
 }
 
+// Pre-computed server-side base URL origin to avoid repeated URL construction.
+// On the server, the base is always 'http://n' (a dummy origin).
+const SERVER_ORIGIN = 'http://n'
+
 /**
  * Parses path-relative urls (e.g. `/hello/world?foo=bar`). If url isn't path-relative
  * (e.g. `./hello`) then at least base must be.
@@ -37,26 +41,52 @@ export function parseRelativeUrl(
   base?: string,
   parseQuery = true
 ): ParsedRelativeUrl | Omit<ParsedRelativeUrl, 'query'> {
+  // Server fast path: most SSR calls have no base and url starts with '/'.
+  // This avoids constructing 2-3 URL objects (globalBase, resolvedBase, final)
+  // and instead constructs only 1.
+  if (typeof window === 'undefined' && !base && url.startsWith('/')) {
+    const parsed = new URL(`${SERVER_ORIGIN}${url}`)
+    if (parsed.origin !== SERVER_ORIGIN) {
+      throw new Error(
+        `invariant: invalid relative URL, router received ${url}`
+      )
+    }
+    return {
+      auth: null,
+      host: null,
+      hostname: null,
+      pathname: parsed.pathname,
+      port: null,
+      protocol: null,
+      query: parseQuery
+        ? searchParamsToUrlQuery(parsed.searchParams)
+        : undefined,
+      search: parsed.search,
+      hash: parsed.hash,
+      href: parsed.href.slice(SERVER_ORIGIN.length),
+      slashes: null,
+    }
+  }
+
   const globalBase = new URL(
-    typeof window === 'undefined' ? 'http://n' : getLocationOrigin()
+    typeof window === 'undefined' ? SERVER_ORIGIN : getLocationOrigin()
   )
 
   const resolvedBase = base
     ? new URL(base, globalBase)
     : url.startsWith('.')
       ? new URL(
-          typeof window === 'undefined' ? 'http://n' : window.location.href
+          typeof window === 'undefined' ? SERVER_ORIGIN : window.location.href
         )
       : globalBase
 
-  const { pathname, searchParams, search, hash, href, origin } = url.startsWith(
-    '/'
-  )
-    ? // 'http://localhost:3000///' would be received as '///' in Node.js' IncomingMessage
-      // See https://nodejs.org/api/http.html#messageurl
-      // Not using `origin` to support other protocols
-      new URL(`${resolvedBase.protocol}//${resolvedBase.host}${url}`)
-    : new URL(url, resolvedBase)
+  const { pathname, searchParams, search, hash, href, origin } =
+    url.startsWith('/')
+      ? // 'http://localhost:3000///' would be received as '///' in Node.js' IncomingMessage
+        // See https://nodejs.org/api/http.html#messageurl
+        // Not using `origin` to support other protocols
+        new URL(`${resolvedBase.protocol}//${resolvedBase.host}${url}`)
+      : new URL(url, resolvedBase)
 
   if (origin !== globalBase.origin) {
     throw new Error(`invariant: invalid relative URL, router received ${url}`)


### PR DESCRIPTION
## Summary

`parseRelativeUrl` constructs up to **3 `new URL()` objects** per call:

1. `globalBase = new URL('http://n')` — always created on the server
2. `resolvedBase = new URL(base, globalBase)` — when a base is provided
3. `new URL(protocol + host + url)` — the actual URL parsing

In CPU profiles, this function appears at **~17ms** on the hot path. It is called on every incoming request during SSR (from `app-render.tsx` via `parseRelativeUrl(req.url, undefined, false)`).

### What this PR does

Adds a **server-side fast path** for the most common SSR call pattern: no `base` argument, and `url` starts with `/`. In this case, the dummy origin `http://n` is always used, so `globalBase` and `resolvedBase` are predictable constants.

Instead of constructing 2-3 URL objects, the fast path constructs **only 1**:

```ts
const parsed = new URL(`http://n${url}`)
```

The `SERVER_ORIGIN` constant is hoisted to module level, avoiding repeated string allocation.

**Client-side code paths are completely unchanged** — the `typeof window === 'undefined'` guard ensures the fast path only runs on the server.

### Before (server, every call)
- `new URL('http://n')` → globalBase
- `globalBase` reused as resolvedBase (no base arg, url starts with `/`)
- `new URL('http://n' + url)` → actual parse
- `origin !== globalBase.origin` → compares two URL object properties

### After (server fast path)
- `new URL('http://n' + url)` → single parse
- `origin !== 'http://n'` → string comparison against constant

## Test plan

- [x] Existing `parse-relative-url.test.ts` (3 tests) — all pass
- [x] Existing `test/unit/parse-relative-url.test.ts` (6 tests, client-side paths) — all pass
- [ ] No new tests needed — behavior is identical, only fewer URL allocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)