### PR TITLE
Fix missing route in otel spans without base-server

### DIFF
--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -720,7 +720,7 @@ export async function handler(
           return
         }
 
-        const route = rootSpanAttributes.get('next.route') || srcPage
+        const route = rootSpanAttributes.get('next.route') || normalizedSrcPage
         const name = `${method} ${route}`
 
         span.setAttributes({

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -651,6 +651,13 @@ export async function handler(
   const isWrappedByNextServer = Boolean(
     routerServerContext?.isWrappedByNextServer
   )
+  const activeHandleRequestSpan =
+    isWrappedByNextServer &&
+    activeSpan &&
+    tracer.getRootSpanAttributes()?.get('next.span_type') ===
+      BaseServerSpan.handleRequest
+      ? activeSpan
+      : undefined
   const remainingFallbackRouteParams =
     nextConfig.experimental.partialFallbacks === true &&
     remainingPrerenderableParams.length > 0
@@ -713,25 +720,21 @@ export async function handler(
           return
         }
 
-        const route = rootSpanAttributes.get('next.route')
-        if (route) {
-          const name = `${method} ${route}`
+        const route = rootSpanAttributes.get('next.route') || srcPage
+        const name = `${method} ${route}`
 
-          span.setAttributes({
-            'next.route': route,
-            'http.route': route,
-            'next.span_name': name,
-          })
-          span.updateName(name)
+        span.setAttributes({
+          'next.route': route,
+          'http.route': route,
+          'next.span_name': name,
+        })
+        span.updateName(name)
 
-          // Propagate http.route to the parent span if one exists (e.g.
-          // a platform-created HTTP span in adapter deployments).
-          if (parentSpan && parentSpan !== span) {
-            parentSpan.setAttribute('http.route', route)
-            parentSpan.updateName(name)
-          }
-        } else {
-          span.updateName(`${method} ${srcPage}`)
+        // Propagate http.route to the parent span if one exists (e.g.
+        // a platform-created HTTP span in adapter deployments).
+        if (parentSpan && parentSpan !== span) {
+          parentSpan.setAttribute('http.route', route)
+          parentSpan.updateName(name)
         }
       })
     }
@@ -1830,8 +1833,8 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (isWrappedByNextServer && activeSpan) {
-      await handleResponse(activeSpan)
+    if (activeHandleRequestSpan) {
+      await handleResponse(activeHandleRequestSpan)
     } else {
       parentSpan = tracer.getActiveScopeSpan()
       return await tracer.withPropagatedContext(
@@ -1850,7 +1853,7 @@ export async function handler(
             handleResponse
           ),
         undefined,
-        !isWrappedByNextServer
+        !activeHandleRequestSpan
       )
     }
   } catch (err) {

--- a/packages/next/src/build/templates/app-page.ts
+++ b/packages/next/src/build/templates/app-page.ts
@@ -651,13 +651,6 @@ export async function handler(
   const isWrappedByNextServer = Boolean(
     routerServerContext?.isWrappedByNextServer
   )
-  const activeHandleRequestSpan =
-    isWrappedByNextServer &&
-    activeSpan &&
-    tracer.getRootSpanAttributes()?.get('next.span_type') ===
-      BaseServerSpan.handleRequest
-      ? activeSpan
-      : undefined
   const remainingFallbackRouteParams =
     nextConfig.experimental.partialFallbacks === true &&
     remainingPrerenderableParams.length > 0
@@ -1833,8 +1826,8 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (activeHandleRequestSpan) {
-      await handleResponse(activeHandleRequestSpan)
+    if (isWrappedByNextServer && activeSpan) {
+      await handleResponse(activeSpan)
     } else {
       parentSpan = tracer.getActiveScopeSpan()
       return await tracer.withPropagatedContext(
@@ -1853,7 +1846,7 @@ export async function handler(
             handleResponse
           ),
         undefined,
-        !activeHandleRequestSpan
+        !isWrappedByNextServer
       )
     }
   } catch (err) {

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -216,13 +216,6 @@ export async function handler(
   const isWrappedByNextServer = Boolean(
     routerServerContext?.isWrappedByNextServer
   )
-  const activeHandleRequestSpan =
-    isWrappedByNextServer &&
-    activeSpan &&
-    tracer.getRootSpanAttributes()?.get('next.span_type') ===
-      BaseServerSpan.handleRequest
-      ? activeSpan
-      : undefined
   const isMinimalMode = Boolean(getRequestMeta(req, 'minimalMode'))
 
   const incrementalCache =
@@ -515,8 +508,8 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (activeHandleRequestSpan) {
-      await handleResponse(activeHandleRequestSpan)
+    if (isWrappedByNextServer && activeSpan) {
+      await handleResponse(activeSpan)
     } else {
       parentSpan = tracer.getActiveScopeSpan()
       await tracer.withPropagatedContext(
@@ -535,7 +528,7 @@ export async function handler(
             handleResponse
           ),
         undefined,
-        !activeHandleRequestSpan
+        !isWrappedByNextServer
       )
     }
   } catch (err) {

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -308,7 +308,7 @@ export async function handler(
           return
         }
 
-        const route = rootSpanAttributes.get('next.route') || srcPage
+        const route = rootSpanAttributes.get('next.route') || normalizedSrcPage
         const name = `${method} ${route}`
 
         span.setAttributes({

--- a/packages/next/src/build/templates/app-route.ts
+++ b/packages/next/src/build/templates/app-route.ts
@@ -216,6 +216,13 @@ export async function handler(
   const isWrappedByNextServer = Boolean(
     routerServerContext?.isWrappedByNextServer
   )
+  const activeHandleRequestSpan =
+    isWrappedByNextServer &&
+    activeSpan &&
+    tracer.getRootSpanAttributes()?.get('next.span_type') ===
+      BaseServerSpan.handleRequest
+      ? activeSpan
+      : undefined
   const isMinimalMode = Boolean(getRequestMeta(req, 'minimalMode'))
 
   const incrementalCache =
@@ -301,25 +308,21 @@ export async function handler(
           return
         }
 
-        const route = rootSpanAttributes.get('next.route')
-        if (route) {
-          const name = `${method} ${route}`
+        const route = rootSpanAttributes.get('next.route') || srcPage
+        const name = `${method} ${route}`
 
-          span.setAttributes({
-            'next.route': route,
-            'http.route': route,
-            'next.span_name': name,
-          })
-          span.updateName(name)
+        span.setAttributes({
+          'next.route': route,
+          'http.route': route,
+          'next.span_name': name,
+        })
+        span.updateName(name)
 
-          // Propagate http.route to the parent span if one exists (e.g.
-          // a platform-created HTTP span in adapter deployments).
-          if (parentSpan && parentSpan !== span) {
-            parentSpan.setAttribute('http.route', route)
-            parentSpan.updateName(name)
-          }
-        } else {
-          span.updateName(`${method} ${srcPage}`)
+        // Propagate http.route to the parent span if one exists (e.g.
+        // a platform-created HTTP span in adapter deployments).
+        if (parentSpan && parentSpan !== span) {
+          parentSpan.setAttribute('http.route', route)
+          parentSpan.updateName(name)
         }
       })
     }
@@ -512,8 +515,8 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (isWrappedByNextServer && activeSpan) {
-      await handleResponse(activeSpan)
+    if (activeHandleRequestSpan) {
+      await handleResponse(activeHandleRequestSpan)
     } else {
       parentSpan = tracer.getActiveScopeSpan()
       await tracer.withPropagatedContext(
@@ -532,7 +535,7 @@ export async function handler(
             handleResponse
           ),
         undefined,
-        !isWrappedByNextServer
+        !activeHandleRequestSpan
       )
     }
   } catch (err) {

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -83,13 +83,6 @@ export async function handler(
     const isWrappedByNextServer = Boolean(
       routerServerContext?.isWrappedByNextServer
     )
-    const activeHandleRequestSpan =
-      isWrappedByNextServer &&
-      activeSpan &&
-      tracer.getRootSpanAttributes()?.get('next.span_type') ===
-        BaseServerSpan.handleRequest
-        ? activeSpan
-        : undefined
     const onRequestError =
       routeModule.instrumentationOnRequestError.bind(routeModule)
 
@@ -165,8 +158,8 @@ export async function handler(
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (activeHandleRequestSpan) {
-      await invokeRouteModule(activeHandleRequestSpan)
+    if (isWrappedByNextServer && activeSpan) {
+      await invokeRouteModule(activeSpan)
     } else {
       parentSpan = tracer.getActiveScopeSpan()
       await tracer.withPropagatedContext(
@@ -185,7 +178,7 @@ export async function handler(
             invokeRouteModule
           ),
         undefined,
-        !activeHandleRequestSpan
+        !isWrappedByNextServer
       )
     }
   } catch (err) {

--- a/packages/next/src/build/templates/pages-api.ts
+++ b/packages/next/src/build/templates/pages-api.ts
@@ -83,6 +83,13 @@ export async function handler(
     const isWrappedByNextServer = Boolean(
       routerServerContext?.isWrappedByNextServer
     )
+    const activeHandleRequestSpan =
+      isWrappedByNextServer &&
+      activeSpan &&
+      tracer.getRootSpanAttributes()?.get('next.span_type') ===
+        BaseServerSpan.handleRequest
+        ? activeSpan
+        : undefined
     const onRequestError =
       routeModule.instrumentationOnRequestError.bind(routeModule)
 
@@ -138,32 +145,28 @@ export async function handler(
             return
           }
 
-          const route = rootSpanAttributes.get('next.route')
-          if (route) {
-            const name = `${method} ${route}`
+          const route = rootSpanAttributes.get('next.route') || srcPage
+          const name = `${method} ${route}`
 
-            span.setAttributes({
-              'next.route': route,
-              'http.route': route,
-              'next.span_name': name,
-            })
-            span.updateName(name)
+          span.setAttributes({
+            'next.route': route,
+            'http.route': route,
+            'next.span_name': name,
+          })
+          span.updateName(name)
 
-            // Propagate http.route to the parent span if one exists (e.g.
-            // a platform-created HTTP span in adapter deployments).
-            if (parentSpan && parentSpan !== span) {
-              parentSpan.setAttribute('http.route', route)
-              parentSpan.updateName(name)
-            }
-          } else {
-            span.updateName(`${method} ${srcPage}`)
+          // Propagate http.route to the parent span if one exists (e.g.
+          // a platform-created HTTP span in adapter deployments).
+          if (parentSpan && parentSpan !== span) {
+            parentSpan.setAttribute('http.route', route)
+            parentSpan.updateName(name)
           }
         })
 
     // TODO: activeSpan code path is for when wrapped by
     // next-server can be removed when this is no longer used
-    if (isWrappedByNextServer && activeSpan) {
-      await invokeRouteModule(activeSpan)
+    if (activeHandleRequestSpan) {
+      await invokeRouteModule(activeHandleRequestSpan)
     } else {
       parentSpan = tracer.getActiveScopeSpan()
       await tracer.withPropagatedContext(
@@ -182,7 +185,7 @@ export async function handler(
             invokeRouteModule
           ),
         undefined,
-        !isWrappedByNextServer
+        !activeHandleRequestSpan
       )
     }
   } catch (err) {

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -227,13 +227,6 @@ export const getHandler = ({
     const isWrappedByNextServer = Boolean(
       routerServerContext?.isWrappedByNextServer
     )
-    const activeHandleRequestSpan =
-      isWrappedByNextServer &&
-      activeSpan &&
-      tracer.getRootSpanAttributes()?.get('next.span_type') ===
-        BaseServerSpan.handleRequest
-        ? activeSpan
-        : undefined
 
     try {
       const method = req.method || 'GET'
@@ -756,8 +749,8 @@ export const getHandler = ({
 
       // TODO: activeSpan code path is for when wrapped by
       // next-server can be removed when this is no longer used
-      if (activeHandleRequestSpan) {
-        await handleResponse(activeHandleRequestSpan)
+      if (isWrappedByNextServer && activeSpan) {
+        await handleResponse(activeSpan)
       } else {
         parentSpan = tracer.getActiveScopeSpan()
         await tracer.withPropagatedContext(
@@ -776,7 +769,7 @@ export const getHandler = ({
               handleResponse
             ),
           undefined,
-          !activeHandleRequestSpan
+          !isWrappedByNextServer
         )
       }
     } catch (err) {

--- a/packages/next/src/server/route-modules/pages/pages-handler.ts
+++ b/packages/next/src/server/route-modules/pages/pages-handler.ts
@@ -224,6 +224,16 @@ export const getHandler = ({
 
     const tracer = getTracer()
     const activeSpan = tracer.getActiveScopeSpan()
+    const isWrappedByNextServer = Boolean(
+      routerServerContext?.isWrappedByNextServer
+    )
+    const activeHandleRequestSpan =
+      isWrappedByNextServer &&
+      activeSpan &&
+      tracer.getRootSpanAttributes()?.get('next.span_type') ===
+        BaseServerSpan.handleRequest
+        ? activeSpan
+        : undefined
 
     try {
       const method = req.method || 'GET'
@@ -413,26 +423,22 @@ export const getHandler = ({
                     return
                   }
 
-                  const route = rootSpanAttributes.get('next.route')
-                  if (route) {
-                    const name = `${method} ${route}`
+                  const route = rootSpanAttributes.get('next.route') || srcPage
+                  const name = `${method} ${route}`
 
-                    span.setAttributes({
-                      'next.route': route,
-                      'http.route': route,
-                      'next.span_name': name,
-                    })
-                    span.updateName(name)
+                  span.setAttributes({
+                    'next.route': route,
+                    'http.route': route,
+                    'next.span_name': name,
+                  })
+                  span.updateName(name)
 
-                    // Propagate http.route to the parent span if one exists
-                    // (e.g. a platform-created HTTP span in adapter
-                    // deployments).
-                    if (parentSpan && parentSpan !== span) {
-                      parentSpan.setAttribute('http.route', route)
-                      parentSpan.updateName(name)
-                    }
-                  } else {
-                    span.updateName(`${method} ${srcPage}`)
+                  // Propagate http.route to the parent span if one exists
+                  // (e.g. a platform-created HTTP span in adapter
+                  // deployments).
+                  if (parentSpan && parentSpan !== span) {
+                    parentSpan.setAttribute('http.route', route)
+                    parentSpan.updateName(name)
                   }
                 })
             } catch (err: unknown) {
@@ -750,23 +756,27 @@ export const getHandler = ({
 
       // TODO: activeSpan code path is for when wrapped by
       // next-server can be removed when this is no longer used
-      if (activeSpan) {
-        await handleResponse()
+      if (activeHandleRequestSpan) {
+        await handleResponse(activeHandleRequestSpan)
       } else {
         parentSpan = tracer.getActiveScopeSpan()
-        await tracer.withPropagatedContext(req.headers, () =>
-          tracer.trace(
-            BaseServerSpan.handleRequest,
-            {
-              spanName: `${method} ${srcPage}`,
-              kind: SpanKind.SERVER,
-              attributes: {
-                'http.method': method,
-                'http.target': req.url,
+        await tracer.withPropagatedContext(
+          req.headers,
+          () =>
+            tracer.trace(
+              BaseServerSpan.handleRequest,
+              {
+                spanName: `${method} ${srcPage}`,
+                kind: SpanKind.SERVER,
+                attributes: {
+                  'http.method': method,
+                  'http.target': req.url,
+                },
               },
-            },
-            handleResponse
-          )
+              handleResponse
+            ),
+          undefined,
+          !activeHandleRequestSpan
         )
       }
     } catch (err) {

--- a/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
+++ b/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
@@ -38,11 +38,35 @@ async function main() {
     'rsc-fetch',
     'page.js',
   ])
+  const appRouteHandler = loadEntrypointHandler([
+    'app',
+    'api',
+    'app',
+    '[param]',
+    'data',
+    'route.js',
+  ])
+  const pagesRouteHandler = loadEntrypointHandler([
+    'pages',
+    'pages',
+    '[param]',
+    'getServerSideProps.js',
+  ])
+  const pagesApiRouteHandler = loadEntrypointHandler([
+    'pages',
+    'api',
+    'pages',
+    '[param]',
+    'basic.js',
+  ])
 
   const tracer = trace.getTracer('custom-entrypoint-server', '1.0.0')
 
   const resolveHandler = (pathname: string): EntrypointHandler | undefined => {
     if (pathname.startsWith('/app/')) return appPageHandler
+    if (pathname.startsWith('/api/app/')) return appRouteHandler
+    if (pathname.startsWith('/pages/')) return pagesRouteHandler
+    if (pathname.startsWith('/api/pages/')) return pagesApiRouteHandler
     return undefined
   }
 

--- a/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
+++ b/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
@@ -18,7 +18,11 @@ type EntrypointHandler = (
 
 function loadEntrypointHandler(pathParts: string[]): EntrypointHandler {
   const entrypointPath = path.join(__dirname, '.next', 'server', ...pathParts)
-  return (require(entrypointPath) as { handler: EntrypointHandler }).handler
+  const mod = require(entrypointPath) as { handler?: EntrypointHandler }
+  if (typeof mod.handler !== 'function') {
+    throw new Error(`Entrypoint handler missing at ${entrypointPath}`)
+  }
+  return mod.handler
 }
 
 async function main() {
@@ -34,18 +38,11 @@ async function main() {
     'rsc-fetch',
     'page.js',
   ])
-  const pagesPageHandler = loadEntrypointHandler([
-    'pages',
-    'pages',
-    '[param]',
-    'getServerSideProps.js',
-  ])
 
   const tracer = trace.getTracer('custom-entrypoint-server', '1.0.0')
 
   const resolveHandler = (pathname: string): EntrypointHandler | undefined => {
     if (pathname.startsWith('/app/')) return appPageHandler
-    if (pathname.startsWith('/pages/')) return pagesPageHandler
     return undefined
   }
 

--- a/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
+++ b/test/e2e/opentelemetry/instrumentation/custom-entrypoint-server.ts
@@ -1,5 +1,6 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'http'
 import path from 'path'
+import { parse } from 'url'
 import getPort from 'get-port'
 import { trace } from '@opentelemetry/api'
 
@@ -15,29 +16,52 @@ type EntrypointHandler = (
   }
 ) => Promise<unknown>
 
+function loadEntrypointHandler(pathParts: string[]): EntrypointHandler {
+  const entrypointPath = path.join(__dirname, '.next', 'server', ...pathParts)
+  return (require(entrypointPath) as { handler: EntrypointHandler }).handler
+}
+
 async function main() {
   const port = await getPort()
   const hostname = 'localhost'
 
   require('next/dist/server/node-environment')
 
-  const entrypointPath = path.join(
-    __dirname,
-    '.next',
-    'server',
+  const appPageHandler = loadEntrypointHandler([
     'app',
     'app',
     '[param]',
     'rsc-fetch',
-    'page.js'
-  )
-  const { handler } = require(entrypointPath) as { handler: EntrypointHandler }
+    'page.js',
+  ])
+  const pagesPageHandler = loadEntrypointHandler([
+    'pages',
+    'pages',
+    '[param]',
+    'getServerSideProps.js',
+  ])
 
   const tracer = trace.getTracer('custom-entrypoint-server', '1.0.0')
 
+  const resolveHandler = (pathname: string): EntrypointHandler | undefined => {
+    if (pathname.startsWith('/app/')) return appPageHandler
+    if (pathname.startsWith('/pages/')) return pagesPageHandler
+    return undefined
+  }
+
   createServer((req, res) => {
+    const method = req.method || 'GET'
+    const pathname = parse(req.url || '/', false).pathname || '/'
+    const handler = resolveHandler(pathname)
+
+    if (!handler) {
+      res.statusCode = 404
+      res.end('Not Found')
+      return
+    }
+
     // Simulate a custom parent span around direct entrypoint invocation.
-    tracer.startActiveSpan('custom-entrypoint-request', async (span) => {
+    tracer.startActiveSpan(method, async (span) => {
       try {
         await handler(req, res, {
           waitUntil: () => {},

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -11,6 +11,7 @@ const EXTERNAL = {
 } as const
 
 const COLLECTOR_PORT = 9001
+const isStartMode = process.env.NEXT_TEST_MODE === 'start'
 
 describe('opentelemetry', () => {
   const { next, skipped, isNextDev } = nextTestSetup({
@@ -1418,7 +1419,7 @@ describe('opentelemetry with custom server', () => {
   })
 })
 
-if (!isNextDev) {
+if (isStartMode) {
   describe('opentelemetry with direct entrypoint handler', () => {
     const { next, skipped } = nextTestSetup({
       files: __dirname,

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1,5 +1,5 @@
 import { isNextDev, nextTestSetup } from 'e2e-utils'
-import { check } from 'next-test-utils'
+import { check, retry } from 'next-test-utils'
 import { NEXT_RSC_UNION_QUERY } from 'next/dist/client/components/app-router-headers'
 
 import { SavedSpan } from './constants'
@@ -1458,32 +1458,45 @@ if (!isNextDev) {
 
     it('should add route names to handleRequest and parent spans for direct entrypoints', async () => {
       await next.fetch('/app/param/rsc-fetch')
-      await next.fetch('/pages/param/getServerSideProps')
 
-      await check(async () => {
-        const spans = collector.getSpans()
-
-        for (const target of [
-          '/app/param/rsc-fetch',
-          '/pages/param/getServerSideProps',
-        ]) {
+      await retry(
+        async () => {
+          const spans = collector.getSpans()
           const handleRequestSpan = spans.find(
             (span) =>
               span.attributes?.['next.span_type'] ===
-                'BaseServer.handleRequest' &&
-              span.attributes?.['http.target'] === target
+                'BaseServer.handleRequest' && span.name?.includes('/app/')
           )
 
           expect(handleRequestSpan).toBeDefined()
+          expect(handleRequestSpan!.name).toContain(' /app/')
+          expect(handleRequestSpan!.attributes?.['http.target']).toContain(
+            '/app/param/rsc-fetch'
+          )
+          expect(handleRequestSpan!.attributes?.['next.route']).toContain(
+            '/app/'
+          )
+          expect(handleRequestSpan!.attributes?.['http.route']).toContain(
+            '/app/'
+          )
+          expect(handleRequestSpan!.attributes?.['next.span_name']).toBe(
+            handleRequestSpan!.name
+          )
 
           const parentSpan = spans.find(
-            (span) => span.id === handleRequestSpan!.parentId
+            (span) =>
+              span.traceId === handleRequestSpan!.traceId &&
+              !span.parentId &&
+              !span.attributes?.['next.span_type'] &&
+              span.name === handleRequestSpan!.name
           )
           expect(parentSpan).toBeDefined()
-          expect(parentSpan!.name).toBe(handleRequestSpan!.name)
-          expect(parentSpan!.name).toContain(' /')
-        }
-      }, 30_000)
+          expect(parentSpan!.name).toContain(' /app/')
+        },
+        30_000,
+        1_000,
+        'direct entrypoint span route naming'
+      )
     })
 
     it('should propagate incoming context without next-server wrapper', async () => {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1456,6 +1456,36 @@ if (!isNextDev) {
       await collector.shutdown()
     })
 
+    it('should add route names to handleRequest and parent spans for direct entrypoints', async () => {
+      await next.fetch('/app/param/rsc-fetch')
+      await next.fetch('/pages/param/getServerSideProps')
+
+      await check(async () => {
+        const spans = collector.getSpans()
+
+        for (const target of [
+          '/app/param/rsc-fetch',
+          '/pages/param/getServerSideProps',
+        ]) {
+          const handleRequestSpan = spans.find(
+            (span) =>
+              span.attributes?.['next.span_type'] ===
+                'BaseServer.handleRequest' &&
+              span.attributes?.['http.target'] === target
+          )
+
+          expect(handleRequestSpan).toBeDefined()
+
+          const parentSpan = spans.find(
+            (span) => span.id === handleRequestSpan!.parentId
+          )
+          expect(parentSpan).toBeDefined()
+          expect(parentSpan!.name).toBe(handleRequestSpan!.name)
+          expect(parentSpan!.name).toContain(' /')
+        }
+      }, 30_000)
+    })
+
     it('should propagate incoming context without next-server wrapper', async () => {
       await next.fetch('/app/param/rsc-fetch', {
         headers: {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1508,7 +1508,7 @@ if (!isNextDev) {
 
       await expectTrace(getCollector(), [
         {
-          name: 'GET /app/[param]/rsc-fetch/page',
+          name: 'GET /app/[param]/rsc-fetch',
           traceId: EXTERNAL.traceId,
           parentId: EXTERNAL.spanId,
           attributes: {

--- a/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
+++ b/test/e2e/opentelemetry/instrumentation/opentelemetry.test.ts
@@ -1457,68 +1457,93 @@ if (isStartMode) {
       await collector.shutdown()
     })
 
-    it('should add route names to handleRequest and parent spans for direct entrypoints', async () => {
-      await next.fetch('/app/param/rsc-fetch')
+    const directEntrypointCases = [
+      { pathname: '/app/param/rsc-fetch', route: '/app/[param]/rsc-fetch' },
+      { pathname: '/api/app/param/data', route: '/api/app/[param]/data' },
+      {
+        pathname: '/pages/param/getServerSideProps',
+        route: '/pages/[param]/getServerSideProps',
+      },
+      {
+        pathname: '/api/pages/param/basic',
+        route: '/api/pages/[param]/basic',
+      },
+    ] as const
 
-      await retry(
-        async () => {
-          const spans = collector.getSpans()
-          const handleRequestSpan = spans.find(
-            (span) =>
-              span.attributes?.['next.span_type'] ===
-                'BaseServer.handleRequest' && span.name?.includes('/app/')
-          )
+    describe.each(directEntrypointCases)(
+      'direct entrypoint $pathname',
+      ({ pathname, route }) => {
+        it(`should add route names to handleRequest and parent spans for direct entrypoint ${pathname}`, async () => {
+          const response = await next.fetch(pathname)
+          expect(response.status).toBe(200)
 
-          expect(handleRequestSpan).toBeDefined()
-          expect(handleRequestSpan!.name).toContain(' /app/')
-          expect(handleRequestSpan!.attributes?.['http.target']).toContain(
-            '/app/param/rsc-fetch'
-          )
-          expect(handleRequestSpan!.attributes?.['next.route']).toContain(
-            '/app/'
-          )
-          expect(handleRequestSpan!.attributes?.['http.route']).toContain(
-            '/app/'
-          )
-          expect(handleRequestSpan!.attributes?.['next.span_name']).toBe(
-            handleRequestSpan!.name
-          )
+          await retry(
+            async () => {
+              const spans = collector.getSpans()
+              const handleRequestSpan = spans.find((span) => {
+                if (
+                  span.attributes?.['next.span_type'] !==
+                  'BaseServer.handleRequest'
+                ) {
+                  return false
+                }
+                const target = span.attributes?.['http.target'] as
+                  | string
+                  | undefined
+                return Boolean(target && target.includes(pathname))
+              })
 
-          const parentSpan = spans.find(
-            (span) =>
-              span.traceId === handleRequestSpan!.traceId &&
-              !span.parentId &&
-              !span.attributes?.['next.span_type'] &&
-              span.name === handleRequestSpan!.name
+              expect(handleRequestSpan).toBeDefined()
+              expect(handleRequestSpan!.name).toBe(`GET ${route}`)
+              expect(handleRequestSpan!.attributes?.['http.target']).toContain(
+                pathname
+              )
+              expect(handleRequestSpan!.attributes?.['next.route']).toBe(route)
+              expect(handleRequestSpan!.attributes?.['http.route']).toBe(route)
+              expect(handleRequestSpan!.attributes?.['next.span_name']).toBe(
+                `GET ${route}`
+              )
+
+              const parentSpan = spans.find(
+                (span) =>
+                  span.traceId === handleRequestSpan!.traceId &&
+                  !span.parentId &&
+                  !span.attributes?.['next.span_type'] &&
+                  span.name === handleRequestSpan!.name
+              )
+              expect(parentSpan).toBeDefined()
+              expect(parentSpan!.name).toBe(`GET ${route}`)
+            },
+            30_000,
+            1_000,
+            `direct entrypoint span route naming ${pathname}`
           )
-          expect(parentSpan).toBeDefined()
-          expect(parentSpan!.name).toContain(' /app/')
-        },
-        30_000,
-        1_000,
-        'direct entrypoint span route naming'
-      )
-    })
+        })
 
-    it('should propagate incoming context without next-server wrapper', async () => {
-      await next.fetch('/app/param/rsc-fetch', {
-        headers: {
-          traceparent: `00-${EXTERNAL.traceId}-${EXTERNAL.spanId}-01`,
-        },
-      })
+        it(`should propagate incoming context without next-server wrapper for direct entrypoint ${pathname}`, async () => {
+          const response = await next.fetch(pathname, {
+            headers: {
+              traceparent: `00-${EXTERNAL.traceId}-${EXTERNAL.spanId}-01`,
+            },
+          })
+          expect(response.status).toBe(200)
 
-      await expectTrace(getCollector(), [
-        {
-          name: 'GET /app/[param]/rsc-fetch',
-          traceId: EXTERNAL.traceId,
-          parentId: EXTERNAL.spanId,
-          attributes: {
-            'http.target': '/app/param/rsc-fetch',
-            'next.span_type': 'BaseServer.handleRequest',
-          },
-        },
-      ])
-    })
+          await expectTrace(getCollector(), [
+            {
+              name: `GET ${route}`,
+              traceId: EXTERNAL.traceId,
+              parentId: EXTERNAL.spanId,
+              attributes: {
+                'http.target': pathname,
+                'next.span_type': 'BaseServer.handleRequest',
+                'http.route': route,
+                'next.route': route,
+              },
+            },
+          ])
+        })
+      }
+    )
   })
 }
 


### PR DESCRIPTION
When invoking `handler` exports directly without `base-server` we need to ensure span names are still updated with the route correctly so not just method name is in span name. 