### PR TITLE
perf: optimize response writer for dynamic SSR

### DIFF
--- a/packages/next/src/server/pipe-readable.ts
+++ b/packages/next/src/server/pipe-readable.ts
@@ -19,19 +19,18 @@ function createWriterFromResponse(
 ): WritableStream<Uint8Array> {
   let started = false
 
-  // Create a promise that will resolve once the response has drained. See
-  // https://nodejs.org/api/stream.html#stream_event_drain
-  let drained = new DetachedPromise<void>()
-  function onDrain() {
-    drained.resolve()
-  }
-  res.on('drain', onDrain)
+  // Lazily created on first backpressure event. For typical responses
+  // (< ~64KB), res.write() never returns false so this is never allocated.
+  let drained: DetachedPromise<void> | undefined
 
-  // If the finish event fires, it means we shouldn't block and wait for the
-  // drain event.
+  function onDrain() {
+    drained?.resolve()
+  }
+
+  // If the response closes, resolve any pending drain wait and stop listening.
   res.once('close', () => {
     res.off('drain', onDrain)
-    drained.resolve()
+    drained?.resolve()
   })
 
   // Create a promise that will resolve once the response has finished. See
@@ -40,6 +39,13 @@ function createWriterFromResponse(
   res.once('finish', () => {
     finished.resolve()
   })
+
+  // Cache the flush check once instead of per-chunk. The `flush` method is
+  // added by the `compression` middleware and won't appear/disappear mid-request.
+  const flushFn =
+    'flush' in res && typeof (res as any).flush === 'function'
+      ? (res as any).flush.bind(res)
+      : null
 
   // Create a writable stream that will write to the response.
   return new WritableStream<Uint8Array>({
@@ -73,6 +79,7 @@ function createWriterFromResponse(
           NextNodeServerSpan.startResponse,
           {
             spanName: 'start response',
+            hideSpan: true,
           },
           () => undefined
         )
@@ -81,15 +88,18 @@ function createWriterFromResponse(
       try {
         const ok = res.write(chunk)
 
-        // Added by the `compression` middleware, this is a function that will
-        // flush the partially-compressed response to the client.
-        if ('flush' in res && typeof res.flush === 'function') {
-          res.flush()
+        // Flush the partially-compressed response to the client.
+        if (flushFn) {
+          flushFn()
         }
 
         // If the write returns false, it means there's some backpressure, so
         // wait until it's streamed before continuing.
         if (!ok) {
+          if (!drained) {
+            drained = new DetachedPromise<void>()
+            res.on('drain', onDrain)
+          }
           await drained.promise
 
           // Reset the drained promise so that we can wait for the next drain event.


### PR DESCRIPTION
## Summary

Reduces per-request overhead in `createWriterFromResponse` (`packages/next/src/server/pipe-readable.ts`) for dynamic SSR responses:

- **Lazy backpressure promise**: Only allocate the `drained` DetachedPromise and register the `drain` event listener when `res.write()` actually returns `false`. For typical responses under the highWaterMark (~64KB), backpressure never occurs — saves 1 promise allocation + 1 event listener per request.
- **Skip noop trace span**: The `startResponse` trace created a full OTel span every request just to call `() => undefined`. Since `startResponse` is in `NextVanillaSpanAllowlist`, this bypassed the fast path and went through full span creation. Adding `hideSpan: true` makes the tracer call `fn()` directly (line 304 of tracer.ts), avoiding context/span overhead while preserving the call site.
- **Cache flush check**: Move the `'flush' in res` property existence check + `typeof` guard from per-chunk to once per-request. The compression middleware's `flush` method is stable for the lifetime of the response.

Net savings per request (no backpressure path): **1 DetachedPromise, 1 event listener registration, 1 OTel span creation, N-1 property lookups** (where N = chunk count, typically 6 for a ~9.8KB page).

## Test plan

- [ ] Verify `next build && next start` serves dynamic SSR pages correctly
- [ ] Verify streaming SSR (React Suspense boundaries) still flushes incrementally
- [ ] Verify backpressure handling: slow client consuming a large streamed response should not lose data
- [ ] Verify `compression` middleware flush still works (response arrives compressed)
- [ ] Existing integration tests in `test/integration/` and `test/e2e/` cover these paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)