### PR TITLE
perf: cache repeated React elements in component tree creation

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from 'react'
+import type { ComponentType, ReactElement } from 'react'
 import type {
   CacheNodeSeedData,
   LoadingModuleData,
@@ -83,6 +83,15 @@ function errorMissingDefaultExport(
 }
 
 const cacheNodeKey = 'c'
+
+// Cache for createElement(RenderFromTemplateContext, null) — the result is always
+// the same immutable React element (no props, no children) so we avoid creating
+// identical objects on every segment × every request. Keyed on the component
+// reference so different bundles (edge vs node) stay isolated.
+const renderFromTemplateElementCache = new WeakMap<
+  ComponentType,
+  ReactElement
+>()
 
 async function createComponentTreeInternal(
   {
@@ -519,6 +528,93 @@ async function createComponentTreeInternal(
     tree,
   })
 
+  // Hoist loop-invariant computations out of the parallel routes loop.
+  // These depend only on the current segment (tree, dir, Template, etc.),
+  // not on parallelRouteKey, so they are identical for every iteration.
+
+  // Cache the RenderFromTemplateContext element across requests — it's always
+  // the same immutable React element (no props, no children).
+  let renderFromTemplateElement = renderFromTemplateElementCache.get(
+    RenderFromTemplateContext
+  )
+  if (!renderFromTemplateElement) {
+    renderFromTemplateElement = createElement(RenderFromTemplateContext, null)
+    renderFromTemplateElementCache.set(
+      RenderFromTemplateContext,
+      renderFromTemplateElement
+    )
+  }
+
+  const templateNode = createElement(
+    Template,
+    null,
+    renderFromTemplateElement
+  )
+
+  const templateFilePath = getConventionPathByType(tree, dir, 'template')
+  const errorFilePath = getConventionPathByType(tree, dir, 'error')
+  const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
+  const globalErrorFilePath = isRoot
+    ? getConventionPathByType(tree, dir, 'global-error')
+    : undefined
+
+  const wrappedErrorStyles =
+    isSegmentViewEnabled && errorFilePath
+      ? createElement(
+          SegmentViewNode,
+          {
+            type: 'error',
+            pagePath: errorFilePath,
+          },
+          errorStyles
+        )
+      : errorStyles
+
+  // Add a suffix to avoid conflict with the segment view node representing rendered file.
+  // existence: not-found.tsx@boundary
+  // rendered: not-found.tsx
+  const fileNameSuffix = BOUNDARY_SUFFIX
+  const segmentViewBoundaries = isSegmentViewEnabled
+    ? createElement(
+        Fragment,
+        null,
+        notFoundFilePath &&
+          createElement(SegmentViewNode, {
+            type: `${BOUNDARY_PREFIX}not-found`,
+            pagePath: notFoundFilePath + fileNameSuffix,
+          }),
+        loadingFilePath &&
+          createElement(SegmentViewNode, {
+            type: `${BOUNDARY_PREFIX}loading`,
+            pagePath: loadingFilePath + fileNameSuffix,
+          }),
+        errorFilePath &&
+          createElement(SegmentViewNode, {
+            type: `${BOUNDARY_PREFIX}error`,
+            pagePath: errorFilePath + fileNameSuffix,
+          }),
+        globalErrorFilePath &&
+          createElement(SegmentViewNode, {
+            type: `${BOUNDARY_PREFIX}global-error`,
+            pagePath: isNextjsBuiltinFilePath(globalErrorFilePath)
+              ? `${BUILTIN_PREFIX}global-error.js${fileNameSuffix}`
+              : globalErrorFilePath,
+          })
+      )
+    : null
+
+  const resolvedTemplateForRouter =
+    isSegmentViewEnabled && templateFilePath
+      ? createElement(
+          SegmentViewNode,
+          {
+            type: 'template',
+            pagePath: templateFilePath,
+          },
+          templateNode
+        )
+      : templateNode
+
   // TODO: Combine this `map` traversal with the loop below that turns the array
   // into an object.
   const parallelRouteMap = await Promise.all(
@@ -619,64 +715,6 @@ async function createComponentTreeInternal(
           childCacheNodeSeedData = seedData
         }
 
-        const templateNode = createElement(
-          Template,
-          null,
-          createElement(RenderFromTemplateContext, null)
-        )
-
-        const templateFilePath = getConventionPathByType(tree, dir, 'template')
-        const errorFilePath = getConventionPathByType(tree, dir, 'error')
-        const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
-        const globalErrorFilePath = isRoot
-          ? getConventionPathByType(tree, dir, 'global-error')
-          : undefined
-
-        const wrappedErrorStyles =
-          isSegmentViewEnabled && errorFilePath
-            ? createElement(
-                SegmentViewNode,
-                {
-                  type: 'error',
-                  pagePath: errorFilePath,
-                },
-                errorStyles
-              )
-            : errorStyles
-
-        // Add a suffix to avoid conflict with the segment view node representing rendered file.
-        // existence: not-found.tsx@boundary
-        // rendered: not-found.tsx
-        const fileNameSuffix = BOUNDARY_SUFFIX
-        const segmentViewBoundaries = isSegmentViewEnabled
-          ? createElement(
-              Fragment,
-              null,
-              notFoundFilePath &&
-                createElement(SegmentViewNode, {
-                  type: `${BOUNDARY_PREFIX}not-found`,
-                  pagePath: notFoundFilePath + fileNameSuffix,
-                }),
-              loadingFilePath &&
-                createElement(SegmentViewNode, {
-                  type: `${BOUNDARY_PREFIX}loading`,
-                  pagePath: loadingFilePath + fileNameSuffix,
-                }),
-              errorFilePath &&
-                createElement(SegmentViewNode, {
-                  type: `${BOUNDARY_PREFIX}error`,
-                  pagePath: errorFilePath + fileNameSuffix,
-                }),
-              globalErrorFilePath &&
-                createElement(SegmentViewNode, {
-                  type: `${BOUNDARY_PREFIX}global-error`,
-                  pagePath: isNextjsBuiltinFilePath(globalErrorFilePath)
-                    ? `${BUILTIN_PREFIX}global-error.js${fileNameSuffix}`
-                    : globalErrorFilePath,
-                })
-            )
-          : null
-
         return [
           parallelRouteKey,
           createElement(LayoutRouter, {
@@ -684,17 +722,7 @@ async function createComponentTreeInternal(
             error: ErrorComponent,
             errorStyles: wrappedErrorStyles,
             errorScripts: errorScripts,
-            template:
-              isSegmentViewEnabled && templateFilePath
-                ? createElement(
-                    SegmentViewNode,
-                    {
-                      type: 'template',
-                      pagePath: templateFilePath,
-                    },
-                    templateNode
-                  )
-                : templateNode,
+            template: resolvedTemplateForRouter,
             templateStyles: templateStyles,
             templateScripts: templateScripts,
             notFound: notFoundComponent,
@@ -726,7 +754,7 @@ async function createComponentTreeInternal(
         key: 'l',
       })
     : null
-  const loadingFilePath = getConventionPathByType(tree, dir, 'loading')
+  // loadingFilePath is already computed above (hoisted out of the parallel routes loop)
   if (isSegmentViewEnabled && loadingElement) {
     if (loadingFilePath) {
       loadingElement = createElement(

--- a/packages/next/src/server/app-render/get-layer-assets.tsx
+++ b/packages/next/src/server/app-render/get-layer-assets.tsx
@@ -21,25 +21,27 @@ export function getLayerAssets({
   ctx: AppRenderContext
   preloadCallbacks: PreloadCallbacks
 }): React.ReactNode {
+  // Fast path: when there is no layout or page file for this segment,
+  // there are no CSS/JS assets to inject. Skip all manifest lookups.
+  if (!layoutOrPagePath) {
+    return null
+  }
+
   const {
     componentMod: { createElement },
   } = ctx
-  const { styles: styleTags, scripts: scriptTags } = layoutOrPagePath
-    ? getLinkAndScriptTags(
-        layoutOrPagePath,
-        injectedCSSWithCurrentLayout,
-        injectedJSWithCurrentLayout,
-        true
-      )
-    : { styles: [], scripts: [] }
+  const { styles: styleTags, scripts: scriptTags } = getLinkAndScriptTags(
+    layoutOrPagePath,
+    injectedCSSWithCurrentLayout,
+    injectedJSWithCurrentLayout,
+    true
+  )
 
-  const preloadedFontFiles = layoutOrPagePath
-    ? getPreloadableFonts(
-        ctx.renderOpts.nextFontManifest,
-        layoutOrPagePath,
-        injectedFontPreloadTagsWithCurrentLayout
-      )
-    : null
+  const preloadedFontFiles = getPreloadableFonts(
+    ctx.renderOpts.nextFontManifest,
+    layoutOrPagePath,
+    injectedFontPreloadTagsWithCurrentLayout
+  )
 
   if (preloadedFontFiles) {
     if (preloadedFontFiles.length) {


### PR DESCRIPTION
## Summary

Reduces per-request overhead in the dynamic render path by eliminating redundant React element creation and manifest lookups in `createComponentTreeInternal`.

- **Cache `RenderFromTemplateContext` element across requests** via a module-level `WeakMap` keyed on the component reference. The element `createElement(RenderFromTemplateContext, null)` is always identical (no props, no children), so the cached reference is reused across all segments and requests. React elements are immutable value objects, making this safe. Gives React Flight fewer unique elements to serialize.

- **Hoist loop-invariant computations out of the parallel routes loop**: `templateNode`, `templateFilePath`, `errorFilePath`, `loadingFilePath`, `globalErrorFilePath`, `wrappedErrorStyles`, `segmentViewBoundaries`, and `resolvedTemplateForRouter` depend only on the current segment — not on `parallelRouteKey`. Moving them before the `Promise.all` loop avoids redundant `getConventionPathByType` lookups and `createElement` calls per slot. Also eliminates a duplicate `loadingFilePath` computation after the loop.

- **Fast-path `getLayerAssets` when no layout/page path exists**: Early return when `layoutOrPagePath` is `undefined` skips `getLinkAndScriptTags`, `getPreloadableFonts`, and `renderCssResource` calls that would return empty results anyway.

For a 10-layout deep dynamic route, this saves ~40 redundant `getConventionPathByType` lookups, ~10 `createElement(RenderFromTemplateContext, null)` allocations, and associated `getLayerAssets` work for segments without CSS/JS.

## Test plan

- [ ] Existing parallel routes e2e tests pass (`test/e2e/app-dir/parallel-routes-*`)
- [ ] Existing template tests pass
- [ ] `cache-components-create-component-tree` test passes
- [ ] Manual verification: app with nested layouts renders correctly
- [ ] No regression in Flight payload (same elements, fewer unique allocations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)