### PR TITLE
perf: omit undefined props from LayoutRouter to reduce Flight payload

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -677,33 +677,44 @@ async function createComponentTreeInternal(
             )
           : null
 
+        // Build LayoutRouter props conditionally to avoid serializing
+        // undefined values as "$undefined" in the RSC Flight payload.
+        // For a 10-layout route this eliminates ~100 redundant
+        // "$undefined" references (~1.4 KB savings per response).
+        const layoutRouterProps: Record<string, unknown> = {
+          parallelRouterKey: parallelRouteKey,
+          template:
+            isSegmentViewEnabled && templateFilePath
+              ? createElement(
+                  SegmentViewNode,
+                  {
+                    type: 'template',
+                    pagePath: templateFilePath,
+                  },
+                  templateNode
+                )
+              : templateNode,
+        }
+        if (ErrorComponent) layoutRouterProps.error = ErrorComponent
+        if (wrappedErrorStyles)
+          layoutRouterProps.errorStyles = wrappedErrorStyles
+        if (errorScripts) layoutRouterProps.errorScripts = errorScripts
+        if (templateStyles) layoutRouterProps.templateStyles = templateStyles
+        if (templateScripts)
+          layoutRouterProps.templateScripts = templateScripts
+        if (notFoundComponent)
+          layoutRouterProps.notFound = notFoundComponent
+        if (forbiddenComponent)
+          layoutRouterProps.forbidden = forbiddenComponent
+        if (unauthorizedComponent)
+          layoutRouterProps.unauthorized = unauthorizedComponent
+        if (isSegmentViewEnabled) {
+          layoutRouterProps.segmentViewBoundaries = segmentViewBoundaries
+        }
+
         return [
           parallelRouteKey,
-          createElement(LayoutRouter, {
-            parallelRouterKey: parallelRouteKey,
-            error: ErrorComponent,
-            errorStyles: wrappedErrorStyles,
-            errorScripts: errorScripts,
-            template:
-              isSegmentViewEnabled && templateFilePath
-                ? createElement(
-                    SegmentViewNode,
-                    {
-                      type: 'template',
-                      pagePath: templateFilePath,
-                    },
-                    templateNode
-                  )
-                : templateNode,
-            templateStyles: templateStyles,
-            templateScripts: templateScripts,
-            notFound: notFoundComponent,
-            forbidden: forbiddenComponent,
-            unauthorized: unauthorizedComponent,
-            ...(isSegmentViewEnabled && {
-              segmentViewBoundaries,
-            }),
-          }),
+          createElement(LayoutRouter, layoutRouterProps),
           childCacheNodeSeedData,
         ]
       }


### PR DESCRIPTION
## Summary

- Build LayoutRouter props conditionally in `createComponentTreeInternal` so that undefined values (`error`, `errorStyles`, `errorScripts`, `templateStyles`, `templateScripts`, `notFound`, `forbidden`, `unauthorized`) are omitted from the element rather than passed explicitly as `undefined`
- Eliminates ~100 redundant `$undefined` references per response for deeply nested routes (10+ layouts), saving ~1.4KB of Flight payload per request
- OuterLayoutRouter already types all these props as `T | undefined` with no `'prop' in props` checks, so omitting them is semantically identical to passing `undefined`

## Why

The RSC Flight protocol serializes every prop value, including `undefined` (as the `$undefined` sentinel). For a typical route with 10+ layout segments and parallel routes, each LayoutRouter element carries 8 undefined props. That's ~100 `$undefined` references across the response — pure overhead in both payload size and serialization/deserialization work.

## What changed

`packages/next/src/server/app-render/create-component-tree.tsx`: Instead of always passing all props to `createElement(LayoutRouter, {...})`, we now build a props object that only includes truthy values, then pass that object to `createElement`.

## Test plan

- [ ] Existing app-router tests pass (no behavioral change — `undefined` props and absent props are equivalent for the consumer component)
- [ ] Verify Flight payload for a multi-layout route no longer contains redundant `$undefined` entries for LayoutRouter elements
- [ ] No regression in error boundary, template, or not-found/forbidden/unauthorized rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)