### PR TITLE
perf: reduce AsyncLocalStorage access overhead

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -311,10 +311,13 @@ async function createComponentTreeInternal(
     validateRevalidate(layoutOrPageMod?.revalidate, workStore.route)
   }
 
+  // Cache the work unit store lookup once for use across the revalidate check,
+  // stale time check, and vary params accumulator below, avoiding redundant
+  // AsyncLocalStorage.getStore() calls per segment.
+  const workUnitStore = workUnitAsyncStorage.getStore()
+
   if (typeof layoutOrPageMod?.revalidate === 'number') {
     const defaultRevalidate = layoutOrPageMod.revalidate as number
-
-    const workUnitStore = workUnitAsyncStorage.getStore()
 
     if (workUnitStore) {
       switch (workUnitStore.type) {
@@ -365,7 +368,6 @@ async function createComponentTreeInternal(
     typeof layoutOrPageMod?.unstable_dynamicStaleTime === 'number'
   ) {
     const pageStaleTime = layoutOrPageMod.unstable_dynamicStaleTime
-    const workUnitStore = workUnitAsyncStorage.getStore()
 
     if (workUnitStore) {
       switch (workUnitStore.type) {
@@ -816,7 +818,7 @@ async function createComponentTreeInternal(
       ? // Client components with Cache Components enabled don't receive params
         // from the server, so they have an empty vary params set.
         emptyVaryParamsAccumulator
-      : createVaryParamsAccumulator()
+      : createVaryParamsAccumulator(workUnitStore)
 
   if (
     process.env.NODE_ENV === 'development' &&

--- a/packages/next/src/server/app-render/vary-params.ts
+++ b/packages/next/src/server/app-render/vary-params.ts
@@ -1,6 +1,9 @@
 import type { Params } from '../request/params'
 import type { SearchParams } from '../request/search-params'
-import { workUnitAsyncStorage } from './work-unit-async-storage.external'
+import {
+  workUnitAsyncStorage,
+  type WorkUnitStore,
+} from './work-unit-async-storage.external'
 import type {
   VaryParamsThenable,
   VaryParams,
@@ -111,9 +114,14 @@ export function createResponseVaryParamsAccumulator(): ResponseVaryParamsAccumul
  * Returns a thenable that resolves to the segment's vary params once rendering
  * is complete. The thenable can be passed directly to React Flight for
  * serialization.
+ *
+ * @param cachedWorkUnitStore - Optional pre-fetched WorkUnitStore to avoid
+ * a redundant AsyncLocalStorage.getStore() call when the caller already has it.
  */
-export function createVaryParamsAccumulator(): VaryParamsAccumulator | null {
-  const workUnitStore = workUnitAsyncStorage.getStore()
+export function createVaryParamsAccumulator(
+  cachedWorkUnitStore?: WorkUnitStore
+): VaryParamsAccumulator | null {
+  const workUnitStore = cachedWorkUnitStore ?? workUnitAsyncStorage.getStore()
   if (workUnitStore) {
     switch (workUnitStore.type) {
       case 'prerender':

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -431,12 +431,23 @@ export class IncrementalCache implements IncrementalCacheType {
     cacheKey: string,
     ctx: GetIncrementalFetchCacheContext | GetIncrementalResponseCacheContext
   ): Promise<IncrementalCacheEntry | null> {
+    // Cache the store lookups once for FETCH requests, avoiding redundant
+    // AsyncLocalStorage.getStore() calls across the RDC check and cache
+    // handler result processing below.
+    const fetchWorkUnitStore =
+      ctx.kind === IncrementalCacheKind.FETCH
+        ? workUnitAsyncStorage.getStore()
+        : undefined
+    const fetchWorkStore =
+      ctx.kind === IncrementalCacheKind.FETCH
+        ? workAsyncStorage.getStore()
+        : undefined
+
     // Unlike other caches if we have a resume data cache, we use it even if
     // testmode would normally disable it or if requestHeaders say 'no-cache'.
     if (ctx.kind === IncrementalCacheKind.FETCH) {
-      const workUnitStore = workUnitAsyncStorage.getStore()
-      const resumeDataCache = workUnitStore
-        ? getRenderResumeDataCache(workUnitStore)
+      const resumeDataCache = fetchWorkUnitStore
+        ? getRenderResumeDataCache(fetchWorkUnitStore)
         : null
       if (resumeDataCache) {
         const memoryCacheData = resumeDataCache.fetch.get(cacheKey)
@@ -444,12 +455,11 @@ export class IncrementalCache implements IncrementalCacheType {
           // Check if any tags were recently revalidated before returning RDC entry.
           // When a server action calls updateTag(), the re-render should see fresh
           // data instead of stale RDC data.
-          const workStore = workAsyncStorage.getStore()
           const combinedTags = [...(ctx.tags || []), ...(ctx.softTags || [])]
           const hasRevalidatedTag = combinedTags.some(
             (tag) =>
               this.revalidatedTags?.includes(tag) ||
-              workStore?.pendingRevalidatedTags?.some(
+              fetchWorkStore?.pendingRevalidatedTags?.some(
                 (item) => item.tag === tag
               )
           )
@@ -505,14 +515,15 @@ export class IncrementalCache implements IncrementalCacheType {
         )
       }
 
-      const workStore = workAsyncStorage.getStore()
       const combinedTags = [...(ctx.tags || []), ...(ctx.softTags || [])]
       // if a tag was revalidated we don't return stale data
       if (
         combinedTags.some(
           (tag) =>
             this.revalidatedTags?.includes(tag) ||
-            workStore?.pendingRevalidatedTags?.some((item) => item.tag === tag)
+            fetchWorkStore?.pendingRevalidatedTags?.some(
+              (item) => item.tag === tag
+            )
         )
       ) {
         if (IncrementalCache.debug) {
@@ -530,10 +541,9 @@ export class IncrementalCache implements IncrementalCacheType {
       //
       // We add it to the RDC so that the next fetch call will be able to use it
       // and it won't have to reach into the fetch cache implementation.
-      const workUnitStore = workUnitAsyncStorage.getStore()
-      if (workUnitStore) {
+      if (fetchWorkUnitStore) {
         const prerenderResumeDataCache =
-          getPrerenderResumeDataCache(workUnitStore)
+          getPrerenderResumeDataCache(fetchWorkUnitStore)
         if (prerenderResumeDataCache) {
           if (IncrementalCache.debug) {
             console.log('IncrementalCache: rdc:set', cacheKey)


### PR DESCRIPTION
## Summary

- Cache `getStore()` results in local variables when the same AsyncLocalStorage store is accessed multiple times within the same synchronous scope
- Eliminates ~20-30 redundant `getStore()` calls per request in apps with deeply nested layouts (10+ segments)
- Saves 2 redundant `getStore()` calls per fetch cache lookup in `IncrementalCache.get()`

## Background

In production CPU profiles, `AsyncLocalStorage` operations (`AsyncContextFrame` constructor, `getStore`, `bind`, `run`) account for ~1.2% of CPU time. While individual `getStore()` calls are cheap (~1-2μs), they accumulate significantly when called redundantly in hot paths that execute per-segment or per-fetch.

## Changes

**`createComponentTreeInternal` (create-component-tree.tsx)**
- Hoist `workUnitAsyncStorage.getStore()` before the revalidate and stale-time config blocks
- Pass the cached store to `createVaryParamsAccumulator()` to avoid a third redundant lookup
- This function is called recursively for every layout/page segment in the route tree

**`createVaryParamsAccumulator` (vary-params.ts)**
- Accept an optional pre-fetched `WorkUnitStore` parameter
- Falls back to `getStore()` when no cached store is provided (backward compatible)

**`IncrementalCache.get()` (incremental-cache/index.ts)**
- Cache both `workUnitAsyncStorage.getStore()` and `workAsyncStorage.getStore()` at method entry for FETCH requests
- Reuse across the resume data cache (RDC) check and cache handler result processing

All optimizations stay within single `run()` scopes where the ALS context is guaranteed not to change, preserving correctness.

## Test plan

- [ ] Verify existing e2e tests pass (app-dir rendering, caching, revalidation)
- [ ] `test/e2e/app-dir/segment-cache/vary-params` passes
- [ ] `test/e2e/app-dir/cache-components-create-component-tree` passes
- [ ] No behavioral changes — these are purely mechanical refactors that cache identical lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)