### PR TITLE
Add block-no-verify hooks to prevent agents from bypassing git hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [{ "type": "command", "command": "npx block-no-verify@1.1.2" }]
+      }
+    ]
+  }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,7 @@
+{
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "npx block-no-verify@1.1.2", "event": "beforeShellExecution" }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `.claude/settings.json` with `block-no-verify@1.1.2` as a `PreToolUse` Bash hook
- Creates `.cursor/hooks.json` with `block-no-verify@1.1.2` as a `beforeShellExecution` hook
- Prevents both Claude Code and Cursor agents from bypassing git hooks via the hook-skip flag

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads the command from the hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block.

The existing `.claude/skills` and `.cursor/commands` + `worktrees.json` are unchanged.

Closes #91667

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
