### PR TITLE
Skip CI for agent/editor config directory changes

### DIFF
--- a/scripts/run-for-change.mjs
+++ b/scripts/run-for-change.mjs
@@ -7,6 +7,9 @@ const exec = promisify(execOrig)
 
 const CHANGE_ITEM_GROUPS = {
   docs: [
+    '.agents',
+    '.claude',
+    '.cursor',
     'bench',
     'docs',
     'apps/docs',


### PR DESCRIPTION
## Summary
- Add `.agents`, `.claude`, and `.cursor` to the `docs` group in `CHANGE_ITEM_GROUPS` in `scripts/run-for-change.mjs`
- Changes to these directories (agent skill definitions, editor configs) don't affect Next.js build/runtime/tests, so CI should skip for them — same as docs-only changes
- Both `build_and_deploy.yml` and `build_and_test.yml` already use `run-for-change.mjs --not --type docs` to detect non-docs changes; this extends that behavior to agent/editor config files