### PR TITLE
Unflake router events deploy test

### DIFF
--- a/test/e2e/basepath/router-events.test.ts
+++ b/test/e2e/basepath/router-events.test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert'
 import webdriver from 'next-webdriver'
 import { nextTestSetup } from 'e2e-utils'
-import { check, retry } from 'next-test-utils'
+import { retry } from 'next-test-utils'
 
 describe('basePath', () => {
   const basePath = '/docs'
@@ -20,9 +20,8 @@ describe('basePath', () => {
   it('should use urls with basepath in router events', async () => {
     const browser = await webdriver(next.url, `${basePath}/hello`)
     try {
-      await check(
-        () => browser.eval('window.next.router.isReady ? "ready" : "no"'),
-        'ready'
+      await retry(() =>
+        expect(browser.eval('window.next.router.isReady')).resolves.toBe(true)
       )
       await browser.eval('window._clearEventLog()')
       await browser
@@ -46,22 +45,28 @@ describe('basePath', () => {
   it('should use urls with basepath in router events for hash changes', async () => {
     const browser = await webdriver(next.url, `${basePath}/hello`)
     try {
-      await check(
-        () => browser.eval('window.next.router.isReady ? "ready" : "no"'),
-        'ready'
+      await retry(() =>
+        expect(browser.eval('window.next.router.isReady')).resolves.toBe(true)
       )
       await browser.eval('window._clearEventLog()')
       await browser.elementByCss('#hash-change').click()
 
-      const eventLog = await browser.eval('window._getEventLog()')
-      expect(eventLog).toEqual([
-        ['hashChangeStart', `${basePath}/hello#some-hash`, { shallow: false }],
-        [
-          'hashChangeComplete',
-          `${basePath}/hello#some-hash`,
-          { shallow: false },
-        ],
-      ])
+      await retry(async () => {
+        const eventLog = await browser.eval('window._getEventLog()')
+
+        expect(eventLog).toEqual([
+          [
+            'hashChangeStart',
+            `${basePath}/hello#some-hash`,
+            { shallow: false },
+          ],
+          [
+            'hashChangeComplete',
+            `${basePath}/hello#some-hash`,
+            { shallow: false },
+          ],
+        ])
+      })
     } finally {
       await browser.close()
     }
@@ -70,9 +75,8 @@ describe('basePath', () => {
   it('should use urls with basepath in router events for cancelled routes', async () => {
     const browser = await webdriver(next.url, `${basePath}/hello`)
     try {
-      await check(
-        () => browser.eval('window.next.router.isReady ? "ready" : "no"'),
-        'ready'
+      await retry(() =>
+        expect(browser.eval('window.next.router.isReady')).resolves.toBe(true)
       )
       await browser.eval('window._clearEventLog()')
 
@@ -105,9 +109,8 @@ describe('basePath', () => {
   it('should use urls with basepath in router events for failed route change', async () => {
     const browser = await webdriver(next.url, `${basePath}/hello`)
     try {
-      await check(
-        () => browser.eval('window.next.router.isReady ? "ready" : "no"'),
-        'ready'
+      await retry(() =>
+        expect(browser.eval('window.next.router.isReady')).resolves.toBe(true)
       )
       await browser.eval('window._clearEventLog()')
       await browser.elementByCss('#error-route').click()


### PR DESCRIPTION
[Flakiness metrics](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.status%3A%22fail%22%20%40test.name%3A%22basePath%20should%20use%20urls%20with%20basepath%20in%20router%20events%20for%20hash%20changes%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&index=citest&start=1773244604685&end=1773849404685&paused=false)

After upgrading Playwright in #91250 (which brought some performance improvements), some tests are now exposed to be missing retries around assertions. `test/e2e/basepath/router-events.test.ts` is one of those tests, and this PR adds a `retry` around the event log assertion. We're also replacing the deprecated `check` utility with `retry` when waiting for the router to be ready.