### PR TITLE
fix(next-routing): denormalize data URLs in standalone dynamic route check

### DIFF
--- a/packages/next-routing/src/resolve-routes.ts
+++ b/packages/next-routing/src/resolve-routes.ts
@@ -813,58 +813,25 @@ export async function resolveRoutes(
   }
 
   // Check dynamic routes
-  for (const route of routes.dynamicRoutes) {
-    const match = matchDynamicRoute(currentUrl.pathname, route)
-
-    if (match.matched) {
-      // Check has/missing conditions
-      const hasResult = checkHasConditions(
-        route.has,
-        currentUrl,
-        currentRequestHeaders
-      )
-      const missingMatched = checkMissingConditions(
-        route.missing,
-        currentUrl,
-        currentRequestHeaders
-      )
-
-      if (hasResult.matched && missingMatched) {
-        const replacedDestination = route.destination
-          ? replaceDestination(
-              route.destination,
-              match.regexMatches || null,
-              hasResult.captures
-            )
-          : undefined
-        // Check if the destination pathname (template path) is in the provided pathnames list
-        // For dynamic routes, the destination contains the template path like /dynamic/[slug]
-        const pathnameToCheck = replacedDestination
-          ? replacedDestination.split('?')[0]
-          : currentUrl.pathname
-        matchedPath = matchesPathname(pathnameToCheck, pathnames)
-        if (matchedPath) {
-          const resolvedUrl = replacedDestination
-            ? mergeDestinationQueryIntoUrl(currentUrl, replacedDestination)
-            : currentUrl
-          const finalHeaders = applyOnMatchHeaders(
-            routes.onMatch,
-            resolvedUrl,
-            currentRequestHeaders,
-            currentResponseHeaders
-          )
-          return withResolvedInvocationTarget({
-            result: {
-              routeMatches: match.params,
-              resolvedHeaders: finalHeaders,
-              status: currentStatus,
-            },
-            url: resolvedUrl,
-            resolvedPathname: matchedPath,
-            invocationPathname: currentUrl.pathname,
-          })
-        }
+  {
+    const dynamicResult = checkDynamicRoutes(
+      routes.dynamicRoutes,
+      currentUrl,
+      pathnames,
+      currentRequestHeaders,
+      currentResponseHeaders,
+      routes.onMatch,
+      basePath,
+      buildId,
+      shouldNormalizeNextData,
+      isDataUrl
+    )
+    if (dynamicResult.matched && dynamicResult.result) {
+      // Reset URL to the denormalized version if it matched
+      if (dynamicResult.resetUrl) {
+        currentUrl = dynamicResult.resetUrl
       }
+      return { ...dynamicResult.result, status: currentStatus }
     }
   }
 


### PR DESCRIPTION
## What?

Replaces the inline dynamic route matching loop after `afterFiles` processing with a call to the existing `checkDynamicRoutes` helper.

## Why?

The standalone dynamic route check (after `afterFiles` routes are exhausted) used an inline loop that matched against `currentUrl.pathname` directly. However, by the time execution reaches this point, the URL may still be in its normalized data URL form — it was re-normalized at line 700 for `afterFiles` processing and never denormalized back if no `afterFiles` route matched.

The `checkDynamicRoutes` helper already handles this correctly: it conditionally denormalizes data URLs before matching (lines 307-310). This helper is already used for the equivalent dynamic route checks inside both the `afterFiles` loop (line 762) and the `fallback` loop (line 929), making this the only dynamic route matching site that was missing the denormalization step.

Without this fix, dynamic routes with `has`/`missing` conditions could silently fail to match when reached via the standalone path with a data URL request.

## How?

Replaced the 51-line inline loop with a call to `checkDynamicRoutes`, matching the exact pattern already established at the `afterFiles` and `fallback` call sites. The replacement is structurally identical — same arguments, same post-call handling (`resetUrl` propagation, `status` merge).

## Test plan

- [ ] Existing `resolve-routes` unit tests pass
- [ ] Data URL requests that fall through `afterFiles` without matching now correctly denormalize before dynamic route matching