### PR TITLE
fix(eslint-plugin): respect pageExtensions in no-html-link-for-pages rule

### DIFF
--- a/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
+++ b/packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts
@@ -10,6 +10,47 @@ import {
   getUrlFromAppDirectory,
 } from '../utils/url'
 
+const DEFAULT_PAGE_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
+
+function loadPageExtensionsFromConfig(rootDir: string): string[] | null {
+  const configFiles = ['next.config.js', 'next.config.ts', 'next.config.mjs']
+  for (const configFile of configFiles) {
+    const configPath = path.join(rootDir, configFile)
+    if (!fs.existsSync(configPath)) continue
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const config = require(configPath)
+      const resolved = config?.default ?? config
+      if (Array.isArray(resolved?.pageExtensions) && resolved.pageExtensions.length > 0) {
+        return resolved.pageExtensions
+      }
+    } catch {}
+  }
+  return null
+}
+
+const loadPageExtensionsFromConfigMemo = new Map<string, string[] | null>()
+
+function getPageExtensions(rootDirs: string[], settings: any): string[] {
+  const fromSettings = settings?.next?.pageExtensions
+  if (Array.isArray(fromSettings) && fromSettings.length > 0) {
+    return fromSettings.filter((ext): ext is string => typeof ext === 'string' && ext.length > 0)
+  }
+
+  for (const rootDir of rootDirs) {
+    if (!loadPageExtensionsFromConfigMemo.has(rootDir)) {
+      loadPageExtensionsFromConfigMemo.set(
+        rootDir,
+        loadPageExtensionsFromConfig(rootDir)
+      )
+    }
+    const fromConfig = loadPageExtensionsFromConfigMemo.get(rootDir)
+    if (fromConfig) return fromConfig
+  }
+
+  return DEFAULT_PAGE_EXTENSIONS
+}
+
 const pagesDirWarning = execOnce((pagesDirs) => {
   console.warn(
     `Pages directory cannot be found at ${pagesDirs.join(' or ')}. ` +
@@ -19,7 +60,7 @@ const pagesDirWarning = execOnce((pagesDirs) => {
 
 // Cache for fs.existsSync lookup.
 // Prevent multiple blocking IO requests that have already been calculated.
-const fsExistsSyncCache = {}
+const fsExistsSyncCache: Record<string, boolean> = {}
 
 const memoize = <T = any>(fn: (...args: any[]) => T) => {
   const cache = {}
@@ -32,10 +73,18 @@ const memoize = <T = any>(fn: (...args: any[]) => T) => {
   }
 }
 
-const cachedGetUrlFromPagesDirectories = memoize(getUrlFromPagesDirectories)
-const cachedGetUrlFromAppDirectory = memoize(getUrlFromAppDirectory)
+const cachedGetUrlFromPagesDirectories = memoize(
+  (urlPrefix: string, dirs: string[], exts: string[]) =>
+    getUrlFromPagesDirectories(urlPrefix, dirs, exts)
+)
+const cachedGetUrlFromAppDirectory = memoize(
+  (urlPrefix: string, dirs: string[], exts: string[]) =>
+    getUrlFromAppDirectory(urlPrefix, dirs, exts)
+)
 
 const url = 'https://nextjs.org/docs/messages/no-html-link-for-pages'
+
+
 
 export default defineRule({
   meta: {
@@ -73,6 +122,7 @@ export default defineRule({
     const [customPagesDirectory] = ruleOptions
 
     const rootDirs = getRootDirs(context)
+    const pageExtensions = getPageExtensions(rootDirs, context.settings)
 
     const pagesDirs = (
       customPagesDirectory
@@ -107,8 +157,8 @@ export default defineRule({
       return {}
     }
 
-    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs)
-    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs)
+    const pageUrls = cachedGetUrlFromPagesDirectories('/', foundPagesDirs, pageExtensions)
+    const appDirUrls = cachedGetUrlFromAppDirectory('/', foundAppDirs, pageExtensions)
     const allUrlRegex = [...pageUrls, ...appDirUrls]
 
     return {
@@ -125,7 +175,7 @@ export default defineRule({
           (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'target'
         )
 
-        if (target && target.value.value === '_blank') {
+        if (target && target.value?.value === '_blank') {
           return
         }
 

--- a/packages/eslint-plugin-next/src/utils/url.ts
+++ b/packages/eslint-plugin-next/src/utils/url.ts
@@ -5,28 +5,46 @@ import * as fs from 'fs'
 // Prevent multiple blocking IO requests that have already been calculated.
 const fsReadDirSyncCache = {}
 
+const DEFAULT_PAGE_EXTENSIONS = ['js', 'jsx', 'ts', 'tsx']
+
+/**
+ * Builds a RegExp that matches filenames with the given extensions.
+ */
+function buildExtensionsRegex(pageExtensions: string[]): RegExp {
+  const escaped = pageExtensions.map((ext) =>
+    ext.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  )
+  return new RegExp(`\\.(${escaped.join('|')})$`)
+}
+
 /**
  * Recursively parse directory for page URLs.
  */
-function parseUrlForPages(urlprefix: string, directory: string) {
+function parseUrlForPages(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extRegex = buildExtensionsRegex(pageExtensions)
+  const indexRegex = new RegExp(
+    `^index\\.(${pageExtensions.map((e) => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`
+  )
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^index(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(
-          `${urlprefix}${dirent.name.replace(/^index(\.(j|t)sx?)$/, '')}`
-        )
+    if (extRegex.test(dirent.name)) {
+      if (indexRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(indexRegex, '')}`)
       }
-      res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+      res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
     } else {
       const dirPath = path.join(directory, dirent.name)
       if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+        res.push(
+          ...parseUrlForPages(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -36,24 +54,35 @@ function parseUrlForPages(urlprefix: string, directory: string) {
 /**
  * Recursively parse app directory for URLs.
  */
-function parseUrlForAppDir(urlprefix: string, directory: string) {
+function parseUrlForAppDir(
+  urlprefix: string,
+  directory: string,
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
+) {
   fsReadDirSyncCache[directory] ??= fs.readdirSync(directory, {
     withFileTypes: true,
   })
+  const extRegex = buildExtensionsRegex(pageExtensions)
+  const pageRegex = new RegExp(
+    `^page\\.(${pageExtensions.map((e) => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`
+  )
+  const layoutRegex = new RegExp(
+    `^layout\\.(${pageExtensions.map((e) => e.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})$`
+  )
   const res = []
   fsReadDirSyncCache[directory].forEach((dirent) => {
-    // TODO: this should account for all page extensions
-    // not just js(x) and ts(x)
-    if (/(\.(j|t)sx?)$/.test(dirent.name)) {
-      if (/^page(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/^page(\.(j|t)sx?)$/, '')}`)
-      } else if (!/^layout(\.(j|t)sx?)$/.test(dirent.name)) {
-        res.push(`${urlprefix}${dirent.name.replace(/(\.(j|t)sx?)$/, '')}`)
+    if (extRegex.test(dirent.name)) {
+      if (pageRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(pageRegex, '')}`)
+      } else if (!layoutRegex.test(dirent.name)) {
+        res.push(`${urlprefix}${dirent.name.replace(extRegex, '')}`)
       }
     } else {
       const dirPath = path.join(directory, dirent.name)
-      if (dirent.isDirectory(dirPath) && !dirent.isSymbolicLink()) {
-        res.push(...parseUrlForPages(urlprefix + dirent.name + '/', dirPath))
+      if (dirent.isDirectory() && !dirent.isSymbolicLink()) {
+        res.push(
+          ...parseUrlForAppDir(urlprefix + dirent.name + '/', dirPath, pageExtensions)
+        )
       }
     }
   })
@@ -136,13 +165,16 @@ export function normalizeAppPath(route: string) {
  */
 export function getUrlFromPagesDirectories(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .flatMap((directory) => parseUrlForPages(urlPrefix, directory))
+        .flatMap((directory) =>
+          parseUrlForPages(urlPrefix, directory, pageExtensions)
+        )
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.
           (url) => `^${normalizeURL(url)}$`
@@ -156,13 +188,16 @@ export function getUrlFromPagesDirectories(
 
 export function getUrlFromAppDirectory(
   urlPrefix: string,
-  directories: string[]
+  directories: string[],
+  pageExtensions: string[] = DEFAULT_PAGE_EXTENSIONS
 ) {
   return Array.from(
     // De-duplicate similar pages across multiple directories.
     new Set(
       directories
-        .map((directory) => parseUrlForAppDir(urlPrefix, directory))
+        .map((directory) =>
+          parseUrlForAppDir(urlPrefix, directory, pageExtensions)
+        )
         .flat()
         .map(
           // Since the URLs are normalized we add `^` and `$` to the RegExp to make sure they match exactly.

--- a/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
+++ b/test/unit/eslint-plugin-next/no-html-link-for-pages.test.ts
@@ -6,10 +6,14 @@ import path from 'path'
 
 const NextESLintRule = rules['no-html-link-for-pages']
 
+
 const withCustomPagesDir = path.join(__dirname, 'with-custom-pages-dir')
 const withNestedPagesDir = path.join(__dirname, 'with-nested-pages-dir')
 const withoutPagesDir = path.join(__dirname, 'without-pages-dir')
 const withAppDir = path.join(__dirname, 'with-app-dir')
+const withPageExtensions = path.join(__dirname, 'with-page-extensions')
+const withMjsConfig = path.join(__dirname, 'with-mjs-config')
+const withEmptyExtensions = path.join(__dirname, 'with-empty-extensions')
 
 const linters = {
   withoutPages: new Linter({
@@ -26,6 +30,18 @@ const linters = {
   }),
   withCustomPages: new Linter({
     cwd: withCustomPagesDir,
+    configType: 'eslintrc',
+  }),
+  withPageExtensions: new Linter({
+    cwd: withPageExtensions,
+    configType: 'eslintrc',
+  }),
+  withMjsConfig: new Linter({
+    cwd: withMjsConfig,
+    configType: 'eslintrc',
+  }),
+  withEmptyExtensions: new Linter({
+    cwd: withEmptyExtensions,
     configType: 'eslintrc',
   }),
 }
@@ -256,6 +272,10 @@ export class Blah extends Head {
 }
 `
 describe('no-html-link-for-pages', function () {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
   it('does not print warning when there are "pages" or "app" directories with rootDir in context settings', function () {
     const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
     linters.withNestedPages.verify(
@@ -493,6 +513,81 @@ describe('no-html-link-for-pages', function () {
     assert.equal(
       report.message,
       'Do not use an `<a>` element to navigate to `/photo/1/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  
+  it('invalid static route with pageExtensions', function () {
+    const [report] = linters.withPageExtensions.verify(
+      invalidStaticCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  
+  it('invalid about route with pageExtensions', function () {
+    const aboutInvalidCode = `
+import Link from 'next/link';
+
+export class Blah extends Head {
+  render() {
+    return (
+      <div>
+        <a href='/about'>About</a>
+        <h1>Hello title</h1>
+      </div>
+    );
+  }
+}
+`
+    const [report] = linters.withPageExtensions.verify(
+      aboutInvalidCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/about/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+  
+  it('valid link element with pageExtensions', function () {
+    const [report] = linters.withPageExtensions.verify(
+      validCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.deepEqual(report, [])
+  })
+
+  it('falls back to default extensions when config is .mjs (ESM)', function () {
+    const [report] = linters.withMjsConfig.verify(
+      invalidStaticCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
+    )
+  })
+
+  it('falls back to default extensions when pageExtensions is empty array', function () {
+    const [report] = linters.withEmptyExtensions.verify(
+      invalidStaticCode,
+      linterConfig,
+      { filename: 'foo.js' }
+    )
+    assert.notEqual(report, undefined, 'No lint errors found.')
+    assert.equal(
+      report.message,
+      'Do not use an `<a>` element to navigate to `/`. Use `<Link />` from `next/link` instead. See: https://nextjs.org/docs/messages/no-html-link-for-pages'
     )
   })
 })

--- a/test/unit/eslint-plugin-next/with-empty-extensions/next.config.js
+++ b/test/unit/eslint-plugin-next/with-empty-extensions/next.config.js
@@ -1,0 +1,1 @@
+module.exports = { pageExtensions: [] }

--- a/test/unit/eslint-plugin-next/with-empty-extensions/pages/about.jsx
+++ b/test/unit/eslint-plugin-next/with-empty-extensions/pages/about.jsx
@@ -1,0 +1,3 @@
+export default function AboutPage() {
+  return <h1>About Page</h1>
+}

--- a/test/unit/eslint-plugin-next/with-empty-extensions/pages/index.jsx
+++ b/test/unit/eslint-plugin-next/with-empty-extensions/pages/index.jsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home Page</h1>
+}

--- a/test/unit/eslint-plugin-next/with-mjs-config/next.config.mjs
+++ b/test/unit/eslint-plugin-next/with-mjs-config/next.config.mjs
@@ -1,0 +1,1 @@
+export default { pageExtensions: ['page.tsx', 'page.ts'] }

--- a/test/unit/eslint-plugin-next/with-mjs-config/pages/about.jsx
+++ b/test/unit/eslint-plugin-next/with-mjs-config/pages/about.jsx
@@ -1,0 +1,3 @@
+export default function AboutPage() {
+  return <h1>About Page</h1>
+}

--- a/test/unit/eslint-plugin-next/with-mjs-config/pages/index.jsx
+++ b/test/unit/eslint-plugin-next/with-mjs-config/pages/index.jsx
@@ -1,0 +1,3 @@
+export default function HomePage() {
+  return <h1>Home Page</h1>
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions/next.config.js
+++ b/test/unit/eslint-plugin-next/with-page-extensions/next.config.js
@@ -1,0 +1,3 @@
+module.exports = { 
+  pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'] 
+}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/about.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/about.page.tsx
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/index.page.tsx
@@ -1,0 +1,1 @@
+export default () => {}

--- a/test/unit/eslint-plugin-next/with-page-extensions/pages/list/[id].page.tsx
+++ b/test/unit/eslint-plugin-next/with-page-extensions/pages/list/[id].page.tsx
@@ -1,0 +1,1 @@
+export default () => {}


### PR DESCRIPTION
## What?

The `no-html-link-for-pages` ESLint rule was ignoring `pageExtensions` configured in `next.config.js`, causing false negatives for projects using custom page file extensions.

Fixes #53473

## Why?

In `url.ts`, `parseUrlForPages` and `parseUrlForAppDir` had a hardcoded regex `/(\.( j|t)sx?)$/` with a `TODO` comment acknowledging the limitation. This fix resolves those TODOs.

## How?

### `packages/eslint-plugin-next/src/utils/url.ts`
- Added optional `pageExtensions` parameter (default: `['js', 'jsx', 'ts', 'tsx']`) to `parseUrlForPages`, `parseUrlForAppDir`, `getUrlFromPagesDirectories`, and `getUrlFromAppDirectory`
- Builds extension regexes dynamically from the provided extensions

### `packages/eslint-plugin-next/src/rules/no-html-link-for-pages.ts`
- Added `getPageExtensions()` helper that resolves `pageExtensions` with the following priority:
  1. **ESLint settings** (`settings.next.pageExtensions`) — explicit user override, consistent with how `rootDir` is configured
  2. **`next.config.js` / `next.config.ts`** — auto-detected from the project root
  3. **Next.js defaults** — `['js', 'jsx', 'ts', 'tsx']`

## Testing

To test, create a Next.js project with:
```js
// next.config.js
module.exports = { pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'] }
```

Before this fix, the rule would not detect `<a>` links to `.page.tsx` pages.
After this fix, it correctly identifies them.