### PR TITLE
perf: replace structuredClone with shallow copy for params and regex reference

### DIFF
--- a/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
+++ b/packages/next/src/shared/lib/router/utils/get-dynamic-param.ts
@@ -45,7 +45,7 @@ export function interpolateParallelRouteParams(
   pagePath: string,
   fallbackRouteParams: OpaqueFallbackRouteParams | null
 ): Params {
-  const interpolated = structuredClone(params)
+  const interpolated: Params = { ...params }
 
   // Stack-based traversal with depth tracking
   const stack: Array<{ tree: LoaderTree; depth: number }> = [

--- a/packages/next/src/shared/lib/router/utils/route-regex.ts
+++ b/packages/next/src/shared/lib/router/utils/route-regex.ts
@@ -280,7 +280,10 @@ function getNamedParametrizedRoute(
   const inverseParts: string[] = []
 
   // Ensure we don't mutate the original reference object.
-  reference = structuredClone(reference)
+  reference = {
+    names: { ...reference.names },
+    intercepted: { ...reference.intercepted },
+  }
 
   for (const segment of removeTrailingSlash(route).slice(1).split('/')) {
     const hasInterceptionMarker = INTERCEPTION_ROUTE_MARKERS.some((m) =>


### PR DESCRIPTION
## Summary

`structuredClone` is **1140ms (3.1%)** self-time in CPU profiles. Two per-request calls clone simple flat objects where shallow copy is semantically equivalent and orders of magnitude faster:

- **`get-dynamic-param.ts`** — `interpolateParallelRouteParams` clones `params` (`Record<string, string | string[]>`). The cloned object only receives new property assignments; existing array values are never mutated. Replaced with `{ ...params }`.
- **`route-regex.ts`** — `getNamedParametrizedRoute` clones `reference` (`{ names: Record<string, string>, intercepted: Record<string, string> }`). Both inner objects are flat string records. Replaced with a two-level spread.

## Test plan

- [x] Verified existing unit tests for `route-regex.test.ts` and `get-dynamic-param.test.ts` cover the affected code paths
- [x] Confirmed array values in `params` are only read or replaced (not mutated in place) after cloning
- [x] Confirmed `reference.names` and `reference.intercepted` are flat `Record<string, string>` — no nested objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)