### PR TITLE
perf: skip convention path lookups in production renders

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -647,12 +647,21 @@ async function createComponentTreeInternal(
           createElement(RenderFromTemplateContext, null)
         )
 
-        const templateFilePath = getConventionPathByType(tree, dir, 'template')
-        const errorFilePath = getConventionPathByType(tree, dir, 'error')
-        const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
-        const globalErrorFilePath = isRoot
-          ? getConventionPathByType(tree, dir, 'global-error')
+        // Only resolve convention file paths when the segment explorer is
+        // active (dev mode). In production these are unused.
+        const templateFilePath = isSegmentViewEnabled && template
+          ? getConventionPathByType(tree, dir, 'template')
           : undefined
+        const errorFilePath = isSegmentViewEnabled && error
+          ? getConventionPathByType(tree, dir, 'error')
+          : undefined
+        const loadingFilePath = isSegmentViewEnabled && loading
+          ? getConventionPathByType(tree, dir, 'loading')
+          : undefined
+        const globalErrorFilePath =
+          isSegmentViewEnabled && isRoot
+            ? getConventionPathByType(tree, dir, 'global-error')
+            : undefined
 
         const wrappedErrorStyles =
           isSegmentViewEnabled && errorFilePath
@@ -764,7 +773,10 @@ async function createComponentTreeInternal(
         key: 'l',
       })
     : null
-  const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
+  const loadingFilePath =
+    isSegmentViewEnabled && Loading
+      ? getConventionPathByType(tree, dir, 'loading')
+      : undefined
   if (isSegmentViewEnabled && loadingElement) {
     if (loadingFilePath) {
       loadingElement = createElement(
@@ -896,9 +908,10 @@ async function createComponentTreeInternal(
     }
 
     const isDefaultSegment = segment === DEFAULT_SEGMENT_KEY
-    const pageFilePath =
-      getConventionPathByType(tree, dir, 'page') ??
-      getConventionPathByType(tree, dir, 'defaultPage')
+    const pageFilePath = isSegmentViewEnabled
+      ? (getConventionPathByType(tree, dir, 'page') ??
+         getConventionPathByType(tree, dir, 'defaultPage'))
+      : undefined
     const segmentType = isDefaultSegment ? 'default' : 'page'
     const wrappedPageElement =
       isSegmentViewEnabled && pageFilePath
@@ -1123,7 +1136,9 @@ async function createComponentTreeInternal(
       }
     }
 
-    const layoutFilePath = getConventionPathByType(tree, dir, 'layout')
+    const layoutFilePath = isSegmentViewEnabled
+      ? getConventionPathByType(tree, dir, 'layout')
+      : undefined
     const wrappedSegmentNode =
       isSegmentViewEnabled && layoutFilePath
         ? createElement(
@@ -1271,7 +1286,10 @@ async function createBoundaryConventionElement({
     ? createElement(Fragment, null, createElement(Component, null), styles)
     : undefined
 
-  const pagePath = getConventionPathByType(tree, dir, conventionName)
+  const pagePath =
+    isSegmentViewEnabled && Component
+      ? getConventionPathByType(tree, dir, conventionName)
+      : undefined
 
   const wrappedElement =
     isSegmentViewEnabled && element

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -625,12 +625,21 @@ async function createComponentTreeInternal(
           createElement(RenderFromTemplateContext, null)
         )
 
-        const templateFilePath = getConventionPathByType(tree, dir, 'template')
-        const errorFilePath = getConventionPathByType(tree, dir, 'error')
-        const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
-        const globalErrorFilePath = isRoot
-          ? getConventionPathByType(tree, dir, 'global-error')
+        // Only resolve convention file paths when the segment explorer is
+        // active (dev mode). In production these are unused.
+        const templateFilePath = isSegmentViewEnabled && template
+          ? getConventionPathByType(tree, dir, 'template')
           : undefined
+        const errorFilePath = isSegmentViewEnabled && error
+          ? getConventionPathByType(tree, dir, 'error')
+          : undefined
+        const loadingFilePath = isSegmentViewEnabled && loading
+          ? getConventionPathByType(tree, dir, 'loading')
+          : undefined
+        const globalErrorFilePath =
+          isSegmentViewEnabled && isRoot
+            ? getConventionPathByType(tree, dir, 'global-error')
+            : undefined
 
         const wrappedErrorStyles =
           isSegmentViewEnabled && errorFilePath
@@ -726,7 +735,10 @@ async function createComponentTreeInternal(
         key: 'l',
       })
     : null
-  const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
+  const loadingFilePath =
+    isSegmentViewEnabled && Loading
+      ? getConventionPathByType(tree, dir, 'loading')
+      : undefined
   if (isSegmentViewEnabled && loadingElement) {
     if (loadingFilePath) {
       loadingElement = createElement(
@@ -899,9 +911,10 @@ async function createComponentTreeInternal(
     }
 
     const isDefaultSegment = segment === DEFAULT_SEGMENT_KEY
-    const pageFilePath =
-      getConventionPathByType(tree, dir, 'page') ??
-      getConventionPathByType(tree, dir, 'defaultPage')
+    const pageFilePath = isSegmentViewEnabled
+      ? (getConventionPathByType(tree, dir, 'page') ??
+         getConventionPathByType(tree, dir, 'defaultPage'))
+      : undefined
     const segmentType = isDefaultSegment ? 'default' : 'page'
     const wrappedPageElement =
       isSegmentViewEnabled && pageFilePath
@@ -1126,7 +1139,9 @@ async function createComponentTreeInternal(
       }
     }
 
-    const layoutFilePath = getConventionPathByType(tree, dir, 'layout')
+    const layoutFilePath = isSegmentViewEnabled
+      ? getConventionPathByType(tree, dir, 'layout')
+      : undefined
     const wrappedSegmentNode =
       isSegmentViewEnabled && layoutFilePath
         ? createElement(
@@ -1274,7 +1289,10 @@ async function createBoundaryConventionElement({
     ? createElement(Fragment, null, createElement(Component, null), styles)
     : undefined
 
-  const pagePath = getConventionPathByType(tree, dir, conventionName)
+  const pagePath =
+    isSegmentViewEnabled && Component
+      ? getConventionPathByType(tree, dir, conventionName)
+      : undefined
 
   const wrappedElement =
     isSegmentViewEnabled && element


### PR DESCRIPTION
## Summary

- Guard all `getConventionPathByType` calls in `createComponentTreeInternal` with `isSegmentViewEnabled` check, since the file paths are only consumed by `SegmentViewNode` rendering (dev-only feature)
- Additionally guard with convention existence checks (`template`, `error`, `loading`, etc.) to skip lookups even in dev when the segment doesn't define that convention file
- Same treatment applied to `createBoundaryConventionElement` helper for not-found, forbidden, and unauthorized conventions

## Why

`getConventionPathByType` performs a tree lookup (`tree[2][conventionType]`) followed by `normalizeConventionFilePath` which does multiple regex replacements and string manipulations. This function is called 7-10 times per segment for template, error, loading, not-found, forbidden, unauthorized, layout, page, defaultPage, and global-error conventions.

The results are **only used for `SegmentViewNode` rendering**, which is gated behind `isSegmentViewEnabled` (`!!process.env.__NEXT_DEV_SERVER`). In production, every one of these calls produces a value that is never read.

For a typical app with ~20 route segments where most don't have template/error/loading/not-found/forbidden/unauthorized files, this eliminates ~100+ unnecessary function calls and string operations per production render.

## Test plan

- [ ] Verify existing `test/e2e/app-dir/` tests pass (no behavioral change -- the values were already unused in production paths)
- [ ] Verify dev mode segment explorer still shows convention file annotations correctly (the `isSegmentViewEnabled` guard preserves existing behavior)
- [ ] `test/e2e/app-dir/cache-components-create-component-tree/` test should pass unchanged

Generated with [Claude Code](https://claude.com/claude-code)