### PR TITLE
Unify strict and non-strict typegen variants

### DIFF
--- a/packages/next/src/server/lib/router-utils/route-types-utils.ts
+++ b/packages/next/src/server/lib/router-utils/route-types-utils.ts
@@ -10,8 +10,6 @@ import {
   generateRouteTypesFile,
   generateLinkTypesFile,
   generateValidatorFile,
-  generateValidatorFileStrict,
-  generateRouteTypesFileStrict,
 } from './typegen'
 import { tryToParsePath } from '../../../lib/try-to-parse-path'
 import {
@@ -367,9 +365,7 @@ export async function writeRouteTypesManifest(
   // Write the main routes.d.ts file
   await fs.promises.writeFile(
     filePath,
-    config.experimental.strictRouteTypes
-      ? generateRouteTypesFileStrict(manifest)
-      : generateRouteTypesFile(manifest)
+    generateRouteTypesFile(manifest, config.experimental.strictRouteTypes)
   )
 
   // Write the link.d.ts file if typedRoutes is enabled
@@ -390,10 +386,5 @@ export async function writeValidatorFile(
     await fs.promises.mkdir(dirname, { recursive: true })
   }
 
-  await fs.promises.writeFile(
-    filePath,
-    strict
-      ? generateValidatorFileStrict(manifest)
-      : generateValidatorFile(manifest)
-  )
+  await fs.promises.writeFile(filePath, generateValidatorFile(manifest, strict))
 }

--- a/packages/next/src/server/lib/router-utils/typegen.ts
+++ b/packages/next/src/server/lib/router-utils/typegen.ts
@@ -409,7 +409,8 @@ declare module 'next/form' {
 }
 
 export function generateValidatorFile(
-  routesManifest: RouteTypesManifest
+  routesManifest: RouteTypesManifest,
+  strict?: boolean
 ): string {
   const generateValidations = (
     paths: string[],
@@ -446,6 +447,16 @@ export function generateValidatorFile(
             type === 'RouteHandlerConfig')
             ? `${type}<${JSON.stringify(route)}>`
             : type
+
+        if (strict) {
+          return `// Validate ${filePath}
+{
+  const handler = {} as typeof import(${JSON.stringify(
+    importPath.replace(/\.tsx?$/, '.js')
+  )})
+  handler satisfies ${typeWithRoute}
+}`
+        }
 
         // NOTE: we previously used `satisfies` here, but it's not supported by TypeScript 4.8 and below.
         // If we ever raise the TS minimum version, we can switch back.
@@ -497,242 +508,8 @@ export function generateValidatorFile(
   let typeDefinitions = ''
 
   if (appPageValidations) {
-    typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
-  default: React.ComponentType<{ params: Promise<ParamMap[Route]> } & any> | ((props: { params: Promise<ParamMap[Route]> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
-  generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
-  generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
-    parent: ResolvingMetadata
-  ) => Promise<any> | any
-  generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
-    parent: ResolvingViewport
-  ) => Promise<any> | any
-  metadata?: any
-  viewport?: any
-}
-
-`
-  }
-
-  if (pagesRouterPageValidations) {
-    typeDefinitions += `type PagesPageConfig = {
-  default: React.ComponentType<any> | ((props: any) => React.ReactNode | Promise<React.ReactNode> | never | void)
-  getStaticProps?: (context: any) => Promise<any> | any
-  getStaticPaths?: (context: any) => Promise<any> | any
-  getServerSideProps?: (context: any) => Promise<any> | any
-  getInitialProps?: (context: any) => Promise<any> | any
-  /**
-   * Segment configuration for legacy Pages Router pages.
-   * Validated at build-time by parsePagesSegmentConfig.
-   */
-  config?: {
-    maxDuration?: number
-    runtime?: 'edge' | 'experimental-edge' | 'nodejs' | string // necessary unless config is exported as const
-    regions?: string[]
-  }
-}
-
-`
-  }
-
-  if (layoutValidations) {
-    typeDefinitions += `type LayoutConfig<Route extends LayoutRoutes = LayoutRoutes> = {
-  default: React.ComponentType<LayoutProps<Route>> | ((props: LayoutProps<Route>) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
-  generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
-  generateMetadata?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
-    parent: ResolvingMetadata
-  ) => Promise<any> | any
-  generateViewport?: (
-    props: { params: Promise<ParamMap[Route]> } & any,
-    parent: ResolvingViewport
-  ) => Promise<any> | any
-  metadata?: any
-  viewport?: any
-}
-
-`
-  }
-
-  if (appRouteHandlerValidations) {
-    typeDefinitions += `type RouteHandlerConfig<Route extends AppRouteHandlerRoutes = AppRouteHandlerRoutes> = {
-  GET?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  POST?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  PUT?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  PATCH?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  DELETE?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  HEAD?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-  OPTIONS?: (request: NextRequest, context: { params: Promise<ParamMap[Route]> }) => Promise<Response | void> | Response | void
-}
-
-`
-  }
-
-  if (pagesApiRouteValidations) {
-    typeDefinitions += `type ApiRouteConfig = {
-  default: (req: any, res: any) => ReturnType<NextApiHandler>
-  config?: {
-    api?: {
-      bodyParser?: boolean | { sizeLimit?: number | string }
-      responseLimit?: string | number | boolean
-      externalResolver?: boolean
-    }
-    runtime?: 'edge' | 'experimental-edge' | 'nodejs' | string // necessary unless config is exported as const
-    maxDuration?: number
-  }
-}
-
-`
-  }
-
-  // Build import statement based on what's actually needed
-  const routeImports = []
-
-  // Only import AppRoutes if there are app pages
-  if (appPageValidations) {
-    routeImports.push('AppRoutes')
-  }
-
-  // Only import LayoutRoutes if there are layouts
-  if (layoutValidations) {
-    routeImports.push('LayoutRoutes')
-  }
-
-  // Only import ParamMap if there are routes that use it
-  if (appPageValidations || layoutValidations || appRouteHandlerValidations) {
-    routeImports.push('ParamMap')
-  }
-
-  if (hasAppRouteHandlers) {
-    routeImports.push('AppRouteHandlerRoutes')
-  }
-
-  const routeImportStatement =
-    routeImports.length > 0
-      ? `import type { ${routeImports.join(', ')} } from "./routes.js"`
-      : ''
-
-  const nextRequestImport = hasAppRouteHandlers
-    ? "import type { NextRequest } from 'next/server.js'\n"
-    : ''
-
-  // Conditionally import types from next/types, merged into a single statement
-  const nextTypes: string[] = []
-  if (pagesApiRouteValidations) {
-    nextTypes.push('NextApiHandler')
-  }
-  if (appPageValidations || layoutValidations) {
-    nextTypes.push('ResolvingMetadata', 'ResolvingViewport')
-  }
-  const nextTypesImport =
-    nextTypes.length > 0
-      ? `import type { ${nextTypes.join(', ')} } from "next/types.js"\n`
-      : ''
-
-  return `// This file is generated automatically by Next.js
-// Do not edit this file manually
-// This file validates that all pages and layouts export the correct types
-
-${routeImportStatement}
-${nextTypesImport}${nextRequestImport}
-${typeDefinitions}
-${appPageValidations}
-
-${appRouteHandlerValidations}
-
-${pagesRouterPageValidations}
-
-${pagesApiRouteValidations}
-
-${layoutValidations}
-`
-}
-
-export function generateValidatorFileStrict(
-  routesManifest: RouteTypesManifest
-): string {
-  const generateValidations = (
-    paths: string[],
-    type:
-      | 'AppPageConfig'
-      | 'PagesPageConfig'
-      | 'LayoutConfig'
-      | 'RouteHandlerConfig'
-      | 'ApiRouteConfig',
-    pathToRouteMap?: Map<string, string>
-  ) =>
-    paths
-      .sort()
-      // Only validate TypeScript files - JavaScript files have too many type inference limitations
-      .filter(
-        (filePath) => filePath.endsWith('.ts') || filePath.endsWith('.tsx')
-      )
-      .filter(
-        // Don't include metadata routes or pages
-        // (e.g. /manifest.webmanifest)
-        (filePath) =>
-          type !== 'AppPageConfig' ||
-          filePath.endsWith('page.ts') ||
-          filePath.endsWith('page.tsx')
-      )
-      .map((filePath) => {
-        // Keep the file extension for TypeScript imports to support node16 module resolution
-        const importPath = filePath
-        const route = pathToRouteMap?.get(filePath)
-        const typeWithRoute =
-          route &&
-          (type === 'AppPageConfig' ||
-            type === 'LayoutConfig' ||
-            type === 'RouteHandlerConfig')
-            ? `${type}<${JSON.stringify(route)}>`
-            : type
-
-        return `// Validate ${filePath}
-{
-  const handler = {} as typeof import(${JSON.stringify(
-    importPath.replace(/\.tsx?$/, '.js')
-  )})
-  handler satisfies ${typeWithRoute}
-}`
-      })
-      .join('\n\n')
-
-  // Use direct mappings from the manifest
-
-  // Generate validations for different route types
-  const appPageValidations = generateValidations(
-    Array.from(routesManifest.appPagePaths).sort(),
-    'AppPageConfig',
-    routesManifest.filePathToRoute
-  )
-  const appRouteHandlerValidations = generateValidations(
-    Array.from(routesManifest.appRouteHandlers).sort(),
-    'RouteHandlerConfig',
-    routesManifest.filePathToRoute
-  )
-  const pagesRouterPageValidations = generateValidations(
-    Array.from(routesManifest.pagesRouterPagePaths).sort(),
-    'PagesPageConfig'
-  )
-  const pagesApiRouteValidations = generateValidations(
-    Array.from(routesManifest.pageApiRoutes).sort(),
-    'ApiRouteConfig'
-  )
-  const layoutValidations = generateValidations(
-    Array.from(routesManifest.layoutPaths).sort(),
-    'LayoutConfig',
-    routesManifest.filePathToRoute
-  )
-
-  const hasAppRouteHandlers =
-    Object.keys(routesManifest.appRouteHandlerRoutes).length > 0
-
-  // Build type definitions based on what's actually used
-  let typeDefinitions = ''
-
-  if (appPageValidations) {
-    typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
+    if (strict) {
+      typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
   default: React.JSXElementConstructor<PageProps<Route>>
   generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
   generateMetadata?: (
@@ -748,6 +525,24 @@ export function generateValidatorFileStrict(
 }
 
 `
+    } else {
+      typeDefinitions += `type AppPageConfig<Route extends AppRoutes = AppRoutes> = {
+  default: React.ComponentType<{ params: Promise<ParamMap[Route]> } & any> | ((props: { params: Promise<ParamMap[Route]> } & any) => React.ReactNode | Promise<React.ReactNode> | never | void | Promise<void>)
+  generateStaticParams?: (props: { params: ParamMap[Route] }) => Promise<any[]> | any[]
+  generateMetadata?: (
+    props: { params: Promise<ParamMap[Route]> } & any,
+    parent: ResolvingMetadata
+  ) => Promise<any> | any
+  generateViewport?: (
+    props: { params: Promise<ParamMap[Route]> } & any,
+    parent: ResolvingViewport
+  ) => Promise<any> | any
+  metadata?: any
+  viewport?: any
+}
+
+`
+    }
   }
 
   if (pagesRouterPageValidations) {
@@ -865,7 +660,11 @@ export function generateValidatorFileStrict(
       ? `import type { ${nextTypes.join(', ')} } from "next/types.js"\n`
       : ''
 
-  return `// This file is generated automatically by Next.js with experimental.strictRouteTypes
+  const header = strict
+    ? '// This file is generated automatically by Next.js with experimental.strictRouteTypes'
+    : '// This file is generated automatically by Next.js'
+
+  return `${header}
 // Do not edit this file manually
 // This file validates that all pages and layouts export the correct types
 
@@ -885,7 +684,8 @@ ${layoutValidations}
 }
 
 export function generateRouteTypesFile(
-  routesManifest: RouteTypesManifest
+  routesManifest: RouteTypesManifest,
+  strict?: boolean
 ): string {
   const routeTypes = generateRouteTypes(routesManifest)
   const paramTypes = generateParamTypes(routesManifest)
@@ -895,14 +695,17 @@ export function generateRouteTypesFile(
     Object.keys(routesManifest.appRouteHandlerRoutes).length > 0
 
   // Build export statement based on what's actually generated
-  const routeExports = [
-    'AppRoutes',
+  const routeExports = ['AppRoutes']
+  if (strict) {
+    routeExports.push('PageProps')
+  }
+  routeExports.push(
     'PageRoutes',
     'LayoutRoutes',
     'RedirectRoutes',
     'RewriteRoutes',
-    'ParamMap',
-  ]
+    'ParamMap'
+  )
   if (hasAppRouteHandlers) {
     routeExports.push('AppRouteHandlerRoutes')
   }
@@ -927,99 +730,11 @@ export function generateRouteTypesFile(
   }`
     : ''
 
-  return `// This file is generated automatically by Next.js
-// Do not edit this file manually
+  const header = strict
+    ? '// This file is generated automatically by Next.js with experimental.strictRouteTypes'
+    : '// This file is generated automatically by Next.js'
 
-${routeTypes}
-
-${paramTypes}
-
-export type ParamsOf<Route extends Routes> = ParamMap[Route]
-
-${layoutSlotMap}
-
-${exportStatement}
-
-declare global {
-  /**
-   * Props for Next.js App Router page components
-   * @example
-   * \`\`\`tsx
-   * export default function Page(props: PageProps<'/blog/[slug]'>) {
-   *   const { slug } = await props.params
-   *   return <div>Blog post: {slug}</div>
-   * }
-   * \`\`\`
-   */
-  interface PageProps<AppRoute extends AppRoutes> {
-    params: Promise<ParamMap[AppRoute]>
-    searchParams: Promise<Record<string, string | string[] | undefined>>
-  }
-
-  /**
-   * Props for Next.js App Router layout components
-   * @example
-   * \`\`\`tsx
-   * export default function Layout(props: LayoutProps<'/dashboard'>) {
-   *   return <div>{props.children}</div>
-   * }
-   * \`\`\`
-   */
-  type LayoutProps<LayoutRoute extends LayoutRoutes> = {
-    params: Promise<ParamMap[LayoutRoute]>
-    children: React.ReactNode
-  } & {
-    [K in LayoutSlotMap[LayoutRoute]]: React.ReactNode
-  }${routeContextInterface}
-}
-`
-}
-
-export function generateRouteTypesFileStrict(
-  routesManifest: RouteTypesManifest
-): string {
-  const routeTypes = generateRouteTypes(routesManifest)
-  const paramTypes = generateParamTypes(routesManifest)
-  const layoutSlotMap = generateLayoutSlotMap(routesManifest)
-
-  const hasAppRouteHandlers =
-    Object.keys(routesManifest.appRouteHandlerRoutes).length > 0
-
-  // Build export statement based on what's actually generated
-  const routeExports = [
-    'AppRoutes',
-    'PageProps',
-    'PageRoutes',
-    'LayoutRoutes',
-    'RedirectRoutes',
-    'RewriteRoutes',
-    'ParamMap',
-  ]
-  if (hasAppRouteHandlers) {
-    routeExports.push('AppRouteHandlerRoutes')
-  }
-
-  const exportStatement = `export type { ${routeExports.join(', ')} }`
-
-  const routeContextInterface = hasAppRouteHandlers
-    ? `
-
-  /**
-   * Context for Next.js App Router route handlers
-   * @example
-   * \`\`\`tsx
-   * export async function GET(request: NextRequest, context: RouteContext<'/api/users/[id]'>) {
-   *   const { id } = await context.params
-   *   return Response.json({ id })
-   * }
-   * \`\`\`
-   */
-  interface RouteContext<AppRouteHandlerRoute extends AppRouteHandlerRoutes> {
-    params: Promise<ParamMap[AppRouteHandlerRoute]>
-  }`
-    : ''
-
-  return `// This file is generated automatically by Next.js with experimental.strictRouteTypes
+  return `${header}
 // Do not edit this file manually
 
 ${routeTypes}


### PR DESCRIPTION
## What?

Merges the duplicated strict/non-strict typegen function pairs into single functions with an optional `strict` parameter:

- `generateValidatorFile` + `generateValidatorFileStrict` → `generateValidatorFile(manifest, strict?)`
- `generateRouteTypesFile` + `generateRouteTypesFileStrict` → `generateRouteTypesFile(manifest, strict?)`

## Why?

The strict variants were near-verbatim copies of the non-strict functions. `generateValidatorFile` / `generateValidatorFileStrict` shared ~93% identical code (~174 of ~186 structural lines), differing only in the validation pattern (`__IsExpected` type trick vs `satisfies`) and `AppPageConfig` type signatures. `generateRouteTypesFile` / `generateRouteTypesFileStrict` shared ~96% identical code, differing only in whether `PageProps` appears in the export list and the file header comment.

The call sites in `route-types-utils.ts` already selected between variants via a boolean (`config.experimental.strictRouteTypes`), confirming the parameterization is natural.

## How?

- Added optional `strict?: boolean` parameter to both `generateValidatorFile` and `generateRouteTypesFile`
- Used conditional branches only at the points of actual divergence (validation template, `AppPageConfig` type definition, export list, header comment)
- Updated `route-types-utils.ts` to pass the boolean directly instead of using ternary function selection
- Removed the now-unused `Strict` variant exports

This also simplifies the eventual migration when `strictRouteTypes` becomes the default (tracked by the existing TODO in `config.ts`).

## Test plan

- [ ] Existing `typed-routes` e2e tests continue to pass (non-strict path)
- [ ] `strictRouteTypes` e2e tests continue to pass (strict path)
- [ ] Generated `.d.ts` output is byte-identical before and after this change for both modes