### PR TITLE
perf: fast-path interception route check and cache bot-detection regex

### DIFF
--- a/packages/next/src/server/lib/streaming-metadata.ts
+++ b/packages/next/src/server/lib/streaming-metadata.ts
@@ -4,16 +4,23 @@ import {
 } from '../../shared/lib/router/utils/is-bot'
 import type { BaseNextRequest } from '../base-http'
 
+// Cache compiled RegExp per pattern string to avoid re-creating it on every
+// request. The pattern comes from `nextConfig.htmlLimitedBots` which is a
+// static config value, so the cache will hold at most 1-2 entries.
+let cachedPattern: string | undefined
+let cachedRegex: RegExp | undefined
+
 export function shouldServeStreamingMetadata(
   userAgent: string,
   htmlLimitedBots: string | undefined
 ): boolean {
-  const blockingMetadataUARegex = new RegExp(
-    htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING,
-    'i'
-  )
+  const pattern = htmlLimitedBots || HTML_LIMITED_BOT_UA_RE_STRING
+  if (pattern !== cachedPattern) {
+    cachedPattern = pattern
+    cachedRegex = new RegExp(pattern, 'i')
+  }
   // Only block metadata for HTML-limited bots
-  if (userAgent && blockingMetadataUARegex.test(userAgent)) {
+  if (userAgent && cachedRegex!.test(userAgent)) {
     return false
   }
   return true

--- a/packages/next/src/shared/lib/router/utils/interception-routes.ts
+++ b/packages/next/src/shared/lib/router/utils/interception-routes.ts
@@ -11,7 +11,10 @@ export const INTERCEPTION_ROUTE_MARKERS = [
 export type InterceptionMarker = (typeof INTERCEPTION_ROUTE_MARKERS)[number]
 
 export function isInterceptionRouteAppPath(path: string): boolean {
-  // TODO-APP: add more serious validation
+  // Fast path: interception markers always start with '(' — skip the
+  // split + find for the vast majority of paths that have no parentheses.
+  if (!path.includes('(')) return false
+
   return (
     path
       .split('/')


### PR DESCRIPTION
## Summary

Two targeted optimizations from CPU profile hotspots:

- **`isInterceptionRouteAppPath` (~37ms):** Added an early return for paths that don't contain `(`. All interception route markers (`(.)`, `(..)`, `(...)`, `(..)(..)`) start with a parenthesis, so a cheap `path.includes('(')` pre-check avoids the `.split('/') + nested .find()` for the vast majority of non-interception routes.

- **`shouldServeStreamingMetadata` (~31ms):** Cached the compiled `RegExp` for the HTML-limited bot UA pattern. The pattern comes from static config (`nextConfig.htmlLimitedBots`) and never changes between requests, but `new RegExp(...)` was being constructed on every single request.

Both changes are zero-risk: the first adds a pre-check that's logically equivalent (no parenthesis means no marker can match), and the second caches a regex that was being identically reconstructed each time.

## Test plan

- [ ] Existing `interception-routes.test.ts` unit tests pass (verified locally with inline logic tests — true/false cases including route groups with parens, plain paths, and all 4 interception markers)
- [ ] Bot detection behavior unchanged: bot UAs still return `false`, normal UAs still return `true`, custom `htmlLimitedBots` config still works
- [ ] No new test files needed — behavior is identical, only performance changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)