### PR TITLE
[test] Unflake "infinite streaming fetch" test

### DIFF
--- a/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
+++ b/test/development/app-dir/server-components-hmr-cache/server-components-hmr-cache.test.ts
@@ -233,5 +233,5 @@ describe('server-components-hmr-cache', () => {
     expect(next.cliOutput.slice(cliOutputLength)).not.toContain(
       'Failed to set fetch cache'
     )
-  }, 10_000) // fail fast
+  })
 })


### PR DESCRIPTION
[Flakiness metric](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22server-components-hmr-cache%20should%20support%20reading%20from%20an%20infinite%20streaming%20fetch%22%20%40test.status%3Afail%20%40duration%3A%3E%3D1ns&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1773310422894&end=1773915222894&paused=false)

This test times out frequently on slow CI machines. To fix this, we're removing the low custom 10 second test timeout (using the default 60 second timeout instead).