### PR TITLE
fix: use origin for path-absolute URLs in router.replace/push

### DIFF
--- a/packages/next/src/client/components/app-router-instance.ts
+++ b/packages/next/src/client/components/app-router-instance.ts
@@ -291,7 +291,8 @@ export function dispatchNavigateAction(
     }
   }
 
-  const url = new URL(addBasePath(href), location.href)
+  const base = href.startsWith('/') ? location.origin : location.href
+  const url = new URL(addBasePath(href), base)
   if (process.env.__NEXT_APP_NAV_FAIL_HANDLING) {
     window.next.__pendingUrl = url
   }
@@ -350,7 +351,8 @@ function gesturePush(href: string, options?: NavigateOptions): void {
     if (state === null) {
       return
     }
-    const url = new URL(addBasePath(href), location.href)
+    const base = href.startsWith('/') ? location.origin : location.href
+    const url = new URL(addBasePath(href), base)
     if (isExternalURL(url)) {
       return
     }

--- a/packages/next/src/client/components/app-router-utils.ts
+++ b/packages/next/src/client/components/app-router-utils.ts
@@ -20,7 +20,8 @@ export function createPrefetchURL(href: string): URL | null {
 
   let url: URL
   try {
-    url = new URL(addBasePath(href), window.location.href)
+    const base = href.startsWith('/') ? window.location.origin : window.location.href
+    url = new URL(addBasePath(href), base)
   } catch (_) {
     // TODO: Does this need to throw or can we just console.error instead? Does
     // anyone rely on this throwing? (Seems unlikely.)


### PR DESCRIPTION
### What?

- Use location.origin for absolute hrefs.
- Keep location.href for relative hrefs.

### Why?

- Avoid query/hash carry-over.
- Make URL resolution explicit.

### How?

- Updated app-router-instance.
- Updated app-router-utils.

Closes : #91658