### PR TITLE
[test] Increase `retry` timeouts for two flaky `app-action` tests

### DIFF
--- a/test/e2e/app-dir/actions/app-action.test.ts
+++ b/test/e2e/app-dir/actions/app-action.test.ts
@@ -1335,7 +1335,7 @@ describe('app-dir action handling', () => {
         )
         expect(await browser.url()).toBe(`${next.url}/pages-dir`)
         expect(mpaTriggered).toBe(true)
-      }, 5000)
+      }, 10_000)
     })
 
     it('should handle revalidatePath', async () => {
@@ -1610,7 +1610,7 @@ describe('app-dir action handling', () => {
       expect(await browser.elementById('modal-data').text()).toContain(
         'in "modal"'
       )
-    })
+    }, 10_000)
 
     // Submit the action
     await browser.elementById('submit-intercept-action').click()


### PR DESCRIPTION
- [Flakiness metric for `should handle redirects to routes that provide an invalid RSC response`](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22app-dir%20action%20handling%20fetch%20actions%20should%20handle%20redirects%20to%20routes%20that%20provide%20an%20invalid%20RSC%20response%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22&agg_m=count&agg_m_source=base&agg_t=count&currentTab=overview&eventStack=&fromUser=false&graphType=flamegraph&index=citest&start=1773313490002&end=1773918290002&paused=false)
- [Flakiness metric for `should work with interception routes`](https://app.datadoghq.com/ci/test/runs?query=test_level%3Atest%20%40git.repository.id%3A%22github.com%2Fvercel%2Fnext.js%22%20%40test.name%3A%22app-dir%20action%20handling%20should%20work%20with%20interception%20routes%22%20%40test.type%3A%22nextjs%22%20%40test.status%3A%22fail%22&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=citest&start=1773313571516&end=1773918371516&paused=false)