### PR TITLE
perf: cache runtime checks and IncrementalCache handler for static serving

### DIFF
--- a/packages/next/src/server/base-http/helpers.ts
+++ b/packages/next/src/server/base-http/helpers.ts
@@ -9,6 +9,13 @@ import type { WebNextRequest, WebNextResponse } from './web'
  * elimination.
  */
 
+// Cache the runtime check at module level. process.env access in Node.js
+// involves a property lookup on a special object that is not free, and
+// NEXT_RUNTIME never changes after process start. These guards are called
+// multiple times per request (5+), so caching avoids repeated overhead.
+const _isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'
+const _isNodeRuntime = !_isEdgeRuntime
+
 /**
  * Type guard to determine if a request is a WebNextRequest. This does not
  * actually check the type of the request, but rather the runtime environment.
@@ -16,7 +23,7 @@ import type { WebNextRequest, WebNextResponse } from './web'
  * base request is a WebNextRequest.
  */
 export const isWebNextRequest = (req: BaseNextRequest): req is WebNextRequest =>
-  process.env.NEXT_RUNTIME === 'edge'
+  _isEdgeRuntime
 
 /**
  * Type guard to determine if a response is a WebNextResponse. This does not
@@ -26,7 +33,7 @@ export const isWebNextRequest = (req: BaseNextRequest): req is WebNextRequest =>
  */
 export const isWebNextResponse = (
   res: BaseNextResponse
-): res is WebNextResponse => process.env.NEXT_RUNTIME === 'edge'
+): res is WebNextResponse => _isEdgeRuntime
 
 /**
  * Type guard to determine if a request is a NodeNextRequest. This does not
@@ -36,7 +43,7 @@ export const isWebNextResponse = (
  */
 export const isNodeNextRequest = (
   req: BaseNextRequest
-): req is NodeNextRequest => process.env.NEXT_RUNTIME !== 'edge'
+): req is NodeNextRequest => _isNodeRuntime
 
 /**
  * Type guard to determine if a response is a NodeNextResponse. This does not
@@ -46,4 +53,4 @@ export const isNodeNextRequest = (
  */
 export const isNodeNextResponse = (
   res: BaseNextResponse
-): res is NodeNextResponse => process.env.NEXT_RUNTIME !== 'edge'
+): res is NodeNextResponse => _isNodeRuntime

--- a/packages/next/src/server/lib/incremental-cache/index.ts
+++ b/packages/next/src/server/lib/incremental-cache/index.ts
@@ -96,6 +96,13 @@ export class IncrementalCache implements IncrementalCacheType {
 
   private static readonly debug: boolean =
     !!process.env.NEXT_PRIVATE_DEBUG_CACHE
+  // Cache env lookups that are checked per-request but never change.
+  private static readonly _disableForTestmode: boolean =
+    process.env.NEXT_PRIVATE_TEST_PROXY === 'true'
+  private static readonly _testMaxIsrCache: number | undefined =
+    process.env.__NEXT_TEST_MAX_ISR_CACHE
+      ? parseInt(process.env.__NEXT_TEST_MAX_ISR_CACHE, 10)
+      : undefined
   private readonly locks = new Map<string, Promise<void>>()
 
   /**
@@ -162,12 +169,12 @@ export class IncrementalCache implements IncrementalCacheType {
       )
     }
 
-    if (process.env.__NEXT_TEST_MAX_ISR_CACHE) {
+    if (IncrementalCache._testMaxIsrCache !== undefined) {
       // Allow cache size to be overridden for testing purposes
-      maxMemoryCacheSize = parseInt(process.env.__NEXT_TEST_MAX_ISR_CACHE, 10)
+      maxMemoryCacheSize = IncrementalCache._testMaxIsrCache
     }
     this.dev = dev
-    this.disableForTestmode = process.env.NEXT_PRIVATE_TEST_PROXY === 'true'
+    this.disableForTestmode = IncrementalCache._disableForTestmode
     // this is a hack to avoid Webpack knowing this is equal to this.minimalMode
     // because we replace this.minimalMode to true in production bundles.
     const minimalModeKey = 'minimalMode'

--- a/packages/next/src/server/next-server.ts
+++ b/packages/next/src/server/next-server.ts
@@ -412,15 +412,21 @@ export default class NextNodeServer extends BaseServer<
     }
   }
 
-  protected async getIncrementalCache({
-    requestHeaders,
-  }: {
-    requestHeaders: IncrementalCache['requestHeaders']
-  }) {
-    const dev = !!this.dev
+  // Cache the resolved CacheHandler class so we skip the dynamic import
+  // and loadCustomCacheHandlers() on every request. The handler class never
+  // changes after the first resolution.
+  private _resolvedCacheHandlerPromise: Promise<any> | undefined = undefined
+
+  private async resolveCacheHandler(): Promise<any> {
+    if (this._resolvedCacheHandlerPromise) return this._resolvedCacheHandlerPromise
+
+    this._resolvedCacheHandlerPromise = this._doResolveCacheHandler()
+    return this._resolvedCacheHandlerPromise
+  }
+
+  private async _doResolveCacheHandler(): Promise<any> {
     let CacheHandler: any
     const { cacheHandler } = this.nextConfig
-
     if (cacheHandler) {
       CacheHandler = interopDefault(
         await dynamicImportEsmDefault(
@@ -430,6 +436,16 @@ export default class NextNodeServer extends BaseServer<
     }
 
     await this.loadCustomCacheHandlers()
+    return CacheHandler
+  }
+
+  protected async getIncrementalCache({
+    requestHeaders,
+  }: {
+    requestHeaders: IncrementalCache['requestHeaders']
+  }) {
+    const dev = !!this.dev
+    const CacheHandler = await this.resolveCacheHandler()
 
     // incremental-cache is request specific
     // although can have shared caches in module scope


### PR DESCRIPTION
## Summary

Three targeted optimizations for the static page serving hot path, reducing per-request overhead from repeated environment variable lookups and unnecessary dynamic imports.

- **Cache `process.env.NEXT_RUNTIME` in `helpers.ts`** -- `isNodeNextRequest`/`isNodeNextResponse`/`isWebNextRequest`/`isWebNextResponse` checked `process.env.NEXT_RUNTIME` on every call (5+ times per request). `process.env` access in Node.js involves a property lookup on a special object that is not free. Now cached at module level since the runtime never changes after process start. Follows existing precedent in `use-cache-wrapper.ts` which already does `const isEdgeRuntime = process.env.NEXT_RUNTIME === 'edge'`.

- **Cache CacheHandler class resolution in `next-server.ts`** -- `getIncrementalCache()` resolved the CacheHandler class via `dynamicImportEsmDefault()` and called `loadCustomCacheHandlers()` on every request, even though the resolved class never changes. Now cached as a promise (also preventing duplicate imports from concurrent requests during startup). The `IncrementalCache` instance itself is still created per-request since it derives request-specific state from headers (`isOnDemandRevalidate`, `revalidatedTags`).

- **Cache env lookups in `IncrementalCache` constructor** -- `NEXT_PRIVATE_TEST_PROXY` and `__NEXT_TEST_MAX_ISR_CACHE` were read from `process.env` in the constructor on every request. Now cached as static class properties, following the existing pattern used by the `debug` property.

### Files changed
- `packages/next/src/server/base-http/helpers.ts`
- `packages/next/src/server/next-server.ts`
- `packages/next/src/server/lib/incremental-cache/index.ts`

## Test plan

- [ ] Verify existing tests pass (no behavioral changes, only caching of already-constant values)
- [ ] `isNodeNextRequest`/`isNodeNextResponse` still return correct values in Node runtime
- [ ] `isWebNextRequest`/`isWebNextResponse` still return correct values in Edge runtime
- [ ] Custom `cacheHandler` config still resolves correctly on first request
- [ ] `loadCustomCacheHandlers` still called (via the cached promise path)
- [ ] IncrementalCache still respects `__NEXT_TEST_MAX_ISR_CACHE` and `NEXT_PRIVATE_TEST_PROXY` when set before module load

🤖 Generated with [Claude Code](https://claude.com/claude-code)