### PR TITLE
fix :  build-time validation for dynamic slug name conflicts in app routes

### DIFF
--- a/packages/next/src/build/validate-app-paths.test.ts
+++ b/packages/next/src/build/validate-app-paths.test.ts
@@ -512,6 +512,17 @@ describe('validateAppPaths', () => {
     })
   })
 
+  describe('sibling routes with different dynamic slug names', () => {
+    it('detects conflict when sibling routes use different param names at same depth', () => {
+      const paths = [
+        '/api/items/[item_id]/details',
+        '/api/items/[parent_item_id]/purge',
+      ]
+
+      expect(() => validateAppPaths(paths)).toThrow(/different slug names/)
+    })
+  })
+
   describe('error message quality', () => {
     it('provides clear error message with normalized path', () => {
       const paths = ['/blog/[slug]', '/blog/[modalSlug]']

--- a/packages/next/src/build/validate-app-paths.ts
+++ b/packages/next/src/build/validate-app-paths.ts
@@ -8,6 +8,7 @@ import {
   type NormalizedAppRoute,
   type NormalizedAppRouteSegment,
 } from '../shared/lib/router/routes/app'
+import { getSortedRoutes } from '../shared/lib/router/utils'
 
 /**
  * Validates segment parameters for common syntax errors.
@@ -276,6 +277,8 @@ export function validateAppPaths(
         `Please ensure that dynamic segments have unique patterns or use different static segments.`
     )
   }
+
+  getSortedRoutes(appPaths)
 
   return Array.from(paramsByPath.values())
 }


### PR DESCRIPTION
### What?

- Fail next build when app routes have mismatched dynamic slug names at the same path depth.

### Why?

- These conflicts currently slip past validateAppPaths, then crash next start at runtime.

### How?

- Run getSortedRoutes(appPaths) inside validateAppPaths and add a unit test for the sibling-slug mismatch case.

Closes NEXT-

Fixes : #91628