### PR TITLE
perf: remove unnecessary async from createBoundaryConventionElement

### DIFF
--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -505,7 +505,7 @@ async function createComponentTreeInternal(
       : ctx.renderOpts.dir) || ''
 
   const [notFoundElement, notFoundFilePath] =
-    await createBoundaryConventionElement({
+    createBoundaryConventionElement({
       ctx,
       conventionName: 'not-found',
       Component: NotFound,
@@ -513,7 +513,7 @@ async function createComponentTreeInternal(
       tree,
     })
 
-  const [forbiddenElement] = await createBoundaryConventionElement({
+  const [forbiddenElement] = createBoundaryConventionElement({
     ctx,
     conventionName: 'forbidden',
     Component: Forbidden,
@@ -521,7 +521,7 @@ async function createComponentTreeInternal(
     tree,
   })
 
-  const [unauthorizedElement] = await createBoundaryConventionElement({
+  const [unauthorizedElement] = createBoundaryConventionElement({
     ctx,
     conventionName: 'unauthorized',
     Component: Unauthorized,
@@ -1240,7 +1240,7 @@ function getRootParamsImpl(
   }
 }
 
-async function createBoundaryConventionElement({
+function createBoundaryConventionElement({
   ctx,
   conventionName,
   Component,

--- a/packages/next/src/server/app-render/create-component-tree.tsx
+++ b/packages/next/src/server/app-render/create-component-tree.tsx
@@ -495,7 +495,7 @@ async function createComponentTreeInternal(
       : ctx.renderOpts.dir) || ''
 
   const [notFoundElement, notFoundFilePath] =
-    await createBoundaryConventionElement({
+    createBoundaryConventionElement({
       ctx,
       conventionName: 'not-found',
       Component: NotFound,
@@ -503,7 +503,7 @@ async function createComponentTreeInternal(
       tree,
     })
 
-  const [forbiddenElement] = await createBoundaryConventionElement({
+  const [forbiddenElement] = createBoundaryConventionElement({
     ctx,
     conventionName: 'forbidden',
     Component: Forbidden,
@@ -511,7 +511,7 @@ async function createComponentTreeInternal(
     tree,
   })
 
-  const [unauthorizedElement] = await createBoundaryConventionElement({
+  const [unauthorizedElement] = createBoundaryConventionElement({
     ctx,
     conventionName: 'unauthorized',
     Component: Unauthorized,
@@ -1243,7 +1243,7 @@ function getRootParamsImpl(
   }
 }
 
-async function createBoundaryConventionElement({
+function createBoundaryConventionElement({
   ctx,
   conventionName,
   Component,


### PR DESCRIPTION
## Summary

- Remove `async` keyword from `createBoundaryConventionElement` in `create-component-tree.tsx` — the function body is entirely synchronous (zero `await` expressions)
- Remove `await` from all 3 call sites (not-found, forbidden, unauthorized boundary elements)
- Eliminates ~30 unnecessary Promise allocations + microtask ticks per request (3 calls per segment, ~10 segments per typical render tree)

## Details

`createBoundaryConventionElement` was declared `async` but its body only performs synchronous operations: `createElement` calls, property access, string concatenation, and conditional expressions. The `async` keyword caused every call to wrap the return value in a Promise and schedule a microtask tick (~2-4μs each), adding unnecessary overhead to the hot dynamic render path.

## Test plan

- [ ] Existing e2e tests for app-dir pass (not-found, forbidden, unauthorized boundaries still render correctly)
- [ ] No behavioral change — the function was already returning synchronously; the Promise wrapper was pure overhead


🤖 Generated with [Claude Code](https://claude.com/claude-code)