### PR TITLE
[test] Unflake `deterministic build - changing deployment id` test

### DIFF
--- a/test/production/deterministic-build/deployment-id.test.ts
+++ b/test/production/deterministic-build/deployment-id.test.ts
@@ -226,10 +226,10 @@ const FILES = {
     })
 
     describe.each([
-      { test: 'standard', mode: 'builder' },
-      { test: 'standard', mode: 'adapter' },
-      { test: 'cacheComponents', mode: 'builder' },
-      { test: 'cacheComponents', mode: 'adapter' },
+      { test: 'standard', mode: 'builder' } as const,
+      { test: 'standard', mode: 'adapter' } as const,
+      { test: 'cacheComponents', mode: 'builder' } as const,
+      { test: 'cacheComponents', mode: 'adapter' } as const,
     ])('build output API - $test $mode', ({ test, mode }) => {
       const { next } = nextTestSetup({
         files: {
@@ -258,26 +258,33 @@ const FILES = {
         disableAutoSkewProtection: true,
       })
 
-      it('should produce identical build outputs even when changing deployment id', async () => {
-        let { run1, run2 } = await runTest(next, readFilesBuilder)
+      it(
+        'should produce identical build outputs even when changing deployment id',
+        async () => {
+          let { run1, run2 } = await runTest(next, readFilesBuilder)
 
-        expect(run1.size).toBeGreaterThan(0)
-        expect([...run1.keys()]).toEqual([...run2.keys()])
+          expect(run1.size).toBeGreaterThan(0)
+          expect([...run1.keys()]).toEqual([...run2.keys()])
 
-        if (test === 'standard') {
-          expect([...run1.keys()]).toIncludeAllMembers([
-            '.vercel/output/functions/app-page.func/.vc-config.json',
-            '.vercel/output/functions/app-page.rsc.func/.vc-config.json',
-            '.vercel/output/functions/app-route.func/.vc-config.json',
-            '.vercel/output/functions/app-route.rsc.func/.vc-config.json',
-            '.vercel/output/functions/pages-dynamic.func/.vc-config.json',
-            '.vercel/output/functions/pages-static-gsp.func/.vc-config.json',
-          ])
-          expect([...run1.keys()]).toSatisfyAny((k) =>
-            k.includes('middleware.func')
-          )
-        }
-      })
+          if (test === 'standard') {
+            expect([...run1.keys()]).toIncludeAllMembers([
+              '.vercel/output/functions/app-page.func/.vc-config.json',
+              '.vercel/output/functions/app-page.rsc.func/.vc-config.json',
+              '.vercel/output/functions/app-route.func/.vc-config.json',
+              '.vercel/output/functions/app-route.rsc.func/.vc-config.json',
+              '.vercel/output/functions/pages-dynamic.func/.vc-config.json',
+              '.vercel/output/functions/pages-static-gsp.func/.vc-config.json',
+            ])
+            expect([...run1.keys()]).toSatisfyAny((k) =>
+              k.includes('middleware.func')
+            )
+          }
+        },
+        // The builder mode can take a bit longer, so we increase the timeout
+        // for these tests. The adapter mode should be faster, so we leave it as
+        // the default.
+        mode === 'builder' ? 120_000 : undefined
+      )
     })
   }
 )


### PR DESCRIPTION
[Test duration metric](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22deterministic%20build%20-%20changing%20deployment%20id%20build%20output%20API%20-%20standard%20builder%20should%20produce%20identical%20build%20outputs%20even%20when%20changing%20deployment%20id%22%20%40test.type%3A%22turbopack%22%20%40test.status%3Apass&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1773311049123&end=1773915849123&paused=false)

The test frequently times out in CI. When it succeeds, it runs close to the 60 second timeout limit, so we increase it to 120 seconds to reduce flakiness.