### PR TITLE
[turbopack] Use bail! instead of panic! for duplicate module ident error

### DIFF
--- a/turbopack/crates/turbopack-core/src/module_graph/mod.rs
+++ b/turbopack/crates/turbopack-core/src/module_graph/mod.rs
@@ -406,7 +406,7 @@ impl SingleModuleGraph {
                     for (key, debug, parents) in duplicate_modules {
                         map.entry(key).or_default().push((debug, parents));
                     }
-                    panic!("Duplicate module idents in graph: {map:#?}",);
+                    bail!("Duplicate module idents in graph: {map:#?}",);
                 }
             }
         }


### PR DESCRIPTION
### What?

In `turbopack/crates/turbopack-core/src/module_graph/mod.rs`, the `#[cfg(debug_assertions)]` duplicate module ident detection block inside `SingleModuleGraph::new_inner` called `panic!` when duplicates were found.

### Why?

`panic!` terminates the process hard, bypassing the normal error-handling chain. The enclosing function `new_inner` already returns `anyhow::Result<Vc<Self>>`, and `bail!` is already imported and used elsewhere in the same file. Using `bail!` converts this into a propagatable error, consistent with the rest of the error-handling idioms in the module.

### How?

Single-line change: replace `panic!(...)` with `bail!(...)` at the duplicate module detection site. No new imports needed — `bail!` was already in scope via `use anyhow::{Context, Result, bail};`.