### PR TITLE
perf: skip rewrite processing when no rewrites configured

### DIFF
--- a/packages/next/src/server/server-utils.ts
+++ b/packages/next/src/server/server-utils.ts
@@ -216,10 +216,26 @@ export function getServerUtils({
     defaultRouteMatches = dynamicRouteMatcher(page) as ParsedUrlQuery
   }
 
+  // Precompute whether any rewrites are configured to enable fast path
+  const hasRewrites =
+    (rewrites.beforeFiles && rewrites.beforeFiles.length > 0) ||
+    (rewrites.afterFiles && rewrites.afterFiles.length > 0) ||
+    (rewrites.fallback && rewrites.fallback.length > 0)
+
   function handleRewrites(
     req: BaseNextRequest | IncomingMessage,
     parsedUrl: DeepReadonly<NextUrlWithParsedQuery>
   ) {
+    // Fast path: when no rewrites are configured, skip the deep clone,
+    // closure creation, and array iteration entirely. The caller never
+    // mutates the returned URL in a way that would require a separate copy.
+    if (!hasRewrites) {
+      return {
+        rewriteParams: {} as Record<string, string>,
+        rewrittenParsedUrl: parsedUrl as NextUrlWithParsedQuery,
+      }
+    }
+
     // Here we deep clone the parsedUrl to avoid mutating the original. We also
     // cast this to a mutable type so we can mutate it within this scope.
     const rewrittenParsedUrl = structuredClone(
@@ -419,6 +435,7 @@ export function getServerUtils({
 
   return {
     handleRewrites,
+    hasRewrites: !!hasRewrites,
     defaultRouteRegex,
     dynamicRouteMatcher,
     defaultRouteMatches,


### PR DESCRIPTION
## Summary

- Adds a fast path in `handleRewrites` (in `server-utils.ts`) that returns the original `parsedUrl` immediately when no rewrites are configured, avoiding a per-request `structuredClone`, closure creation, and empty array iteration
- Precomputes a `hasRewrites` flag once in `getServerUtils` (at route setup time) rather than checking array lengths on every request
- Exposes `hasRewrites` on the returned utils object for caller awareness

## Why

For Next.js apps that don't use rewrites (the common case), every request through the minimal-mode code path in `base-server.ts` and the `route-module.ts` render path called `handleRewrites`, which:

1. Called `structuredClone(parsedUrl)` — a deep clone of the URL + query object
2. Created `matchesPage` and `checkRewrite` closures (allocating two function objects)
3. Iterated three empty arrays (`beforeFiles`, `afterFiles`, `fallback`)
4. Returned the clone unchanged

With this change, when all three rewrite arrays are empty (or undefined), the function returns immediately with the original `parsedUrl` reference and an empty `rewriteParams` object. This is safe because:

- `base-server.ts` only reads from `rewrittenParsedUrl` (to create `rewrittenQueryParams` copy and check `didRewrite`)
- `route-module.ts` line `Object.assign(parsedUrl.query, rewrittenParsedUrl.query)` becomes a self-assign no-op
- `normalizeLocalePath` on `rewrittenParsedUrl.pathname` is idempotent when it equals `parsedUrl.pathname`

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit` on `packages/next` — 0 new errors)
- [x] Existing `server-utils.test.ts` tests all use `rewrites: {}` (empty config), exercising the new fast path
- [x] Prettier + ESLint pass (lint-staged)
- [ ] Existing e2e rewrite tests should continue to pass — the slow path (with actual rewrites) is unchanged