### PR TITLE
perf: cache manifest loading and component resolution per route

### DIFF
--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -197,6 +197,14 @@ export default class NextNodeServer extends BaseServer<
   private isDev: boolean
   private sriEnabled: boolean
 
+  /**
+   * Cache for loadComponents results keyed by `pagePath:isAppPath`. In
+   * production, component modules and their manifests are immutable between
+   * deploys, so we can avoid repeated manifest loading and module resolution
+   * on every request.
+   */
+  private componentsCache?: Map<string, LoadComponentsReturnType>
+
   constructor(options: Options) {
     // Initialize super class
     super(options)
@@ -861,14 +869,30 @@ export default class NextNodeServer extends BaseServer<
 
     for (const pagePath of pagePaths) {
       try {
-        const components = await loadComponents({
-          distDir: this.distDir,
-          page: pagePath,
-          isAppPath,
-          isDev: this.isDev,
-          sriEnabled: this.sriEnabled,
-          needsManifestsForLegacyReasons: false,
-        })
+        // In production, component modules and manifests are immutable so we
+        // cache the result to avoid repeated manifest loading and module
+        // resolution on every request.
+        const cacheKey = `${pagePath}:${isAppPath}`
+        let components = !this.isDev
+          ? this.componentsCache?.get(cacheKey)
+          : undefined
+
+        if (!components) {
+          components = await loadComponents({
+            distDir: this.distDir,
+            page: pagePath,
+            isAppPath,
+            isDev: this.isDev,
+            sriEnabled: this.sriEnabled,
+            needsManifestsForLegacyReasons: false,
+          })
+          if (!this.isDev) {
+            if (!this.componentsCache) {
+              this.componentsCache = new Map()
+            }
+            this.componentsCache.set(cacheKey, components)
+          }
+        }
 
         if (
           locale &&

--- a/packages/next/src/server/route-modules/route-module.ts
+++ b/packages/next/src/server/route-modules/route-module.ts
@@ -68,6 +68,27 @@ import { removeTrailingSlash } from '../../shared/lib/router/utils/remove-traili
 import { isInterceptionRouteRewrite } from '../../lib/is-interception-route-rewrite'
 
 /**
+ * The result of loading all manifests for a route. Extracted as a named type so
+ * the per-route cache can reference it without relying on ReturnType of a
+ * private method.
+ */
+type LoadedManifests = {
+  buildId: string
+  buildManifest: BuildManifest
+  fallbackBuildManifest: BuildManifest
+  routesManifest: DeepReadonly<DevRoutesManifest>
+  nextFontManifest: DeepReadonly<NextFontManifest>
+  prerenderManifest: DeepReadonly<PrerenderManifest>
+  serverFilesManifest: DeepReadonly<RequiredServerFilesManifest> | undefined
+  reactLoadableManifest: DeepReadonly<ReactLoadableManifest>
+  subresourceIntegrityManifest: any
+  clientReferenceManifest: any
+  serverActionsManifest: any
+  dynamicCssManifest: any
+  interceptionRoutePatterns: RegExp[]
+}
+
+/**
  * RouteModuleOptions is the options that are passed to the route module, other
  * route modules should extend this class to add specific options for their
  * route.
@@ -128,6 +149,14 @@ export abstract class RouteModule<
   public relativeProjectDir: string
   public incrementCache?: IncrementalCache
   public responseCache?: ResponseCache
+
+  /**
+   * Cache for loadManifests results keyed by srcPage. In production, manifests
+   * are immutable between deploys so the per-request overhead of 10+
+   * path.join() calls and loadManifestFromRelativePath invocations can be
+   * eliminated by caching the assembled result object.
+   */
+  private manifestsCache?: Map<string, LoadedManifests>
 
   constructor({
     userland,
@@ -200,21 +229,7 @@ export abstract class RouteModule<
   private loadManifests(
     srcPage: string,
     projectDir?: string
-  ): {
-    buildId: string
-    buildManifest: BuildManifest
-    fallbackBuildManifest: BuildManifest
-    routesManifest: DeepReadonly<DevRoutesManifest>
-    nextFontManifest: DeepReadonly<NextFontManifest>
-    prerenderManifest: DeepReadonly<PrerenderManifest>
-    serverFilesManifest: DeepReadonly<RequiredServerFilesManifest> | undefined
-    reactLoadableManifest: DeepReadonly<ReactLoadableManifest>
-    subresourceIntegrityManifest: any
-    clientReferenceManifest: any
-    serverActionsManifest: any
-    dynamicCssManifest: any
-    interceptionRoutePatterns: RegExp[]
-  } {
+  ): LoadedManifests {
     let result
     if (process.env.NEXT_RUNTIME === 'edge') {
       const { getEdgePreviewProps } =
@@ -648,7 +663,22 @@ export abstract class RouteModule<
       // onRequestError below
       ensureInstrumentationRegistered(absoluteProjectDir, this.distDir)
     }
-    const manifests = this.loadManifests(srcPage, absoluteProjectDir)
+    // In production, manifests are immutable so we can cache the entire
+    // assembled result to avoid 10+ path.join() + loadManifestFromRelativePath
+    // calls on every request.
+    let manifests: LoadedManifests | undefined
+    if (!this.isDev) {
+      manifests = this.manifestsCache?.get(srcPage)
+    }
+    if (!manifests) {
+      manifests = this.loadManifests(srcPage, absoluteProjectDir)
+      if (!this.isDev) {
+        if (!this.manifestsCache) {
+          this.manifestsCache = new Map()
+        }
+        this.manifestsCache.set(srcPage, manifests)
+      }
+    }
     const { routesManifest, prerenderManifest, serverFilesManifest } = manifests
 
     const { basePath, i18n, rewrites } = routesManifest


### PR DESCRIPTION
## Summary

- **Cache `loadManifests` result per route** in `RouteModule.prepare()` — eliminates 10+ `path.join()` + `loadManifestFromRelativePath` calls per request in production
- **Cache `loadComponents` result per page** in `NextNodeServer.findPageComponentsImpl()` — avoids repeated manifest loading and module resolution per request in production
- Both caches are **production-only** (`!isDev`) and lazily initialized

## Background

In production, manifests and component modules are immutable between deploys. However, `loadManifests` and `loadComponents` are called on every incoming request. While the underlying file reads are already cached by `loadManifest`/`evalManifest` in `load-manifest.external.ts`, the overhead of:

- 10+ `path.join()` calls to construct manifest paths
- 10+ function call + parameter destructuring overheads for `loadManifestFromRelativePath`
- Building the 12-property result object
- `loadComponents` doing `requirePage` + manifest loading per request

...adds measurable latency under sustained load.

### Changes

**`packages/next/src/server/route-modules/route-module.ts`**
- Extract `LoadedManifests` type alias (was inline on `loadManifests` return)
- Add `manifestsCache: Map<string, LoadedManifests>` (lazily initialized, production-only)
- Cache `loadManifests` result by `srcPage` key in `prepare()`

**`packages/next/src/server/next-server.ts`**
- Add `componentsCache: Map<string, LoadComponentsReturnType>` (lazily initialized, production-only)
- Cache `loadComponents` result by `pagePath:isAppPath` key in `findPageComponentsImpl()`

### Safety

- Caches are **disabled in dev mode** where manifests change on recompilation
- `LoadedManifests` contains only manifest data and compiled module references — no per-request state
- `LoadComponentsReturnType` contains component modules, manifest data, and static getters — no per-request state
- Existing `loadManifest` file-level caching is preserved as a lower-level cache

## Test plan

- [ ] Existing test suite passes (no behavioral changes, only caching of already-deterministic results)
- [ ] Verify dev mode is unaffected (caches are not populated when `isDev` is true)
- [ ] Production builds serve pages correctly with cached manifests and components

🤖 Generated with [Claude Code](https://claude.com/claude-code)